### PR TITLE
Update fixture and function for upserting platforms

### DIFF
--- a/learning_resources/fixtures/platforms.json
+++ b/learning_resources/fixtures/platforms.json
@@ -2,7 +2,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "ocw",
+      "code": "ocw",
       "name": "OCW",
       "is_edx": false,
       "has_content_files": true,
@@ -14,7 +14,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "edx",
+      "code": "edx",
       "name": "edX",
       "is_edx": true,
       "has_content_files": true,
@@ -26,7 +26,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "mitxonline",
+      "code": "mitxonline",
       "name": "MITx Online",
       "is_edx": true,
       "has_content_files": true,
@@ -38,7 +38,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "bootcamps",
+      "code": "bootcamps",
       "name": "Bootcamps",
       "is_edx": false,
       "has_content_files": false,
@@ -50,7 +50,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "xpro",
+      "code": "xpro",
       "name": "xPRO",
       "is_edx": true,
       "has_content_files": true,
@@ -62,7 +62,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "podcast",
+      "code": "podcast",
       "name": "Podcast",
       "is_edx": false,
       "has_content_files": false,
@@ -74,7 +74,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "csail",
+      "code": "csail",
       "name": "CSAIL",
       "is_edx": false,
       "has_content_files": false,
@@ -86,7 +86,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "mitpe",
+      "code": "mitpe",
       "name": "MIT Professional Education",
       "is_edx": false,
       "has_content_files": false,
@@ -98,7 +98,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "see",
+      "code": "see",
       "name": "Sloan Executive Education",
       "is_edx": false,
       "has_content_files": false,
@@ -110,7 +110,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "scc",
+      "code": "scc",
       "name": "Schwarzman College of Computing",
       "is_edx": false,
       "has_content_files": false,
@@ -122,7 +122,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "ctl",
+      "code": "ctl",
       "name": "Center for Transportation & Logistics",
       "is_edx": false,
       "has_content_files": false,
@@ -134,19 +134,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "podcast",
-      "name": "Podcast",
-      "is_edx": false,
-      "has_content_files": false,
-      "url": "",
-      "created_on": "2023-08-14T14:27:25.128989+00:00",
-      "updated_on": "2023-08-14T14:27:25.128989+00:00"
-    }
-  },
-  {
-    "model": "learning_resources.LearningResourcePlatform",
-    "fields": {
-      "platform": "emeritus",
+      "code": "emeritus",
       "name": "Emeritus",
       "is_edx": false,
       "has_content_files": false,
@@ -158,7 +146,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "simplilearn",
+      "code": "simplilearn",
       "name": "Simplilearn",
       "is_edx": false,
       "has_content_files": false,
@@ -170,7 +158,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "globalalumni",
+      "code": "globalalumni",
       "name": "Global Alumni",
       "is_edx": false,
       "has_content_files": false,
@@ -182,7 +170,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "susskind",
+      "code": "susskind",
       "name": "Susskind",
       "is_edx": false,
       "has_content_files": false,
@@ -194,7 +182,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "whu",
+      "code": "whu",
       "name": "WHU",
       "is_edx": false,
       "has_content_files": false,
@@ -206,7 +194,7 @@
   {
     "model": "learning_resources.LearningResourcePlatform",
     "fields": {
-      "platform": "oll",
+      "code": "oll",
       "name": "Open Learning Library",
       "is_edx": true,
       "has_content_files": false,

--- a/learning_resources/management/commands/update_platforms.py
+++ b/learning_resources/management/commands/update_platforms.py
@@ -16,6 +16,8 @@ class Command(BaseCommand):
 
         self.stdout.write("Updating platform data")
         start = now_in_utc()
-        upsert_platform_data()
+        platform_codes = upsert_platform_data()
         total_seconds = (now_in_utc() - start).total_seconds()
-        self.stdout.write(f"Update of platforms finished, took {total_seconds} seconds")
+        self.stdout.write(
+            f"Upserted {len(platform_codes)} platforms, took {total_seconds} seconds"
+        )

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -308,11 +308,12 @@ def upsert_platform_data():
             for platform in platform_json:
                 platform_fields = platform["fields"]
                 LearningResourcePlatform.objects.update_or_create(
-                    platform=platform_fields["platform"],
+                    code=platform_fields["code"],
                     defaults=platform_fields,
                 )
-                platforms.append(platform_fields["platform"])
-            LearningResourcePlatform.objects.exclude(platform__in=platforms).delete()
+                platforms.append(platform_fields["code"])
+            LearningResourcePlatform.objects.exclude(code__in=platforms).delete()
+        return platforms
 
 
 def resource_upserted_actions(resource: LearningResource):


### PR DESCRIPTION
# What are the relevant tickets?
Fixes a loose end from #113

# Description (What does it do?)
- Gets rid of a dupe platform in fixtures json file
- Changes "platform" to "code" in the fixture json file
- Fixes the `upsert_platform_data` function used by the `update_platforms` mgmt command

# How can this be tested?
Run `./manage.py update_platforms` - it should complete without errors and you should have 17 platforms in the database afterward.
