### PR TITLE
search api

### DIFF
--- a/authentication/middleware_test.py
+++ b/authentication/middleware_test.py
@@ -75,7 +75,7 @@ def test_process_view_blocked_ip_middleware(  # pylint:disable=too-many-argument
 ):
     """Check that `process_view` raises a PermissionDenied error when appropriate"""
     user = UserFactory.create(is_superuser=is_super)
-    view = "search"
+    view = "learning_resources_search"
     request = rf.post(reverse(view))
     request.user = user
 

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -1489,6 +1489,31 @@ export interface LearningResourceTopic {
   name: string
 }
 /**
+ *
+ * @export
+ * @interface LearningResourcesSearchResponse
+ */
+export interface LearningResourcesSearchResponse {
+  /**
+   *
+   * @type {number}
+   * @memberof LearningResourcesSearchResponse
+   */
+  count: number
+  /**
+   *
+   * @type {Array<LearningResource>}
+   * @memberof LearningResourcesSearchResponse
+   */
+  results: Array<LearningResource>
+  /**
+   *
+   * @type {any}
+   * @memberof LearningResourcesSearchResponse
+   */
+  metadata: any
+}
+/**
  * Serializer containing only parent and child ids for a learning path relationship
  * @export
  * @interface MicroLearningPathRelationship
@@ -7606,6 +7631,553 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * LearningResourcesSearchApi - axios parameter creator
+ * @export
+ */
+export const LearningResourcesSearchApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * View for executing searches of learning resources
+     * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
+     * @param {Array<string>} [certification]
+     * @param {Array<string>} [department]
+     * @param {Array<string>} [level]
+     * @param {number} [limit]
+     * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
+     * @param {number} [offset]
+     * @param {Array<'edx' | 'ocw' | 'oll' | 'mitxonline' | 'bootcamps' | 'xpro' | 'csail' | 'mitpe' | 'see' | 'scc' | 'ctl' | 'whu' | 'susskind' | 'globalalumni' | 'simplilearn' | 'emeritus' | 'podcast'>} [platform]
+     * @param {Array<'true' | 'false'>} [professional]
+     * @param {string} [q] The search text
+     * @param {Array<string>} [resource_content_tags]
+     * @param {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode'>} [resource_type]
+     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'runs.start_date' | '-runs.start_date'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;readable_id&#x60; - readable_id * &#x60;-readable_id&#x60; - -readable_id * &#x60;last_modified&#x60; - last_modified * &#x60;-last_modified&#x60; - -last_modified * &#x60;runs.start_date&#x60; - runs.start_date * &#x60;-runs.start_date&#x60; - -runs.start_date
+     * @param {Array<string>} [topic]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    learningResourcesSearchRetrieve: async (
+      aggregations?: Array<
+        | "resource_type"
+        | "certification"
+        | "offered_by"
+        | "platform"
+        | "topic"
+        | "department"
+        | "level"
+        | "resource_content_tags"
+        | "professional"
+      >,
+      certification?: Array<string>,
+      department?: Array<string>,
+      level?: Array<string>,
+      limit?: number,
+      offered_by?: Array<
+        | "mitx"
+        | "ocw"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+      >,
+      offset?: number,
+      platform?: Array<
+        | "edx"
+        | "ocw"
+        | "oll"
+        | "mitxonline"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "mitpe"
+        | "see"
+        | "scc"
+        | "ctl"
+        | "whu"
+        | "susskind"
+        | "globalalumni"
+        | "simplilearn"
+        | "emeritus"
+        | "podcast"
+      >,
+      professional?: Array<"true" | "false">,
+      q?: string,
+      resource_content_tags?: Array<string>,
+      resource_type?: Array<
+        "course" | "program" | "learning_path" | "podcast" | "podcast_episode"
+      >,
+      sortby?:
+        | "id"
+        | "-id"
+        | "readable_id"
+        | "-readable_id"
+        | "last_modified"
+        | "-last_modified"
+        | "runs.start_date"
+        | "-runs.start_date",
+      topic?: Array<string>,
+      options: AxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/api/v1/learning_resources_search/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      // authentication cookieAuth required
+
+      if (aggregations) {
+        localVarQueryParameter["aggregations"] = aggregations
+      }
+
+      if (certification) {
+        localVarQueryParameter["certification"] = certification
+      }
+
+      if (department) {
+        localVarQueryParameter["department"] = department
+      }
+
+      if (level) {
+        localVarQueryParameter["level"] = level
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter["limit"] = limit
+      }
+
+      if (offered_by) {
+        localVarQueryParameter["offered_by"] = offered_by
+      }
+
+      if (offset !== undefined) {
+        localVarQueryParameter["offset"] = offset
+      }
+
+      if (platform) {
+        localVarQueryParameter["platform"] = platform
+      }
+
+      if (professional) {
+        localVarQueryParameter["professional"] = professional
+      }
+
+      if (q !== undefined) {
+        localVarQueryParameter["q"] = q
+      }
+
+      if (resource_content_tags) {
+        localVarQueryParameter["resource_content_tags"] = resource_content_tags
+      }
+
+      if (resource_type) {
+        localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
+      }
+
+      if (topic) {
+        localVarQueryParameter["topic"] = topic
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * LearningResourcesSearchApi - functional programming interface
+ * @export
+ */
+export const LearningResourcesSearchApiFp = function (
+  configuration?: Configuration,
+) {
+  const localVarAxiosParamCreator =
+    LearningResourcesSearchApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * View for executing searches of learning resources
+     * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
+     * @param {Array<string>} [certification]
+     * @param {Array<string>} [department]
+     * @param {Array<string>} [level]
+     * @param {number} [limit]
+     * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
+     * @param {number} [offset]
+     * @param {Array<'edx' | 'ocw' | 'oll' | 'mitxonline' | 'bootcamps' | 'xpro' | 'csail' | 'mitpe' | 'see' | 'scc' | 'ctl' | 'whu' | 'susskind' | 'globalalumni' | 'simplilearn' | 'emeritus' | 'podcast'>} [platform]
+     * @param {Array<'true' | 'false'>} [professional]
+     * @param {string} [q] The search text
+     * @param {Array<string>} [resource_content_tags]
+     * @param {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode'>} [resource_type]
+     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'runs.start_date' | '-runs.start_date'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;readable_id&#x60; - readable_id * &#x60;-readable_id&#x60; - -readable_id * &#x60;last_modified&#x60; - last_modified * &#x60;-last_modified&#x60; - -last_modified * &#x60;runs.start_date&#x60; - runs.start_date * &#x60;-runs.start_date&#x60; - -runs.start_date
+     * @param {Array<string>} [topic]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async learningResourcesSearchRetrieve(
+      aggregations?: Array<
+        | "resource_type"
+        | "certification"
+        | "offered_by"
+        | "platform"
+        | "topic"
+        | "department"
+        | "level"
+        | "resource_content_tags"
+        | "professional"
+      >,
+      certification?: Array<string>,
+      department?: Array<string>,
+      level?: Array<string>,
+      limit?: number,
+      offered_by?: Array<
+        | "mitx"
+        | "ocw"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+      >,
+      offset?: number,
+      platform?: Array<
+        | "edx"
+        | "ocw"
+        | "oll"
+        | "mitxonline"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "mitpe"
+        | "see"
+        | "scc"
+        | "ctl"
+        | "whu"
+        | "susskind"
+        | "globalalumni"
+        | "simplilearn"
+        | "emeritus"
+        | "podcast"
+      >,
+      professional?: Array<"true" | "false">,
+      q?: string,
+      resource_content_tags?: Array<string>,
+      resource_type?: Array<
+        "course" | "program" | "learning_path" | "podcast" | "podcast_episode"
+      >,
+      sortby?:
+        | "id"
+        | "-id"
+        | "readable_id"
+        | "-readable_id"
+        | "last_modified"
+        | "-last_modified"
+        | "runs.start_date"
+        | "-runs.start_date",
+      topic?: Array<string>,
+      options?: AxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<LearningResourcesSearchResponse>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.learningResourcesSearchRetrieve(
+          aggregations,
+          certification,
+          department,
+          level,
+          limit,
+          offered_by,
+          offset,
+          platform,
+          professional,
+          q,
+          resource_content_tags,
+          resource_type,
+          sortby,
+          topic,
+          options,
+        )
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration,
+      )
+    },
+  }
+}
+
+/**
+ * LearningResourcesSearchApi - factory interface
+ * @export
+ */
+export const LearningResourcesSearchApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = LearningResourcesSearchApiFp(configuration)
+  return {
+    /**
+     * View for executing searches of learning resources
+     * @param {LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    learningResourcesSearchRetrieve(
+      requestParameters: LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest = {},
+      options?: AxiosRequestConfig,
+    ): AxiosPromise<LearningResourcesSearchResponse> {
+      return localVarFp
+        .learningResourcesSearchRetrieve(
+          requestParameters.aggregations,
+          requestParameters.certification,
+          requestParameters.department,
+          requestParameters.level,
+          requestParameters.limit,
+          requestParameters.offered_by,
+          requestParameters.offset,
+          requestParameters.platform,
+          requestParameters.professional,
+          requestParameters.q,
+          requestParameters.resource_content_tags,
+          requestParameters.resource_type,
+          requestParameters.sortby,
+          requestParameters.topic,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for learningResourcesSearchRetrieve operation in LearningResourcesSearchApi.
+ * @export
+ * @interface LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest
+ */
+export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest {
+  /**
+   *
+   * @type {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly aggregations?: Array<
+    | "resource_type"
+    | "certification"
+    | "offered_by"
+    | "platform"
+    | "topic"
+    | "department"
+    | "level"
+    | "resource_content_tags"
+    | "professional"
+  >
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly certification?: Array<string>
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly department?: Array<string>
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly level?: Array<string>
+
+  /**
+   *
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly limit?: number
+
+  /**
+   *
+   * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly offered_by?: Array<
+    | "mitx"
+    | "ocw"
+    | "bootcamps"
+    | "xpro"
+    | "csail"
+    | "professional education"
+    | "sloan executive education"
+    | "schwarzman college of computing"
+    | "center for transportation & logistics"
+  >
+
+  /**
+   *
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly offset?: number
+
+  /**
+   *
+   * @type {Array<'edx' | 'ocw' | 'oll' | 'mitxonline' | 'bootcamps' | 'xpro' | 'csail' | 'mitpe' | 'see' | 'scc' | 'ctl' | 'whu' | 'susskind' | 'globalalumni' | 'simplilearn' | 'emeritus' | 'podcast'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly platform?: Array<
+    | "edx"
+    | "ocw"
+    | "oll"
+    | "mitxonline"
+    | "bootcamps"
+    | "xpro"
+    | "csail"
+    | "mitpe"
+    | "see"
+    | "scc"
+    | "ctl"
+    | "whu"
+    | "susskind"
+    | "globalalumni"
+    | "simplilearn"
+    | "emeritus"
+    | "podcast"
+  >
+
+  /**
+   *
+   * @type {Array<'true' | 'false'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly professional?: Array<"true" | "false">
+
+  /**
+   * The search text
+   * @type {string}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly q?: string
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly resource_content_tags?: Array<string>
+
+  /**
+   *
+   * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly resource_type?: Array<
+    "course" | "program" | "learning_path" | "podcast" | "podcast_episode"
+  >
+
+  /**
+   * if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;readable_id&#x60; - readable_id * &#x60;-readable_id&#x60; - -readable_id * &#x60;last_modified&#x60; - last_modified * &#x60;-last_modified&#x60; - -last_modified * &#x60;runs.start_date&#x60; - runs.start_date * &#x60;-runs.start_date&#x60; - -runs.start_date
+   * @type {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'runs.start_date' | '-runs.start_date'}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly sortby?:
+    | "id"
+    | "-id"
+    | "readable_id"
+    | "-readable_id"
+    | "last_modified"
+    | "-last_modified"
+    | "runs.start_date"
+    | "-runs.start_date"
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly topic?: Array<string>
+}
+
+/**
+ * LearningResourcesSearchApi - object-oriented interface
+ * @export
+ * @class LearningResourcesSearchApi
+ * @extends {BaseAPI}
+ */
+export class LearningResourcesSearchApi extends BaseAPI {
+  /**
+   * View for executing searches of learning resources
+   * @param {LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof LearningResourcesSearchApi
+   */
+  public learningResourcesSearchRetrieve(
+    requestParameters: LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest = {},
+    options?: AxiosRequestConfig,
+  ) {
+    return LearningResourcesSearchApiFp(this.configuration)
+      .learningResourcesSearchRetrieve(
+        requestParameters.aggregations,
+        requestParameters.certification,
+        requestParameters.department,
+        requestParameters.level,
+        requestParameters.limit,
+        requestParameters.offered_by,
+        requestParameters.offset,
+        requestParameters.platform,
+        requestParameters.professional,
+        requestParameters.q,
+        requestParameters.resource_content_tags,
+        requestParameters.resource_type,
+        requestParameters.sortby,
+        requestParameters.topic,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1,14 +1,22 @@
 """API for general search-related functionality"""
+import re
 from base64 import urlsafe_b64encode
 
 from opensearch_dsl import Search
 
 from learning_resources_search.connection import get_default_alias_name
-from open_discussions.utils import extract_values
-from search.constants import ALIAS_ALL_INDICES, VALID_OBJECT_TYPES
+from learning_resources_search.constants import (
+    LEARNING_RESOURCE_QUERY_FIELDS,
+    LEARNING_RESOURCE_SEARCH_FILTERS,
+    LEARNING_RESOURCE_TYPES,
+    RUN_INSTRUCTORS_QUERY_FIELDS,
+    RUNS_QUERY_FIELDS,
+    SEARCH_NESTED_FILTERS,
+    TOPICS_QUERY_FIELDS,
+)
 
-RELATED_POST_RELEVANT_FIELDS = ["plain_text", "post_title", "author_id", "channel_name"]
 SIMILAR_RESOURCE_RELEVANT_FIELDS = ["title", "short_description"]
+LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 
 
 def gen_course_id(platform, readable_id):
@@ -17,7 +25,7 @@ def gen_course_id(platform, readable_id):
 
     Args:
         platform (str): The platform of a LearningResource object
-        course_id (str): The readable_id of a LearningResource object
+        readable_id (str): The readable_id of a LearningResource object
 
     Returns:
         str: The OpenSearch document id for this object
@@ -39,43 +47,340 @@ def gen_program_id(program_obj):
     return f"program_{program_obj.learning_resource_id}"
 
 
-def relevant_indexes(query):
+def relevant_indexes(resource_types, aggregations):
     """
-    Return True if the query includes learning resource types, False otherwise
+    Return list of relevent index type for the query
 
     Args:
-        query (dict): The query sent to opensearch
+        resource_types (list): the resource type parameter for the search
+        aggregations (list): the aggregations parameter for the search
 
     Returns:
         Array(string): array of index names
 
     """
-    object_types = set(extract_values(query, "object_type"))
 
-    valid_index_types = set(VALID_OBJECT_TYPES)
+    if not resource_types or (aggregations and "resource_type" in aggregations):
+        return map(get_default_alias_name, LEARNING_RESOURCE_TYPES)
 
-    object_types = object_types.intersection(valid_index_types)
-
-    if not object_types:
-        return [get_default_alias_name(ALIAS_ALL_INDICES)]
-
-    # if RESOURCE_FILE_TYPE in object_types:
-
-    return map(get_default_alias_name, object_types)
+    return map(get_default_alias_name, resource_types)
 
 
-def execute_learn_search(*, query):
+def generate_sort_clause(sort):
     """
-    Execute a learning resources search based on the queryq
+    Return sort clause for the query
+
+    Args:
+        sort (string): the sort parameter
+    Returns:
+        dict or String: either a dictionary with the sort clause for
+            nested sort params or just sort parameter
+    """
+
+    if "." in sort:
+        if sort.startswith("-"):
+            field = sort[1:]
+            direction = "desc"
+        else:
+            field = sort
+            direction = "asc"
+
+        path = ".".join(field.split(".")[:-1])
+
+        return {field: {"order": direction, "nested": {"path": path}}}
+
+    else:
+        return sort
+
+
+def generate_text_clause(text):
+    """
+    Return text clause for the query
+
+    Args:
+        text (string): the text string
+    Returns:
+        dict: dictionary with the opensearch text clause
+    """
+
+    query_type = (
+        "query_string" if text.startswith('"') and text.endswith('"') else "multi_match"
+    )
+
+    if text:
+        text_query = {
+            "should": [
+                {query_type: {"query": text, "fields": LEARNING_RESOURCE_QUERY_FIELDS}},
+                {
+                    "nested": {
+                        "path": "topics",
+                        "query": {
+                            query_type: {"query": text, "fields": TOPICS_QUERY_FIELDS}
+                        },
+                    }
+                },
+                {
+                    "wildcard": {
+                        "readable_id": {
+                            "value": f"{text.upper()}*",
+                            "rewrite": "constant_score",
+                        }
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            query_type: {"query": text, "fields": RUNS_QUERY_FIELDS}
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "nested": {
+                                "path": "runs.instructors",
+                                "query": {
+                                    query_type: {
+                                        "query": text,
+                                        "fields": RUN_INSTRUCTORS_QUERY_FIELDS,
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            ]
+        }
+    else:
+        text_query = {}
+
+    text_bool_clause = [{"bool": text_query}] if text_query else []
+
+    return {
+        "bool": {
+            "filter": {
+                "bool": {"must": text_bool_clause},
+            },
+            # Add multimatch text query here again to score results based on match
+            **text_query,
+        }
+    }
+
+
+def generate_filter_clauses(search_params):
+    """
+    Return the filter clauses for the query
+
+    Args:
+        search_params (dict): the query parameters for the search
+    Returns:
+        dict: dictionary with the opensearch filter clauses. Because the filters are
+        used to generate aggregations, this function returns a dictionary with each of
+        the active filters as the keys and the opensearch filter clause for that
+        filter as the query
+    """
+    filter_clauses = {}
+
+    for search_filter in LEARNING_RESOURCE_SEARCH_FILTERS:
+        if search_params.get(search_filter):
+            filter_clauses_for_filter = []
+
+            for option in search_params.get(search_filter):
+                if search_filter in SEARCH_NESTED_FILTERS:
+                    filter_clauses_for_filter.append(
+                        {
+                            "nested": {
+                                "path": SEARCH_NESTED_FILTERS[search_filter].split(".")[
+                                    0
+                                ],
+                                "query": {
+                                    "term": {
+                                        SEARCH_NESTED_FILTERS[search_filter]: {
+                                            "value": option,
+                                            "case_insensitive": True,
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    )
+
+                else:
+                    filter_clauses_for_filter.append(
+                        {
+                            "term": {
+                                search_filter: {
+                                    "value": option,
+                                    "case_insensitive": True,
+                                }
+                            }
+                        }
+                    )
+
+            filter_clauses[search_filter] = {
+                "bool": {"should": filter_clauses_for_filter}
+            }
+
+    return filter_clauses
+
+
+def generate_suggest_clause(text):
+    """
+    Return the suggest clause for the query
+
+    Args:
+        text (string): the text string
+    Returns:
+        dict: dictionary with the opensearch suggest clause
+    """
+
+    suggest = {"text": text}
+
+    for field in LEARN_SUGGEST_FIELDS:
+        suggest[field] = {
+            "phrase": {
+                "field": field,
+                "size": 5,
+                "gram_size": 1,
+                "confidence": 0.0001,
+                "max_errors": 3,
+                "collate": {
+                    "query": {
+                        "source": {"match_phrase": {"{{field_name}}": "{{suggestion}}"}}
+                    },
+                    "params": {"field_name": field},
+                    "prune": True,
+                },
+            }
+        }
+
+    return suggest
+
+
+def generate_aggregation_clauses(search_params, filter_clauses):
+    """
+    Return the aggregations for the query
+
+    Args:
+        search_params (dict): the query parameters for the search
+        filter_clauses(dict): the filter clauses generated by generate_filter_clauses
+    Returns:
+        dict: dictionary with the opensearch aggregation clause
+    """
+    aggregation_clauses = {}
+    if search_params.get("aggregations"):
+        for aggregation in search_params.get("aggregations"):
+            # Each aggregation clause contains a filter which includes all the filters
+            # except it's own
+
+            other_filters = [
+                filter_clauses[key] for key in filter_clauses if key != aggregation
+            ]
+
+            if other_filters:
+                if aggregation in SEARCH_NESTED_FILTERS:
+                    aggregation_clauses[aggregation] = {
+                        "aggs": {
+                            aggregation: {
+                                "nested": {
+                                    "path": SEARCH_NESTED_FILTERS[aggregation].split(
+                                        "."
+                                    )[0]
+                                },
+                                "aggs": {
+                                    aggregation: {
+                                        "terms": {
+                                            "field": SEARCH_NESTED_FILTERS[aggregation],
+                                            "size": 10000,
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                        "filter": {"bool": {"must": other_filters}},
+                    }
+                else:
+                    aggregation_clauses[aggregation] = {
+                        "aggs": {
+                            aggregation: {
+                                "terms": {
+                                    "field": aggregation,
+                                    "size": 10000,
+                                }
+                            }
+                        },
+                        "filter": {"bool": {"must": other_filters}},
+                    }
+            elif aggregation in SEARCH_NESTED_FILTERS:
+                aggregation_clauses[aggregation] = {
+                    "nested": {
+                        "path": SEARCH_NESTED_FILTERS[aggregation].split(".")[0]
+                    },
+                    "aggs": {
+                        aggregation: {
+                            "terms": {
+                                "field": SEARCH_NESTED_FILTERS[aggregation],
+                                "size": 10000,
+                            }
+                        }
+                    },
+                }
+            else:
+                aggregation_clauses[aggregation] = {
+                    "terms": {
+                        "field": aggregation,
+                        "size": 10000,
+                    }
+                }
+    return aggregation_clauses
+
+
+def execute_learn_search(search_params):
+    """
+    Execute a learning resources search based on the query
 
 
     Args:
-        query (dict): The opensearch query constructed in the frontend
+        search_params (dict): The opensearch query params returned from
+        LearningResourcesSearchRequestSerializer
 
     Returns:
         dict: The opensearch response dict
     """
-    indexes = ",".join(relevant_indexes(query))
-    search = Search(index=indexes)
-    search.update_from_dict(query)
+
+    indexes = relevant_indexes(
+        search_params.get("resource_type"), search_params.get("aggregations")
+    )
+    search = Search(index=",".join(indexes))
+
+    if search_params.get("offset"):
+        search = search.extra(from_=search_params.get("offset"))
+
+    if search_params.get("limit"):
+        search = search.extra(size=search_params.get("limit"))
+
+    if search_params.get("sortby"):
+        sort = generate_sort_clause(search_params.get("sortby"))
+
+        search = search.sort(sort)
+
+    if search_params.get("q"):
+        text = re.sub("[\u201c\u201d]", '"', search_params.get("q"))
+        text_query = generate_text_clause(text)
+        suggest = generate_suggest_clause(text)
+        search = search.query("bool", should=[text_query])
+        search = search.extra(suggest=suggest)
+
+    filter_clauses = generate_filter_clauses(search_params)
+    if filter_clauses:
+        search = search.post_filter("bool", must=list(filter_clauses.values()))
+
+    if search_params.get("aggregations"):
+        aggregation_clauses = generate_aggregation_clauses(
+            search_params, filter_clauses
+        )
+        search = search.extra(aggs=aggregation_clauses)
+
     return search.execute().to_dict()

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -5,27 +5,776 @@ import pytest
 
 from learning_resources_search.api import (
     execute_learn_search,
+    generate_aggregation_clauses,
+    generate_filter_clauses,
+    generate_sort_clause,
+    generate_suggest_clause,
+    generate_text_clause,
+    relevant_indexes,
 )
-from learning_resources_search.connection import get_default_alias_name
-from learning_resources_search.constants import ALIAS_ALL_INDICES, COURSE_TYPE
 
 
-@pytest.mark.parametrize("has_resource_type_subquery", [True, False])
-def test_execute_learn_search(opensearch, has_resource_type_subquery):
-    """execute_learn_search should execute an opensearch search for learning resources"""
+@pytest.mark.parametrize(
+    ("resourse_types", "aggregations", "result"),
+    [
+        (["course"], [], ["testindex_course_default"]),
+        (
+            ["course"],
+            ["resource_type"],
+            ["testindex_course_default", "testindex_program_default"],
+        ),
+        ([], [], ["testindex_course_default", "testindex_program_default"]),
+    ],
+)
+def test_relevant_indexes(resourse_types, aggregations, result):
+    assert list(relevant_indexes(resourse_types, aggregations)) == result
+
+
+@pytest.mark.parametrize(
+    ("sort_param", "result"),
+    [
+        ("prices", "prices"),
+        ("-prices", "-prices"),
+        (
+            "runs.start_date",
+            {"runs.start_date": {"order": "asc", "nested": {"path": "runs"}}},
+        ),
+        (
+            "-runs.start_date",
+            {"runs.start_date": {"order": "desc", "nested": {"path": "runs"}}},
+        ),
+    ],
+)
+def test_generate_sort_clause(sort_param, result):
+    assert generate_sort_clause(sort_param) == result
+
+
+def test_generate_text_clause():
+    result1 = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "multi_match": {
+                                            "query": "math",
+                                            "fields": [
+                                                "title.english^3",
+                                                "description.english^2",
+                                                "full_description.english",
+                                                "topics",
+                                                "platform",
+                                                "readable_id",
+                                                "offered_by",
+                                                "department",
+                                                "resource_content_tags",
+                                            ],
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "topics",
+                                            "query": {
+                                                "multi_match": {
+                                                    "query": "math",
+                                                    "fields": ["topics.name"],
+                                                }
+                                            },
+                                        }
+                                    },
+                                    {
+                                        "wildcard": {
+                                            "readable_id": {
+                                                "value": "MATH*",
+                                                "rewrite": "constant_score",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "runs",
+                                            "query": {
+                                                "multi_match": {
+                                                    "query": "math",
+                                                    "fields": [
+                                                        "runs.year",
+                                                        "runs.semester",
+                                                        "runs.level",
+                                                    ],
+                                                }
+                                            },
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "runs",
+                                            "query": {
+                                                "nested": {
+                                                    "path": "runs.instructors",
+                                                    "query": {
+                                                        "multi_match": {
+                                                            "query": "math",
+                                                            "fields": [
+                                                                "runs.instructors.first_name",
+                                                                "runs.instructors.last_name",
+                                                                "runs.instructors.full_name",
+                                                            ],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                        }
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "should": [
+                {
+                    "multi_match": {
+                        "query": "math",
+                        "fields": [
+                            "title.english^3",
+                            "description.english^2",
+                            "full_description.english",
+                            "topics",
+                            "platform",
+                            "readable_id",
+                            "offered_by",
+                            "department",
+                            "resource_content_tags",
+                        ],
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "topics",
+                        "query": {
+                            "multi_match": {"query": "math", "fields": ["topics.name"]}
+                        },
+                    }
+                },
+                {
+                    "wildcard": {
+                        "readable_id": {"value": "MATH*", "rewrite": "constant_score"}
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "multi_match": {
+                                "query": "math",
+                                "fields": ["runs.year", "runs.semester", "runs.level"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "nested": {
+                                "path": "runs.instructors",
+                                "query": {
+                                    "multi_match": {
+                                        "query": "math",
+                                        "fields": [
+                                            "runs.instructors.first_name",
+                                            "runs.instructors.last_name",
+                                            "runs.instructors.full_name",
+                                        ],
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            ],
+        }
+    }
+    result2 = {
+        "bool": {
+            "filter": {
+                "bool": {
+                    "must": [
+                        {
+                            "bool": {
+                                "should": [
+                                    {
+                                        "query_string": {
+                                            "query": '"math"',
+                                            "fields": [
+                                                "title.english^3",
+                                                "description.english^2",
+                                                "full_description.english",
+                                                "topics",
+                                                "platform",
+                                                "readable_id",
+                                                "offered_by",
+                                                "department",
+                                                "resource_content_tags",
+                                            ],
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "topics",
+                                            "query": {
+                                                "query_string": {
+                                                    "query": '"math"',
+                                                    "fields": ["topics.name"],
+                                                }
+                                            },
+                                        }
+                                    },
+                                    {
+                                        "wildcard": {
+                                            "readable_id": {
+                                                "value": '"MATH"*',
+                                                "rewrite": "constant_score",
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "runs",
+                                            "query": {
+                                                "query_string": {
+                                                    "query": '"math"',
+                                                    "fields": [
+                                                        "runs.year",
+                                                        "runs.semester",
+                                                        "runs.level",
+                                                    ],
+                                                }
+                                            },
+                                        }
+                                    },
+                                    {
+                                        "nested": {
+                                            "path": "runs",
+                                            "query": {
+                                                "nested": {
+                                                    "path": "runs.instructors",
+                                                    "query": {
+                                                        "query_string": {
+                                                            "query": '"math"',
+                                                            "fields": [
+                                                                "runs.instructors.first_name",
+                                                                "runs.instructors.last_name",
+                                                                "runs.instructors.full_name",
+                                                            ],
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                        }
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "should": [
+                {
+                    "query_string": {
+                        "query": '"math"',
+                        "fields": [
+                            "title.english^3",
+                            "description.english^2",
+                            "full_description.english",
+                            "topics",
+                            "platform",
+                            "readable_id",
+                            "offered_by",
+                            "department",
+                            "resource_content_tags",
+                        ],
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "topics",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": ["topics.name"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "wildcard": {
+                        "readable_id": {"value": '"MATH"*', "rewrite": "constant_score"}
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "query_string": {
+                                "query": '"math"',
+                                "fields": ["runs.year", "runs.semester", "runs.level"],
+                            }
+                        },
+                    }
+                },
+                {
+                    "nested": {
+                        "path": "runs",
+                        "query": {
+                            "nested": {
+                                "path": "runs.instructors",
+                                "query": {
+                                    "query_string": {
+                                        "query": '"math"',
+                                        "fields": [
+                                            "runs.instructors.first_name",
+                                            "runs.instructors.last_name",
+                                            "runs.instructors.full_name",
+                                        ],
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            ],
+        }
+    }
+    assert generate_text_clause("math") == result1
+    assert generate_text_clause('"math"') == result2
+
+
+def test_generate_suggest_clause():
+    result = {
+        "text": "math",
+        "title.trigram": {
+            "phrase": {
+                "field": "title.trigram",
+                "size": 5,
+                "gram_size": 1,
+                "confidence": 0.0001,
+                "max_errors": 3,
+                "collate": {
+                    "query": {
+                        "source": {"match_phrase": {"{{field_name}}": "{{suggestion}}"}}
+                    },
+                    "params": {"field_name": "title.trigram"},
+                    "prune": True,
+                },
+            }
+        },
+        "description.trigram": {
+            "phrase": {
+                "field": "description.trigram",
+                "size": 5,
+                "gram_size": 1,
+                "confidence": 0.0001,
+                "max_errors": 3,
+                "collate": {
+                    "query": {
+                        "source": {"match_phrase": {"{{field_name}}": "{{suggestion}}"}}
+                    },
+                    "params": {"field_name": "description.trigram"},
+                    "prune": True,
+                },
+            }
+        },
+    }
+    assert generate_suggest_clause("math") == result
+
+
+def test_generate_filter_clauses():
+    query = {"offered_by": ["ocw", "xpro"], "level": ["Undergraduate"]}
+    result = {
+        "offered_by": {
+            "bool": {
+                "should": [
+                    {
+                        "term": {
+                            "offered_by": {
+                                "value": "ocw",
+                                "case_insensitive": True,
+                            }
+                        }
+                    },
+                    {
+                        "term": {
+                            "offered_by": {"value": "xpro", "case_insensitive": True}
+                        }
+                    },
+                ]
+            }
+        },
+        "level": {
+            "bool": {
+                "should": [
+                    {
+                        "nested": {
+                            "path": "runs",
+                            "query": {
+                                "term": {
+                                    "runs.level": {
+                                        "value": "Undergraduate",
+                                        "case_insensitive": True,
+                                    }
+                                }
+                            },
+                        }
+                    }
+                ]
+            }
+        },
+    }
+    assert generate_filter_clauses(query) == result
+
+
+def test_generate_aggregation_clauses_when_there_is_no_filter():
+    params = {"aggregations": ["offered_by", "level"]}
+    result = {
+        "offered_by": {"terms": {"field": "offered_by", "size": 10000}},
+        "level": {
+            "nested": {"path": "runs"},
+            "aggs": {"level": {"terms": {"field": "runs.level", "size": 10000}}},
+        },
+    }
+    assert generate_aggregation_clauses(params, {}) == result
+
+
+def test_generate_aggregation_clauses_with_filter():
+    params = {"aggregations": ["offered_by", "level"]}
+    filters = {"platform": "the filter"}
+    result = {
+        "offered_by": {
+            "aggs": {"offered_by": {"terms": {"field": "offered_by", "size": 10000}}},
+            "filter": {"bool": {"must": ["the filter"]}},
+        },
+        "level": {
+            "aggs": {
+                "level": {
+                    "nested": {"path": "runs"},
+                    "aggs": {
+                        "level": {"terms": {"field": "runs.level", "size": 10000}}
+                    },
+                }
+            },
+            "filter": {"bool": {"must": ["the filter"]}},
+        },
+    }
+    assert generate_aggregation_clauses(params, filters) == result
+
+
+def test_generate_aggregation_clauses_with_same_filters_as_aggregation():
+    params = {"aggregations": ["offered_by", "level"]}
+    filters = {
+        "platform": "platform filter",
+        "offered_by": "offered_by filter",
+        "level": "level filter",
+    }
+    result = {
+        "offered_by": {
+            "aggs": {"offered_by": {"terms": {"field": "offered_by", "size": 10000}}},
+            "filter": {"bool": {"must": ["platform filter", "level filter"]}},
+        },
+        "level": {
+            "aggs": {
+                "level": {
+                    "nested": {"path": "runs"},
+                    "aggs": {
+                        "level": {"terms": {"field": "runs.level", "size": 10000}}
+                    },
+                }
+            },
+            "filter": {"bool": {"must": ["platform filter", "offered_by filter"]}},
+        },
+    }
+    assert generate_aggregation_clauses(params, filters) == result
+
+
+def test_execute_learn_search(opensearch):
     opensearch.conn.search.return_value = {
         "hits": {"total": {"value": 10, "relation": "eq"}}
     }
+    search_params = {
+        "aggregations": ["offered_by"],
+        "q": "math",
+        "resource_type": ["course"],
+        "limit": 1,
+        "offset": 1,
+        "sortby": "prices",
+    }
 
-    if has_resource_type_subquery:
-        query = {"a": {"bool": {"object_type": COURSE_TYPE}}}
-    else:
-        query = {"a": "query"}
+    query = {
+        "query": {
+            "bool": {
+                "should": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "bool": {
+                                        "must": [
+                                            {
+                                                "bool": {
+                                                    "should": [
+                                                        {
+                                                            "multi_match": {
+                                                                "query": "math",
+                                                                "fields": [
+                                                                    "title.english^3",
+                                                                    "description.english^2",
+                                                                    "full_description.english",
+                                                                    "topics",
+                                                                    "platform",
+                                                                    "readable_id",
+                                                                    "offered_by",
+                                                                    "department",
+                                                                    "resource_content_tags",
+                                                                ],
+                                                            }
+                                                        },
+                                                        {
+                                                            "nested": {
+                                                                "path": "topics",
+                                                                "query": {
+                                                                    "multi_match": {
+                                                                        "query": "math",
+                                                                        "fields": [
+                                                                            "topics.name"
+                                                                        ],
+                                                                    }
+                                                                },
+                                                            }
+                                                        },
+                                                        {
+                                                            "wildcard": {
+                                                                "readable_id": {
+                                                                    "value": "MATH*",
+                                                                    "rewrite": "constant_score",
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "nested": {
+                                                                "path": "runs",
+                                                                "query": {
+                                                                    "multi_match": {
+                                                                        "query": "math",
+                                                                        "fields": [
+                                                                            "runs.year",
+                                                                            "runs.semester",
+                                                                            "runs.level",
+                                                                        ],
+                                                                    }
+                                                                },
+                                                            }
+                                                        },
+                                                        {
+                                                            "nested": {
+                                                                "path": "runs",
+                                                                "query": {
+                                                                    "nested": {
+                                                                        "path": "runs.instructors",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "runs.instructors.first_name",
+                                                                                    "runs.instructors.last_name",
+                                                                                    "runs.instructors.full_name",
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                            }
+                                                        },
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "should": [
+                                {
+                                    "multi_match": {
+                                        "query": "math",
+                                        "fields": [
+                                            "title.english^3",
+                                            "description.english^2",
+                                            "full_description.english",
+                                            "topics",
+                                            "platform",
+                                            "readable_id",
+                                            "offered_by",
+                                            "department",
+                                            "resource_content_tags",
+                                        ],
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "topics",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": ["topics.name"],
+                                            }
+                                        },
+                                    }
+                                },
+                                {
+                                    "wildcard": {
+                                        "readable_id": {
+                                            "value": "MATH*",
+                                            "rewrite": "constant_score",
+                                        }
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "runs",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": [
+                                                    "runs.year",
+                                                    "runs.semester",
+                                                    "runs.level",
+                                                ],
+                                            }
+                                        },
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "runs",
+                                        "query": {
+                                            "nested": {
+                                                "path": "runs.instructors",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": [
+                                                            "runs.instructors.first_name",
+                                                            "runs.instructors.last_name",
+                                                            "runs.instructors.full_name",
+                                                        ],
+                                                    }
+                                                },
+                                            }
+                                        },
+                                    }
+                                },
+                            ],
+                        }
+                    }
+                ]
+            }
+        },
+        "post_filter": {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "should": [
+                                {
+                                    "term": {
+                                        "resource_type": {
+                                            "value": "course",
+                                            "case_insensitive": True,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "sort": ["prices"],
+        "from": 1,
+        "size": 1,
+        "suggest": {
+            "text": "math",
+            "title.trigram": {
+                "phrase": {
+                    "field": "title.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "title.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+            "description.trigram": {
+                "phrase": {
+                    "field": "description.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "description.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+        },
+        "aggs": {
+            "offered_by": {
+                "aggs": {
+                    "offered_by": {"terms": {"field": "offered_by", "size": 10000}}
+                },
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "bool": {
+                                    "should": [
+                                        {
+                                            "term": {
+                                                "resource_type": {
+                                                    "value": "course",
+                                                    "case_insensitive": True,
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        },
+    }
 
-    assert execute_learn_search(query=query) == opensearch.conn.search.return_value
+    assert execute_learn_search(search_params) == opensearch.conn.search.return_value
 
-    index_type = COURSE_TYPE if has_resource_type_subquery else ALIAS_ALL_INDICES
     opensearch.conn.search.assert_called_once_with(
-        body={**query},
-        index=[get_default_alias_name(index_type)],
+        body=query,
+        index=["testindex_course_default"],
     )

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -50,6 +50,23 @@ GLOBAL_DOC_TYPE = "_doc"
 
 SCRIPTING_LANG = "painless"
 UPDATE_CONFLICT_SETTING = "proceed"
+LEARNING_RESOURCE_SEARCH_FILTERS = [
+    "resource_type",
+    "certification",
+    "offered_by",
+    "topic",
+    "department",
+    "level",
+    "resource_content_tags",
+    "platform",
+    "professional",
+]
+
+SEARCH_NESTED_FILTERS = {
+    "topic": "topics.name",
+    "level": "runs.level",
+    "department": "departments.name",
+}
 
 ENGLISH_TEXT_FIELD = {
     "type": "text",
@@ -67,6 +84,7 @@ ENGLISH_TEXT_FIELD_WITH_SUGGEST = {
 
 LEARNING_RESOURCE_TYPE = {
     "id": {"type": "long"},
+    "certification": {"type": "keyword"},
     "readable_id": {"type": "keyword"},
     "title": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
     "description": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
@@ -78,7 +96,7 @@ LEARNING_RESOURCE_TYPE = {
         "properties": {
             "url": {"type": "keyword"},
             "description": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
-            "alt": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
+            "alt": ENGLISH_TEXT_FIELD,
         },
     },
     "platform": {"type": "keyword"},
@@ -118,13 +136,14 @@ LEARNING_RESOURCE_TYPE = {
             "end_date": {"type": "date"},
             "enrollment_start": {"type": "date"},
             "enrollment_end": {"type": "date"},
+            "level": {"type": "keyword"},
             "instructors": {
                 "type": "nested",
                 "properties": {
                     "id": {"type": "long"},
                     "first_name": {"type": "keyword"},
                     "last_name": {"type": "keyword"},
-                    "full_name": {"type": "keyword"},
+                    "full_name": ENGLISH_TEXT_FIELD,
                 },
             },
             "prices": {"type": "scaled_float", "scaling_factor": 100},
@@ -132,26 +151,47 @@ LEARNING_RESOURCE_TYPE = {
     },
 }
 
-COURSE_OBJECT_TYPE = {
-    **LEARNING_RESOURCE_TYPE,
-    "department_course_numbers": {
-        "type": "nested",
-        "properties": {
-            "coursenum": {"type": "keyword"},
-            "sort_coursenum": {"type": "keyword"},
-            "department": {"type": "keyword"},
-            "primary": {"type": "boolean"},
-        },
-    },
-}
+LEARNING_RESOURCE_QUERY_FIELDS = [
+    "title.english^3",
+    "description.english^2",
+    "full_description.english",
+    "topics",
+    "platform",
+    "readable_id",
+    "offered_by",
+    "department",
+    "resource_content_tags",
+]
 
+AGGREGATIONS = [
+    "resource_type",
+    "certification",
+    "offered_by",
+    "platform",
+    "topic",
+    "department",
+    "level",
+    "resource_content_tags",
+    "professional",
+]
 
-PROGRAM_OBJECT_TYPE = {**LEARNING_RESOURCE_TYPE, "id": {"type": "long"}}
+TOPICS_QUERY_FIELDS = ["topics.name"]
 
+RUNS_QUERY_FIELDS = [
+    "runs.year",
+    "runs.semester",
+    "runs.level",
+]
+
+RUN_INSTRUCTORS_QUERY_FIELDS = [
+    "runs.instructors.first_name",
+    "runs.instructors.last_name",
+    "runs.instructors.full_name",
+]
 
 MAPPING = {
-    COURSE_TYPE: COURSE_OBJECT_TYPE,
-    PROGRAM_TYPE: PROGRAM_OBJECT_TYPE,
+    COURSE_TYPE: LEARNING_RESOURCE_TYPE,
+    PROGRAM_TYPE: LEARNING_RESOURCE_TYPE,
 }
 
 SEARCH_CONN_EXCEPTIONS = (ESConnectionError, UrlTimeoutError)

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -1,7 +1,13 @@
 """Serializers for opensearch data"""
 # pylint: disable=unused-argument,too-many-lines
 import logging
+from collections import defaultdict
 
+from django.conf import settings
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from learning_resources.constants import LearningResourceType, OfferedBy, PlatformType
 from learning_resources.models import Course, Program
 from learning_resources.serializers import (
     LearningResourceSerializer,
@@ -10,8 +16,221 @@ from learning_resources_search.api import (
     gen_course_id,
     gen_program_id,
 )
+from learning_resources_search.constants import AGGREGATIONS
 
 log = logging.getLogger()
+
+
+def extract_values(obj, key):
+    """
+    Pull all values of specified key from nested JSON.
+
+    Args:
+        obj(dict): The JSON object
+        key(str): The JSON key to search for and extract
+
+    Returns:
+        list of matching key values
+
+    """
+    array = []
+
+    def extract(obj, array, key):
+        """Recursively search for values of key in JSON tree."""
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == key:
+                    array.append(v)
+                if isinstance(v, dict | list):
+                    extract(v, array, key)
+        elif isinstance(obj, list):
+            for item in obj:
+                extract(item, array, key)
+        return array
+
+    return extract(obj, array, key)
+
+
+class StringArrayField(serializers.ListField):
+    """
+    Character separated ListField.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def to_internal_value(self, data):
+        return ",".join(data)
+
+    def to_representation(self, data):
+        return data.split(",")
+
+
+SORTBY_OPTIONS = [
+    "id",
+    "-id",
+    "readable_id",
+    "-readable_id",
+    "last_modified",
+    "-last_modified",
+    "runs.start_date",
+    "-runs.start_date",
+]
+
+
+class LearningResourcesSearchRequestSerializer(serializers.Serializer):
+    q = serializers.CharField(required=False, help_text="The search text")
+    offset = serializers.IntegerField(required=False)
+    limit = serializers.IntegerField(required=False)
+    sortby = serializers.ChoiceField(
+        required=False,
+        choices=SORTBY_OPTIONS,
+        help_text="if the parameter starts with '-' the sort is in descending order",
+    )
+    resource_type = StringArrayField(
+        required=False,
+        child=serializers.ChoiceField(
+            choices=[e.value.lower() for e in LearningResourceType]
+        ),
+    )
+    professional = StringArrayField(
+        required=False,
+        child=serializers.ChoiceField(choices=["true", "false"]),
+    )
+    certification = StringArrayField(required=False, child=serializers.CharField())
+    offered_by = StringArrayField(
+        required=False,
+        child=serializers.ChoiceField(choices=[e.value.lower() for e in OfferedBy]),
+    )
+    platform = StringArrayField(
+        required=False,
+        child=serializers.ChoiceField(choices=[e.value.lower() for e in PlatformType]),
+    )
+    topic = StringArrayField(required=False, child=serializers.CharField())
+    department = StringArrayField(required=False, child=serializers.CharField())
+    level = StringArrayField(required=False, child=serializers.CharField())
+    resource_content_tags = StringArrayField(
+        required=False, child=serializers.CharField()
+    )
+    aggregations = StringArrayField(
+        required=False,
+        child=serializers.ChoiceField(choices=AGGREGATIONS),
+    )
+
+    def validate_resource_type(self, data):
+        if data:
+            for resource_type_value in data.split(","):
+                if resource_type_value.lower() not in [
+                    e.value.lower() for e in LearningResourceType
+                ]:
+                    msg = f"{resource_type_value} is not a valid option"
+                    raise serializers.ValidationError(msg)
+
+        return data
+
+    def validate_offered_by(self, data):
+        if data:
+            for offered_by_value in data.split(","):
+                if offered_by_value.lower() not in [e.value.lower() for e in OfferedBy]:
+                    msg = f"{offered_by_value} is not a valid option"
+                    raise serializers.ValidationError(msg)
+        return data
+
+    def validate_platform(self, data):
+        if data:
+            for platform_value in data.split(","):
+                if platform_value.lower() not in [
+                    e.value.lower() for e in PlatformType
+                ]:
+                    msg = f"{platform_value} is not a valid option"
+                    raise serializers.ValidationError(msg)
+        return data
+
+    def validate_professional(self, data):
+        if data:
+            for professional_value in data.split(","):
+                if professional_value.lower() not in ["true", "false"]:
+                    msg = f"{professional_value} is not a valid option"
+                    raise serializers.ValidationError(msg)
+        return data
+
+    def validate_aggregations(self, data):
+        if data:
+            for agg_value in data.split(","):
+                if agg_value.lower() not in AGGREGATIONS:
+                    msg = f"{agg_value} is not a valid option"
+                    raise serializers.ValidationError(msg)
+        return data
+
+
+def _transform_aggregations(aggregations):
+    formatted_aggregations = {}
+    for key, value in aggregations.items():
+        if value.get("buckets"):
+            formatted_aggregations[key] = value.get("buckets")
+        elif value.get(key, {}).get("buckets"):
+            formatted_aggregations[key] = value.get(key, {}).get("buckets")
+        else:
+            formatted_aggregations[key] = value.get(key, {}).get(key, {}).get("buckets")
+    return formatted_aggregations
+
+
+def _transform_search_results_suggest(search_result):
+    """
+    Transform suggest results from opensearch
+
+    Args:
+        search_result (dict): The results from opensearch
+
+    Returns:
+        dict: The opensearch response dict with transformed suggestions
+    """
+
+    es_suggest = search_result.pop("suggest", {})
+    if (
+        search_result.get("hits", {}).get("total", {}).get("value")
+        <= settings.OPENSEARCH_MAX_SUGGEST_HITS
+    ):
+        suggestion_dict = defaultdict(int)
+        suggestions = [
+            suggestion
+            for suggestion_list in extract_values(es_suggest, "options")
+            for suggestion in suggestion_list
+            if suggestion["collate_match"] is True
+        ]
+        for suggestion in suggestions:
+            suggestion_dict[suggestion["text"]] = (
+                suggestion_dict[suggestion["text"]] + suggestion["score"]
+            )
+        return [
+            key
+            for key, value in sorted(
+                suggestion_dict.items(), key=lambda item: item[1], reverse=True
+            )
+        ][: settings.OPENSEARCH_MAX_SUGGEST_RESULTS]
+    else:
+        return []
+
+
+class LearningResourcesSearchResponseSerializer(serializers.Serializer):
+    count = serializers.SerializerMethodField()
+    results = serializers.SerializerMethodField()
+    metadata = serializers.SerializerMethodField()
+
+    def get_count(self, instance) -> int:
+        return instance.get("hits", {}).get("total", {}).get("value")
+
+    @extend_schema_field(LearningResourceSerializer(many=True))
+    def get_results(self, instance):
+        hits = instance.get("hits", {}).get("hits", [])
+        return (hit.get("_source") for hit in hits)
+
+    @extend_schema_field({"example": {"aggregations": [{}], "suggest": ["string"]}})
+    def get_metadata(self, instance):
+        return {
+            "aggregations": _transform_aggregations(instance.get("aggregations", {})),
+            "suggest": _transform_search_results_suggest(instance),
+        }
 
 
 def serialize_bulk_courses(ids):

--- a/learning_resources_search/urls.py
+++ b/learning_resources_search/urls.py
@@ -1,8 +1,12 @@
 """URLs for search"""
 from django.urls import re_path
 
-from learning_resources_search.views import SearchView
+from learning_resources_search.views import LearningResourcesSearchView
 
 urlpatterns = [
-    re_path(r"api/v1/search/", SearchView.as_view(), name="search"),
+    re_path(
+        r"api/v1/learning_resources_search/",
+        LearningResourcesSearchView.as_view(),
+        name="learning_resources_search",
+    )
 ]

--- a/open_discussions/urls_spectacular.py
+++ b/open_discussions/urls_spectacular.py
@@ -5,4 +5,5 @@ from django.urls import include, re_path
 urlpatterns = [
     re_path(r"", include("learning_resources.urls")),
     re_path(r"", include("articles.urls")),
+    re_path(r"", include("learning_resources_search.urls")),
 ]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1726,6 +1726,220 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedLearningResourceList'
           description: ''
+  /api/v1/learning_resources_search/:
+    get:
+      operationId: learning_resources_search_retrieve
+      description: View for executing searches of learning resources
+      parameters:
+      - in: query
+        name: aggregations
+        schema:
+          type: array
+          items:
+            enum:
+            - resource_type
+            - certification
+            - offered_by
+            - platform
+            - topic
+            - department
+            - level
+            - resource_content_tags
+            - professional
+            type: string
+            description: |-
+              * `resource_type` - resource_type
+              * `certification` - certification
+              * `offered_by` - offered_by
+              * `platform` - platform
+              * `topic` - topic
+              * `department` - department
+              * `level` - level
+              * `resource_content_tags` - resource_content_tags
+              * `professional` - professional
+      - in: query
+        name: certification
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      - in: query
+        name: department
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      - in: query
+        name: level
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      - in: query
+        name: limit
+        schema:
+          type: integer
+      - in: query
+        name: offered_by
+        schema:
+          type: array
+          items:
+            enum:
+            - mitx
+            - ocw
+            - bootcamps
+            - xpro
+            - csail
+            - professional education
+            - sloan executive education
+            - schwarzman college of computing
+            - center for transportation & logistics
+            type: string
+            description: |-
+              * `mitx` - mitx
+              * `ocw` - ocw
+              * `bootcamps` - bootcamps
+              * `xpro` - xpro
+              * `csail` - csail
+              * `professional education` - professional education
+              * `sloan executive education` - sloan executive education
+              * `schwarzman college of computing` - schwarzman college of computing
+              * `center for transportation & logistics` - center for transportation & logistics
+      - in: query
+        name: offset
+        schema:
+          type: integer
+      - in: query
+        name: platform
+        schema:
+          type: array
+          items:
+            enum:
+            - edx
+            - ocw
+            - oll
+            - mitxonline
+            - bootcamps
+            - xpro
+            - csail
+            - mitpe
+            - see
+            - scc
+            - ctl
+            - whu
+            - susskind
+            - globalalumni
+            - simplilearn
+            - emeritus
+            - podcast
+            type: string
+            description: |-
+              * `edx` - edx
+              * `ocw` - ocw
+              * `oll` - oll
+              * `mitxonline` - mitxonline
+              * `bootcamps` - bootcamps
+              * `xpro` - xpro
+              * `csail` - csail
+              * `mitpe` - mitpe
+              * `see` - see
+              * `scc` - scc
+              * `ctl` - ctl
+              * `whu` - whu
+              * `susskind` - susskind
+              * `globalalumni` - globalalumni
+              * `simplilearn` - simplilearn
+              * `emeritus` - emeritus
+              * `podcast` - podcast
+      - in: query
+        name: professional
+        schema:
+          type: array
+          items:
+            enum:
+            - 'true'
+            - 'false'
+            type: string
+            description: |-
+              * `true` - true
+              * `false` - false
+      - in: query
+        name: q
+        schema:
+          type: string
+          minLength: 1
+        description: The search text
+      - in: query
+        name: resource_content_tags
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      - in: query
+        name: resource_type
+        schema:
+          type: array
+          items:
+            enum:
+            - course
+            - program
+            - learning_path
+            - podcast
+            - podcast_episode
+            type: string
+            description: |-
+              * `course` - course
+              * `program` - program
+              * `learning_path` - learning_path
+              * `podcast` - podcast
+              * `podcast_episode` - podcast_episode
+      - in: query
+        name: sortby
+        schema:
+          enum:
+          - id
+          - -id
+          - readable_id
+          - -readable_id
+          - last_modified
+          - -last_modified
+          - runs.start_date
+          - -runs.start_date
+          type: string
+          minLength: 1
+        description: |-
+          if the parameter starts with '-' the sort is in descending order
+
+          * `id` - id
+          * `-id` - -id
+          * `readable_id` - readable_id
+          * `-readable_id` - -readable_id
+          * `last_modified` - last_modified
+          * `-last_modified` - -last_modified
+          * `runs.start_date` - runs.start_date
+          * `-runs.start_date` - -runs.start_date
+      - in: query
+        name: topic
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      tags:
+      - learning_resources_search
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LearningResourcesSearchResponse'
+          description: ''
   /api/v1/learningpaths/:
     get:
       operationId: learningpaths_list
@@ -6148,6 +6362,28 @@ components:
       required:
       - id
       - name
+    LearningResourcesSearchResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+          readOnly: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResource'
+          readOnly: true
+        metadata:
+          example:
+            aggregations:
+            - {}
+            suggest:
+            - string
+          readOnly: true
+      required:
+      - count
+      - metadata
+      - results
     MicroLearningPathRelationship:
       type: object
       description: Serializer containing only parent and child ids for a learning


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/110

# Description (What does it do?)
This pr replaces the current open search endpoint with an api that allows you to 
search based on query params

The allowed search parameters are
- text 
- offset
-  limit 
- sort - The sort paramenter. Can start with '-' to sort in descentding order." Can also refer to a nested value. For example `-runs.start_date`    
-  resource_type - Valid values are ['course', 'program', 'learning_path', 'podcast','podcast_episode']
-  professional - Valid values are: ['true', 'false']
- certification 
- offered_by - Valid values are: ['mitx', 'ocw', 'bootcamps', 'xpro', 'csail', 'professional education', 'sloan executive education', 'schwarzman college of computing', 'center for transportation & logistics']

 - topic 
 -  department 
 - level 
 - resource_content_tags 
 - aggregations - Valid values are: ['resource_type', 'audience', 'certification', 'offered_by', 'platform', 'topic', 'department', 'level', 'resource_content_tags']

You can search by multiple values for each parameter except text, limit, offset and sort

ex platform=ocw,xpro

# How can this be tested?
1) Make sure you have data in both your database and your open search index. If not, run
- docker-compose run web ./manage.py backpopulate_xpro_data
- docker-compose run web ./manage.py recreate_index --all

2) Go to http://localhost:8063/api/v1/learning_resources_search/ and verify that there are search results

3) Here is the documentation for the allowed parameters http://localhost:8063/api/v1/schema/swagger-ui/#/learning_resources_search/learning_resources_search_retrieve
Play around with them and see that you have the expected results. An example query http://localhost:8063/api/v1/learning_resources_search/?resource_type=course,program&offered_by=xpro&aggregations=resource_type

The expected behavior for aggregations is to include all filters except for the aggregation parameter. For example a search where you have "offered_by" as a search filter and ["offered_by" and "resource_type"] as the aggregation the filter will affect the aggregation results for resource type but not offered by.

A known bug is that sort works for fields that are saved as keyword in the index but not those that are saved as text. So sorting by title, for example throws an error.