### PR TITLE
Multiple filter options for learningresources and contenfiles API rest endpoints

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -4397,41 +4397,37 @@ export const ContentfilesApiAxiosParamCreator = function (
     /**
      * Viewset for ContentFiles
      * @summary List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {ContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<ContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     contentfilesList: async (
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: ContentfilesListOfferedByEnum,
+      offered_by?: Array<ContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: ContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<ContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'learning_resource_id2' is not null or undefined
+      // verify required parameter 'learning_resource_id' is not null or undefined
       assertParamExists(
         "contentfilesList",
-        "learning_resource_id2",
-        learning_resource_id2,
+        "learning_resource_id",
+        learning_resource_id,
       )
       const localVarPath = `/api/v1/contentfiles/`.replace(
         `{${"learning_resource_id"}}`,
-        encodeURIComponent(String(learning_resource_id2)),
+        encodeURIComponent(String(learning_resource_id)),
       )
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -4448,24 +4444,16 @@ export const ContentfilesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (content_feature_type !== undefined) {
-        localVarQueryParameter["content_feature_type"] = content_feature_type
-      }
-
-      if (learning_resource_id !== undefined) {
-        localVarQueryParameter["learning_resource_id"] = learning_resource_id
-      }
-
-      if (learning_resource_readable_id !== undefined) {
-        localVarQueryParameter["learning_resource_readable_id"] =
-          learning_resource_readable_id
+      if (content_feature_type) {
+        localVarQueryParameter["content_feature_type"] =
+          content_feature_type.join(COLLECTION_FORMATS.csv)
       }
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -4473,16 +4461,18 @@ export const ContentfilesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
-      if (run_id !== undefined) {
-        localVarQueryParameter["run_id"] = run_id
+      if (resource_id) {
+        localVarQueryParameter["resource_id"] = resource_id.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (run_readable_id !== undefined) {
-        localVarQueryParameter["run_readable_id"] = run_readable_id
+      if (run_id) {
+        localVarQueryParameter["run_id"] = run_id.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -4569,30 +4559,26 @@ export const ContentfilesApiFp = function (configuration?: Configuration) {
     /**
      * Viewset for ContentFiles
      * @summary List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {ContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<ContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async contentfilesList(
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: ContentfilesListOfferedByEnum,
+      offered_by?: Array<ContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: ContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<ContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -4602,16 +4588,14 @@ export const ContentfilesApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.contentfilesList(
-          learning_resource_id2,
-          content_feature_type,
           learning_resource_id,
-          learning_resource_readable_id,
+          content_feature_type,
           limit,
           offered_by,
           offset,
           platform,
+          resource_id,
           run_id,
-          run_readable_id,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -4684,16 +4668,14 @@ export const ContentfilesApiFactory = function (
     ): AxiosPromise<PaginatedContentFileList> {
       return localVarFp
         .contentfilesList(
-          requestParameters.learning_resource_id2,
-          requestParameters.content_feature_type,
           requestParameters.learning_resource_id,
-          requestParameters.learning_resource_readable_id,
+          requestParameters.content_feature_type,
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
+          requestParameters.resource_id,
           requestParameters.run_id,
-          requestParameters.run_readable_id,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -4731,28 +4713,14 @@ export interface ContentfilesApiContentfilesListRequest {
    * @type {number}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly learning_resource_id2: number
+  readonly learning_resource_id: number
 
   /**
-   * Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly content_feature_type?: string
-
-  /**
-   * The id of the learning resource the content file belongs to
-   * @type {number}
-   * @memberof ContentfilesApiContentfilesList
-   */
-  readonly learning_resource_id?: number
-
-  /**
-   * The readable id of the learning resource the content file belongs to
-   * @type {string}
-   * @memberof ContentfilesApiContentfilesList
-   */
-  readonly learning_resource_readable_id?: string
+  readonly content_feature_type?: Array<string>
 
   /**
    * Number of results to return per page.
@@ -4763,10 +4731,10 @@ export interface ContentfilesApiContentfilesListRequest {
 
   /**
    * The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly offered_by?: ContentfilesListOfferedByEnum
+  readonly offered_by?: Array<ContentfilesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -4777,24 +4745,24 @@ export interface ContentfilesApiContentfilesListRequest {
 
   /**
    * The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly platform?: ContentfilesListPlatformEnum
+  readonly platform?: Array<ContentfilesListPlatformEnum>
 
   /**
-   * The id of the learning resource run the content file belongs to
-   * @type {number}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly run_id?: number
+  readonly resource_id?: Array<number>
 
   /**
-   * The readable id of the learning resource run the content file belongs to
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof ContentfilesApiContentfilesList
    */
-  readonly run_readable_id?: string
+  readonly run_id?: Array<number>
 }
 
 /**
@@ -4839,16 +4807,14 @@ export class ContentfilesApi extends BaseAPI {
   ) {
     return ContentfilesApiFp(this.configuration)
       .contentfilesList(
-        requestParameters.learning_resource_id2,
-        requestParameters.content_feature_type,
         requestParameters.learning_resource_id,
-        requestParameters.learning_resource_readable_id,
+        requestParameters.content_feature_type,
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
+        requestParameters.resource_id,
         requestParameters.run_id,
-        requestParameters.run_readable_id,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -5241,42 +5207,38 @@ export const CoursesApiAxiosParamCreator = function (
     /**
      * Show content files for a learning resource
      * @summary Learning Resource Content File List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<CoursesContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     coursesContentfilesList: async (
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: CoursesContentfilesListOfferedByEnum,
+      offered_by?: Array<CoursesContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<CoursesContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'learning_resource_id2' is not null or undefined
+      // verify required parameter 'learning_resource_id' is not null or undefined
       assertParamExists(
         "coursesContentfilesList",
-        "learning_resource_id2",
-        learning_resource_id2,
+        "learning_resource_id",
+        learning_resource_id,
       )
       const localVarPath =
         `/api/v1/courses/{learning_resource_id}/contentfiles/`.replace(
           `{${"learning_resource_id"}}`,
-          encodeURIComponent(String(learning_resource_id2)),
+          encodeURIComponent(String(learning_resource_id)),
         )
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -5293,24 +5255,16 @@ export const CoursesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (content_feature_type !== undefined) {
-        localVarQueryParameter["content_feature_type"] = content_feature_type
-      }
-
-      if (learning_resource_id !== undefined) {
-        localVarQueryParameter["learning_resource_id"] = learning_resource_id
-      }
-
-      if (learning_resource_readable_id !== undefined) {
-        localVarQueryParameter["learning_resource_readable_id"] =
-          learning_resource_readable_id
+      if (content_feature_type) {
+        localVarQueryParameter["content_feature_type"] =
+          content_feature_type.join(COLLECTION_FORMATS.csv)
       }
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -5318,16 +5272,18 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
-      if (run_id !== undefined) {
-        localVarQueryParameter["run_id"] = run_id
+      if (resource_id) {
+        localVarQueryParameter["resource_id"] = resource_id.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (run_readable_id !== undefined) {
-        localVarQueryParameter["run_readable_id"] = run_readable_id
+      if (run_id) {
+        localVarQueryParameter["run_id"] = run_id.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -5404,32 +5360,32 @@ export const CoursesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of courses
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     coursesList: async (
-      course_feature?: string,
-      department?: CoursesListDepartmentEnum,
-      level?: CoursesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesListDepartmentEnum>,
+      level?: Array<CoursesListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesListOfferedByEnum,
+      offered_by?: Array<CoursesListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesListPlatformEnum,
+      platform?: Array<CoursesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesListResourceTypeEnum,
+      resource_type?: Array<CoursesListResourceTypeEnum>,
       sortby?: CoursesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/`
@@ -5448,15 +5404,17 @@ export const CoursesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -5464,7 +5422,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -5472,7 +5430,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -5480,7 +5438,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -5488,8 +5446,8 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -5509,32 +5467,32 @@ export const CoursesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of newly released Courses.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     coursesNewList: async (
-      course_feature?: string,
-      department?: CoursesNewListDepartmentEnum,
-      level?: CoursesNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesNewListDepartmentEnum>,
+      level?: Array<CoursesNewListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesNewListOfferedByEnum,
+      offered_by?: Array<CoursesNewListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesNewListPlatformEnum,
+      platform?: Array<CoursesNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesNewListResourceTypeEnum,
+      resource_type?: Array<CoursesNewListResourceTypeEnum>,
       sortby?: CoursesNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/new/`
@@ -5553,15 +5511,17 @@ export const CoursesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -5569,7 +5529,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -5577,7 +5537,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -5585,7 +5545,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -5593,8 +5553,8 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -5660,32 +5620,32 @@ export const CoursesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of upcoming Courses.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     coursesUpcomingList: async (
-      course_feature?: string,
-      department?: CoursesUpcomingListDepartmentEnum,
-      level?: CoursesUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesUpcomingListDepartmentEnum>,
+      level?: Array<CoursesUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesUpcomingListOfferedByEnum,
+      offered_by?: Array<CoursesUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesUpcomingListPlatformEnum,
+      platform?: Array<CoursesUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesUpcomingListResourceTypeEnum,
+      resource_type?: Array<CoursesUpcomingListResourceTypeEnum>,
       sortby?: CoursesUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/courses/upcoming/`
@@ -5704,15 +5664,17 @@ export const CoursesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -5720,7 +5682,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -5728,7 +5690,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -5736,7 +5698,7 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -5744,8 +5706,8 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -5775,30 +5737,26 @@ export const CoursesApiFp = function (configuration?: Configuration) {
     /**
      * Show content files for a learning resource
      * @summary Learning Resource Content File List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<CoursesContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async coursesContentfilesList(
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: CoursesContentfilesListOfferedByEnum,
+      offered_by?: Array<CoursesContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<CoursesContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -5808,16 +5766,14 @@ export const CoursesApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.coursesContentfilesList(
-          learning_resource_id2,
-          content_feature_type,
           learning_resource_id,
-          learning_resource_readable_id,
+          content_feature_type,
           limit,
           offered_by,
           offset,
           platform,
+          resource_id,
           run_id,
-          run_readable_id,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -5867,32 +5823,32 @@ export const CoursesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of courses
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async coursesList(
-      course_feature?: string,
-      department?: CoursesListDepartmentEnum,
-      level?: CoursesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesListDepartmentEnum>,
+      level?: Array<CoursesListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesListOfferedByEnum,
+      offered_by?: Array<CoursesListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesListPlatformEnum,
+      platform?: Array<CoursesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesListResourceTypeEnum,
+      resource_type?: Array<CoursesListResourceTypeEnum>,
       sortby?: CoursesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -5928,32 +5884,32 @@ export const CoursesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of newly released Courses.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async coursesNewList(
-      course_feature?: string,
-      department?: CoursesNewListDepartmentEnum,
-      level?: CoursesNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesNewListDepartmentEnum>,
+      level?: Array<CoursesNewListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesNewListOfferedByEnum,
+      offered_by?: Array<CoursesNewListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesNewListPlatformEnum,
+      platform?: Array<CoursesNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesNewListResourceTypeEnum,
+      resource_type?: Array<CoursesNewListResourceTypeEnum>,
       sortby?: CoursesNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -6017,32 +5973,32 @@ export const CoursesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of upcoming Courses.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {CoursesUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {CoursesUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<CoursesUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<CoursesUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {CoursesUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<CoursesUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {CoursesUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<CoursesUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {CoursesUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<CoursesUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {CoursesUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async coursesUpcomingList(
-      course_feature?: string,
-      department?: CoursesUpcomingListDepartmentEnum,
-      level?: CoursesUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<CoursesUpcomingListDepartmentEnum>,
+      level?: Array<CoursesUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: CoursesUpcomingListOfferedByEnum,
+      offered_by?: Array<CoursesUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: CoursesUpcomingListPlatformEnum,
+      platform?: Array<CoursesUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: CoursesUpcomingListResourceTypeEnum,
+      resource_type?: Array<CoursesUpcomingListResourceTypeEnum>,
       sortby?: CoursesUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -6103,16 +6059,14 @@ export const CoursesApiFactory = function (
     ): AxiosPromise<PaginatedContentFileList> {
       return localVarFp
         .coursesContentfilesList(
-          requestParameters.learning_resource_id2,
-          requestParameters.content_feature_type,
           requestParameters.learning_resource_id,
-          requestParameters.learning_resource_readable_id,
+          requestParameters.content_feature_type,
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
+          requestParameters.resource_id,
           requestParameters.run_id,
-          requestParameters.run_readable_id,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -6249,28 +6203,14 @@ export interface CoursesApiCoursesContentfilesListRequest {
    * @type {number}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly learning_resource_id2: number
+  readonly learning_resource_id: number
 
   /**
-   * Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly content_feature_type?: string
-
-  /**
-   * The id of the learning resource the content file belongs to
-   * @type {number}
-   * @memberof CoursesApiCoursesContentfilesList
-   */
-  readonly learning_resource_id?: number
-
-  /**
-   * The readable id of the learning resource the content file belongs to
-   * @type {string}
-   * @memberof CoursesApiCoursesContentfilesList
-   */
-  readonly learning_resource_readable_id?: string
+  readonly content_feature_type?: Array<string>
 
   /**
    * Number of results to return per page.
@@ -6281,10 +6221,10 @@ export interface CoursesApiCoursesContentfilesListRequest {
 
   /**
    * The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly offered_by?: CoursesContentfilesListOfferedByEnum
+  readonly offered_by?: Array<CoursesContentfilesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -6295,24 +6235,24 @@ export interface CoursesApiCoursesContentfilesListRequest {
 
   /**
    * The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly platform?: CoursesContentfilesListPlatformEnum
+  readonly platform?: Array<CoursesContentfilesListPlatformEnum>
 
   /**
-   * The id of the learning resource run the content file belongs to
-   * @type {number}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly run_id?: number
+  readonly resource_id?: Array<number>
 
   /**
-   * The readable id of the learning resource run the content file belongs to
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof CoursesApiCoursesContentfilesList
    */
