### PR TITLE
Article editor: embedding external content

### DIFF
--- a/frontends/mit-open/src/pages/articles/ArticleDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/articles/ArticleDetailsPage.tsx
@@ -7,6 +7,7 @@ import { useParams } from "react-router"
 import Button from "@mui/material/Button"
 import Grid from "@mui/material/Grid"
 import { articlesEditView } from "../urls"
+import { CkeditorDisplay } from "ol-ckeditor"
 
 type RouteParams = {
   id: string
@@ -49,11 +50,8 @@ const ArticlesDetailPage: React.FC = () => {
                 <LoadingSpinner loading={true} />
               </Grid>
             )}
-            <div
-              className="ck-content"
-              dangerouslySetInnerHTML={{
-                __html: article.data?.html ?? "",
-              }}
+            <CkeditorDisplay
+              dangerouslySetInnerHTML={article.data?.html ?? ""}
             />
           </GridColumn>
         </GridContainer>

--- a/frontends/mit-open/src/scss/combined.scss
+++ b/frontends/mit-open/src/scss/combined.scss
@@ -16,7 +16,6 @@
 @use "ol-util/assets/sortable";
 @use "demopage";
 @use "articles";
-@use "ol-ckeditor/assets/vendor/ckeditor_content_styles";
 
 html {
   font-family: theme.$font-family-default;

--- a/frontends/ol-ckeditor/package.json
+++ b/frontends/ol-ckeditor/package.json
@@ -4,8 +4,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./test_utils": "./src/test_utils.tsx",
-    "./webpack-utils": "./src/webpack-utils.js",
-    "./assets/vendor/ckeditor_content_styles": "./assets/vendor/ckeditor_content_styles"
+    "./webpack-utils": "./src/webpack-utils.js"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^40.0.0",

--- a/frontends/ol-ckeditor/src/components/CkeditorDisplay.test.tsx
+++ b/frontends/ol-ckeditor/src/components/CkeditorDisplay.test.tsx
@@ -1,0 +1,67 @@
+/* eslint-disable testing-library/no-node-access */
+import React from "react"
+import { render } from "@testing-library/react"
+import CkeditorDisplay from "./CkeditorDisplay"
+
+describe("CkeditorDisplay", () => {
+  it("Renders <oembed> tags as embedly cards", () => {
+    const htmlIn = `
+<p>Some text</p>
+<figure class="media">
+  <oembed url="https://openlearning.mit.edu/"></oembed>
+</figure>
+<p>More text</p>
+<figure class="media">
+  <oembed url="https://mit.edu/"></oembed>
+</figure>
+<p>Some more text</p>
+    `.trim()
+    const expectedHtmlOut = `
+<p>Some text</p>
+<a data-card-chrome="0" data-card-controls="0" data-card-key="embedly_key" class="embedly-card" href="https://openlearning.mit.edu/"></a>
+<p>More text</p>
+<a data-card-chrome="0" data-card-controls="0" data-card-key="embedly_key" class="embedly-card" href="https://mit.edu/"></a>
+<p>Some more text</p>
+    `.trim()
+    const view = render(<CkeditorDisplay dangerouslySetInnerHTML={htmlIn} />)
+    expect(view.container.children.length).toBe(1)
+    const container = view.container.children[0]
+    expect(container.innerHTML).toBe(expectedHtmlOut)
+  })
+
+  it("Adds ck-content class to container", () => {
+    const view = render(<CkeditorDisplay dangerouslySetInnerHTML="Hello" />)
+    expect(view.container.firstChild).toHaveClass("ck-content")
+  })
+
+  test("HTML re-renders correctly", () => {
+    /**
+     * Normally we wouldn't check re-rendering logic like this, but we're
+     * manipulating the raw HTML, and depending on how one does that, it can
+     * be susceptible to re-rendering bugs.
+     */
+
+    const input0 = `
+<p>Some text</p>
+<figure class="media">
+  <oembed url="https://openlearning.mit.edu/"></oembed>
+</figure>
+<p>More text</p>
+<figure class="media">
+  <oembed url="https://mit.edu/"></oembed>
+</figure>
+<p>Some more text</p>
+        `.trim()
+    const input1 = input0
+    const input2 = `input2`
+    const view = render(<CkeditorDisplay dangerouslySetInnerHTML={input0} />)
+    const html0 = view.container.innerHTML
+    view.rerender(<CkeditorDisplay dangerouslySetInnerHTML={input1} />)
+    const html1 = view.container.innerHTML
+    expect(html0).toBe(html1)
+
+    view.rerender(<CkeditorDisplay dangerouslySetInnerHTML={input2} />)
+    const html2 = view.container.children[0].innerHTML
+    expect(html2).toBe("input2")
+  })
+})

--- a/frontends/ol-ckeditor/src/components/CkeditorDisplay.tsx
+++ b/frontends/ol-ckeditor/src/components/CkeditorDisplay.tsx
@@ -1,0 +1,80 @@
+import React, { useMemo, useEffect } from "react"
+import classNames from "classnames"
+import "../../assets/vendor/ckeditor_content_styles.scss"
+import { embedlyCardHtml, ensureEmbedlyPlatform } from "ol-util"
+
+const parser = new DOMParser()
+interface Replacer {
+  selector: string
+  replacer: (match: Element) => Node | null
+}
+/**
+ * Make replacementments in and HTML string.
+ */
+const htmlFindAndReplace = (html: string, replacers: Replacer[]): string => {
+  const dom = parser.parseFromString(html, "text/html")
+  replacers.forEach(({ selector, replacer }) =>
+    dom.querySelectorAll(selector).forEach((match) => {
+      const replacement = replacer(match)
+      const parent = match.parentNode
+      if (parent && replacement) {
+        parent.replaceChild(replacement, match)
+      }
+    }),
+  )
+  return dom.body.innerHTML
+}
+
+/**
+ * Display content created with Ckeditor.
+ *
+ * NOTE: This is not an editor!
+ *
+ * This component:
+ *  - applies a stylesheet expected by Ckeditor-created content. (E.g., image
+ * alignment)
+ *  - Replaces <oembed> tags with embedly cards.
+ */
+const CkeditorDisplay: React.FC<{
+  dangerouslySetInnerHTML: string
+  className?: string
+}> = ({ dangerouslySetInnerHTML, className }) => {
+  useEffect(() => {
+    ensureEmbedlyPlatform()
+  }, [])
+
+  /**
+   * A reasonable alternative to this might be
+   * https://www.npmjs.com/package/html-react-parser
+   * particularly if we want to replace html with react components.
+   * Currently, we are replacing html with html.
+   */
+  const html = useMemo(
+    () =>
+      htmlFindAndReplace(dangerouslySetInnerHTML, [
+        {
+          selector: "figure.media",
+          replacer: (match) => {
+            const url = match
+              .querySelector("oembed")
+              ?.attributes.getNamedItem("url")?.value
+            if (!url) return null
+            const template = document.createElement("template")
+            template.innerHTML = embedlyCardHtml(url)
+            return template.content.firstChild
+          },
+        },
+      ]),
+    [dangerouslySetInnerHTML],
+  )
+  return (
+    <div
+      className={classNames("ck-content", className)}
+      dangerouslySetInnerHTML={{
+        __html: html,
+      }}
+    />
+  )
+}
+
+export default CkeditorDisplay

--- a/frontends/ol-ckeditor/src/index.ts
+++ b/frontends/ol-ckeditor/src/index.ts
@@ -4,3 +4,4 @@
 import "./styles.scss"
 
 export * from "./components/lazyEditors"
+export { default as CkeditorDisplay } from "./components/CkeditorDisplay"

--- a/frontends/ol-util/src/components/embedly/util.ts
+++ b/frontends/ol-util/src/components/embedly/util.ts
@@ -95,8 +95,7 @@ const embedlyCardHtml = (url: string) => {
   data-card-controls="0"
   data-card-key=${embedlyKey}
   class="embedly-card"
-  href="${url}">
-</a>`
+  href="${url}"></a>`
 }
 
 export {


### PR DESCRIPTION
# What are the relevant tickets?
#124 

# Description (What does it do?)
This PR enables the article editor's display mode (read-only) to display Ckeditor's "media embed" content.

# Screenshots (if appropriate):
<img width="350" alt="Screenshot 2023-10-13 at 3 16 35 PM" src="https://github.com/mitodl/mit-open/assets/9010790/0a55595a-ac2b-425e-9247-5a39367f1c5b"> 
<img width="305" alt="Screenshot 2023-10-13 at 3 16 43 PM" src="https://github.com/mitodl/mit-open/assets/9010790/afe84532-5f83-4b11-b37a-5b1fd64eb6ba">

# How can this be tested?
1. Ensure you have the following environment variables set: `CKEDITOR_ENVIRONMENT_ID`,`CKEDITOR_SECRET_KEY`,`CKEDITOR_UPLOAD_URL`, `EMBEDLY_KEY`. You can get them from RC.
2. Visit http://localhost:8063/api/v1/articles/ to get some article ids. If you don't have any articles, create a few.
    - must be logged in as staff
    - there is currently no frontend for article listings OR article creation (just editing)
3. Visit `http://localhost:8063/articles/ARTICLE_ID_HERE`.
4. Click "Edit". Add "media embed" content. There are two ways:
    - The "+" button that shows up to left of editor when you focus a line
    - or directly pasting URLs into the editor.
5. After you add embedded content, you should see a preview **in the editor**. Click save.
6. **Check the display:** You should get a preview of the embedded content, just like you did in the editor mode.
    - if you check the dev console, you should see it's an Embedly card.
7. **Check the database:** Visit `http://localhost:8063/api/v1/articles/ARTICLE_ID_HERE`. Check that the HTML output contains something like:
    ```html
    <figure class="media">
        <oembed url="some-url-here"></oembed>
    </figure>
    ```
    That is, it should NOT contain an embedly card, but a semantic "embedded content" tag. In particular, the embedly key should NOT be stored in the article content.
