### PR TITLE
Change default ordering parameter to "sortby", add options documentation to learning_resources endpoint

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -4611,10 +4611,10 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4669,7 +4669,6 @@ export const CoursesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -4695,6 +4694,17 @@ export const CoursesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/`
@@ -4731,10 +4741,6 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -4745,6 +4751,10 @@ export const CoursesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -4768,10 +4778,10 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4826,7 +4836,6 @@ export const CoursesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -4852,6 +4861,17 @@ export const CoursesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/new/`
@@ -4888,10 +4908,6 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -4902,6 +4918,10 @@ export const CoursesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -4973,10 +4993,10 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5031,7 +5051,6 @@ export const CoursesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -5057,6 +5076,17 @@ export const CoursesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/upcoming/`
@@ -5093,10 +5123,6 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -5107,6 +5133,10 @@ export const CoursesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -5206,10 +5236,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5264,7 +5294,6 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -5290,6 +5319,17 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -5302,10 +5342,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -5322,10 +5362,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5380,7 +5420,6 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -5406,6 +5445,17 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -5418,10 +5468,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -5465,10 +5515,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5523,7 +5573,6 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -5549,6 +5598,17 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -5562,10 +5622,10 @@ export const CoursesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -5645,10 +5705,10 @@ export const CoursesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -5670,10 +5730,10 @@ export const CoursesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -5710,10 +5770,10 @@ export const CoursesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -5865,13 +5925,6 @@ export interface CoursesApiCoursesListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof CoursesApiCoursesList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof CoursesApiCoursesList
@@ -5913,6 +5966,23 @@ export interface CoursesApiCoursesListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof CoursesApiCoursesList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -5996,13 +6066,6 @@ export interface CoursesApiCoursesNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof CoursesApiCoursesNewList
@@ -6044,6 +6107,23 @@ export interface CoursesApiCoursesNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof CoursesApiCoursesNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -6141,13 +6221,6 @@ export interface CoursesApiCoursesUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof CoursesApiCoursesUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof CoursesApiCoursesUpcomingList
@@ -6189,6 +6262,23 @@ export interface CoursesApiCoursesUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof CoursesApiCoursesUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -6259,10 +6349,10 @@ export class CoursesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -6286,10 +6376,10 @@ export class CoursesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -6330,10 +6420,10 @@ export class CoursesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -7705,7 +7795,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7713,7 +7803,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'parent_id' is not null or undefined
@@ -7748,8 +7838,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -7827,10 +7917,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7885,7 +7975,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -7911,6 +8000,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/`
@@ -7947,10 +8047,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -7961,6 +8057,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -7984,10 +8084,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8042,7 +8142,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -8068,6 +8167,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/new/`
@@ -8104,10 +8214,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -8118,6 +8224,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -8189,10 +8299,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8247,7 +8357,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -8273,6 +8382,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/upcoming/`
@@ -8309,10 +8429,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -8323,6 +8439,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -8421,7 +8541,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8429,7 +8549,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -8442,7 +8562,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           parent_id,
           limit,
           offset,
-          ordering,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -8489,10 +8609,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8547,7 +8667,6 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -8573,6 +8692,17 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -8586,10 +8716,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -8606,10 +8736,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8664,7 +8794,6 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -8690,6 +8819,17 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -8703,10 +8843,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -8748,10 +8888,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8806,7 +8946,6 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -8832,6 +8971,17 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -8845,10 +8995,10 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -8926,7 +9076,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.parent_id,
           requestParameters.limit,
           requestParameters.offset,
-          requestParameters.ordering,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -8966,10 +9116,10 @@ export const LearningResourcesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -8991,10 +9141,10 @@ export const LearningResourcesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -9031,10 +9181,10 @@ export const LearningResourcesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -9137,7 +9287,7 @@ export interface LearningResourcesApiLearningResourcesItemsListRequest {
    * @type {string}
    * @memberof LearningResourcesApiLearningResourcesItemsList
    */
-  readonly ordering?: string
+  readonly sortby?: string
 }
 
 /**
@@ -9242,13 +9392,6 @@ export interface LearningResourcesApiLearningResourcesListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningResourcesApiLearningResourcesList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningResourcesApiLearningResourcesList
@@ -9290,6 +9433,23 @@ export interface LearningResourcesApiLearningResourcesListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningResourcesApiLearningResourcesList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -9373,13 +9533,6 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningResourcesApiLearningResourcesNewList
@@ -9421,6 +9574,23 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningResourcesApiLearningResourcesNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -9518,13 +9688,6 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningResourcesApiLearningResourcesUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
@@ -9566,6 +9729,23 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningResourcesApiLearningResourcesUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -9634,7 +9814,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.parent_id,
         requestParameters.limit,
         requestParameters.offset,
-        requestParameters.ordering,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -9678,10 +9858,10 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -9705,10 +9885,10 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -9749,10 +9929,10 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -9782,7 +9962,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {string} [q] The search text
      * @param {Array<string>} [resource_content_tags]
      * @param {Array<'course' | 'program' | 'learning path' | 'podcast' | 'podcast episode'>} [resource_type]
-     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'created_on' | '-created_on' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {Array<string>} [topic]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -9848,6 +10028,8 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         | "-readable_id"
         | "last_modified"
         | "-last_modified"
+        | "created_on"
+        | "-created_on"
         | "start_date"
         | "-start_date"
         | "mitcoursenumber"
@@ -9975,7 +10157,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {string} [q] The search text
      * @param {Array<string>} [resource_content_tags]
      * @param {Array<'course' | 'program' | 'learning path' | 'podcast' | 'podcast episode'>} [resource_type]
-     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+     * @param {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'created_on' | '-created_on' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {Array<string>} [topic]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -10041,6 +10223,8 @@ export const LearningResourcesSearchApiFp = function (
         | "-readable_id"
         | "last_modified"
         | "-last_modified"
+        | "created_on"
+        | "-created_on"
         | "start_date"
         | "-start_date"
         | "mitcoursenumber"
@@ -10262,8 +10446,8 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   >
 
   /**
-   * if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'}
+   * if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'id' | '-id' | 'readable_id' | '-readable_id' | 'last_modified' | '-last_modified' | 'created_on' | '-created_on' | 'start_date' | '-start_date' | 'mitcoursenumber' | '-mitcoursenumber'}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly sortby?:
@@ -10273,6 +10457,8 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
     | "-readable_id"
     | "last_modified"
     | "-last_modified"
+    | "created_on"
+    | "-created_on"
     | "start_date"
     | "-start_date"
     | "mitcoursenumber"
@@ -10444,10 +10630,10 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -10502,7 +10688,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -10528,6 +10713,17 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learningpaths/`
@@ -10564,10 +10760,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -10578,6 +10770,10 @@ export const LearningpathsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -10601,10 +10797,10 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -10659,7 +10855,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -10685,6 +10880,17 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learningpaths/new/`
@@ -10721,10 +10927,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -10735,6 +10937,10 @@ export const LearningpathsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -10925,7 +11131,7 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -10933,7 +11139,7 @@ export const LearningpathsApiAxiosParamCreator = function (
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'parent_id' is not null or undefined
@@ -10968,8 +11174,8 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -11223,10 +11429,10 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11281,7 +11487,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -11307,6 +11512,17 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learningpaths/upcoming/`
@@ -11343,10 +11559,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -11357,6 +11569,10 @@ export const LearningpathsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -11501,10 +11717,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11559,7 +11775,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -11585,6 +11800,17 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -11598,10 +11824,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -11618,10 +11844,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11676,7 +11902,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -11702,6 +11927,17 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -11715,10 +11951,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -11820,7 +12056,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11828,7 +12064,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -11841,7 +12077,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
           parent_id,
           limit,
           offset,
-          ordering,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -11979,10 +12215,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12037,7 +12273,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -12063,6 +12298,17 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -12076,10 +12322,10 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -12181,10 +12427,10 @@ export const LearningpathsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -12206,10 +12452,10 @@ export const LearningpathsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -12283,7 +12529,7 @@ export const LearningpathsApiFactory = function (
           requestParameters.parent_id,
           requestParameters.limit,
           requestParameters.offset,
-          requestParameters.ordering,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -12376,10 +12622,10 @@ export const LearningpathsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -12514,13 +12760,6 @@ export interface LearningpathsApiLearningpathsListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningpathsApiLearningpathsList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningpathsApiLearningpathsList
@@ -12562,6 +12801,23 @@ export interface LearningpathsApiLearningpathsListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningpathsApiLearningpathsList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -12645,13 +12901,6 @@ export interface LearningpathsApiLearningpathsNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningpathsApiLearningpathsNewList
@@ -12693,6 +12942,23 @@ export interface LearningpathsApiLearningpathsNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningpathsApiLearningpathsNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -12790,7 +13056,7 @@ export interface LearningpathsApiLearningpathsResourcesListRequest {
    * @type {string}
    * @memberof LearningpathsApiLearningpathsResourcesList
    */
