### PR TITLE
Create favorites list for new users

### DIFF
--- a/app.json
+++ b/app.json
@@ -298,6 +298,10 @@
     "MITOPEN_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to."
     },
+    "MITOPEN_AUTHENTICATION_PLUGINS": {
+      "description": "List of pluggy plugins to use for authentication",
+      "required": false
+    },
     "MITOPEN_BASE_URL": {
       "description": "Base url to link users to in emails"
     },

--- a/authentication/apps.py
+++ b/authentication/apps.py
@@ -1,9 +1,13 @@
 """Authentication Apps"""
 
 from django.apps import AppConfig
+from pluggy import HookimplMarker, HookspecMarker
 
 
 class AuthenticationConfig(AppConfig):
     """Authentication AppConfig"""
 
     name = "authentication"
+
+    hookimpl = HookimplMarker(name)
+    hookspec = HookspecMarker(name)

--- a/authentication/hooks.py
+++ b/authentication/hooks.py
@@ -1,0 +1,32 @@
+"""Pluggy hooks for authentication"""
+import logging
+
+import pluggy
+from django.apps import apps
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+log = logging.getLogger(__name__)
+
+app_config = apps.get_app_config("authentication")
+hookspec = app_config.hookspec
+
+
+class AuthenticationHooks:
+    """Pluggy hooks specs for authentication"""
+
+    @hookspec
+    def user_created(self, user):
+        """Trigger actions after a user is created"""
+
+
+def get_plugin_manager():
+    """Return the plugin manager for authentication hooks"""
+    pm = pluggy.PluginManager(app_config.name)
+    pm.add_hookspecs(AuthenticationHooks)
+    for module in settings.MITOPEN_AUTHENTICATION_PLUGINS.split(","):
+        if module:
+            plugin_cls = import_string(module)
+            pm.register(plugin_cls())
+
+    return pm

--- a/authentication/pipeline/user.py
+++ b/authentication/pipeline/user.py
@@ -2,6 +2,8 @@
 
 from social_core.exceptions import AuthException
 
