### PR TITLE
Save OCW contentfile urls as absolute instead of relative

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -105,7 +105,7 @@ def transform_page(s3_key: str, page_data: dict) -> dict:
     s3_path = s3_key.split("data.json")[0]
     return {
         "content_type": CONTENT_TYPE_PAGE,
-        "url": "../" + urlparse(s3_path).path.lstrip("/"),
+        "url": urljoin(settings.OCW_BASE_URL, urlparse(s3_path).path.lstrip("/")),
         "title": page_data.get("title"),
         "content_title": page_data.get("title"),
         "content": page_data.get("content"),
@@ -206,7 +206,7 @@ def transform_contentfile(
         "description": contentfile_data.get("description"),
         "file_type": file_type,
         "content_type": content_type,
-        "url": "../" + urlparse(s3_path).path.lstrip("/"),
+        "url": urljoin(settings.OCW_BASE_URL, urlparse(s3_path).path.lstrip("/")),
         "title": title,
         "content_title": title,
         "key": s3_path,

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -26,11 +26,13 @@ pytestmark = pytest.mark.django_db
 
 
 @mock_s3
-def test_transform_content_files(settings, mocker):
+@pytest.mark.parametrize("base_ocw_url", ["http://test.edu/", "http://test.edu"])
+def test_transform_content_files(settings, mocker, base_ocw_url):
     """
     Test transform_content_files
     """
-
+    settings.OCW_BASE_URL = base_ocw_url
+    ocw_url = base_ocw_url.rstrip("/")
     setup_s3_ocw(settings)
     s3_resource = boto3.resource("s3")
     mocker.patch(
@@ -53,7 +55,7 @@ def test_transform_content_files(settings, mocker):
         "published": True,
         "title": "Pages",
         "content_title": "Pages",
-        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
+        "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/",
     }
 
     assert content_data[1] == {
@@ -63,7 +65,7 @@ def test_transform_content_files(settings, mocker):
         "published": True,
         "title": "Syllabus",
         "content_title": "Syllabus",
-        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
+        "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/pages/syllabus/",
     }
 
     assert content_data[2] == {
@@ -79,7 +81,7 @@ def test_transform_content_files(settings, mocker):
         "published": True,
         "title": "Resource Title",
         "content_title": "Resource Title",
-        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
+        "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/resource/",
     }
 
     assert content_data[3] == {
@@ -92,7 +94,7 @@ def test_transform_content_files(settings, mocker):
         "published": True,
         "title": None,
         "content_title": None,
-        "url": "../courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
+        "url": f"{ocw_url}/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/resources/video/",
         "image_src": "https://img.youtube.com/vi/vKer2U5W5-s/default.jpg",
     }
 

--- a/learning_resources/migrations/0036_update_ocw_contentfile_urls.py
+++ b/learning_resources/migrations/0036_update_ocw_contentfile_urls.py
@@ -1,0 +1,31 @@
+"""Manually generated migration to update OCW contentfile urls"""
+
+from django.conf import settings
+from django.db import migrations
+from django.db.models import F, Value
+from django.db.models.functions import Replace
+
+from learning_resources.etl.constants import ETLSource
+
+
+def update_urls(apps, schema_editor):
+    """
+    Convert relative urls to absolute urls
+    """
+    ContentFile = apps.get_model("learning_resources", "ContentFile")
+    base_url = f"{settings.OCW_BASE_URL.rstrip('/')}/"
+    ContentFile.objects.filter(
+        run__learning_resource__etl_source=ETLSource.ocw.value
+    ).filter(url__startswith="../").update(
+        url=Replace(F("url"), Value("../"), Value(base_url))
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0035_alter_created_on"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_urls, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
Closes #387 

### Description (What does it do?)
Updates the OCW ETL code to make contentfile urls absolute.
Adds a migration to fix existing urls.


### How can this be tested?
- If you don't have any OCW contentfiles already, import some on the main branch (not this branch):
  - Copy AWS and OCW settings from RC to your .env file
  - Run `./manage.py backpopulate_ocw_data --course-name 6-801-machine-vision-fall-2020`
- Verify that you have OCW contentfiles with relative urls:
  ```
  from learning_resources.models import ContentFile
  ContentFile.objects.filter(run__learning_resource__etl_source="ocw").filter(url__startswith="../").count()
  ```
- Switch to this branch, restart containers.  
- The new migration script should complete successfully.
- Run the query above again, it should return 0
- Check that urls are absolute, correct, and work:
  ```
  for cf in ContentFile.objects.filter(run__learning_resource__etl_source="ocw")[:20]:
      print(cf.url)
  ```
-  Run `./manage.py backpopulate_ocw_data --course-name <some_other_new_course>` --overwrite
- Check that urls for the newly imported course are absolute, correct, and work.
