### PR TITLE
Allow for blank OCW terms/years (and adjust readable_id accordingly)

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -235,8 +235,8 @@ def transform_run(course_data: dict) -> dict:
         "published": True,
         "instructors": parse_instructors(course_data.get("instructors", [])),
         "description": course_data.get("course_description"),
-        "year": course_data.get("year"),
-        "semester": course_data.get("term"),
+        "year": course_data.get("year") or None,
+        "semester": course_data.get("term") or None,
         "availability": AvailabilityType.current.value,
         "image": {
             "url": urljoin(settings.OCW_BASE_URL, image_src) if image_src else None,
@@ -289,8 +289,11 @@ def transform_course(course_data: dict) -> dict:
         extra_course_numbers = [num.strip() for num in extra_course_numbers.split(",")]
     else:
         extra_course_numbers = []
-
-    readable_id = f"{course_data[PRIMARY_COURSE_ID]}+{slugify(course_data.get('term'))}_{course_data.get('year')}"  # noqa: E501
+    term = course_data.get("term")
+    year = course_data.get("year")
+    readable_term = f"+{slugify(term)}" if term else ""
+    readable_year = f"_{course_data.get('year')}" if year else ""
+    readable_id = f"{course_data[PRIMARY_COURSE_ID]}{readable_term}{readable_year}"
     topics = [
         {"name": topic_name}
         for topic_name in list(

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -164,14 +164,26 @@ def test_transform_content_file_needs_text_update(
 
 @mock_s3
 @pytest.mark.parametrize(
-    ("legacy_uid", "site_uid", "expected_uid", "has_extra_num"),
+    (
+        "legacy_uid",
+        "site_uid",
+        "expected_uid",
+        "has_extra_num",
+        "term",
+        "year",
+        "expected_id",
+    ),
     [
-        ("legacy-uid", None, "legacyuid", False),
-        (None, "site-uid", "siteuid", True),
-        (None, None, None, True),
+        ("legacy-uid", None, "legacyuid", False, "Spring", "2005", "16.01+spring_2005"),
+        (None, "site-uid", "siteuid", True, "", 2005, "16.01_2005"),
+        (None, "site-uid", "siteuid", True, "", "", "16.01"),
+        (None, "site-uid", "siteuid", True, None, None, "16.01"),
+        (None, None, None, True, "Spring", "2005", None),
     ],
 )
-def test_transform_course(settings, legacy_uid, site_uid, expected_uid, has_extra_num):
+def test_transform_course(  # noqa: PLR0913
+    settings, legacy_uid, site_uid, expected_uid, has_extra_num, term, year, expected_id
+):
     """transform_course should return expected data"""
     settings.OCW_BASE_URL = "http://test.edu/"
     with Path.open(
@@ -181,6 +193,8 @@ def test_transform_course(settings, legacy_uid, site_uid, expected_uid, has_extr
     ) as inf:
         course_json = json.load(inf)
 
+    course_json["term"] = term
+    course_json["year"] = year
     course_json["legacy_uid"] = legacy_uid
     course_json["site_uid"] = site_uid
     course_json["extra_course_numbers"] = "1, 2" if has_extra_num else None
@@ -192,10 +206,12 @@ def test_transform_course(settings, legacy_uid, site_uid, expected_uid, has_extr
     }
     transformed_json = transform_course(extracted_json)
     if expected_uid:
-        assert transformed_json["readable_id"] == "16.01+fall_2005"
+        assert transformed_json["readable_id"] == expected_id
         assert transformed_json["etl_source"] == ETLSource.ocw.name
         assert transformed_json["runs"][0]["run_id"] == expected_uid
         assert transformed_json["runs"][0]["level"] == ["Undergraduate"]
+        assert transformed_json["runs"][0]["semester"] == (term if term else None)
+        assert transformed_json["runs"][0]["year"] == (year if year else None)
         assert (
             transformed_json["image"]["url"]
             == "http://test.edu/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg"

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -23,6 +23,7 @@ from learning_resources.etl.constants import (
     ETLSource,
     ProgramLoaderConfig,
 )
+from learning_resources.etl.exceptions import ExtractException
 
 log = logging.getLogger(__name__)
 
@@ -117,7 +118,7 @@ def ocw_courses_etl(
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
     )
-
+    exceptions = []
     for url_path in url_paths:
         try:
             data = ocw.extract_course(
@@ -140,3 +141,6 @@ def ocw_courses_etl(
                 log.info("No course data found for %s", url_path)
         except:  # noqa: E722
             log.exception("Error encountered parsing OCW json for %s", url_path)
+            exceptions.append(url_path)
+    if exceptions:
+        raise ExtractException("Some OCW urls raised errors: %s" % ",".join(exceptions))


### PR DESCRIPTION
### What are the relevant tickets?
Closes #441 

### Description (What does it do?)
- Allows for blank terms/years in OCW courses, and adjusts the readable_id value accordingly
- If exceptions occur during a batch of ocw url paths processed by the `learning_resources.etl.pipelines.ocw_courses_etl` function, raise an `ExtractException` at the end indicating which ocw url's failed.


### How can this be tested?

- Use the same AWS credentials and `OCW_*` settings as RC in your .env file.
- Run `./manage.py backpopulate_ocw_data --course-name=res-hs-002-chemistry-behind-the-magic-chemical-demonstrations-for-the-classroom `
- Check that the learning resource imported, and the readable id is `RES.HS-002`
- Temporarily modify this line in `learning_resources.etl.ocw.transform_run` function to be the same as the main branch:
  ```python
   "year": course_data.get("year")
  ```
- Restart containers and run the mgmt command again (with `--overwrite`).  You should get an error.