### PR TITLE
Normalize learning resource serializers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           MITOPEN_COOKIE_NAME: cookie_monster
 
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml
 
@@ -136,7 +136,7 @@ jobs:
           NODE_ENV: test
 
       - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: coverage/lcov.info
 
@@ -153,7 +153,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.15.1"
+          node-version: "18.18.2"
           cache: "yarn"
 
       - name: Install dependencies
@@ -168,7 +168,7 @@ jobs:
           command-args: |
             --output $GENERATOR_OUTPUT_DIR_CI \
             --ignore-file-override $GENERATOR_IGNORE_FILE \
-            --additional-properties=useSingleRequestParameter=true,paramNaming=original
+            -c scripts/openapi-configs/typescript-axios.yaml
       - name: Format freshly generated client
         run: npx prettier $GENERATOR_OUTPUT_DIR_CI/**/*.ts --no-semi --write
       - name: Check VC client is up-to-date

--- a/Dockerfile-node
+++ b/Dockerfile-node
@@ -1,6 +1,12 @@
-FROM node:16.20.1
+FROM node:18.18.2
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 RUN apt-get update && apt-get install libelf1
 
 USER node
+
+# Workaround for ownership issues on /src
+# Your user in the host system owns this directory anda corresponding user
+# with the same uid doesn't exist in the container. This makes git unhappy,
+# which also makes commands like `yarn run test-watch` unhappy.
+RUN git config --global --add safe.directory /src

--- a/channels/factories.py
+++ b/channels/factories.py
@@ -1,13 +1,14 @@
 """Factories for channels"""
 
 import factory
+from factory.django import DjangoModelFactory
 
 from channels.api import create_field_groups_and_roles
 from channels.models import FieldChannel, FieldList, Subfield
 from learning_resources.factories import LearningPathFactory
 
 
-class FieldChannelFactory(factory.DjangoModelFactory):
+class FieldChannelFactory(DjangoModelFactory):
     """Factory for a channels.models.FieldChannel object"""
 
     name = factory.fuzzy.FuzzyText(length=21)
@@ -37,9 +38,10 @@ class FieldChannelFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = FieldChannel
+        skip_postgeneration_save = True
 
 
-class SubfieldFactory(factory.DjangoModelFactory):
+class SubfieldFactory(DjangoModelFactory):
     """Factory for channels.models.Subfield object"""
 
     position = factory.Sequence(lambda n: n)
@@ -50,7 +52,7 @@ class SubfieldFactory(factory.DjangoModelFactory):
         model = Subfield
 
 
-class FieldListFactory(factory.DjangoModelFactory):
+class FieldListFactory(DjangoModelFactory):
     """Factory for channels.models.FieldList object"""
 
     learning_path = factory.SubFactory(LearningPathFactory)

--- a/course_catalog/factories.py
+++ b/course_catalog/factories.py
@@ -201,6 +201,7 @@ class CourseFactory(AbstractCourseFactory):
 
     class Meta:
         model = Course
+        skip_postgeneration_save = True
 
 
 class LearningResourceRunFactory(AbstractCourseFactory):
@@ -264,6 +265,7 @@ class LearningResourceRunFactory(AbstractCourseFactory):
 
     class Meta:
         model = LearningResourceRun
+        skip_postgeneration_save = True
 
     class Params:
         no_prices = factory.Trait(prices=[])
@@ -380,6 +382,7 @@ class ProgramFactory(LearningResourceFactory):
 
     class Meta:
         model = Program
+        skip_postgeneration_save = True
 
 
 class UserListFactory(DjangoModelFactory):
@@ -404,6 +407,7 @@ class UserListFactory(DjangoModelFactory):
 
     class Meta:
         model = UserList
+        skip_postgeneration_save = True
 
     class Params:
         is_learning_path = factory.Trait(list_type=UserListType.LEARNING_PATH.value)
@@ -420,6 +424,7 @@ class StaffListItemFactory(ListItemFactory):
 
     class Meta:
         model = StaffListItem
+        skip_postgeneration_save = True
 
     class Params:
         is_course = factory.Trait(
@@ -465,6 +470,7 @@ class StaffListFactory(DjangoModelFactory):
 
     class Meta:
         model = StaffList
+        skip_postgeneration_save = True
 
     class Params:
         is_path = factory.Trait(list_type=StaffListType.PATH.value)
@@ -496,6 +502,7 @@ class VideoFactory(LearningResourceFactory):
 
     class Meta:
         model = Video
+        skip_postgeneration_save = True
 
 
 class VideoChannelFactory(LearningResourceFactory):
@@ -519,6 +526,7 @@ class VideoChannelFactory(LearningResourceFactory):
 
     class Meta:
         model = VideoChannel
+        skip_postgeneration_save = True
 
 
 class PlaylistFactory(LearningResourceFactory):
@@ -544,6 +552,7 @@ class PlaylistFactory(LearningResourceFactory):
 
     class Meta:
         model = Playlist
+        skip_postgeneration_save = True
 
 
 class PodcastFactory(LearningResourceFactory):
@@ -561,6 +570,7 @@ class PodcastFactory(LearningResourceFactory):
 
     class Meta:
         model = Podcast
+        skip_postgeneration_save = True
 
 
 class PodcastEpisodeFactory(LearningResourceFactory):
@@ -578,3 +588,4 @@ class PodcastEpisodeFactory(LearningResourceFactory):
 
     class Meta:
         model = PodcastEpisode
+        skip_postgeneration_save = True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,9 @@ services:
       - django_media:/var/media
 
   watch:
-    image: node:18.18.2
+    build:
+      context: .
+      dockerfile: Dockerfile-node
     working_dir: /src
     command: ./scripts/run-watch-dev.sh
     ports:

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -357,6 +357,226 @@ export interface CourseRequest {
   course_numbers: Array<CourseNumberRequest> | null
 }
 /**
+ * Serializer for course resources
+ * @export
+ * @interface CourseResource
+ */
+export interface CourseResource {
+  /**
+   *
+   * @type {number}
+   * @memberof CourseResource
+   */
+  id: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof CourseResource
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof CourseResource
+   */
+  offered_by: LearningResourceOfferor | null
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof CourseResource
+   */
+  platform: LearningResourcePlatform | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof CourseResource
+   */
+  resource_content_tags: Array<string> | null
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof CourseResource
+   */
+  departments: Array<LearningResourceDepartment> | null
+  /**
+   * Returns the certification for the learning resource
+   * @type {string}
+   * @memberof CourseResource
+   */
+  certification: string | null
+  /**
+   * Returns the prices for the learning resource
+   * @type {string}
+   * @memberof CourseResource
+   */
+  prices: string | null
+  /**
+   *
+   * @type {Array<LearningResourceRun>}
+   * @memberof CourseResource
+   */
+  runs: Array<LearningResourceRun> | null
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof CourseResource
+   */
+  image: LearningResourceImage | null
+  /**
+   *
+   * @type {Array<MicroLearningPathRelationship>}
+   * @memberof CourseResource
+   */
+  learning_path_parents: Array<MicroLearningPathRelationship> | null
+  /**
+   *
+   * @type {Array<MicroUserListRelationship>}
+   * @memberof CourseResource
+   */
+  user_list_parents: Array<MicroUserListRelationship> | null
+  /**
+   *
+   * @type {CourseResourceResourceTypeEnum}
+   * @memberof CourseResource
+   */
+  resource_type: CourseResourceResourceTypeEnum
+  /**
+   *
+   * @type {Course}
+   * @memberof CourseResource
+   */
+  course: Course
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof CourseResource
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof CourseResource
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResource
+   */
+  url?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof CourseResource
+   */
+  professional: boolean
+}
+
+/**
+ * Serializer for course resources
+ * @export
+ * @interface CourseResourceRequest
+ */
+export interface CourseResourceRequest {
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof CourseResourceRequest
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof CourseResourceRequest
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof CourseResourceRequest
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof CourseResourceRequest
+   */
+  url?: string | null
+}
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const CourseResourceResourceTypeEnum = {
+  Course: "course",
+} as const
+
+export type CourseResourceResourceTypeEnum =
+  (typeof CourseResourceResourceTypeEnum)[keyof typeof CourseResourceResourceTypeEnum]
+
+/**
  * Serializer for FieldChannel
  * @export
  * @interface FieldChannel
@@ -831,30 +1051,6 @@ export interface LearningPathResource {
   prices: string | null
   /**
    *
-   * @type {Course}
-   * @memberof LearningPathResource
-   */
-  course: Course | null
-  /**
-   *
-   * @type {LearningPath}
-   * @memberof LearningPathResource
-   */
-  learning_path: LearningPath | null
-  /**
-   *
-   * @type {Podcast}
-   * @memberof LearningPathResource
-   */
-  podcast: Podcast | null
-  /**
-   *
-   * @type {PodcastEpisode}
-   * @memberof LearningPathResource
-   */
-  podcast_episode: PodcastEpisode | null
-  /**
-   *
    * @type {Array<LearningResourceRun>}
    * @memberof LearningPathResource
    */
@@ -879,10 +1075,16 @@ export interface LearningPathResource {
   user_list_parents: Array<MicroUserListRelationship> | null
   /**
    *
-   * @type {Program}
+   * @type {LearningPathResourceResourceTypeEnum}
    * @memberof LearningPathResource
    */
-  program: Program | null
+  resource_type: LearningPathResourceResourceTypeEnum
+  /**
+   *
+   * @type {LearningPath}
+   * @memberof LearningPathResource
+   */
+  learning_path: LearningPath
   /**
    *
    * @type {string}
@@ -933,22 +1135,10 @@ export interface LearningPathResource {
   url?: string | null
   /**
    *
-   * @type {ResourceTypeEnum}
-   * @memberof LearningPathResource
-   */
-  resource_type: ResourceTypeEnum
-  /**
-   *
    * @type {boolean}
    * @memberof LearningPathResource
    */
   professional?: boolean
-  /**
-   *
-   * @type {Array<number>}
-   * @memberof LearningPathResource
-   */
-  resources: Array<number>
 }
 
 /**
@@ -968,12 +1158,6 @@ export interface LearningPathResourceRequest {
    * @type {string}
    * @memberof LearningPathResourceRequest
    */
-  readable_id: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningPathResourceRequest
-   */
   title: string
   /**
    *
@@ -1011,12 +1195,6 @@ export interface LearningPathResourceRequest {
    * @memberof LearningPathResourceRequest
    */
   url?: string | null
-  /**
-   *
-   * @type {ResourceTypeEnum}
-   * @memberof LearningPathResourceRequest
-   */
-  resource_type: ResourceTypeEnum
   /**
    *
    * @type {boolean}
@@ -1024,340 +1202,29 @@ export interface LearningPathResourceRequest {
    */
   professional?: boolean
 }
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const LearningPathResourceResourceTypeEnum = {
+  LearningPath: "learning_path",
+} as const
+
+export type LearningPathResourceResourceTypeEnum =
+  (typeof LearningPathResourceResourceTypeEnum)[keyof typeof LearningPathResourceResourceTypeEnum]
 
 /**
- * Serializer for LearningResource, with program included
+ * @type LearningResource
  * @export
- * @interface LearningResource
  */
-export interface LearningResource {
-  /**
-   *
-   * @type {number}
-   * @memberof LearningResource
-   */
-  id: number
-  /**
-   *
-   * @type {Array<LearningResourceTopic>}
-   * @memberof LearningResource
-   */
-  topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {LearningResourceOfferor}
-   * @memberof LearningResource
-   */
-  offered_by: LearningResourceOfferor | null
-  /**
-   *
-   * @type {LearningResourcePlatform}
-   * @memberof LearningResource
-   */
-  platform: LearningResourcePlatform | null
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LearningResource
-   */
-  resource_content_tags: Array<string> | null
-  /**
-   *
-   * @type {Array<LearningResourceDepartment>}
-   * @memberof LearningResource
-   */
-  departments: Array<LearningResourceDepartment> | null
-  /**
-   * Returns the certification for the learning resource
-   * @type {string}
-   * @memberof LearningResource
-   */
-  certification: string | null
-  /**
-   * Returns the prices for the learning resource
-   * @type {string}
-   * @memberof LearningResource
-   */
-  prices: string | null
-  /**
-   *
-   * @type {Course}
-   * @memberof LearningResource
-   */
-  course: Course | null
-  /**
-   *
-   * @type {LearningPath}
-   * @memberof LearningResource
-   */
-  learning_path: LearningPath | null
-  /**
-   *
-   * @type {Podcast}
-   * @memberof LearningResource
-   */
-  podcast: Podcast | null
-  /**
-   *
-   * @type {PodcastEpisode}
-   * @memberof LearningResource
-   */
-  podcast_episode: PodcastEpisode | null
-  /**
-   *
-   * @type {Array<LearningResourceRun>}
-   * @memberof LearningResource
-   */
-  runs: Array<LearningResourceRun> | null
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof LearningResource
-   */
-  image: LearningResourceImage | null
-  /**
-   *
-   * @type {Array<MicroLearningPathRelationship>}
-   * @memberof LearningResource
-   */
-  learning_path_parents: Array<MicroLearningPathRelationship> | null
-  /**
-   *
-   * @type {Array<MicroUserListRelationship>}
-   * @memberof LearningResource
-   */
-  user_list_parents: Array<MicroUserListRelationship> | null
-  /**
-   *
-   * @type {Program}
-   * @memberof LearningResource
-   */
-  program: Program | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  readable_id: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  full_description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  last_modified?: string | null
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResource
-   */
-  published?: boolean
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LearningResource
-   */
-  languages?: Array<string> | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResource
-   */
-  url?: string | null
-  /**
-   *
-   * @type {ResourceTypeEnum}
-   * @memberof LearningResource
-   */
-  resource_type: ResourceTypeEnum
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResource
-   */
-  professional: boolean
-}
-
-/**
- * Serializer for LearningResource, minus program
- * @export
- * @interface LearningResourceBase
- */
-export interface LearningResourceBase {
-  /**
-   *
-   * @type {number}
-   * @memberof LearningResourceBase
-   */
-  id: number
-  /**
-   *
-   * @type {Array<LearningResourceTopic>}
-   * @memberof LearningResourceBase
-   */
-  topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {LearningResourceOfferor}
-   * @memberof LearningResourceBase
-   */
-  offered_by: LearningResourceOfferor | null
-  /**
-   *
-   * @type {LearningResourcePlatform}
-   * @memberof LearningResourceBase
-   */
-  platform: LearningResourcePlatform | null
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LearningResourceBase
-   */
-  resource_content_tags: Array<string> | null
-  /**
-   *
-   * @type {Array<LearningResourceDepartment>}
-   * @memberof LearningResourceBase
-   */
-  departments: Array<LearningResourceDepartment> | null
-  /**
-   * Returns the certification for the learning resource
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  certification: string | null
-  /**
-   * Returns the prices for the learning resource
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  prices: string | null
-  /**
-   *
-   * @type {Course}
-   * @memberof LearningResourceBase
-   */
-  course: Course | null
-  /**
-   *
-   * @type {LearningPath}
-   * @memberof LearningResourceBase
-   */
-  learning_path: LearningPath | null
-  /**
-   *
-   * @type {Podcast}
-   * @memberof LearningResourceBase
-   */
-  podcast: Podcast | null
-  /**
-   *
-   * @type {PodcastEpisode}
-   * @memberof LearningResourceBase
-   */
-  podcast_episode: PodcastEpisode | null
-  /**
-   *
-   * @type {Array<LearningResourceRun>}
-   * @memberof LearningResourceBase
-   */
-  runs: Array<LearningResourceRun> | null
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof LearningResourceBase
-   */
-  image: LearningResourceImage | null
-  /**
-   *
-   * @type {Array<MicroLearningPathRelationship>}
-   * @memberof LearningResourceBase
-   */
-  learning_path_parents: Array<MicroLearningPathRelationship> | null
-  /**
-   *
-   * @type {Array<MicroUserListRelationship>}
-   * @memberof LearningResourceBase
-   */
-  user_list_parents: Array<MicroUserListRelationship> | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  readable_id: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  full_description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  last_modified?: string | null
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResourceBase
-   */
-  published?: boolean
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LearningResourceBase
-   */
-  languages?: Array<string> | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceBase
-   */
-  url?: string | null
-  /**
-   *
-   * @type {ResourceTypeEnum}
-   * @memberof LearningResourceBase
-   */
-  resource_type: ResourceTypeEnum
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResourceBase
-   */
-  professional: boolean
-}
+export type LearningResource =
+  | ({ resource_type: "course" } & CourseResource)
+  | ({ resource_type: "learning_path" } & LearningPathResource)
+  | ({ resource_type: "podcast" } & PodcastResource)
+  | ({ resource_type: "podcast_episode" } & PodcastEpisodeResource)
+  | ({ resource_type: "program" } & ProgramResource)
 
 /**
  * Serializer for LearningResourceRelationship children
@@ -1599,72 +1466,15 @@ export interface LearningResourcePlatformRequest {
   name?: string
 }
 /**
- * Serializer for LearningResource, with program included
+ * @type LearningResourceRequest
  * @export
- * @interface LearningResourceRequest
  */
