### PR TITLE
Optionally skip loading OCW content files

### DIFF
--- a/app.json
+++ b/app.json
@@ -251,16 +251,12 @@
       "description": "Name of S3 bucket to upload OCW course media",
       "required": false
     },
-    "OCW_NEXT_BASE_URL": {
-      "description": "Base url for OCW",
-      "required": false
-    },
-    "OCW_NEXT_SEARCH_WEBHOOK_KEY": {
-      "description": "Authentication parameter value that should be passed in a webhook",
-      "required": false
-    },
     "OCW_UPLOAD_IMAGE_ONLY": {
       "description": "Upload course image only instead of all OCW files",
+      "required": false
+    },
+    "OCW_SKIP_CONTENT_FILES": {
+      "description": "Skip upserting of OCW content files",
       "required": false
     },
     "OCW_WEBHOOK_DELAY": {

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -101,6 +101,7 @@ def ocw_courses_etl(
     url_paths: list[str],
     force_overwrite: bool,
     start_timestamp: datetime | None = None,
+    skip_content_files: bool = settings.OCW_SKIP_CONTENT_FILES,
 ):
     """
     Sync OCW courses to the database
@@ -127,7 +128,7 @@ def ocw_courses_etl(
             if data:
                 ocw_course_data = ocw.transform_course(data)
                 course_resource = loaders.load_course(ocw_course_data, [], [])
-                if course_resource:
+                if course_resource and not skip_content_files:
                     loaders.load_content_files(
                         course_resource.runs.filter(published=True).first(),
                         ocw.transform_content_files(

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -110,6 +110,7 @@ def ocw_courses_etl(
         url_paths (list of str): The course url paths to process
         force_overwrite (bool): force incoming course data to overwrite existing data
         start_timestamp (datetime or None): backpopulate start time
+        skip_content_files (bool): skip loading content files
     """
     s3_resource = boto3.resource(
         "s3",

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -190,9 +190,9 @@ def test_podcast_etl():
 
 @mock_s3
 @pytest.mark.django_db()
-def test_ocw_courses_etl(settings, mocker):
+@pytest.mark.parametrize("skip_content_files", [True, False])
+def test_ocw_courses_etl(settings, mocker, skip_content_files):
     """Test ocw_courses_etl"""
-
     setup_s3_ocw(settings)
 
     mocker.patch(
@@ -208,6 +208,7 @@ def test_ocw_courses_etl(settings, mocker):
         url_paths=[OCW_TEST_PREFIX],
         force_overwrite=True,
         start_timestamp=datetime(2020, 12, 15, tzinfo=pytz.utc),
+        skip_content_files=skip_content_files,
     )
 
     resource = LearningResource.objects.first()
@@ -225,7 +226,7 @@ def test_ocw_courses_etl(settings, mocker):
     run = resource.runs.first()
     assert run.instructors.count() == 10
     assert run.run_id == "97db384ef34009a64df7cb86cf701979"
-    assert run.content_files.count() == 4
+    assert run.content_files.count() == (0 if skip_content_files else 4)
 
 
 @mock_s3

--- a/open_discussions/settings_course_etl.py
+++ b/open_discussions/settings_course_etl.py
@@ -2,7 +2,7 @@
 Django settings specific to learning_resources ingestion
 """
 
-from open_discussions.envs import get_int, get_string
+from open_discussions.envs import get_bool, get_int, get_string
 
 # EDX API Credentials
 EDX_API_URL = get_string("EDX_API_URL", None)
@@ -19,6 +19,7 @@ GITHUB_ACCESS_TOKEN = get_string("GITHUB_ACCESS_TOKEN", None)
 # OCW settings
 OCW_LIVE_BUCKET = get_string("OCW_LIVE_BUCKET", None)
 OCW_ITERATOR_CHUNK_SIZE = get_int("OCW_ITERATOR_CHUNK_SIZE", 1000)
+OCW_SKIP_CONTENT_FILES = get_bool("OCW_SKIP_CONTENT_FILES", default=False)
 OCW_WEBHOOK_KEY = get_string("OCW_WEBHOOK_KEY", None)
 MAX_S3_GET_ITERATIONS = get_int("MAX_S3_GET_ITERATIONS", 3)
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes #408 

### Description (What does it do?)
- Adds a new setting `OCW_SKIP_CONTENT_FILES` with default value `False`
- Modifies various functions to have a bool keyword argument `skip_content_files` with default value of that setting
- Adds an optional `skip-contentfiles` argument to the `backpopulate_ocw_data` command


### How can this be tested?
Run `./manage.py backpopulate_ocw_data --skip-contentfiles  --course-name 20-106j-systems-microbiology-fall-2006` (or set `OCW_SKIP_CONTENT_FILES=True` in your .env file and run `./manage.py backpopulate_ocw_data  --course-name 20-106j-systems-microbiology-fall-2006` instead).

You should see this and the task should run without loading contentfiles:

> Started task <task_id> to get ocw next course data w/force_overwrite=False, course_name=None, skip_content_files=True


Run `./manage.py backpopulate_ocw_data  --course-name 20-106j-systems-microbiology-fall-2006` (with`OCW_SKIP_CONTENT_FILES=False` or absent in your .env file).

You should see this and the task should run and also load contentfiles:

> Started task <task_id> to get ocw next course data w/force_overwrite=False, course_name=None, skip_content_files=False

