### PR TITLE
Added support to set SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS

### DIFF
--- a/app.json
+++ b/app.json
@@ -547,6 +547,10 @@
       "description": "The client secret provided by the OpenID Connect provider.",
       "required": false
     },
+    "SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS": {
+      "description": "The list of additional redirect hosts allowed for social auth.",
+      "required": false
+    },
     "USERINFO_URL": {
       "description": "Provder endpoint where client sends requests for identity claims.",
       "required": false

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -7,8 +7,12 @@ from authentication.views import CustomLogoutView
 
 urlpatterns = [
     re_path(r"", include("social_django.urls", namespace="social")),
-    re_path(r"^login/$", RedirectView.as_view(
-        url=reverse_lazy("social:begin", args=["ol-oidc"]), query_string=True
-    ), name="login"),
+    re_path(
+        r"^login/$",
+        RedirectView.as_view(
+            url=reverse_lazy("social:begin", args=["ol-oidc"]), query_string=True
+        ),
+        name="login",
+    ),
     re_path(r"^logout/$", CustomLogoutView.as_view(), name="logout"),
 ]

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -1,9 +1,14 @@
 """URL configurations for authentication"""
 
-from django.urls import re_path
+from django.urls import include, re_path, reverse_lazy
+from django.views.generic.base import RedirectView
 
 from authentication.views import CustomLogoutView
 
 urlpatterns = [
+    re_path(r"", include("social_django.urls", namespace="social")),
+    re_path(r"^login/$", RedirectView.as_view(
+        url=reverse_lazy("social:begin", args=["ol-oidc"]), query_string=True
+    ), name="login"),
     re_path(r"^logout/$", CustomLogoutView.as_view(), name="logout"),
 ]

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -225,10 +225,16 @@ AUTHENTICATION_BACKENDS = (
 
 SOCIAL_AUTH_LOGIN_REDIRECT_URL = "/"
 SOCIAL_AUTH_LOGIN_ERROR_URL = "login"
-SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [urlparse(SITE_BASE_URL).netloc]
+SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [
+    *get_list_of_str(
+        name="SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS",
+        default=[],
+    ),
+    urlparse(SITE_BASE_URL).netloc
+]
 
 SOCIAL_AUTH_PIPELINE = (
-    # Checks if an admin user attempts to login/register while hijacking another user.
+# Checks if an admin user attempts to login/register while hijacking another user.
     "authentication.pipeline.user.forbid_hijack",
     # Get the information we can about the user and return it in a simple
     # format to create the user instance later. On some cases the details are

--- a/open_discussions/settings.py
+++ b/open_discussions/settings.py
@@ -230,11 +230,11 @@ SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [
         name="SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS",
         default=[],
     ),
-    urlparse(SITE_BASE_URL).netloc
+    urlparse(SITE_BASE_URL).netloc,
 ]
 
 SOCIAL_AUTH_PIPELINE = (
-# Checks if an admin user attempts to login/register while hijacking another user.
+    # Checks if an admin user attempts to login/register while hijacking another user.
     "authentication.pipeline.user.forbid_hijack",
     # Get the information we can about the user and return it in a simple
     # format to create the user instance later. On some cases the details are

--- a/open_discussions/urls.py
+++ b/open_discussions/urls.py
@@ -34,7 +34,6 @@ handler404 = "open_discussions.views.handle_404"
 urlpatterns = [  # noqa: RUF005
     re_path(r"^admin/", admin.site.urls),
     re_path(r"", include("authentication.urls")),
-    re_path(r"", include("social_django.urls", namespace="social")),
     re_path(r"", include("channels.urls")),
     re_path(r"", include("profiles.urls")),
     re_path(r"", include("embedly.urls")),


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/mit-open/issues/420

### Description (What does it do?)
Adds a setting for `SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS` to support allowing a redirect to OCW on login.


### How can this be tested?
- Navigate to `/login`, it should forward you on to `/login/ol-oidc` and when you complete login you end up at the home page.
- Next try `/login?next=http://ocw.odl.local`, you should get redirected to `/login/ol-oidc/?next=http://ocw.odl.local` and then it should ignore the `next` parameter and redirect you to the home page.
- In your `.env` file, set `SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS=["ocw.odl.local"]`
- Now try `/login?next=http://ocw.odl.local` again, you should get redirected to `/login/ol-oidc/?next=http://ocw.odl.local` and then subsequently `http://ocw.odl.local` (doesn't matter that this doesn't exist).
