### PR TITLE
Fix a flaky python test

### DIFF
--- a/learning_resources/etl/prolearn_test.py
+++ b/learning_resources/etl/prolearn_test.py
@@ -27,15 +27,11 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(autouse=True)
 def _mock_offerors_platforms():
     """Make sure necessary platforms and offerors exist"""
-    LearningResourceOfferorFactory.create(name="CSAIL", code="csail", professional=True)
+    LearningResourceOfferorFactory.create(code="csail", professional=True)
     LearningResourcePlatformFactory.create(platform="csail")
-    LearningResourceOfferorFactory.create(
-        name="Professional Education", code="mitpe", professional=True
-    )
+    LearningResourceOfferorFactory.create(code="mitpe", professional=True)
     LearningResourcePlatformFactory.create(platform="mitpe")
-    LearningResourceOfferorFactory.create(
-        name="Center for Transportation & Logistics", code="ctl", professional=True
-    )
+    LearningResourceOfferorFactory.create(code="ctl", professional=True)
 
 
 @pytest.fixture(autouse=True)

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -123,7 +123,7 @@ class LearningResourceDepartmentFactory(DjangoModelFactory):
 class LearningResourceOfferorFactory(DjangoModelFactory):
     """Factory for LearningResourceOfferor"""
 
-    name = FuzzyChoice([offeror.value for offeror in constants.OfferedBy])
+    name = factory.LazyAttribute(lambda obj: constants.OfferedBy[obj.code].value)
     code = FuzzyChoice([offeror.name for offeror in constants.OfferedBy])
     professional = Faker("boolean")
 

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -5,7 +5,6 @@ from learning_resources import constants
 from learning_resources.constants import LearningResourceType
 from learning_resources.factories import (
     CourseFactory,
-    LearningResourceOfferorFactory,
     ProgramFactory,
 )
 
@@ -87,8 +86,6 @@ def test_course_creation():
 )
 def test_lr_certification(offered_by, availability, has_cert):
     """The certification property should return the expected value"""
-    offered_by = LearningResourceOfferorFactory.create(name=offered_by)
-
     course = CourseFactory.create(
         offered_by=offered_by,
         runs=[],


### PR DESCRIPTION
# What are the relevant tickets?
#180 

# Description (What does it do?)
This PR changes LearningResourceOfferorFactory so that its `name` and `code` are consistent. See code comment for more.


# How can this be tested?
1.  change `test_learning_resource_filter_offered_by` to
    ```python
    @pytest.mark.parametrize('execution_number', range(100))
    def test_learning_resource_filter_offered_by(mock_courses, execution_number):
    ```
2. Run `pytest -s --no-cov learning_resources/filters_test.py -k test_learning_resource_filter_offered_by`. All tests should pass. *On `main`, there's a ~25% failure rate.*

