### PR TITLE
Modify OCW webhook endpoint to handle multiple courses

### DIFF
--- a/learning_resources/urls.py
+++ b/learning_resources/urls.py
@@ -5,7 +5,7 @@ from rest_framework.routers import SimpleRouter
 from rest_framework_nested.routers import NestedSimpleRouter
 
 from learning_resources import views
-from learning_resources.views import WebhookOCWNextView
+from learning_resources.views import WebhookOCWView
 
 router = SimpleRouter()
 router.register(
@@ -96,7 +96,7 @@ urlpatterns = [
     re_path(r"^podcasts/rss_feed", views.podcast_rss_feed, name="podcast-rss-feed"),
     re_path(
         r"^api/v1/ocw_next_webhook/$",
-        WebhookOCWNextView.as_view(),
+        WebhookOCWView.as_view(),
         name="ocw-next-webhook",
     ),
 ]

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -414,8 +414,14 @@ def test_get_podcast_items_endpoint(client, url):
 @pytest.mark.parametrize(
     "data",
     [
-        {"webhook_key": "fake_key", "prefix": "prefix", "version": "live"},
-        {"webhook_key": "fake_key", "prefix": "prefix", "version": "draft"},
+        {"webhook_key": "fake_key", "prefix": "prefix1", "version": "live"},
+        {"webhook_key": "fake_key", "prefix": "prefix2", "version": "draft"},
+        {"webhook_key": "fake_key", "prefixes": "prefix1, prefix2", "version": "live"},
+        {
+            "webhook_key": "fake_key",
+            "prefixes": ["prefix1", "prefix2"],
+            "version": "live",
+        },
         {"webhook_key": "fake_key", "version": "live"},
     ],
 )
@@ -425,16 +431,37 @@ def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
     mock_get_ocw = mocker.patch(
         "learning_resources.views.get_ocw_courses.delay", autospec=True
     )
-    client.post(
+    response = client.post(
         reverse("ocw-next-webhook"), data=data, headers={"Content-Type": "text/plain"}
     )
 
     prefix = data.get("prefix")
+    prefixes = data.get("prefixes")
 
-    if prefix is not None and data.get("version") == "live":
-        mock_get_ocw.assert_called_once_with(url_paths=[prefix], force_overwrite=False)
+    expected_prefixes = [prefix] if prefix else prefixes
+    if isinstance(expected_prefixes, str):
+        expected_prefixes = [prefix.strip() for prefix in expected_prefixes.split(",")]
+
+    if expected_prefixes and data.get("version") == "live":
+        mock_get_ocw.assert_called_once_with(
+            url_paths=expected_prefixes, force_overwrite=False
+        )
+        assert response.status_code == 200
+        assert (
+            response.data["message"]
+            == f"OCW courses queued for indexing: {expected_prefixes}"
+        )
     else:
         mock_get_ocw.assert_not_called()
+        if data.get("version") != "live":
+            assert response.data["message"] == "Not a live version, ignoring"
+            assert response.status_code == 200
+        else:
+            assert (
+                response.data["message"]
+                == f"Could not determine appropriate action based on webhook content: {data}"
+            )
+            assert response.status_code == 400
 
 
 @pytest.mark.parametrize(
@@ -454,7 +481,10 @@ def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
         {"site_uid": None, "version": "live", "unpublished": True},
     ],
 )
-def test_ocw_next_webhook_endpoint_unpublished(client, mocker, settings, data):
+@pytest.mark.parametrize("run_exists", [True, False])
+def test_ocw_next_webhook_endpoint_unpublished(
+    client, mocker, settings, data, run_exists
+):
     """Test that the OCW webhook endpoint removes an unpublished task from the search index"""
     settings.OCW_WEBHOOK_KEY = "fake_key"
     mock_delete_course = mocker.patch(
@@ -462,14 +492,14 @@ def test_ocw_next_webhook_endpoint_unpublished(client, mocker, settings, data):
     )
     run_id = data.get("site_uid")
     course_run = None
-    if run_id:
+    if run_id and run_exists:
         course_run = LearningResourceRunFactory.create(
             run_id=run_id,
             learning_resource=CourseFactory.create(
                 platform=PlatformType.ocw.name
             ).learning_resource,
         )
-    client.post(
+    response = client.post(
         reverse("ocw-next-webhook"),
         data={"webhook_key": "fake_key", **data},
         headers={"Content-Type": "text/plain"},
@@ -480,7 +510,18 @@ def test_ocw_next_webhook_endpoint_unpublished(client, mocker, settings, data):
         and data.get("unpublished") is True
         and data.get("version") == "live"
     ):
-        mock_delete_course.assert_called_once_with(course_run.learning_resource)
+        assert response.status_code == 200
+        if run_exists:
+            mock_delete_course.assert_called_once_with(course_run.learning_resource)
+            assert (
+                response.data["message"]
+                == f"OCW course {run_id} queued for unpublishing"
+            )
+        else:
+            assert (
+                response.data["message"]
+                == f"OCW course {run_id} not found, so nothing to unpublish"
+            )
     else:
         mock_delete_course.assert_not_called()
 

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -459,7 +459,7 @@ def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
         else:
             assert (
                 response.data["message"]
-                == f"Could not determine appropriate action based on webhook content: {data}"
+                == f"Could not determine appropriate action from request: {data}"
             )
             assert response.status_code == 400
 

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -425,7 +425,7 @@ def test_get_podcast_items_endpoint(client, url):
         {"webhook_key": "fake_key", "version": "live"},
     ],
 )
