### PR TITLE
add id filter to learning_resources_search

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -7650,6 +7650,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
      * @param {Array<string>} [certification]
      * @param {Array<string>} [department]
+     * @param {Array<string>} [id]
      * @param {Array<string>} [level]
      * @param {number} [limit]
      * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
@@ -7678,6 +7679,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       >,
       certification?: Array<string>,
       department?: Array<string>,
+      id?: Array<string>,
       level?: Array<string>,
       limit?: number,
       offered_by?: Array<
@@ -7759,6 +7761,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["department"] = department
       }
 
+      if (id) {
+        localVarQueryParameter["id"] = id
+      }
+
       if (level) {
         localVarQueryParameter["level"] = level
       }
@@ -7835,6 +7841,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
      * @param {Array<string>} [certification]
      * @param {Array<string>} [department]
+     * @param {Array<string>} [id]
      * @param {Array<string>} [level]
      * @param {number} [limit]
      * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
@@ -7863,6 +7870,7 @@ export const LearningResourcesSearchApiFp = function (
       >,
       certification?: Array<string>,
       department?: Array<string>,
+      id?: Array<string>,
       level?: Array<string>,
       limit?: number,
       offered_by?: Array<
@@ -7924,6 +7932,7 @@ export const LearningResourcesSearchApiFp = function (
           aggregations,
           certification,
           department,
+          id,
           level,
           limit,
           offered_by,
@@ -7973,6 +7982,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.aggregations,
           requestParameters.certification,
           requestParameters.department,
+          requestParameters.id,
           requestParameters.level,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -8027,6 +8037,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly department?: Array<string>
+
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly id?: Array<string>
 
   /**
    *
@@ -8167,6 +8184,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.aggregations,
         requestParameters.certification,
         requestParameters.department,
+        requestParameters.id,
         requestParameters.level,
         requestParameters.limit,
         requestParameters.offered_by,

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1,6 +1,5 @@
 """API for general search-related functionality"""
 import re
-from base64 import urlsafe_b64encode
 
 from opensearch_dsl import Search
 
@@ -17,34 +16,6 @@ from learning_resources_search.constants import (
 
 SIMILAR_RESOURCE_RELEVANT_FIELDS = ["title", "short_description"]
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
-
-
-def gen_course_id(platform, readable_id):
-    """
-    Generate the OpenSearch document id for a course
-
-    Args:
-        platform (str): The platform of a LearningResource object
-        readable_id (str): The readable_id of a LearningResource object
-
-    Returns:
-        str: The OpenSearch document id for this object
-    """
-    safe_id = urlsafe_b64encode(readable_id.encode("utf-8")).decode("utf-8").rstrip("=")
-    return f"co_{platform}_{safe_id}"
-
-
-def gen_program_id(program_obj):
-    """
-    Generate the OpenSearch document id for a Program
-
-    Args:
-        program_obj (Program): The Program object
-
-    Returns:
-        str: The OpenSearch document id for this object
-    """
-    return f"program_{program_obj.learning_resource_id}"
 
 
 def relevant_indexes(resource_types, aggregations):

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -60,6 +60,7 @@ LEARNING_RESOURCE_SEARCH_FILTERS = [
     "resource_content_tags",
     "platform",
     "professional",
+    "id",
 ]
 
 SEARCH_NESTED_FILTERS = {
@@ -83,7 +84,7 @@ ENGLISH_TEXT_FIELD_WITH_SUGGEST = {
 
 
 LEARNING_RESOURCE_TYPE = {
-    "id": {"type": "long"},
+    "id": {"type": "keyword"},
     "certification": {"type": "keyword"},
     "readable_id": {"type": "keyword"},
     "title": ENGLISH_TEXT_FIELD_WITH_SUGGEST,

--- a/learning_resources_search/search_index_helpers.py
+++ b/learning_resources_search/search_index_helpers.py
@@ -4,10 +4,6 @@ Functions that execute search-related asynchronous tasks
 import logging
 
 from learning_resources_search import tasks
-from learning_resources_search.api import (
-    gen_course_id,
-    gen_program_id,
-)
 from learning_resources_search.constants import (
     COURSE_TYPE,
     PROGRAM_TYPE,
@@ -47,9 +43,7 @@ def deindex_course(learning_resource_obj):
     """
     try_with_retry_as_task(
         deindex_document,
-        gen_course_id(
-            learning_resource_obj.platform, learning_resource_obj.readable_id
-        ),
+        learning_resource_obj.id,
         COURSE_TYPE,
     )
 
@@ -73,6 +67,4 @@ def deindex_program(learning_resource_obj):
         learning_resource_obj (learning_resource.models.LearningResource): A
             LearningResource object with resource_type Program
     """
-    try_with_retry_as_task(
-        deindex_document, gen_program_id(learning_resource_obj.program), PROGRAM_TYPE
-    )
+    try_with_retry_as_task(deindex_document, learning_resource_obj.id, PROGRAM_TYPE)

--- a/learning_resources_search/search_index_helpers_test.py
+++ b/learning_resources_search/search_index_helpers_test.py
@@ -6,9 +6,6 @@ from learning_resources.factories import (
     CourseFactory,
     ProgramFactory,
 )
-from learning_resources_search.api import (
-    gen_course_id,
-)
 from learning_resources_search.constants import (
     COURSE_TYPE,
 )
@@ -40,12 +37,9 @@ def test_delete_course(mocker):
     )
 
     course = CourseFactory.create()
-    course_es_id = gen_course_id(
-        course.learning_resource.platform, course.learning_resource.readable_id
-    )
 
     deindex_course(course.learning_resource)
-    mock_del_document.assert_called_once_with(course_es_id, COURSE_TYPE)
+    mock_del_document.assert_called_once_with(course.learning_resource.id, COURSE_TYPE)
 
 
 @pytest.mark.django_db()

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -8,7 +8,7 @@ from rest_framework.renderers import JSONRenderer
 from learning_resources import factories
 from learning_resources.models import Course, Program
 from learning_resources.serializers import LearningResourceSerializer
-from learning_resources_search import api, serializers
+from learning_resources_search import serializers
 from learning_resources_search.serializers import (
     LearningResourcesSearchRequestSerializer,
     LearningResourcesSearchResponseSerializer,
@@ -31,7 +31,7 @@ def test_serialize_bulk_courses(mocker):
         )
     )
     for course in courses:
-        mock_serialize_course.assert_any_call(course)
+        mock_serialize_course.assert_any_call(course.learning_resource)
 
 
 @pytest.mark.django_db()
@@ -40,10 +40,8 @@ def test_serialize_course_for_bulk():
     Test that serialize_course_for_bulk yields a valid LearningResourceSerializer
     """
     course = factories.CourseFactory.create()
-    assert serializers.serialize_course_for_bulk(course) == {
-        "_id": api.gen_course_id(
-            course.learning_resource.platform, course.learning_resource.readable_id
-        ),
+    assert serializers.serialize_course_for_bulk(course.learning_resource) == {
+        "_id": course.learning_resource.id,
         **LearningResourceSerializer(course.learning_resource).data,
     }
 
@@ -63,7 +61,7 @@ def test_serialize_bulk_programs(mocker):
         )
     )
     for program in programs:
-        mock_serialize_program.assert_any_call(program)
+        mock_serialize_program.assert_any_call(program.learning_resource)
 
 
 @pytest.mark.django_db()
@@ -72,8 +70,8 @@ def test_serialize_program_for_bulk():
     Test that serialize_program_for_bulk yields a valid LearningResourceSerializer
     """
     program = factories.ProgramFactory.create()
-    assert serializers.serialize_program_for_bulk(program) == {
-        "_id": api.gen_program_id(program),
+    assert serializers.serialize_program_for_bulk(program.learning_resource) == {
+        "_id": program.learning_resource.id,
         **LearningResourceSerializer(program.learning_resource).data,
     }
 
@@ -88,9 +86,7 @@ def test_serialize_bulk_courses_for_deletion():
         serializers.serialize_bulk_courses_for_deletion([course.learning_resource_id])
     ) == [
         {
-            "_id": api.gen_course_id(
-                course.learning_resource.platform, course.learning_resource.readable_id
-            ),
+            "_id": course.learning_resource.id,
             "_op_type": "delete",
         }
     ]
@@ -104,7 +100,7 @@ def test_serialize_bulk_programs_for_deletion():
     program = factories.ProgramFactory.create()
     assert list(
         serializers.serialize_bulk_programs_for_deletion([program.learning_resource_id])
-    ) == [{"_id": api.gen_program_id(program), "_op_type": "delete"}]
+    ) == [{"_id": program.learning_resource.id, "_op_type": "delete"}]
 
 
 def test_extract_values():

--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -15,7 +15,6 @@ from learning_resources.models import Course, LearningResource, Program
 from learning_resources.serializers import LearningResourceSerializer
 from learning_resources.utils import load_course_blocklist
 from learning_resources_search import indexing_api as api
-from learning_resources_search.api import gen_course_id, gen_program_id
 from learning_resources_search.constants import (
     COURSE_TYPE,
     PROGRAM_TYPE,
@@ -53,7 +52,7 @@ def upsert_course(course_id):
     course_obj = LearningResource.objects.get(id=course_id)
     course_data = LearningResourceSerializer(course_obj).data
     api.upsert_document(
-        gen_course_id(course_obj.platform, course_obj.readable_id),
+        course_id,
         course_data,
         COURSE_TYPE,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
@@ -67,7 +66,7 @@ def upsert_program(program_id):
     program_obj = Program.objects.get(learning_resource_id=program_id)
     program_data = LearningResourceSerializer(program_obj.learning_resource).data
     api.upsert_document(
-        gen_program_id(program_obj),
+        program_obj.learning_resource.id,
         program_data,
         PROGRAM_TYPE,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,

--- a/learning_resources_search/tasks_test.py
+++ b/learning_resources_search/tasks_test.py
@@ -16,10 +16,6 @@ from learning_resources.factories import (
 from learning_resources.models import LearningResourcePlatform
 from learning_resources.serializers import LearningResourceSerializer
 from learning_resources_search import tasks
-from learning_resources_search.api import (
-    gen_course_id,
-    gen_program_id,
-)
 from learning_resources_search.constants import (
     COURSE_TYPE,
     PROGRAM_TYPE,
@@ -65,9 +61,7 @@ def test_upsert_course_task(mocked_api):
     upsert_course(course.learning_resource_id)
     data = LearningResourceSerializer(course.learning_resource).data
     mocked_api.upsert_document.assert_called_once_with(
-        gen_course_id(
-            course.learning_resource.platform, course.learning_resource.readable_id
-        ),
+        course.learning_resource.id,
         data,
         COURSE_TYPE,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,
@@ -80,7 +74,7 @@ def test_upsert_program_task(mocked_api):
     upsert_program(program)
     data = LearningResourceSerializer(program.learning_resource).data
     mocked_api.upsert_document.assert_called_once_with(
-        gen_program_id(program),
+        program.learning_resource.id,
         data,
         PROGRAM_TYPE,
         retry_on_conflict=settings.INDEXING_ERROR_RETRIES,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1772,6 +1772,13 @@ paths:
             type: string
             minLength: 1
       - in: query
+        name: id
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+      - in: query
         name: level
         schema:
           type: array


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/164

# Description (What does it do?)
This pr adds an id filter to the /learning_resources_search endpoint. It also updates the indexing ids for objects in open search to the learning resource object id 

# How to test
Run docker-compose run web ./manage.py recreate_index --all
Got to http://localhost:8063/api/v1/learning_resources_search/ and verify that it loads
For ids that exist in your database try searching with the id param for example
http://localhost:8063/api/v1/learning_resources_search/?id=5147,5140
or 
http://localhost:8063/api/v1/learning_resources_search/?id=5147

This stacks with other filters too

