### PR TITLE
Downgrade prettier to a non-alpha version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: check-toml
       - id: debug-statements
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.7
+    rev: v3.1.0
     hooks:
       - id: prettier
         types_or:


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Downgrades the version of prettier used by pre-commit to 3.1.0, because the 4.x alpha version caused an error when the `openapi.yaml` file was included in a commit.

# How can this be tested?
On main branch: make a simple change in your `openapi.yaml` file like adding an exclamation point to a description, then try to commit.  prettier will error out with message "No files matching the given patterns were found".
Switch to this branch and try again, the commit should complete without any errors from prettier.

