### PR TITLE
Remove put method from DRF views

### DIFF
--- a/articles/views.py
+++ b/articles/views.py
@@ -24,7 +24,7 @@ class DefaultPagination(LimitOffsetPagination):
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
     destroy=extend_schema(summary="Destroy"),
-    partial_update=extend_schema(summary="Partial Update"),
+    partial_update=extend_schema(summary="Update"),
 )
 class ArticleViewSet(viewsets.ModelViewSet):
     """

--- a/articles/views.py
+++ b/articles/views.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAdminUser
 
 from articles.models import Article
 from articles.serializers import ArticleSerializer
+from open_discussions.constants import VALID_HTTP_METHODS
 
 # Create your views here.
 
@@ -22,7 +23,6 @@ class DefaultPagination(LimitOffsetPagination):
     list=extend_schema(summary="List"),
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
-    update=extend_schema(summary="Update"),
     destroy=extend_schema(summary="Destroy"),
     partial_update=extend_schema(summary="Partial Update"),
 )
@@ -36,3 +36,4 @@ class ArticleViewSet(viewsets.ModelViewSet):
     pagination_class = DefaultPagination
 
     permission_classes = [IsAdminUser]
+    http_method_names = VALID_HTTP_METHODS

--- a/channels/views.py
+++ b/channels/views.py
@@ -21,6 +21,7 @@ from channels.serializers import (
     FieldModeratorSerializer,
 )
 from learning_resources.views import LargePagination
+from open_discussions.constants import VALID_HTTP_METHODS
 
 log = logging.getLogger(__name__)
 
@@ -49,7 +50,6 @@ def extend_schema_responses(serializer):
     list=extend_schema(summary="List"),
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
-    update=extend_schema(summary="Update"),
     destroy=extend_schema(summary="Destroy"),
     partial_update=extend_schema(summary="Partial Update"),
 )
@@ -68,6 +68,7 @@ class FieldChannelViewSet(
 
     pagination_class = LargePagination
     permission_classes = (HasFieldPermission,)
+    http_method_names = VALID_HTTP_METHODS
     lookup_field = "name"
     lookup_url_kwarg = "field_name"
 

--- a/channels/views.py
+++ b/channels/views.py
@@ -51,7 +51,7 @@ def extend_schema_responses(serializer):
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
     destroy=extend_schema(summary="Destroy"),
-    partial_update=extend_schema(summary="Partial Update"),
+    partial_update=extend_schema(summary="Update"),
 )
 class FieldChannelViewSet(
     mixins.ListModelMixin,

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -754,61 +754,6 @@ export interface FieldChannelFeaturedList {
   id: number
 }
 /**
- * Similar to FieldChannelCreateSerializer, with read-only name
- * @export
- * @interface FieldChannelWriteRequest
- */
-export interface FieldChannelWriteRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof FieldChannelWriteRequest
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof FieldChannelWriteRequest
-   */
-  public_description?: string
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof FieldChannelWriteRequest
-   */
-  subfields?: Array<string>
-  /**
-   * Learng path featured in this field.
-   * @type {number}
-   * @memberof FieldChannelWriteRequest
-   */
-  featured_list?: number | null
-  /**
-   * Learng paths in this field.
-   * @type {Array<number>}
-   * @memberof FieldChannelWriteRequest
-   */
-  lists?: Array<number>
-  /**
-   * Get the avatar image URL
-   * @type {string}
-   * @memberof FieldChannelWriteRequest
-   */
-  avatar?: string
-  /**
-   * Get the banner image URL
-   * @type {string}
-   * @memberof FieldChannelWriteRequest
-   */
-  banner?: string
-  /**
-   *
-   * @type {{ [key: string]: any; }}
-   * @memberof FieldChannelWriteRequest
-   */
-  about?: { [key: string]: any } | null
-}
-/**
  * Serializer for moderators
  * @export
  * @interface FieldModerator
@@ -3871,63 +3816,6 @@ export const ArticlesApiAxiosParamCreator = function (
         options: localVarRequestOptions,
       }
     },
-    /**
-     * Viewset for Article viewing and editing.
-     * @summary Update
-     * @param {number} id A unique integer value identifying this article.
-     * @param {ArticleRequest} ArticleRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    articlesUpdate: async (
-      id: number,
-      ArticleRequest: ArticleRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists("articlesUpdate", "id", id)
-      // verify required parameter 'ArticleRequest' is not null or undefined
-      assertParamExists("articlesUpdate", "ArticleRequest", ArticleRequest)
-      const localVarPath = `/api/v1/articles/{id}/`.replace(
-        `{${"id"}}`,
-        encodeURIComponent(String(id)),
-      )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        ArticleRequest,
-        localVarRequestOptions,
-        configuration,
-      )
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
   }
 }
 
@@ -4066,33 +3954,6 @@ export const ArticlesApiFp = function (configuration?: Configuration) {
         configuration,
       )
     },
-    /**
-     * Viewset for Article viewing and editing.
-     * @summary Update
-     * @param {number} id A unique integer value identifying this article.
-     * @param {ArticleRequest} ArticleRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async articlesUpdate(
-      id: number,
-      ArticleRequest: ArticleRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<Article>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.articlesUpdate(
-        id,
-        ArticleRequest,
-        options,
-      )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
   }
 }
 
@@ -4190,25 +4051,6 @@ export const ArticlesApiFactory = function (
         .articlesRetrieve(requestParameters.id, options)
         .then((request) => request(axios, basePath))
     },
-    /**
-     * Viewset for Article viewing and editing.
-     * @summary Update
-     * @param {ArticlesApiArticlesUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    articlesUpdate(
-      requestParameters: ArticlesApiArticlesUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<Article> {
-      return localVarFp
-        .articlesUpdate(
-          requestParameters.id,
-          requestParameters.ArticleRequest,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
   }
 }
 
@@ -4294,27 +4136,6 @@ export interface ArticlesApiArticlesRetrieveRequest {
    * @memberof ArticlesApiArticlesRetrieve
    */
   readonly id: number
-}
-
-/**
- * Request parameters for articlesUpdate operation in ArticlesApi.
- * @export
- * @interface ArticlesApiArticlesUpdateRequest
- */
-export interface ArticlesApiArticlesUpdateRequest {
-  /**
-   * A unique integer value identifying this article.
-   * @type {number}
-   * @memberof ArticlesApiArticlesUpdate
-   */
-  readonly id: number
-
-  /**
-   *
-   * @type {ArticleRequest}
-   * @memberof ArticlesApiArticlesUpdate
-   */
-  readonly ArticleRequest: ArticleRequest
 }
 
 /**
@@ -4410,27 +4231,6 @@ export class ArticlesApi extends BaseAPI {
   ) {
     return ArticlesApiFp(this.configuration)
       .articlesRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Viewset for Article viewing and editing.
-   * @summary Update
-   * @param {ArticlesApiArticlesUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof ArticlesApi
-   */
-  public articlesUpdate(
-    requestParameters: ArticlesApiArticlesUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return ArticlesApiFp(this.configuration)
-      .articlesUpdate(
-        requestParameters.id,
-        requestParameters.ArticleRequest,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -8538,67 +8338,6 @@ export const FieldsApiAxiosParamCreator = function (
         options: localVarRequestOptions,
       }
     },
-    /**
-     * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Update
-     * @param {string} field_name
-     * @param {FieldChannelWriteRequest} FieldChannelWriteRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    fieldsUpdate: async (
-      field_name: string,
-      FieldChannelWriteRequest: FieldChannelWriteRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'field_name' is not null or undefined
-      assertParamExists("fieldsUpdate", "field_name", field_name)
-      // verify required parameter 'FieldChannelWriteRequest' is not null or undefined
-      assertParamExists(
-        "fieldsUpdate",
-        "FieldChannelWriteRequest",
-        FieldChannelWriteRequest,
-      )
-      const localVarPath = `/api/v1/fields/{field_name}/`.replace(
-        `{${"field_name"}}`,
-        encodeURIComponent(String(field_name)),
-      )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        FieldChannelWriteRequest,
-        localVarRequestOptions,
-        configuration,
-      )
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
   }
 }
 
@@ -8823,33 +8562,6 @@ export const FieldsApiFp = function (configuration?: Configuration) {
         configuration,
       )
     },
-    /**
-     * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Update
-     * @param {string} field_name
-     * @param {FieldChannelWriteRequest} FieldChannelWriteRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async fieldsUpdate(
-      field_name: string,
-      FieldChannelWriteRequest: FieldChannelWriteRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<FieldChannel>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.fieldsUpdate(
-        field_name,
-        FieldChannelWriteRequest,
-        options,
-      )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
   }
 }
 
@@ -8996,25 +8708,6 @@ export const FieldsApiFactory = function (
         .fieldsRetrieve(requestParameters.field_name, options)
         .then((request) => request(axios, basePath))
     },
-    /**
-     * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Update
-     * @param {FieldsApiFieldsUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    fieldsUpdate(
-      requestParameters: FieldsApiFieldsUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<FieldChannel> {
-      return localVarFp
-        .fieldsUpdate(
-          requestParameters.field_name,
-          requestParameters.FieldChannelWriteRequest,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
   }
 }
 
@@ -9156,27 +8849,6 @@ export interface FieldsApiFieldsRetrieveRequest {
    * @memberof FieldsApiFieldsRetrieve
    */
   readonly field_name: string
-}
-
-/**
- * Request parameters for fieldsUpdate operation in FieldsApi.
- * @export
- * @interface FieldsApiFieldsUpdateRequest
- */
-export interface FieldsApiFieldsUpdateRequest {
-  /**
-   *
-   * @type {string}
-   * @memberof FieldsApiFieldsUpdate
-   */
-  readonly field_name: string
-
-  /**
-   *
-   * @type {FieldChannelWriteRequest}
-   * @memberof FieldsApiFieldsUpdate
-   */
-  readonly FieldChannelWriteRequest: FieldChannelWriteRequest
 }
 
 /**
@@ -9331,27 +9003,6 @@ export class FieldsApi extends BaseAPI {
   ) {
     return FieldsApiFp(this.configuration)
       .fieldsRetrieve(requestParameters.field_name, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-   * @summary Update
-   * @param {FieldsApiFieldsUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof FieldsApi
-   */
-  public fieldsUpdate(
-    requestParameters: FieldsApiFieldsUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return FieldsApiFp(this.configuration)
-      .fieldsUpdate(
-        requestParameters.field_name,
-        requestParameters.FieldChannelWriteRequest,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -13251,70 +12902,6 @@ export const LearningpathsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Update
-     * @param {number} id A unique integer value identifying this learning resource relationship.
-     * @param {number} parent_id
-     * @param {LearningPathRelationshipRequest} LearningPathRelationshipRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsResourcesUpdate: async (
-      id: number,
-      parent_id: number,
-      LearningPathRelationshipRequest: LearningPathRelationshipRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists("learningpathsResourcesUpdate", "id", id)
-      // verify required parameter 'parent_id' is not null or undefined
-      assertParamExists("learningpathsResourcesUpdate", "parent_id", parent_id)
-      // verify required parameter 'LearningPathRelationshipRequest' is not null or undefined
-      assertParamExists(
-        "learningpathsResourcesUpdate",
-        "LearningPathRelationshipRequest",
-        LearningPathRelationshipRequest,
-      )
-      const localVarPath = `/api/v1/learningpaths/{parent_id}/resources/{id}/`
-        .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-        .replace(`{${"parent_id"}}`, encodeURIComponent(String(parent_id)))
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        LearningPathRelationshipRequest,
-        localVarRequestOptions,
-        configuration,
-      )
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Retrive a single learning path
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this learning resource.
@@ -13354,67 +12941,6 @@ export const LearningpathsApiAxiosParamCreator = function (
         ...headersFromBaseOptions,
         ...options.headers,
       }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * Update all fields of a learning path
-     * @summary Update
-     * @param {number} id A unique integer value identifying this learning resource.
-     * @param {LearningPathResourceRequest} LearningPathResourceRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsUpdate: async (
-      id: number,
-      LearningPathResourceRequest: LearningPathResourceRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists("learningpathsUpdate", "id", id)
-      // verify required parameter 'LearningPathResourceRequest' is not null or undefined
-      assertParamExists(
-        "learningpathsUpdate",
-        "LearningPathResourceRequest",
-        LearningPathResourceRequest,
-      )
-      const localVarPath = `/api/v1/learningpaths/{id}/`.replace(
-        `{${"id"}}`,
-        encodeURIComponent(String(id)),
-      )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        LearningPathResourceRequest,
-        localVarRequestOptions,
-        configuration,
-      )
 
       return {
         url: toPathString(localVarUrlObj),
@@ -13820,40 +13346,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Update
-     * @param {number} id A unique integer value identifying this learning resource relationship.
-     * @param {number} parent_id
-     * @param {LearningPathRelationshipRequest} LearningPathRelationshipRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async learningpathsResourcesUpdate(
-      id: number,
-      parent_id: number,
-      LearningPathRelationshipRequest: LearningPathRelationshipRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<LearningPathRelationship>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.learningpathsResourcesUpdate(
-          id,
-          parent_id,
-          LearningPathRelationshipRequest,
-          options,
-        )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
      * Retrive a single learning path
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this learning resource.
@@ -13871,37 +13363,6 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningpathsRetrieve(id, options)
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Update all fields of a learning path
-     * @summary Update
-     * @param {number} id A unique integer value identifying this learning resource.
-     * @param {LearningPathResourceRequest} LearningPathResourceRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async learningpathsUpdate(
-      id: number,
-      LearningPathResourceRequest: LearningPathResourceRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<LearningPathResource>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.learningpathsUpdate(
-          id,
-          LearningPathResourceRequest,
-          options,
-        )
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -14102,26 +13563,6 @@ export const LearningpathsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Update
-     * @param {LearningpathsApiLearningpathsResourcesUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsResourcesUpdate(
-      requestParameters: LearningpathsApiLearningpathsResourcesUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningPathRelationship> {
-      return localVarFp
-        .learningpathsResourcesUpdate(
-          requestParameters.id,
-          requestParameters.parent_id,
-          requestParameters.LearningPathRelationshipRequest,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
      * Retrive a single learning path
      * @summary Retrieve
      * @param {LearningpathsApiLearningpathsRetrieveRequest} requestParameters Request parameters.
@@ -14134,25 +13575,6 @@ export const LearningpathsApiFactory = function (
     ): AxiosPromise<LearningPathResource> {
       return localVarFp
         .learningpathsRetrieve(requestParameters.id, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Update all fields of a learning path
-     * @summary Update
-     * @param {LearningpathsApiLearningpathsUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    learningpathsUpdate(
-      requestParameters: LearningpathsApiLearningpathsUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<LearningPathResource> {
-      return localVarFp
-        .learningpathsUpdate(
-          requestParameters.id,
-          requestParameters.LearningPathResourceRequest,
-          options,
-        )
         .then((request) => request(axios, basePath))
     },
   }
@@ -14505,34 +13927,6 @@ export interface LearningpathsApiLearningpathsResourcesRetrieveRequest {
 }
 
 /**
- * Request parameters for learningpathsResourcesUpdate operation in LearningpathsApi.
- * @export
- * @interface LearningpathsApiLearningpathsResourcesUpdateRequest
- */
-export interface LearningpathsApiLearningpathsResourcesUpdateRequest {
-  /**
-   * A unique integer value identifying this learning resource relationship.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsResourcesUpdate
-   */
-  readonly id: number
-
-  /**
-   *
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsResourcesUpdate
-   */
-  readonly parent_id: number
-
-  /**
-   *
-   * @type {LearningPathRelationshipRequest}
-   * @memberof LearningpathsApiLearningpathsResourcesUpdate
-   */
-  readonly LearningPathRelationshipRequest: LearningPathRelationshipRequest
-}
-
-/**
  * Request parameters for learningpathsRetrieve operation in LearningpathsApi.
  * @export
  * @interface LearningpathsApiLearningpathsRetrieveRequest
@@ -14544,27 +13938,6 @@ export interface LearningpathsApiLearningpathsRetrieveRequest {
    * @memberof LearningpathsApiLearningpathsRetrieve
    */
   readonly id: number
-}
-
-/**
- * Request parameters for learningpathsUpdate operation in LearningpathsApi.
- * @export
- * @interface LearningpathsApiLearningpathsUpdateRequest
- */
-export interface LearningpathsApiLearningpathsUpdateRequest {
-  /**
-   * A unique integer value identifying this learning resource.
-   * @type {number}
-   * @memberof LearningpathsApiLearningpathsUpdate
-   */
-  readonly id: number
-
-  /**
-   *
-   * @type {LearningPathResourceRequest}
-   * @memberof LearningpathsApiLearningpathsUpdate
-   */
-  readonly LearningPathResourceRequest: LearningPathResourceRequest
 }
 
 /**
@@ -14771,28 +14144,6 @@ export class LearningpathsApi extends BaseAPI {
   }
 
   /**
-   * Viewset for LearningPath related resources
-   * @summary Learning Path Resource Relationship Update
-   * @param {LearningpathsApiLearningpathsResourcesUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LearningpathsApi
-   */
-  public learningpathsResourcesUpdate(
-    requestParameters: LearningpathsApiLearningpathsResourcesUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LearningpathsApiFp(this.configuration)
-      .learningpathsResourcesUpdate(
-        requestParameters.id,
-        requestParameters.parent_id,
-        requestParameters.LearningPathRelationshipRequest,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Retrive a single learning path
    * @summary Retrieve
    * @param {LearningpathsApiLearningpathsRetrieveRequest} requestParameters Request parameters.
@@ -14806,27 +14157,6 @@ export class LearningpathsApi extends BaseAPI {
   ) {
     return LearningpathsApiFp(this.configuration)
       .learningpathsRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Update all fields of a learning path
-   * @summary Update
-   * @param {LearningpathsApiLearningpathsUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof LearningpathsApi
-   */
-  public learningpathsUpdate(
-    requestParameters: LearningpathsApiLearningpathsUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return LearningpathsApiFp(this.configuration)
-      .learningpathsUpdate(
-        requestParameters.id,
-        requestParameters.LearningPathResourceRequest,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }
@@ -19842,70 +19172,6 @@ export const UserlistsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Update
-     * @param {number} id A unique integer value identifying this user list relationship.
-     * @param {number} parent_id
-     * @param {UserListRelationshipRequest} UserListRelationshipRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    userlistsResourcesUpdate: async (
-      id: number,
-      parent_id: number,
-      UserListRelationshipRequest: UserListRelationshipRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists("userlistsResourcesUpdate", "id", id)
-      // verify required parameter 'parent_id' is not null or undefined
-      assertParamExists("userlistsResourcesUpdate", "parent_id", parent_id)
-      // verify required parameter 'UserListRelationshipRequest' is not null or undefined
-      assertParamExists(
-        "userlistsResourcesUpdate",
-        "UserListRelationshipRequest",
-        UserListRelationshipRequest,
-      )
-      const localVarPath = `/api/v1/userlists/{parent_id}/resources/{id}/`
-        .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-        .replace(`{${"parent_id"}}`, encodeURIComponent(String(parent_id)))
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        UserListRelationshipRequest,
-        localVarRequestOptions,
-        configuration,
-      )
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
      * Viewset for UserLists
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this user list.
@@ -19945,63 +19211,6 @@ export const UserlistsApiAxiosParamCreator = function (
         ...headersFromBaseOptions,
         ...options.headers,
       }
-
-      return {
-        url: toPathString(localVarUrlObj),
-        options: localVarRequestOptions,
-      }
-    },
-    /**
-     * Viewset for UserLists
-     * @summary Update
-     * @param {number} id A unique integer value identifying this user list.
-     * @param {UserListRequest} UserListRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    userlistsUpdate: async (
-      id: number,
-      UserListRequest: UserListRequest,
-      options: AxiosRequestConfig = {},
-    ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists("userlistsUpdate", "id", id)
-      // verify required parameter 'UserListRequest' is not null or undefined
-      assertParamExists("userlistsUpdate", "UserListRequest", UserListRequest)
-      const localVarPath = `/api/v1/userlists/{id}/`.replace(
-        `{${"id"}}`,
-        encodeURIComponent(String(id)),
-      )
-      // use dummy base URL string because the URL constructor only accepts absolute URLs.
-      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
-      let baseOptions
-      if (configuration) {
-        baseOptions = configuration.baseOptions
-      }
-
-      const localVarRequestOptions = {
-        method: "PUT",
-        ...baseOptions,
-        ...options,
-      }
-      const localVarHeaderParameter = {} as any
-      const localVarQueryParameter = {} as any
-
-      localVarHeaderParameter["Content-Type"] = "application/json"
-
-      setSearchParams(localVarUrlObj, localVarQueryParameter)
-      let headersFromBaseOptions =
-        baseOptions && baseOptions.headers ? baseOptions.headers : {}
-      localVarRequestOptions.headers = {
-        ...localVarHeaderParameter,
-        ...headersFromBaseOptions,
-        ...options.headers,
-      }
-      localVarRequestOptions.data = serializeDataIfNeeded(
-        UserListRequest,
-        localVarRequestOptions,
-        configuration,
-      )
 
       return {
         url: toPathString(localVarUrlObj),
@@ -20281,40 +19490,6 @@ export const UserlistsApiFp = function (configuration?: Configuration) {
       )
     },
     /**
-     * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Update
-     * @param {number} id A unique integer value identifying this user list relationship.
-     * @param {number} parent_id
-     * @param {UserListRelationshipRequest} UserListRelationshipRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async userlistsResourcesUpdate(
-      id: number,
-      parent_id: number,
-      UserListRelationshipRequest: UserListRelationshipRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (
-        axios?: AxiosInstance,
-        basePath?: string,
-      ) => AxiosPromise<UserListRelationship>
-    > {
-      const localVarAxiosArgs =
-        await localVarAxiosParamCreator.userlistsResourcesUpdate(
-          id,
-          parent_id,
-          UserListRelationshipRequest,
-          options,
-        )
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
      * Viewset for UserLists
      * @summary Retrieve
      * @param {number} id A unique integer value identifying this user list.
@@ -20329,33 +19504,6 @@ export const UserlistsApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.userlistsRetrieve(id, options)
-      return createRequestFunction(
-        localVarAxiosArgs,
-        globalAxios,
-        BASE_PATH,
-        configuration,
-      )
-    },
-    /**
-     * Viewset for UserLists
-     * @summary Update
-     * @param {number} id A unique integer value identifying this user list.
-     * @param {UserListRequest} UserListRequest
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    async userlistsUpdate(
-      id: number,
-      UserListRequest: UserListRequest,
-      options?: AxiosRequestConfig,
-    ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<UserList>
-    > {
-      const localVarAxiosArgs = await localVarAxiosParamCreator.userlistsUpdate(
-        id,
-        UserListRequest,
-        options,
-      )
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -20543,26 +19691,6 @@ export const UserlistsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Update
-     * @param {UserlistsApiUserlistsResourcesUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    userlistsResourcesUpdate(
-      requestParameters: UserlistsApiUserlistsResourcesUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<UserListRelationship> {
-      return localVarFp
-        .userlistsResourcesUpdate(
-          requestParameters.id,
-          requestParameters.parent_id,
-          requestParameters.UserListRelationshipRequest,
-          options,
-        )
-        .then((request) => request(axios, basePath))
-    },
-    /**
      * Viewset for UserLists
      * @summary Retrieve
      * @param {UserlistsApiUserlistsRetrieveRequest} requestParameters Request parameters.
@@ -20575,25 +19703,6 @@ export const UserlistsApiFactory = function (
     ): AxiosPromise<UserList> {
       return localVarFp
         .userlistsRetrieve(requestParameters.id, options)
-        .then((request) => request(axios, basePath))
-    },
-    /**
-     * Viewset for UserLists
-     * @summary Update
-     * @param {UserlistsApiUserlistsUpdateRequest} requestParameters Request parameters.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     */
-    userlistsUpdate(
-      requestParameters: UserlistsApiUserlistsUpdateRequest,
-      options?: AxiosRequestConfig,
-    ): AxiosPromise<UserList> {
-      return localVarFp
-        .userlistsUpdate(
-          requestParameters.id,
-          requestParameters.UserListRequest,
-          options,
-        )
         .then((request) => request(axios, basePath))
     },
   }
@@ -20789,34 +19898,6 @@ export interface UserlistsApiUserlistsResourcesRetrieveRequest {
 }
 
 /**
- * Request parameters for userlistsResourcesUpdate operation in UserlistsApi.
- * @export
- * @interface UserlistsApiUserlistsResourcesUpdateRequest
- */
-export interface UserlistsApiUserlistsResourcesUpdateRequest {
-  /**
-   * A unique integer value identifying this user list relationship.
-   * @type {number}
-   * @memberof UserlistsApiUserlistsResourcesUpdate
-   */
-  readonly id: number
-
-  /**
-   *
-   * @type {number}
-   * @memberof UserlistsApiUserlistsResourcesUpdate
-   */
-  readonly parent_id: number
-
-  /**
-   *
-   * @type {UserListRelationshipRequest}
-   * @memberof UserlistsApiUserlistsResourcesUpdate
-   */
-  readonly UserListRelationshipRequest: UserListRelationshipRequest
-}
-
-/**
  * Request parameters for userlistsRetrieve operation in UserlistsApi.
  * @export
  * @interface UserlistsApiUserlistsRetrieveRequest
@@ -20828,27 +19909,6 @@ export interface UserlistsApiUserlistsRetrieveRequest {
    * @memberof UserlistsApiUserlistsRetrieve
    */
   readonly id: number
-}
-
-/**
- * Request parameters for userlistsUpdate operation in UserlistsApi.
- * @export
- * @interface UserlistsApiUserlistsUpdateRequest
- */
-export interface UserlistsApiUserlistsUpdateRequest {
-  /**
-   * A unique integer value identifying this user list.
-   * @type {number}
-   * @memberof UserlistsApiUserlistsUpdate
-   */
-  readonly id: number
-
-  /**
-   *
-   * @type {UserListRequest}
-   * @memberof UserlistsApiUserlistsUpdate
-   */
-  readonly UserListRequest: UserListRequest
 }
 
 /**
@@ -21038,28 +20098,6 @@ export class UserlistsApi extends BaseAPI {
   }
 
   /**
-   * Viewset for UserListRelationships
-   * @summary User List Resource Relationship Update
-   * @param {UserlistsApiUserlistsResourcesUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof UserlistsApi
-   */
-  public userlistsResourcesUpdate(
-    requestParameters: UserlistsApiUserlistsResourcesUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return UserlistsApiFp(this.configuration)
-      .userlistsResourcesUpdate(
-        requestParameters.id,
-        requestParameters.parent_id,
-        requestParameters.UserListRelationshipRequest,
-        options,
-      )
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
    * Viewset for UserLists
    * @summary Retrieve
    * @param {UserlistsApiUserlistsRetrieveRequest} requestParameters Request parameters.
@@ -21073,27 +20111,6 @@ export class UserlistsApi extends BaseAPI {
   ) {
     return UserlistsApiFp(this.configuration)
       .userlistsRetrieve(requestParameters.id, options)
-      .then((request) => request(this.axios, this.basePath))
-  }
-
-  /**
-   * Viewset for UserLists
-   * @summary Update
-   * @param {UserlistsApiUserlistsUpdateRequest} requestParameters Request parameters.
-   * @param {*} [options] Override http request option.
-   * @throws {RequiredError}
-   * @memberof UserlistsApi
-   */
-  public userlistsUpdate(
-    requestParameters: UserlistsApiUserlistsUpdateRequest,
-    options?: AxiosRequestConfig,
-  ) {
-    return UserlistsApiFp(this.configuration)
-      .userlistsUpdate(
-        requestParameters.id,
-        requestParameters.UserListRequest,
-        options,
-      )
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -3717,7 +3717,7 @@ export const ArticlesApiAxiosParamCreator = function (
     },
     /**
      * Viewset for Article viewing and editing.
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this article.
      * @param {PatchedArticleRequest} [PatchedArticleRequest]
      * @param {*} [options] Override http request option.
@@ -3906,7 +3906,7 @@ export const ArticlesApiFp = function (configuration?: Configuration) {
     },
     /**
      * Viewset for Article viewing and editing.
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this article.
      * @param {PatchedArticleRequest} [PatchedArticleRequest]
      * @param {*} [options] Override http request option.
@@ -4019,7 +4019,7 @@ export const ArticlesApiFactory = function (
     },
     /**
      * Viewset for Article viewing and editing.
-     * @summary Partial Update
+     * @summary Update
      * @param {ArticlesApiArticlesPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4198,7 +4198,7 @@ export class ArticlesApi extends BaseAPI {
 
   /**
    * Viewset for Article viewing and editing.
-   * @summary Partial Update
+   * @summary Update
    * @param {ArticlesApiArticlesPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -8239,7 +8239,7 @@ export const FieldsApiAxiosParamCreator = function (
     },
     /**
      * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Partial Update
+     * @summary Update
      * @param {string} field_name
      * @param {PatchedFieldChannelWriteRequest} [PatchedFieldChannelWriteRequest]
      * @param {*} [options] Override http request option.
@@ -8512,7 +8512,7 @@ export const FieldsApiFp = function (configuration?: Configuration) {
     },
     /**
      * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Partial Update
+     * @summary Update
      * @param {string} field_name
      * @param {PatchedFieldChannelWriteRequest} [PatchedFieldChannelWriteRequest]
      * @param {*} [options] Override http request option.
@@ -8676,7 +8676,7 @@ export const FieldsApiFactory = function (
     },
     /**
      * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-     * @summary Partial Update
+     * @summary Update
      * @param {FieldsApiFieldsPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -8970,7 +8970,7 @@ export class FieldsApi extends BaseAPI {
 
   /**
    * CRUD Operations related to Fields. Fields may represent groups or organizations at MIT and are a high-level categorization of content.
-   * @summary Partial Update
+   * @summary Update
    * @param {FieldsApiFieldsPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -12557,7 +12557,7 @@ export const LearningpathsApiAxiosParamCreator = function (
     },
     /**
      * Update individual fields of a learning path
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this learning resource.
      * @param {PatchedLearningPathResourceRequest} [PatchedLearningPathResourceRequest]
      * @param {*} [options] Override http request option.
@@ -12788,7 +12788,7 @@ export const LearningpathsApiAxiosParamCreator = function (
     },
     /**
      * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Partial Update
+     * @summary Learning Path Resource Relationship Update
      * @param {number} id A unique integer value identifying this learning resource relationship.
      * @param {number} parent_id
      * @param {PatchedLearningPathRelationshipRequest} [PatchedLearningPathRelationshipRequest]
@@ -13155,7 +13155,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Update individual fields of a learning path
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this learning resource.
      * @param {PatchedLearningPathResourceRequest} [PatchedLearningPathResourceRequest]
      * @param {*} [options] Override http request option.
@@ -13282,7 +13282,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Partial Update
+     * @summary Learning Path Resource Relationship Update
      * @param {number} id A unique integer value identifying this learning resource relationship.
      * @param {number} parent_id
      * @param {PatchedLearningPathRelationshipRequest} [PatchedLearningPathRelationshipRequest]
@@ -13447,7 +13447,7 @@ export const LearningpathsApiFactory = function (
     },
     /**
      * Update individual fields of a learning path
-     * @summary Partial Update
+     * @summary Update
      * @param {LearningpathsApiLearningpathsPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13525,7 +13525,7 @@ export const LearningpathsApiFactory = function (
     },
     /**
      * Viewset for LearningPath related resources
-     * @summary Learning Path Resource Relationship Partial Update
+     * @summary Learning Path Resource Relationship Update
      * @param {LearningpathsApiLearningpathsResourcesPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -14016,7 +14016,7 @@ export class LearningpathsApi extends BaseAPI {
 
   /**
    * Update individual fields of a learning path
-   * @summary Partial Update
+   * @summary Update
    * @param {LearningpathsApiLearningpathsPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -14102,7 +14102,7 @@ export class LearningpathsApi extends BaseAPI {
 
   /**
    * Viewset for LearningPath related resources
-   * @summary Learning Path Resource Relationship Partial Update
+   * @summary Learning Path Resource Relationship Update
    * @param {LearningpathsApiLearningpathsResourcesPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -18839,7 +18839,7 @@ export const UserlistsApiAxiosParamCreator = function (
     },
     /**
      * Viewset for UserLists
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this user list.
      * @param {PatchedUserListRequest} [PatchedUserListRequest]
      * @param {*} [options] Override http request option.
@@ -19062,7 +19062,7 @@ export const UserlistsApiAxiosParamCreator = function (
     },
     /**
      * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Partial Update
+     * @summary User List Resource Relationship Update
      * @param {number} id A unique integer value identifying this user list relationship.
      * @param {number} parent_id
      * @param {PatchedUserListRelationshipRequest} [PatchedUserListRelationshipRequest]
@@ -19305,7 +19305,7 @@ export const UserlistsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Viewset for UserLists
-     * @summary Partial Update
+     * @summary Update
      * @param {number} id A unique integer value identifying this user list.
      * @param {PatchedUserListRequest} [PatchedUserListRequest]
      * @param {*} [options] Override http request option.
@@ -19426,7 +19426,7 @@ export const UserlistsApiFp = function (configuration?: Configuration) {
     },
     /**
      * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Partial Update
+     * @summary User List Resource Relationship Update
      * @param {number} id A unique integer value identifying this user list relationship.
      * @param {number} parent_id
      * @param {PatchedUserListRelationshipRequest} [PatchedUserListRelationshipRequest]
@@ -19576,7 +19576,7 @@ export const UserlistsApiFactory = function (
     },
     /**
      * Viewset for UserLists
-     * @summary Partial Update
+     * @summary Update
      * @param {UserlistsApiUserlistsPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -19653,7 +19653,7 @@ export const UserlistsApiFactory = function (
     },
     /**
      * Viewset for UserListRelationships
-     * @summary User List Resource Relationship Partial Update
+     * @summary User List Resource Relationship Update
      * @param {UserlistsApiUserlistsResourcesPartialUpdateRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -19971,7 +19971,7 @@ export class UserlistsApi extends BaseAPI {
 
   /**
    * Viewset for UserLists
-   * @summary Partial Update
+   * @summary Update
    * @param {UserlistsApiUserlistsPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
@@ -20056,7 +20056,7 @@ export class UserlistsApi extends BaseAPI {
 
   /**
    * Viewset for UserListRelationships
-   * @summary User List Resource Relationship Partial Update
+   * @summary User List Resource Relationship Update
    * @param {UserlistsApiUserlistsResourcesPartialUpdateRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -358,7 +358,7 @@ class PodcastEpisodeViewSet(BaseLearningResourceViewSet):
     create=extend_schema(summary="Create", description="Create a learning path"),
     destroy=extend_schema(summary="Destroy", description="Remove a learning path"),
     partial_update=extend_schema(
-        summary="Partial Update",
+        summary="Update",
         description="Update individual fields of a learning path",
     ),
 )
@@ -433,9 +433,7 @@ class ResourceListItemsViewSet(NestedParentMixin, viewsets.ReadOnlyModelViewSet)
 @extend_schema_view(
     create=extend_schema(summary="Learning Path Resource Relationship Add"),
     destroy=extend_schema(summary="Learning Path Resource Relationship Remove"),
-    partial_update=extend_schema(
-        summary="Learning Path Resource Relationship Partial Update"
-    ),
+    partial_update=extend_schema(summary="Learning Path Resource Relationship Update"),
 )
 class LearningPathItemsViewSet(ResourceListItemsViewSet, viewsets.ModelViewSet):
     """
