### PR TITLE
do not index any pages, for now

### DIFF
--- a/open_discussions/templatetags/noindex_meta.py
+++ b/open_discussions/templatetags/noindex_meta.py
@@ -1,7 +1,6 @@
 """Adds in noindex meta tag to all pages for non-production environments."""
 
 from django import template
-from django.conf import settings
 from django.utils.html import format_html
 
 register = template.Library()
@@ -12,6 +11,7 @@ def noindex_meta():
     """Add noindex for non-production environments."""
     return (
         format_html("""<meta name="robots" content="noindex">""")
-        if settings.ENVIRONMENT not in ("production", "prod")
-        else ""
+        # Restore conditional inclusion after launch
+        # if settings.ENVIRONMENT not in ("production", "prod")
+        # else ""
     )


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/223

# Description (What does it do?)
Changes our noindex template to add `<meta name="robots" content="noindex">` in all environments, not just non-production environments.

# How can this be tested?
Check http://localhost:8063 when `MITOPEN_ENVIRONMENT=production`. The page should have a noindex meta tag.