### PR TITLE
Env var warnings and readme for ETL tasks/commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,31 @@ MIT Open uses [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest
 
 ### Load initial data
 
-Run the following to load platforms, departments, and offerors into the database:
+Run the following to load platforms, departments, and offers. This populates the database with the fixture files contained in [learning_resources/fixtures](learning_resources/fixtures). Note that you will first need to run the Django models to schema migrations detailed in the [Handbook Initial Setup](https://mitodl.github.io/handbook/how-to/common-web-app-guide.html#3-create-database-tables-from-the-django-models) step.
 
 ```bash
 docker compose run --rm web python manage.py loaddata platforms departments offered_by
+```
+
+To populate course catalog data (courses, videos, podcasts, programs), run the custom [django-admin](https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/) command scripts in [learning_resources/management/commands](learning_resources/management/commands), e.g.
+
+```bash
+docker compose run --rm web python manage.py backpopulate_xpro_data
+```
+
+These run the respective [ETL scripts](learning_resources/etl) (see filenames for commands) and will need S3 bucket access credentials and the following `.env` settings, depending on the source catalog:
+
+```env
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_STORAGE_BUCKET_NAME=
+MICROMASTERS_CATALOG_API_URL=
+OCW_BASE_URL=
+OCW_LIVE_BUCKET=
+PROLEARN_CATALOG_API_URL=
+XPRO_CATALOG_API_URL=
+XPRO_COURSES_API_URL=
+XPRO_LEARNING_COURSE_BUCKET_NAME=
 ```
 
 # Committing & Formatting

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This application provides a central interface from which learners can browse MIT
 1. [Committing & Formatting](#committing-&-formatting)
 1. [Optional Setup](#optional-setup)
 
-# Initial Setup
+## Initial Setup
 
 MIT Open follows the same [initial setup steps outlined in the common OL web app guide](https://mitodl.github.io/handbook/how-to/common-web-app-guide.html).
 Run through those steps **including the addition of `/etc/hosts` aliases and the optional step for running the
@@ -35,15 +35,7 @@ The following settings must be configured before running the app:
   Sets the hostname required by webpack for building the frontend. Should likely be whatever you set
   the host to in your /etc/hosts or the hostname that you're accessing it from. Likely `od.odl.local`.
 
-# Code Generation
-
-MIT Open uses [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/) to generate and OpenAPI spec from Django views. Additionally, we use [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate Typescript declarations and an API Client. These generated files are checked into source control; CI checks that they are up-to-date. To regenerate these files, run
-
-```bash
-./scripts/generate_openapi.sh
-```
-
-### Load initial data
+### Loading Data
 
 Run the following to load platforms, departments, and offers. This populates the database with the fixture files contained in [learning_resources/fixtures](learning_resources/fixtures). Note that you will first need to run the Django models to schema migrations detailed in the [Handbook Initial Setup](https://mitodl.github.io/handbook/how-to/common-web-app-guide.html#3-create-database-tables-from-the-django-models) step.
 
@@ -51,28 +43,32 @@ Run the following to load platforms, departments, and offers. This populates the
 docker compose run --rm web python manage.py loaddata platforms departments offered_by
 ```
 
-To populate course catalog data (courses, videos, podcasts, programs), run the custom [django-admin](https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/) command scripts in [learning_resources/management/commands](learning_resources/management/commands), e.g.
+The MIT Open platform aggregates data from many sources. These data are populated by ETL (extract, transform, load) pipelines that run automatically on a regular schedule. Django [management commands](https://docs.djangoproject.com/en/4.2/howto/custom-management-commands/) are also available to force the pipelines to run—particularly useful for local development.
+
+To load data from [xpro](https://github.com/mitodl/mitxpro), for example, ensure you have the relevant environment variables
+
+```
+XPRO_CATALOG_API_URL
+XPRO_COURSES_API_URL
+```
+
+and run
 
 ```bash
 docker compose run --rm web python manage.py backpopulate_xpro_data
 ```
 
-These run the respective [ETL scripts](learning_resources/etl) (see filenames for commands) and will need S3 bucket access credentials and the following `.env` settings, depending on the source catalog:
+See [learning_resources/management/commands](learning_resources/management/commands) and [open_discussions/settings_course_etl.py](open_discussions/settings_course_etl.py) for more ETL commands and their relevant environment variables.
 
-```env
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-AWS_STORAGE_BUCKET_NAME=
-MICROMASTERS_CATALOG_API_URL=
-OCW_BASE_URL=
-OCW_LIVE_BUCKET=
-PROLEARN_CATALOG_API_URL=
-XPRO_CATALOG_API_URL=
-XPRO_COURSES_API_URL=
-XPRO_LEARNING_COURSE_BUCKET_NAME=
+## Code Generation
+
+MIT Open uses [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/) to generate and OpenAPI spec from Django views. Additionally, we use [OpenAPITools/openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate Typescript declarations and an API Client. These generated files are checked into source control; CI checks that they are up-to-date. To regenerate these files, run
+
+```bash
+./scripts/generate_openapi.sh
 ```
 
-# Committing & Formatting
+## Committing & Formatting
 
 To ensure commits to GitHub are safe, first install [pre-commit](https://pre-commit.com/):
 
@@ -94,7 +90,7 @@ git config --global init.templateDir ~/.git-template
 pre-commit init-templatedir ~/.git-template
 ```
 
-# Optional Setup
+## Optional Setup
 
 Described below are some setup steps that are not strictly necessary
 for running MIT Open
@@ -133,20 +129,18 @@ broken images unless you configure your app to upload to S3. Steps:
 
 To enable searching the course catalog on opensearch, run through these steps:
 
-1. Start the services with `docker-compose up`
+1. Start the services with `docker compose up`
 2. With the above running, run this management command, which kicks off a celery task, to create an opensearch index:
    ```
-   docker-compose  run web python manage.py recreate_index --all
+   docker compose  run web python manage.py recreate_index --all
    ```
    If there is an error running the above command, observe what traceback gets logged in the celery service.
-3. Once created and with `docker-compose up` running, hit this endpoint in your browser to see if the index exists: `http://localhost:9101/discussions_local_all_default/_search`
+3. Once created and with `docker compose up` running, hit this endpoint in your browser to see if the index exists: `http://localhost:9101/discussions_local_all_default/_search`
 4. If yes, to run a specific query, make a `POST` request (using `curl`, [Postman](https://www.getpostman.com/downloads/), Python `requests`, etc.) to the above endpoint with a `json` payload. For example, to search for all courses, run a query with Content-Type as `application/json` and with a body `{"query":{"term":{"object_type":"course"}}}`
 
 ### Running the app in a notebook
 
-This repo includes a config for running a [Jupyter notebook](https://jupyter.org/) in a
-Docker container. This enables you to do in a Jupyter notebook anything you might
-otherwise do in a Django shell. To get started:
+This repo includes a config for running a [Jupyter notebook](https://jupyter.org/) in a Docker container. This enables you to do in a Jupyter notebook anything you might otherwise do in a Django shell. To get started:
 
 - Copy the example file
   ```bash
@@ -155,32 +149,18 @@ otherwise do in a Django shell. To get started:
   ```
 - Build the `notebook` container _(for first time use, or when requirements change)_
   ```bash
-  docker-compose -f docker-compose-notebook.yml build
+  docker compose -f docker-compose-notebook.yml build
   ```
-- Run all the standard containers (`docker-compose up`)
+- Run all the standard containers (`docker compose up`)
 - In another terminal window, run the `notebook` container
   ```bash
-  docker-compose -f docker-compose-notebook.yml run --rm --service-ports notebook
+  docker compose -f docker-compose-notebook.yml run --rm --service-ports notebook
   ```
-- Visit the running notebook server in your browser. The `notebook` container log output will
-  indicate the URL and `token` param with some output that looks like this:
-  ```
-  notebook_1  |     To access the notebook, open this file in a browser:
-  notebook_1  |         file:///home/mitodl/.local/share/jupyter/runtime/nbserver-8-open.html
-  notebook_1  |     Or copy and paste one of these URLs:
-  notebook_1  |         http://(2c19429d04d0 or 127.0.0.1):8080/?token=2566e5cbcd723e47bdb1b058398d6bb9fbf7a31397e752ea
-  ```
-  Here is a one-line command that will produce a browser-ready URL from that output. Run this in a separate terminal:
-  ```bash
-  APP_HOST="open.ol.local"; docker logs $(docker ps --format '{{.Names}}' | grep "_notebook_run_") | grep -E "http://(.*):8080[^ ]+\w" | tail -1 | sed -e 's/^[[:space:]]*//' | sed -e "s/(.*)/$APP_HOST/"
-  ```
-  OSX users can pipe that output to `xargs open` to open a browser window directly with the URL from that command.
-- Click the `.ipynb` file that you created to run the notebook
-- Execute the first block to confirm it's working properly (click inside the block
-  and press Shift+Enter)
+- The notebook container log output will indicate a URL at which you can interact with the notebook server.
+- After visiting the notebook url, click the `.ipynb` file that you created to run the notebook
+- Execute the first block to confirm it's working properly (click inside the block and press Shift+Enter)
 
-From there, you should be able to run code snippets with a live Django app just like you
-would in a Django shell.
+From there, you should be able to run code snippets with a live Django app just like you would in a Django shell.
 
 ### Connecting with an OpenID Connect provider for authentication
 

--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -1,7 +1,8 @@
 """MicroMasters ETL"""
 
-import requests
 import logging
+
+import requests
 from django.conf import settings
 
 from learning_resources.constants import LearningResourceType, OfferedBy, PlatformType
@@ -13,6 +14,7 @@ READABLE_ID_PREFIX = "micromasters-program-"
 DEDP = "/dedp/"
 
 log = logging.getLogger(__name__)
+
 
 def extract():
     """Load the MicroMasters catalog data"""

--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -1,6 +1,7 @@
 """MicroMasters ETL"""
 
 import requests
+import logging
 from django.conf import settings
 
 from learning_resources.constants import LearningResourceType, OfferedBy, PlatformType
@@ -11,6 +12,7 @@ OFFERED_BY = {"code": OfferedBy.mitx.name}
 READABLE_ID_PREFIX = "micromasters-program-"
 DEDP = "/dedp/"
 
+log = logging.getLogger(__name__)
 
 def extract():
     """Load the MicroMasters catalog data"""
@@ -20,6 +22,7 @@ def extract():
             headers={**COMMON_HEADERS},
             timeout=settings.REQUESTS_TIMEOUT,
         ).json()
+    log.warning("Missing required setting MICROMASTERS_CATALOG_API_URL")
     return []
 
 

--- a/learning_resources/etl/mit_edx.py
+++ b/learning_resources/etl/mit_edx.py
@@ -80,7 +80,7 @@ def _remap_mit_edx_topics(course):
 
 def get_open_edx_config():
     """
-    Returns the OpenEdxConfiguration for edX.
+    Return the OpenEdxConfiguration for edX.
     """
     required_settings = [
         "EDX_API_CLIENT_ID",

--- a/learning_resources/etl/mit_edx.py
+++ b/learning_resources/etl/mit_edx.py
@@ -77,10 +77,22 @@ def _remap_mit_edx_topics(course):
 
     return {**course, "topics": topics}
 
-
-# use the OpenEdx factory to create our extract and transform funcs
-extract, _transform = openedx_extract_transform_factory(
-    lambda: OpenEdxConfiguration(
+def get_open_edx_config():
+    """
+    Returns the OpenEdxConfiguration for edX.
+    """
+    required_settings = [
+        "EDX_API_CLIENT_ID",
+        "EDX_API_CLIENT_SECRET",
+        "EDX_API_ACCESS_TOKEN_URL",
+        "EDX_API_URL",
+        "EDX_BASE_URL",
+        "EDX_ALT_URL",
+    ]
+    for setting in required_settings:
+        if not getattr(settings, setting):
+            log.warning("Missing required setting %s", setting)
+    return OpenEdxConfiguration(
         settings.EDX_API_CLIENT_ID,
         settings.EDX_API_CLIENT_SECRET,
         settings.EDX_API_ACCESS_TOKEN_URL,
@@ -91,7 +103,9 @@ extract, _transform = openedx_extract_transform_factory(
         OfferedBy.mitx.name,
         ETLSource.mit_edx.name,
     )
-)
+
+# use the OpenEdx factory to create our extract and transform funcs
+extract, _transform = openedx_extract_transform_factory(get_open_edx_config)
 
 # modified transform function that filters the course list to ones that pass the _is_mit_course() predicate  # noqa: E501
 transform = compose(

--- a/learning_resources/etl/mit_edx.py
+++ b/learning_resources/etl/mit_edx.py
@@ -77,6 +77,7 @@ def _remap_mit_edx_topics(course):
 
     return {**course, "topics": topics}
 
+
 def get_open_edx_config():
     """
     Returns the OpenEdxConfiguration for edX.
@@ -103,6 +104,7 @@ def get_open_edx_config():
         OfferedBy.mitx.name,
         ETLSource.mit_edx.name,
     )
+
 
 # use the OpenEdx factory to create our extract and transform funcs
 extract, _transform = openedx_extract_transform_factory(get_open_edx_config)

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -66,6 +66,7 @@ def extract_programs():
     """Loads the MITx Online catalog data"""  # noqa: D401
     if settings.MITX_ONLINE_PROGRAMS_API_URL:
         return requests.get(settings.MITX_ONLINE_PROGRAMS_API_URL).json()  # noqa: S113
+    log.warning("Missing required setting MITX_ONLINE_PROGRAMS_API_URL")
     return []
 
 
@@ -73,6 +74,7 @@ def extract_courses():
     """Loads the MITx Online catalog data"""  # noqa: D401
     if settings.MITX_ONLINE_COURSES_API_URL:
         return requests.get(settings.MITX_ONLINE_COURSES_API_URL).json()  # noqa: S113
+    log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
     return []
 
 

--- a/learning_resources/etl/oll.py
+++ b/learning_resources/etl/oll.py
@@ -1,5 +1,6 @@
 """MITx learning_resources ETL"""
 import logging
+
 from django.conf import settings
 
 from learning_resources.constants import OfferedBy, PlatformType
@@ -10,6 +11,7 @@ from learning_resources.etl.openedx import (
 )
 
 log = logging.getLogger(__name__)
+
 
 def get_open_edx_config():
     """
@@ -37,6 +39,7 @@ def get_open_edx_config():
         OfferedBy.mitx.name,
         ETLSource.mit_edx.name,
     )
+
 
 # use the OpenEdx factory to create our extract and transform funcs
 extract, transform = openedx_extract_transform_factory(get_open_edx_config)

--- a/learning_resources/etl/oll.py
+++ b/learning_resources/etl/oll.py
@@ -1,4 +1,5 @@
 """MITx learning_resources ETL"""
+import logging
 from django.conf import settings
 
 from learning_resources.constants import OfferedBy, PlatformType
@@ -8,17 +9,34 @@ from learning_resources.etl.openedx import (
     openedx_extract_transform_factory,
 )
 
-# use the OpenEdx factory to create our extract and transform funcs
-extract, transform = openedx_extract_transform_factory(
-    lambda: OpenEdxConfiguration(
+log = logging.getLogger(__name__)
+
+def get_open_edx_config():
+    """
+    Returns the OpenEdxConfiguration for edX.
+    """
+    required_settings = [
+        "OLL_API_CLIENT_ID",
+        "OLL_API_CLIENT_SECRET",
+        "OLL_API_ACCESS_TOKEN_URL",
+        "OLL_API_URL",
+        "OLL_BASE_URL",
+        "OLL_ALT_URL",
+    ]
+    for setting in required_settings:
+        if not getattr(settings, setting):
+            log.warning("Missing required setting %s", setting)
+    return OpenEdxConfiguration(
         settings.OLL_API_CLIENT_ID,
         settings.OLL_API_CLIENT_SECRET,
         settings.OLL_API_ACCESS_TOKEN_URL,
         settings.OLL_API_URL,
         settings.OLL_BASE_URL,
         settings.OLL_ALT_URL,
-        PlatformType.oll.name,
+        PlatformType.edx.name,
         OfferedBy.mitx.name,
-        ETLSource.oll.name,
+        ETLSource.mit_edx.name,
     )
-)
+
+# use the OpenEdx factory to create our extract and transform funcs
+extract, transform = openedx_extract_transform_factory(get_open_edx_config)

--- a/learning_resources/etl/oll.py
+++ b/learning_resources/etl/oll.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 def get_open_edx_config():
     """
-    Returns the OpenEdxConfiguration for edX.
+    Return the OpenEdxConfiguration for edX.
     """
     required_settings = [
         "OLL_API_CLIENT_ID",

--- a/learning_resources/etl/oll.py
+++ b/learning_resources/etl/oll.py
@@ -35,9 +35,9 @@ def get_open_edx_config():
         settings.OLL_API_URL,
         settings.OLL_BASE_URL,
         settings.OLL_ALT_URL,
-        PlatformType.edx.name,
+        PlatformType.oll.name,
         OfferedBy.mitx.name,
-        ETLSource.mit_edx.name,
+        ETLSource.oll.name,
     )
 
 

--- a/learning_resources/etl/prolearn.py
+++ b/learning_resources/etl/prolearn.py
@@ -182,6 +182,7 @@ def extract_data(course_or_program: str) -> list[dict]:
             ),
         ).json()
         return response["data"]["searchAPISearch"]["documents"]
+    log.warning("Missing required setting PROLEARN_CATALOG_API_URL")
     return []
 
 

--- a/learning_resources/etl/xpro.py
+++ b/learning_resources/etl/xpro.py
@@ -43,6 +43,7 @@ def extract_programs():
     """Loads the xPro catalog data"""  # noqa: D401
     if settings.XPRO_CATALOG_API_URL:
         return requests.get(settings.XPRO_CATALOG_API_URL, timeout=20).json()
+    log.warning("Missing required setting XPRO_CATALOG_API_URL")
     return []
 
 
@@ -50,6 +51,7 @@ def extract_courses():
     """Loads the xPro catalog data"""  # noqa: D401
     if settings.XPRO_COURSES_API_URL:
         return requests.get(settings.XPRO_COURSES_API_URL, timeout=20).json()
+    log.warning("Missing required setting XPRO_COURSES_API_URL")
     return []
 
 

--- a/learning_resources/management/commands/backpopulate_micromasters_data.py
+++ b/learning_resources/management/commands/backpopulate_micromasters_data.py
@@ -39,10 +39,13 @@ class Command(BaseCommand):
             self.stdout.write(f"Started task {task} to get micromasters course data")
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 "Population of micromasters data finished, took {} seconds".format(
                     total_seconds
                 )
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_mit_edx_data.py
+++ b/learning_resources/management/commands/backpopulate_mit_edx_data.py
@@ -38,8 +38,11 @@ class Command(BaseCommand):
             self.stdout.write(f"Started task {task} to get MIT edX course data")
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 f"Population of MIT edX data finished, took {total_seconds} seconds"
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_mitxonline_data.py
+++ b/learning_resources/management/commands/backpopulate_mitxonline_data.py
@@ -38,8 +38,11 @@ class Command(BaseCommand):
             self.stdout.write(f"Started task {task} to get MITx Online course data")
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 f"Population of MITX Online data finished, took {total_seconds} seconds"
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_ocw_data.py
+++ b/learning_resources/management/commands/backpopulate_ocw_data.py
@@ -73,5 +73,5 @@ class Command(BaseCommand):
             task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
-                f"Population of ocw data finished, took {total_seconds} seconds"
+                f"Population of ocw data finished, took {total_seconds} seconds. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_ocw_data.py
+++ b/learning_resources/management/commands/backpopulate_ocw_data.py
@@ -73,5 +73,6 @@ class Command(BaseCommand):
             task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
-                f"Population of ocw data finished, took {total_seconds} seconds. See celery logs for details."
+                f"Population of ocw data finished, took {total_seconds} seconds."
             )
+            self.stdout.write("See celery logs for details.")

--- a/learning_resources/management/commands/backpopulate_oll_data.py
+++ b/learning_resources/management/commands/backpopulate_oll_data.py
@@ -38,8 +38,11 @@ class Command(BaseCommand):
             self.stdout.write(f"Started task {task} to get oll course data")
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 f"Population of oll data finished, took {total_seconds} seconds"
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_prolearn_data.py
+++ b/learning_resources/management/commands/backpopulate_prolearn_data.py
@@ -40,8 +40,11 @@ class Command(BaseCommand):
             )
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 f"Population of prolearn data finished, took {total_seconds} seconds"
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/management/commands/backpopulate_xpro_data.py
+++ b/learning_resources/management/commands/backpopulate_xpro_data.py
@@ -51,8 +51,11 @@ class Command(BaseCommand):
             self.stdout.write(f"Started task {task} to get xpro course data")
             self.stdout.write("Waiting on task...")
             start = now_in_utc()
-            task.get()
+            count = task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(
                 f"Population of xpro data finished, took {total_seconds} seconds"
+            )
+            self.stdout.write(
+                f"Populated {count} resources. See celery logs for details."
             )

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -30,26 +30,30 @@ log = logging.getLogger(__name__)
 @app.task
 def get_micromasters_data():
     """Execute the MicroMasters ETL pipeline"""
-    pipelines.micromasters_etl()
+    programs = pipelines.micromasters_etl()
+    return len(programs)
 
 
 @app.task
-def get_mit_edx_data():
+def get_mit_edx_data() -> int:
     """Task to sync MIT edX data with the database"""
-    pipelines.mit_edx_etl()
+    courses = pipelines.mit_edx_etl()
+    return len(courses)
 
 
 @app.task
-def get_mitxonline_data():
+def get_mitxonline_data() -> int:
     """Execute the MITX Online ETL pipeline"""
-    pipelines.mitxonline_courses_etl()
-    pipelines.mitxonline_programs_etl()
+    courses = pipelines.mitxonline_courses_etl()
+    programs = pipelines.mitxonline_programs_etl()
+    return len(courses + programs)
 
 
 @app.task
 def get_oll_data():
     """Execute the OLL ETL pipeline"""
-    pipelines.oll_etl()
+    courses = pipelines.oll_etl()
+    return len(courses)
 
 
 @app.task
@@ -63,8 +67,9 @@ def get_prolearn_data():
 @app.task
 def get_xpro_data():
     """Execute the xPro ETL pipeline"""
-    pipelines.xpro_courses_etl()
-    pipelines.xpro_programs_etl()
+    courses = pipelines.xpro_courses_etl()
+    programs = pipelines.xpro_programs_etl()
+    return len(courses + programs)
 
 
 @app.task


### PR DESCRIPTION
# What are the relevant tickets?
Closes #175 

# Description (What does it do?)
This PR:
- Adds more warnings for missing env vars in many of the ETL pipelines. *Some had them, some didn't.*
- Adds a line similar to `"Populated {count} resources. See celery logs for details."` to most of the ETL backpopulate management commands.
- Updates the README a bit

# How can this be tested?
I have tested this by running the following management commands, with and without relevant environment variables, which you can find in `open_discussions/settings_course_etl.py`.
```
docker compose exec web ./manage.py backpopulate_micromasters_data
docker compose exec web ./manage.py backpopulate_mit_edx_data
docker compose exec web ./manage.py backpopulate_mitxonline_data
docker compose exec web ./manage.py backpopulate_ocw_data
docker compose exec web ./manage.py backpopulate_oll_data
docker compose exec web ./manage.py backpopulate_prolearn_data
docker compose exec web ./manage.py backpopulate_xpro_data
```