### PR TITLE
fix watch container default NODE_ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       - "8062:8062"
     environment:
       DOCKER_HOST: ${DOCKER_HOST:-missing}
+      NODE_ENV: ${NODE_ENV:-development}
       CONTAINER_NAME: "watch"
       WEBPACK_PORT_MITOPEN: 8062
     env_file: .env


### PR DESCRIPTION
# What are the relevant tickets?
- This fixes a bug introduced in #152 for #136 

# Description (What does it do?)
Sets `development` as the default value of `NODE_ENV` in `watch` container.

# How can this be tested?
Remove `NODE_ENV` from your `.env` file if it there.

1. Run `docker compose up` on main branch. Visit http://localhost:8063. Nothing will load.
2. Run `docker compose up` on this branch. Visit http://localhost:8063. Frontend should load.

# Additional Context
In #152 when I merged the docker-compose.overrides.yml into docker-compose.yml, I made an error in not including NODE_ENV in the `watch` container. My best guess is that we missed it because me/reviewer had `NODE_ENV` set in their env file.