-def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
+def test_ocw_webhook_endpoint(client, mocker, settings, data):
     """Test that the OCW webhook endpoint schedules a get_ocw_courses task"""
     settings.OCW_WEBHOOK_KEY = "fake_key"
     mock_get_ocw = mocker.patch(
@@ -482,9 +482,7 @@ def test_ocw_next_webhook_endpoint(client, mocker, settings, data):
     ],
 )
 @pytest.mark.parametrize("run_exists", [True, False])
-def test_ocw_next_webhook_endpoint_unpublished(
-    client, mocker, settings, data, run_exists
-):
+def test_ocw_webhook_endpoint_unpublished(client, mocker, settings, data, run_exists):
     """Test that the OCW webhook endpoint removes an unpublished task from the search index"""
     settings.OCW_WEBHOOK_KEY = "fake_key"
     mock_delete_course = mocker.patch(
@@ -526,7 +524,7 @@ def test_ocw_next_webhook_endpoint_unpublished(
         mock_delete_course.assert_not_called()
 
 
-def test_ocw_next_webhook_endpoint_bad_key(settings, client):
+def test_ocw_webhook_endpoint_bad_key(settings, client):
     """Test that a webhook exception is raised if a bad key is sent"""
     settings.OCW_WEBHOOK_KEY = "fake_key"
     with pytest.raises(WebhookException):


### PR DESCRIPTION
**###** What are the relevant tickets?
Closes #406 

### Description (What does it do?)
Updates the OCW webhook endpoint to handle multiple urls instead of just one.  Expects the request JSON to have either a `prefix` attribute (single urll, to maintain compatibility with current ocw-studio pipelines) or `prefixes` attribute (multiple urls, as either a formal list or a comma-delimited string).  Returns a response indicating what it did or didn't do.  Also renames the view (removes the `Next` part from the name).


### How can this be tested?

Set `OCW_WEBHOOK_KEY=key` in your .env file

Try the following POST requests to `http://localhost:8063/api/v1/ocw_next_webhook/` , they should all work, kick off `get_ocw_courses` tasks, and return a helpful message in the response.

```
{
   "webhook_key": "key",
   "prefixes": 
    "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring-2007/, courses/18-657-mathematics-of-machine-learning-fall-2015/",
   "version": "live"
}
```

```

```
{
   "webhook_key": "key",
   "prefixes":  [
        "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring-2007/", 
        "courses/18-657-mathematics-of-machine-learning-fall-2015/"
    ],
   "version": "live"
}
```

```
{
   "webhook_key": "key",
   "prefix":  "courses/esd-04j-frameworks-and-models-in-engineering-systems-engineering-system-design-spring/"
   "version": "live"
}
```
