### PR TITLE
Articles: disable "save" while image uploading

### DIFF
--- a/frontends/mit-open/src/pages/articles/ArticlesEditPage.tsx
+++ b/frontends/mit-open/src/pages/articles/ArticlesEditPage.tsx
@@ -47,6 +47,7 @@ const ArticleForm = ({
   onSaved,
 }: ArticleFormProps) => {
   const [editoryReady, setEditorReady] = useToggle(false)
+  const [busy, setBusy] = useToggle(false)
   const editArticle = useArticlePartialUpdate()
   const article = useArticleDetail(id)
 
@@ -87,12 +88,13 @@ const ArticleForm = ({
         error={!!formik.errors.title}
         helperText={formik.errors.title}
       />
-      <FormControl fullWidth>
+      <FormControl fullWidth sx={{ position: "relative" }}>
         <CkeditorArticleLazy
           fallbackLines={10}
           className="article-editor"
           initialData={article.data?.html}
           onReady={setEditorReady.on}
+          onChangeHasPendingActions={setBusy}
           onChange={(value) => {
             formik.setFieldValue("html", value)
           }}
@@ -117,7 +119,7 @@ const ArticleForm = ({
           <Button variant="outlined" disabled={!isReady} onClick={onCancel}>
             Cancel
           </Button>
-          <Button variant="contained" disabled={!isReady} type="submit">
+          <Button variant="contained" disabled={!isReady || busy} type="submit">
             Save
           </Button>
         </Grid>

--- a/frontends/ol-ckeditor/src/components/CkeditorArticle.tsx
+++ b/frontends/ol-ckeditor/src/components/CkeditorArticle.tsx
@@ -3,6 +3,7 @@ import { CKEditor } from "@ckeditor/ckeditor5-react"
 
 import { ClassicEditor } from "@ckeditor/ckeditor5-editor-classic"
 import type { EditorConfig } from "@ckeditor/ckeditor5-core"
+import { PendingActions } from "@ckeditor/ckeditor5-core"
 
 import { Essentials } from "@ckeditor/ckeditor5-essentials"
 import { UploadAdapter } from "@ckeditor/ckeditor5-adapter-ckfinder"
@@ -29,6 +30,7 @@ import { BlockToolbar } from "@ckeditor/ckeditor5-ui"
 import { ParagraphButtonUI } from "@ckeditor/ckeditor5-paragraph"
 import { ensureEmbedlyPlatform, embedlyCardHtml } from "ol-util"
 import cloudServicesConfig from "./cloudServices"
+import { useOnChangePendingActions } from "./util"
 
 const baseEditorConfig: EditorConfig = {
   plugins: [
@@ -52,6 +54,7 @@ const baseEditorConfig: EditorConfig = {
     ImageUpload,
     ImageCaption,
     ParagraphButtonUI,
+    PendingActions,
   ],
   blockToolbar: {
     items: ["imageUpload", "mediaEmbed"],
@@ -99,6 +102,7 @@ type CkeditorArticleProps = {
   initialData?: string
   onReady?: () => void
   onChange?: (value: string) => void
+  onChangeHasPendingActions?: (hasPendingActions: boolean) => void
   onBlur?: () => void
   id?: string
   className?: string
@@ -109,6 +113,7 @@ const CkeditorArticle: React.FC<CkeditorArticleProps> = ({
   initialData,
   onReady,
   onChange,
+  onChangeHasPendingActions,
   onBlur,
   id,
   className,
@@ -138,6 +143,8 @@ const CkeditorArticle: React.FC<CkeditorArticleProps> = ({
     },
     [onChange],
   )
+
+  useOnChangePendingActions({ editor, onChange: onChangeHasPendingActions })
 
   return (
     <div id={id} className={className}>

--- a/frontends/ol-ckeditor/src/components/util.test.ts
+++ b/frontends/ol-ckeditor/src/components/util.test.ts
@@ -1,0 +1,42 @@
+import { ClassicEditor } from "@ckeditor/ckeditor5-editor-classic"
+import { PendingActions } from "@ckeditor/ckeditor5-core"
+import { renderHook, waitFor } from "@testing-library/react"
+import { useOnChangePendingActions } from "./util"
+
+test("useOnChangePendingActions attaches and detaches handlers correctly", async () => {
+  const editor = await ClassicEditor.create("<p>Hello world</p>", {
+    plugins: [PendingActions],
+  })
+  const pendingActions = editor.plugins.get("PendingActions")
+
+  const onChange1 = jest.fn()
+  const view = renderHook(useOnChangePendingActions, {
+    initialProps: { editor, onChange: onChange1 },
+  })
+
+  // Fire an action and check that onChangeHasPendingActions is called
+  const action1 = pendingActions.add("foo")
+  await waitFor(() => {
+    expect(onChange1).toHaveBeenCalledWith(true)
+  })
+  pendingActions.remove(action1)
+  await waitFor(() => {
+    expect(onChange1).toHaveBeenCalledWith(false)
+  })
+  onChange1.mockClear()
+
+  // Re-render with a new handler
+  // We will check the new handler is called and NOT the old one.
+  const onChange2 = jest.fn()
+  view.rerender({ editor, onChange: onChange2 })
+
+  const action2 = pendingActions.add("foo")
+  await waitFor(() => {
+    expect(onChange2).toHaveBeenCalledWith(true)
+  })
+  pendingActions.remove(action2)
+  await waitFor(() => {
+    expect(onChange2).toHaveBeenCalledWith(false)
+  })
+  expect(onChange1).not.toHaveBeenCalled()
+})

--- a/frontends/ol-ckeditor/src/components/util.ts
+++ b/frontends/ol-ckeditor/src/components/util.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react"
+import type { Editor } from "@ckeditor/ckeditor5-core"
+import { PendingActions } from "@ckeditor/ckeditor5-core"
+
+type OnChangePendingActionsProps = {
+  editor: Editor | null
+  onChange?: (hasPendingActions: boolean) => void
+}
+
+const useOnChangePendingActions = ({
+  editor,
+  onChange,
+}: OnChangePendingActionsProps) => {
+  useEffect(() => {
+    if (!editor) return
+    if (!onChange) return
+    const pendingActions = editor.plugins.get(PendingActions)
+    const handler = () => {
+      onChange(pendingActions.hasAny)
+    }
+    pendingActions.on("change:hasAny", handler)
+    return () => {
+      pendingActions.off("change:hasAny", handler)
+    }
+  }, [editor, onChange])
+}
+
+export { useOnChangePendingActions }


### PR DESCRIPTION
# What are the relevant tickets?
#128 

# Description (What does it do?)
This PR adds the CKEditor [PendingActions](https://ckeditor.com/docs/ckeditor5/latest/api/module_core_pendingactions-PendingActions.html) plugin. This plugin emits events when there are "pending actions" like an incomplete file upload.

# Screenshots (if appropriate):
Note the "Save" button is disabled—the image is currently uploading.

<img width="512" alt="Screenshot 2023-10-18 at 7 16 27 PM" src="https://github.com/mitodl/mit-open/assets/9010790/fe7f58ef-067b-4f22-9ae2-81d8aa67da94">


# How can this be tested?
As a logged-in user,
1. Create some articles at http://localhost:8063/api/v1/articles/ *There's no creation UI; just editing and viewing.*
2. Visit http://localhost:8063/articles/ARTICLE_ID
3. *Optional*: In your network tab, enable throttling. "fast-3g" or "slow-3g" are both good. This isn't necessary, but it makes the effect easier to see.
4. Upload an image. You can drag an image into the editor, or you can:
    - click the editor
    - click the floating "+" icon that shows up on the left hand side
5. **While the image is uploading:**
    - you will see a very thin blue progress bar near the top of the image
    - the "save" button should be disabled **This is the new behavior in this PR.**
    - When the image finishes uploading, you'll see a green check mark in its upper-right corner (briefly). 



# Additional Context
I'm not sure this is the optimal UX for this. I could see users being confused ("why did the 'Save' button flash gray when I added a new image?"). I'm open to suggestions, but we can always improve the UX later.

I did consider an approach where users can _always_ click "Save", but the button waits to make the actual API clal until the editor has no pending actions. After looking into this a bit, it seemed more complicated to implement, so unless we definitively want that behavior, I don't think it's worth the effort.