### PR TITLE
Use root document counts to avoid overcounting in aggregations

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -398,9 +398,13 @@ def generate_aggregation_clause(
         if _current_path_length == 1:
             return bucket_agg
         else:
-            # In case of nested aggregations, we want to return the root
-            # document count; the reverse_nested aggregation with no path
-            # property goes back to root
+            # In case of nested aggregations, use reverse_nested to return the
+            # root document count to avoid overcounting. For example, a resource
+            # with 5 runs all with level high_school would otherwise count 5
+            # times toward a level aggregation.
+            #
+            # Strictly speaking, this is only necessary for fields that may
+            # contain arrays with duplicated field values.
             return {**bucket_agg, "aggs": {"root": {"reverse_nested": {}}}}
 
     return {

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -394,7 +394,14 @@ def generate_aggregation_clause(
     current_path = ".".join(path_pieces[0:_current_path_length])
 
     if current_path == path:
-        return {"terms": {"field": path, "size": 10000}}
+        bucket_agg = {"terms": {"field": path, "size": 10000}}
+        if _current_path_length == 1:
+            return bucket_agg
+        else:
+            # In case of nested aggregations, we want to return the root
+            # document count; the reverse_nested aggregation with no path
+            # property goes back to root
+            return {**bucket_agg, "aggs": {"root": {"reverse_nested": {}}}}
 
     return {
         "nested": {"path": current_path},

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -317,6 +317,9 @@ def _transform_aggregations(aggregations):
         copy = {**bucket}
         if "key_as_string" in bucket:
             copy["key"] = copy.pop("key_as_string")
+        if "root" in bucket:
+            root_doc_count = copy.pop("root")["doc_count"]
+            copy["doc_count"] = root_doc_count
         return copy
 
     return {


### PR DESCRIPTION
### What are the relevant tickets?
Closes #474 

### Description (What does it do?)
This PR changes our search aggregations to use root document count for nested fields. This prevents a course with N runs having level `high_school` being counted N times. 

### How can this be tested?
**Prerequesites:**
-  Ensure you have some MIT Edx courses locally; these can be retrieved via `./manage.py backpopulate_mit_edx_data` if you don't have any. We need some courses both levels and multiple runs; OCW courses do not satisfy that (they have 1 run).
- search indexes: `./manage.py recreate_index --courses`

1. Notice that on RC the APIs below indicate different `counts` for `advanced` learning resources:
    - https://mit-open-rc.odl.mit.edu/api/v1/learning_resources/?level=advanced (`count` property)
    - https://mit-open-rc.odl.mit.edu/api/v1/learning_resources_search/?aggregations=level&limit=1 (`advanced` under level aggregation)
2.  Locally on this branch, both APIs should return the same number.
    - http://localhost:8063/api/v1/learning_resources/?level=advanced
    - http://localhost:8063/api/v1/learning_resources_search/?aggregations=level

### Additional Context
Docs:
- https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-reverse-nested-aggregation.html
- https://opensearch.org/docs/latest/aggregations/bucket/reverse-nested/