### PR TITLE
Update calculation of `LearningResource.resource_num` property

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -220,7 +220,7 @@ export interface ContentFile {
    * @type {string}
    * @memberof ContentFile
    */
-  resource_readable_num: string
+  course_number: string
   /**
    *
    * @type {string}

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -12,6 +12,7 @@ from factory.fuzzy import FuzzyChoice, FuzzyText
 
 from learning_resources import constants, models
 from learning_resources.constants import DEPARTMENTS, PlatformType
+from learning_resources.etl.constants import CourseNumberType
 from open_discussions.factories import UserFactory
 
 # pylint:disable=unused-argument
@@ -288,7 +289,7 @@ class CourseFactory(DjangoModelFactory):
             {
                 "value": f"{random.randint(1,20)}.0001",  # noqa: S311
                 "department": None,
-                "listing_type": "Primary",
+                "listing_type": CourseNumberType.primary.name,
                 "primary": True,
                 "sort_coursenum": f"{random.randint(1, 20):02d}",  # noqa: S311
             }

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -12,6 +12,7 @@ from learning_resources.constants import (
     LearningResourceType,
     PrivacyLevel,
 )
+from learning_resources.etl.constants import CourseNumberType
 from open_discussions.models import TimestampedModel
 
 
@@ -208,7 +209,15 @@ class LearningResource(TimestampedModel):
     @property
     def resource_num(self):
         """Extracts the course/program number from the readable_id"""
-        return self.readable_id.split("+")[-1]  # pylint:disable=use-maxsplit-arg
+        if hasattr(self, "course"):
+            primary_course = [
+                course_num["value"]
+                for course_num in self.course.course_numbers
+                if course_num["listing_type"] == CourseNumberType.primary.value
+            ]
+            if primary_course:
+                return primary_course[0]
+        return self.readable_id.split("+")[-1]
 
     class Meta:
         unique_together = (("platform", "readable_id", "resource_type"),)

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -12,7 +12,6 @@ from learning_resources.constants import (
     LearningResourceType,
     PrivacyLevel,
 )
-from learning_resources.etl.constants import CourseNumberType
 from open_discussions.models import TimestampedModel
 
 
@@ -208,16 +207,16 @@ class LearningResource(TimestampedModel):
 
     @property
     def resource_num(self):
-        """Extracts the course/program number from the readable_id"""
+        """Extracts the primary course number from the readable_id"""
         if hasattr(self, "course"):
             primary_course = [
                 course_num["value"]
                 for course_num in self.course.course_numbers
-                if course_num["listing_type"] == CourseNumberType.primary.value
+                if course_num["primary"]
             ]
             if primary_course:
                 return primary_course[0]
-        return self.readable_id.split("+")[-1]
+        return None
 
     class Meta:
         unique_together = (("platform", "readable_id", "resource_type"),)

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -205,19 +205,6 @@ class LearningResource(TimestampedModel):
             )
         )
 
-    @property
-    def resource_num(self):
-        """Extracts the primary course number from the readable_id"""
-        if hasattr(self, "course"):
-            primary_course = [
-                course_num["value"]
-                for course_num in self.course.course_numbers
-                if course_num["primary"]
-            ]
-            if primary_course:
-                return primary_course[0]
-        return None
-
     class Meta:
         unique_together = (("platform", "readable_id", "resource_type"),)
 

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -97,3 +97,11 @@ def test_lr_certification(offered_by, availability, has_cert):
     )
 
     assert course.learning_resource.certification == has_cert
+
+
+def test_resource_num():
+    """The resource_num property should return the expected value"""
+    course = CourseFactory.create()
+    assert course.learning_resource.resource_num == course.course_numbers[0]["value"]
+    program = ProgramFactory.create()
+    assert program.learning_resource.resource_num is None

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -97,11 +97,3 @@ def test_lr_certification(offered_by, availability, has_cert):
     )
 
     assert course.learning_resource.certification == has_cert
-
-
-def test_resource_num():
-    """The resource_num property should return the expected value"""
-    course = CourseFactory.create()
-    assert course.learning_resource.resource_num == course.course_numbers[0]["value"]
-    program = ProgramFactory.create()
-    assert program.learning_resource.resource_num is None

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import ValidationError
 
 from learning_resources import constants, models
 from learning_resources.etl.loaders import update_index
+from learning_resources.constants import LearningResourceType
 from open_discussions.serializers import WriteableSerializerMethodField
 
 COMMON_IGNORED_FIELDS = ("created_on", "updated_on")
@@ -575,9 +576,7 @@ class ContentFileSerializer(serializers.ModelSerializer):
     resource_readable_id = serializers.CharField(
         source="run.learning_resource.readable_id"
     )
-    resource_readable_num = serializers.CharField(
-        source="run.learning_resource.resource_num"
-    )
+    course_number = serializers.SerializerMethodField()
     content_feature_type = LearningResourceContentTagField(source="content_tags")
     offered_by = LearningResourceOfferorSerializer(
         source="run.learning_resource.offered_by"
@@ -585,6 +584,15 @@ class ContentFileSerializer(serializers.ModelSerializer):
     platform = LearningResourcePlatformSerializer(
         source="run.learning_resource.platform"
     )
+
+    def get_course_number(self, instance):
+        """Extract the course number(s) from the associated course"""
+        if hasattr(instance.run.learning_resource, LearningResourceType.course.name):
+            return [
+                coursenum["value"]
+                for coursenum in instance.run.learning_resource.course.course_numbers
+            ]
+        return []
 
     class Meta:
         model = models.ContentFile
@@ -611,7 +619,7 @@ class ContentFileSerializer(serializers.ModelSerializer):
             "image_src",
             "resource_id",
             "resource_readable_id",
-            "resource_readable_num",
+            "course_number",
             "file_type",
             "offered_by",
             "platform",

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -11,8 +11,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
 from learning_resources import constants, models
-from learning_resources.etl.loaders import update_index
 from learning_resources.constants import LearningResourceType
+from learning_resources.etl.loaders import update_index
 from open_discussions.serializers import WriteableSerializerMethodField
 
 COMMON_IGNORED_FIELDS = ("created_on", "updated_on")

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -442,9 +442,10 @@ def test_content_file_serializer(expected_types):
             "image_src": content_file.image_src,
             "resource_id": str(content_file.run.learning_resource.id),
             "resource_readable_id": content_file.run.learning_resource.readable_id,
-            "resource_readable_num": (
-                content_file.run.learning_resource.course.course_numbers[0]["value"]
-            ),
+            "course_number": [
+                coursenum["value"]
+                for coursenum in content_file.run.learning_resource.course.course_numbers
+            ],
             "content_feature_type": [
                 tag.name for tag in content_file.content_tags.all()
             ],

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -443,7 +443,7 @@ def test_content_file_serializer(expected_types):
             "resource_id": str(content_file.run.learning_resource.id),
             "resource_readable_id": content_file.run.learning_resource.readable_id,
             "resource_readable_num": (
-                content_file.run.learning_resource.readable_id.split("+")[-1]
+                content_file.run.learning_resource.course.course_numbers[0]["value"]
             ),
             "content_feature_type": [
                 tag.name for tag in content_file.content_tags.all()

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -492,7 +492,12 @@ class ContentFileViewSet(viewsets.ReadOnlyModelViewSet):
 
     serializer_class = ContentFileSerializer
     permission_classes = (AnonymousAccessReadonlyPermission,)
-    queryset = ContentFile.objects.filter(published=True).order_by("-updated_on")
+    queryset = (
+        ContentFile.objects.select_related("run")
+        .prefetch_related("content_tags")
+        .filter(published=True)
+        .order_by("-updated_on")
+    )
     pagination_class = DefaultPagination
     filter_backends = [DjangoFilterBackend]
     filterset_class = ContentFileFilter

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -209,7 +209,7 @@ CONTENT_FILE_MAP = {
     "image_src": {"type": "keyword"},
     "resource_id": {"type": "long"},
     "resource_readable_id": {"type": "keyword"},
-    "resource_readable_num": {"type": "keyword"},
+    "course_number": {"type": "keyword"},
     "resource_type": {"type": "keyword"},
     "offered_by": {
         "type": "nested",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5591,8 +5591,9 @@ components:
           type: string
         resource_readable_id:
           type: string
-        resource_readable_num:
+        course_number:
           type: string
+          readOnly: true
         file_type:
           type: string
           nullable: true
@@ -5605,13 +5606,13 @@ components:
           type: string
       required:
       - content_feature_type
+      - course_number
       - departments
       - id
       - offered_by
       - platform
       - resource_id
       - resource_readable_id
-      - resource_readable_num
       - run_id
       - run_readable_id
       - run_slug


### PR DESCRIPTION
# What are the relevant tickets?
Fixes #320 

# Description (What does it do?)
- Gets rid of this property from the `LearnbingResource` model and moves it to the `ContentFileSerializer` since that is the only place it was being used.
- Renames it to `course_number` and makes it an array of `Course.course_numbers.value` strings


# How can this be tested?

Run `./manage.py recreate_index --all`
Run `./manage.py backpopulate_ocw_data --overwrite  --course-name 11-014j-american-urban-history-ii-fall-2011` and maybe import some other courses if you don't have anymore, OCW and otherwise.

Go to the following urls, you should see `course_number` in results, as an array containing at least one value and possibly more.
http://localhost:8063/api/v1/contentfiles/
http://localhost:8063/api/v1/content_file_search/
http://localhost:8063/api/v1/content_file_search/?platform=ocw&q=21H.232J

The last one should return contentfiles with a `course_number` value of `[ "11.014J", "21H.232J"]`

# Additional Context
Not sure if it would make sense to add another filter on this (for both opensearch and db-backed api's), for now it is queryable in opensearch via the `q` parameter.


