### PR TITLE
fix learning resource default in documentating for search

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -453,6 +453,9 @@ def execute_learn_search(search_params):
         dict: The opensearch response dict
     """
 
+    if not search_params.get("resource_type"):
+        search_params["resource_type"] = list(LEARNING_RESOURCE_TYPES)
+
     indexes = relevant_indexes(
         search_params.get("resource_type"), search_params.get("aggregations")
     )

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -25,7 +25,6 @@ from learning_resources.serializers import (
 from learning_resources_search.api import gen_content_file_id
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
-    LEARNING_RESOURCE_TYPES,
 )
 
 log = logging.getLogger()
@@ -206,7 +205,6 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
             f"The type of learning resource \
             \n\n{build_choice_description_list(resource_choices)}"
         ),
-        default=LEARNING_RESOURCE_TYPES,
     )
     professional = ArrayWrappedBoolean(
         required=False,

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -191,13 +191,6 @@ def test_learning_resources_search_request_serializer():
         "limit": 1,
         "id": [1],
         "sortby": "-start_date",
-        "resource_type": [
-            "course",
-            "program",
-            "podcast",
-            "podcast_episode",
-            "learning_path",
-        ],
         "professional": [True],
         "certification": [False],
         "offered_by": ["xpro", "ocw"],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3056,12 +3056,6 @@ paths:
               * `learning_path` - learning path
               * `podcast` - podcast
               * `podcast_episode` - podcast episode
-          default:
-          - course
-          - program
-          - podcast
-          - podcast_episode
-          - learning_path
         description: "The type of learning resource             \n\n* `course` - course\n\
           * `program` - program\n* `learning_path` - learning path\n* `podcast` -\
           \ podcast\n* `podcast_episode` - podcast episode"


### PR DESCRIPTION
# What are the relevant tickets?
closes https://github.com/mitodl/mit-open/issues/362

# Description (What does it do?)
This pr removes the default value for learning_resource from the learning_resources_search serializer since it's displayed oddly in the documentation

# How can this be tested?
Go to http://localhost:8063/api/v1/learning_resources_search
The search should work the same as previously when there is no resource_type parameter
The search should also work the same as previously when resource_type is specified
e.i http://localhost:8063/api/v1/learning_resources_search/?resource_type=podcast,podcast_episode