### PR TITLE
Fixed a test that serializer rework made flaky

### DIFF
--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -51,6 +51,8 @@ def serialize_learning_resource_for_update(
 
     """
     serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
+    # Note: this is an ES-specific field that is filtered out on retrieval
+    #       see SOURCE_EXCLUDED_FIELDS in learning_resources_search/constants.py
     if learning_resource_obj.resource_type == LearningResourceType.course.name:
         serialized_data["course"]["course_numbers"] = [
             SearchCourseNumberSerializer(instance=num).data

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -5,7 +5,7 @@ from django.http import QueryDict
 from rest_framework.renderers import JSONRenderer
 
 from learning_resources import factories
-from learning_resources.constants import DEPARTMENTS
+from learning_resources.constants import DEPARTMENTS, LearningResourceType
 from learning_resources.etl.constants import CourseNumberType
 from learning_resources.models import LearningResource
 from learning_resources.serializers import LearningResourceSerializer
@@ -40,11 +40,16 @@ def test_serialize_bulk_learning_resources(mocker):
 
 
 @pytest.mark.django_db()
-def test_serialize_learning_resource_for_bulk():
+@pytest.mark.parametrize(
+    "resource_type",
+    set(LearningResourceType.names()) - {LearningResourceType.course.name},
+)
+def test_serialize_learning_resource_for_bulk(resource_type):
     """
-    Test that serialize_program_for_bulk yields a valid LearningResourceSerializer
+    Test that serialize_program_for_bulk yields a valid LearningResourceSerializer for resource types other than "course"
+    The "course" resource type is tested by `test_serialize_course_numbers_for_bulk` below.
     """
-    resource = factories.LearningResourceFactory.create()
+    resource = factories.LearningResourceFactory.create(resource_type=resource_type)
     assert serializers.serialize_learning_resource_for_bulk(resource) == {
         "_id": resource.id,
         "resource_relations": {"name": "resource"},


### PR DESCRIPTION
# What are the relevant tickets?
Fixes #253

# Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes a test that started failing in a flaky manner due to being run against resource types selected at random. It parametrizes over all resource types _except_ course since that is already covered by a more specific test.

# How can this be tested?
This is a test-only change, so just verify the tests pass.