### PR TITLE
Avoid integrity errors when loading instructors

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -104,7 +104,7 @@ def load_instructors(
                 "title",
                 f"{prof.get('first_name', '')} {prof.get('last_name', '')}".strip(),
             )
-        instructor, _ = LearningResourceInstructor.objects.get_or_create(
+        instructor, _ = LearningResourceInstructor.objects.update_or_create(
             full_name=prof.pop("full_name"),
             defaults={key: value for key, value in prof.items() if value},
         )

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -98,12 +98,15 @@ def load_instructors(
 ) -> list[LearningResourceInstructor]:
     """Load the instructors for a resource into the database"""
     instructors = []
-    for instructor_data in instructors_data:
-        if "full_name" not in instructor_data:
-            instructor_data["full_name"] = instructor_data.get("title", None)
-
+    for prof in instructors_data:
+        if "full_name" not in prof:
+            prof["full_name"] = prof.pop(
+                "title",
+                f"{prof.get('first_name', '')} {prof.get('last_name', '')}".strip(),
+            )
         instructor, _ = LearningResourceInstructor.objects.get_or_create(
-            **instructor_data
+            full_name=prof.pop("full_name"),
+            defaults={key: value for key, value in prof.items() if value},
         )
         instructors.append(instructor)
 

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -94,9 +94,9 @@ def load_departments(
 
 
 def load_instructors(
-    resource: LearningResource, instructors_data: list[dict]
+    run: LearningResourceRun, instructors_data: list[dict]
 ) -> list[LearningResourceInstructor]:
-    """Load the instructors for a resource into the database"""
+    """Load the instructors for a resource run into the database"""
     instructors = []
     valid_attributes = ["first_name", "last_name"]
     for prof in instructors_data:
@@ -115,8 +115,8 @@ def load_instructors(
             )
             instructors.append(instructor)
 
-    resource.instructors.set(instructors)
-    resource.save()
+    run.instructors.set(instructors)
+    run.save()
     return instructors
 
 

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -98,17 +98,22 @@ def load_instructors(
 ) -> list[LearningResourceInstructor]:
     """Load the instructors for a resource into the database"""
     instructors = []
+    valid_attributes = ["first_name", "last_name"]
     for prof in instructors_data:
-        if "full_name" not in prof:
-            prof["full_name"] = prof.pop(
-                "title",
-                f"{prof.get('first_name', '')} {prof.get('last_name', '')}".strip(),
+        full_name = (
+            prof.get("full_name", "")
+            or f"{prof.get('first_name') or ''} {prof.get('last_name') or ''}"
+        ).strip()
+        if full_name:
+            instructor, _ = LearningResourceInstructor.objects.update_or_create(
+                full_name=full_name,
+                defaults={
+                    key: value
+                    for key, value in prof.items()
+                    if value and key in valid_attributes
+                },
             )
-        instructor, _ = LearningResourceInstructor.objects.update_or_create(
-            full_name=prof.pop("full_name"),
-            defaults={key: value for key, value in prof.items() if value},
-        )
-        instructors.append(instructor)
+            instructors.append(instructor)
 
     resource.instructors.set(instructors)
     resource.save()

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -525,9 +525,10 @@ def test_load_instructors_dupe_full_names():
     """Test that no dupe instructors are created and no integrity errors are raised"""
     instructor_data = [
         {"full_name": "John Doe", "first_name": "John", "last_name": "Doe"},
-        {"full_name": "John Doe"},
-        {"first_name": "John", "last_name": "Doe"},
-        {"title": "John Doe", "first_name": None, "last_name": ""},
+        {"full_name": "", "first_name": "John", "last_name": "Doe"},
+        {"full_name": None, "first_name": "John", "last_name": "Doe"},
+        {"full_name": "John Doe", "email": "johndoe@test.edu"},
+        {"first_name": "John", "last_name": "Doe", "profession": "QA analyst"},
     ]
     run = LearningResourceRunFactory.create(no_instructors=True)
 
@@ -539,6 +540,20 @@ def test_load_instructors_dupe_full_names():
     assert run.instructors.first().full_name == "John Doe"
     assert run.instructors.first().first_name == "John"
     assert run.instructors.first().last_name == "Doe"
+
+
+def test_load_instructors_no_full_name():
+    """Test that instructors with no full name are not created"""
+    instructor_data = [
+        {"full_name": " ", "first_name": "", "last_name": " "},
+        {"full_name": "", "first_name": None, "last_name": ""},
+        {"full_name": None, "first_name": "", "last_name": None},
+    ]
+    run = LearningResourceRunFactory.create(no_instructors=True)
+
+    assert run.instructors.count() == 0
+    load_instructors(run, instructor_data)
+    assert run.instructors.count() == 0
 
 
 @pytest.mark.parametrize("parent_factory", [CourseFactory, ProgramFactory])

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -521,6 +521,26 @@ def test_load_instructors(instructor_exists):
     assert run.instructors.count() == len(instructors)
 
 
+def test_load_instructors_dupe_full_names():
+    """Test that no dupe instructors are created and no integrity errors are raised"""
+    instructor_data = [
+        {"full_name": "John Doe", "first_name": "John", "last_name": "Doe"},
+        {"full_name": "John Doe"},
+        {"first_name": "John", "last_name": "Doe"},
+        {"title": "John Doe", "first_name": None, "last_name": ""},
+    ]
+    run = LearningResourceRunFactory.create(no_instructors=True)
+
+    assert run.instructors.count() == 0
+
+    load_instructors(run, instructor_data)
+
+    assert run.instructors.count() == 1
+    assert run.instructors.first().full_name == "John Doe"
+    assert run.instructors.first().first_name == "John"
+    assert run.instructors.first().last_name == "Doe"
+
+
 @pytest.mark.parametrize("parent_factory", [CourseFactory, ProgramFactory])
 @pytest.mark.parametrize("offeror_exists", [True, False])
 @pytest.mark.parametrize("has_other_offered_by", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
Closes #477 

### Description (What does it do?)
Adjusts the `learning_resources.etl.loaders.load_instructors` function to avoid IntegrityErrors.


### How can this be tested?
- Create the following instructor on your local instance if it doesn't already exist:
  ```python
  {"full_name": "Prof. Eric von Hippel", "first_name": None, "last_name": None}
  ```
- On the **main** branch, run `./manage.py backpopulate_ocw_data --overwrite --course-name=15-356-how-to-develop-breakthrough-products-and-services-spring-2004`
- An `IntegrityError` should be raised.
- Switch to this branch, restart containers, and try again.
- There should not be an `IntegrityError`, and if you refresh the instructor created in the first step, the first and last names should now be populated.