-  readonly run_readable_id?: string
+  readonly run_id?: Array<number>
 }
 
 /**
@@ -6343,25 +6283,25 @@ export interface CoursesApiCoursesContentfilesRetrieveRequest {
  */
 export interface CoursesApiCoursesListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof CoursesApiCoursesList
    */
-  readonly department?: CoursesListDepartmentEnum
+  readonly department?: Array<CoursesListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof CoursesApiCoursesList
    */
-  readonly level?: CoursesListLevelEnum
+  readonly level?: Array<CoursesListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -6372,10 +6312,10 @@ export interface CoursesApiCoursesListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof CoursesApiCoursesList
    */
-  readonly offered_by?: CoursesListOfferedByEnum
+  readonly offered_by?: Array<CoursesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -6386,10 +6326,10 @@ export interface CoursesApiCoursesListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof CoursesApiCoursesList
    */
-  readonly platform?: CoursesListPlatformEnum
+  readonly platform?: Array<CoursesListPlatformEnum>
 
   /**
    *
@@ -6400,10 +6340,10 @@ export interface CoursesApiCoursesListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof CoursesApiCoursesList
    */
-  readonly resource_type?: CoursesListResourceTypeEnum
+  readonly resource_type?: Array<CoursesListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -6413,11 +6353,11 @@ export interface CoursesApiCoursesListRequest {
   readonly sortby?: CoursesListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -6427,25 +6367,25 @@ export interface CoursesApiCoursesListRequest {
  */
 export interface CoursesApiCoursesNewListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly department?: CoursesNewListDepartmentEnum
+  readonly department?: Array<CoursesNewListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly level?: CoursesNewListLevelEnum
+  readonly level?: Array<CoursesNewListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -6456,10 +6396,10 @@ export interface CoursesApiCoursesNewListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly offered_by?: CoursesNewListOfferedByEnum
+  readonly offered_by?: Array<CoursesNewListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -6470,10 +6410,10 @@ export interface CoursesApiCoursesNewListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly platform?: CoursesNewListPlatformEnum
+  readonly platform?: Array<CoursesNewListPlatformEnum>
 
   /**
    *
@@ -6484,10 +6424,10 @@ export interface CoursesApiCoursesNewListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly resource_type?: CoursesNewListResourceTypeEnum
+  readonly resource_type?: Array<CoursesNewListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -6497,11 +6437,11 @@ export interface CoursesApiCoursesNewListRequest {
   readonly sortby?: CoursesNewListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesNewList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -6525,25 +6465,25 @@ export interface CoursesApiCoursesRetrieveRequest {
  */
 export interface CoursesApiCoursesUpcomingListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly department?: CoursesUpcomingListDepartmentEnum
+  readonly department?: Array<CoursesUpcomingListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly level?: CoursesUpcomingListLevelEnum
+  readonly level?: Array<CoursesUpcomingListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -6554,10 +6494,10 @@ export interface CoursesApiCoursesUpcomingListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly offered_by?: CoursesUpcomingListOfferedByEnum
+  readonly offered_by?: Array<CoursesUpcomingListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -6568,10 +6508,10 @@ export interface CoursesApiCoursesUpcomingListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly platform?: CoursesUpcomingListPlatformEnum
+  readonly platform?: Array<CoursesUpcomingListPlatformEnum>
 
   /**
    *
@@ -6582,10 +6522,10 @@ export interface CoursesApiCoursesUpcomingListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly resource_type?: CoursesUpcomingListResourceTypeEnum
+  readonly resource_type?: Array<CoursesUpcomingListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -6595,11 +6535,11 @@ export interface CoursesApiCoursesUpcomingListRequest {
   readonly sortby?: CoursesUpcomingListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof CoursesApiCoursesUpcomingList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -6623,16 +6563,14 @@ export class CoursesApi extends BaseAPI {
   ) {
     return CoursesApiFp(this.configuration)
       .coursesContentfilesList(
-        requestParameters.learning_resource_id2,
-        requestParameters.content_feature_type,
         requestParameters.learning_resource_id,
-        requestParameters.learning_resource_readable_id,
+        requestParameters.content_feature_type,
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
+        requestParameters.resource_id,
         requestParameters.run_id,
-        requestParameters.run_readable_id,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -7520,42 +7458,38 @@ export const LearningResourcesApiAxiosParamCreator = function (
     /**
      * Show content files for a learning resource
      * @summary Learning Resource Content File List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<LearningResourcesContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesContentfilesList: async (
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: LearningResourcesContentfilesListOfferedByEnum,
+      offered_by?: Array<LearningResourcesContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<LearningResourcesContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
-      // verify required parameter 'learning_resource_id2' is not null or undefined
+      // verify required parameter 'learning_resource_id' is not null or undefined
       assertParamExists(
         "learningResourcesContentfilesList",
-        "learning_resource_id2",
-        learning_resource_id2,
+        "learning_resource_id",
+        learning_resource_id,
       )
       const localVarPath =
         `/api/v1/learning_resources/{learning_resource_id}/contentfiles/`.replace(
           `{${"learning_resource_id"}}`,
-          encodeURIComponent(String(learning_resource_id2)),
+          encodeURIComponent(String(learning_resource_id)),
         )
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
@@ -7572,24 +7506,16 @@ export const LearningResourcesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (content_feature_type !== undefined) {
-        localVarQueryParameter["content_feature_type"] = content_feature_type
-      }
-
-      if (learning_resource_id !== undefined) {
-        localVarQueryParameter["learning_resource_id"] = learning_resource_id
-      }
-
-      if (learning_resource_readable_id !== undefined) {
-        localVarQueryParameter["learning_resource_readable_id"] =
-          learning_resource_readable_id
+      if (content_feature_type) {
+        localVarQueryParameter["content_feature_type"] =
+          content_feature_type.join(COLLECTION_FORMATS.csv)
       }
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -7597,16 +7523,18 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
-      if (run_id !== undefined) {
-        localVarQueryParameter["run_id"] = run_id
+      if (resource_id) {
+        localVarQueryParameter["resource_id"] = resource_id.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (run_readable_id !== undefined) {
-        localVarQueryParameter["run_readable_id"] = run_readable_id
+      if (run_id) {
+        localVarQueryParameter["run_id"] = run_id.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -7809,32 +7737,32 @@ export const LearningResourcesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of learning resources.
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesList: async (
-      course_feature?: string,
-      department?: LearningResourcesListDepartmentEnum,
-      level?: LearningResourcesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesListDepartmentEnum>,
+      level?: Array<LearningResourcesListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesListOfferedByEnum,
+      offered_by?: Array<LearningResourcesListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesListPlatformEnum,
+      platform?: Array<LearningResourcesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesListResourceTypeEnum>,
       sortby?: LearningResourcesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/`
@@ -7853,15 +7781,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -7869,7 +7799,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -7877,7 +7807,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -7885,7 +7815,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -7893,8 +7823,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -7914,32 +7844,32 @@ export const LearningResourcesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of newly released Learning Resources.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesNewList: async (
-      course_feature?: string,
-      department?: LearningResourcesNewListDepartmentEnum,
-      level?: LearningResourcesNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesNewListDepartmentEnum>,
+      level?: Array<LearningResourcesNewListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesNewListOfferedByEnum,
+      offered_by?: Array<LearningResourcesNewListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesNewListPlatformEnum,
+      platform?: Array<LearningResourcesNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesNewListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesNewListResourceTypeEnum>,
       sortby?: LearningResourcesNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/new/`
@@ -7958,15 +7888,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -7974,7 +7906,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -7982,7 +7914,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -7990,7 +7922,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -7998,8 +7930,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -8065,32 +7997,32 @@ export const LearningResourcesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of upcoming Learning Resources.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesUpcomingList: async (
-      course_feature?: string,
-      department?: LearningResourcesUpcomingListDepartmentEnum,
-      level?: LearningResourcesUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesUpcomingListDepartmentEnum>,
+      level?: Array<LearningResourcesUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesUpcomingListOfferedByEnum,
+      offered_by?: Array<LearningResourcesUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesUpcomingListPlatformEnum,
+      platform?: Array<LearningResourcesUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesUpcomingListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesUpcomingListResourceTypeEnum>,
       sortby?: LearningResourcesUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources/upcoming/`
@@ -8109,15 +8041,17 @@ export const LearningResourcesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -8125,7 +8059,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -8133,7 +8067,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -8141,7 +8075,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -8149,8 +8083,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -8181,30 +8115,26 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
     /**
      * Show content files for a learning resource
      * @summary Learning Resource Content File List
-     * @param {number} learning_resource_id2 id of the parent learning resource
-     * @param {string} [content_feature_type] Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {number} [learning_resource_id] The id of the learning resource the content file belongs to
-     * @param {string} [learning_resource_readable_id] The readable id of the learning resource the content file belongs to
+     * @param {number} learning_resource_id id of the parent learning resource
+     * @param {Array<string>} [content_feature_type] Multiple values may be separated by commas.
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesContentfilesListOfferedByEnum} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesContentfilesListOfferedByEnum>} [offered_by] The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesContentfilesListPlatformEnum} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-     * @param {number} [run_id] The id of the learning resource run the content file belongs to
-     * @param {string} [run_readable_id] The readable id of the learning resource run the content file belongs to
+     * @param {Array<LearningResourcesContentfilesListPlatformEnum>} [platform] The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<number>} [resource_id] Multiple values may be separated by commas.
+     * @param {Array<number>} [run_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesContentfilesList(
-      learning_resource_id2: number,
-      content_feature_type?: string,
-      learning_resource_id?: number,
-      learning_resource_readable_id?: string,
+      learning_resource_id: number,
+      content_feature_type?: Array<string>,
       limit?: number,
-      offered_by?: LearningResourcesContentfilesListOfferedByEnum,
+      offered_by?: Array<LearningResourcesContentfilesListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesContentfilesListPlatformEnum,
-      run_id?: number,
-      run_readable_id?: string,
+      platform?: Array<LearningResourcesContentfilesListPlatformEnum>,
+      resource_id?: Array<number>,
+      run_id?: Array<number>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -8214,16 +8144,14 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningResourcesContentfilesList(
-          learning_resource_id2,
-          content_feature_type,
           learning_resource_id,
-          learning_resource_readable_id,
+          content_feature_type,
           limit,
           offered_by,
           offset,
           platform,
+          resource_id,
           run_id,
-          run_readable_id,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -8356,32 +8284,32 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of learning resources.
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesList(
-      course_feature?: string,
-      department?: LearningResourcesListDepartmentEnum,
-      level?: LearningResourcesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesListDepartmentEnum>,
+      level?: Array<LearningResourcesListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesListOfferedByEnum,
+      offered_by?: Array<LearningResourcesListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesListPlatformEnum,
+      platform?: Array<LearningResourcesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesListResourceTypeEnum>,
       sortby?: LearningResourcesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -8420,32 +8348,32 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of newly released Learning Resources.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesNewList(
-      course_feature?: string,
-      department?: LearningResourcesNewListDepartmentEnum,
-      level?: LearningResourcesNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesNewListDepartmentEnum>,
+      level?: Array<LearningResourcesNewListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesNewListOfferedByEnum,
+      offered_by?: Array<LearningResourcesNewListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesNewListPlatformEnum,
+      platform?: Array<LearningResourcesNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesNewListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesNewListResourceTypeEnum>,
       sortby?: LearningResourcesNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -8515,32 +8443,32 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of upcoming Learning Resources.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningResourcesUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningResourcesUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningResourcesUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningResourcesUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningResourcesUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningResourcesUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningResourcesUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningResourcesUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningResourcesUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningResourcesUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesUpcomingList(
-      course_feature?: string,
-      department?: LearningResourcesUpcomingListDepartmentEnum,
-      level?: LearningResourcesUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningResourcesUpcomingListDepartmentEnum>,
+      level?: Array<LearningResourcesUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: LearningResourcesUpcomingListOfferedByEnum,
+      offered_by?: Array<LearningResourcesUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: LearningResourcesUpcomingListPlatformEnum,
+      platform?: Array<LearningResourcesUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningResourcesUpcomingListResourceTypeEnum,
+      resource_type?: Array<LearningResourcesUpcomingListResourceTypeEnum>,
       sortby?: LearningResourcesUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -8603,16 +8531,14 @@ export const LearningResourcesApiFactory = function (
     ): AxiosPromise<PaginatedContentFileList> {
       return localVarFp
         .learningResourcesContentfilesList(
-          requestParameters.learning_resource_id2,
-          requestParameters.content_feature_type,
           requestParameters.learning_resource_id,
-          requestParameters.learning_resource_readable_id,
+          requestParameters.content_feature_type,
           requestParameters.limit,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
+          requestParameters.resource_id,
           requestParameters.run_id,
-          requestParameters.run_readable_id,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -8789,28 +8715,14 @@ export interface LearningResourcesApiLearningResourcesContentfilesListRequest {
    * @type {number}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly learning_resource_id2: number
+  readonly learning_resource_id: number
 
   /**
-   * Content feature type for the content file. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly content_feature_type?: string
-
-  /**
-   * The id of the learning resource the content file belongs to
-   * @type {number}
-   * @memberof LearningResourcesApiLearningResourcesContentfilesList
-   */
-  readonly learning_resource_id?: number
-
-  /**
-   * The readable id of the learning resource the content file belongs to
-   * @type {string}
-   * @memberof LearningResourcesApiLearningResourcesContentfilesList
-   */
-  readonly learning_resource_readable_id?: string
+  readonly content_feature_type?: Array<string>
 
   /**
    * Number of results to return per page.
@@ -8821,10 +8733,10 @@ export interface LearningResourcesApiLearningResourcesContentfilesListRequest {
 
   /**
    * The organization that offers a learning resource the content file belongs to  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly offered_by?: LearningResourcesContentfilesListOfferedByEnum
+  readonly offered_by?: Array<LearningResourcesContentfilesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -8835,24 +8747,24 @@ export interface LearningResourcesApiLearningResourcesContentfilesListRequest {
 
   /**
    * The platform on which learning resources the content file belongs to is offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly platform?: LearningResourcesContentfilesListPlatformEnum
+  readonly platform?: Array<LearningResourcesContentfilesListPlatformEnum>
 
   /**
-   * The id of the learning resource run the content file belongs to
-   * @type {number}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly run_id?: number
+  readonly resource_id?: Array<number>
 
   /**
-   * The readable id of the learning resource run the content file belongs to
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<number>}
    * @memberof LearningResourcesApiLearningResourcesContentfilesList
    */
-  readonly run_readable_id?: string
+  readonly run_id?: Array<number>
 }
 
 /**
@@ -8939,25 +8851,25 @@ export interface LearningResourcesApiLearningResourcesItemsRetrieveRequest {
  */
 export interface LearningResourcesApiLearningResourcesListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly department?: LearningResourcesListDepartmentEnum
+  readonly department?: Array<LearningResourcesListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly level?: LearningResourcesListLevelEnum
+  readonly level?: Array<LearningResourcesListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -8968,10 +8880,10 @@ export interface LearningResourcesApiLearningResourcesListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly offered_by?: LearningResourcesListOfferedByEnum
+  readonly offered_by?: Array<LearningResourcesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -8982,10 +8894,10 @@ export interface LearningResourcesApiLearningResourcesListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly platform?: LearningResourcesListPlatformEnum
+  readonly platform?: Array<LearningResourcesListPlatformEnum>
 
   /**
    *
@@ -8996,10 +8908,10 @@ export interface LearningResourcesApiLearningResourcesListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly resource_type?: LearningResourcesListResourceTypeEnum
+  readonly resource_type?: Array<LearningResourcesListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -9009,11 +8921,11 @@ export interface LearningResourcesApiLearningResourcesListRequest {
   readonly sortby?: LearningResourcesListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -9023,25 +8935,25 @@ export interface LearningResourcesApiLearningResourcesListRequest {
  */
 export interface LearningResourcesApiLearningResourcesNewListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly department?: LearningResourcesNewListDepartmentEnum
+  readonly department?: Array<LearningResourcesNewListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly level?: LearningResourcesNewListLevelEnum
+  readonly level?: Array<LearningResourcesNewListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -9052,10 +8964,10 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly offered_by?: LearningResourcesNewListOfferedByEnum
+  readonly offered_by?: Array<LearningResourcesNewListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -9066,10 +8978,10 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly platform?: LearningResourcesNewListPlatformEnum
+  readonly platform?: Array<LearningResourcesNewListPlatformEnum>
 
   /**
    *
@@ -9080,10 +8992,10 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly resource_type?: LearningResourcesNewListResourceTypeEnum
+  readonly resource_type?: Array<LearningResourcesNewListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -9093,11 +9005,11 @@ export interface LearningResourcesApiLearningResourcesNewListRequest {
   readonly sortby?: LearningResourcesNewListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesNewList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -9121,25 +9033,25 @@ export interface LearningResourcesApiLearningResourcesRetrieveRequest {
  */
 export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly department?: LearningResourcesUpcomingListDepartmentEnum
+  readonly department?: Array<LearningResourcesUpcomingListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly level?: LearningResourcesUpcomingListLevelEnum
+  readonly level?: Array<LearningResourcesUpcomingListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -9150,10 +9062,10 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly offered_by?: LearningResourcesUpcomingListOfferedByEnum
+  readonly offered_by?: Array<LearningResourcesUpcomingListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -9164,10 +9076,10 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly platform?: LearningResourcesUpcomingListPlatformEnum
+  readonly platform?: Array<LearningResourcesUpcomingListPlatformEnum>
 
   /**
    *
@@ -9178,10 +9090,10 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly resource_type?: LearningResourcesUpcomingListResourceTypeEnum
+  readonly resource_type?: Array<LearningResourcesUpcomingListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -9191,11 +9103,11 @@ export interface LearningResourcesApiLearningResourcesUpcomingListRequest {
   readonly sortby?: LearningResourcesUpcomingListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesUpcomingList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -9219,16 +9131,14 @@ export class LearningResourcesApi extends BaseAPI {
   ) {
     return LearningResourcesApiFp(this.configuration)
       .learningResourcesContentfilesList(
-        requestParameters.learning_resource_id2,
-        requestParameters.content_feature_type,
         requestParameters.learning_resource_id,
-        requestParameters.learning_resource_readable_id,
+        requestParameters.content_feature_type,
         requestParameters.limit,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
+        requestParameters.resource_id,
         requestParameters.run_id,
-        requestParameters.run_readable_id,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -10833,32 +10743,32 @@ export const LearningpathsApiAxiosParamCreator = function (
     /**
      * Get a paginated list of learning paths
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningpathsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningpathsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningpathsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningpathsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningpathsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningpathsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningpathsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningpathsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningpathsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningpathsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningpathsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningpathsList: async (
-      course_feature?: string,
-      department?: LearningpathsListDepartmentEnum,
-      level?: LearningpathsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningpathsListDepartmentEnum>,
+      level?: Array<LearningpathsListLevelEnum>,
       limit?: number,
-      offered_by?: LearningpathsListOfferedByEnum,
+      offered_by?: Array<LearningpathsListOfferedByEnum>,
       offset?: number,
-      platform?: LearningpathsListPlatformEnum,
+      platform?: Array<LearningpathsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningpathsListResourceTypeEnum,
+      resource_type?: Array<LearningpathsListResourceTypeEnum>,
       sortby?: LearningpathsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learningpaths/`
@@ -10877,15 +10787,17 @@ export const LearningpathsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -10893,7 +10805,7 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -10901,7 +10813,7 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -10909,7 +10821,7 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -10917,8 +10829,8 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -11298,32 +11210,32 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of learning paths
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {LearningpathsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {LearningpathsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<LearningpathsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<LearningpathsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {LearningpathsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<LearningpathsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {LearningpathsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<LearningpathsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {LearningpathsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<LearningpathsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {LearningpathsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningpathsList(
-      course_feature?: string,
-      department?: LearningpathsListDepartmentEnum,
-      level?: LearningpathsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<LearningpathsListDepartmentEnum>,
+      level?: Array<LearningpathsListLevelEnum>,
       limit?: number,
-      offered_by?: LearningpathsListOfferedByEnum,
+      offered_by?: Array<LearningpathsListOfferedByEnum>,
       offset?: number,
-      platform?: LearningpathsListPlatformEnum,
+      platform?: Array<LearningpathsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: LearningpathsListResourceTypeEnum,
+      resource_type?: Array<LearningpathsListResourceTypeEnum>,
       sortby?: LearningpathsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -11795,25 +11707,25 @@ export interface LearningpathsApiLearningpathsItemsRetrieveRequest {
  */
 export interface LearningpathsApiLearningpathsListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly department?: LearningpathsListDepartmentEnum
+  readonly department?: Array<LearningpathsListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly level?: LearningpathsListLevelEnum
+  readonly level?: Array<LearningpathsListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -11824,10 +11736,10 @@ export interface LearningpathsApiLearningpathsListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly offered_by?: LearningpathsListOfferedByEnum
+  readonly offered_by?: Array<LearningpathsListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -11838,10 +11750,10 @@ export interface LearningpathsApiLearningpathsListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly platform?: LearningpathsListPlatformEnum
+  readonly platform?: Array<LearningpathsListPlatformEnum>
 
   /**
    *
@@ -11852,10 +11764,10 @@ export interface LearningpathsApiLearningpathsListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly resource_type?: LearningpathsListResourceTypeEnum
+  readonly resource_type?: Array<LearningpathsListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -11865,11 +11777,11 @@ export interface LearningpathsApiLearningpathsListRequest {
   readonly sortby?: LearningpathsListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof LearningpathsApiLearningpathsList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -12881,32 +12793,32 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
     /**
      * Get a paginated list of podcast episodes
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {PodcastEpisodesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {PodcastEpisodesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<PodcastEpisodesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<PodcastEpisodesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {PodcastEpisodesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<PodcastEpisodesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {PodcastEpisodesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<PodcastEpisodesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {PodcastEpisodesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<PodcastEpisodesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {PodcastEpisodesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     podcastEpisodesList: async (
-      course_feature?: string,
-      department?: PodcastEpisodesListDepartmentEnum,
-      level?: PodcastEpisodesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<PodcastEpisodesListDepartmentEnum>,
+      level?: Array<PodcastEpisodesListLevelEnum>,
       limit?: number,
-      offered_by?: PodcastEpisodesListOfferedByEnum,
+      offered_by?: Array<PodcastEpisodesListOfferedByEnum>,
       offset?: number,
-      platform?: PodcastEpisodesListPlatformEnum,
+      platform?: Array<PodcastEpisodesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: PodcastEpisodesListResourceTypeEnum,
+      resource_type?: Array<PodcastEpisodesListResourceTypeEnum>,
       sortby?: PodcastEpisodesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcast_episodes/`
@@ -12925,15 +12837,17 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -12941,7 +12855,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -12949,7 +12863,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -12957,7 +12871,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -12965,8 +12879,8 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -13043,32 +12957,32 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of podcast episodes
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {PodcastEpisodesListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {PodcastEpisodesListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<PodcastEpisodesListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<PodcastEpisodesListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {PodcastEpisodesListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<PodcastEpisodesListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {PodcastEpisodesListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<PodcastEpisodesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {PodcastEpisodesListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<PodcastEpisodesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {PodcastEpisodesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async podcastEpisodesList(
-      course_feature?: string,
-      department?: PodcastEpisodesListDepartmentEnum,
-      level?: PodcastEpisodesListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<PodcastEpisodesListDepartmentEnum>,
+      level?: Array<PodcastEpisodesListLevelEnum>,
       limit?: number,
-      offered_by?: PodcastEpisodesListOfferedByEnum,
+      offered_by?: Array<PodcastEpisodesListOfferedByEnum>,
       offset?: number,
-      platform?: PodcastEpisodesListPlatformEnum,
+      platform?: Array<PodcastEpisodesListPlatformEnum>,
       professional?: boolean,
-      resource_type?: PodcastEpisodesListResourceTypeEnum,
+      resource_type?: Array<PodcastEpisodesListResourceTypeEnum>,
       sortby?: PodcastEpisodesListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -13201,25 +13115,25 @@ export const PodcastEpisodesApiFactory = function (
  */
 export interface PodcastEpisodesApiPodcastEpisodesListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly department?: PodcastEpisodesListDepartmentEnum
+  readonly department?: Array<PodcastEpisodesListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly level?: PodcastEpisodesListLevelEnum
+  readonly level?: Array<PodcastEpisodesListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -13230,10 +13144,10 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly offered_by?: PodcastEpisodesListOfferedByEnum
+  readonly offered_by?: Array<PodcastEpisodesListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -13244,10 +13158,10 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly platform?: PodcastEpisodesListPlatformEnum
+  readonly platform?: Array<PodcastEpisodesListPlatformEnum>
 
   /**
    *
@@ -13258,10 +13172,10 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly resource_type?: PodcastEpisodesListResourceTypeEnum
+  readonly resource_type?: Array<PodcastEpisodesListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -13271,11 +13185,11 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
   readonly sortby?: PodcastEpisodesListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -13613,32 +13527,32 @@ export const PodcastsApiAxiosParamCreator = function (
     /**
      * Get a paginated list of podcasts
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {PodcastsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {PodcastsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<PodcastsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<PodcastsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {PodcastsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<PodcastsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {PodcastsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<PodcastsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {PodcastsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<PodcastsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {PodcastsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     podcastsList: async (
-      course_feature?: string,
-      department?: PodcastsListDepartmentEnum,
-      level?: PodcastsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<PodcastsListDepartmentEnum>,
+      level?: Array<PodcastsListLevelEnum>,
       limit?: number,
-      offered_by?: PodcastsListOfferedByEnum,
+      offered_by?: Array<PodcastsListOfferedByEnum>,
       offset?: number,
-      platform?: PodcastsListPlatformEnum,
+      platform?: Array<PodcastsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: PodcastsListResourceTypeEnum,
+      resource_type?: Array<PodcastsListResourceTypeEnum>,
       sortby?: PodcastsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/podcasts/`
@@ -13657,15 +13571,17 @@ export const PodcastsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -13673,7 +13589,7 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -13681,7 +13597,7 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -13689,7 +13605,7 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -13697,8 +13613,8 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -13850,32 +13766,32 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of podcasts
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {PodcastsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {PodcastsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<PodcastsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<PodcastsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {PodcastsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<PodcastsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {PodcastsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<PodcastsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {PodcastsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<PodcastsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {PodcastsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async podcastsList(
-      course_feature?: string,
-      department?: PodcastsListDepartmentEnum,
-      level?: PodcastsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<PodcastsListDepartmentEnum>,
+      level?: Array<PodcastsListLevelEnum>,
       limit?: number,
-      offered_by?: PodcastsListOfferedByEnum,
+      offered_by?: Array<PodcastsListOfferedByEnum>,
       offset?: number,
-      platform?: PodcastsListPlatformEnum,
+      platform?: Array<PodcastsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: PodcastsListResourceTypeEnum,
+      resource_type?: Array<PodcastsListResourceTypeEnum>,
       sortby?: PodcastsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -14100,25 +14016,25 @@ export interface PodcastsApiPodcastsItemsRetrieveRequest {
  */
 export interface PodcastsApiPodcastsListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly department?: PodcastsListDepartmentEnum
+  readonly department?: Array<PodcastsListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly level?: PodcastsListLevelEnum
+  readonly level?: Array<PodcastsListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -14129,10 +14045,10 @@ export interface PodcastsApiPodcastsListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly offered_by?: PodcastsListOfferedByEnum
+  readonly offered_by?: Array<PodcastsListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -14143,10 +14059,10 @@ export interface PodcastsApiPodcastsListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly platform?: PodcastsListPlatformEnum
+  readonly platform?: Array<PodcastsListPlatformEnum>
 
   /**
    *
@@ -14157,10 +14073,10 @@ export interface PodcastsApiPodcastsListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly resource_type?: PodcastsListResourceTypeEnum
+  readonly resource_type?: Array<PodcastsListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -14170,11 +14086,11 @@ export interface PodcastsApiPodcastsListRequest {
   readonly sortby?: PodcastsListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof PodcastsApiPodcastsList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -14431,32 +14347,32 @@ export const ProgramsApiAxiosParamCreator = function (
     /**
      * Get a paginated list of programs
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     programsList: async (
-      course_feature?: string,
-      department?: ProgramsListDepartmentEnum,
-      level?: ProgramsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsListDepartmentEnum>,
+      level?: Array<ProgramsListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsListOfferedByEnum,
+      offered_by?: Array<ProgramsListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsListPlatformEnum,
+      platform?: Array<ProgramsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsListResourceTypeEnum,
+      resource_type?: Array<ProgramsListResourceTypeEnum>,
       sortby?: ProgramsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/`
@@ -14475,15 +14391,17 @@ export const ProgramsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -14491,7 +14409,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -14499,7 +14417,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -14507,7 +14425,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -14515,8 +14433,8 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -14536,32 +14454,32 @@ export const ProgramsApiAxiosParamCreator = function (
     /**
      * Get a paginated list of newly released Programs.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     programsNewList: async (
-      course_feature?: string,
-      department?: ProgramsNewListDepartmentEnum,
-      level?: ProgramsNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsNewListDepartmentEnum>,
+      level?: Array<ProgramsNewListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsNewListOfferedByEnum,
+      offered_by?: Array<ProgramsNewListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsNewListPlatformEnum,
+      platform?: Array<ProgramsNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsNewListResourceTypeEnum,
+      resource_type?: Array<ProgramsNewListResourceTypeEnum>,
       sortby?: ProgramsNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/new/`
@@ -14580,15 +14498,17 @@ export const ProgramsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -14596,7 +14516,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -14604,7 +14524,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -14612,7 +14532,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -14620,8 +14540,8 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -14687,32 +14607,32 @@ export const ProgramsApiAxiosParamCreator = function (
     /**
      * Get a paginated list of upcoming Programs.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     programsUpcomingList: async (
-      course_feature?: string,
-      department?: ProgramsUpcomingListDepartmentEnum,
-      level?: ProgramsUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsUpcomingListDepartmentEnum>,
+      level?: Array<ProgramsUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsUpcomingListOfferedByEnum,
+      offered_by?: Array<ProgramsUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsUpcomingListPlatformEnum,
+      platform?: Array<ProgramsUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsUpcomingListResourceTypeEnum,
+      resource_type?: Array<ProgramsUpcomingListResourceTypeEnum>,
       sortby?: ProgramsUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/programs/upcoming/`
@@ -14731,15 +14651,17 @@ export const ProgramsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
-      if (course_feature !== undefined) {
-        localVarQueryParameter["course_feature"] = course_feature
+      if (course_feature) {
+        localVarQueryParameter["course_feature"] = course_feature.join(
+          COLLECTION_FORMATS.csv,
+        )
       }
 
-      if (department !== undefined) {
+      if (department) {
         localVarQueryParameter["department"] = department
       }
 
-      if (level !== undefined) {
+      if (level) {
         localVarQueryParameter["level"] = level
       }
 
@@ -14747,7 +14669,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
-      if (offered_by !== undefined) {
+      if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
 
@@ -14755,7 +14677,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (platform !== undefined) {
+      if (platform) {
         localVarQueryParameter["platform"] = platform
       }
 
@@ -14763,7 +14685,7 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (resource_type !== undefined) {
+      if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
@@ -14771,8 +14693,8 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
-      if (topic !== undefined) {
-        localVarQueryParameter["topic"] = topic
+      if (topic) {
+        localVarQueryParameter["topic"] = topic.join(COLLECTION_FORMATS.csv)
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -14802,32 +14724,32 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of programs
      * @summary List
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async programsList(
-      course_feature?: string,
-      department?: ProgramsListDepartmentEnum,
-      level?: ProgramsListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsListDepartmentEnum>,
+      level?: Array<ProgramsListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsListOfferedByEnum,
+      offered_by?: Array<ProgramsListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsListPlatformEnum,
+      platform?: Array<ProgramsListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsListResourceTypeEnum,
+      resource_type?: Array<ProgramsListResourceTypeEnum>,
       sortby?: ProgramsListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -14863,32 +14785,32 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of newly released Programs.
      * @summary List New
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsNewListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsNewListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsNewListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsNewListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsNewListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsNewListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsNewListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsNewListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsNewListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsNewListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsNewListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async programsNewList(
-      course_feature?: string,
-      department?: ProgramsNewListDepartmentEnum,
-      level?: ProgramsNewListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsNewListDepartmentEnum>,
+      level?: Array<ProgramsNewListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsNewListOfferedByEnum,
+      offered_by?: Array<ProgramsNewListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsNewListPlatformEnum,
+      platform?: Array<ProgramsNewListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsNewListResourceTypeEnum,
+      resource_type?: Array<ProgramsNewListResourceTypeEnum>,
       sortby?: ProgramsNewListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -14953,32 +14875,32 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
     /**
      * Get a paginated list of upcoming Programs.
      * @summary List Upcoming
-     * @param {string} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {ProgramsUpcomingListDepartmentEnum} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {ProgramsUpcomingListLevelEnum} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {Array<string>} [course_feature] Multiple values may be separated by commas.
+     * @param {Array<ProgramsUpcomingListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {Array<ProgramsUpcomingListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
      * @param {number} [limit] Number of results to return per page.
-     * @param {ProgramsUpcomingListOfferedByEnum} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
+     * @param {Array<ProgramsUpcomingListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {ProgramsUpcomingListPlatformEnum} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
+     * @param {Array<ProgramsUpcomingListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
      * @param {boolean} [professional]
-     * @param {ProgramsUpcomingListResourceTypeEnum} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
+     * @param {Array<ProgramsUpcomingListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
      * @param {ProgramsUpcomingListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
-     * @param {string} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [topic] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async programsUpcomingList(
-      course_feature?: string,
-      department?: ProgramsUpcomingListDepartmentEnum,
-      level?: ProgramsUpcomingListLevelEnum,
+      course_feature?: Array<string>,
+      department?: Array<ProgramsUpcomingListDepartmentEnum>,
+      level?: Array<ProgramsUpcomingListLevelEnum>,
       limit?: number,
-      offered_by?: ProgramsUpcomingListOfferedByEnum,
+      offered_by?: Array<ProgramsUpcomingListOfferedByEnum>,
       offset?: number,
-      platform?: ProgramsUpcomingListPlatformEnum,
+      platform?: Array<ProgramsUpcomingListPlatformEnum>,
       professional?: boolean,
-      resource_type?: ProgramsUpcomingListResourceTypeEnum,
+      resource_type?: Array<ProgramsUpcomingListResourceTypeEnum>,
       sortby?: ProgramsUpcomingListSortbyEnum,
-      topic?: string,
+      topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -15135,25 +15057,25 @@ export const ProgramsApiFactory = function (
  */
 export interface ProgramsApiProgramsListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly department?: ProgramsListDepartmentEnum
+  readonly department?: Array<ProgramsListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly level?: ProgramsListLevelEnum
+  readonly level?: Array<ProgramsListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -15164,10 +15086,10 @@ export interface ProgramsApiProgramsListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly offered_by?: ProgramsListOfferedByEnum
+  readonly offered_by?: Array<ProgramsListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -15178,10 +15100,10 @@ export interface ProgramsApiProgramsListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly platform?: ProgramsListPlatformEnum
+  readonly platform?: Array<ProgramsListPlatformEnum>
 
   /**
    *
@@ -15192,10 +15114,10 @@ export interface ProgramsApiProgramsListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly resource_type?: ProgramsListResourceTypeEnum
+  readonly resource_type?: Array<ProgramsListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -15205,11 +15127,11 @@ export interface ProgramsApiProgramsListRequest {
   readonly sortby?: ProgramsListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -15219,25 +15141,25 @@ export interface ProgramsApiProgramsListRequest {
  */
 export interface ProgramsApiProgramsNewListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly department?: ProgramsNewListDepartmentEnum
+  readonly department?: Array<ProgramsNewListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly level?: ProgramsNewListLevelEnum
+  readonly level?: Array<ProgramsNewListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -15248,10 +15170,10 @@ export interface ProgramsApiProgramsNewListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly offered_by?: ProgramsNewListOfferedByEnum
+  readonly offered_by?: Array<ProgramsNewListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -15262,10 +15184,10 @@ export interface ProgramsApiProgramsNewListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly platform?: ProgramsNewListPlatformEnum
+  readonly platform?: Array<ProgramsNewListPlatformEnum>
 
   /**
    *
@@ -15276,10 +15198,10 @@ export interface ProgramsApiProgramsNewListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly resource_type?: ProgramsNewListResourceTypeEnum
+  readonly resource_type?: Array<ProgramsNewListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -15289,11 +15211,11 @@ export interface ProgramsApiProgramsNewListRequest {
   readonly sortby?: ProgramsNewListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsNewList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**
@@ -15317,25 +15239,25 @@ export interface ProgramsApiProgramsRetrieveRequest {
  */
 export interface ProgramsApiProgramsUpcomingListRequest {
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly course_feature?: string
+  readonly course_feature?: Array<string>
 
   /**
    * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'}
+   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'RES' | 'STS' | 'WGS'>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly department?: ProgramsUpcomingListDepartmentEnum
+  readonly department?: Array<ProgramsUpcomingListDepartmentEnum>
 
   /**
    * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'}
+   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly level?: ProgramsUpcomingListLevelEnum
+  readonly level?: Array<ProgramsUpcomingListLevelEnum>
 
   /**
    * Number of results to return per page.
@@ -15346,10 +15268,10 @@ export interface ProgramsApiProgramsUpcomingListRequest {
 
   /**
    * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - OCW * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'mitpe' | 'mitx' | 'ocw' | 'scc' | 'see' | 'xpro'>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly offered_by?: ProgramsUpcomingListOfferedByEnum
+  readonly offered_by?: Array<ProgramsUpcomingListOfferedByEnum>
 
   /**
    * The initial index from which to return the results.
@@ -15360,10 +15282,10 @@ export interface ProgramsApiProgramsUpcomingListRequest {
 
   /**
    * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast
-   * @type {'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'}
+   * @type {Array<'bootcamps' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro'>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly platform?: ProgramsUpcomingListPlatformEnum
+  readonly platform?: Array<ProgramsUpcomingListPlatformEnum>
 
   /**
    *
@@ -15374,10 +15296,10 @@ export interface ProgramsApiProgramsUpcomingListRequest {
 
   /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode
-   * @type {'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'}
+   * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program'>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly resource_type?: ProgramsUpcomingListResourceTypeEnum
+  readonly resource_type?: Array<ProgramsUpcomingListResourceTypeEnum>
 
   /**
    * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;created_on&#x60; - Creation Date ascending * &#x60;-created_on&#x60; - CreationDate descending * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending
@@ -15387,11 +15309,11 @@ export interface ProgramsApiProgramsUpcomingListRequest {
   readonly sortby?: ProgramsUpcomingListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
-   * @type {string}
+   * Multiple values may be separated by commas.
+   * @type {Array<string>}
    * @memberof ProgramsApiProgramsUpcomingList
    */
-  readonly topic?: string
+  readonly topic?: Array<string>
 }
 
 /**

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -30,7 +30,7 @@ def multi_or_filter(
 ) -> QuerySet:
     """Filter attribute by value string with n comma-delimited values"""
     query_or_filters = Q()
-    for query in [Q(**{f"{attribute}": value}) for value in values]:
+    for query in [Q(**{attribute: value}) for value in values]:
         query_or_filters |= query
     return queryset.filter(query_or_filters)
 

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -1,7 +1,16 @@
 """Filters for learning_resources API"""
 import logging
 
-from django_filters import CharFilter, ChoiceFilter, FilterSet, NumberFilter
+from django.db.models import Q, QuerySet
+from django_filters import (
+    BaseInFilter,
+    CharFilter,
+    ChoiceFilter,
+    FilterSet,
+    MultipleChoiceFilter,
+    NumberFilter,
+)
+from django_filters.rest_framework import DjangoFilterBackend
 
 from learning_resources.constants import (
     DEPARTMENTS,
@@ -16,56 +25,110 @@ from learning_resources.models import ContentFile, LearningResource
 log = logging.getLogger(__name__)
 
 
+def multi_or_filter(
+    queryset: QuerySet, attribute: str, values: list[str or list]
+) -> QuerySet:
+    """Filter attribute by value string with n comma-delimited values"""
+    query_or_filters = Q()
+    for query in [Q(**{f"{attribute}": value}) for value in values]:
+        query_or_filters |= query
+    return queryset.filter(query_or_filters)
+
+
+class CharInFilter(BaseInFilter, CharFilter):
+    """Filter that allows for multiple character values"""
+
+
+class NumberInFilter(BaseInFilter, NumberFilter):
+    """Filter that allows for multiple numeric values"""
+
+
+class MultipleOptionsFilterBackend(DjangoFilterBackend):
+    """
+    Custom filter backend that handles multiple values for the same key
+    in various formats
+    """
+
+    def get_filterset_kwargs(self, request, queryset, view):  # noqa: ARG002
+        """
+        Adjust the query parameters to handle multiple values for the same key,
+        regardless of whether they are in the form 'key=x&key=y' or 'key=x,y'
+        """
+        query_params = request.query_params.copy()
+        for key in query_params:
+            filter_key = request.parser_context[
+                "view"
+            ].filterset_class.base_filters.get(key)
+            if filter_key:
+                values = query_params.getlist(key)
+                if isinstance(filter_key, MultipleChoiceFilter):
+                    split_values = [
+                        value.split(",") for value in query_params.getlist(key)
+                    ]
+                    values = [value for val_list in split_values for value in val_list]
+                    query_params.setlist(key, values)
+                elif (isinstance(filter_key, CharInFilter | NumberInFilter)) and len(
+                    values
+                ) > 1:
+                    query_params[key] = ",".join(list(values))
+
+        return {
+            "data": query_params,
+            "queryset": queryset,
+            "request": request,
+        }
+
+
 class LearningResourceFilter(FilterSet):
     """LearningResource filter"""
 
-    department = ChoiceFilter(
+    department = MultipleChoiceFilter(
         label="The department that offers learning resources",
-        method="filter_department",
         field_name="departments__department_id",
         choices=(list(DEPARTMENTS.items())),
     )
 
-    resource_type = ChoiceFilter(
+    resource_type = MultipleChoiceFilter(
         label="The type of learning resource",
-        method="filter_resource_type",
         choices=(
             [
                 (resource_type.name, resource_type.value)
                 for resource_type in LearningResourceType
             ]
         ),
+        field_name="resource_type",
+        lookup_expr="iexact",
     )
-    offered_by = ChoiceFilter(
+    offered_by = MultipleChoiceFilter(
         label="The organization that offers a learning resource",
-        method="filter_offered_by",
         choices=([(offeror.name, offeror.value) for offeror in OfferedBy]),
+        field_name="offered_by",
+        lookup_expr="exact",
     )
 
-    platform = ChoiceFilter(
+    platform = MultipleChoiceFilter(
         label="The platform on which learning resources are offered",
-        method="filter_platform",
         choices=([(platform.name, platform.value) for platform in PlatformType]),
+        field_name="platform",
+        lookup_expr="exact",
     )
 
-    level = ChoiceFilter(
+    level = MultipleChoiceFilter(
         label="The academic level of the resources",
         method="filter_level",
         choices=([(level.name, level.value) for level in LevelType]),
     )
 
-    topic = CharFilter(
+    topic = CharInFilter(
         label="Topics covered by the resources. Load the '/api/v1/topics' endpoint "
         "for a list of topics",
-        field_name="topics__name",
-        lookup_expr="iexact",
+        method="filter_topic",
     )
 
-    course_feature = CharFilter(
+    course_feature = CharInFilter(
         label="Content feature for the resources. Load the 'api/v1/course_features' "
         "endpoint for a list of course features",
-        field_name="content_tags__name",
-        lookup_expr="iexact",
+        method="filter_course_feature",
     )
 
     sortby = ChoiceFilter(
@@ -79,25 +142,18 @@ class LearningResourceFilter(FilterSet):
         ),
     )
 
-    def filter_resource_type(self, queryset, _, value):
-        """resource_type Filter for learning resources"""
-        return queryset.filter(resource_type=value)
-
-    def filter_offered_by(self, queryset, _, value):
-        """OfferedBy Filter for learning resources"""
-        return queryset.filter(offered_by__code=value)
-
-    def filter_platform(self, queryset, _, value):
-        """Platform Filter for learning resources"""
-        return queryset.filter(platform__code=value)
-
-    def filter_department(self, queryset, _, value):
-        """Department ID Filter for learning resources"""
-        return queryset.filter(departments__department_id=value)
-
     def filter_level(self, queryset, _, value):
         """Level Filter for learning resources"""
-        return queryset.filter(runs__level__contains=[LevelType[value].value])
+        values = [[LevelType[val].value] for val in value]
+        return multi_or_filter(queryset, "runs__level__contains", values)
+
+    def filter_topic(self, queryset, _, value):
+        """Topic Filter for learning resources"""
+        return multi_or_filter(queryset, "topics__name__iexact", value)
+
+    def filter_course_feature(self, queryset, _, value):
+        """Topic Filter for learning resources"""
+        return multi_or_filter(queryset, "content_tags__name__iexact", value)
 
     def filter_sortby(self, queryset, _, value):
         """Sort the queryset in the order specified by the value"""
@@ -111,63 +167,57 @@ class LearningResourceFilter(FilterSet):
 class ContentFileFilter(FilterSet):
     """ContentFile filter"""
 
-    run_id = NumberFilter(
+    run_id = NumberInFilter(
         label="The id of the learning resource run the content file belongs to",
-        field_name="run_id",
-        lookup_expr="exact",
+        method="filter_run_id",
     )
 
-    learning_resource_id = NumberFilter(
+    resource_id = NumberInFilter(
         label="The id of the learning resource the content file belongs to",
-        field_name="run__learning_resource_id",
-        lookup_expr="exact",
+        method="filter_resource_id",
     )
 
-    content_feature_type = CharFilter(
+    content_feature_type = CharInFilter(
         label="Content feature type for the content file. Load the "
         "'api/v1/course_features' endpoint for a list of course features",
-        field_name="content_tags__name",
-        lookup_expr="iexact",
+        method="filter_content_feature_type",
     )
 
-    offered_by = ChoiceFilter(
+    offered_by = MultipleChoiceFilter(
         label="The organization that offers a learning resource the content file "
         "belongs to",
-        method="filter_offered_by",
+        field_name="run__learning_resource__offered_by",
+        lookup_expr="exact",
         choices=([(offeror.name, offeror.value) for offeror in OfferedBy]),
     )
 
-    platform = ChoiceFilter(
+    platform = MultipleChoiceFilter(
         label="The platform on which learning resources the content file belongs "
         "to is offered",
-        method="filter_platform",
+        field_name="run__learning_resource__platform",
+        lookup_expr="exact",
         choices=([(platform.name, platform.value) for platform in PlatformType]),
     )
 
-    run_readable_id = CharFilter(
-        label="The readable id of the learning resource run the content file "
-        "belongs to",
-        field_name="run__run_id",
-        lookup_expr="exact",
-    )
+    def filter_run_id(self, queryset, _, value):
+        """Run ID Filter for contentfiles"""
+        return multi_or_filter(queryset, "run_id", value)
 
-    learning_resource_readable_id = CharFilter(
-        label="The readable id of the learning resource the content file belongs to",
-        field_name="run__learning_resource__readable_id",
-        lookup_expr="exact",
-    )
+    def filter_resource_id(self, queryset, _, value):
+        """Resource ID Filter for contentfiles"""
+        return multi_or_filter(queryset, "run__learning_resource__id", value)
 
-    def filter_offered_by(self, queryset, _, value):
-        """OfferedBy Filter for content files"""
-        return queryset.filter(run__learning_resource__offered_by__code=value)
+    def filter_run_readable_id(self, queryset, _, value):
+        """Run Readable ID Filter for contentfiles"""
+        return multi_or_filter(queryset, "run__run_id", value)
 
-    def filter_platform(self, queryset, _, value):
-        """Platform Filter for content files"""
-        return queryset.filter(run__learning_resource__platform__code=value)
+    def filter_resource_readable_id(self, queryset, _, value):
+        """Resource Readable ID Filter for contentfiles"""
+        return multi_or_filter(queryset, "run__learning_resource__readable_id", value)
 
-    def filter_learning_resource_types(self, queryset, _, value):
-        """Level Filter for learning resources"""
-        return queryset.filter(learning_resource_types__contains=[value])
+    def filter_content_feature_type(self, queryset, _, value):
+        """Content feature type filter for contentfiles"""
+        return multi_or_filter(queryset, "content_tags__name__iexact", value)
 
     class Meta:
         model = ContentFile

--- a/learning_resources/filters_test.py
+++ b/learning_resources/filters_test.py
@@ -7,22 +7,27 @@ import pytest
 from learning_resources.constants import (
     LEARNING_RESOURCE_SORTBY_OPTIONS,
     LearningResourceType,
-    LevelType,
     OfferedBy,
     PlatformType,
 )
 from learning_resources.factories import (
     ContentFileFactory,
     CourseFactory,
+    LearningPathFactory,
     LearningResourceContentTagFactory,
     LearningResourceFactory,
+    LearningResourceOfferorFactory,
+    LearningResourcePlatformFactory,
     LearningResourceRunFactory,
     PodcastFactory,
+    ProgramFactory,
 )
-from learning_resources.filters import ContentFileFilter, LearningResourceFilter
-from learning_resources.models import LearningResourceRun
+from learning_resources.models import ContentFile, LearningResourceRun
 
 pytestmark = pytest.mark.django_db
+
+RESOURCE_API_URL = "/api/v1/learning_resources/"
+CONTENT_API_URL = "/api/v1/contentfiles/"
 
 
 @pytest.fixture()
@@ -40,43 +45,109 @@ def mock_courses():
         offered_by=OfferedBy.mitx.name,
     ).learning_resource
 
+    mitpe_course = CourseFactory.create(
+        platform=PlatformType.mitpe.name,
+        department="9",
+        offered_by=OfferedBy.mitpe.name,
+    ).learning_resource
+
     return SimpleNamespace(
-        ocw_course=ocw_course,
-        mitx_course=mitx_course,
+        ocw_course=ocw_course, mitx_course=mitx_course, mitpe_course=mitpe_course
     )
 
 
-def test_learning_resource_filter_department(mock_courses):
+@pytest.fixture()
+def mock_content_files():
+    content_files = []
+    for platform, offeror in [
+        [PlatformType.ocw.name, OfferedBy.ocw.name],
+        [PlatformType.xpro.name, OfferedBy.xpro.name],
+        [PlatformType.mitxonline.name, OfferedBy.mitx.name],
+    ]:
+        content_files.append(
+            ContentFileFactory.create(
+                run=LearningResourceRunFactory.create(
+                    learning_resource=LearningResourceFactory.create(
+                        platform=LearningResourcePlatformFactory.create(code=platform),
+                        offered_by=LearningResourceOfferorFactory.create(code=offeror),
+                    )
+                )
+            ),
+        )
+    ContentFile.objects.exclude(id__in=[cf.id for cf in content_files[:2]]).delete()
+    return content_files
+
+
+@pytest.mark.parametrize(
+    "multifilter", ["department={}&department={}", "department={},{}"]
+)
+def test_learning_resource_filter_department(mock_courses, client, multifilter):
     """Test that the department_id filter works"""
-    ocw_department_id = mock_courses.ocw_course.departments.first().department_id
+    ocw_department = mock_courses.ocw_course.departments.first()
+    mitx_department = mock_courses.mitx_course.departments.first()
 
-    query = LearningResourceFilter({"department": ocw_department_id}).qs
-    assert query.count() == 1
+    results = client.get(
+        f"{RESOURCE_API_URL}?department={ocw_department.department_id}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
 
-    assert mock_courses.ocw_course in query
-    assert mock_courses.mitx_course not in query
+    dept_filter = multifilter.format(
+        ocw_department.department_id, mitx_department.department_id
+    )
+    results = client.get(f"{RESOURCE_API_URL}?{dept_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [mock_courses.ocw_course.readable_id, mock_courses.mitx_course.readable_id]
+    )
 
 
-def test_learning_resource_filter_offered_by(mock_courses):
+@pytest.mark.parametrize(
+    "multifilter", ["offered_by={}&offered_by={}", "offered_by={},{}"]
+)
+def test_learning_resource_filter_offered_by(mock_courses, client, multifilter):
     """Test that the offered_by filter works"""
 
-    query = LearningResourceFilter({"offered_by": OfferedBy.ocw.name}).qs
+    ocw_offeror = mock_courses.ocw_course.offered_by
+    mitx_offeror = mock_courses.mitx_course.offered_by
 
-    assert mock_courses.ocw_course in query
-    assert mock_courses.mitx_course not in query
+    results = client.get(f"{RESOURCE_API_URL}?offered_by={ocw_offeror.code}").json()[
+        "results"
+    ]
+    assert len(results) == 1
+    assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
+
+    offered_filter = multifilter.format(ocw_offeror.code, mitx_offeror.code)
+    results = client.get(f"{RESOURCE_API_URL}?{offered_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [mock_courses.ocw_course.readable_id, mock_courses.mitx_course.readable_id]
+    )
 
 
-def test_learning_resource_filter_platform(mock_courses):
+@pytest.mark.parametrize("multifilter", ["platform={}&platform={}", "platform={},{}"])
+def test_learning_resource_filter_platform(mock_courses, client, multifilter):
     """Test that the platform filter works"""
 
-    query = LearningResourceFilter({"platform": PlatformType.ocw.name}).qs
+    ocw_platform = mock_courses.ocw_course.platform
+    mitx_platform = mock_courses.mitx_course.platform
 
-    assert mock_courses.ocw_course in query
-    assert mock_courses.mitx_course not in query
+    results = client.get(f"{RESOURCE_API_URL}?platform={ocw_platform.code}").json()[
+        "results"
+    ]
+    assert len(results) == 1
+    assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
+
+    platform_filter = multifilter.format(ocw_platform.code, mitx_platform.code)
+    results = client.get(f"{RESOURCE_API_URL}?{platform_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [mock_courses.ocw_course.readable_id, mock_courses.mitx_course.readable_id]
+    )
 
 
 @pytest.mark.parametrize("is_professional", [True, False])
-def test_learning_resource_filter_professional(is_professional):
+def test_learning_resource_filter_professional(is_professional, client):
     """Test that the professional filter works"""
 
     professional_course = CourseFactory.create(
@@ -86,44 +157,52 @@ def test_learning_resource_filter_professional(is_professional):
         platform=PlatformType.xpro.name
     ).learning_resource
 
-    assert professional_course.professional is True
-    assert open_course.professional is False
+    results = client.get(f"{RESOURCE_API_URL}?professional={is_professional}").json()[
+        "results"
+    ]
+    assert len(results) == 1
+    assert results[0]["id"] == (
+        professional_course.id if is_professional else open_course.id
+    )
 
-    query = LearningResourceFilter({"professional": is_professional}).qs
 
-    assert (professional_course in query) is is_professional
-    assert (open_course in query) is not is_professional
-
-
-def test_learning_resource_filter_resource_type():
+@pytest.mark.parametrize(
+    "multifilter", ["resource_type={}&resource_type={}", "resource_type={},{}"]
+)
+def test_learning_resource_filter_resource_type(client, multifilter):
     """Test that the resource type filter works"""
-
-    course = CourseFactory.create().learning_resource
+    ProgramFactory.create()
     podcast = PodcastFactory.create().learning_resource
+    learning_path = LearningPathFactory.create().learning_resource
 
-    query = LearningResourceFilter(
-        {"resource_type": LearningResourceType.podcast.name}
-    ).qs
+    results = client.get(
+        f"{RESOURCE_API_URL}?resource_type={LearningResourceType.podcast.name}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == podcast.id
 
-    assert podcast in query
-    assert course not in query
+    resource_filter = multifilter.format(
+        LearningResourceType.podcast.name, LearningResourceType.learning_path.name
+    )
+    results = client.get(f"{RESOURCE_API_URL}?{resource_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [podcast.readable_id, learning_path.readable_id]
+    )
 
 
 @pytest.mark.parametrize("sortby", ["created_on", "readable_id", "id"])
 @pytest.mark.parametrize("descending", [True, False])
-def test_learning_resource_sortby(sortby, descending):
+def test_learning_resource_sortby(client, sortby, descending):
     """Test that the query is sorted in the correct order"""
     resources = [course.learning_resource for course in CourseFactory.create_batch(3)]
     sortby_param = sortby
     if descending:
         sortby_param = f"-{sortby}"
-    query = LearningResourceFilter(
-        {
-            "resource_type": LearningResourceType.course.name,
-            "sortby": sortby_param,
-        }
-    ).qs
-    assert list(query.values_list("id", flat=True)) == sorted(
+
+    results = client.get(f"{RESOURCE_API_URL}?sortby={sortby_param}").json()["results"]
+
+    assert [result["id"] for result in results] == sorted(
         [
             resource.id
             for resource in sorted(
@@ -137,26 +216,38 @@ def test_learning_resource_sortby(sortby, descending):
     )
 
 
-def test_learning_resource_filter_topics():
+@pytest.mark.parametrize("multifilter", ["topic={}&topic={}", "topic={},{}"])
+def test_learning_resource_filter_topics(mock_courses, client, multifilter):
     """Test that the topic filter works"""
-    resource_1, resource_2 = (
-        course.learning_resource for course in CourseFactory.create_batch(2)
-    )
     assert (
         list(
-            set(resource_1.topics.all().values_list("name", flat=True))
-            & set(resource_2.topics.all().values_list("name", flat=True))
+            set(mock_courses.ocw_course.topics.all().values_list("name", flat=True))
+            & set(mock_courses.mitx_course.topics.all().values_list("name", flat=True))
         )
         == []
     )
 
-    query = LearningResourceFilter({"topic": resource_1.topics.first().name.upper()}).qs
+    results = client.get(
+        f"{RESOURCE_API_URL}?topic={mock_courses.mitx_course.topics.first().name.lower()}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == mock_courses.mitx_course.id
 
-    assert resource_1 in query
-    assert resource_2 not in query
+    topic_filter = multifilter.format(
+        mock_courses.mitx_course.topics.first().name.lower(),
+        mock_courses.ocw_course.topics.first().name.upper(),
+    )
+    results = client.get(f"{RESOURCE_API_URL}?{topic_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [mock_courses.mitx_course.readable_id, mock_courses.ocw_course.readable_id]
+    )
 
 
-def test_learning_resource_filter_features():
+@pytest.mark.parametrize(
+    "multifilter", ["course_feature={}&course_feature={}", "course_feature={},{}"]
+)
+def test_learning_resource_filter_course_features(client, multifilter):
     """Test that the resource_content_tag filter works"""
 
     resource_with_exams = LearningResourceFactory.create(
@@ -167,135 +258,173 @@ def test_learning_resource_filter_features():
             1, name="Lecture Notes"
         )
     )
+    LearningResourceFactory.create(
+        content_tags=LearningResourceContentTagFactory.create_batch(1, name="Other")
+    )
 
-    query = LearningResourceFilter({"course_feature": "ExamS"}).qs
+    results = client.get(f"{RESOURCE_API_URL}?course_feature=exams").json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == resource_with_exams.id
 
-    assert resource_with_exams in query
-    assert resource_with_notes not in query
+    feature_filter = multifilter.format("EXAMS", "lEcture nOtes")
+    results = client.get(f"{RESOURCE_API_URL}?{feature_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["readable_id"] for result in results]) == sorted(
+        [resource_with_exams.readable_id, resource_with_notes.readable_id]
+    )
 
 
-def test_learning_resource_filter_level():
+@pytest.mark.parametrize(
+    "multifilter",
+    [
+        "level=high_school&level=graduate",
+        "level=high_school,graduate",
+        "level=high_school,graduate&level=graduate",
+    ],
+)
+def test_learning_resource_filter_level(client, multifilter):
     """Test that the level filter works"""
 
     hs_run = LearningResourceRunFactory.create(level=["High School", "Undergraduate"])
     grad_run = LearningResourceRunFactory.create(level=["Undergraduate", "Graduate"])
-    hs_resource = hs_run.learning_resource
-    grad_resource = grad_run.learning_resource
+    other_run = LearningResourceRunFactory.create(level=["Other"])
 
-    LearningResourceRun.objects.exclude(id__in=[hs_run.id, grad_run.id]).delete()
+    LearningResourceRun.objects.exclude(
+        id__in=[hs_run.id, grad_run.id, other_run.id]
+    ).delete()
 
-    query = LearningResourceFilter({"level": LevelType.high_school.name}).qs
+    results = client.get(f"{RESOURCE_API_URL}?level=high_school").json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == hs_run.learning_resource.id
 
-    assert hs_resource in query
-    assert grad_resource not in query
+    results = client.get(f"{RESOURCE_API_URL}?level=graduate").json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == grad_run.learning_resource.id
 
-    query = LearningResourceFilter({"level": LevelType.graduate.name}).qs
-
-    assert hs_resource not in query
-    assert grad_resource in query
-
-
-def test_content_file_filter_run_id():
-    """Test that the run_id type filter works"""
-
-    content_file1 = ContentFileFactory.create()
-    content_file2 = ContentFileFactory.create()
-
-    query = ContentFileFilter({"run_id": content_file1.run_id}).qs
-
-    assert content_file1 in query
-    assert content_file2 not in query
+    results = client.get(f"{RESOURCE_API_URL}?{multifilter}").json()["results"]
+    assert len(results) == 2
 
 
-def test_content_file_filter_learning_resource_id():
-    """Test that the learning_resource_id type filter works"""
+@pytest.mark.parametrize("multifilter", ["run_id={}&run_id={}", "run_id={},{}"])
+def test_content_file_filter_run_id(mock_content_files, client, multifilter):
+    """Test that the run_id filter works for contentfiles"""
 
-    content_file1 = ContentFileFactory.create()
-    content_file2 = ContentFileFactory.create()
+    results = client.get(
+        f"{CONTENT_API_URL}?run_id={mock_content_files[1].run.id}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == mock_content_files[1].id
 
-    query = ContentFileFilter(
-        {"learning_resource_id": content_file1.run.learning_resource_id}
-    ).qs
+    feature_filter = multifilter.format(
+        mock_content_files[0].run.id, mock_content_files[1].run.id
+    )
+    results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["run_id"] for result in results]) == sorted(
+        [mock_content_files[0].run.id, mock_content_files[1].run.id]
+    )
 
-    assert content_file1 in query
-    assert content_file2 not in query
+
+@pytest.mark.parametrize(
+    "multifilter", ["resource_id={}&resource_id={}", "resource_id={},{}"]
+)
+def test_content_file_filter_resource_id(mock_content_files, client, multifilter):
+    """Test that the resource_id filter works for contentfiles"""
+
+    results = client.get(
+        f"{CONTENT_API_URL}?resource_id={mock_content_files[1].run.learning_resource.id}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert (
+        int(results[0]["resource_id"]) == mock_content_files[1].run.learning_resource.id
+    )
+
+    feature_filter = multifilter.format(
+        mock_content_files[0].run.learning_resource.id,
+        mock_content_files[1].run.learning_resource.id,
+    )
+    results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([int(result["resource_id"]) for result in results]) == sorted(
+        [
+            mock_content_files[0].run.learning_resource.id,
+            mock_content_files[1].run.learning_resource.id,
+        ]
+    )
 
 
-def test_content_file_filter_content_feature_type():
-    """Test that the content_feature_type type filter works"""
+@pytest.mark.parametrize("multifilter", ["platform={}&platform={}", "platform={},{}"])
+def test_content_file_filter_platform(mock_content_files, client, multifilter):
+    """Test that the platform filter works"""
 
-    resource_with_exams = ContentFileFactory.create(
+    results = client.get(
+        f"{CONTENT_API_URL}?platform={mock_content_files[1].run.learning_resource.platform.code}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == mock_content_files[1].id
+
+    platform_filter = multifilter.format(
+        mock_content_files[1].run.learning_resource.platform.code,
+        mock_content_files[0].run.learning_resource.platform.code,
+    )
+    results = client.get(f"{CONTENT_API_URL}?{platform_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["id"] for result in results]) == sorted(
+        [cf.id for cf in mock_content_files[:2]]
+    )
+
+
+@pytest.mark.parametrize(
+    "multifilter", ["offered_by={}&offered_by={}", "offered_by={},{}"]
+)
+def test_content_file_filter_offered_by(mock_content_files, client, multifilter):
+    """Test that the offered_by filter works for contentfiles"""
+
+    results = client.get(
+        f"{CONTENT_API_URL}?offered_by={mock_content_files[1].run.learning_resource.offered_by.code}"
+    ).json()["results"]
+    assert len(results) == 1
+    assert results[0]["id"] == mock_content_files[1].id
+
+    offered_filter = multifilter.format(
+        mock_content_files[1].run.learning_resource.offered_by.code,
+        mock_content_files[0].run.learning_resource.offered_by.code,
+    )
+    results = client.get(f"{CONTENT_API_URL}?{offered_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["id"] for result in results]) == sorted(
+        [cf.id for cf in mock_content_files[:2]]
+    )
+
+
+@pytest.mark.parametrize(
+    "multifilter",
+    ["content_feature_type={}&content_feature_type={}", "content_feature_type={},{}"],
+)
+def test_learning_resource_filter_content_feature_type(client, multifilter):
+    """Test that the resource_content_tag filter works"""
+
+    cf_with_exams = ContentFileFactory.create(
         content_tags=LearningResourceContentTagFactory.create_batch(1, name="Exams")
     )
-    resource_with_notes = ContentFileFactory.create(
+    cf_with_notes = ContentFileFactory.create(
         content_tags=LearningResourceContentTagFactory.create_batch(
             1, name="Lecture Notes"
         )
     )
+    ContentFileFactory.create(
+        content_tags=LearningResourceContentTagFactory.create_batch(1, name="Other")
+    )
 
-    query = ContentFileFilter({"content_feature_type": "ExamS"}).qs
+    results = client.get(f"{CONTENT_API_URL}?content_feature_type=exams").json()[
+        "results"
+    ]
+    assert len(results) == 1
+    assert results[0]["id"] == cf_with_exams.id
 
-    assert resource_with_exams in query
-    assert resource_with_notes not in query
-
-
-def test_content_file_filter_offered_by():
-    """Test that the offered_by filter works"""
-
-    ocw_resource = CourseFactory.create(offered_by=OfferedBy.ocw.name).learning_resource
-    mitx_resource = CourseFactory.create(
-        offered_by=OfferedBy.mitx.name
-    ).learning_resource
-
-    ocw_content_file = ContentFileFactory.create(run=ocw_resource.runs.first())
-    mitx_content_file = ContentFileFactory.create(run=mitx_resource.runs.first())
-    query = ContentFileFilter({"offered_by": OfferedBy.ocw.name}).qs
-
-    assert ocw_content_file in query
-    assert mitx_content_file not in query
-
-
-def test_content_file_filter_platform():
-    """Test that the offered_by filter works"""
-
-    ocw_resource = CourseFactory.create(
-        platform=PlatformType.ocw.name
-    ).learning_resource
-    mitx_resource = CourseFactory.create(
-        platform=PlatformType.mitxonline.name
-    ).learning_resource
-
-    ocw_content_file = ContentFileFactory.create(run=ocw_resource.runs.first())
-    mitx_content_file = ContentFileFactory.create(run=mitx_resource.runs.first())
-    query = ContentFileFilter({"platform": OfferedBy.ocw.name}).qs
-
-    assert ocw_content_file in query
-    assert mitx_content_file not in query
-
-
-def test_content_file_filter_run_readable_id():
-    """Test that the run_readable_id type filter works"""
-
-    content_file1 = ContentFileFactory.create()
-    content_file2 = ContentFileFactory.create()
-
-    query = ContentFileFilter({"run_readable_id": content_file1.run.run_id}).qs
-
-    assert content_file1 in query
-    assert content_file2 not in query
-
-
-def test_content_file_filter_learning_resource_readable_id():
-    """Test that the learning_resource_readable_id type filter works"""
-
-    content_file1 = ContentFileFactory.create()
-    content_file2 = ContentFileFactory.create()
-
-    query = ContentFileFilter(
-        {
-            "learning_resource_readable_id": content_file1.run.learning_resource.readable_id
-        }
-    ).qs
-
-    assert content_file1 in query
-    assert content_file2 not in query
+    feature_filter = multifilter.format("EXAMS", "lEcture nOtes")
+    results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["id"] for result in results]) == sorted(
+        [cf_with_exams.id, cf_with_notes.id]
+    )

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -11,7 +11,6 @@ from django.http import HttpResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
-from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from rest_framework import views, viewsets
@@ -32,7 +31,11 @@ from learning_resources.constants import (
 )
 from learning_resources.etl.podcast import generate_aggregate_podcast_rss
 from learning_resources.exceptions import WebhookException
-from learning_resources.filters import ContentFileFilter, LearningResourceFilter
+from learning_resources.filters import (
+    ContentFileFilter,
+    LearningResourceFilter,
+    MultipleOptionsFilterBackend,
+)
 from learning_resources.models import (
     ContentFile,
     LearningResource,
@@ -117,7 +120,7 @@ class BaseLearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
 
     permission_classes = (AnonymousAccessReadonlyPermission,)
     pagination_class = DefaultPagination
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [MultipleOptionsFilterBackend]
     filterset_class = LearningResourceFilter
     lookup_field = "id"
 
@@ -524,7 +527,7 @@ class ContentFileViewSet(viewsets.ReadOnlyModelViewSet):
         .order_by("-created_on")
     )
     pagination_class = DefaultPagination
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [MultipleOptionsFilterBackend]
     filterset_class = ContentFileFilter
 
 

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -110,12 +110,12 @@ def test_get_course_content_files_filtered(client, url):
     ContentFileFactory.create_batch(3, run=course.learning_resource.runs.last())
 
     resp = client.get(
-        f"{reverse(url, args=[course.learning_resource.id])}?run_readable_id={course.learning_resource.runs.first().run_id}"
+        f"{reverse(url, args=[course.learning_resource.id])}?run_id={course.learning_resource.runs.first().id}"
     )
     assert resp.data.get("count") == 2
 
     resp = client.get(
-        f"{reverse(url, args=[course.learning_resource.id])}?run_readable_id={course.learning_resource.runs.last().run_id}"
+        f"{reverse(url, args=[course.learning_resource.id])}?run_id={course.learning_resource.runs.last().id}"
     )
     assert resp.data.get("count") == 3
 
@@ -270,12 +270,10 @@ def test_list_content_files_list_filtered(client):
     )
     assert resp.data.get("count") == 2
     resp = client.get(
-        f"{reverse('lr:v1:contentfiles_api-list')}?learning_resource_id={course_2.learning_resource.id}"
+        f"{reverse('lr:v1:contentfiles_api-list')}?resource_id={course_2.learning_resource.id}"
     )
     assert resp.data.get("count") == 3
-    resp = client.get(
-        f"{reverse('lr:v1:contentfiles_api-list')}?learning_resource_id=1001001"
-    )
+    resp = client.get(f"{reverse('lr:v1:contentfiles_api-list')}?resource_id=1001001")
     assert resp.data.get("count") == 0
 
 

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -318,26 +318,18 @@ paths:
       - in: query
         name: content_feature_type
         schema:
-          type: string
-        description: Content feature type for the content file. Load the 'api/v1/course_features'
-          endpoint for a list of course features
-      - in: query
-        name: learning_resource_id
-        schema:
-          type: number
-        description: The id of the learning resource the content file belongs to
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: path
         name: learning_resource_id
         schema:
           type: integer
         description: id of the parent learning resource
         required: true
-      - in: query
-        name: learning_resource_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource the content file belongs
-          to
       - name: limit
         required: false
         in: query
@@ -347,17 +339,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource the content file belongs to
 
@@ -370,6 +364,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -379,25 +375,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources the content file belongs to is offered
 
@@ -418,18 +416,26 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
+      - in: query
+        name: resource_id
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: run_id
         schema:
-          type: number
-        description: The id of the learning resource run the content file belongs
-          to
-      - in: query
-        name: run_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource run the content file
-          belongs to
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - contentfiles
       responses:
@@ -522,51 +528,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -607,18 +618,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -629,6 +644,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -638,17 +655,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -661,6 +680,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -670,25 +691,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -709,6 +732,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -716,13 +741,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -731,6 +758,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -766,9 +795,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - courses
       responses:
@@ -808,26 +840,18 @@ paths:
       - in: query
         name: content_feature_type
         schema:
-          type: string
-        description: Content feature type for the content file. Load the 'api/v1/course_features'
-          endpoint for a list of course features
-      - in: query
-        name: learning_resource_id
-        schema:
-          type: number
-        description: The id of the learning resource the content file belongs to
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: path
         name: learning_resource_id
         schema:
           type: integer
         description: id of the parent learning resource
         required: true
-      - in: query
-        name: learning_resource_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource the content file belongs
-          to
       - name: limit
         required: false
         in: query
@@ -837,17 +861,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource the content file belongs to
 
@@ -860,6 +886,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -869,25 +897,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources the content file belongs to is offered
 
@@ -908,18 +938,26 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
+      - in: query
+        name: resource_id
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: run_id
         schema:
-          type: number
-        description: The id of the learning resource run the content file belongs
-          to
-      - in: query
-        name: run_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource run the content file
-          belongs to
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - courses
       responses:
@@ -965,51 +1003,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -1050,18 +1093,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -1072,6 +1119,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -1081,17 +1130,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -1104,6 +1155,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -1113,25 +1166,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -1152,6 +1207,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -1159,13 +1216,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -1174,6 +1233,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -1209,9 +1270,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - courses
       responses:
@@ -1230,51 +1294,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -1315,18 +1384,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -1337,6 +1410,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -1346,17 +1421,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -1369,6 +1446,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -1378,25 +1457,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -1417,6 +1498,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -1424,13 +1507,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -1439,6 +1524,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -1474,9 +1561,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - courses
       responses:
@@ -1543,51 +1633,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -1628,18 +1723,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -1650,6 +1749,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -1659,17 +1760,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -1682,6 +1785,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -1691,25 +1796,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -1730,6 +1837,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -1737,13 +1846,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -1752,6 +1863,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -1787,9 +1900,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - learning_resources
       responses:
@@ -1829,26 +1945,18 @@ paths:
       - in: query
         name: content_feature_type
         schema:
-          type: string
-        description: Content feature type for the content file. Load the 'api/v1/course_features'
-          endpoint for a list of course features
-      - in: query
-        name: learning_resource_id
-        schema:
-          type: number
-        description: The id of the learning resource the content file belongs to
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: path
         name: learning_resource_id
         schema:
           type: integer
         description: id of the parent learning resource
         required: true
-      - in: query
-        name: learning_resource_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource the content file belongs
-          to
       - name: limit
         required: false
         in: query
@@ -1858,17 +1966,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource the content file belongs to
 
@@ -1881,6 +1991,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -1890,25 +2002,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources the content file belongs to is offered
 
@@ -1929,18 +2043,26 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
+      - in: query
+        name: resource_id
+        schema:
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: run_id
         schema:
-          type: number
-        description: The id of the learning resource run the content file belongs
-          to
-      - in: query
-        name: run_readable_id
-        schema:
-          type: string
-        description: The readable id of the learning resource run the content file
-          belongs to
+          type: array
+          items:
+            type: number
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - learning_resources
       responses:
@@ -2052,51 +2174,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -2137,18 +2264,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -2159,6 +2290,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -2168,17 +2301,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -2191,6 +2326,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -2200,25 +2337,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -2239,6 +2378,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -2246,13 +2387,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -2261,6 +2404,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -2296,9 +2441,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - learning_resources
       responses:
@@ -2317,51 +2465,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -2402,18 +2555,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -2424,6 +2581,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -2433,17 +2592,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -2456,6 +2617,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -2465,25 +2628,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -2504,6 +2669,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -2511,13 +2678,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -2526,6 +2695,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -2561,9 +2732,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - learning_resources
       responses:
@@ -2932,51 +3106,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -3017,18 +3196,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -3039,6 +3222,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -3048,17 +3233,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -3071,6 +3258,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -3080,25 +3269,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -3119,6 +3310,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -3126,13 +3319,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -3141,6 +3336,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -3176,9 +3373,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - learningpaths
       responses:
@@ -3543,51 +3743,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -3628,18 +3833,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -3650,6 +3859,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -3659,17 +3870,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -3682,6 +3895,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -3691,25 +3906,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -3730,6 +3947,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -3737,13 +3956,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -3752,6 +3973,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -3787,9 +4010,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - podcast_episodes
       responses:
@@ -3829,51 +4055,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -3914,18 +4145,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -3936,6 +4171,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -3945,17 +4182,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -3968,6 +4207,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -3977,25 +4218,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -4016,6 +4259,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -4023,13 +4268,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -4038,6 +4285,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -4073,9 +4322,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - podcasts
       responses:
@@ -4181,51 +4433,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -4266,18 +4523,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -4288,6 +4549,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -4297,17 +4560,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -4320,6 +4585,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -4329,25 +4596,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -4368,6 +4637,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -4375,13 +4646,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -4390,6 +4663,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -4425,9 +4700,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - programs
       responses:
@@ -4467,51 +4745,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -4552,18 +4835,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -4574,6 +4861,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -4583,17 +4872,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -4606,6 +4897,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -4615,25 +4908,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -4654,6 +4949,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -4661,13 +4958,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -4676,6 +4975,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -4711,9 +5012,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - programs
       responses:
@@ -4732,51 +5036,56 @@ paths:
       - in: query
         name: course_feature
         schema:
-          type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       - in: query
         name: department
         schema:
-          type: string
-          enum:
-          - '1'
-          - '10'
-          - '11'
-          - '12'
-          - '14'
-          - '15'
-          - '16'
-          - '17'
-          - '18'
-          - '2'
-          - '20'
-          - 21A
-          - 21G
-          - 21H
-          - 21L
-          - 21M
-          - '22'
-          - '24'
-          - '3'
-          - '4'
-          - '5'
-          - '6'
-          - '7'
-          - '8'
-          - '9'
-          - CC
-          - CMS-W
-          - EC
-          - ES
-          - ESD
-          - HST
-          - IDS
-          - MAS
-          - PE
-          - RES
-          - STS
-          - WGS
+          type: array
+          items:
+            type: string
+            enum:
+            - '1'
+            - '10'
+            - '11'
+            - '12'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '2'
+            - '20'
+            - 21A
+            - 21G
+            - 21H
+            - 21L
+            - 21M
+            - '22'
+            - '24'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
+            - CC
+            - CMS-W
+            - EC
+            - ES
+            - ESD
+            - HST
+            - IDS
+            - MAS
+            - PE
+            - RES
+            - STS
+            - WGS
         description: |-
           The department that offers learning resources
 
@@ -4817,18 +5126,22 @@ paths:
           * `RES` - Supplemental Resources
           * `STS` - Science, Technology, and Society
           * `WGS` - Women's and Gender Studies
+        explode: true
+        style: form
       - in: query
         name: level
         schema:
-          type: string
-          enum:
-          - advanced
-          - graduate
-          - high_school
-          - intermediate
-          - introductory
-          - noncredit
-          - undergraduate
+          type: array
+          items:
+            type: string
+            enum:
+            - advanced
+            - graduate
+            - high_school
+            - intermediate
+            - introductory
+            - noncredit
+            - undergraduate
         description: |-
           The academic level of the resources
 
@@ -4839,6 +5152,8 @@ paths:
           * `advanced` - Advanced
           * `intermediate` - Intermediate
           * `introductory` - Introductory
+        explode: true
+        style: form
       - name: limit
         required: false
         in: query
@@ -4848,17 +5163,19 @@ paths:
       - in: query
         name: offered_by
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - mitpe
-          - mitx
-          - ocw
-          - scc
-          - see
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - mitpe
+            - mitx
+            - ocw
+            - scc
+            - see
+            - xpro
         description: |-
           The organization that offers a learning resource
 
@@ -4871,6 +5188,8 @@ paths:
           * `see` - Sloan Executive Education
           * `scc` - Schwarzman College of Computing
           * `ctl` - Center for Transportation & Logistics
+        explode: true
+        style: form
       - name: offset
         required: false
         in: query
@@ -4880,25 +5199,27 @@ paths:
       - in: query
         name: platform
         schema:
-          type: string
-          enum:
-          - bootcamps
-          - csail
-          - ctl
-          - edx
-          - emeritus
-          - globalalumni
-          - mitpe
-          - mitxonline
-          - ocw
-          - oll
-          - podcast
-          - scc
-          - see
-          - simplilearn
-          - susskind
-          - whu
-          - xpro
+          type: array
+          items:
+            type: string
+            enum:
+            - bootcamps
+            - csail
+            - ctl
+            - edx
+            - emeritus
+            - globalalumni
+            - mitpe
+            - mitxonline
+            - ocw
+            - oll
+            - podcast
+            - scc
+            - see
+            - simplilearn
+            - susskind
+            - whu
+            - xpro
         description: |-
           The platform on which learning resources are offered
 
@@ -4919,6 +5240,8 @@ paths:
           * `simplilearn` - Simplilearn
           * `emeritus` - Emeritus
           * `podcast` - Podcast
+        explode: true
+        style: form
       - in: query
         name: professional
         schema:
@@ -4926,13 +5249,15 @@ paths:
       - in: query
         name: resource_type
         schema:
-          type: string
-          enum:
-          - course
-          - learning_path
-          - podcast
-          - podcast_episode
-          - program
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_path
+            - podcast
+            - podcast_episode
+            - program
         description: |-
           The type of learning resource
 
@@ -4941,6 +5266,8 @@ paths:
           * `learning_path` - Learning Path
           * `podcast` - Podcast
           * `podcast_episode` - Podcast Episode
+        explode: true
+        style: form
       - in: query
         name: sortby
         schema:
@@ -4976,9 +5303,12 @@ paths:
       - in: query
         name: topic
         schema:
-          type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
+          type: array
+          items:
+            type: string
+        description: Multiple values may be separated by commas.
+        explode: false
+        style: form
       tags:
       - programs
       responses:


### PR DESCRIPTION
### What are the relevant tickets?
Closes #293 

### Description (What does it do?)
Allows both the learning_resources and contentfiles API endpoints to filter by multiple values for the same attribute, via two different query parameter formats, similar to the search API endpoint.  Examples:

http://localhost:8063/api/v1/learning_resources/?platform=ocw,xpro
http://localhost:8063/api/v1/learning_resources/?platform=ocw&platform=xpro
http://localhost:8063/api/v1/learning_resources/?platform=ocw


Also gets rid of some contentfiles filters that are not present in the search api (run_readable_id, resource_readable_id)


### How can this be tested?
Try variations of the above urls for different filterable fields, on both the contentfiles and learning_resources API endpoints.  They should return expected results that match the same filters for the search API endpoints.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