-  readonly ordering?: string
+  readonly sortby?: string
 }
 
 /**
@@ -12965,13 +13231,6 @@ export interface LearningpathsApiLearningpathsUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof LearningpathsApiLearningpathsUpcomingList
@@ -13013,6 +13272,23 @@ export interface LearningpathsApiLearningpathsUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof LearningpathsApiLearningpathsUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -13096,10 +13372,10 @@ export class LearningpathsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13123,10 +13399,10 @@ export class LearningpathsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13208,7 +13484,7 @@ export class LearningpathsApi extends BaseAPI {
         requestParameters.parent_id,
         requestParameters.limit,
         requestParameters.offset,
-        requestParameters.ordering,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13311,10 +13587,10 @@ export class LearningpathsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13356,10 +13632,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13414,7 +13690,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -13440,6 +13715,17 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcast_episodes/`
@@ -13476,10 +13762,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -13490,6 +13772,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -13513,10 +13799,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13571,7 +13857,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -13597,6 +13882,17 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcast_episodes/new/`
@@ -13633,10 +13929,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -13647,6 +13939,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -13718,10 +14014,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13776,7 +14072,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -13802,6 +14097,17 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcast_episodes/upcoming/`
@@ -13838,10 +14144,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -13852,6 +14154,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -13886,10 +14192,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13944,7 +14250,6 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -13970,6 +14275,17 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -13983,10 +14299,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -14003,10 +14319,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14061,7 +14377,6 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -14087,6 +14402,17 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -14100,10 +14426,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -14145,10 +14471,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14203,7 +14529,6 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -14229,6 +14554,17 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -14242,10 +14578,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -14286,10 +14622,10 @@ export const PodcastEpisodesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -14311,10 +14647,10 @@ export const PodcastEpisodesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -14351,10 +14687,10 @@ export const PodcastEpisodesApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -14443,13 +14779,6 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastEpisodesApiPodcastEpisodesList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
@@ -14491,6 +14820,23 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastEpisodesApiPodcastEpisodesList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -14574,13 +14920,6 @@ export interface PodcastEpisodesApiPodcastEpisodesNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastEpisodesApiPodcastEpisodesNewList
@@ -14622,6 +14961,23 @@ export interface PodcastEpisodesApiPodcastEpisodesNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -14719,13 +15075,6 @@ export interface PodcastEpisodesApiPodcastEpisodesUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
@@ -14767,6 +15116,23 @@ export interface PodcastEpisodesApiPodcastEpisodesUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -14794,10 +15160,10 @@ export class PodcastEpisodesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -14821,10 +15187,10 @@ export class PodcastEpisodesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -14865,10 +15231,10 @@ export class PodcastEpisodesApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -14888,7 +15254,7 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14896,7 +15262,7 @@ export const PodcastsApiAxiosParamCreator = function (
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'parent_id' is not null or undefined
@@ -14930,8 +15296,8 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -15005,10 +15371,10 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15063,7 +15429,6 @@ export const PodcastsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15089,6 +15454,17 @@ export const PodcastsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcasts/`
@@ -15125,10 +15501,6 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -15139,6 +15511,10 @@ export const PodcastsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -15162,10 +15538,10 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15220,7 +15596,6 @@ export const PodcastsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15246,6 +15621,17 @@ export const PodcastsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcasts/new/`
@@ -15282,10 +15668,6 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -15296,6 +15678,10 @@ export const PodcastsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -15367,10 +15753,10 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15425,7 +15811,6 @@ export const PodcastsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15451,6 +15836,17 @@ export const PodcastsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcasts/upcoming/`
@@ -15487,10 +15883,6 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -15501,6 +15893,10 @@ export const PodcastsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -15532,7 +15928,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {number} parent_id
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
+     * @param {string} [sortby] Which field to use when ordering the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15540,7 +15936,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
       parent_id: number,
       limit?: number,
       offset?: number,
-      ordering?: string,
+      sortby?: string,
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -15553,7 +15949,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
           parent_id,
           limit,
           offset,
-          ordering,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -15600,10 +15996,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15658,7 +16054,6 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15684,6 +16079,17 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -15696,10 +16102,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -15716,10 +16122,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15774,7 +16180,6 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15800,6 +16205,17 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -15812,10 +16228,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -15857,10 +16273,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15915,7 +16331,6 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -15941,6 +16356,17 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -15954,10 +16380,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -15996,7 +16422,7 @@ export const PodcastsApiFactory = function (
           requestParameters.parent_id,
           requestParameters.limit,
           requestParameters.offset,
-          requestParameters.ordering,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -16036,10 +16462,10 @@ export const PodcastsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -16061,10 +16487,10 @@ export const PodcastsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -16101,10 +16527,10 @@ export const PodcastsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -16144,7 +16570,7 @@ export interface PodcastsApiPodcastsItemsListRequest {
    * @type {string}
    * @memberof PodcastsApiPodcastsItemsList
    */
