### PR TITLE
fix release: rename oasdiff workflow

### DIFF
--- a/.github/workflows/openapi-diff.yml
+++ b/.github/workflows/openapi-diff.yml
@@ -1,4 +1,4 @@
-name: CI
+name: OpenAPI Diff
 on: [pull_request]
 jobs:
   openapi-diff:


### PR DESCRIPTION
### What are the relevant tickets?
Related to  #435 

### Description (What does it do?)
Renames OpenAPI diff workflow so that when it fails it does not block release.

A failing workflow indicates breaking changes in the OpenAPI spec, but that should not block release. The workflow is meant more as a warning than a hard-block. 
- The failing changes might be desirable bugfixes in the specification, without actually changing the APIs
- Especially in the near future, we may decide to release breaking changes to APIs.


### How can this be tested?
Merge it and re-trigger doof.
