### PR TITLE
new content file search filters

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -91,10 +91,10 @@ export interface ContentFile {
   id: number
   /**
    *
-   * @type {string}
+   * @type {number}
    * @memberof ContentFile
    */
-  run_id: string
+  run_id: number
   /**
    *
    * @type {string}
@@ -245,6 +245,24 @@ export interface ContentFile {
    * @memberof ContentFile
    */
   file_type?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFile
+   */
+  offered_by: string
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFile
+   */
+  platform: string
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFile
+   */
+  run_readable_id: string
 }
 
 /**
@@ -3589,24 +3607,62 @@ export const ContentFileSearchApiAxiosParamCreator = function (
   return {
     /**
      * View for executing searches of learning resources
-     * @param {Array<'topic' | 'content_category'>} [aggregations]
+     * @param {Array<'topic' | 'content_category' | 'platform' | 'offered_by'>} [aggregations]
      * @param {Array<string>} [content_category]
-     * @param {Array<string>} [id]
+     * @param {Array<number>} [id]
      * @param {number} [limit]
+     * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
      * @param {number} [offset]
+     * @param {Array<'edx' | 'ocw' | 'open learning library' | 'mitx online' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics' | 'whu' | 'susskind' | 'global alumni' | 'simplilearn' | 'emeritus' | 'podcast'>} [platform]
      * @param {string} [q] The search text
+     * @param {Array<number>} [resource_id]
+     * @param {Array<number>} [run_id]
      * @param {'id' | '-id' | 'resource_readable_id' | '-resource_readable_id'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     contentFileSearchRetrieve: async (
-      aggregations?: Array<"topic" | "content_category">,
+      aggregations?: Array<
+        "topic" | "content_category" | "platform" | "offered_by"
+      >,
       content_category?: Array<string>,
-      id?: Array<string>,
+      id?: Array<number>,
       limit?: number,
+      offered_by?: Array<
+        | "mitx"
+        | "ocw"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+      >,
       offset?: number,
+      platform?: Array<
+        | "edx"
+        | "ocw"
+        | "open learning library"
+        | "mitx online"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+        | "whu"
+        | "susskind"
+        | "global alumni"
+        | "simplilearn"
+        | "emeritus"
+        | "podcast"
+      >,
       q?: string,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       sortby?: "id" | "-id" | "resource_readable_id" | "-resource_readable_id",
       topic?: Array<string>,
       options: AxiosRequestConfig = {},
@@ -3645,12 +3701,28 @@ export const ContentFileSearchApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
+      if (offered_by) {
+        localVarQueryParameter["offered_by"] = offered_by
+      }
+
       if (offset !== undefined) {
         localVarQueryParameter["offset"] = offset
       }
 
+      if (platform) {
+        localVarQueryParameter["platform"] = platform
+      }
+
       if (q !== undefined) {
         localVarQueryParameter["q"] = q
+      }
+
+      if (resource_id) {
+        localVarQueryParameter["resource_id"] = resource_id
+      }
+
+      if (run_id) {
+        localVarQueryParameter["run_id"] = run_id
       }
 
       if (sortby !== undefined) {
@@ -3688,24 +3760,62 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
   return {
     /**
      * View for executing searches of learning resources
-     * @param {Array<'topic' | 'content_category'>} [aggregations]
+     * @param {Array<'topic' | 'content_category' | 'platform' | 'offered_by'>} [aggregations]
      * @param {Array<string>} [content_category]
-     * @param {Array<string>} [id]
+     * @param {Array<number>} [id]
      * @param {number} [limit]
+     * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
      * @param {number} [offset]
+     * @param {Array<'edx' | 'ocw' | 'open learning library' | 'mitx online' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics' | 'whu' | 'susskind' | 'global alumni' | 'simplilearn' | 'emeritus' | 'podcast'>} [platform]
      * @param {string} [q] The search text
+     * @param {Array<number>} [resource_id]
+     * @param {Array<number>} [run_id]
      * @param {'id' | '-id' | 'resource_readable_id' | '-resource_readable_id'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async contentFileSearchRetrieve(
-      aggregations?: Array<"topic" | "content_category">,
+      aggregations?: Array<
+        "topic" | "content_category" | "platform" | "offered_by"
+      >,
       content_category?: Array<string>,
-      id?: Array<string>,
+      id?: Array<number>,
       limit?: number,
+      offered_by?: Array<
+        | "mitx"
+        | "ocw"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+      >,
       offset?: number,
+      platform?: Array<
+        | "edx"
+        | "ocw"
+        | "open learning library"
+        | "mitx online"
+        | "bootcamps"
+        | "xpro"
+        | "csail"
+        | "professional education"
+        | "sloan executive education"
+        | "schwarzman college of computing"
+        | "center for transportation & logistics"
+        | "whu"
+        | "susskind"
+        | "global alumni"
+        | "simplilearn"
+        | "emeritus"
+        | "podcast"
+      >,
       q?: string,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       sortby?: "id" | "-id" | "resource_readable_id" | "-resource_readable_id",
       topic?: Array<string>,
       options?: AxiosRequestConfig,
@@ -3718,8 +3828,12 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
           content_category,
           id,
           limit,
+          offered_by,
           offset,
+          platform,
           q,
+          resource_id,
+          run_id,
           sortby,
           topic,
           options,
@@ -3761,8 +3875,12 @@ export const ContentFileSearchApiFactory = function (
           requestParameters.content_category,
           requestParameters.id,
           requestParameters.limit,
+          requestParameters.offered_by,
           requestParameters.offset,
+          requestParameters.platform,
           requestParameters.q,
+          requestParameters.resource_id,
+          requestParameters.run_id,
           requestParameters.sortby,
           requestParameters.topic,
           options,
@@ -3780,10 +3898,12 @@ export const ContentFileSearchApiFactory = function (
 export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
   /**
    *
-   * @type {Array<'topic' | 'content_category'>}
+   * @type {Array<'topic' | 'content_category' | 'platform' | 'offered_by'>}
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
-  readonly aggregations?: Array<"topic" | "content_category">
+  readonly aggregations?: Array<
+    "topic" | "content_category" | "platform" | "offered_by"
+  >
 
   /**
    *
@@ -3794,10 +3914,10 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
 
   /**
    *
-   * @type {Array<string>}
+   * @type {Array<number>}
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
-  readonly id?: Array<string>
+  readonly id?: Array<number>
 
   /**
    *
@@ -3808,10 +3928,52 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
 
   /**
    *
+   * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly offered_by?: Array<
+    | "mitx"
+    | "ocw"
+    | "bootcamps"
+    | "xpro"
+    | "csail"
+    | "professional education"
+    | "sloan executive education"
+    | "schwarzman college of computing"
+    | "center for transportation & logistics"
+  >
+
+  /**
+   *
    * @type {number}
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
   readonly offset?: number
+
+  /**
+   *
+   * @type {Array<'edx' | 'ocw' | 'open learning library' | 'mitx online' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics' | 'whu' | 'susskind' | 'global alumni' | 'simplilearn' | 'emeritus' | 'podcast'>}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly platform?: Array<
+    | "edx"
+    | "ocw"
+    | "open learning library"
+    | "mitx online"
+    | "bootcamps"
+    | "xpro"
+    | "csail"
+    | "professional education"
+    | "sloan executive education"
+    | "schwarzman college of computing"
+    | "center for transportation & logistics"
+    | "whu"
+    | "susskind"
+    | "global alumni"
+    | "simplilearn"
+    | "emeritus"
+    | "podcast"
+  >
 
   /**
    * The search text
@@ -3819,6 +3981,20 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
   readonly q?: string
+
+  /**
+   *
+   * @type {Array<number>}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly resource_id?: Array<number>
+
+  /**
+   *
+   * @type {Array<number>}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly run_id?: Array<number>
 
   /**
    * if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
@@ -3863,8 +4039,12 @@ export class ContentFileSearchApi extends BaseAPI {
         requestParameters.content_category,
         requestParameters.id,
         requestParameters.limit,
+        requestParameters.offered_by,
         requestParameters.offset,
+        requestParameters.platform,
         requestParameters.q,
+        requestParameters.resource_id,
+        requestParameters.run_id,
         requestParameters.sortby,
         requestParameters.topic,
         options,
@@ -9592,7 +9772,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
      * @param {Array<string>} [certification]
      * @param {Array<string>} [department]
-     * @param {Array<string>} [id]
+     * @param {Array<number>} [id]
      * @param {Array<string>} [level]
      * @param {number} [limit]
      * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
@@ -9621,7 +9801,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       >,
       certification?: Array<string>,
       department?: Array<string>,
-      id?: Array<string>,
+      id?: Array<number>,
       level?: Array<string>,
       limit?: number,
       offered_by?: Array<
@@ -9785,7 +9965,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<'resource_type' | 'certification' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'resource_content_tags' | 'professional'>} [aggregations]
      * @param {Array<string>} [certification]
      * @param {Array<string>} [department]
-     * @param {Array<string>} [id]
+     * @param {Array<number>} [id]
      * @param {Array<string>} [level]
      * @param {number} [limit]
      * @param {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'csail' | 'professional education' | 'sloan executive education' | 'schwarzman college of computing' | 'center for transportation & logistics'>} [offered_by]
@@ -9814,7 +9994,7 @@ export const LearningResourcesSearchApiFp = function (
       >,
       certification?: Array<string>,
       department?: Array<string>,
-      id?: Array<string>,
+      id?: Array<number>,
       level?: Array<string>,
       limit?: number,
       offered_by?: Array<
@@ -9983,10 +10163,10 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
 
   /**
    *
-   * @type {Array<string>}
+   * @type {Array<number>}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
-  readonly id?: Array<string>
+  readonly id?: Array<number>
 
   /**
    *

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -463,7 +463,8 @@ class ContentFileSerializer(serializers.ModelSerializer):
     Serializer class for course run ContentFiles
     """
 
-    run_id = serializers.CharField(source="run.run_id")
+    run_id = serializers.IntegerField(source="run.id")
+    run_readable_id = serializers.CharField(source="run.run_id")
     run_title = serializers.CharField(source="run.title")
     run_slug = serializers.CharField(source="run.slug")
     semester = serializers.CharField(source="run.semester")
@@ -480,6 +481,8 @@ class ContentFileSerializer(serializers.ModelSerializer):
         source="run.learning_resource.resource_num"
     )
     content_category = serializers.SerializerMethodField()
+    offered_by = LearningResourceOfferorField(source="run.learning_resource.offered_by")
+    platform = serializers.CharField(source="run.learning_resource.platform.platform")
 
     def get_content_category(self, instance):  # noqa: ARG002
         """
@@ -518,6 +521,9 @@ class ContentFileSerializer(serializers.ModelSerializer):
             "resource_readable_id",
             "resource_readable_num",
             "file_type",
+            "offered_by",
+            "platform",
+            "run_readable_id",
         ]
 
 

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -202,7 +202,10 @@ def test_content_file_serializer():
         serialized,
         {
             "id": content_file.id,
-            "run_id": content_file.run.run_id,
+            "run_id": content_file.run.id,
+            "run_readable_id": content_file.run.run_id,
+            "platform": content_file.run.learning_resource.platform.platform,
+            "offered_by": content_file.run.learning_resource.offered_by.name,
             "run_title": content_file.run.title,
             "run_slug": content_file.run.slug,
             "departments": [

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -314,7 +314,7 @@ def generate_filter_clauses(search_params):
                 else:
                     filter_term = {"term": {search_filter: {"value": option}}}
 
-                    if search_filter != "id":
+                    if not search_filter.endswith("id"):
                         filter_term["term"][search_filter]["case_insensitive"] = True
 
                     filter_clauses_for_filter.append(filter_term)

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -52,7 +52,9 @@ LEARNING_RESOURCE_SEARCH_FILTERS = [
     "platform",
     "professional",
     "id",
-    "course",
+    "content_category",
+    "run_id",
+    "resource_id",
 ]
 
 SEARCH_NESTED_FILTERS = {
@@ -166,7 +168,8 @@ LEARNING_RESOURCE_MAP = {
 
 CONTENT_FILE_MAP = {
     "id": {"type": "long"},
-    "run_id": {"type": "keyword"},
+    "run_id": {"type": "long"},
+    "run_readble_id": {"type": "keyword"},
     "run_title": ENGLISH_TEXT_FIELD,
     "run_slug": {"type": "keyword"},
     "departments": {
@@ -198,6 +201,8 @@ CONTENT_FILE_MAP = {
     "resource_readable_id": {"type": "keyword"},
     "resource_readable_num": {"type": "keyword"},
     "resource_type": {"type": "keyword"},
+    "offered_by": {"type": "keyword"},
+    "platform": {"type": "keyword"},
 }
 
 

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -193,6 +193,7 @@ def test_learning_resources_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
+        "id": "1",
         "sortby": "-start_date",
         "professional": "true",
         "certification": "Certificates",
@@ -210,6 +211,7 @@ def test_learning_resources_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
+        "id": [1],
         "sortby": "-start_date",
         "resource_type": ["course", "program"],
         "professional": ["true"],
@@ -236,10 +238,15 @@ def test_content_file_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
+        "id": "1",
         "sortby": "-id",
         "topic": "Math",
         "aggregations": "topic",
         "content_category": "Assignment",
+        "run_id": "1,2",
+        "resource_id": "1,2,3",
+        "offered_by": "xpro,ocw",
+        "platform": "xpro,edx,ocw",
         "extra_field": "ignored",
     }
 
@@ -247,11 +254,16 @@ def test_content_file_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
+        "id": [1],
         "sortby": "-id",
         "resource_type": ["content_file"],
         "topic": ["Math"],
         "aggregations": ["topic"],
         "content_category": ["Assignment"],
+        "run_id": [1, 2],
+        "resource_id": [1, 2, 3],
+        "offered_by": ["xpro", "ocw"],
+        "platform": ["xpro", "edx", "ocw"],
     }
 
     request_data = QueryDict("", mutable=True)
@@ -281,9 +293,9 @@ def test_learning_resources_search_request_serializer_invalid(parameter, value):
 
     serialized = LearningResourcesSearchRequestSerializer(data=request_data)
     assert serialized.is_valid() is False
-    assert JSONRenderer().render(serialized.errors) == JSONRenderer().render(
-        {parameter: ["spaceship is not a valid option"]}
-    )
+    assert list(serialized.errors[parameter].values()) == [
+        ['"spaceship" is not a valid choice.']
+    ]
 
 
 def test_learning_resources_search_response_serializer(settings):

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -1,6 +1,7 @@
 """View for search"""
 
 import logging
+from itertools import chain
 
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema, extend_schema_view
@@ -55,7 +56,12 @@ class LearningResourcesSearchView(ESView):
             response = execute_learn_search(request_data.data)
             return Response(SearchResponseSerializer(response).data)
         else:
-            return Response(request_data.errors, status=400)
+            errors = {}
+
+            for key, errors_dict in request_data.errors.items():
+                errors[key] = list(set(chain(*errors_dict.values())))
+
+            return Response(errors, status=400)
 
 
 @method_decorator(blocked_ip_exempt, name="dispatch")
@@ -80,4 +86,9 @@ class ContentFileSearchView(ESView):
             response = execute_learn_search(request_data.data)
             return Response(SearchResponseSerializer(response).data)
         else:
-            return Response(request_data.errors, status=400)
+            errors = {}
+
+            for key, errors_dict in request_data.errors.items():
+                errors[key] = list(set(chain(*errors_dict.values())))
+
+            return Response(errors, status=400)

--- a/learning_resources_search/views_test.py
+++ b/learning_resources_search/views_test.py
@@ -66,7 +66,7 @@ def test_learn_resources_search(mocker, client, learning_resources_search_view):
         autospec=True,
         return_value=FAKE_SEARCH_RESPONSE,
     )
-    params = {"resource_type": "course"}
+    params = {"resource_type": ["course"]}
     resp = client.get(learning_resources_search_view.url, params)
     search_mock.assert_called_once_with(
         LearningResourcesSearchRequestSerializer(params).data
@@ -89,7 +89,7 @@ def test_learn_search_with_invalid_params(
     resp = client.get(learning_resources_search_view.url, params)
     search_mock.assert_not_called()
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
-        {"resource_type": ["book is not a valid option"]}
+        {"resource_type": ['"book" is not a valid choice.']}
     )
 
 
@@ -121,5 +121,5 @@ def test_content_file_search_with_invalid_params(
     resp = client.get(content_file_search_view.url, params)
     search_mock.assert_not_called()
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
-        {"aggregations": ["invalid is not a valid option"]}
+        {"aggregations": ['"invalid" is not a valid choice.']}
     )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -175,10 +175,14 @@ paths:
             enum:
             - topic
             - content_category
+            - platform
+            - offered_by
             type: string
             description: |-
               * `topic` - topic
               * `content_category` - content_category
+              * `platform` - platform
+              * `offered_by` - offered_by
       - in: query
         name: content_category
         schema:
@@ -191,22 +195,101 @@ paths:
         schema:
           type: array
           items:
-            type: string
-            minLength: 1
+            type: integer
       - in: query
         name: limit
         schema:
           type: integer
       - in: query
+        name: offered_by
+        schema:
+          type: array
+          items:
+            enum:
+            - mitx
+            - ocw
+            - bootcamps
+            - xpro
+            - csail
+            - professional education
+            - sloan executive education
+            - schwarzman college of computing
+            - center for transportation & logistics
+            type: string
+            description: |-
+              * `mitx` - mitx
+              * `ocw` - ocw
+              * `bootcamps` - bootcamps
+              * `xpro` - xpro
+              * `csail` - csail
+              * `professional education` - professional education
+              * `sloan executive education` - sloan executive education
+              * `schwarzman college of computing` - schwarzman college of computing
+              * `center for transportation & logistics` - center for transportation & logistics
+      - in: query
         name: offset
         schema:
           type: integer
+      - in: query
+        name: platform
+        schema:
+          type: array
+          items:
+            enum:
+            - edx
+            - ocw
+            - open learning library
+            - mitx online
+            - bootcamps
+            - xpro
+            - csail
+            - professional education
+            - sloan executive education
+            - schwarzman college of computing
+            - center for transportation & logistics
+            - whu
+            - susskind
+            - global alumni
+            - simplilearn
+            - emeritus
+            - podcast
+            type: string
+            description: |-
+              * `edx` - edx
+              * `ocw` - ocw
+              * `open learning library` - open learning library
+              * `mitx online` - mitx online
+              * `bootcamps` - bootcamps
+              * `xpro` - xpro
+              * `csail` - csail
+              * `professional education` - professional education
+              * `sloan executive education` - sloan executive education
+              * `schwarzman college of computing` - schwarzman college of computing
+              * `center for transportation & logistics` - center for transportation & logistics
+              * `whu` - whu
+              * `susskind` - susskind
+              * `global alumni` - global alumni
+              * `simplilearn` - simplilearn
+              * `emeritus` - emeritus
+              * `podcast` - podcast
       - in: query
         name: q
         schema:
           type: string
           minLength: 1
         description: The search text
+      - in: query
+        name: resource_id
+        schema:
+          type: array
+          items:
+            type: integer
+      - in: query
+        name: run_id
+        schema:
+          type: array
+          items:
+            type: integer
       - in: query
         name: sortby
         schema:
@@ -2102,8 +2185,7 @@ paths:
         schema:
           type: array
           items:
-            type: string
-            minLength: 1
+            type: integer
       - in: query
         name: level
         schema:
@@ -2230,6 +2312,9 @@ paths:
               * `learning path` - learning path
               * `podcast` - podcast
               * `podcast episode` - podcast episode
+          default:
+          - course
+          - program
       - in: query
         name: sortby
         schema:
@@ -5658,7 +5743,7 @@ components:
           type: integer
           readOnly: true
         run_id:
-          type: string
+          type: integer
         run_title:
           type: string
         run_slug:
@@ -5739,14 +5824,23 @@ components:
           type: string
           nullable: true
           maxLength: 128
+        offered_by:
+          type: string
+        platform:
+          type: string
+        run_readable_id:
+          type: string
       required:
       - content_category
       - departments
       - id
+      - offered_by
+      - platform
       - resource_id
       - resource_readable_id
       - resource_readable_num
       - run_id
+      - run_readable_id
       - run_slug
       - run_title
       - semester


### PR DESCRIPTION
# What are the relevant tickets?
Part of https://github.com/mitodl/mit-open/issues/199

# Description (What does it do?)
This pr adds
run_id
resource_id
platform
offered_by

As search filters for the content file search

# How to test
Recreate the index with
docker-compose run web ./manage.py recreate_index --all

Go to 
http://localhost:8063/api/v1/learning_resources_search/ 
and try out the new filters

http://localhost:8063/api/v1/content_file_search/?run_id=1017,1018
http://localhost:8063/api/v1/content_file_search/?resource_id=5383
http://localhost:8063/api/v1/content_file_search/?platform=xpro
http://localhost:8063/api/v1/content_file_search/?offered_by=ocw
