### PR TITLE
Filter 'published' the same for /learningpaths and /learning_resource?resource_type=learning_path

### DIFF
--- a/learning_resources/views_learningpath_test.py
+++ b/learning_resources/views_learningpath_test.py
@@ -43,8 +43,13 @@ def test_learning_path_endpoint_get(client, is_public, is_editor, user):
 
     # Logged in user should get public lists or all lists if editor
     client.force_login(user)
+    ## using the dedicated API
     resp = client.get(reverse("lr_learningpaths_api-list"))
     assert resp.data["count"] == (2 if is_public or is_editor else 0)
+    ## using the general API and filtering by type
+    resp = client.get(
+        f"{reverse('learning_resources_api-list')}?resource_type={LearningResourceType.learning_path.value}"
+    )
 
     resp = client.get(
         reverse(


### PR DESCRIPTION
#### What are the relevant tickets?
A potential fix for #67 

#### What's this PR do?
This PR refactors how the published filtering works so that `/learningpaths` and `/learning_resources?resource_type=learning_path` return the same results.

#### How should this be manually tested?
1. View http://localhost:8063/api/v1/learningpaths/ and http://localhost:8063/api/v1/learning_resources/?resource_type=learning_path as anonymous user or a user without `learning_path_editor` permission (or as admin).
    - both endpoints should **not** include unpublished learningpaths
2. Repeat (1) but now with the `learning_path_editor` permission (or as admin). 
    - both endpoints **should** include unpublished learningpaths