-  readonly ordering?: string
+  readonly sortby?: string
 }
 
 /**
@@ -16249,13 +16675,6 @@ export interface PodcastsApiPodcastsListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastsApiPodcastsList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastsApiPodcastsList
@@ -16297,6 +16716,23 @@ export interface PodcastsApiPodcastsListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastsApiPodcastsList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -16380,13 +16816,6 @@ export interface PodcastsApiPodcastsNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastsApiPodcastsNewList
@@ -16428,6 +16857,23 @@ export interface PodcastsApiPodcastsNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastsApiPodcastsNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -16525,13 +16971,6 @@ export interface PodcastsApiPodcastsUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof PodcastsApiPodcastsUpcomingList
@@ -16573,6 +17012,23 @@ export interface PodcastsApiPodcastsUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof PodcastsApiPodcastsUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -16598,7 +17054,7 @@ export class PodcastsApi extends BaseAPI {
         requestParameters.parent_id,
         requestParameters.limit,
         requestParameters.offset,
-        requestParameters.ordering,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -16642,10 +17098,10 @@ export class PodcastsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -16669,10 +17125,10 @@ export class PodcastsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -16713,10 +17169,10 @@ export class PodcastsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -16738,10 +17194,10 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16796,7 +17252,6 @@ export const ProgramsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -16822,6 +17277,17 @@ export const ProgramsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/`
@@ -16858,10 +17324,6 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -16872,6 +17334,10 @@ export const ProgramsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -16895,10 +17361,10 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16953,7 +17419,6 @@ export const ProgramsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -16979,6 +17444,17 @@ export const ProgramsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/new/`
@@ -17015,10 +17491,6 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -17029,6 +17501,10 @@ export const ProgramsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -17100,10 +17576,10 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17158,7 +17634,6 @@ export const ProgramsApiAxiosParamCreator = function (
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -17184,6 +17659,17 @@ export const ProgramsApiAxiosParamCreator = function (
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/upcoming/`
@@ -17220,10 +17706,6 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (ordering !== undefined) {
-        localVarQueryParameter["ordering"] = ordering
-      }
-
       if (platform !== undefined) {
         localVarQueryParameter["platform"] = platform
       }
@@ -17234,6 +17716,10 @@ export const ProgramsApiAxiosParamCreator = function (
 
       if (resource_type !== undefined) {
         localVarQueryParameter["resource_type"] = resource_type
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -17267,10 +17753,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17325,7 +17811,6 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -17351,6 +17836,17 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -17363,10 +17859,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -17383,10 +17879,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17441,7 +17937,6 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -17467,6 +17962,17 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -17479,10 +17985,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         limit,
         offered_by,
         offset,
-        ordering,
         platform,
         professional,
         resource_type,
+        sortby,
         options,
       )
       return createRequestFunction(
@@ -17524,10 +18030,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] Offered By  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {string} [ordering] Which field to use when ordering the results.
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17582,7 +18088,6 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "see"
         | "xpro",
       offset?: number,
-      ordering?: string,
       platform?:
         | "bootcamps"
         | "csail"
@@ -17608,6 +18113,17 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "podcast"
         | "podcast_episode"
         | "program",
+      sortby?:
+        | "-created_on"
+        | "-id"
+        | "-last_modified"
+        | "-readable_id"
+        | "-start_date"
+        | "created_on"
+        | "id"
+        | "last_modified"
+        | "readable_id"
+        | "start_date",
       options?: AxiosRequestConfig,
     ): Promise<
       (
@@ -17621,10 +18137,10 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
           limit,
           offered_by,
           offset,
-          ordering,
           platform,
           professional,
           resource_type,
+          sortby,
           options,
         )
       return createRequestFunction(
@@ -17665,10 +18181,10 @@ export const ProgramsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -17690,10 +18206,10 @@ export const ProgramsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -17730,10 +18246,10 @@ export const ProgramsApiFactory = function (
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
-          requestParameters.ordering,
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.resource_type,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -17822,13 +18338,6 @@ export interface ProgramsApiProgramsListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof ProgramsApiProgramsList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof ProgramsApiProgramsList
@@ -17870,6 +18379,23 @@ export interface ProgramsApiProgramsListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof ProgramsApiProgramsList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -17953,13 +18479,6 @@ export interface ProgramsApiProgramsNewListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof ProgramsApiProgramsNewList
@@ -18001,6 +18520,23 @@ export interface ProgramsApiProgramsNewListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof ProgramsApiProgramsNewList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -18098,13 +18634,6 @@ export interface ProgramsApiProgramsUpcomingListRequest {
   readonly offset?: number
 
   /**
-   * Which field to use when ordering the results.
-   * @type {string}
-   * @memberof ProgramsApiProgramsUpcomingList
-   */
-  readonly ordering?: string
-
-  /**
    * Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
    * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
    * @memberof ProgramsApiProgramsUpcomingList
@@ -18146,6 +18675,23 @@ export interface ProgramsApiProgramsUpcomingListRequest {
     | "podcast"
     | "podcast_episode"
     | "program"
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * @memberof ProgramsApiProgramsUpcomingList
+   */
+  readonly sortby?:
+    | "-created_on"
+    | "-id"
+    | "-last_modified"
+    | "-readable_id"
+    | "-start_date"
+    | "created_on"
+    | "id"
+    | "last_modified"
+    | "readable_id"
+    | "start_date"
 }
 
 /**
@@ -18173,10 +18719,10 @@ export class ProgramsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -18200,10 +18746,10 @@ export class ProgramsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -18244,10 +18790,10 @@ export class ProgramsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
-        requestParameters.ordering,
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.resource_type,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -288,10 +288,60 @@ export type ContentTypeEnum =
 export interface Course {
   /**
    *
-   * @type {{ [key: string]: any; }}
+   * @type {Array<CourseNumber>}
    * @memberof Course
    */
-  course_numbers?: { [key: string]: any } | null
+  course_numbers: Array<CourseNumber> | null
+}
+/**
+ * Serializer for CourseNumber
+ * @export
+ * @interface CourseNumber
+ */
+export interface CourseNumber {
+  /**
+   *
+   * @type {string}
+   * @memberof CourseNumber
+   */
+  value: string
+  /**
+   *
+   * @type {LearningResourceDepartment}
+   * @memberof CourseNumber
+   */
+  department: LearningResourceDepartment
+  /**
+   *
+   * @type {string}
+   * @memberof CourseNumber
+   */
+  listing_type: string
+}
+/**
+ * Serializer for CourseNumber
+ * @export
+ * @interface CourseNumberRequest
+ */
+export interface CourseNumberRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof CourseNumberRequest
+   */
+  value: string
+  /**
+   *
+   * @type {LearningResourceDepartmentRequest}
+   * @memberof CourseNumberRequest
+   */
+  department: LearningResourceDepartmentRequest
+  /**
+   *
+   * @type {string}
+   * @memberof CourseNumberRequest
+   */
+  listing_type: string
 }
 /**
  * Serializer for the Course model
@@ -301,10 +351,10 @@ export interface Course {
 export interface CourseRequest {
   /**
    *
-   * @type {{ [key: string]: any; }}
+   * @type {Array<CourseNumberRequest>}
    * @memberof CourseRequest
    */
