### PR TITLE
83: Add noindex meta tag in non-prod

### DIFF
--- a/open_discussions/templates/index.html
+++ b/open_discussions/templates/index.html
@@ -1,4 +1,5 @@
 {% load render_bundle from webpack_loader %}
+{% load noindex_meta %}
 <!doctype html>
 <html lang="en">
   <head>
@@ -16,6 +17,7 @@
     />
     {% endspaceless %}
     {{ js_settings|json_script:'js-settings' }}
+    {% noindex_meta %}
     <script type="text/javascript">
       var SETTINGS = JSON.parse(
           document.getElementById('js-settings').textContent,

--- a/open_discussions/templatetags/noindex_meta.py
+++ b/open_discussions/templatetags/noindex_meta.py
@@ -1,0 +1,16 @@
+"""Adds in noindex meta tag to all pages for non-production environments."""
+from django import template
+from django.conf import settings
+from django.utils.html import format_html
+
+register = template.Library()
+
+
+@register.simple_tag()
+def noindex_meta():
+    """Add noindex for non-production environments."""
+    return (
+        format_html("""<meta name="robots" content="noindex">""")
+        if settings.ENVIRONMENT not in ("production", "prod")
+        else ""
+    )


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/83

# Description (What does it do?)
Adds `<meta name="robots" content="noindex">` within the `header` of each HTML page when `MITOPEN_ENVIRONMENT` is not equal to `prod` or `production`.


# How can this be tested?

1. Using this branch, view the page source code in your browser for any MIT Open page.  Verify that the `header` element contains `<meta name="robots" content="noindex">`.
2. Shut down the application.
3. Add `MITOPEN_ENVIRONMENT=production` or `MITOPEN_ENVIRONMENT=prod` to your `.env`.
4. Start the application and view the page source code in your browser for any MIT Open page.  Verify that the `header` element DOES NOT contain `<meta name="robots" content="noindex">`.
