### PR TITLE
Fix webhook url

### DIFF
--- a/learning_resources/urls.py
+++ b/learning_resources/urls.py
@@ -90,7 +90,7 @@ v1_urls = [
     *nested_podcast_router.urls,
     *nested_userlist_router.urls,
     path(
-        "api/v1/ocw_next_webhook/",
+        "ocw_next_webhook/",
         WebhookOCWView.as_view(),
         name="ocw-next-webhook",
     ),

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -437,6 +437,7 @@ def test_ocw_webhook_endpoint(client, mocker, settings, data):
     mock_get_ocw = mocker.patch(
         "learning_resources.views.get_ocw_courses.delay", autospec=True
     )
+    assert reverse("lr:v1:ocw-next-webhook") == "/api/v1/ocw_next_webhook/"
     response = client.post(
         reverse("lr:v1:ocw-next-webhook"),
         data=data,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes the OCW webhook url and tests that it is what's expected.


### How can this be tested?
Post the following to http://localhost:8063/api/v1/ocw_next_webook/, you should  not get a 404:

```
{
    "webhook_key": "<value of settings.OCW_WEBHOOK_KEY>",
    "unpublished": true, 
    "site_uid": "0bc2ffc76cb64553822955c21c91db54","version": "live"
}
```

