### PR TITLE
Add github action to check for breaking OpenAPI changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [workflow_dispatch] ### Temporary change
 jobs:
   python-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -1,0 +1,62 @@
+name: CI
+on: [pull_request]
+jobs:
+  openapi-diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          path: head
+      - name: Checkout BASE
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+      - name: Run docker manually
+        id: oasdif_changelog
+        run: | # Capture changelog as a multiline output
+          echo "changelog<<EOF" > $GITHUB_OUTPUT
+          docker run --rm \
+            --workdir ${{ github.workspace }} \
+            --volume ${{ github.workspace }}:${{ github.workspace }}:rw \
+            -e GITHUB_WORKSPACE=${{ github.workspace }} \
+            tufin/oasdiff changelog --composed \
+            'base/openapi/specs/*.yaml' \
+            'head/openapi/specs/*.yaml' \
+            >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Get summary
+        id: oasdif_summary
+        run: |
+          echo summary=$(echo "${{ steps.oasdif_changelog.outputs.changelog }}" | head -1 ) \
+          >> $GITHUB_OUTPUT
+      - name: Post changes as comment
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ## OpenAPI Changes
+
+            <details>
+            <summary>Show/hide ${{ steps.oasdif_summary.outputs.summary }}</summary>
+
+            ```
+            ${{ steps.oasdif_changelog.outputs.changelog }}
+            ```
+            </details>
+          comment_tag: oasdiff_changelog
+          mode: upsert
+      - name: Check for breaking changes
+        id: oasdif_breaking
+        run: |
+          docker run --rm \
+            --workdir ${{ github.workspace }} \
+            --volume ${{ github.workspace }}:${{ github.workspace }}:ro \
+            -e GITHUB_WORKSPACE=${{ github.workspace }} \
+            tufin/oasdiff breaking \
+            --fail-on ERR \
+            --format githubactions \
+            --composed \
+            'base/openapi/specs/*.yaml' \
+            'head/openapi/specs/*.yaml'


### PR DESCRIPTION
### What are the relevant tickets?
#417 

### Description (What does it do?)
This PR adds a github action using https://github.com/Tufin/oasdiff to check for breaking changes in our OpenAPI specifications.

### How can this be tested?
1. See https://github.com/mitodl/mit-open/pull/422 for demonstration of action
    - changelog in comment https://github.com/mitodl/mit-open/pull/422#issuecomment-1912763999
    - breaking changes cause failure https://github.com/mitodl/mit-open/actions/runs/7700014735/job/20982877114#step:7:14
2. If you want to try out `oasdiff` locally, make edits to `openapi/specs/v1.yaml` and run
    ```sh
    docker run --rm -it -v $(pwd)/openapi:/openapi:ro tufin/oasdiff \
        changelog \
        https://raw.githubusercontent.com/mitodl/mit-open/main/openapi/specs/v1.yaml \
        /openapi/specs/v1.yaml
    ```

    (or v0). The CI check uses "composed" mode where we can diff globs, but I don't think there's a way to do that with remote specs, which is most convenient for experimentation. 