### PR TITLE
Fix Test timeout

### DIFF
--- a/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
+++ b/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
@@ -96,23 +96,20 @@ describe("LearningPathDetailsPage", () => {
     },
   )
 
-  test.each(new Array(100).fill(null))(
-    "Clicking reorder makes items reorderable, clicking Done makes them static",
-    async () => {
-      const path = factories.learningResources.learningPath()
-      setup({ path, userSettings: { is_learning_path_editor: true } })
-      const reorderButton = await screen.findByRole("button", {
-        name: "Reorder",
-      })
-      expectLastProps(spyItemsListing, { sortable: false })
-      await user.click(reorderButton)
-      expectLastProps(spyItemsListing, { sortable: true })
+  test("Clicking reorder makes items reorderable, clicking Done makes them static", async () => {
+    const path = factories.learningResources.learningPath()
+    setup({ path, userSettings: { is_learning_path_editor: true } })
+    const reorderButton = await screen.findByRole("button", {
+      name: "Reorder",
+    })
+    expectLastProps(spyItemsListing, { sortable: false })
+    await user.click(reorderButton)
+    expectLastProps(spyItemsListing, { sortable: true })
 
-      expect(reorderButton).toHaveAccessibleName("Done ordering")
-      await user.click(reorderButton)
-      expectLastProps(spyItemsListing, { sortable: false })
-    },
-  )
+    expect(reorderButton).toHaveAccessibleName("Done ordering")
+    await user.click(reorderButton)
+    expectLastProps(spyItemsListing, { sortable: false })
+  })
 
   it.each([
     {

--- a/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
+++ b/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
@@ -108,10 +108,8 @@ describe("LearningPathDetailsPage", () => {
       await user.click(reorderButton)
       expectLastProps(spyItemsListing, { sortable: true })
 
-      const doneButton = await screen.findByRole("button", {
-        name: "Done ordering",
-      })
-      await user.click(doneButton)
+      expect(reorderButton).toHaveAccessibleName("Done ordering")
+      await user.click(reorderButton)
       expectLastProps(spyItemsListing, { sortable: false })
     },
   )

--- a/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
+++ b/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
@@ -96,20 +96,25 @@ describe("LearningPathDetailsPage", () => {
     },
   )
 
-  test("Clicking reorder makes items reorderable, clicking Done makes them static", async () => {
-    const path = factories.learningResources.learningPath()
-    setup({ path, userSettings: { is_learning_path_editor: true } })
-    const reorderButton = await screen.findByRole("button", { name: "Reorder" })
-    expectLastProps(spyItemsListing, { sortable: false })
-    await user.click(reorderButton)
-    expectLastProps(spyItemsListing, { sortable: true })
+  test.each(new Array(100).fill(null))(
+    "Clicking reorder makes items reorderable, clicking Done makes them static",
+    async () => {
+      const path = factories.learningResources.learningPath()
+      setup({ path, userSettings: { is_learning_path_editor: true } })
+      const reorderButton = await screen.findByRole("button", {
+        name: "Reorder",
+      })
+      expectLastProps(spyItemsListing, { sortable: false })
+      await user.click(reorderButton)
+      expectLastProps(spyItemsListing, { sortable: true })
 
-    const doneButton = await screen.findByRole("button", {
-      name: "Done ordering",
-    })
-    await user.click(doneButton)
-    expectLastProps(spyItemsListing, { sortable: false })
-  })
+      const doneButton = await screen.findByRole("button", {
+        name: "Done ordering",
+      })
+      await user.click(doneButton)
+      expectLastProps(spyItemsListing, { sortable: false })
+    },
+  )
 
   it.each([
     {


### PR DESCRIPTION
# What are the relevant tickets?
Closes #98 

# Description (What does it do?)
This PR changes one test that was being problematic.

# How ~can this be~ has this been tested?
1. I ran the original test in a `.each()` block, repeated it 100 times, on both CI and locally. See https://github.com/mitodl/mit-open/actions/runs/6301758705/job/17107497440?pr=100 
    - locally: that test file took ~130 seconds
    - on CI:  4 ❌, 96 ✅ 
2. I removed an unnecessary `findByRole` query, and repeated (1), running 100 tests. See https://github.com/mitodl/mit-open/actions/runs/6301882578
    - locally: that test file took ~55 seconds
    - on CI: 100 ✅

So, the test is a lot faster now.

# Additional Context
Testing Library's `*byRole` queiries are their recommended query because they provide a number of accessibility checks, but they apparently slower than related queries that do not make similar accessibility checks (e.g., `*byText*`). See for example:
 - https://github.com/testing-library/dom-testing-library/issues/820#issuecomment-726936225
 - https://github.com/testing-library/dom-testing-library/issues/698#issuecomment-658714611

**But the performance is getting better:** The unreleased branch of `jest-environment-jsdom` uses JSDom v22 (we're on v20). Trying that locally brought 100 repetitions down to undo 40 seconds. 