-  course_numbers?: { [key: string]: any } | null
+  course_numbers: Array<CourseNumberRequest> | null
 }
 /**
  * Serializer for FieldChannel
@@ -4614,7 +4664,7 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4698,11 +4748,13 @@ export const CoursesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -4781,7 +4833,7 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4865,11 +4917,13 @@ export const CoursesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -4996,7 +5050,7 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5080,11 +5134,13 @@ export const CoursesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -5239,7 +5295,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5323,11 +5379,13 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -5365,7 +5423,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5449,11 +5507,13 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -5518,7 +5578,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -5602,11 +5662,13 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -5968,19 +6030,21 @@ export interface CoursesApiCoursesListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof CoursesApiCoursesList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -6109,19 +6173,21 @@ export interface CoursesApiCoursesNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof CoursesApiCoursesNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -6264,19 +6330,21 @@ export interface CoursesApiCoursesUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof CoursesApiCoursesUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -7920,7 +7988,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8004,11 +8072,13 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -8087,7 +8157,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8171,11 +8241,13 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -8302,7 +8374,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8386,11 +8458,13 @@ export const LearningResourcesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -8612,7 +8686,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8696,11 +8770,13 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -8739,7 +8815,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8823,11 +8899,13 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -8891,7 +8969,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -8975,11 +9053,13 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -9435,19 +9515,21 @@ export interface LearningResourcesApiLearningResourcesListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningResourcesApiLearningResourcesList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -9576,19 +9658,21 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -9731,19 +9815,21 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -10633,7 +10719,7 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -10717,11 +10803,13 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -10800,7 +10888,7 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -10884,11 +10972,13 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -11432,7 +11522,7 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11516,11 +11606,13 @@ export const LearningpathsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -11720,7 +11812,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11804,11 +11896,13 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -11847,7 +11941,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11931,11 +12025,13 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -12218,7 +12314,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12302,11 +12398,13 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -12803,19 +12901,21 @@ export interface LearningpathsApiLearningpathsListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningpathsApiLearningpathsList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -12944,19 +13044,21 @@ export interface LearningpathsApiLearningpathsNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningpathsApiLearningpathsNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -13274,19 +13376,21 @@ export interface LearningpathsApiLearningpathsUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningpathsApiLearningpathsUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -13635,7 +13739,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13719,11 +13823,13 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -13802,7 +13908,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -13886,11 +13992,13 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -14017,7 +14125,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14101,11 +14209,13 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -14195,7 +14305,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14279,11 +14389,13 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -14322,7 +14434,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14406,11 +14518,13 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -14474,7 +14588,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -14558,11 +14672,13 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -14822,19 +14938,21 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -14963,19 +15081,21 @@ export interface PodcastEpisodesApiPodcastEpisodesNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastEpisodesApiPodcastEpisodesNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -15118,19 +15238,21 @@ export interface PodcastEpisodesApiPodcastEpisodesUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -15374,7 +15496,7 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15458,11 +15580,13 @@ export const PodcastsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -15541,7 +15665,7 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15625,11 +15749,13 @@ export const PodcastsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -15756,7 +15882,7 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -15840,11 +15966,13 @@ export const PodcastsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -15999,7 +16127,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16083,11 +16211,13 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -16125,7 +16255,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16209,11 +16339,13 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -16276,7 +16408,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16360,11 +16492,13 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -16718,19 +16852,21 @@ export interface PodcastsApiPodcastsListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastsApiPodcastsList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -16859,19 +16995,21 @@ export interface PodcastsApiPodcastsNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastsApiPodcastsNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -17014,19 +17152,21 @@ export interface PodcastsApiPodcastsUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof PodcastsApiPodcastsUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -17197,7 +17337,7 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17281,11 +17421,13 @@ export const ProgramsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -17364,7 +17506,7 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17448,11 +17590,13 @@ export const ProgramsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -17579,7 +17723,7 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17663,11 +17807,13 @@ export const ProgramsApiAxiosParamCreator = function (
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options: AxiosRequestConfig = {},
@@ -17756,7 +17902,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17840,11 +17986,13 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -17882,7 +18030,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17966,11 +18114,13 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -18033,7 +18183,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] Platform  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
      * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] Resource Type  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
+     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -18117,11 +18267,13 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         | "-created_on"
         | "-id"
         | "-last_modified"
+        | "-mitcoursenumber"
         | "-readable_id"
         | "-start_date"
         | "created_on"
         | "id"
         | "last_modified"
+        | "mitcoursenumber"
         | "readable_id"
         | "start_date",
       options?: AxiosRequestConfig,
@@ -18381,19 +18533,21 @@ export interface ProgramsApiProgramsListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof ProgramsApiProgramsList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -18522,19 +18676,21 @@ export interface ProgramsApiProgramsNewListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof ProgramsApiProgramsNewList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }
@@ -18677,19 +18833,21 @@ export interface ProgramsApiProgramsUpcomingListRequest {
     | "program"
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'readable_id' | 'start_date'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
+   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof ProgramsApiProgramsUpcomingList
    */
   readonly sortby?:
     | "-created_on"
     | "-id"
     | "-last_modified"
+    | "-mitcoursenumber"
     | "-readable_id"
     | "-start_date"
     | "created_on"
     | "id"
     | "last_modified"
+    | "mitcoursenumber"
     | "readable_id"
     | "start_date"
 }

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -3,6 +3,7 @@ import type { Factory } from "ol-util/factories"
 import { makePaginatedFactory } from "ol-util/factories"
 import type { PaginatedResult } from "ol-util"
 import type {
+  CourseNumber,
   LearningResource,
   LearningResourceImage,
   LearningResourceDepartment,
@@ -99,6 +100,19 @@ const learningResourceTopics = makePaginatedFactory(learningResourceTopic)
 const learningResourceType = () =>
   faker.helpers.arrayElement(Object.values(ResourceTypeEnum))
 
+const learningResourceCourseNumber: Factory<CourseNumber> = (
+  overrides = {},
+) => {
+  return {
+    department: learningResourceDepartment(),
+    value: faker.lorem.word(),
+    listing_type: "primary",
+    primary: faker.datatype.boolean(),
+    sort_coursenum: faker.lorem.word(),
+    ...overrides,
+  }
+}
+
 const learningResource: Factory<LearningResource> = (
   overrides = {},
 ): LearningResource => {
@@ -139,7 +153,8 @@ const learningResource: Factory<LearningResource> = (
         certification: faker.lorem.word(),
         offered_by: faker.lorem.word(),
         course: {
-          course_numbers: maybe(() => repeat(faker.datatype.json)) ?? [],
+          course_numbers:
+            maybe(() => repeat(learningResourceCourseNumber)) ?? [],
         },
       }
     } else if (type === ResourceTypeEnum.Program) {

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -228,4 +228,12 @@ LEARNING_RESOURCE_SORTBY_OPTIONS = {
         "title": "Start Date descending",
         "sort": "-runs__start_date",
     },
+    "mitcoursenumber": {
+        "title": "MIT course number ascending",
+        "sort": "course__course_numbers__0__sort_coursenum",
+    },
+    "-mitcoursenumber": {
+        "title": "MIT course number descending",
+        "sort": "-course__course_numbers__0__sort_coursenum",
+    },
 }

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -185,3 +185,47 @@ DEPARTMENTS = {
     "STS": "Science, Technology, and Society",
     "WGS": "Women's and Gender Studies",
 }
+
+
+LEARNING_RESOURCE_SORTBY_OPTIONS = {
+    "id": {
+        "title": "Object ID ascending",
+        "sort": "id",
+    },
+    "-id": {
+        "title": "Object ID descending",
+        "sort": "-id",
+    },
+    "readable_id": {
+        "title": "Readable ID ascending",
+        "sort": "readable_id",
+    },
+    "-readable_id": {
+        "title": "Readable ID descending",
+        "sort": "-readable_id",
+    },
+    "last_modified": {
+        "title": "Last Modified Date ascending",
+        "sort": "last_modified",
+    },
+    "-last_modified": {
+        "title": "Last Modified Date descending",
+        "sort": "-last_modified",
+    },
+    "created_on": {
+        "title": "Creation Date ascending",
+        "sort": "created_on",
+    },
+    "-created_on": {
+        "title": "CreationDate descending",
+        "sort": "-created_on",
+    },
+    "start_date": {
+        "title": "Start Date ascending",
+        "sort": "runs__start_date",
+    },
+    "-start_date": {
+        "title": "Start Date descending",
+        "sort": "-runs__start_date",
+    },
+}

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -202,6 +202,8 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                                 "value": course_data["readable_id"],
                                 "department": ANY,
                                 "listing_type": CourseNumberType.primary.value,
+                                "primary": True,
+                                "sort_coursenum": course_data["readable_id"],
                             }
                         ]
                     },
@@ -292,6 +294,8 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                         "value": course_data["readable_id"],
                         "department": ANY,
                         "listing_type": CourseNumberType.primary.value,
