### PR TITLE
Upgrade version of poetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 
 ## Set some poetry config
 ENV  \
-  POETRY_VERSION=1.5.1 \
+  POETRY_VERSION=1.7.1 \
   POETRY_VIRTUALENVS_CREATE=true \
   POETRY_CACHE_DIR='/tmp/cache/poetry' \
   POETRY_HOME='/home/mitodl/.local' \


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes #479  
<!--- N/A --->

### Description (What does it do?)
Upgrades poetry version so connection timeout does not occur during docker build

### How can this be tested?
Run a docker build of mit-open repo from scratch (steps listed in issue)

### Checklist:
- [ ] verified a fresh docker-compose build completes without errors

