### PR TITLE
Poetry install to virtualenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 ## Set some poetry config
 ENV  \
   POETRY_VERSION=1.5.1 \
-  POETRY_VIRTUALENVS_CREATE=false \
+  POETRY_VIRTUALENVS_CREATE=true \
   POETRY_CACHE_DIR='/tmp/cache/poetry' \
   POETRY_HOME='/home/mitodl/.local' \
   VIRTUAL_ENV="/opt/venv"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,28 +18,42 @@ RUN mkdir /src
 RUN adduser --disabled-password --gecos "" mitodl
 RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
-# Poetry env configuration
+## Set some poetry config
 ENV  \
-  # poetry:
   POETRY_VERSION=1.5.1 \
   POETRY_VIRTUALENVS_CREATE=false \
-  POETRY_CACHE_DIR='/tmp/cache/poetry'
+  POETRY_CACHE_DIR='/tmp/cache/poetry' \
+  POETRY_HOME='/home/mitodl/.local' \
+  VIRTUAL_ENV="/opt/venv"
+ENV PATH="$VIRTUAL_ENV/bin:$POETRY_HOME/bin:$PATH"
 
 # Install poetry
 RUN pip install "poetry==$POETRY_VERSION"
 
-# Install project packages
 COPY pyproject.toml /src
 COPY poetry.lock /src
+RUN chown -R mitodl:mitodl /src
+RUN mkdir ${VIRTUAL_ENV} && chown -R mitodl:mitodl ${VIRTUAL_ENV}
+
+## Install poetry itself, and pre-create a venv with predictable name
+USER mitodl
+RUN curl -sSL https://install.python-poetry.org \
+  | \
+  POETRY_VERSION=${POETRY_VERSION} \
+  POETRY_HOME=${POETRY_HOME} \
+  python3 -q
 WORKDIR /src
+RUN python3 -m venv $VIRTUAL_ENV
 RUN poetry install
 
 # Add project
+USER root
 COPY . /src
 WORKDIR /src
 RUN chown -R mitodl:mitodl /src
 
 RUN apt-get clean && apt-get purge
+
 USER mitodl
 
 EXPOSE 8063


### PR DESCRIPTION
### What are the relevant tickets?

[Let Poetry use a virtualenv in docker container **#434**](https://github.com/mitodl/mit-open/issues/434)


### Description (What does it do?)
<!--- Describe your changes in detail -->

Updates the Docker build config for Poetry’s installation to create a virtual environment for the project.

Aligns the container build with [OCW Studio](https://github.com/mitodl/ocw-studio/blob/master/Dockerfile) and [MITxOnline](https://github.com/mitodl/mitxonline/blob/main/Dockerfile).

Note that we're setting `POETRY_VIRTUALENVS_CREATE` to the default true so it reads better (it is false in other projects). The assumption is that this has no impact as true creates if one does not already exist (we create before the poetry install with `python3 -m venv $VIRTUAL_ENV`).

We get the same output for containers created with either:

```
$ poetry env list
-- empty --

$ poetry env info

Virtualenv
Python:         3.11.5
Implementation: CPython
Path:           /opt/venv
Executable:     /opt/venv/bin/python
Valid:          True

System
Platform:   linux
OS:         posix
Python:     3.11.5
Path:       /usr/local
Executable: /usr/local/bin/python3.11
```

### How can this be tested?

#### Locally:

- The container for the `web` service builds successfully
```bash
docker compose build web
```

- Services start and site loads
```bash
yarn run build
docker compose up
```
Navigate to http://localhost:8063

#### RC:

- This needs a post deployment check. Confirm successful deployment to RC post release or roll back.