+                        "primary": True,
+                        "sort_coursenum": course_data["readable_id"],
                     }
                 ]
             },

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -206,6 +206,8 @@ def test_transform_course(settings, legacy_uid, site_uid, expected_uid, has_extr
             "value": "16.01",
             "department": {"department_id": "16", "name": DEPARTMENTS["16"]},
             "listing_type": CourseNumberType.primary.value,
+            "primary": True,
+            "sort_coursenum": "16.01",
         }
         assert transformed_json["course"]["course_numbers"][1:] == (
             [
@@ -213,11 +215,15 @@ def test_transform_course(settings, legacy_uid, site_uid, expected_uid, has_extr
                     "value": "1",
                     "department": {"department_id": "1", "name": DEPARTMENTS["1"]},
                     "listing_type": CourseNumberType.cross_listed.value,
+                    "primary": False,
+                    "sort_coursenum": "01",
                 },
                 {
                     "value": "2",
                     "department": {"department_id": "2", "name": DEPARTMENTS["2"]},
                     "listing_type": CourseNumberType.cross_listed.value,
+                    "primary": False,
+                    "sort_coursenum": "02",
                 },
             ]
             if has_extra_num

--- a/learning_resources/etl/openedx_test.py
+++ b/learning_resources/etl/openedx_test.py
@@ -182,6 +182,8 @@ def test_transform_course(  # noqa: PLR0913
                             "name": "Sloan School of Management",
                         },
                         "listing_type": CourseNumberType.primary.value,
+                        "primary": True,
+                        "sort_coursenum": "MITx+15.071x",
                     }
                 ]
             },

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -548,6 +548,15 @@ def generate_course_numbers_json(
     course_numbers.extend(extra_nums)
     for idx, num in enumerate(course_numbers):
         dept_id = extract_valid_department_from_id(num, is_ocw=is_ocw)
+        if (
+            dept_id
+            and dept_id[0].isdigit()
+            and len(dept_id[0]) == 1
+            and num.startswith(dept_id[0])
+        ):
+            sort_coursenum = f"0{num}"
+        else:
+            sort_coursenum = num
         course_number_json.append(
             {
                 "value": num,
@@ -564,6 +573,8 @@ def generate_course_numbers_json(
                     if dept_id
                     else None
                 ),
+                "sort_coursenum": sort_coursenum,
+                "primary": idx == 0,
             }
         )
     return course_number_json

--- a/learning_resources/etl/xpro_test.py
+++ b/learning_resources/etl/xpro_test.py
@@ -173,6 +173,8 @@ def test_xpro_transform_programs(mock_xpro_programs_data):
                                 "value": course_data["readable_id"],
                                 "department": None,
                                 "listing_type": CourseNumberType.primary.value,
+                                "primary": True,
+                                "sort_coursenum": course_data["readable_id"],
                             }
                         ]
                     },
@@ -240,6 +242,8 @@ def test_xpro_transform_courses(mock_xpro_courses_data):
                         "value": course_data["readable_id"],
                         "department": None,
                         "listing_type": CourseNumberType.primary.value,
+                        "primary": True,
+                        "sort_coursenum": course_data["readable_id"],
                     }
                 ]
             },

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -194,6 +194,8 @@ class CourseFactory(DjangoModelFactory):
                 "value": f"{random.randint(1,20)}.0001",  # noqa: S311
                 "department": None,
                 "listing_type": "Primary",
+                "primary": True,
+                "sort_coursenum": f"{random.randint(1, 20):02d}",  # noqa: S311
             }
         ]
     )

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -1,14 +1,18 @@
 """Filters for learning_resources API"""
+import logging
 
 from django_filters import ChoiceFilter, FilterSet
 
 from learning_resources.constants import (
     DEPARTMENTS,
+    LEARNING_RESOURCE_SORTBY_OPTIONS,
     LearningResourceType,
     OfferedBy,
     PlatformType,
 )
 from learning_resources.models import LearningResource
+
+log = logging.getLogger(__name__)
 
 
 class LearningResourceFilter(FilterSet):
@@ -46,6 +50,17 @@ class LearningResourceFilter(FilterSet):
         choices=([(platform.name, platform.value) for platform in PlatformType]),
     )
 
+    sortby = ChoiceFilter(
+        label="Sort By",
+        method="filter_sortby",
+        choices=(
+            [
+                (key, value["title"])
+                for key, value in LEARNING_RESOURCE_SORTBY_OPTIONS.items()
+            ]
+        ),
+    )
+
     def filter_resource_type(self, queryset, _, value):
         """resource_type Filter for learning resources"""
         return queryset.filter(resource_type=value)
@@ -61,6 +76,10 @@ class LearningResourceFilter(FilterSet):
     def filter_department(self, queryset, _, value):
         """Department ID Filter for learning resources"""
         return queryset.filter(departments__department_id=value)
+
+    def filter_sortby(self, queryset, _, value):
+        """Sort the queryset in the order specified by the value"""
+        return queryset.order_by(LEARNING_RESOURCE_SORTBY_OPTIONS[value]["sort"])
 
     class Meta:
         model = LearningResource

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -101,6 +101,34 @@ class LearningResourceInstructor(TimestampedModel):
 class LearningResource(TimestampedModel):
     """Core model for all learning resources"""
 
+    prefetches = [
+        "topics",
+        "offered_by",
+        "departments",
+        "resource_content_tags",
+        "runs",
+        "runs__instructors",
+        "runs__image",
+        "children__child",
+        "children__child__runs",
+        "children__child__runs__instructors",
+        "children__child__course",
+        "children__child__program",
+        "children__child__learning_path",
+        "children__child__departments",
+        "children__child__platform",
+        "children__child__topics",
+        "children__child__image",
+        "children__child__offered_by",
+        "children__child__resource_content_tags",
+    ]
+
+    related_selects = [
+        "image",
+        "platform",
+        *([item.name for item in LearningResourceType]),
+    ]
+
     readable_id = models.CharField(max_length=128, null=False, blank=False)
     title = models.CharField(max_length=256)
     description = models.TextField(null=True, blank=True)  # noqa: DJ001

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -148,8 +148,18 @@ class ResourceListMixin(serializers.Serializer):
         )
 
 
+class CourseNumberSerializer(serializers.Serializer):
+    """Serializer for CourseNumber"""
+
+    value = serializers.CharField()
+    department = LearningResourceDepartmentSerializer()
+    listing_type = serializers.CharField()
+
+
 class CourseSerializer(serializers.ModelSerializer):
     """Serializer for the Course model"""
+
+    course_numbers = CourseNumberSerializer(many=True, allow_null=True)
 
     class Meta:
         model = models.Course

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -130,36 +130,8 @@ class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
         lr_query = LearningResource.objects.all()
         if resource_type:
             lr_query = lr_query.filter(resource_type=resource_type)
-
-        prefetches = [
-            "topics",
-            "offered_by",
-            "departments",
-            "resource_content_tags",
-            "runs",
-            "runs__instructors",
-            "runs__image",
-            "children",
-            "children__child",
-            "children__child__runs",
-            "children__child__runs__instructors",
-            "children__child__course",
-            "children__child__program",
-            "children__child__learning_path",
-            "children__child__departments",
-            "children__child__platform",
-            "children__child__topics",
-            "children__child__image",
-            "children__child__offered_by",
-            "children__child__resource_content_tags",
-        ]
-
-        lr_query = lr_query.select_related(
-            "image",
-            "platform",
-            *([item.name for item in LearningResourceType]),
-        )
-        return lr_query.prefetch_related(*prefetches).distinct()
+        lr_query = lr_query.select_related(*LearningResource.related_selects)
+        return lr_query.prefetch_related(*LearningResource.prefetches).distinct()
 
     def get_queryset(self) -> QuerySet:
         """

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -13,7 +13,10 @@ from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import (
+    extend_schema,
+    extend_schema_view,
+)
 from rest_framework import views, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
@@ -109,10 +112,8 @@ class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = LearningResourceSerializer
     permission_classes = (AnonymousAccessReadonlyPermission,)
     pagination_class = DefaultPagination
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [DjangoFilterBackend]
     filterset_class = LearningResourceFilter
-    ordering_fields = ["id", "readable_id", "last_modified", "title"]
-    ordering = ["id"]
 
     def _get_base_queryset(self, resource_type: str | None = None) -> QuerySet:
         """

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -322,10 +322,10 @@ def test_get_podcast_detail_endpoint(client, url):
 @pytest.mark.parametrize(
     ("url", "params"),
     [
-        ("lr_podcast_episodes_api-list", "ordering=-last_modified"),
+        ("lr_podcast_episodes_api-list", "sortby=-last_modified"),
         (
             "learning_resources_api-list",
-            "resource_type=podcast_episode&ordering=-last_modified",
+            "resource_type=podcast_episode&sortby=-last_modified",
         ),
     ],
 )

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -12,12 +12,12 @@ from learning_resources_search.constants import (
     DEPARTMENT_QUERY_FIELDS,
     LEARNING_RESOURCE_QUERY_FIELDS,
     LEARNING_RESOURCE_SEARCH_FILTERS,
-    LEARNING_RESOURCE_SORTBY_OPTIONS,
     LEARNING_RESOURCE_TYPES,
     RESOURCEFILE_QUERY_FIELDS,
     RUN_INSTRUCTORS_QUERY_FIELDS,
     RUNS_QUERY_FIELDS,
     SEARCH_NESTED_FILTERS,
+    SEARCH_SORTBY_OPTIONS,
     SOURCE_EXCLUDED_FIELDS,
     TOPICS_QUERY_FIELDS,
 )