+from authentication.hooks import get_plugin_manager
+
 
 def forbid_hijack(
     strategy,
@@ -19,3 +21,13 @@ def forbid_hijack(
         msg = "You are hijacking another user, don't try to login again"
         raise AuthException(msg)
     return {}
+
+
+def user_created_actions(**kwargs):
+    """
+    Trigger plugins when a user is created
+    """
+    if kwargs.get("is_new"):
+        pm = get_plugin_manager()
+        hook = pm.hook
+        hook.user_created(user=kwargs["user"])

--- a/authentication/pipeline/user_test.py
+++ b/authentication/pipeline/user_test.py
@@ -3,6 +3,7 @@
 import pytest
 
 from authentication.pipeline import user as user_actions
+from open_discussions.factories import UserFactory
 
 
 @pytest.mark.parametrize("hijacked", [True, False])
@@ -25,3 +26,19 @@ def test_forbid_hijack(mocker, hijacked):
             user_actions.forbid_hijack(**kwargs)
     else:
         assert user_actions.forbid_hijack(**kwargs) == {}
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("is_new", [True, False])
+def test_user_created_actions(mocker, is_new):
+    """
+    Tests that user_created_actions creates a favorites list for new users only
+    """
+    user = UserFactory.create()
+    kwargs = {
+        "user": user,
+        "is_new": is_new,
+    }
+
+    user_actions.user_created_actions(**kwargs)
+    assert user.user_lists.count() == (1 if is_new else 0)

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -42,7 +42,7 @@ def warnings_as_errors():  # noqa: PT004
         # Ignore deprecation warnings in third party libraries
         warnings.filterwarnings(
             "ignore",
-            module=".*(api_jwt|api_jws|rest_framework_jwt|astroid|celery).*",
+            module=".*(api_jwt|api_jws|rest_framework_jwt|astroid|celery|factory).*",
             category=DeprecationWarning,
         )
         yield

--- a/learning_resources/admin.py
+++ b/learning_resources/admin.py
@@ -111,6 +111,14 @@ class LearningResourceAdmin(admin.ModelAdmin):
     autocomplete_fields = ("topics",)
 
 
+class UserListAdmin(admin.ModelAdmin):
+    """UserList Admin"""
+
+    model = models.UserList
+    search_fields = ("title", "author__username", "author__email")
+    list_display = ("title", "author", "created_on", "updated_on")
+
+
 admin.site.register(models.LearningResourceTopic, LearningResourceTopicAdmin)
 admin.site.register(models.LearningResourceInstructor, LearningResourceInstructorAdmin)
 admin.site.register(models.LearningResource, LearningResourceAdmin)
@@ -118,3 +126,4 @@ admin.site.register(models.LearningResourceRun, LearningResourceRunAdmin)
 admin.site.register(models.LearningResourceDepartment, LearningResourceDepartmentAdmin)
 admin.site.register(models.LearningResourcePlatform, LearningResourcePlatformAdmin)
 admin.site.register(models.LearningResourceOfferor, LearningResourceOfferorAdmin)
+admin.site.register(models.UserList, UserListAdmin)

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -8,6 +8,8 @@ OPEN = "Open Content"
 PROFESSIONAL = "Professional Offerings"
 CERTIFICATE = "Certificates"
 
+FAVORITES_TITLE = "Favorites"
+
 
 class AvailabilityType(Enum):
     """

--- a/learning_resources/management/commands/backpopulate_favorites_lists.py
+++ b/learning_resources/management/commands/backpopulate_favorites_lists.py
@@ -1,0 +1,46 @@
+"""Management command to create user Favorites lists"""
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand
+
+from learning_resources.constants import FAVORITES_TITLE
+from learning_resources.models import UserList
+from open_discussions.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Create a Favorites userlist for every active user"""
+
+    help = "Create a Favorites userlist for every active user"  # noqa: A003
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete all existing Favorites user lists",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Create a Favorites userlist for every active user"""
+        if options["delete"]:
+            self.stdout.write("Deleting all existing Favorites userlists")
+            UserList.objects.filter(title=FAVORITES_TITLE).delete()
+        else:
+            self.stdout.write("Creating Favorites lists for each user")
+            start = now_in_utc()
+            user_ids = UserList.objects.filter(title=FAVORITES_TITLE).values_list(
+                "author_id", flat=True
+            )
+            for user in User.objects.exclude(id__in=user_ids).exclude(is_active=False):
+                UserList.objects.get_or_create(
+                    author=user,
+                    title=FAVORITES_TITLE,
+                    defaults={"description": "My Favorites"},
+                )
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(
+                "Population of user favorites list finished, took {} seconds".format(
+                    total_seconds
+                )
+            )

--- a/learning_resources/plugins.py
+++ b/learning_resources/plugins.py
@@ -1,0 +1,21 @@
+"""Pluggy plugins for learning resources"""
+from django.apps import apps
+
+from learning_resources.constants import FAVORITES_TITLE
+from learning_resources.models import UserList
+
+
+class FavoritesListPlugin:
+    hookimpl = apps.get_app_config("authentication").hookimpl
+
+    @hookimpl
+    def user_created(self, user):
+        """
+        Perform functions on a newly created user
+
+        Args:
+            user(User): The user to create the list for
+        """
+        UserList.objects.get_or_create(
+            author=user, title=FAVORITES_TITLE, defaults={"description": "My Favorites"}
+        )

--- a/learning_resources/plugins_test.py
+++ b/learning_resources/plugins_test.py
@@ -1,0 +1,21 @@
+"""Tests for learning_resources plugins"""
+import pytest
+
+from learning_resources.constants import FAVORITES_TITLE
+from learning_resources.factories import UserListFactory
+from learning_resources.plugins import FavoritesListPlugin
+from open_discussions.factories import UserFactory
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize("existing_list", [True, False])
+def test_favorites_plugin_user_created(existing_list):
+    """A UserList with title favorites should be created if it doesn't exist"""
+    user = UserFactory.create()
+    if existing_list:
+        UserListFactory.create(
+            author=user, title=FAVORITES_TITLE, description="My Favorites"
+        )
+    FavoritesListPlugin().user_created(user)
+    user.refresh_from_db()
+    assert user.user_lists.count() == 1

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -20,7 +20,10 @@ from learning_resources.constants import (
     GROUP_STAFF_LISTS_EDITORS,
     semester_mapping,
 )
-from learning_resources.models import LearningResourceOfferor, LearningResourcePlatform
+from learning_resources.models import (
+    LearningResourceOfferor,
+    LearningResourcePlatform,
+)
 from open_discussions.utils import generate_filepath
 
 log = logging.getLogger()

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -30,6 +30,7 @@ from open_discussions.envs import (
 from open_discussions.sentry import init_sentry
 from open_discussions.settings_celery import *  # noqa: F403
 from open_discussions.settings_course_etl import *  # noqa: F403
+from open_discussions.settings_pluggy import *  # noqa: F403
 from open_discussions.settings_spectacular import open_spectacular_settings
 
 VERSION = "0.223.0"
@@ -264,6 +265,8 @@ SOCIAL_AUTH_PIPELINE = (
     "social_core.pipeline.social_auth.load_extra_data",
     # Update the user record with any changed info from the auth service.
     "social_core.pipeline.user.user_details",
+    # Create a favorites list for new users
+    "authentication.pipeline.user.user_created_actions",
 )
 
 SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT = get_string(

--- a/open_discussions/settings_pluggy.py
+++ b/open_discussions/settings_pluggy.py
@@ -1,0 +1,6 @@
+from open_discussions.envs import get_string
+
+MITOPEN_AUTHENTICATION_PLUGINS = get_string(
+    "MITOPEN_AUTHENTICATION_PLUGINS",
+    "learning_resources.plugins.FavoritesListPlugin",
+)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2376,13 +2376,13 @@ tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "pa
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
 
 [package.extras]
@@ -3893,4 +3893,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.5"
-content-hash = "0fb36c13018a58b030d8f21d2ab1632fd7e940c10564165f93e5835d36acf670"
+content-hash = "0534a24131eaf99e00174631cb5254ff565b97320508366f66475fbce722021a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ xbundle = "^0.3.1"
 social-auth-core = {extras = ["openidconnect"], version = "^4.4.2"}
 nh3 = "^0.2.14"
 retry2 = "^0.9.5"
+pluggy = "^1.3.0"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.24"


### PR DESCRIPTION
# What are the relevant tickets?
Closes #80 
Closes #111 

# Description (What does it do?)
- Integrates pluggy (#111)
- Uses pluggy to create a UserList with title "Favorites" for every new user (#80)
- Adds a mgmt command to add a "Favorites" list to every active user who doesn't already have one. (#80)

# How can this be tested?
- Enable keycloak as described in [this PR](https://github.com/mitodl/open-discussions/pull/4230) 
- Go to `http://od.odl.local:8063/login/ol-oidc/` and register a new user
- After you click on the verification email and are logged in, you should have a favorites list (go to http://od.odl.local:8063/api/v1/userlists/ to see it).
- Log out (http://od.odl.local:8063/logout/) then log back in.  You should still have only 1 favorites userlist.
- Run `./manage.py backpopulate_favorites_lists`, after that all your existing users (including admin user) should have a favorites list.  You can log into django admin to see them all.
- Run the above command again, there should still be only one per user.
