### PR TITLE
fix topics schema

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -133,10 +133,10 @@ export interface ContentFile {
   year: number
   /**
    *
-   * @type {Array<string>}
+   * @type {Array<LearningResourceTopic>}
    * @memberof ContentFile
    */
-  topics: Array<string>
+  topics: Array<LearningResourceTopic>
   /**
    *
    * @type {string}

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -95,15 +95,6 @@ class LearningResourceContentTagField(serializers.Field):
         return [tag.name for tag in value.all()]
 
 
-@extend_schema_field({"type": "array", "items": {"type": "string"}})
-class LearningResourceTopicsField(serializers.Field):
-    """Serializer field for LearningResourceTopics"""
-
-    def to_representation(self, value):
-        """Serialize list of topics"""
-        return [LearningResourceTopicSerializer(topic).data for topic in value.all()]
-
-
 class LearningResourcePlatformSerializer(serializers.ModelSerializer):
     """Serializer for LearningResourcePlatform"""
 
@@ -573,7 +564,9 @@ class ContentFileSerializer(serializers.ModelSerializer):
     run_slug = serializers.CharField(source="run.slug")
     semester = serializers.CharField(source="run.semester")
     year = serializers.IntegerField(source="run.year")
-    topics = LearningResourceTopicsField(source="run.learning_resource.topics")
+    topics = LearningResourceTopicSerializer(
+        source="run.learning_resource.topics", many=True
+    )
     resource_id = serializers.CharField(source="run.learning_resource.id")
     departments = LearningResourceDepartmentSerializer(
         source="run.learning_resource.departments", many=True

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -5692,7 +5692,7 @@ components:
         topics:
           type: array
           items:
-            type: string
+            $ref: '#/components/schemas/LearningResourceTopic'
         key:
           type: string
           nullable: true


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/mit-open/issues/485
### Description (What does it do?)
This pr fixes the schema documentation for content file topics

### How can this be tested?
Got to http://localhost:8063/api/v1/contentfiles/. Verify that topics look normal.

Go to 
http://localhost:8063/api/v1/schema/swagger-ui/#/content_file_search/content_file_search_retrieve
and
http://localhost:8063/api/v1/schema/swagger-ui/#/contentfiles/contentfiles_list

Verify that the topics are an array of objects with parameters {id:, name:} in the response schema