### PR TITLE
Avoid using get_or_create for LearningResourceImage object that has no unique constraint

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -123,8 +123,10 @@ def load_instructors(
 def load_image(resource: LearningResource, image_data: dict) -> LearningResourceImage:
     """Load the image for a resource into the database"""
     if image_data:
-        image, _ = LearningResourceImage.objects.get_or_create(**image_data)
-
+        if LearningResourceImage.objects.filter(**image_data).exists():
+            image = LearningResourceImage.objects.filter(**image_data).first()
+        else:
+            image = LearningResourceImage.objects.create(**image_data)
         resource.image = image
     else:
         resource.image = None

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -123,10 +123,11 @@ def load_instructors(
 def load_image(resource: LearningResource, image_data: dict) -> LearningResourceImage:
     """Load the image for a resource into the database"""
     if image_data:
-        if LearningResourceImage.objects.filter(**image_data).exists():
-            image = LearningResourceImage.objects.filter(**image_data).first()
-        else:
-            image = LearningResourceImage.objects.create(**image_data)
+        image, _ = LearningResourceImage.objects.get_or_create(
+            url=image_data.get("url"),
+            description=image_data.get("description"),
+            alt=image_data.get("alt"),
+        )
         resource.image = image
     else:
         resource.image = None

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -685,26 +685,27 @@ def test_load_content_file():
 
 def test_load_image():
     """Test that image resources are uniquely created or retrieved based on parameters"""
-    LearningResourceImage.objects.filter(url="https://mit.edu").delete()
+    resource_url = "https://mit.edu"
+    LearningResourceImage.objects.filter(url=resource_url).delete()
     learning_resource = LearningResourceFactory.create()
 
     # first image should be different from second due to 'description' parameter
-    image_a = load_image(learning_resource, image_data={"url": "https://mit.edu"})
+    image_a = load_image(learning_resource, image_data={"url": resource_url})
     image_b = load_image(
-        learning_resource, image_data={"url": "https://mit.edu", "description": ""}
+        learning_resource, image_data={"url": resource_url, "description": ""}
     )
     assert image_a.id != image_b.id
 
     # first image should be the same as third image since url and alt field matches
     image_c = load_image(
-        learning_resource, image_data={"url": "https://mit.edu", "alt": None}
+        learning_resource, image_data={"url": resource_url, "alt": None}
     )
     assert image_a.id == image_c.id
 
     # fourth image should have a totally new id since all fields are unique
     image_d = load_image(
         learning_resource,
-        image_data={"url": "https://mit.edu", "alt": "test", "description": "new"},
+        image_data={"url": resource_url, "alt": "test", "description": "new"},
     )
     assert image_d.id not in {image_a.id, image_b.id, image_c.id}
 


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #487 

### Description (What does it do?)
The LearningResourceImage object has no uniqueness constraint in the model. In learning_resourcs/etl/loaders.py we load_image method which attempts to populate the 'image' attribute on a LearningResource by using get_or_create to retrieve an image which will fail if we have duplicate objects (more on this caveat [here](https://www.queworx.com/django/django-get_or_create/#:~:text=Uniqueness%20Constraint,the%20object%20and%20return%20it). We can avoid this by checking for existence and getting the object manually instead of using the get_or_create. 

### How can this be tested?
1. Checkout the main branch
2. Make sure you have some data (LearningResource objects available). If not run ```manage.py backpopulate_prolearn_data```
3. get into the django shell and run the following:
```
from learning_resources.models import LearningResource
from learning_resources.etl.loaders import load_image
lr = LearningResource.objects.first()
load_image(lr, image_data={'url': 'http://baker.com'})
load_image(lr, image_data={'url':'http://baker.com', 'alt':None, 'description':None})
load_image(lr, image_data={'url':'http://baker.com', 'alt':None})
```
4. Note that it fails with ```MultipleObjectsReturned: get() returned more than one LearningResourceImage -- it returned 2!```
5. checkout this branch (shanbady/487-flaky-test)
6. re-run step 3 and note that it succeeds without errors

Additionally - to simulate flaky test runs, apply the following patch to the test_loaders file: 
[test.patch](https://github.com/mitodl/mit-open/files/14250846/test.patch) and run the loaders test via ``` pytest learning_resources/etl/loaders_test.py -vvv -k test_load_program -x --no-cov -s --pdb``` - it should not fail at all throughout its hundreds of runs (it will fail on main branch at some point).

### Additional Context
One other route to fixing this was to introduce a uniqueness constraint via data migrations - I avoided this route because I did not have enough context around the existing state of the data and it could introduce side effects elsewhere and also lead us to clean up existing data in some way that is incompatible with existing expectations. If that is something we want to pursue it might be work creating a separate ticket for that since there are likely many non-unique image url objects we would need to consolidate.

### Checklist:
- [ ] Testing steps detailed above have been followed and run successfully
- [ ] There are no other unwanted side effects in data quality/object creation that this could potentially introduce

