### PR TITLE
show 404 page on bad routes

### DIFF
--- a/frontends/mit-open/src/pages/ErrorPage/ErrorPage.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ErrorPage.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { AxiosError } from "axios"
 import ForbiddenPage from "./ForbiddenPage"
 import NotFoundPage from "./NotFoundPage"
-import { useRouteError } from "react-router"
+import { useRouteError, isRouteErrorResponse } from "react-router"
 import ErrorPageTemplate from "./ErrorPageTemplate"
 import { ForbiddenError as ClientSideForbiddenError } from "@/common/permissions"
 
@@ -10,9 +10,13 @@ const AUTH_STATUS_CODES = [401, 403]
 const NOT_FOUND_STATUS_CODES = [404]
 
 const isNotFoundError = (error: unknown) =>
-  error instanceof AxiosError &&
-  error.response &&
-  NOT_FOUND_STATUS_CODES.includes(Number(error.response.status))
+  // frontend routing 404
+  (isRouteErrorResponse(error) &&
+    NOT_FOUND_STATUS_CODES.includes(error.status)) ||
+  // api response 404
+  (error instanceof AxiosError &&
+    error.response &&
+    NOT_FOUND_STATUS_CODES.includes(Number(error.response.status)))
 
 const isForbiddenError = (error: unknown) =>
   error instanceof ClientSideForbiddenError ||
@@ -27,6 +31,8 @@ const ErrorPage = () => {
     return <ForbiddenPage />
   } else if (isNotFoundError(error)) {
     return <NotFoundPage />
+  } else {
+    console.error(error)
   }
 
   return (

--- a/frontends/mit-open/src/test-utils/index.tsx
+++ b/frontends/mit-open/src/test-utils/index.tsx
@@ -44,15 +44,7 @@ const renderRoutesWithProviders = (
   // window.SETTINGS is reset during tests via afterEach hook.
   window.SETTINGS.user = makeUserSettings(options.user)
 
-  const router = createMemoryRouter(
-    [
-      {
-        errorElement: <RethrowError />,
-        children: routes,
-      },
-    ],
-    { initialEntries: [url] },
-  )
+  const router = createMemoryRouter(routes, { initialEntries: [url] })
   const queryClient = createQueryClient()
   const view = render(
     <AppProviders queryClient={queryClient} router={router}></AppProviders>,


### PR DESCRIPTION
# What are the relevant tickets?
Closes #316 

# Description (What does it do?)
Renders react 404 on unmatched routes.

# How can this be tested?
1. Visit https://mit-open-rc.odl.mit.edu/bad/route ... you will see a generic "Something went wrong" page.
2. On this branch, with `DEBUG=False`, visit http://localhost:8063/bad/route. You should see a 404 page.