-export interface LearningResourceRequest {
-  /**
-   *
-   * @type {Array<LearningResourceTopic>}
-   * @memberof LearningResourceRequest
-   */
-  topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  readable_id: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  full_description?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  last_modified?: string | null
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResourceRequest
-   */
-  published?: boolean
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof LearningResourceRequest
-   */
-  languages?: Array<string> | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceRequest
-   */
-  url?: string | null
-  /**
-   *
-   * @type {ResourceTypeEnum}
-   * @memberof LearningResourceRequest
-   */
-  resource_type: ResourceTypeEnum
-}
+export type LearningResourceRequest =
+  | ({ resource_type: "course" } & CourseResourceRequest)
+  | ({ resource_type: "learning_path" } & LearningPathResourceRequest)
+  | ({ resource_type: "podcast" } & PodcastResourceRequest)
+  | ({ resource_type: "podcast_episode" } & PodcastEpisodeResourceRequest)
+  | ({ resource_type: "program" } & ProgramResourceRequest)
 
 /**
  * Serializer for the LearningResourceRun model
@@ -2060,6 +1870,37 @@ export interface PaginatedContentFileList {
 /**
  *
  * @export
+ * @interface PaginatedCourseResourceList
+ */
+export interface PaginatedCourseResourceList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedCourseResourceList
+   */
+  count?: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedCourseResourceList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedCourseResourceList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<CourseResource>}
+   * @memberof PaginatedCourseResourceList
+   */
+  results?: Array<CourseResource>
+}
+/**
+ *
+ * @export
  * @interface PaginatedFieldChannelList
  */
 export interface PaginatedFieldChannelList {
@@ -2246,6 +2087,99 @@ export interface PaginatedLearningResourceTopicList {
 /**
  *
  * @export
+ * @interface PaginatedPodcastEpisodeResourceList
+ */
+export interface PaginatedPodcastEpisodeResourceList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedPodcastEpisodeResourceList
+   */
+  count?: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedPodcastEpisodeResourceList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedPodcastEpisodeResourceList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<PodcastEpisodeResource>}
+   * @memberof PaginatedPodcastEpisodeResourceList
+   */
+  results?: Array<PodcastEpisodeResource>
+}
+/**
+ *
+ * @export
+ * @interface PaginatedPodcastResourceList
+ */
+export interface PaginatedPodcastResourceList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedPodcastResourceList
+   */
+  count?: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedPodcastResourceList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedPodcastResourceList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<PodcastResource>}
+   * @memberof PaginatedPodcastResourceList
+   */
+  results?: Array<PodcastResource>
+}
+/**
+ *
+ * @export
+ * @interface PaginatedProgramResourceList
+ */
+export interface PaginatedProgramResourceList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedProgramResourceList
+   */
+  count?: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedProgramResourceList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedProgramResourceList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<ProgramResource>}
+   * @memberof PaginatedProgramResourceList
+   */
+  results?: Array<ProgramResource>
+}
+/**
+ *
+ * @export
  * @interface PaginatedUserListList
  */
 export interface PaginatedUserListList {
@@ -2421,12 +2355,6 @@ export interface PatchedLearningPathResourceRequest {
    * @type {string}
    * @memberof PatchedLearningPathResourceRequest
    */
-  readable_id?: string
-  /**
-   *
-   * @type {string}
-   * @memberof PatchedLearningPathResourceRequest
-   */
   title?: string
   /**
    *
@@ -2466,18 +2394,11 @@ export interface PatchedLearningPathResourceRequest {
   url?: string | null
   /**
    *
-   * @type {ResourceTypeEnum}
-   * @memberof PatchedLearningPathResourceRequest
-   */
-  resource_type?: ResourceTypeEnum
-  /**
-   *
    * @type {boolean}
    * @memberof PatchedLearningPathResourceRequest
    */
   professional?: boolean
 }
-
 /**
  * Serializer for UserListRelationship model
  * @export
@@ -2641,6 +2562,226 @@ export interface PodcastEpisodeRequest {
   rss?: string | null
 }
 /**
+ * Serializer for podcast episode resources
+ * @export
+ * @interface PodcastEpisodeResource
+ */
+export interface PodcastEpisodeResource {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastEpisodeResource
+   */
+  id: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof PodcastEpisodeResource
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof PodcastEpisodeResource
+   */
+  offered_by: LearningResourceOfferor | null
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof PodcastEpisodeResource
+   */
+  platform: LearningResourcePlatform | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastEpisodeResource
+   */
+  resource_content_tags: Array<string> | null
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof PodcastEpisodeResource
+   */
+  departments: Array<LearningResourceDepartment> | null
+  /**
+   * Returns the certification for the learning resource
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  certification: string | null
+  /**
+   * Returns the prices for the learning resource
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  prices: string | null
+  /**
+   *
+   * @type {Array<LearningResourceRun>}
+   * @memberof PodcastEpisodeResource
+   */
+  runs: Array<LearningResourceRun> | null
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastEpisodeResource
+   */
+  image: LearningResourceImage | null
+  /**
+   *
+   * @type {Array<MicroLearningPathRelationship>}
+   * @memberof PodcastEpisodeResource
+   */
+  learning_path_parents: Array<MicroLearningPathRelationship> | null
+  /**
+   *
+   * @type {Array<MicroUserListRelationship>}
+   * @memberof PodcastEpisodeResource
+   */
+  user_list_parents: Array<MicroUserListRelationship> | null
+  /**
+   *
+   * @type {PodcastEpisodeResourceResourceTypeEnum}
+   * @memberof PodcastEpisodeResource
+   */
+  resource_type: PodcastEpisodeResourceResourceTypeEnum
+  /**
+   *
+   * @type {PodcastEpisode}
+   * @memberof PodcastEpisodeResource
+   */
+  podcast_episode: PodcastEpisode
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastEpisodeResource
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastEpisodeResource
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  url?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastEpisodeResource
+   */
+  professional: boolean
+}
+
+/**
+ * Serializer for podcast episode resources
+ * @export
+ * @interface PodcastEpisodeResourceRequest
+ */
+export interface PodcastEpisodeResourceRequest {
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeResourceRequest
+   */
+  url?: string | null
+}
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const PodcastEpisodeResourceResourceTypeEnum = {
+  PodcastEpisode: "podcast_episode",
+} as const
+
+export type PodcastEpisodeResourceResourceTypeEnum =
+  (typeof PodcastEpisodeResourceResourceTypeEnum)[keyof typeof PodcastEpisodeResourceResourceTypeEnum]
+
+/**
  * Serializer for Podcasts
  * @export
  * @interface PodcastRequest
@@ -2666,6 +2807,226 @@ export interface PodcastRequest {
   rss_url?: string | null
 }
 /**
+ * Serializer for podcast resources
+ * @export
+ * @interface PodcastResource
+ */
+export interface PodcastResource {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastResource
+   */
+  id: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof PodcastResource
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof PodcastResource
+   */
+  offered_by: LearningResourceOfferor | null
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof PodcastResource
+   */
+  platform: LearningResourcePlatform | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastResource
+   */
+  resource_content_tags: Array<string> | null
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof PodcastResource
+   */
+  departments: Array<LearningResourceDepartment> | null
+  /**
+   * Returns the certification for the learning resource
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  certification: string | null
+  /**
+   * Returns the prices for the learning resource
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  prices: string | null
+  /**
+   *
+   * @type {Array<LearningResourceRun>}
+   * @memberof PodcastResource
+   */
+  runs: Array<LearningResourceRun> | null
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastResource
+   */
+  image: LearningResourceImage | null
+  /**
+   *
+   * @type {Array<MicroLearningPathRelationship>}
+   * @memberof PodcastResource
+   */
+  learning_path_parents: Array<MicroLearningPathRelationship> | null
+  /**
+   *
+   * @type {Array<MicroUserListRelationship>}
+   * @memberof PodcastResource
+   */
+  user_list_parents: Array<MicroUserListRelationship> | null
+  /**
+   *
+   * @type {PodcastResourceResourceTypeEnum}
+   * @memberof PodcastResource
+   */
+  resource_type: PodcastResourceResourceTypeEnum
+  /**
+   *
+   * @type {Podcast}
+   * @memberof PodcastResource
+   */
+  podcast: Podcast
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastResource
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastResource
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  url?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastResource
+   */
+  professional: boolean
+}
+
+/**
+ * Serializer for podcast resources
+ * @export
+ * @interface PodcastResourceRequest
+ */
+export interface PodcastResourceRequest {
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof PodcastResourceRequest
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof PodcastResourceRequest
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PodcastResourceRequest
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastResourceRequest
+   */
+  url?: string | null
+}
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const PodcastResourceResourceTypeEnum = {
+  Podcast: "podcast",
+} as const
+
+export type PodcastResourceResourceTypeEnum =
+  (typeof PodcastResourceResourceTypeEnum)[keyof typeof PodcastResourceResourceTypeEnum]
+
+/**
  * * `private` - private * `unlisted` - unlisted
  * @export
  * @enum {string}
@@ -2687,13 +3048,233 @@ export type PrivacyLevelEnum =
 export interface Program {
   /**
    *
-   * @type {Array<LearningResourceBase>}
+   * @type {Array<CourseResource>}
    * @memberof Program
    */
-  courses: Array<LearningResourceBase> | null
+  courses: Array<CourseResource> | null
 }
 /**
- * * `course` - Course * `program` - Program * `learning_path` - Learning Path * `podcast` - Podcast * `podcast_episode` - Podcast Episode
+ * Serializer for program resources
+ * @export
+ * @interface ProgramResource
+ */
+export interface ProgramResource {
+  /**
+   *
+   * @type {number}
+   * @memberof ProgramResource
+   */
+  id: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof ProgramResource
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof ProgramResource
+   */
+  offered_by: LearningResourceOfferor | null
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof ProgramResource
+   */
+  platform: LearningResourcePlatform | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ProgramResource
+   */
+  resource_content_tags: Array<string> | null
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof ProgramResource
+   */
+  departments: Array<LearningResourceDepartment> | null
+  /**
+   * Returns the certification for the learning resource
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  certification: string | null
+  /**
+   * Returns the prices for the learning resource
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  prices: string | null
+  /**
+   *
+   * @type {Array<LearningResourceRun>}
+   * @memberof ProgramResource
+   */
+  runs: Array<LearningResourceRun> | null
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof ProgramResource
+   */
+  image: LearningResourceImage | null
+  /**
+   *
+   * @type {Array<MicroLearningPathRelationship>}
+   * @memberof ProgramResource
+   */
+  learning_path_parents: Array<MicroLearningPathRelationship> | null
+  /**
+   *
+   * @type {Array<MicroUserListRelationship>}
+   * @memberof ProgramResource
+   */
+  user_list_parents: Array<MicroUserListRelationship> | null
+  /**
+   *
+   * @type {ProgramResourceResourceTypeEnum}
+   * @memberof ProgramResource
+   */
+  resource_type: ProgramResourceResourceTypeEnum
+  /**
+   *
+   * @type {Program}
+   * @memberof ProgramResource
+   */
+  program: Program
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof ProgramResource
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ProgramResource
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  url?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof ProgramResource
+   */
+  professional: boolean
+}
+
+/**
+ * Serializer for program resources
+ * @export
+ * @interface ProgramResourceRequest
+ */
+export interface ProgramResourceRequest {
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof ProgramResourceRequest
+   */
+  topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  full_description?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  last_modified?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof ProgramResourceRequest
+   */
+  published?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ProgramResourceRequest
+   */
+  languages?: Array<string> | null
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramResourceRequest
+   */
+  url?: string | null
+}
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const ProgramResourceResourceTypeEnum = {
+  Program: "program",
+} as const
+
+export type ProgramResourceResourceTypeEnum =
+  (typeof ProgramResourceResourceTypeEnum)[keyof typeof ProgramResourceResourceTypeEnum]
+
+/**
+ * * `course` - course * `program` - program * `learning_path` - learning_path * `podcast` - podcast * `podcast_episode` - podcast_episode
  * @export
  * @enum {string}
  */
