### PR TITLE
Remove author from LearningPath serializer

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -821,12 +821,6 @@ export interface LearningPath {
    * @memberof LearningPath
    */
   item_count: number
-  /**
-   *
-   * @type {number}
-   * @memberof LearningPath
-   */
-  author: number
 }
 /**
  * Serializer for a minimal preview of Learning Paths
@@ -914,19 +908,6 @@ export interface LearningPathRelationshipRequest {
    * @memberof LearningPathRelationshipRequest
    */
   child: number
-}
-/**
- * Serializer for the LearningPath model
- * @export
- * @interface LearningPathRequest
- */
-export interface LearningPathRequest {
-  /**
-   *
-   * @type {number}
-   * @memberof LearningPathRequest
-   */
-  author: number
 }
 /**
  * CRUD serializer for LearningPath resources

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -235,7 +235,6 @@ const learningPath: LearningResourceFactory<LearningPathResource> = (
       learning_path: {
         id: faker.helpers.unique(faker.datatype.number),
         item_count: faker.datatype.number({ min: 1, max: 30 }),
-        author: faker.datatype.number(),
       },
       learning_path_parents: [],
     },

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -207,7 +207,7 @@ class LearningPathSerializer(serializers.ModelSerializer, ResourceListMixin):
 
     class Meta:
         model = models.LearningPath
-        exclude = ("learning_resource", *COMMON_IGNORED_FIELDS)
+        exclude = ("learning_resource", "author", *COMMON_IGNORED_FIELDS)
 
 
 class PodcastEpisodeSerializer(serializers.ModelSerializer):

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -77,7 +77,6 @@ def test_serialize_learning_path_to_json():
     assert_json_equal(
         serializer.data,
         {
-            "author": learning_path.author_id,
             "id": learning_path.id,
             "item_count": learning_path.learning_resource.children.count(),
         },

--- a/learning_resources/views_learningpath_test.py
+++ b/learning_resources/views_learningpath_test.py
@@ -124,7 +124,6 @@ def test_learning_path_endpoint_create(  # pylint: disable=too-many-arguments  #
     if resp.status_code == 201:
         assert resp.data.get("title") == resp.data.get("title")
         assert resp.data.get("description") == resp.data.get("description")
-        assert resp.data.get("learning_path").get("author") == user.id
     assert mock_opensearch.upsert.call_count == (
         1 if has_permission and is_published else 0
     )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6042,10 +6042,7 @@ components:
           type: integer
           description: Return the number of items in the list
           readOnly: true
-        author:
-          type: integer
       required:
-      - author
       - id
       - item_count
     LearningPathPreview:
@@ -6105,14 +6102,6 @@ components:
       required:
       - child
       - parent
-    LearningPathRequest:
-      type: object
-      description: Serializer for the LearningPath model
-      properties:
-        author:
-          type: integer
-      required:
-      - author
     LearningPathResource:
       type: object
       description: CRUD serializer for LearningPath resources


### PR DESCRIPTION
### What are the relevant tickets?
Closes #328

### Description (What does it do?)
Removes "author" field from LearningPathSerializer


### How can this be tested?
Unit tests should pass.
Create a learning path if you don't already have any (log in as an admin and go to http://localhost:8063/learningpaths/)
Check the serializer output at http://localhost:8063/api/v1/learningpaths.  You should see something like this, with no `author` field present:

```
            "learning_path": {
                "id": 1,
                "item_count": 2
            },
```            

