### PR TITLE
Fix bad course department numbers

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -36,6 +36,7 @@ from learning_resources.constants import (
 from learning_resources.etl.constants import CourseNumberType, ETLSource
 from learning_resources.models import (
     ContentFile,
+    Course,
     LearningResourceRun,
 )
 
@@ -566,3 +567,28 @@ def generate_course_numbers_json(
             }
         )
     return course_number_json
+
+
+def update_course_numbers_json(course: Course):
+    """
+    Update the course_numbers JSON for a Course
+
+    Args:
+        course (Course): The Course to update
+    """
+    is_ocw = course.learning_resource.etl_source == ETLSource.ocw.name
+    extra_nums = [
+        num["value"]
+        for num in course.course_numbers
+        if num["listing_type"] == CourseNumberType.cross_listed.value
+    ]
+    course.course_numbers = generate_course_numbers_json(
+        (
+            course.learning_resource.readable_id.split("+")[0]
+            if is_ocw
+            else course.learning_resource.readable_id
+        ),
+        extra_nums=extra_nums,
+        is_ocw=is_ocw,
+    )
+    course.save()

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -512,7 +512,7 @@ def extract_valid_department_from_id(
     Returns:
         department (str): parsed department string
     """  # noqa: D401
-    num_pattern = r"^(\d+)\.*" if is_ocw else r"\+([^\.]*)\."
+    num_pattern = r"^([0-9A-Za-z\-]+)\.*" if is_ocw else r"\+([^\.]*)\."
     department_string = re.search(num_pattern, course_string)
     if department_string:
         dept_candidate = department_string.groups()[0]

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -305,14 +305,21 @@ def test_get_learning_course_bucket(
     )
 
 
-def test_extract_valid_department_from_id():
+@pytest.mark.parametrize(
+    ("readable_id", "is_ocw", "dept_ids"),
+    [
+        ("MITx+7.03.2x", False, ["7"]),
+        ("course-v1:MITxT+21A.819.2x", False, ["21A"]),
+        ("11.343", True, ["11"]),
+        ("21W.202", True, ["CMS-W"]),
+        ("21H.331", True, ["21H"]),
+        ("course-v1:MITxT+123.658.2x", False, []),
+        ("MITx+CITE101x", False, []),
+        ("RanD0mStr1ng", False, []),
+    ],
+)
+def test_extract_valid_department_from_id(readable_id, is_ocw, dept_ids):
     """Test that correct department is extracted from ID"""
-    assert utils.extract_valid_department_from_id("MITx+7.03.2x") == ["7"]
-    assert utils.extract_valid_department_from_id("course-v1:MITxT+21A.819.2x") == [
-        "21A"
-    ]
-    # Has a department not in the list and thus should not be entered
-    assert utils.extract_valid_department_from_id("course-v1:MITxT+123.658.2x") == []
-    # Has no discernible department
-    assert utils.extract_valid_department_from_id("MITx+CITE101x") == []
-    assert utils.extract_valid_department_from_id("RanD0mStr1ng") == []
+    assert (
+        utils.extract_valid_department_from_id(readable_id, is_ocw=is_ocw) == dept_ids
+    )

--- a/learning_resources/management/commands/update_course_number_departments.py
+++ b/learning_resources/management/commands/update_course_number_departments.py
@@ -1,0 +1,25 @@
+"""Management command for updating course.course_numbers JSON"""
+
+from django.core.management import BaseCommand
+
+from learning_resources.etl.utils import update_course_numbers_json
+from learning_resources.models import Course
+from open_discussions.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Update course.course_numbers JSON"""
+
+    help = "Update course.course_numbers JSON"  # noqa: A003
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Update LearningResourceDepartment data"""
+
+        self.stdout.write("Updating course.course_numbers JSON data for courses")
+        start = now_in_utc()
+        for course in Course.objects.select_related("learning_resource").iterator():
+            update_course_numbers_json(course)
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            f"Update of course.course_numbers finished, took {total_seconds} seconds"
+        )

--- a/learning_resources/migrations/0025_update_course_number_depts.py
+++ b/learning_resources/migrations/0025_update_course_number_depts.py
@@ -1,0 +1,42 @@
+# Generated on 2023-11-13 15:06
+
+from django.db import migrations
+
+from learning_resources.etl.constants import CourseNumberType, ETLSource
+from learning_resources.etl.utils import generate_course_numbers_json
+
+
+def set_course_number_departments(apps, schema_editor):
+    """
+    Update course_number departments for every course
+    """
+    Course = apps.get_model("learning_resources", "Course")
+    for course in Course.objects.select_related("learning_resource").iterator():
+        is_ocw = course.learning_resource.etl_source == ETLSource.ocw.name
+        extra_nums = [
+            num["value"]
+            for num in course.course_numbers
+            if num["listing_type"] == CourseNumberType.cross_listed.value
+        ]
+        course.course_numbers = generate_course_numbers_json(
+            (
+                course.learning_resource.readable_id.split("+")[0]
+                if is_ocw
+                else course.learning_resource.readable_id
+            ),
+            extra_nums=extra_nums,
+            is_ocw=is_ocw,
+        )
+        course.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0024_remove_course_extra_course_numbers"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_course_number_departments, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/learning_resources/migrations/0025_update_course_number_depts.py
+++ b/learning_resources/migrations/0025_update_course_number_depts.py
@@ -2,8 +2,7 @@
 
 from django.db import migrations
 
-from learning_resources.etl.constants import CourseNumberType, ETLSource
-from learning_resources.etl.utils import generate_course_numbers_json
+from learning_resources.etl.utils import update_course_numbers_json
 
 
 def set_course_number_departments(apps, schema_editor):
@@ -12,22 +11,7 @@ def set_course_number_departments(apps, schema_editor):
     """
     Course = apps.get_model("learning_resources", "Course")
     for course in Course.objects.select_related("learning_resource").iterator():
-        is_ocw = course.learning_resource.etl_source == ETLSource.ocw.name
-        extra_nums = [
-            num["value"]
-            for num in course.course_numbers
-            if num["listing_type"] == CourseNumberType.cross_listed.value
-        ]
-        course.course_numbers = generate_course_numbers_json(
-            (
-                course.learning_resource.readable_id.split("+")[0]
-                if is_ocw
-                else course.learning_resource.readable_id
-            ),
-            extra_nums=extra_nums,
-            is_ocw=is_ocw,
-        )
-        course.save()
+        update_course_numbers_json(course)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
# What are the relevant tickets?
Closes #212 

# Description (What does it do?)
Fixes the `learning_resources.etl.utils.extract_valid_department_from_id` function and adds a migration to fix existing course number departments.

# How can this be tested?
- On main branch, run:
```
./manage.py backpopulate_ocw_data --course-name 21h-104j-riots-strikes-and-conspiracies-in-american-history-fall-2010
```
- Go to http://localhost:8063/api/v1/courses/?department=21H, that course (and some other courses in dept 21H you may have) will have a `course.course_numbers` field with `null` department values.
- Switch to this branch and restart containers.
- Go to http://localhost:8063/api/v1/courses/?department=21H again, the departments should no longer be null.  `{"department_id": "21H", "name": "History"}`
- Import some other 21H courses from OCW, they should also have correct departments assigned under `course.course_numbers`

