### PR TITLE
Get rid of tika verify warning

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -134,8 +134,12 @@ def extract_text_metadata(data, *, other_headers=None):
     headers = {**other_headers} if other_headers else {}
     if settings.TIKA_ACCESS_TOKEN:
         headers["X-Access-Token"] = settings.TIKA_ACCESS_TOKEN
-    request_options = {"headers": headers} if headers else {}
-    request_options["timeout"] = settings.TIKA_TIMEOUT
+
+    request_options = {
+        "timeout": settings.TIKA_TIMEOUT,
+        "verify": True,
+        "headers": headers,
+    }
 
     return tika_parser.from_buffer(data, requestOptions=request_options)
 

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -75,14 +75,13 @@ def test_extract_text_metadata(mocker, data, token, settings, headers):
     response = utils.extract_text_metadata(data, other_headers=headers)
 
     expected_headers = {}
-    expected_options = {"timeout": 120}
+    expected_options = {"timeout": 120, "verify": True}
 
     if token:
         expected_headers["X-Access-Token"] = token
     if headers:
         expected_headers = {**expected_headers, **headers}
-    if expected_headers:
-        expected_options["headers"] = expected_headers
+    expected_options["headers"] = expected_headers
 
     if data:
         assert response == mock_response


### PR DESCRIPTION
### What are the relevant tickets?
Closes #405 

### Description (What does it do?)
Adds `verify: true` to the tika request options, which avoids the warning



### How can this be tested?
Try this with each of these sets of .env values

Set 1: 
```
TIKA_SERVER_ENDPOINT=http://tika:9998/
TIKA_ACCESS_TOKEN=
```

Set 2:
```
TIKA_SERVER_ENDPOINT=<same as on heroku rc>
TIKA_ACCESS_TOKEN=<same as on heroku rc>
```

Run the following:
```
from learning_resources.etl.utils import extract_text_metadata
extract_text_metadata("<html><body>Hello World</body></html>")
```

You should get a valid tika response back with each set, without any warnings getting logged.

