### PR TITLE
Fix prolearn etl

### DIFF
--- a/learning_resources/etl/prolearn.py
+++ b/learning_resources/etl/prolearn.py
@@ -1,6 +1,5 @@
 """Prolearn ETL"""
 
-import json
 import logging
 import re
 from datetime import datetime
@@ -176,9 +175,7 @@ def extract_data(course_or_program: str) -> list[dict]:
     if settings.PROLEARN_CATALOG_API_URL:
         response = requests.post(  # noqa: S113
             settings.PROLEARN_CATALOG_API_URL,
-            data=json.dumps(
-                {"query": PROLEARN_QUERY % (course_or_program, PROLEARN_QUERY_FIELDS)}
-            ),
+            json={"query": PROLEARN_QUERY % (course_or_program, PROLEARN_QUERY_FIELDS)},
         ).json()
         return response["data"]["searchAPISearch"]["documents"]
     log.warning("Missing required setting PROLEARN_CATALOG_API_URL")


### PR DESCRIPTION
### What are the relevant tickets?
Closes #447 

### Description (What does it do?)
Makes a small tweak to the prolearn api request code so that it works again.


### How can this be tested?
- Set `PROLEARN_CATALOG_API_URL=https://prolearn.mit.edu/graphql` in your .env file
- Start containers
- Run `./manage.py backpopulate_prolearn_data`
- It should complete successfully and you should have a. few hundred new courses/programs with platform = mitpe, see, scc, etc.

