### PR TITLE
Fix several issues with ETL Pipelines

### DIFF
--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -58,7 +58,7 @@ def transform(programs):
             "title": program["title"],
             "platform": PlatformType.edx.value,
             "offered_by": OFFERED_BY,
-            "url": program["programpage_url"],
+            "url": program.get("programpage_url"),
             "image": _transform_image(program),
             "runs": [
                 {
@@ -96,5 +96,5 @@ def transform(programs):
             ],
         }
         for program in programs
-        if DEDP not in program["programpage_url"]
+        if program and DEDP not in (program.get("programpage_url", "") or "")
     ]

--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -49,52 +49,56 @@ def _transform_image(micromasters_data: dict) -> dict:
     return {"url": image_url} if image_url else None
 
 
-def transform(programs):
+def transform(programs_data):
     """Transform the micromasters catalog data"""
-    return [
-        {
-            "readable_id": f"{READABLE_ID_PREFIX}{program['id']}",
-            "etl_source": ETLSource.micromasters.value,
-            "title": program["title"],
-            "platform": PlatformType.edx.value,
-            "offered_by": OFFERED_BY,
-            "url": program.get("programpage_url"),
-            "image": _transform_image(program),
-            "runs": [
+    programs = []
+    for program in programs_data:
+        url = program.get("programpage_url")
+        if url and DEDP not in url:
+            programs.append(
                 {
-                    "run_id": f"{READABLE_ID_PREFIX}{program['id']}",
+                    "readable_id": f"{READABLE_ID_PREFIX}{program['id']}",
+                    "etl_source": ETLSource.micromasters.value,
                     "title": program["title"],
-                    "instructors": [
-                        {"full_name": instructor["name"]}
-                        for instructor in program["instructors"]
-                    ],
-                    "prices": [program["total_price"]],
-                    "start_date": program["start_date"],
-                    "end_date": program["end_date"],
-                    "enrollment_start": program["enrollment_start"],
-                }
-            ],
-            "topics": program["topics"],
-            # only need positioning of courses by course_id for course data
-            "courses": [
-                {
-                    "readable_id": course["edx_key"],
                     "platform": PlatformType.edx.value,
                     "offered_by": OFFERED_BY,
-                    "published": _is_published(course["edx_key"]),
+                    "url": program.get("programpage_url"),
+                    "image": _transform_image(program),
                     "runs": [
                         {
-                            "run_id": run["edx_course_key"],
+                            "run_id": f"{READABLE_ID_PREFIX}{program['id']}",
+                            "title": program["title"],
+                            "instructors": [
+                                {"full_name": instructor["name"]}
+                                for instructor in program["instructors"]
+                            ],
+                            "prices": [program["total_price"]],
+                            "start_date": program["start_date"],
+                            "end_date": program["end_date"],
+                            "enrollment_start": program["enrollment_start"],
                         }
-                        for run in course["course_runs"]
-                        if run.get("edx_course_key", None)
+                    ],
+                    "topics": program["topics"],
+                    # only need positioning of courses by course_id for course data
+                    "courses": [
+                        {
+                            "readable_id": course["edx_key"],
+                            "platform": PlatformType.edx.value,
+                            "offered_by": OFFERED_BY,
+                            "published": _is_published(course["edx_key"]),
+                            "runs": [
+                                {
+                                    "run_id": run["edx_course_key"],
+                                }
+                                for run in course["course_runs"]
+                                if run.get("edx_course_key", None)
+                            ],
+                        }
+                        for course in sorted(
+                            program["courses"],
+                            key=lambda course: course["position_in_program"],
+                        )
                     ],
                 }
-                for course in sorted(
-                    program["courses"], key=lambda course: course["position_in_program"]
-                )
-            ],
-        }
-        for program in programs
-        if program and DEDP not in (program.get("programpage_url", "") or "")
-    ]
+            )
+    return programs

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -98,18 +98,21 @@ def test_micromasters_extract_disabled(settings):
 
 
 @pytest.mark.django_db()
-def test_micromasters_transform(mock_micromasters_data):
+@pytest.mark.parametrize("missing_url", [True, False])
+def test_micromasters_transform(mock_micromasters_data, missing_url):
     """Test that micromasters data is correctly transformed into our normalized structure"""
     LearningResourceFactory.create(
         readable_id="1",
         resource_type=LearningResourceType.course.value,
         etl_source=ETLSource.mit_edx.value,
     )