@@ -529,7 +527,7 @@ class LearningResourceContentFilesViewSet(NestedViewSetMixin, ContentFileViewSet
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
     destroy=extend_schema(summary="Destroy"),
-    partial_update=extend_schema(summary="Partial Update"),
+    partial_update=extend_schema(summary="Update"),
 )
 class UserListViewSet(NestedParentMixin, viewsets.ModelViewSet):
     """
@@ -577,9 +575,7 @@ class UserListViewSet(NestedParentMixin, viewsets.ModelViewSet):
     retrieve=extend_schema(summary="User List Resources Retrieve"),
     create=extend_schema(summary="User List Resource Relationship Add"),
     destroy=extend_schema(summary="User List Resource Relationship Remove"),
-    partial_update=extend_schema(
-        summary="User List Resource Relationship Partial Update"
-    ),
+    partial_update=extend_schema(summary="User List Resource Relationship Update"),
 )
 class UserListItemViewSet(NestedParentMixin, viewsets.ModelViewSet):
     """

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -70,6 +70,7 @@ from learning_resources.serializers import (
 )
 from learning_resources.tasks import get_ocw_courses
 from learning_resources.utils import resource_unpublished_actions
+from open_discussions.constants import VALID_HTTP_METHODS
 from open_discussions.permissions import (
     AnonymousAccessReadonlyPermission,
     is_admin_user,
@@ -355,9 +356,6 @@ class PodcastEpisodeViewSet(BaseLearningResourceViewSet):
         summary="Retrieve", description="Retrive a single learning path"
     ),
     create=extend_schema(summary="Create", description="Create a learning path"),
