### PR TITLE
Add a placeholder dashboard page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
         ],
       },
     ],
+    quotes: ["error", "double", { avoidEscape: true }],
   },
   overrides: [
     {

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -41,3 +41,5 @@ export const login = ({
   const next = `${pathname}${encodeURIComponent(search)}`
   return `${LOGIN}?next=${next}`
 }
+
+export const DASHBOARD = "/dashboard/"

--- a/frontends/mit-open/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-open/src/page-components/Header/UserMenu.tsx
@@ -45,6 +45,12 @@ const getUserMenuItems = (location: Location): SimpleMenuItem[] => {
       LinkComponent: "a",
     },
     {
+      label: "Dashboard",
+      key: "dashboard",
+      allow: hasPermission(Permissions.Authenticated),
+      href: urls.DASHBOARD,
+    },
+    {
       label: "Learning Paths",
       key: "learningpaths",
       allow: hasPermission(Permissions.LearningPathEditor),

--- a/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
@@ -3,7 +3,7 @@ import { renderTestApp, screen, waitFor } from "../../test-utils"
 describe("DashboardPage", () => {
   test("Renders title", async () => {
     renderTestApp({
-      url: `/dashboard`,
+      url: "/dashboard",
       user: { is_authenticated: true },
     })
     await waitFor(() => {

--- a/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
@@ -1,0 +1,16 @@
+import { renderTestApp, screen, waitFor } from "../../test-utils"
+
+describe("DashboardPage", () => {
+  test("Renders title", async () => {
+    renderTestApp({
+      url: `/dashboard`,
+      user: { is_authenticated: true },
+    })
+    await waitFor(() => {
+      expect(document.title).toBe("Dashboard")
+    })
+    screen.getByRole("heading", {
+      name: "Dashboard",
+    })
+  })
+})

--- a/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,0 +1,17 @@
+import { Container } from "ol-components"
+import { MetaTags } from "ol-utilities"
+import React from "react"
+
+const DashboardPage: React.FC = () => {
+  return (
+    <Container>
+      <MetaTags>
+        <title>Dashboard</title>
+      </MetaTags>
+      <h1>Dashboard</h1>
+      <p>Coming soon!</p>
+    </Container>
+  )
+}
+
+export default DashboardPage

--- a/frontends/mit-open/src/routes.tsx
+++ b/frontends/mit-open/src/routes.tsx
@@ -6,6 +6,7 @@ import LearningPathListingPage from "@/pages/LearningPathListingPage/LearningPat
 import LearningPathDetailsPage from "@/pages/LearningPathDetailsPage/LearningPathDetailsPage"
 import ArticleDetailsPage from "@/pages/ArticleDetailsPage/ArticleDetailsPage"
 import { ArticleCreatePage, ArticleEditPage } from "@/pages/ArticleUpsertPages"
+import DashboardPage from "@/pages/DashboardPage/DashboardPage"
 import ErrorPage from "@/pages/ErrorPage/ErrorPage"
 import * as urls from "@/common/urls"
 import Header from "@/page-components/Header/Header"
@@ -33,6 +34,14 @@ const routes: RouteObject[] = [
       {
         path: urls.LEARNINGPATH_VIEW,
         element: <LearningPathDetailsPage />,
+      },
+      {
+        path: urls.DASHBOARD,
+        element: (
+          <RestrictedRoute requires={Permissions.Authenticated}>
+            <DashboardPage />
+          </RestrictedRoute>
+        ),
       },
       {
         element: <RestrictedRoute requires={Permissions.ArticleEditor} />,

--- a/frontends/mit-open/src/services/react-query/react-query.ts
+++ b/frontends/mit-open/src/services/react-query/react-query.ts
@@ -21,7 +21,7 @@ const createQueryClient = (): QueryClient => {
           const url = queryKey[0]
           if (typeof url !== "string" || queryKey.length !== 1) {
             throw new Error(
-              `Query key must be a single string for use with default queryFn`,
+              "Query key must be a single string for use with default queryFn",
             )
           }
           const { data } = await axios.get(url)

--- a/frontends/ol-ckeditor/src/components/CkeditorDisplay.test.tsx
+++ b/frontends/ol-ckeditor/src/components/CkeditorDisplay.test.tsx
@@ -53,7 +53,7 @@ describe("CkeditorDisplay", () => {
 <p>Some more text</p>
         `.trim()
     const input1 = input0
-    const input2 = `input2`
+    const input2 = "input2"
     const view = render(<CkeditorDisplay dangerouslySetInnerHTML={input0} />)
     const html0 = view.container.innerHTML
     view.rerender(<CkeditorDisplay dangerouslySetInnerHTML={input1} />)

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [  # noqa: RUF005
     re_path(r"^search/", index, name="site-search"),
     re_path(r"^learningpaths/", index, name="learningpaths"),
     re_path(r"^articles/", index, name="articles"),
+    re_path(r"^dashboard/", index, name="dashboard"),
     # Hijack
     re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
### What are the relevant tickets?
#426 

### Description (What does it do?)
Adds a placeholder dashboard page.

### Screenshots (if appropriate):
Not much there:
<img width="1471" alt="Screenshot 2024-01-30 at 10 40 56 AM" src="https://github.com/mitodl/mit-open/assets/9010790/aa7cdce2-daf3-48da-8fe3-2982f5cdb4ad">

### How can this be tested?
1. Navigate to http://localhost:8063/dashboard ... 
    - If you're logged in, you should see a placeholder.
    - if you're anonymous, you'll be redirected to login