@@ -74,8 +74,10 @@ def generate_sort_clause(search_params):
         dict or String: either a dictionary with the sort clause for
             nested sort params or just sort parameter
     """
-    sort = LEARNING_RESOURCE_SORTBY_OPTIONS.get(search_params.get("sortby"), {}).get(
-        "sort"
+    sort = (
+        SEARCH_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
+        .get("sort")
+        .replace("__", ".")
     )
 
     departments = search_params.get("department")

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -4,6 +4,7 @@ import re
 
 from opensearch_dsl import Search
 
+from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
 from learning_resources_search.connection import get_default_alias_name
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
@@ -17,7 +18,6 @@ from learning_resources_search.constants import (
     RUN_INSTRUCTORS_QUERY_FIELDS,
     RUNS_QUERY_FIELDS,
     SEARCH_NESTED_FILTERS,
-    SEARCH_SORTBY_OPTIONS,
     SOURCE_EXCLUDED_FIELDS,
     TOPICS_QUERY_FIELDS,
 )
@@ -75,8 +75,9 @@ def generate_sort_clause(search_params):
             nested sort params or just sort parameter
     """
     sort = (
-        SEARCH_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
+        LEARNING_RESOURCE_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
         .get("sort")
+        .replace("0__", "")
         .replace("__", ".")
     )
 

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -5,8 +5,6 @@ from enum import Enum
 from opensearchpy.exceptions import ConnectionError as ESConnectionError
 from urllib3.exceptions import TimeoutError as UrlTimeoutError
 
-from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
-
 ALIAS_ALL_INDICES = "all"
 COURSE_TYPE = "course"
 PROGRAM_TYPE = "program"
@@ -260,15 +258,3 @@ SOURCE_EXCLUDED_FIELDS = [
     "created_on",
     "resource_relations",
 ]