-    update=extend_schema(
-        summary="Update", description="Update all fields of a learning path"
-    ),
     destroy=extend_schema(summary="Destroy", description="Remove a learning path"),
     partial_update=extend_schema(
         summary="Partial Update",
@@ -371,6 +369,7 @@ class LearningPathViewSet(BaseLearningResourceViewSet, viewsets.ModelViewSet):
 
     serializer_class = LearningPathResourceSerializer
     permission_classes = (permissions.HasLearningPathPermissions,)
+    http_method_names = VALID_HTTP_METHODS
 
     def get_queryset(self):
         """
@@ -433,7 +432,6 @@ class ResourceListItemsViewSet(NestedParentMixin, viewsets.ReadOnlyModelViewSet)
 
 @extend_schema_view(
     create=extend_schema(summary="Learning Path Resource Relationship Add"),
-    update=extend_schema(summary="Learning Path Resource Relationship Update"),
     destroy=extend_schema(summary="Learning Path Resource Relationship Remove"),
     partial_update=extend_schema(
         summary="Learning Path Resource Relationship Partial Update"
@@ -446,6 +444,7 @@ class LearningPathItemsViewSet(ResourceListItemsViewSet, viewsets.ModelViewSet):
 
     serializer_class = LearningPathRelationshipSerializer
     permission_classes = (permissions.HasLearningPathItemPermissions,)
+    http_method_names = VALID_HTTP_METHODS
 
     def create(self, request, *args, **kwargs):
         request.data["parent"] = self.get_parent_id()
@@ -529,7 +528,6 @@ class LearningResourceContentFilesViewSet(NestedViewSetMixin, ContentFileViewSet
     list=extend_schema(summary="List"),
     retrieve=extend_schema(summary="Retrieve"),
     create=extend_schema(summary="Create"),
-    update=extend_schema(summary="Update"),
     destroy=extend_schema(summary="Destroy"),
     partial_update=extend_schema(summary="Partial Update"),
 )
@@ -541,6 +539,7 @@ class UserListViewSet(NestedParentMixin, viewsets.ModelViewSet):
     serializer_class = UserListSerializer
     pagination_class = DefaultPagination
     permission_classes = (HasUserListPermissions,)
+    http_method_names = VALID_HTTP_METHODS
 
     def get_queryset(self):
         """Return a queryset for this user"""
@@ -577,7 +576,6 @@ class UserListViewSet(NestedParentMixin, viewsets.ModelViewSet):
     list=extend_schema(summary="User List Resources List"),
     retrieve=extend_schema(summary="User List Resources Retrieve"),
     create=extend_schema(summary="User List Resource Relationship Add"),
-    update=extend_schema(summary="User List Resource Relationship Update"),
     destroy=extend_schema(summary="User List Resource Relationship Remove"),
     partial_update=extend_schema(
         summary="User List Resource Relationship Partial Update"
@@ -594,6 +592,7 @@ class UserListItemViewSet(NestedParentMixin, viewsets.ModelViewSet):
     serializer_class = UserListRelationshipSerializer
     pagination_class = DefaultPagination
     permission_classes = (HasUserListItemPermissions,)
+    http_method_names = VALID_HTTP_METHODS
 
     def create(self, request, *args, **kwargs):
         user_list_id = self.get_parent_id()

--- a/open_discussions/constants.py
+++ b/open_discussions/constants.py
@@ -10,3 +10,4 @@ DJANGO_PERMISSION_ERROR_TYPES = (
 )
 
 ISOFORMAT = "%Y-%m-%dT%H:%M:%SZ"
+VALID_HTTP_METHODS = ["get", "post", "patch", "delete"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,38 +77,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/Article'
           description: ''
-    put:
-      operationId: articles_update
-      description: Viewset for Article viewing and editing.
-      summary: Update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this article.
-        required: true
-      tags:
-      - articles
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ArticleRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/ArticleRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/ArticleRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Article'
-          description: ''
     patch:
       operationId: articles_partial_update
       description: Viewset for Article viewing and editing.
@@ -1461,39 +1429,6 @@ paths:
         required: true
       tags:
       - fields
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/FieldChannel'
-          description: ''
-    put:
-      operationId: fields_update
-      description: |-
-        CRUD Operations related to Fields. Fields may represent groups or organizations
-        at MIT and are a high-level categorization of content.
-      summary: Update
-      parameters:
-      - in: path
-        name: field_name
-        schema:
-          type: string
-        required: true
-      tags:
-      - fields
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/FieldChannelWriteRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/FieldChannelWriteRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/FieldChannelWriteRequest'
-        required: true
       responses:
         '200':
           content:
@@ -3313,43 +3248,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/LearningPathRelationship'
           description: ''
-    put:
-      operationId: learningpaths_resources_update
-      description: Viewset for LearningPath related resources
-      summary: Learning Path Resource Relationship Update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this learning resource relationship.
-        required: true
-      - in: path
-        name: parent_id
-        schema:
-          type: integer
-        required: true
-      tags:
-      - learningpaths
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LearningPathRelationshipRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/LearningPathRelationshipRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/LearningPathRelationshipRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LearningPathRelationship'
-          description: ''
     patch:
       operationId: learningpaths_resources_partial_update
       description: Viewset for LearningPath related resources
@@ -3421,38 +3319,6 @@ paths:
         required: true
       tags:
       - learningpaths
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LearningPathResource'
-          description: ''
-    put:
-      operationId: learningpaths_update
-      description: Update all fields of a learning path
-      summary: Update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this learning resource.
-        required: true
-      tags:
-      - learningpaths
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/LearningPathResourceRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/LearningPathResourceRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/LearningPathResourceRequest'
-        required: true
       responses:
         '200':
           content:
@@ -5244,43 +5110,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserListRelationship'
           description: ''
-    put:
-      operationId: userlists_resources_update
-      description: Viewset for UserListRelationships
-      summary: User List Resource Relationship Update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user list relationship.
-        required: true
-      - in: path
-        name: parent_id
-        schema:
-          type: integer
-        required: true
-      tags:
-      - userlists
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserListRelationshipRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/UserListRelationshipRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/UserListRelationshipRequest'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserListRelationship'
-          description: ''
     patch:
       operationId: userlists_resources_partial_update
       description: Viewset for UserListRelationships
@@ -5352,38 +5181,6 @@ paths:
         required: true
       tags:
       - userlists
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserList'
-          description: ''
-    put:
-      operationId: userlists_update
-      description: Viewset for UserLists
-      summary: Update
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: integer
-        description: A unique integer value identifying this user list.
-        required: true
-      tags:
-      - userlists
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserListRequest'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/UserListRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/UserListRequest'
-        required: true
       responses:
         '200':
           content:
@@ -5934,43 +5731,6 @@ components:
           nullable: true
       required:
       - name
-      - title
-    FieldChannelWriteRequest:
-      type: object
-      description: Similar to FieldChannelCreateSerializer, with read-only name
-      properties:
-        title:
-          type: string
-          minLength: 1
-          maxLength: 100
-        public_description:
-          type: string
-        subfields:
-          type: array
-          items:
-            type: string
-            minLength: 1
-        featured_list:
-          type: integer
-          nullable: true
-          description: Learng path featured in this field.
-        lists:
-          type: array
-          items:
-            type: integer
-            nullable: true
-          description: Learng paths in this field.
-        avatar:
-          type: string
-          description: Get the avatar image URL
-        banner:
-          type: string
-          description: Get the banner image URL
-        about:
-          type: object
-          additionalProperties: {}
-          nullable: true
-      required:
       - title
     FieldModerator:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -80,7 +80,7 @@ paths:
     patch:
       operationId: articles_partial_update
       description: Viewset for Article viewing and editing.
-      summary: Partial Update
+      summary: Update
       parameters:
       - in: path
         name: id
@@ -1441,7 +1441,7 @@ paths:
       description: |-
         CRUD Operations related to Fields. Fields may represent groups or organizations
         at MIT and are a high-level categorization of content.
-      summary: Partial Update
+      summary: Update
       parameters:
       - in: path
         name: field_name
@@ -3251,7 +3251,7 @@ paths:
     patch:
       operationId: learningpaths_resources_partial_update
       description: Viewset for LearningPath related resources
-      summary: Learning Path Resource Relationship Partial Update
+      summary: Learning Path Resource Relationship Update
       parameters:
       - in: path
         name: id
@@ -3329,7 +3329,7 @@ paths:
     patch:
       operationId: learningpaths_partial_update
       description: Update individual fields of a learning path
-      summary: Partial Update
+      summary: Update
       parameters:
       - in: path
         name: id
@@ -5113,7 +5113,7 @@ paths:
     patch:
       operationId: userlists_resources_partial_update
       description: Viewset for UserListRelationships
-      summary: User List Resource Relationship Partial Update
+      summary: User List Resource Relationship Update
       parameters:
       - in: path
         name: id
@@ -5191,7 +5191,7 @@ paths:
     patch:
       operationId: userlists_partial_update
       description: Viewset for UserLists
-      summary: Partial Update
+      summary: Update
       parameters:
       - in: path
         name: id


### PR DESCRIPTION
# What are the relevant tickets?
Closes #292 

# Description (What does it do?)
Removed the "put" http method from writable API viewsets and schema documentation


# How can this be tested?
Tests should still pass.
The schema documentation for writable api endpoints (channels, articles, learning paths, user lists) should still show PATCH, POST, and DELETE options but no PUT option.
