### PR TITLE
Dockerfile: infer platform; no explicit AMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.11.4
+FROM python:3.11.4
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip


### PR DESCRIPTION
# What are the relevant tickets?
None

# Description (What does it do?)
This PR removes the explicit `--platform` arg from our Dockerfile, which
- is how our other repos are set up ([studio](https://github.com/mitodl/ocw-studio/blob/7d612b599650f69fc6e11c3d69e50df994eb5563/Dockerfile#L1), [mitxonline](https://github.com/mitodl/mitxonline/blob/a10a4e3d6bb465e64ef4949978083916e22536ab/Dockerfile#L1))
- means the platform (ARM64, AMD64, etc) should be inferred by Docker

In particular, this means M1 macs should get an ARM64 build, which is vastly faster: Currently, `pytest` takes about 20-25 minutes to run on my M1. On this branch, it takes a little less than 3 minutes.


# How can this be tested?
1. `docker compose up --build`
2. `docker compose exec web pytest` should run just like it did before (linux + intel macs) and much faster on m1
3. There should be no noticeable changes

# Additional Context
**Caveat:**  The `--platform` arg was introduced in https://github.com/mitodl/mit-open/pull/43/files?show-viewed-files=true&file-filters%5B%5D=#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1 by @Ardiea, who also has an M1 and was unable to get the repo to build successfully without the `--platform` arg. Having talked with @Ardiea about this, we suspect it is a config issue. I feel pretty confident in this change since it works on my M1 **and** is how our other repos are set up.
