### PR TITLE
Upgrade python in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4
+FROM python:3.11.5
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip


### PR DESCRIPTION
# What are the relevant tickets?
Closes #192 

# Description (What does it do?)
Updates the python version in `Dockerfile` to match the version in `pyproject.toml`

# How can this be tested?
`docker compose build --no-cache web celery` should complete without errors.
The app should run fine locally