@@ -4894,108 +5475,12 @@ export const CoursesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    coursesNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    coursesNewRetrieve: async (
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/new/`
@@ -5015,38 +5500,6 @@ export const CoursesApiAxiosParamCreator = function (
       const localVarQueryParameter = {} as any
 
       // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -5111,7 +5564,7 @@ export const CoursesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Courses.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -5463,7 +5916,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedCourseResourceList>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.coursesList(
         department,
@@ -5484,126 +5937,18 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async coursesNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    async coursesNewRetrieve(
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<CourseResource>
     > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.coursesNewList(
-        department,
-        limit,
-        offered_by,
-        offset,
-        platform,
-        professional,
-        resource_type,
-        sortby,
-        options,
-      )
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.coursesNewRetrieve(options)
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -5622,10 +5967,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       id: number,
       options?: AxiosRequestConfig,
     ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<LearningResource>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<CourseResource>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.coursesRetrieve(
         id,
@@ -5639,7 +5981,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Courses.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -5746,7 +6088,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedCourseResourceList>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.coursesUpcomingList(
@@ -5830,7 +6172,7 @@ export const CoursesApiFactory = function (
     coursesList(
       requestParameters: CoursesApiCoursesListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedCourseResourceList> {
       return localVarFp
         .coursesList(
           requestParameters.department,
@@ -5846,28 +6188,16 @@ export const CoursesApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {CoursesApiCoursesNewListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    coursesNewList(
-      requestParameters: CoursesApiCoursesNewListRequest = {},
+    coursesNewRetrieve(
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<CourseResource> {
       return localVarFp
-        .coursesNewList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
+        .coursesNewRetrieve(options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -5880,13 +6210,13 @@ export const CoursesApiFactory = function (
     coursesRetrieve(
       requestParameters: CoursesApiCoursesRetrieveRequest,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningResource> {
+    ): AxiosPromise<CourseResource> {
       return localVarFp
         .coursesRetrieve(requestParameters.id, options)
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Courses.
      * @summary List Upcoming
      * @param {CoursesApiCoursesUpcomingListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -5895,7 +6225,7 @@ export const CoursesApiFactory = function (
     coursesUpcomingList(
       requestParameters: CoursesApiCoursesUpcomingListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedCourseResourceList> {
       return localVarFp
         .coursesUpcomingList(
           requestParameters.department,
@@ -6103,149 +6433,6 @@ export interface CoursesApiCoursesListRequest {
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
    * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof CoursesApiCoursesList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
- * Request parameters for coursesNewList operation in CoursesApi.
- * @export
- * @interface CoursesApiCoursesNewListRequest
- */
-export interface CoursesApiCoursesNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof CoursesApiCoursesNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof CoursesApiCoursesNewList
    */
   readonly sortby?:
     | "-created_on"
@@ -6497,29 +6684,15 @@ export class CoursesApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of newly released resources.
+   * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
    * @summary List New
-   * @param {CoursesApiCoursesNewListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof CoursesApi
    */
-  public coursesNewList(
-    requestParameters: CoursesApiCoursesNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
+  public coursesNewRetrieve(options?: AxiosRequestConfig) {
     return CoursesApiFp(this.configuration)
-      .coursesNewList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
+      .coursesNewRetrieve(options)
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -6541,7 +6714,7 @@ export class CoursesApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of upcoming resources.
+   * Get a paginated list of upcoming $Courses.
    * @summary List Upcoming
    * @param {CoursesApiCoursesUpcomingListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -8218,108 +8391,12 @@ export const LearningResourcesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    learningResourcesNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    learningResourcesNewRetrieve: async (
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/new/`
@@ -8339,38 +8416,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
       const localVarQueryParameter = {} as any
 
       // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -8435,7 +8480,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Learning Resources.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -8876,127 +8921,21 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async learningResourcesNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    async learningResourcesNewRetrieve(
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<LearningResource>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.learningResourcesNewList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
+        await localVarAxiosParamCreator.learningResourcesNewRetrieve(options)
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -9030,7 +8969,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Learning Resources.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -9275,28 +9214,16 @@ export const LearningResourcesApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {LearningResourcesApiLearningResourcesNewListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    learningResourcesNewList(
-      requestParameters: LearningResourcesApiLearningResourcesNewListRequest = {},
+    learningResourcesNewRetrieve(
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<LearningResource> {
       return localVarFp
-        .learningResourcesNewList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
+        .learningResourcesNewRetrieve(options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -9315,7 +9242,7 @@ export const LearningResourcesApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Learning Resources.
      * @summary List Upcoming
      * @param {LearningResourcesApiLearningResourcesUpcomingListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -9588,149 +9515,6 @@ export interface LearningResourcesApiLearningResourcesListRequest {
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
    * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningResourcesApiLearningResourcesList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
- * Request parameters for learningResourcesNewList operation in LearningResourcesApi.
- * @export
- * @interface LearningResourcesApiLearningResourcesNewListRequest
- */
-export interface LearningResourcesApiLearningResourcesNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof LearningResourcesApiLearningResourcesNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof LearningResourcesApiLearningResourcesNewList
    */
   readonly sortby?:
     | "-created_on"
@@ -10024,29 +9808,15 @@ export class LearningResourcesApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of newly released resources.
+   * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
    * @summary List New
-   * @param {LearningResourcesApiLearningResourcesNewListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof LearningResourcesApi
    */
-  public learningResourcesNewList(
-    requestParameters: LearningResourcesApiLearningResourcesNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
+  public learningResourcesNewRetrieve(options?: AxiosRequestConfig) {
     return LearningResourcesApiFp(this.configuration)
-      .learningResourcesNewList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
+      .learningResourcesNewRetrieve(options)
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -10068,7 +9838,7 @@ export class LearningResourcesApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of upcoming resources.
+   * Get a paginated list of upcoming $Learning Resources.
    * @summary List Upcoming
    * @param {LearningResourcesApiLearningResourcesUpcomingListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -11063,175 +10833,6 @@ export const LearningpathsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/learningpaths/new/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Viewset for LearningPaths
      * @param {number} id A unique integer value identifying this learning resource.
      * @param {PatchedLearningPathResourceRequest} [PatchedLearningPathResourceRequest]
@@ -11697,175 +11298,6 @@ export const LearningpathsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsUpcomingList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/learningpaths/upcoming/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Viewset for LearningPaths
      * @param {number} id A unique integer value identifying this learning resource.
      * @param {LearningPathResourceRequest} LearningPathResourceRequest
@@ -12098,135 +11530,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningpathsList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async learningpathsNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.learningpathsNewList(
           department,
           limit,
           offered_by,
@@ -12489,135 +11792,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async learningpathsUpcomingList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.learningpathsUpcomingList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
      * Viewset for LearningPaths
      * @param {number} id A unique integer value identifying this learning resource.
      * @param {LearningPathResourceRequest} LearningPathResourceRequest
@@ -12705,31 +11879,6 @@ export const LearningpathsApiFactory = function (
     ): AxiosPromise<PaginatedLearningPathResourceList> {
       return localVarFp
         .learningpathsList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {LearningpathsApiLearningpathsNewListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsNewList(
-      requestParameters: LearningpathsApiLearningpathsNewListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .learningpathsNewList(
           requestParameters.department,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -12885,31 +12034,6 @@ export const LearningpathsApiFactory = function (
     ): AxiosPromise<LearningPathResource> {
       return localVarFp
         .learningpathsRetrieve(requestParameters.id, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {LearningpathsApiLearningpathsUpcomingListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsUpcomingList(
-      requestParameters: LearningpathsApiLearningpathsUpcomingListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .learningpathsUpcomingList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
         .then((request) => request(axios, basePath))
     },
     /**
@@ -13088,149 +12212,6 @@ export interface LearningpathsApiLearningpathsListRequest {
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
    * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof LearningpathsApiLearningpathsList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
- * Request parameters for learningpathsNewList operation in LearningpathsApi.
- * @export
- * @interface LearningpathsApiLearningpathsNewListRequest
- */
-export interface LearningpathsApiLearningpathsNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof LearningpathsApiLearningpathsNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof LearningpathsApiLearningpathsNewList
    */
   readonly sortby?:
     | "-created_on"
@@ -13437,149 +12418,6 @@ export interface LearningpathsApiLearningpathsRetrieveRequest {
 }
 
 /**
- * Request parameters for learningpathsUpcomingList operation in LearningpathsApi.
- * @export
- * @interface LearningpathsApiLearningpathsUpcomingListRequest
- */
-export interface LearningpathsApiLearningpathsUpcomingListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof LearningpathsApiLearningpathsUpcomingList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
  * Request parameters for learningpathsUpdate operation in LearningpathsApi.
  * @export
  * @interface LearningpathsApiLearningpathsUpdateRequest
@@ -13656,33 +12494,6 @@ export class LearningpathsApi extends BaseAPI {
   ) {
     return LearningpathsApiFp(this.configuration)
       .learningpathsList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Get a paginated list of newly released resources.
-   * @summary List New
-   * @param {LearningpathsApiLearningpathsNewListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LearningpathsApi
-   */
-  public learningpathsNewList(
-    requestParameters: LearningpathsApiLearningpathsNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return LearningpathsApiFp(this.configuration)
-      .learningpathsNewList(
         requestParameters.department,
         requestParameters.limit,
         requestParameters.offered_by,
@@ -13854,33 +12665,6 @@ export class LearningpathsApi extends BaseAPI {
   ) {
     return LearningpathsApiFp(this.configuration)
       .learningpathsRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Get a paginated list of upcoming resources.
-   * @summary List Upcoming
-   * @param {LearningpathsApiLearningpathsUpcomingListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LearningpathsApi
-   */
-  public learningpathsUpcomingList(
-    requestParameters: LearningpathsApiLearningpathsUpcomingListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return LearningpathsApiFp(this.configuration)
-      .learningpathsUpcomingList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -14083,175 +12867,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastEpisodesNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/podcast_episodes/new/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Retrieve a single learning resource.
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this learning resource.
@@ -14284,175 +12899,6 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
       const localVarQueryParameter = {} as any
 
       // authentication cookieAuth required
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastEpisodesUpcomingList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/podcast_episodes/upcoming/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -14587,139 +13033,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedPodcastEpisodeResourceList>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.podcastEpisodesList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async podcastEpisodesNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.podcastEpisodesNewList(
           department,
           limit,
           offered_by,
@@ -14751,139 +13068,10 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<LearningResource>
+      ) => AxiosPromise<PodcastEpisodeResource>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.podcastEpisodesRetrieve(id, options)
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async podcastEpisodesUpcomingList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.podcastEpisodesUpcomingList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -14915,34 +13103,9 @@ export const PodcastEpisodesApiFactory = function (
     podcastEpisodesList(
       requestParameters: PodcastEpisodesApiPodcastEpisodesListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedPodcastEpisodeResourceList> {
       return localVarFp
         .podcastEpisodesList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {PodcastEpisodesApiPodcastEpisodesNewListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastEpisodesNewList(
-      requestParameters: PodcastEpisodesApiPodcastEpisodesNewListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .podcastEpisodesNewList(
           requestParameters.department,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -14965,34 +13128,9 @@ export const PodcastEpisodesApiFactory = function (
     podcastEpisodesRetrieve(
       requestParameters: PodcastEpisodesApiPodcastEpisodesRetrieveRequest,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningResource> {
+    ): AxiosPromise<PodcastEpisodeResource> {
       return localVarFp
         .podcastEpisodesRetrieve(requestParameters.id, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {PodcastEpisodesApiPodcastEpisodesUpcomingListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastEpisodesUpcomingList(
-      requestParameters: PodcastEpisodesApiPodcastEpisodesUpcomingListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .podcastEpisodesUpcomingList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
         .then((request) => request(axios, basePath))
     },
   }
@@ -15142,149 +13280,6 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
 }
 
 /**
- * Request parameters for podcastEpisodesNewList operation in PodcastEpisodesApi.
- * @export
- * @interface PodcastEpisodesApiPodcastEpisodesNewListRequest
- */
-export interface PodcastEpisodesApiPodcastEpisodesNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesNewList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
  * Request parameters for podcastEpisodesRetrieve operation in PodcastEpisodesApi.
  * @export
  * @interface PodcastEpisodesApiPodcastEpisodesRetrieveRequest
@@ -15296,149 +13291,6 @@ export interface PodcastEpisodesApiPodcastEpisodesRetrieveRequest {
    * @memberof PodcastEpisodesApiPodcastEpisodesRetrieve
    */
   readonly id: number
-}
-
-/**
- * Request parameters for podcastEpisodesUpcomingList operation in PodcastEpisodesApi.
- * @export
- * @interface PodcastEpisodesApiPodcastEpisodesUpcomingListRequest
- */
-export interface PodcastEpisodesApiPodcastEpisodesUpcomingListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof PodcastEpisodesApiPodcastEpisodesUpcomingList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
 }
 
 /**
@@ -15476,33 +13328,6 @@ export class PodcastEpisodesApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of newly released resources.
-   * @summary List New
-   * @param {PodcastEpisodesApiPodcastEpisodesNewListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof PodcastEpisodesApi
-   */
-  public podcastEpisodesNewList(
-    requestParameters: PodcastEpisodesApiPodcastEpisodesNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return PodcastEpisodesApiFp(this.configuration)
-      .podcastEpisodesNewList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Retrieve a single learning resource.
    * @summary Retrieve
    * @param {PodcastEpisodesApiPodcastEpisodesRetrieveRequest} requestParameters Request parameters.
@@ -15516,33 +13341,6 @@ export class PodcastEpisodesApi extends BaseAPI {
   ) {
     return PodcastEpisodesApiFp(this.configuration)
       .podcastEpisodesRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Get a paginated list of upcoming resources.
-   * @summary List Upcoming
-   * @param {PodcastEpisodesApiPodcastEpisodesUpcomingListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof PodcastEpisodesApi
-   */
-  public podcastEpisodesUpcomingList(
-    requestParameters: PodcastEpisodesApiPodcastEpisodesUpcomingListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return PodcastEpisodesApiFp(this.configuration)
-      .podcastEpisodesUpcomingList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -15840,175 +13638,6 @@ export const PodcastsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastsNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/podcasts/new/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Retrieve a single learning resource.
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this learning resource.
@@ -16041,175 +13670,6 @@ export const PodcastsApiAxiosParamCreator = function (
       const localVarQueryParameter = {} as any
 
       // authentication cookieAuth required
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastsUpcomingList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      const localVarPath = `/api/v1/podcasts/upcoming/`
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "GET",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -16409,137 +13869,9 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedPodcastResourceList>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.podcastsList(
-        department,
-        limit,
-        offered_by,
-        offset,
-        platform,
-        professional,
-        resource_type,
-        sortby,
-        options,
-      )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async podcastsNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.podcastsNewList(
         department,
         limit,
         offered_by,
@@ -16571,139 +13903,10 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<LearningResource>
+      ) => AxiosPromise<PodcastResource>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.podcastsRetrieve(id, options)
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async podcastsUpcomingList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.podcastsUpcomingList(
-          department,
-          limit,
-          offered_by,
-          offset,
-          platform,
-          professional,
-          resource_type,
-          sortby,
-          options,
-        )
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -16773,34 +13976,9 @@ export const PodcastsApiFactory = function (
     podcastsList(
       requestParameters: PodcastsApiPodcastsListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedPodcastResourceList> {
       return localVarFp
         .podcastsList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of newly released resources.
-     * @summary List New
-     * @param {PodcastsApiPodcastsNewListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastsNewList(
-      requestParameters: PodcastsApiPodcastsNewListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .podcastsNewList(
           requestParameters.department,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -16823,34 +14001,9 @@ export const PodcastsApiFactory = function (
     podcastsRetrieve(
       requestParameters: PodcastsApiPodcastsRetrieveRequest,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningResource> {
+    ): AxiosPromise<PodcastResource> {
       return localVarFp
         .podcastsRetrieve(requestParameters.id, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Get a paginated list of upcoming resources.
-     * @summary List Upcoming
-     * @param {PodcastsApiPodcastsUpcomingListRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    podcastsUpcomingList(
-      requestParameters: PodcastsApiPodcastsUpcomingListRequest = {},
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
-      return localVarFp
-        .podcastsUpcomingList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
         .then((request) => request(axios, basePath))
     },
   }
@@ -17056,149 +14209,6 @@ export interface PodcastsApiPodcastsListRequest {
 }
 
 /**
- * Request parameters for podcastsNewList operation in PodcastsApi.
- * @export
- * @interface PodcastsApiPodcastsNewListRequest
- */
-export interface PodcastsApiPodcastsNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof PodcastsApiPodcastsNewList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
  * Request parameters for podcastsRetrieve operation in PodcastsApi.
  * @export
  * @interface PodcastsApiPodcastsRetrieveRequest
@@ -17210,149 +14220,6 @@ export interface PodcastsApiPodcastsRetrieveRequest {
    * @memberof PodcastsApiPodcastsRetrieve
    */
   readonly id: number
-}
-
-/**
- * Request parameters for podcastsUpcomingList operation in PodcastsApi.
- * @export
- * @interface PodcastsApiPodcastsUpcomingListRequest
- */
-export interface PodcastsApiPodcastsUpcomingListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof PodcastsApiPodcastsUpcomingList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
 }
 
 /**
@@ -17432,33 +14299,6 @@ export class PodcastsApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of newly released resources.
-   * @summary List New
-   * @param {PodcastsApiPodcastsNewListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof PodcastsApi
-   */
-  public podcastsNewList(
-    requestParameters: PodcastsApiPodcastsNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return PodcastsApiFp(this.configuration)
-      .podcastsNewList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Retrieve a single learning resource.
    * @summary Retrieve
    * @param {PodcastsApiPodcastsRetrieveRequest} requestParameters Request parameters.
@@ -17472,33 +14312,6 @@ export class PodcastsApi extends BaseAPI {
   ) {
     return PodcastsApiFp(this.configuration)
       .podcastsRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Get a paginated list of upcoming resources.
-   * @summary List Upcoming
-   * @param {PodcastsApiPodcastsUpcomingListRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof PodcastsApi
-   */
-  public podcastsUpcomingList(
-    requestParameters: PodcastsApiPodcastsUpcomingListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
-    return PodcastsApiFp(this.configuration)
-      .podcastsUpcomingList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -17681,108 +14494,12 @@ export const ProgramsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    programsNewList: async (
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    programsNewRetrieve: async (
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/new/`
@@ -17802,38 +14519,6 @@ export const ProgramsApiAxiosParamCreator = function (
       const localVarQueryParameter = {} as any
 
       // authentication cookieAuth required
-
-      if (department !== undefined) {
-        localVarQueryParameter["department"] = department
-      }
-
-      if (limit !== undefined) {
-        localVarQueryParameter["limit"] = limit
-      }
-
-      if (offered_by !== undefined) {
-        localVarQueryParameter["offered_by"] = offered_by
-      }
-
-      if (offset !== undefined) {
-        localVarQueryParameter["offset"] = offset
-      }
-
-      if (platform !== undefined) {
-        localVarQueryParameter["platform"] = platform
-      }
-
-      if (professional !== undefined) {
-        localVarQueryParameter["professional"] = professional
-      }
-
-      if (resource_type !== undefined) {
-        localVarQueryParameter["resource_type"] = resource_type
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
-      }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
@@ -17898,7 +14583,7 @@ export const ProgramsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Programs.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -18184,7 +14869,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedProgramResourceList>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.programsList(
         department,
@@ -18205,126 +14890,21 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {number} [limit] Number of results to return per page.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-     * @param {number} [offset] The initial index from which to return the results.
-     * @param {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {boolean} [professional]
-     * @param {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-     * @param {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async programsNewList(
-      department?:
-        | "1"
-        | "10"
-        | "11"
-        | "12"
-        | "14"
-        | "15"
-        | "16"
-        | "17"
-        | "18"
-        | "2"
-        | "20"
-        | "21A"
-        | "21G"
-        | "21H"
-        | "21L"
-        | "21M"
-        | "22"
-        | "24"
-        | "3"
-        | "4"
-        | "5"
-        | "6"
-        | "7"
-        | "8"
-        | "9"
-        | "CC"
-        | "CMS-W"
-        | "EC"
-        | "ES"
-        | "ESD"
-        | "HST"
-        | "IDS"
-        | "MAS"
-        | "PE"
-        | "RES"
-        | "STS"
-        | "WGS",
-      limit?: number,
-      offered_by?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "mitpe"
-        | "mitx"
-        | "ocw"
-        | "scc"
-        | "see"
-        | "xpro",
-      offset?: number,
-      platform?:
-        | "bootcamps"
-        | "csail"
-        | "ctl"
-        | "edx"
-        | "emeritus"
-        | "globalalumni"
-        | "mitpe"
-        | "mitxonline"
-        | "ocw"
-        | "oll"
-        | "podcast"
-        | "scc"
-        | "see"
-        | "simplilearn"
-        | "susskind"
-        | "whu"
-        | "xpro",
-      professional?: boolean,
-      resource_type?:
-        | "course"
-        | "learning_path"
-        | "podcast"
-        | "podcast_episode"
-        | "program",
-      sortby?:
-        | "-created_on"
-        | "-id"
-        | "-last_modified"
-        | "-mitcoursenumber"
-        | "-readable_id"
-        | "-start_date"
-        | "created_on"
-        | "id"
-        | "last_modified"
-        | "mitcoursenumber"
-        | "readable_id"
-        | "start_date",
+    async programsNewRetrieve(
       options?: AxiosRequestConfig,
     ): Promise<
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<ProgramResource>
     > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.programsNewList(
-        department,
-        limit,
-        offered_by,
-        offset,
-        platform,
-        professional,
-        resource_type,
-        sortby,
-        options,
-      )
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.programsNewRetrieve(options)
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -18346,7 +14926,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<LearningResource>
+      ) => AxiosPromise<ProgramResource>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.programsRetrieve(id, options)
@@ -18358,7 +14938,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Programs.
      * @summary List Upcoming
      * @param {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {number} [limit] Number of results to return per page.
@@ -18465,7 +15045,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<PaginatedLearningResourceList>
+      ) => AxiosPromise<PaginatedProgramResourceList>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.programsUpcomingList(
@@ -18510,7 +15090,7 @@ export const ProgramsApiFactory = function (
     programsList(
       requestParameters: ProgramsApiProgramsListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedProgramResourceList> {
       return localVarFp
         .programsList(
           requestParameters.department,
@@ -18526,28 +15106,16 @@ export const ProgramsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of newly released resources.
+     * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
      * @summary List New
-     * @param {ProgramsApiProgramsNewListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    programsNewList(
-      requestParameters: ProgramsApiProgramsNewListRequest = {},
+    programsNewRetrieve(
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<ProgramResource> {
       return localVarFp
-        .programsNewList(
-          requestParameters.department,
-          requestParameters.limit,
-          requestParameters.offered_by,
-          requestParameters.offset,
-          requestParameters.platform,
-          requestParameters.professional,
-          requestParameters.resource_type,
-          requestParameters.sortby,
-          options,
-        )
+        .programsNewRetrieve(options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -18560,13 +15128,13 @@ export const ProgramsApiFactory = function (
     programsRetrieve(
       requestParameters: ProgramsApiProgramsRetrieveRequest,
       options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningResource> {
+    ): AxiosPromise<ProgramResource> {
       return localVarFp
         .programsRetrieve(requestParameters.id, options)
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a paginated list of upcoming resources.
+     * Get a paginated list of upcoming $Programs.
      * @summary List Upcoming
      * @param {ProgramsApiProgramsUpcomingListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -18575,7 +15143,7 @@ export const ProgramsApiFactory = function (
     programsUpcomingList(
       requestParameters: ProgramsApiProgramsUpcomingListRequest = {},
       options?: AxiosRequestConfig,
-    ): AxiosPromise<PaginatedLearningResourceList> {
+    ): AxiosPromise<PaginatedProgramResourceList> {
       return localVarFp
         .programsUpcomingList(
           requestParameters.department,
@@ -18720,149 +15288,6 @@ export interface ProgramsApiProgramsListRequest {
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
    * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
    * @memberof ProgramsApiProgramsList
-   */
-  readonly sortby?:
-    | "-created_on"
-    | "-id"
-    | "-last_modified"
-    | "-mitcoursenumber"
-    | "-readable_id"
-    | "-start_date"
-    | "created_on"
-    | "id"
-    | "last_modified"
-    | "mitcoursenumber"
-    | "readable_id"
-    | "start_date"
-}
-
-/**
- * Request parameters for programsNewList operation in ProgramsApi.
- * @export
- * @interface ProgramsApiProgramsNewListRequest
- */
-export interface ProgramsApiProgramsNewListRequest {
-  /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly department?:
-    | "1"
-    | "10"
-    | "11"
-    | "12"
-    | "14"
-    | "15"
-    | "16"
-    | "17"
-    | "18"
-    | "2"
-    | "20"
-    | "21A"
-    | "21G"
-    | "21H"
-    | "21L"
-    | "21M"
-    | "22"
-    | "24"
-    | "3"
-    | "4"
-    | "5"
-    | "6"
-    | "7"
-    | "8"
-    | "9"
-    | "CC"
-    | "CMS-W"
-    | "EC"
-    | "ES"
-    | "ESD"
-    | "HST"
-    | "IDS"
-    | "MAS"
-    | "PE"
-    | "RES"
-    | "STS"
-    | "WGS"
-
-  /**
-   * Number of results to return per page.
-   * @type {number}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly limit?: number
-
-  /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly offered_by?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "mitpe"
-    | "mitx"
-    | "ocw"
-    | "scc"
-    | "see"
-    | "xpro"
-
-  /**
-   * The initial index from which to return the results.
-   * @type {number}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly offset?: number
-
-  /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly platform?:
-    | "bootcamps"
-    | "csail"
-    | "ctl"
-    | "edx"
-    | "emeritus"
-    | "globalalumni"
-    | "mitpe"
-    | "mitxonline"
-    | "ocw"
-    | "oll"
-    | "podcast"
-    | "scc"
-    | "see"
-    | "simplilearn"
-    | "susskind"
-    | "whu"
-    | "xpro"
-
-  /**
-   *
-   * @type {boolean}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly professional?: boolean
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
-   * @memberof ProgramsApiProgramsNewList
-   */
-  readonly resource_type?:
-    | "course"
-    | "learning_path"
-    | "podcast"
-    | "podcast_episode"
-    | "program"
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-   * @type {'-created_on' | '-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | 'created_on' | 'id' | 'last_modified' | 'mitcoursenumber' | 'readable_id' | 'start_date'}
-   * @memberof ProgramsApiProgramsNewList
    */
   readonly sortby?:
     | "-created_on"
@@ -19071,29 +15496,15 @@ export class ProgramsApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of newly released resources.
+   * Get new LearningResources  Returns:     QuerySet of LearningResource objects ordered by reverse created_on
    * @summary List New
-   * @param {ProgramsApiProgramsNewListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof ProgramsApi
    */
-  public programsNewList(
-    requestParameters: ProgramsApiProgramsNewListRequest = {},
-    options?: AxiosRequestConfig,
-  ) {
+  public programsNewRetrieve(options?: AxiosRequestConfig) {
     return ProgramsApiFp(this.configuration)
-      .programsNewList(
-        requestParameters.department,
-        requestParameters.limit,
-        requestParameters.offered_by,
-        requestParameters.offset,
-        requestParameters.platform,
-        requestParameters.professional,
-        requestParameters.resource_type,
-        requestParameters.sortby,
-        options,
-      )
+      .programsNewRetrieve(options)
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -19115,7 +15526,7 @@ export class ProgramsApi extends BaseAPI {
   }
 
   /**
-   * Get a paginated list of upcoming resources.
+   * Get a paginated list of upcoming $Programs.
    * @summary List Upcoming
    * @param {ProgramsApiProgramsUpcomingListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -82,7 +82,6 @@ const useLearningpathCreate = () => {
   return useMutation({
     mutationFn: (params: LearningPathCreateRequest) =>
       learningpathsApi.learningpathsCreate({
-        // @ts-expect-error 'readable_id' and 'resource_type' are erroneously required
         LearningPathResourceRequest: params,
       }),
     onSettled: () => {

--- a/frontends/mit-open/src/pages/learningpaths/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/pages/learningpaths/AddToListDialog.test.tsx
@@ -51,7 +51,6 @@ const setup = ({
         child: resource.id,
       }),
     )
-    // @ts-expect-errorhttps://github.com/mitodl/mit-open/pull/73 should fix this.
     list.learning_path.item_count += 1
   })
 

--- a/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
+++ b/frontends/mit-open/src/pages/learningpaths/LearningPathDetails.test.ts
@@ -123,12 +123,11 @@ describe("LearningPathDetailsPage", () => {
   ])(
     "Shows 'Reorder' button if and only not empty",
     async ({ itemCount, canReorder }) => {
-      const path = factories.learningResources.learningPath(
-        {},
-        {
+      const path = factories.learningResources.learningPath({
+        learning_path: {
           item_count: itemCount,
         },
-      )
+      })
       setup({ path, userSettings: { is_learning_path_editor: true } })
       await screen.findByRole("heading", { name: path.title })
       const reorderButton = screen.queryByRole("button", { name: "Reorder" })

--- a/frontends/ol-learning-resources/src/components/LearningResourceCardTemplate.test.tsx
+++ b/frontends/ol-learning-resources/src/components/LearningResourceCardTemplate.test.tsx
@@ -13,9 +13,7 @@ const factory = factories.learningResources
 
 describe("LearningResourceCard", () => {
   it("renders title and cover image", () => {
-    const resource = factory.resource({
-      resource_type: ResourceTypeEnum.Course,
-    })
+    const resource = factory.course()
     const imgConfig = makeImgConfig()
     render(
       <LearningResourceCardTemplate
@@ -34,9 +32,7 @@ describe("LearningResourceCard", () => {
   })
 
   it("does not show an image iff suppressImage is true", () => {
-    const resource = factory.resource({
-      resource_type: ResourceTypeEnum.Course,
-    })
+    const resource = factory.course()
     const imgConfig = makeImgConfig()
     const { rerender } = render(
       <LearningResourceCardTemplate
@@ -58,9 +54,7 @@ describe("LearningResourceCard", () => {
   })
 
   it("Calls onActivate when clicking title", async () => {
-    const resource = factory.resource({
-      resource_type: ResourceTypeEnum.Course,
-    })
+    const resource = factory.course()
     const imgConfig = makeImgConfig()
     const onActivate = jest.fn()
     render(
@@ -79,14 +73,12 @@ describe("LearningResourceCard", () => {
 
   it.each([
     { certification: null, hasCertificate: false },
-    { certification: undefined, hasCertificate: false },
     { certification: "cert", hasCertificate: true },
   ])(
     "should render an icon if the object has a certificate",
     ({ certification, hasCertificate }) => {
-      const resource = factory.resource({
+      const resource = factory.course({
         certification,
-        resource_type: ResourceTypeEnum.Course,
       })
       const imgConfig = makeImgConfig()
 

--- a/frontends/ol-learning-resources/src/components/LearningResourceCardTemplate.tsx
+++ b/frontends/ol-learning-resources/src/components/LearningResourceCardTemplate.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react"
 import Dotdotdot from "react-dotdotdot"
 import invariant from "tiny-invariant"
 import classNames from "classnames"
-import type { LearningPathResource, LearningResource } from "api"
+import { ResourceTypeEnum, type LearningResource } from "api"
 
 import { Card, CardContent, Chip, CardMedia } from "ol-design"
 
@@ -18,34 +18,29 @@ import {
 import type { EmbedlyConfig } from "../utils"
 import { pluralize } from "ol-util"
 
-type CardResource = Partial<LearningResource> &
-  Partial<LearningPathResource> &
-  Pick<LearningResource, "id" | "resource_type" | "title">
-
 type CardVariant = "column" | "row" | "row-reverse"
-type OnActivateCard<R extends CardResource = CardResource> = (
-  resource: R,
-) => void
-type LearningResourceCardTemplateProps<R extends CardResource = CardResource> =
-  {
-    /**
-     * Whether the course picture and info display as a column or row.
-     */
-    variant: CardVariant
-    resource: R
-    sortable?: boolean
-    className?: string
-    /**
-     * Config used to generate embedly urls.
-     */
-    imgConfig: EmbedlyConfig
-    onActivate?: OnActivateCard<R>
-    /**
-     * Suppress the image.
-     */
-    suppressImage?: boolean
-    footerActionSlot?: React.ReactNode
-  }
+type OnActivateCard<R extends LearningResource> = (resource: R) => void
+type LearningResourceCardTemplateProps<
+  R extends LearningResource = LearningResource,
+> = {
+  /**
+   * Whether the course picture and info display as a column or row.
+   */
+  variant: CardVariant
+  resource: R
+  sortable?: boolean
+  className?: string
+  /**
+   * Config used to generate embedly urls.
+   */
+  imgConfig: EmbedlyConfig
+  onActivate?: OnActivateCard<R>
+  /**
+   * Suppress the image.
+   */
+  suppressImage?: boolean
+  footerActionSlot?: React.ReactNode
+}
 
 const CertificateIcon = () => (
   <img
@@ -76,7 +71,7 @@ const ResourceFooterDetails: React.FC<
     ? moment(startDate).format("MMMM DD, YYYY")
     : null
 
-  if (resource?.learning_path) {
+  if (resource.resource_type === ResourceTypeEnum.LearningPath) {
     const count = resource.learning_path.item_count
     return (
       <span>
@@ -136,7 +131,7 @@ const variantClasses: Record<CardVariant, string> = {
  * does accept props to build user interaction (e.g., `onActivate` and
  * `footerActionSlot`).
  */
-const LearningResourceCardTemplate = <R extends CardResource>({
+const LearningResourceCardTemplate = <R extends LearningResource>({
   variant,
   resource,
   imgConfig,

--- a/frontends/ol-util/src/factories.ts
+++ b/frontends/ol-util/src/factories.ts
@@ -1,8 +1,10 @@
 import { faker } from "@faker-js/faker/locale/en"
 import type { PaginatedResult } from "./interfaces"
 import { times } from "lodash"
+import { PartialDeep } from "type-fest"
 
 type Factory<T, U = never> = (overrides?: Partial<T>, options?: U) => T
+type PartialFactory<T, U = T> = (overrides?: PartialDeep<T>) => U
 
 const makePaginatedFactory =
   <T>(makeResult: Factory<T>) =>
@@ -31,4 +33,4 @@ const makePaginatedFactory =
 const makeUrl = (): string => new URL(faker.internet.url()).toString()
 
 export { makePaginatedFactory, makeUrl }
-export type { Factory }
+export type { Factory, PartialFactory }

--- a/learning_resources/apps.py
+++ b/learning_resources/apps.py
@@ -10,3 +10,6 @@ class LearningResourcesConfig(AppConfig):
     name = "learning_resources"
     hookimpl = HookimplMarker(name)
     hookspec = HookspecMarker(name)
+
+    def ready(self):
+        from learning_resources import schema  # noqa: F401

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -1,8 +1,7 @@
 """Constants for learning_resources"""
 
-from enum import Enum
-
 from django.db.models import TextChoices
+from named_enum import ExtendedEnum
 
 OPEN = "Open Content"
 PROFESSIONAL = "Professional Offerings"
@@ -11,7 +10,7 @@ CERTIFICATE = "Certificates"
 FAVORITES_TITLE = "Favorites"
 
 
-class AvailabilityType(Enum):
+class AvailabilityType(ExtendedEnum):
     """
     Enum for Course availability options dictated by edX API values.
     While these are the options coming in from edX that we store as is, we
@@ -27,7 +26,7 @@ class AvailabilityType(Enum):
     archived = "Archived"  # displayed as "Prior"
 
 
-class LearningResourceType(Enum):
+class LearningResourceType(ExtendedEnum):
     """Enum for LearningResource resource_type values"""
 
     course = "Course"
@@ -37,7 +36,7 @@ class LearningResourceType(Enum):
     podcast_episode = "Podcast Episode"
 
 
-class OfferedBy(Enum):
+class OfferedBy(ExtendedEnum):
     """
     Enum for our Offered By labels. They are our MIT "brands" for LearningResources
     (Courses, Bootcamps, Programs) and are independent of what platform.
@@ -57,7 +56,7 @@ class OfferedBy(Enum):
     ctl = "Center for Transportation & Logistics"
 
 
-class PlatformType(Enum):
+class PlatformType(ExtendedEnum):
     """
     Enum for platforms, this should be kept in sync
     with LearningResourcePlatform model objects
@@ -82,7 +81,7 @@ class PlatformType(Enum):
     podcast = "Podcast"
 
 
-class PrivacyLevel(Enum):
+class PrivacyLevel(ExtendedEnum):
     """
     Enum tracking privacy levels for user-created UserLists
     """

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -37,6 +37,7 @@ from learning_resources.etl.xpro import _parse_datetime
 from learning_resources.factories import (
     ContentFileFactory,
     CourseFactory,
+    LearningResourceFactory,
     LearningResourceInstructorFactory,
     LearningResourceOfferorFactory,
     LearningResourcePlatformFactory,
@@ -257,9 +258,9 @@ def test_load_course(  # noqa: PLR0913
     platform = LearningResourcePlatformFactory.create()
 
     course = (
-        CourseFactory.create(runs=[], platform=platform.code)
+        CourseFactory.create(learning_resource__runs=[], platform=platform.code)
         if course_exists
-        else CourseFactory.build(runs=[], platform=platform.code)
+        else CourseFactory.build(learning_resource__runs=[], platform=platform.code)
     )
 
     learning_resource = course.learning_resource
@@ -372,13 +373,13 @@ def test_load_duplicate_course(
     platform = LearningResourcePlatformFactory.create()
 
     course = (
-        CourseFactory.create(runs=[], platform=platform.code)
+        CourseFactory.create(learning_resource__runs=[], platform=platform.code)
         if course_exists
         else CourseFactory.build()
     )
 
     duplicate_course = (
-        CourseFactory.create(runs=[], platform=platform.code)
+        CourseFactory.create(learning_resource__runs=[], platform=platform.code)
         if duplicate_course_exists
         else CourseFactory.build()
     )
@@ -446,7 +447,7 @@ def test_load_duplicate_course(
 @pytest.mark.parametrize("run_exists", [True, False])
 def test_load_run(run_exists):
     """Test that load_run loads the course run"""
-    course = CourseFactory.create(runs=[])
+    course = CourseFactory.create(learning_resource__runs=[])
     learning_resource_run = (
         LearningResourceRunFactory.create(learning_resource=course.learning_resource)
         if run_exists
@@ -724,10 +725,12 @@ def test_load_podcast_episode(
 ):
     """Test that load_podcast_episode loads the podcast episode"""
     podcast_episode = (
-        PodcastEpisodeFactory.create(is_unpublished=not is_published)
+        LearningResourceFactory.create(published=is_published, is_podcast_episode=True)
         if podcast_episode_exists
-        else PodcastEpisodeFactory.build(is_unpublished=not is_published)
-    ).learning_resource
+        else LearningResourceFactory.build(
+            published=is_published, is_podcast_episode=True
+        )
+    )
 
     props = model_to_dict(podcast_episode, exclude=non_transformable_attributes)
     props["image"] = {"url": podcast_episode.image.url}

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -92,7 +92,7 @@ def test_lr_certification(offered_by, availability, has_cert):
 
     course = CourseFactory.create(
         offered_by=offered_by.code,
-        runs=[],
+        learning_resource__runs=[],
         is_professional=(has_cert and offered_by != constants.OfferedBy.mitx.name),
     )
 

--- a/learning_resources/schema.py
+++ b/learning_resources/schema.py
@@ -1,0 +1,77 @@
+"""Extensions to drf-spectacular schema"""
+from drf_spectacular.extensions import (
+    OpenApiSerializerExtension,
+    OpenApiSerializerFieldExtension,
+)
+from drf_spectacular.plumbing import ResolvedComponent
+
+from learning_resources import constants, serializers
+
+
+class LearningResourceTypeFieldConstant(OpenApiSerializerFieldExtension):
+    target_class = "learning_resources.serializers.LearningResourceTypeField"
+
+    def map_serializer_field(self, auto_schema, direction):  # noqa: ARG002
+        return {
+            "type": "string",
+            "default": self.target.default,
+            "enum": [self.target.default],
+        }
+
+
+class LearningResourceSerializerExtension(OpenApiSerializerExtension):
+    target_class = "learning_resources.serializers.LearningResourceSerializer"
+
+    def _map_learning_resource_base(self, auto_schema, direction):
+        # this will only be generated on return of map_serializer so mock it for now
+        return ResolvedComponent(
+            name=auto_schema._get_serializer_name(  # noqa: SLF001
+                self.target, direction
+            ),
+            type=ResolvedComponent.SCHEMA,
+            object=self.target,
+            schema=auto_schema._map_basic_serializer(  # noqa: SLF001
+                serializers.LearningResourceBaseSerializer, direction
+            ),
+        )
+
+    def map_serializer(self, auto_schema, direction):
+        sub_serializers = serializers.LearningResourceBaseSerializer.__subclasses__()
+
+        resolved_sub_serializers = [
+            (
+                sub().fields["resource_type"].default,
+                auto_schema.resolve_serializer(sub, direction).ref,
+            )
+            for sub in sub_serializers
+        ]
+
+        # manually register this enum with the schema
+        # it otherwise doesn't automatically get picked up
+        # because of how LearningResourceTypeFieldConstant works
+        resource_type_enum = ResolvedComponent(
+            name="ResourceTypeEnum",
+            object="ResourceTypeEnum",
+            type=ResolvedComponent.SCHEMA,
+            schema={
+                "enum": constants.LearningResourceType.names(),
+                "type": "string",
+                "description": "\n".join(
+                    [
+                        f"* `{lr_type}` - {lr_type}"
+                        for lr_type in constants.LearningResourceType.names()
+                    ]
+                ),
+            },
+        )
+        auto_schema.registry.register_on_missing(resource_type_enum)
+
+        return {
+            "oneOf": [ref for (_, ref) in resolved_sub_serializers],
+            "discriminator": {
+                "propertyName": "resource_type",
+                "mapping": {
+                    name: ref["$ref"] for (name, ref) in resolved_sub_serializers
+                },
+            },
+        }

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -2,7 +2,6 @@
 
 import logging
 from hmac import compare_digest
-from uuid import uuid4
 
 import rapidjson
 from django.conf import settings
@@ -20,7 +19,7 @@ from drf_spectacular.utils import (
 from rest_framework import views, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
-from rest_framework.generics import get_object_or_404
+from rest_framework.generics import GenericAPIView, get_object_or_404
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -52,11 +51,15 @@ from learning_resources.permissions import (
 )
 from learning_resources.serializers import (
     ContentFileSerializer,
+    CourseResourceSerializer,
     LearningPathRelationshipSerializer,
     LearningPathResourceSerializer,
     LearningResourceChildSerializer,
     LearningResourceSerializer,
     LearningResourceTopicSerializer,
+    PodcastEpisodeResourceSerializer,
+    PodcastResourceSerializer,
+    ProgramResourceSerializer,
     UserListRelationshipSerializer,
     UserListSerializer,
 )
@@ -95,21 +98,12 @@ class LargePagination(DefaultPagination):
         summary="Retrieve",
         description="Retrieve a single learning resource.",
     ),
-    new=extend_schema(
-        summary="List New",
-        description="Get a paginated list of newly released resources.",
-    ),
-    upcoming=extend_schema(
-        summary="List Upcoming",
-        description="Get a paginated list of upcoming resources.",
-    ),
 )
-class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
+class BaseLearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
     """
     Viewset for LearningResources
     """
 
-    serializer_class = LearningResourceSerializer
     permission_classes = (AnonymousAccessReadonlyPermission,)
     pagination_class = DefaultPagination
     filter_backends = [DjangoFilterBackend]
@@ -142,7 +136,24 @@ class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
         """
         return self._get_base_queryset().filter(published=True)
 
-    @extend_schema(responses=LearningResourceSerializer(many=True))
+
+class NewResourcesViewSetMixin(GenericAPIView):
+    """ViewSet mixin for adding upcoming resource functionality."""
+
+    resource_type_name_plural: str
+
+    def __init_subclass__(cls) -> None:
+        """Initialize subclasses by updating the view with the correct serializer."""
+        name = cls.resource_type_name_plural
+        # this decorator mutates the view in place so the return value is safely ignored
+        extend_schema_view(
+            upcoming=extend_schema(
+                description=f"Get a paginated list of newly released ${name}.",
+                responses=cls.serializer_class(many=True),
+            ),
+        )(cls)
+
+    @extend_schema(summary="List New")
     @action(methods=["GET"], detail=False, name="New Resources")
     def new(self, request: Request) -> QuerySet:  # noqa: ARG002
         """
@@ -155,7 +166,24 @@ class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
         serializer = self.get_serializer(page, many=True)
         return self.get_paginated_response(serializer.data)
 
-    @extend_schema(responses=LearningResourceSerializer(many=True))
+
+class UpcomingResourcesViewSetMixin(GenericAPIView):
+    """ViewSet mixin for adding upcoming resource functionality."""
+
+    resource_type_name_plural: str
+
+    def __init_subclass__(cls) -> None:
+        """Initialize subclasses by updating the view with the correct serializer."""
+        name = cls.resource_type_name_plural
+        # this decorator mutates the view in place so the return value is safely ignored
+        extend_schema_view(
+            upcoming=extend_schema(
+                description=f"Get a paginated list of upcoming ${name}.",
+                responses=cls.serializer_class(many=True),
+            ),
+        )(cls)
+
+    @extend_schema(summary="List Upcoming")
     @action(methods=["GET"], detail=False, name="Upcoming Resources")
     def upcoming(self, request: Request) -> QuerySet:  # noqa: ARG002
         """
@@ -183,10 +211,27 @@ class LearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
         return self.get_paginated_response(serializer.data)
 
 
-class CourseViewSet(LearningResourceViewSet):
+class LearningResourceViewSet(
+    BaseLearningResourceViewSet, UpcomingResourcesViewSetMixin, NewResourcesViewSetMixin
+):
+    """
+    Viewset for LearningResources
+    """
+
+    resource_type_name_plural = "Learning Resources"
+    serializer_class = LearningResourceSerializer
+
+
+class CourseViewSet(
+    BaseLearningResourceViewSet, UpcomingResourcesViewSetMixin, NewResourcesViewSetMixin
+):
     """
     Viewset for Courses
     """
+
+    resource_type_name_plural = "Courses"
+
+    serializer_class = CourseResourceSerializer
 
     def get_queryset(self) -> QuerySet:
         """
@@ -200,10 +245,16 @@ class CourseViewSet(LearningResourceViewSet):
         ).filter(published=True)
 
 
-class ProgramViewSet(LearningResourceViewSet):
+class ProgramViewSet(
+    BaseLearningResourceViewSet, UpcomingResourcesViewSetMixin, NewResourcesViewSetMixin
+):
     """
     Viewset for Programs
     """
+
+    resource_type_name_plural = "Programs"
+
+    serializer_class = ProgramResourceSerializer
 
     def get_queryset(self):
         """
@@ -217,7 +268,45 @@ class ProgramViewSet(LearningResourceViewSet):
         ).filter(published=True)
 
 
-class LearningPathViewSet(LearningResourceViewSet, viewsets.ModelViewSet):
+class PodcastViewSet(BaseLearningResourceViewSet):
+    """
+    Viewset for Podcasts
+    """
+
+    serializer_class = PodcastResourceSerializer
+
+    def get_queryset(self):
+        """
+        Generate a QuerySet for fetching valid Programs
+
+        Returns:
+            QuerySet of LearningResource objects that are Programs
+        """
+        return self._get_base_queryset(
+            resource_type=LearningResourceType.podcast.name
+        ).filter(published=True)
+
+
+class PodcastEpisodeViewSet(BaseLearningResourceViewSet):
+    """
+    Viewset for Podcast Episodes
+    """
+
+    serializer_class = PodcastEpisodeResourceSerializer
+
+    def get_queryset(self):
+        """
+        Generate a QuerySet for fetching valid Programs
+
+        Returns:
+            QuerySet of LearningResource objects that are Programs
+        """
+        return self._get_base_queryset(
+            resource_type=LearningResourceType.podcast_episode.name
+        ).filter(published=True)
+
+
+class LearningPathViewSet(BaseLearningResourceViewSet, viewsets.ModelViewSet):
     """
     Viewset for LearningPaths
     """
@@ -238,11 +327,6 @@ class LearningPathViewSet(LearningResourceViewSet, viewsets.ModelViewSet):
         if not (is_learning_path_editor(self.request) or is_admin_user(self.request)):
             queryset = queryset.filter(published=True)
         return queryset
-
-    def create(self, request, *args, **kwargs):
-        request.data["readable_id"] = uuid4().hex
-        request.data["resource_type"] = LearningResourceType.learning_path.name
-        return super().create(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
         instance.delete()
@@ -417,40 +501,6 @@ class UserListItemViewSet(NestedParentMixin, viewsets.ModelViewSet):
             parent=instance.parent,
             position__gt=instance.position,
         ).update(position=F("position") - 1)
-
-
-class PodcastViewSet(LearningResourceViewSet):
-    """
-    Viewset for Podcasts
-    """
-
-    def get_queryset(self):
-        """
-        Generate a QuerySet for fetching valid Programs
-
-        Returns:
-            QuerySet of LearningResource objects that are Programs
-        """
-        return self._get_base_queryset(
-            resource_type=LearningResourceType.podcast.name
-        ).filter(published=True)
-
-
-class PodcastEpisodeViewSet(LearningResourceViewSet):
-    """
-    Viewset for Podcast Episodes
-    """
-
-    def get_queryset(self):
-        """
-        Generate a QuerySet for fetching valid Programs
-
-        Returns:
-            QuerySet of LearningResource objects that are Programs
-        """
-        return self._get_base_queryset(
-            resource_type=LearningResourceType.podcast_episode.name
-        ).filter(published=True)
 
 
 @cache_page(60 * settings.RSS_FEED_CACHE_MINUTES)

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -134,23 +134,15 @@ def test_new_courses_endpoint(client, url, params):
 )
 def test_upcoming_courses_endpoint(client, url, params):
     """Test new courses endpoint"""
-    upcoming_course = CourseFactory.create(
-        learning_resource=LearningResourceFactory.create(is_course=True), runs=[]
-    )
-    LearningResourceRunFactory.create(
-        learning_resource=upcoming_course.learning_resource, in_future=True
+    learning_resource = LearningResourceFactory.create(
+        is_course=True, runs__in_future=True
     )
 
-    past_course = CourseFactory.create(
-        learning_resource=LearningResourceFactory.create(is_course=True), runs=[]
-    )
-    LearningResourceRunFactory.create(
-        learning_resource=past_course.learning_resource, in_past=True
-    )
+    LearningResourceFactory.create(is_course=True, runs__in_past=True)
 
     resp = client.get(f"{reverse(url)}upcoming/?{params}")
     assert resp.data.get("count") == 1
-    assert resp.data.get("results")[0]["id"] == upcoming_course.learning_resource.id
+    assert resp.data.get("results")[0]["id"] == learning_resource.id
 
 
 @pytest.mark.parametrize(

--- a/learning_resources_search/plugins_test.py
+++ b/learning_resources_search/plugins_test.py
@@ -64,8 +64,9 @@ def test_search_index_plugin_resource_unpublished(
         resource.id, resource.resource_type
     )
     if resource_type == COURSE_TYPE:
+        assert unpublish_run_mock.call_count == resource.runs.count()
         for run in resource.runs.all():
-            unpublish_run_mock.assert_called_once_with(run.id, False)  # noqa: FBT003
+            unpublish_run_mock.assert_any_call(run.id, False)  # noqa: FBT003
     else:
         unpublish_run_mock.assert_not_called()
 

--- a/manage.py
+++ b/manage.py
@@ -2,7 +2,6 @@
 """
 Standard manage.py command from django startproject
 """
-
 import os
 import sys
 

--- a/open_discussions/factories.py
+++ b/open_discussions/factories.py
@@ -22,6 +22,7 @@ class UserFactory(DjangoModelFactory):
 
     class Meta:
         model = User
+        skip_postgeneration_save = True
 
     class Params:
         no_profile = Trait(profile=None)

--- a/open_discussions/test_utils.py
+++ b/open_discussions/test_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 from django.http.response import HttpResponse
+from rest_framework.renderers import JSONRenderer
 
 
 def any_instance_of(*classes):
@@ -118,8 +119,9 @@ def assert_json_equal(obj1, obj2, sort=False):  # noqa: FBT002
         obj2 (object): the second object
         sort (bool): If true, sort items which are iterable before comparing
     """  # noqa: D401
-    converted1 = json.loads(json.dumps(obj1))
-    converted2 = json.loads(json.dumps(obj2))
+    renderer = JSONRenderer()
+    converted1 = json.loads(renderer.render(obj1))
+    converted2 = json.loads(renderer.render(obj2))
     if sort:
         converted1 = _sort_values_for_testing(converted1)
         converted2 = _sort_values_for_testing(converted2)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -643,7 +643,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedCourseResourceList'
           description: ''
   /api/v1/courses/{id}/:
     get:
@@ -666,7 +666,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LearningResource'
+                $ref: '#/components/schemas/CourseResource'
           description: ''
   /api/v1/courses/{run__learning_resource}/contentfiles/:
     get:
@@ -738,226 +738,13 @@ paths:
           description: ''
   /api/v1/courses/new/:
     get:
-      operationId: courses_new_list
-      description: Get a paginated list of newly released resources.
+      operationId: courses_new_retrieve
+      description: |-
+        Get new LearningResources
+
+        Returns:
+            QuerySet of LearningResource objects ordered by reverse created_on
       summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
       tags:
       - courses
       security:
@@ -967,12 +754,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/CourseResource'
           description: ''
   /api/v1/courses/upcoming/:
     get:
       operationId: courses_upcoming_list
-      description: Get a paginated list of upcoming resources.
+      description: Get a paginated list of upcoming $Courses.
       summary: List Upcoming
       parameters:
       - in: query
@@ -1200,7 +987,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedCourseResourceList'
           description: ''
   /api/v1/fields/:
     get:
@@ -1840,226 +1627,13 @@ paths:
           description: ''
   /api/v1/learning_resources/new/:
     get:
-      operationId: learning_resources_new_list
-      description: Get a paginated list of newly released resources.
+      operationId: learning_resources_new_retrieve
+      description: |-
+        Get new LearningResources
+
+        Returns:
+            QuerySet of LearningResource objects ordered by reverse created_on
       summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
       tags:
       - learning_resources
       security:
@@ -2069,12 +1643,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/LearningResource'
           description: ''
   /api/v1/learning_resources/upcoming/:
     get:
       operationId: learning_resources_upcoming_list
-      description: Get a paginated list of upcoming resources.
+      description: Get a paginated list of upcoming $Learning Resources.
       summary: List Upcoming
       parameters:
       - in: query
@@ -3206,472 +2780,6 @@ paths:
       responses:
         '204':
           description: No response body
-  /api/v1/learningpaths/new/:
-    get:
-      operationId: learningpaths_new_list
-      description: Get a paginated list of newly released resources.
-      summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - learningpaths
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
-          description: ''
-  /api/v1/learningpaths/upcoming/:
-    get:
-      operationId: learningpaths_upcoming_list
-      description: Get a paginated list of upcoming resources.
-      summary: List Upcoming
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - learningpaths
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
-          description: ''
   /api/v1/podcast_episodes/:
     get:
       operationId: podcast_episodes_list
@@ -3903,7 +3011,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedPodcastEpisodeResourceList'
           description: ''
   /api/v1/podcast_episodes/{id}/:
     get:
@@ -3926,473 +3034,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LearningResource'
-          description: ''
-  /api/v1/podcast_episodes/new/:
-    get:
-      operationId: podcast_episodes_new_list
-      description: Get a paginated list of newly released resources.
-      summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - podcast_episodes
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
-          description: ''
-  /api/v1/podcast_episodes/upcoming/:
-    get:
-      operationId: podcast_episodes_upcoming_list
-      description: Get a paginated list of upcoming resources.
-      summary: List Upcoming
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - podcast_episodes
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PodcastEpisodeResource'
           description: ''
   /api/v1/podcasts/:
     get:
@@ -4625,7 +3267,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedPodcastResourceList'
           description: ''
   /api/v1/podcasts/{parent_id}/items/:
     get:
@@ -4714,473 +3356,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LearningResource'
-          description: ''
-  /api/v1/podcasts/new/:
-    get:
-      operationId: podcasts_new_list
-      description: Get a paginated list of newly released resources.
-      summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - podcasts
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
-          description: ''
-  /api/v1/podcasts/upcoming/:
-    get:
-      operationId: podcasts_upcoming_list
-      description: Get a paginated list of upcoming resources.
-      summary: List Upcoming
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-      tags:
-      - podcasts
-      security:
-      - cookieAuth: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PodcastResource'
           description: ''
   /api/v1/programs/:
     get:
@@ -5413,7 +3589,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedProgramResourceList'
           description: ''
   /api/v1/programs/{id}/:
     get:
@@ -5436,230 +3612,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LearningResource'
+                $ref: '#/components/schemas/ProgramResource'
           description: ''
   /api/v1/programs/new/:
     get:
-      operationId: programs_new_list
-      description: Get a paginated list of newly released resources.
+      operationId: programs_new_retrieve
+      description: |-
+        Get new LearningResources
+
+        Returns:
+            QuerySet of LearningResource objects ordered by reverse created_on
       summary: List New
-      parameters:
-      - in: query
-        name: department
-        schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Sloan School of Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Studies and Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Health Sciences and Technology
-          * `IDS` - Institute for Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `RES` - Supplemental Resources
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-      - name: limit
-        required: false
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      - in: query
-        name: offered_by
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - OCW
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-      - name: offset
-        required: false
-        in: query
-        description: The initial index from which to return the results.
-        schema:
-          type: integer
-      - in: query
-        name: platform
-        schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - OCW
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - xPRO
-          * `csail` - CSAIL
-          * `mitpe` - Professional Education
-          * `see` - Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-      - in: query
-        name: professional
-        schema:
-          type: boolean
-      - in: query
-        name: resource_type
-        schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -created_on
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - created_on
-          - id
-          - last_modified
-          - mitcoursenumber
-          - readable_id
-          - start_date
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `created_on` - Creation Date ascending
-          * `-created_on` - CreationDate descending
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
       tags:
       - programs
       security:
@@ -5669,12 +3632,12 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/ProgramResource'
           description: ''
   /api/v1/programs/upcoming/:
     get:
       operationId: programs_upcoming_list
-      description: Get a paginated list of upcoming resources.
+      description: Get a paginated list of upcoming $Programs.
       summary: List Upcoming
       parameters:
       - in: query
@@ -5902,7 +3865,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PaginatedLearningResourceList'
+                $ref: '#/components/schemas/PaginatedProgramResourceList'
           description: ''
   /api/v1/topics/:
     get:
@@ -6505,6 +4468,178 @@ components:
           nullable: true
       required:
       - course_numbers
+    CourseResource:
+      type: object
+      description: Serializer for course resources
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+          nullable: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+          nullable: true
+        resource_content_tags:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          nullable: true
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+          nullable: true
+        certification:
+          type: string
+          nullable: true
+          description: Returns the certification for the learning resource
+          readOnly: true
+        prices:
+          type: string
+          nullable: true
+          description: Returns the prices for the learning resource
+          readOnly: true
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceRun'
+          readOnly: true
+          nullable: true
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+          readOnly: true
+        learning_path_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroLearningPathRelationship'
+          nullable: true
+          readOnly: true
+        user_list_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroUserListRelationship'
+          nullable: true
+          readOnly: true
+        resource_type:
+          allOf:
+          - $ref: '#/components/schemas/CourseResourceResourceTypeEnum'
+          default: course
+          readOnly: true
+        course:
+          allOf:
+          - $ref: '#/components/schemas/Course'
+          readOnly: true
+        readable_id:
+          type: string
+          maxLength: 128
+        title:
+          type: string
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 2048
+        professional:
+          type: boolean
+          readOnly: true
+      required:
+      - certification
+      - course
+      - departments
+      - id
+      - image
+      - learning_path_parents
+      - offered_by
+      - platform
+      - prices
+      - professional
+      - readable_id
+      - resource_content_tags
+      - resource_type
+      - runs
+      - title
+      - user_list_parents
+    CourseResourceRequest:
+      type: object
+      description: Serializer for course resources
+      properties:
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        readable_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          minLength: 1
+          maxLength: 2048
+      required:
+      - readable_id
+      - title
+    CourseResourceResourceTypeEnum:
+      type: string
+      enum:
+      - course
     FieldChannel:
       type: object
       description: Serializer for FieldChannel
@@ -6825,26 +4960,6 @@ components:
           nullable: true
           description: Returns the prices for the learning resource
           readOnly: true
-        course:
-          allOf:
-          - $ref: '#/components/schemas/Course'
-          readOnly: true
-          nullable: true
-        learning_path:
-          allOf:
-          - $ref: '#/components/schemas/LearningPath'
-          readOnly: true
-          nullable: true
-        podcast:
-          allOf:
-          - $ref: '#/components/schemas/Podcast'
-          readOnly: true
-          nullable: true
-        podcast_episode:
-          allOf:
-          - $ref: '#/components/schemas/PodcastEpisode'
-          readOnly: true
-          nullable: true
         runs:
           type: array
           items:
@@ -6868,14 +4983,18 @@ components:
             $ref: '#/components/schemas/MicroUserListRelationship'
           nullable: true
           readOnly: true
-        program:
+        resource_type:
           allOf:
-          - $ref: '#/components/schemas/Program'
+          - $ref: '#/components/schemas/LearningPathResourceResourceTypeEnum'
+          default: learning_path
           readOnly: true
-          nullable: true
+        learning_path:
+          allOf:
+          - $ref: '#/components/schemas/LearningPath'
+          readOnly: true
         readable_id:
           type: string
-          maxLength: 128
+          readOnly: true
         title:
           type: string
           maxLength: 256
@@ -6902,18 +5021,10 @@ components:
           format: uri
           nullable: true
           maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
         professional:
           type: boolean
-        resources:
-          type: array
-          items:
-            type: integer
-          readOnly: true
       required:
       - certification
-      - course
       - departments
       - id
       - image
@@ -6921,14 +5032,10 @@ components:
       - learning_path_parents
       - offered_by
       - platform
-      - podcast
-      - podcast_episode
       - prices
-      - program
       - readable_id
       - resource_content_tags
       - resource_type
-      - resources
       - runs
       - title
       - user_list_parents
@@ -6940,10 +5047,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        readable_id:
-          type: string
-          minLength: 1
-          maxLength: 128
         title:
           type: string
           minLength: 1
@@ -6973,300 +5076,29 @@ components:
           nullable: true
           minLength: 1
           maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
         professional:
           type: boolean
       required:
-      - readable_id
-      - resource_type
       - title
+    LearningPathResourceResourceTypeEnum:
+      type: string
+      enum:
+      - learning_path
     LearningResource:
-      type: object
-      description: Serializer for LearningResource, with program included
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        topics:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceTopic'
-        offered_by:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceOfferor'
-          readOnly: true
-          nullable: true
-        platform:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourcePlatform'
-          readOnly: true
-          nullable: true
-        resource_content_tags:
-          type: array
-          items:
-            type: string
-          readOnly: true
-          nullable: true
-        departments:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceDepartment'
-          readOnly: true
-          nullable: true
-        certification:
-          type: string
-          nullable: true
-          description: Returns the certification for the learning resource
-          readOnly: true
-        prices:
-          type: string
-          nullable: true
-          description: Returns the prices for the learning resource
-          readOnly: true
-        course:
-          allOf:
-          - $ref: '#/components/schemas/Course'
-          readOnly: true
-          nullable: true
-        learning_path:
-          allOf:
-          - $ref: '#/components/schemas/LearningPath'
-          readOnly: true
-          nullable: true
-        podcast:
-          allOf:
-          - $ref: '#/components/schemas/Podcast'
-          readOnly: true
-          nullable: true
-        podcast_episode:
-          allOf:
-          - $ref: '#/components/schemas/PodcastEpisode'
-          readOnly: true
-          nullable: true
-        runs:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceRun'
-          readOnly: true
-          nullable: true
-        image:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceImage'
-          nullable: true
-          readOnly: true
-        learning_path_parents:
-          type: array
-          items:
-            $ref: '#/components/schemas/MicroLearningPathRelationship'
-          nullable: true
-          readOnly: true
-        user_list_parents:
-          type: array
-          items:
-            $ref: '#/components/schemas/MicroUserListRelationship'
-          nullable: true
-          readOnly: true
-        program:
-          allOf:
-          - $ref: '#/components/schemas/Program'
-          readOnly: true
-          nullable: true
-        readable_id:
-          type: string
-          maxLength: 128
-        title:
-          type: string
-          maxLength: 256
-        description:
-          type: string
-          nullable: true
-        full_description:
-          type: string
-          nullable: true
-        last_modified:
-          type: string
-          format: date-time
-          nullable: true
-        published:
-          type: boolean
-        languages:
-          type: array
-          items:
-            type: string
-            maxLength: 24
-          nullable: true
-        url:
-          type: string
-          format: uri
-          nullable: true
-          maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
-        professional:
-          type: boolean
-          readOnly: true
-      required:
-      - certification
-      - course
-      - departments
-      - id
-      - image
-      - learning_path
-      - learning_path_parents
-      - offered_by
-      - platform
-      - podcast
-      - podcast_episode
-      - prices
-      - professional
-      - program
-      - readable_id
-      - resource_content_tags
-      - resource_type
-      - runs
-      - title
-      - user_list_parents
-    LearningResourceBase:
-      type: object
-      description: Serializer for LearningResource, minus program
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        topics:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceTopic'
-        offered_by:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceOfferor'
-          readOnly: true
-          nullable: true
-        platform:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourcePlatform'
-          readOnly: true
-          nullable: true
-        resource_content_tags:
-          type: array
-          items:
-            type: string
-          readOnly: true
-          nullable: true
-        departments:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceDepartment'
-          readOnly: true
-          nullable: true
-        certification:
-          type: string
-          nullable: true
-          description: Returns the certification for the learning resource
-          readOnly: true
-        prices:
-          type: string
-          nullable: true
-          description: Returns the prices for the learning resource
-          readOnly: true
-        course:
-          allOf:
-          - $ref: '#/components/schemas/Course'
-          readOnly: true
-          nullable: true
-        learning_path:
-          allOf:
-          - $ref: '#/components/schemas/LearningPath'
-          readOnly: true
-          nullable: true
-        podcast:
-          allOf:
-          - $ref: '#/components/schemas/Podcast'
-          readOnly: true
-          nullable: true
-        podcast_episode:
-          allOf:
-          - $ref: '#/components/schemas/PodcastEpisode'
-          readOnly: true
-          nullable: true
-        runs:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceRun'
-          readOnly: true
-          nullable: true
-        image:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceImage'
-          nullable: true
-          readOnly: true
-        learning_path_parents:
-          type: array
-          items:
-            $ref: '#/components/schemas/MicroLearningPathRelationship'
-          nullable: true
-          readOnly: true
-        user_list_parents:
-          type: array
-          items:
-            $ref: '#/components/schemas/MicroUserListRelationship'
-          nullable: true
-          readOnly: true
-        readable_id:
-          type: string
-          maxLength: 128
-        title:
-          type: string
-          maxLength: 256
-        description:
-          type: string
-          nullable: true
-        full_description:
-          type: string
-          nullable: true
-        last_modified:
-          type: string
-          format: date-time
-          nullable: true
-        published:
-          type: boolean
-        languages:
-          type: array
-          items:
-            type: string
-            maxLength: 24
-          nullable: true
-        url:
-          type: string
-          format: uri
-          nullable: true
-          maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
-        professional:
-          type: boolean
-          readOnly: true
-      required:
-      - certification
-      - course
-      - departments
-      - id
-      - image
-      - learning_path
-      - learning_path_parents
-      - offered_by
-      - platform
-      - podcast
-      - podcast_episode
-      - prices
-      - professional
-      - readable_id
-      - resource_content_tags
-      - resource_type
-      - runs
-      - title
-      - user_list_parents
+      oneOf:
+      - $ref: '#/components/schemas/ProgramResource'
+      - $ref: '#/components/schemas/CourseResource'
+      - $ref: '#/components/schemas/LearningPathResource'
+      - $ref: '#/components/schemas/PodcastResource'
+      - $ref: '#/components/schemas/PodcastEpisodeResource'
+      discriminator:
+        propertyName: resource_type
+        mapping:
+          program: '#/components/schemas/ProgramResource'
+          course: '#/components/schemas/CourseResource'
+          learning_path: '#/components/schemas/LearningPathResource'
+          podcast: '#/components/schemas/PodcastResource'
+          podcast_episode: '#/components/schemas/PodcastEpisodeResource'
     LearningResourceChild:
       type: object
       description: Serializer for LearningResourceRelationship children
@@ -7434,52 +5266,20 @@ components:
       required:
       - code
     LearningResourceRequest:
-      type: object
-      description: Serializer for LearningResource, with program included
-      properties:
-        topics:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResourceTopic'
-        readable_id:
-          type: string
-          minLength: 1
-          maxLength: 128
-        title:
-          type: string
-          minLength: 1
-          maxLength: 256
-        description:
-          type: string
-          nullable: true
-        full_description:
-          type: string
-          nullable: true
-        last_modified:
-          type: string
-          format: date-time
-          nullable: true
-        published:
-          type: boolean
-        languages:
-          type: array
-          items:
-            type: string
-            minLength: 1
-            maxLength: 24
-          nullable: true
-        url:
-          type: string
-          format: uri
-          nullable: true
-          minLength: 1
-          maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
-      required:
-      - readable_id
-      - resource_type
-      - title
+      oneOf:
+      - $ref: '#/components/schemas/ProgramResourceRequest'
+      - $ref: '#/components/schemas/CourseResourceRequest'
+      - $ref: '#/components/schemas/LearningPathResourceRequest'
+      - $ref: '#/components/schemas/PodcastResourceRequest'
+      - $ref: '#/components/schemas/PodcastEpisodeResourceRequest'
+      discriminator:
+        propertyName: resource_type
+        mapping:
+          program: '#/components/schemas/ProgramResourceRequest'
+          course: '#/components/schemas/CourseResourceRequest'
+          learning_path: '#/components/schemas/LearningPathResourceRequest'
+          podcast: '#/components/schemas/PodcastResourceRequest'
+          podcast_episode: '#/components/schemas/PodcastEpisodeResourceRequest'
     LearningResourceRun:
       type: object
       description: Serializer for the LearningResourceRun model
@@ -7758,6 +5558,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ContentFile'
+    PaginatedCourseResourceList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CourseResource'
     PaginatedFieldChannelList:
       type: object
       properties:
@@ -7878,6 +5698,66 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+    PaginatedPodcastEpisodeResourceList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PodcastEpisodeResource'
+    PaginatedPodcastResourceList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PodcastResource'
+    PaginatedProgramResourceList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProgramResource'
     PaginatedUserListList:
       type: object
       properties:
@@ -7983,10 +5863,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        readable_id:
-          type: string
-          minLength: 1
-          maxLength: 128
         title:
           type: string
           minLength: 1
@@ -8016,8 +5892,6 @@ components:
           nullable: true
           minLength: 1
           maxLength: 2048
-        resource_type:
-          $ref: '#/components/schemas/ResourceTypeEnum'
         professional:
           type: boolean
     PatchedUserListRelationshipRequest:
@@ -8119,6 +5993,178 @@ components:
         rss:
           type: string
           nullable: true
+    PodcastEpisodeResource:
+      type: object
+      description: Serializer for podcast episode resources
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+          nullable: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+          nullable: true
+        resource_content_tags:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          nullable: true
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+          nullable: true
+        certification:
+          type: string
+          nullable: true
+          description: Returns the certification for the learning resource
+          readOnly: true
+        prices:
+          type: string
+          nullable: true
+          description: Returns the prices for the learning resource
+          readOnly: true
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceRun'
+          readOnly: true
+          nullable: true
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+          readOnly: true
+        learning_path_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroLearningPathRelationship'
+          nullable: true
+          readOnly: true
+        user_list_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroUserListRelationship'
+          nullable: true
+          readOnly: true
+        resource_type:
+          allOf:
+          - $ref: '#/components/schemas/PodcastEpisodeResourceResourceTypeEnum'
+          default: podcast_episode
+          readOnly: true
+        podcast_episode:
+          allOf:
+          - $ref: '#/components/schemas/PodcastEpisode'
+          readOnly: true
+        readable_id:
+          type: string
+          maxLength: 128
+        title:
+          type: string
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 2048
+        professional:
+          type: boolean
+          readOnly: true
+      required:
+      - certification
+      - departments
+      - id
+      - image
+      - learning_path_parents
+      - offered_by
+      - platform
+      - podcast_episode
+      - prices
+      - professional
+      - readable_id
+      - resource_content_tags
+      - resource_type
+      - runs
+      - title
+      - user_list_parents
+    PodcastEpisodeResourceRequest:
+      type: object
+      description: Serializer for podcast episode resources
+      properties:
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        readable_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          minLength: 1
+          maxLength: 2048
+      required:
+      - readable_id
+      - title
+    PodcastEpisodeResourceResourceTypeEnum:
+      type: string
+      enum:
+      - podcast_episode
     PodcastRequest:
       type: object
       description: Serializer for Podcasts
@@ -8141,6 +6187,178 @@ components:
           nullable: true
           minLength: 1
           maxLength: 2048
+    PodcastResource:
+      type: object
+      description: Serializer for podcast resources
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+          nullable: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+          nullable: true
+        resource_content_tags:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          nullable: true
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+          nullable: true
+        certification:
+          type: string
+          nullable: true
+          description: Returns the certification for the learning resource
+          readOnly: true
+        prices:
+          type: string
+          nullable: true
+          description: Returns the prices for the learning resource
+          readOnly: true
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceRun'
+          readOnly: true
+          nullable: true
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+          readOnly: true
+        learning_path_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroLearningPathRelationship'
+          nullable: true
+          readOnly: true
+        user_list_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroUserListRelationship'
+          nullable: true
+          readOnly: true
+        resource_type:
+          allOf:
+          - $ref: '#/components/schemas/PodcastResourceResourceTypeEnum'
+          default: podcast
+          readOnly: true
+        podcast:
+          allOf:
+          - $ref: '#/components/schemas/Podcast'
+          readOnly: true
+        readable_id:
+          type: string
+          maxLength: 128
+        title:
+          type: string
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 2048
+        professional:
+          type: boolean
+          readOnly: true
+      required:
+      - certification
+      - departments
+      - id
+      - image
+      - learning_path_parents
+      - offered_by
+      - platform
+      - podcast
+      - prices
+      - professional
+      - readable_id
+      - resource_content_tags
+      - resource_type
+      - runs
+      - title
+      - user_list_parents
+    PodcastResourceRequest:
+      type: object
+      description: Serializer for podcast resources
+      properties:
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        readable_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          minLength: 1
+          maxLength: 2048
+      required:
+      - readable_id
+      - title
+    PodcastResourceResourceTypeEnum:
+      type: string
+      enum:
+      - podcast
     PrivacyLevelEnum:
       enum:
       - private
@@ -8156,11 +6374,183 @@ components:
         courses:
           type: array
           items:
-            $ref: '#/components/schemas/LearningResourceBase'
+            $ref: '#/components/schemas/CourseResource'
           nullable: true
           readOnly: true
       required:
       - courses
+    ProgramResource:
+      type: object
+      description: Serializer for program resources
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+          nullable: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+          nullable: true
+        resource_content_tags:
+          type: array
+          items:
+            type: string
+          readOnly: true
+          nullable: true
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+          nullable: true
+        certification:
+          type: string
+          nullable: true
+          description: Returns the certification for the learning resource
+          readOnly: true
+        prices:
+          type: string
+          nullable: true
+          description: Returns the prices for the learning resource
+          readOnly: true
+        runs:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceRun'
+          readOnly: true
+          nullable: true
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+          readOnly: true
+        learning_path_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroLearningPathRelationship'
+          nullable: true
+          readOnly: true
+        user_list_parents:
+          type: array
+          items:
+            $ref: '#/components/schemas/MicroUserListRelationship'
+          nullable: true
+          readOnly: true
+        resource_type:
+          allOf:
+          - $ref: '#/components/schemas/ProgramResourceResourceTypeEnum'
+          default: program
+          readOnly: true
+        program:
+          allOf:
+          - $ref: '#/components/schemas/Program'
+          readOnly: true
+        readable_id:
+          type: string
+          maxLength: 128
+        title:
+          type: string
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 2048
+        professional:
+          type: boolean
+          readOnly: true
+      required:
+      - certification
+      - departments
+      - id
+      - image
+      - learning_path_parents
+      - offered_by
+      - platform
+      - prices
+      - professional
+      - program
+      - readable_id
+      - resource_content_tags
+      - resource_type
+      - runs
+      - title
+      - user_list_parents
+    ProgramResourceRequest:
+      type: object
+      description: Serializer for program resources
+      properties:
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+        readable_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+        title:
+          type: string
+          minLength: 1
+          maxLength: 256
+        description:
+          type: string
+          nullable: true
+        full_description:
+          type: string
+          nullable: true
+        last_modified:
+          type: string
+          format: date-time
+          nullable: true
+        published:
+          type: boolean
+        languages:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 24
+          nullable: true
+        url:
+          type: string
+          format: uri
+          nullable: true
+          minLength: 1
+          maxLength: 2048
+      required:
+      - readable_id
+      - title
+    ProgramResourceResourceTypeEnum:
+      type: string
+      enum:
+      - program
     ResourceTypeEnum:
       enum:
       - course
@@ -8170,11 +6560,11 @@ components:
       - podcast_episode
       type: string
       description: |-
-        * `course` - Course
-        * `program` - Program
-        * `learning_path` - Learning Path
-        * `podcast` - Podcast
-        * `podcast_episode` - Podcast Episode
+        * `course` - course
+        * `program` - program
+        * `learning_path` - learning_path
+        * `podcast` - podcast
+        * `podcast_episode` - podcast_episode
     SearchResponse:
       type: object
       properties:

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "swc-loader": "^0.2.3",
     "tiny-invariant": "^1.3.1",
     "ts-node": "^10.9.1",
+    "type-fest": "^4.8.1",
     "typescript": "^5.1.6",
     "url-assembler": "^2.1.1"
   }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1265,17 +1265,21 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "factory-boy"
-version = "2.12.0"
+version = "3.3.0"
 description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.7"
 files = [
-    {file = "factory_boy-2.12.0-py2.py3-none-any.whl", hash = "sha256:728df59b372c9588b83153facf26d3d28947fc750e8e3c95cefa9bed0e6394ee"},
-    {file = "factory_boy-2.12.0.tar.gz", hash = "sha256:faf48d608a1735f0d0a3c9cbf536d64f9132b547dae7ba452c4d99a79e84a370"},
+    {file = "factory_boy-3.3.0-py2.py3-none-any.whl", hash = "sha256:a2cdbdb63228177aa4f1c52f4b6d83fab2b8623bf602c7dedd7eb83c0f69c04c"},
+    {file = "factory_boy-3.3.0.tar.gz", hash = "sha256:bc76d97d1a65bbd9842a6d722882098eb549ec8ee1081f9fb2e8ff29f0c300f1"},
 ]
 
 [package.dependencies]
 Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "sqlalchemy-utils", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
@@ -2031,6 +2035,17 @@ s3crc32c = ["PyYAML (>=5.1)", "crc32c", "py-partiql-parser (==0.4.2)"]
 server = ["PyYAML (>=5.1)", "aws-xray-sdk (>=0.93,!=0.96)", "cfn-lint (>=0.40.0)", "docker (>=3.0.0)", "ecdsa (!=0.15)", "flask (!=2.2.0,!=2.2.1)", "flask-cors", "graphql-core", "jsondiff (>=1.1.2)", "openapi-spec-validator (>=0.5.0)", "py-partiql-parser (==0.4.2)", "pyparsing (>=3.0.7)", "python-jose[cryptography] (>=3.1.0,<4.0.0)", "setuptools", "sshpubkeys (>=3.1.0)"]
 ssm = ["PyYAML (>=5.1)"]
 xray = ["aws-xray-sdk (>=0.93,!=0.96)", "setuptools"]
+
+[[package]]
+name = "named-enum"
+version = "1.4.0"
+description = "Python named enumeration, which extends the built-in Enum class with extra features."
+optional = false
+python-versions = ">=3.8.1,<4.0.0"
+files = [
+    {file = "named_enum-1.4.0-py3-none-any.whl", hash = "sha256:cc28cd2d789d3167e31c1cf0ad83a7fcf0fa7912d7800eb8351179bee7d4f8b2"},
+    {file = "named_enum-1.4.0.tar.gz", hash = "sha256:ac7ef5afd9d83d4137c669f72975d299477cbfc7dc6d199adb8738eac702bda8"},
+]
 
 [[package]]
 name = "nested-lookup"
@@ -3843,4 +3858,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "3.11.5"
-content-hash = "b00a931a24dfac4fabb8e3edbf2677c992ac48f67f35fc80829d62f8a9e549d0"
+content-hash = "1d2da46b2be94f6cc270bb2b2bb833775d9d91bc80608c5900c61d551b2970ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,12 +75,13 @@ social-auth-core = {extras = ["openidconnect"], version = "^4.4.2"}
 nh3 = "^0.2.14"
 retry2 = "^0.9.5"
 pluggy = "^1.3.0"
+named-enum = "^1.4.0"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.24"
 ddt = "^1.6.0"
 django-debug-toolbar = "^4.1.0"
-factory_boy = "^2.12.0"
+factory_boy = "^3.3.0"
 faker = "^2.0.0"
 ipdb = "^0.13.13"
 moto = "^4.1.12"

--- a/scripts/generate_openapi.sh
+++ b/scripts/generate_openapi.sh
@@ -9,7 +9,7 @@ fi
 ##################################################
 # Generate OpenAPI Schema
 ##################################################
-docker compose run --rm web \
+docker compose run --no-deps --rm web \
 	./manage.py spectacular \
 	--urlconf open_discussions.urls_spectacular \
 	--file ./openapi.yaml \
@@ -21,13 +21,8 @@ docker compose run --rm web \
 
 GENERATOR_VERSION=v6.6.0
 
-docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli:${GENERATOR_VERSION} \
-	generate \
-	-i /local/openapi.yaml \
-	-g typescript-axios \
-	-o /local/frontends/api/src/generated \
-	--ignore-file-override /local/frontends/api/.openapi-generator-ignore \
-	--additional-properties=useSingleRequestParameter=true,paramNaming=original
+docker run --rm -v "${PWD}:/local" -w /local openapitools/openapi-generator-cli:${GENERATOR_VERSION} \
+	generate -c scripts/openapi-configs/typescript-axios.yaml
 
 # We expect pre-commit to exit with a non-zero status since it is reformatting
 # the generated code.

--- a/scripts/openapi-configs/typescript-axios.yaml
+++ b/scripts/openapi-configs/typescript-axios.yaml
@@ -1,0 +1,7 @@
+generatorName: typescript-axios
+outputDir: frontends/api/src/generated
+inputSpec: openapi.yaml
+ignoreFileOverride: frontends/api/.openapi-generator-ignore
+additionalProperties:
+  paramNaming: original
+  useSingleRequestParameter: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -12666,6 +12666,7 @@ __metadata:
     swc-loader: ^0.2.3
     tiny-invariant: ^1.3.1
     ts-node: ^10.9.1
+    type-fest: ^4.8.1
     typescript: ^5.1.6
     url-assembler: ^2.1.1
   languageName: unknown
@@ -14242,6 +14243,13 @@ __metadata:
   version: 3.13.1
   resolution: "type-fest@npm:3.13.1"
   checksum: c06b0901d54391dc46de3802375f5579868949d71f93b425ce564e19a428a0d411ae8d8cb0e300d330071d86152c3ea86e744c3f2860a42a79585b6ec2fdae8e
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "type-fest@npm:4.8.1"
+  checksum: faffb32d9ab7fe28c91ca6ee6a69da290b66550e114c3f03dccd1c46d7b8e8e73dec3bd8e39e70be2a8e88ad6460e31eda97f9a314bb929a9010c21a1332f663
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes #36 

# Description (What does it do?)

- Refactored the serializers into some smaller packages
- Updated `LearningResourceSerializer` to be a polymorphic wrapper around the resource_type specific variants. This now allows the API schema and thus the typescript generated code to be type specific in places where we know what the type is.

**Main branch:**
![Screenshot 2023-10-20 at 00-14-59 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/bce35b84-d5d6-49d5-9bf0-3733c1d893d7)

**This Branch:**
![Screenshot 2023-10-20 at 00-11-29 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/54e84362-12d7-4325-959a-15773c47bb56)

- Switched `ProgramResourceSerializer.program.courses` to be course learning resources (note the is now typed to `CourseResource`, not a generic LearningResource):

**Main branch:**
![Screenshot 2023-10-20 at 00-16-32 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/a695fe03-936a-4243-bc63-6d1238302d86)


**This Branch:**
![Screenshot 2023-10-20 at 00-12-05 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/d0aeacaf-771d-4432-8c87-97c197985962)

- All type-specific APIs now return a specific type using that type's serializer. For example, the programs API:

**Main branch:**
![Screenshot 2023-10-20 at 00-19-45 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/c2028c13-8341-4855-b613-e7714bf55d2c)

**This Branch:**
![Screenshot 2023-10-20 at 00-20-13 MIT Open Discussions Course Catalog API](https://github.com/mitodl/mit-open/assets/28598/ed31aada-d942-4043-9818-fbdb906bea08)

- Updated `factoryboy` and the factory definitions themselves so that the test data they generate is more internally consistent. Tests were breaking otherwise.

# How can this be tested?

- Check out the schema and make sure it makes sense compared to what's on main/RC.
- Test the API in the swagger UI to verify it's returning the revised data structures.
- Functional test the application.