### PR TITLE
Removed call to manage.py createcachetables in the release process.

### DIFF
--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -10,5 +10,6 @@ MANAGE_FILE=$(find . -maxdepth 3 -type f -name 'manage.py' | head -1)
 # trim "./" from the path
 MANAGE_FILE=${MANAGE_FILE:2}
 
-echo "-----> Generating cache tables"
-python $MANAGE_FILE createcachetable 2>&1 | indent
+# Retaining this script in the should we require future post release actions
+# we will have a recipe set to go.
+echo "----> NOOP"

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -22,6 +22,5 @@ fi
 
 python3 manage.py collectstatic --noinput --clear
 python3 manage.py migrate --noinput
-python3 manage.py createcachetable
 
 uwsgi uwsgi.ini --honour-stdin


### PR DESCRIPTION
# Description (What does it do?)
Removed call to manage.py createcachetable in the release process.

Should resolve issues seen with deployments in heroku. 