-
-SEARCH_SORTBY_OPTIONS = {
-    **LEARNING_RESOURCE_SORTBY_OPTIONS,
-    "mitcoursenumber": {
-        "title": "MIT course number ascending",
-        "sort": "course__course_numbers__sort_coursenum",
-    },
-    "-mitcoursenumber": {
-        "title": "MIT course number descending",
-        "sort": "-course__course_numbers__sort_coursenum",
-    },
-}

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -88,6 +88,7 @@ LEARNING_RESOURCE_MAP = {
     "description": ENGLISH_TEXT_FIELD_WITH_SUGGEST,
     "full_description": ENGLISH_TEXT_FIELD,
     "last_modified": {"type": "date"},
+    "created_on": {"type": "date"},
     "languages": {"type": "keyword"},
     "image": {
         "type": "nested",

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -5,6 +5,8 @@ from enum import Enum
 from opensearchpy.exceptions import ConnectionError as ESConnectionError
 from urllib3.exceptions import TimeoutError as UrlTimeoutError
 
+from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
+
 ALIAS_ALL_INDICES = "all"
 COURSE_TYPE = "course"
 PROGRAM_TYPE = "program"
@@ -254,48 +256,18 @@ SEARCH_CONN_EXCEPTIONS = (ESConnectionError, UrlTimeoutError)
 SOURCE_EXCLUDED_FIELDS = [
     "course.course_numbers.sort_coursenum",
     "course.course_numbers.primary",
+    "created_on",
     "resource_relations",
 ]
 
-LEARNING_RESOURCE_SORTBY_OPTIONS = {
-    "id": {
-        "title": "Object ID ascending",
-        "sort": "id",
-    },
-    "-id": {
-        "title": "Object ID descending",
-        "sort": "-id",
-    },
-    "readable_id": {
-        "title": "Readable ID ascending",
-        "sort": "readable_id",
-    },
-    "-readable_id": {
-        "title": "Readable ID descending",
-        "sort": "-readable_id",
-    },
-    "last_modified": {
-        "title": "Last Modified Date ascending",
-        "sort": "last_modified",
-    },
-    "-last_modified": {
-        "title": "Last Modified Date descending",
-        "sort": "-last_modified",
-    },
-    "start_date": {
-        "title": "Start Date ascending",
-        "sort": "runs.start_date",
-    },
-    "-start_date": {
-        "title": "Start Date descending",
-        "sort": "-runs.start_date",
-    },
+SEARCH_SORTBY_OPTIONS = {
+    **LEARNING_RESOURCE_SORTBY_OPTIONS,
     "mitcoursenumber": {
         "title": "MIT course number ascending",
-        "sort": "course.course_numbers.sort_coursenum",
+        "sort": "course__course_numbers__sort_coursenum",
     },
     "-mitcoursenumber": {
         "title": "MIT course number descending",
-        "sort": "-course.course_numbers.sort_coursenum",
+        "sort": "-course__course_numbers__sort_coursenum",
     },
 }

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -29,30 +29,10 @@ log = logging.getLogger()
 
 
 class SearchCourseNumberSerializer(CourseNumberSerializer):
-    """Serializer for CourseNumbe, including extra fields for search"""
+    """Serializer for CourseNumber, including extra fields for search"""
 
     primary = serializers.BooleanField()
     sort_coursenum = serializers.CharField()
-
-
-def transform_resource_data(learning_resource_obj: LearningResource) -> dict:
-    """
-    Apply transformations on the resource data
-
-    Args:
-        learning_resource_obj(dict): The learning resource
-
-    Returns:
-        dict: The transformed resource data
-
-    """
-    serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
-    if learning_resource_obj.resource_type == LearningResourceType.course.name:
-        serialized_data["course"]["course_numbers"] = [
-            SearchCourseNumberSerializer(instance=num).data
-            for num in learning_resource_obj.course.course_numbers
-        ]
-    return serialized_data
 
 
 def serialize_learning_resource_for_update(
@@ -68,10 +48,16 @@ def serialize_learning_resource_for_update(
         dict: The serialized and transformed resource data
 
     """
+    serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
+    if learning_resource_obj.resource_type == LearningResourceType.course.name:
+        serialized_data["course"]["course_numbers"] = [
+            SearchCourseNumberSerializer(instance=num).data
+            for num in learning_resource_obj.course.course_numbers
+        ]
     return {
         "resource_relations": {"name": "resource"},
         "created_on": learning_resource_obj.created_on,
-        **transform_resource_data(learning_resource_obj),
+        **serialized_data,
     }
 
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -7,60 +7,52 @@ from django.conf import settings
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from learning_resources.constants import LearningResourceType, OfferedBy, PlatformType
-from learning_resources.etl.constants import CourseNumberType
+from learning_resources.constants import (
+    LEARNING_RESOURCE_SORTBY_OPTIONS,
+    LearningResourceType,
+    OfferedBy,
+    PlatformType,
+)
 from learning_resources.models import LearningResource
 from learning_resources.serializers import (
     ContentFileSerializer,
+    CourseNumberSerializer,
     LearningResourceSerializer,
 )
 from learning_resources_search.api import gen_content_file_id
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
     LEARNING_RESOURCE_TYPES,
-    SEARCH_SORTBY_OPTIONS,
 )
 
 log = logging.getLogger()
 
 
-def add_extra_course_number_fields(resource_data: dict):
-    """Add sortable coursenums and primary(boolean) fields to course.course_numbers"""
-    if resource_data.get("course"):
-        course_numbers = resource_data["course"].get("course_numbers", [])
-        for coursenum_data in course_numbers:
-            department_data = coursenum_data.get("department", {})
-            department_num = (
-                department_data.get("department_id") if department_data else None
-            )
-            course_num = coursenum_data.get("value")
-            if (
-                department_num
-                and department_num[0].isdigit()
-                and len(department_num) == 1
-            ):
-                sort_coursenum = f"0{course_num}"
-            else:
-                sort_coursenum = course_num
-            coursenum_data["primary"] = (
-                coursenum_data.get("listing_type") == CourseNumberType.primary.value
-            )
-            coursenum_data["sort_coursenum"] = sort_coursenum
+class SearchCourseNumberSerializer(CourseNumberSerializer):
+    """Serializer for CourseNumbe, including extra fields for search"""
+
+    primary = serializers.BooleanField()
+    sort_coursenum = serializers.CharField()
 
 
-def transform_resource_data(resource_data: dict) -> dict:
+def transform_resource_data(learning_resource_obj: LearningResource) -> dict:
     """
     Apply transformations on the resource data
 
     Args:
-        resource_data(dict): The resource data
+        learning_resource_obj(dict): The learning resource
 
     Returns:
         dict: The transformed resource data
 
     """
-    add_extra_course_number_fields(resource_data)
-    return resource_data
+    serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
+    if learning_resource_obj.resource_type == LearningResourceType.course.name:
+        serialized_data["course"]["course_numbers"] = [
+            SearchCourseNumberSerializer(instance=num).data
+            for num in learning_resource_obj.course.course_numbers
+        ]
+    return serialized_data
 
 
 def serialize_learning_resource_for_update(
@@ -79,9 +71,7 @@ def serialize_learning_resource_for_update(
     return {
         "resource_relations": {"name": "resource"},
         "created_on": learning_resource_obj.created_on,
-        **transform_resource_data(
-            LearningResourceSerializer(learning_resource_obj).data
-        ),
+        **transform_resource_data(learning_resource_obj),
     }
 
 
@@ -173,7 +163,8 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
     sortby = serializers.ChoiceField(
         required=False,
         choices=[
-            (key, SEARCH_SORTBY_OPTIONS[key]["title"]) for key in SEARCH_SORTBY_OPTIONS
+            (key, LEARNING_RESOURCE_SORTBY_OPTIONS[key]["title"])
+            for key in LEARNING_RESOURCE_SORTBY_OPTIONS
         ],
         help_text="if the parameter starts with '-' the sort is in descending order",
     )
@@ -293,7 +284,11 @@ def serialize_bulk_courses(ids):
     Args:
         ids(list of int): List of course id's
     """
-    for learning_resource in LearningResource.objects.filter(id__in=ids):
+    for learning_resource in (
+        LearningResource.objects.select_related(*LearningResource.related_selects)
+        .prefetch_related(*LearningResource.prefetches)
+        .filter(id__in=ids)
+    ):
         yield serialize_course_for_bulk(learning_resource)
 
 
@@ -341,7 +336,11 @@ def serialize_bulk_programs(ids):
     Args:
         ids(list of int): List of program id's
     """
-    for learning_resource in LearningResource.objects.filter(id__in=ids):
+    for learning_resource in (
+        LearningResource.objects.select_related(*LearningResource.related_selects)
+        .prefetch_related(*LearningResource.prefetches)
+        .filter(id__in=ids)
+    ):
         yield serialize_program_for_bulk(learning_resource)
 
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -17,8 +17,8 @@ from learning_resources.serializers import (
 from learning_resources_search.api import gen_content_file_id
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
-    LEARNING_RESOURCE_SORTBY_OPTIONS,
     LEARNING_RESOURCE_TYPES,
+    SEARCH_SORTBY_OPTIONS,
 )
 
 log = logging.getLogger()
@@ -78,6 +78,7 @@ def serialize_learning_resource_for_update(
     """
     return {
         "resource_relations": {"name": "resource"},
+        "created_on": learning_resource_obj.created_on,
         **transform_resource_data(
             LearningResourceSerializer(learning_resource_obj).data
         ),
@@ -172,8 +173,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
     sortby = serializers.ChoiceField(
         required=False,
         choices=[
-            (key, LEARNING_RESOURCE_SORTBY_OPTIONS[key]["title"])
-            for key in LEARNING_RESOURCE_SORTBY_OPTIONS
+            (key, SEARCH_SORTBY_OPTIONS[key]["title"]) for key in SEARCH_SORTBY_OPTIONS
         ],
         help_text="if the parameter starts with '-' the sort is in descending order",
     )

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -73,6 +73,7 @@ def test_serialize_course_for_bulk(
     expected_data = {
         "_id": resource.id,
         "resource_relations": {"name": "resource"},
+        "created_on": resource.created_on,
         **LearningResourceSerializer(resource).data,
     }
     expected_data["course"]["course_numbers"][0] = {
@@ -112,11 +113,12 @@ def test_serialize_program_for_bulk():
     """
     Test that serialize_program_for_bulk yields a valid LearningResourceSerializer
     """
-    program = factories.ProgramFactory.create()
-    assert serializers.serialize_program_for_bulk(program.learning_resource) == {
-        "_id": program.learning_resource.id,
+    resource = factories.ProgramFactory.create().learning_resource
+    assert serializers.serialize_program_for_bulk(resource) == {
+        "_id": resource.id,
         "resource_relations": {"name": "resource"},
-        **LearningResourceSerializer(program.learning_resource).data,
+        "created_on": resource.created_on,
+        **LearningResourceSerializer(resource).data,
     }
 
 

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -59,11 +59,15 @@ def test_serialize_course_for_bulk(
                 "department_id": readable_id,
                 "name": DEPARTMENTS[readable_id],
             },
+            "primary": True,
+            "sort_coursenum": sort_course_num,
         },
         {
             "value": extra_num,
             "listing_type": CourseNumberType.cross_listed.value,
             "department": {"department_id": extra_num, "name": DEPARTMENTS[extra_num]},
+            "primary": False,
+            "sort_coursenum": sorted_extra_num,
         },
     ]
     resource = factories.CourseFactory.create(

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -602,6 +602,7 @@ REST_FRAMEWORK = {
         "rest_framework.renderers.MultiPartRenderer",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "ORDERING_PARAM": "sortby",
 }
 
 USE_X_FORWARDED_PORT = get_bool("USE_X_FORWARDED_PORT", False)  # noqa: FBT003

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -597,11 +597,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -617,6 +619,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - courses
       security:
@@ -917,11 +921,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -937,6 +943,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - courses
       security:
@@ -1146,11 +1154,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -1166,6 +1176,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - courses
       security:
@@ -1621,11 +1633,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -1641,6 +1655,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learning_resources
       security:
@@ -2007,11 +2023,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -2027,6 +2045,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learning_resources
       security:
@@ -2236,11 +2256,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -2256,6 +2278,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learning_resources
       security:
@@ -2696,11 +2720,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -2716,6 +2742,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learningpaths
       security:
@@ -3251,11 +3279,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -3271,6 +3301,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learningpaths
       security:
@@ -3480,11 +3512,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -3500,6 +3534,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learningpaths
       security:
@@ -3709,11 +3745,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -3729,6 +3767,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcast_episodes
       security:
@@ -3961,11 +4001,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -3981,6 +4023,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcast_episodes
       security:
@@ -4190,11 +4234,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -4210,6 +4256,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcast_episodes
       security:
@@ -4419,11 +4467,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -4439,6 +4489,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcasts
       security:
@@ -4737,11 +4789,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -4757,6 +4811,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcasts
       security:
@@ -4966,11 +5022,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -4986,6 +5044,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - podcasts
       security:
@@ -5195,11 +5255,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -5215,6 +5277,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - programs
       security:
@@ -5447,11 +5511,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -5467,6 +5533,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - programs
       security:
@@ -5676,11 +5744,13 @@ paths:
           - -created_on
           - -id
           - -last_modified
+          - -mitcoursenumber
           - -readable_id
           - -start_date
           - created_on
           - id
           - last_modified
+          - mitcoursenumber
           - readable_id
           - start_date
         description: |-
@@ -5696,6 +5766,8 @@ paths:
           * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
+          * `mitcoursenumber` - MIT course number ascending
+          * `-mitcoursenumber` - MIT course number descending
       tags:
       - programs
       security:
@@ -6261,17 +6333,53 @@ components:
       description: Serializer for the Course model
       properties:
         course_numbers:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/CourseNumber'
           nullable: true
+      required:
+      - course_numbers
+    CourseNumber:
+      type: object
+      description: Serializer for CourseNumber
+      properties:
+        value:
+          type: string
+        department:
+          $ref: '#/components/schemas/LearningResourceDepartment'
+        listing_type:
+          type: string
+      required:
+      - department
+      - listing_type
+      - value
+    CourseNumberRequest:
+      type: object
+      description: Serializer for CourseNumber
+      properties:
+        value:
+          type: string
+          minLength: 1
+        department:
+          $ref: '#/components/schemas/LearningResourceDepartmentRequest'
+        listing_type:
+          type: string
+          minLength: 1
+      required:
+      - department
+      - listing_type
+      - value
     CourseRequest:
       type: object
       description: Serializer for the Course model
       properties:
         course_numbers:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/CourseNumberRequest'
           nullable: true
+      required:
+      - course_numbers
     FieldChannel:
       type: object
       description: Serializer for FieldChannel

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -525,12 +525,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -595,6 +589,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - courses
       security:
@@ -823,12 +845,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -893,6 +909,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - courses
       security:
@@ -1030,12 +1074,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -1100,6 +1138,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - courses
       security:
@@ -1483,12 +1549,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -1553,6 +1613,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learning_resources
       security:
@@ -1581,17 +1669,17 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: path
         name: parent_id
         schema:
           type: integer
         required: true
+      - name: sortby
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       tags:
       - learning_resources
       security:
@@ -1847,12 +1935,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -1917,6 +1999,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learning_resources
       security:
@@ -2054,12 +2164,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -2124,6 +2228,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learning_resources
       security:
@@ -2325,6 +2457,8 @@ paths:
           - -readable_id
           - last_modified
           - -last_modified
+          - created_on
+          - -created_on
           - start_date
           - -start_date
           - mitcoursenumber
@@ -2340,6 +2474,8 @@ paths:
           * `-readable_id` - Readable ID descending
           * `last_modified` - Last Modified Date ascending
           * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
           * `start_date` - Start Date ascending
           * `-start_date` - Start Date descending
           * `mitcoursenumber` - MIT course number ascending
@@ -2488,12 +2624,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -2558,6 +2688,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learningpaths
       security:
@@ -2612,17 +2770,17 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: path
         name: parent_id
         schema:
           type: integer
         required: true
+      - name: sortby
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       tags:
       - learningpaths
       security:
@@ -3021,12 +3179,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -3091,6 +3243,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learningpaths
       security:
@@ -3228,12 +3408,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -3298,6 +3472,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - learningpaths
       security:
@@ -3435,12 +3637,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -3505,6 +3701,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcast_episodes
       security:
@@ -3665,12 +3889,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -3735,6 +3953,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcast_episodes
       security:
@@ -3872,12 +4118,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -3942,6 +4182,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcast_episodes
       security:
@@ -4079,12 +4347,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -4149,6 +4411,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcasts
       security:
@@ -4177,17 +4467,17 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: path
         name: parent_id
         schema:
           type: integer
         required: true
+      - name: sortby
+        required: false
+        in: query
+        description: Which field to use when ordering the results.
+        schema:
+          type: string
       tags:
       - podcasts
       security:
@@ -4375,12 +4665,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -4445,6 +4729,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcasts
       security:
@@ -4582,12 +4894,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -4652,6 +4958,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - podcasts
       security:
@@ -4789,12 +5123,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -4859,6 +5187,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - programs
       security:
@@ -5019,12 +5375,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -5089,6 +5439,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - programs
       security:
@@ -5226,12 +5604,6 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
-      - name: ordering
-        required: false
-        in: query
-        description: Which field to use when ordering the results.
-        schema:
-          type: string
       - in: query
         name: platform
         schema:
@@ -5296,6 +5668,34 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created_on
+          - -id
+          - -last_modified
+          - -readable_id
+          - -start_date
+          - created_on
+          - id
+          - last_modified
+          - readable_id
+          - start_date
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `readable_id` - Readable ID ascending
+          * `-readable_id` - Readable ID descending
+          * `last_modified` - Last Modified Date ascending
+          * `-last_modified` - Last Modified Date descending
+          * `created_on` - Creation Date ascending
+          * `-created_on` - CreationDate descending
+          * `start_date` - Start Date ascending
+          * `-start_date` - Start Date descending
       tags:
       - programs
       security:


### PR DESCRIPTION
# What are the relevant tickets?
Closes #220 

# Description (What does it do?)
- Changes the default DRF ordering parameter to "sortby"
- modifies the `LearningResourceFilter` class to also handle the sortby parameter and provide choices that drf_spectacular can translate to better schema documentation

# Screenshots (if appropriate):


![Screenshot 2023-11-16 at 11 12 33 AM](https://github.com/mitodl/mit-open/assets/187676/93487c97-ccb7-49eb-a5f3-3b01021cf1be)

![Screenshot 2023-11-16 at 11 13 32 AM](https://github.com/mitodl/mit-open/assets/187676/31efe0cd-e761-47b9-b233-2e230a2c8803)


![Screenshot 2023-11-16 at 11 14 42 AM](https://github.com/mitodl/mit-open/assets/187676/0f6165ba-d3e4-4cd9-8372-2322e206bd00)


# How can this be tested?

Run `./manage.py update_course_number_departments`

Run `./manage.py recreate_index --all`

Try the following urls, they should return results in the expected sort order based on the specified value:
http://localhost:8063/api/v1/learning_resources/?sortby=-id
http://localhost:8063/api/v1/learning_resources/?sortby=readable_id
http://localhost:8063/api/v1/learning_resources/?sortby=-last_modified
http://localhost:8063/api/v1/learning_resources/?sortby=start_date

Check the swagger and redoc documentation, they should look like screenshots above.