+    if missing_url:
+        mock_micromasters_data[0]["programpage_url"] = None
     assert micromasters.transform(mock_micromasters_data) == [
         {
             "readable_id": f"{READABLE_ID_PREFIX}1",
             "title": "program title 1",
-            "url": "http://example.com/program/1/url",
+            "url": None if missing_url else "http://example.com/program/1/url",
             "image": {"url": "http://example.com/program/1/image/url"},
             "offered_by": micromasters.OFFERED_BY,
             "platform": PlatformType.edx.value,

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -108,49 +108,53 @@ def test_micromasters_transform(mock_micromasters_data, missing_url):
     )
     if missing_url:
         mock_micromasters_data[0]["programpage_url"] = None
-    assert micromasters.transform(mock_micromasters_data) == [
-        {
-            "readable_id": f"{READABLE_ID_PREFIX}1",
-            "title": "program title 1",
-            "url": None if missing_url else "http://example.com/program/1/url",
-            "image": {"url": "http://example.com/program/1/image/url"},
-            "offered_by": micromasters.OFFERED_BY,
-            "platform": PlatformType.edx.value,
-            "etl_source": ETLSource.micromasters.value,
-            "courses": [
-                {
-                    "readable_id": "1",
-                    "platform": PlatformType.edx.value,
-                    "offered_by": micromasters.OFFERED_BY,
-                    "published": True,
-                    "runs": [
-                        {
-                            "run_id": "course_key_1",
-                        }
-                    ],
-                },
-                {
-                    "readable_id": "2",
-                    "platform": PlatformType.edx.value,
-                    "offered_by": micromasters.OFFERED_BY,
-                    "published": False,
-                    "runs": [],
-                },
-            ],
-            "runs": [
-                {
-                    "run_id": f"{READABLE_ID_PREFIX}1",
-                    "title": "program title 1",
-                    "instructors": [
-                        {"full_name": "Dr. Doofenshmirtz"},
-                        {"full_name": "Joey Jo Jo Shabadoo"},
-                    ],
-                    "prices": ["123.45"],
-                    "start_date": "2019-10-04T20:13:26.367297Z",
-                    "end_date": None,
-                    "enrollment_start": "2019-09-29T20:13:26.367297Z",
-                }
-            ],
-            "topics": [{"name": "program"}, {"name": "first"}],
-        }
-    ]
+    assert micromasters.transform(mock_micromasters_data) == (
+        []
+        if missing_url
+        else [
+            {
+                "readable_id": f"{READABLE_ID_PREFIX}1",
+                "title": "program title 1",
+                "url": None if missing_url else "http://example.com/program/1/url",
+                "image": {"url": "http://example.com/program/1/image/url"},
+                "offered_by": micromasters.OFFERED_BY,
+                "platform": PlatformType.edx.value,
+                "etl_source": ETLSource.micromasters.value,
+                "courses": [
+                    {
+                        "readable_id": "1",
+                        "platform": PlatformType.edx.value,
+                        "offered_by": micromasters.OFFERED_BY,
+                        "published": True,
+                        "runs": [
+                            {
+                                "run_id": "course_key_1",
+                            }
+                        ],
+                    },
+                    {
+                        "readable_id": "2",
+                        "platform": PlatformType.edx.value,
+                        "offered_by": micromasters.OFFERED_BY,
+                        "published": False,
+                        "runs": [],
+                    },
+                ],
+                "runs": [
+                    {
+                        "run_id": f"{READABLE_ID_PREFIX}1",
+                        "title": "program title 1",
+                        "instructors": [
+                            {"full_name": "Dr. Doofenshmirtz"},
+                            {"full_name": "Joey Jo Jo Shabadoo"},
+                        ],
+                        "prices": ["123.45"],
+                        "start_date": "2019-10-04T20:13:26.367297Z",
+                        "end_date": None,
+                        "enrollment_start": "2019-09-29T20:13:26.367297Z",
+                    }
+                ],
+                "topics": [{"name": "program"}, {"name": "first"}],
+            }
+        ]
+    )

--- a/learning_resources/etl/prolearn.py
+++ b/learning_resources/etl/prolearn.py
@@ -37,7 +37,8 @@ query {
                 {
                     conjunction: AND,
                     conditions: [
-                        {operator: \"=\", name: \"field_course_or_program\", value: \"%s\"}
+                        {operator: \"=\", name: \"field_course_or_program\", value: \"%s\"},
+                        {operator: \"<>\", name: \"department\", value: \"MIT xPRO\"}
                     ]
                 }
             ]


### PR DESCRIPTION
# What are the relevant tickets?
Closes #162 

# Description (What does it do?)
- Adds a conditional statement to the prolearn API query to filter out xpro
- Adjusts the Micromasters ETL pipeline to handle any programs with null urls


# How can this be tested?
- Set the following in your .env:
  ```
  MICROMASTERS_CATALOG_API_URL=https://micromasters-rc.odl.mit.edu/api/v0/catalog/
  PROLEARN_CATALOG_API_URL=https://prolearn.mit.edu/graphql
  ```
- Delete any existing learning_resources from these sources, if any:
  ```
  from learning_resources.models import LearningResource
  LearningResource.objects.filter(etl_source__in=("prolearn", "micromasters")).delete()
- Run the following:
  ```
  ./manage.py backpopulate_prolearn_data
  ./manage.py backpopulate_micromasters_data
  ```

Both should complete without errors and you should have courses imported from prolearn but none with platform/offered_by = xpro.  You should also have some programs imported from micromasters, none of which should have null urls.
