### PR TITLE
Save user with is_active from SCIM request

### DIFF
--- a/profiles/adapters.py
+++ b/profiles/adapters.py
@@ -157,7 +157,6 @@ class SCIMProfile(SCIMUser):
                 self.obj.user.username = self.obj.email
                 self.obj.user.first_name = self.obj.first_name
                 self.obj.user.last_name = self.obj.last_name
-                self.obj.user.is_active = self.obj.user.is_active
                 self.obj.user.save()
                 self.obj.name = self.display_name
                 self.obj.save()

--- a/profiles/adapters.py
+++ b/profiles/adapters.py
@@ -116,6 +116,8 @@ class SCIMProfile(SCIMUser):
         # Store dict for possible later use when saving user
         self._from_dict_copy = copy.deepcopy(d)
 
+        self.obj.user = User()
+
         self.parse_active(d.get("active"))
 
         self.obj.first_name = d.get("name", {}).get("givenName") or ""
@@ -151,12 +153,12 @@ class SCIMProfile(SCIMUser):
         """
         try:
             with transaction.atomic():
-                user, _ = User.objects.get_or_create(
-                    email=self.obj.email,
-                    username=self.obj.email,
-                    first_name=self.obj.first_name,
-                )
-                self.obj.user = user
+                self.obj.user.email = self.obj.email
+                self.obj.user.username = self.obj.email
+                self.obj.user.first_name = self.obj.first_name
+                self.obj.user.last_name = self.obj.last_name
+                self.obj.user.is_active = self.obj.user.is_active
+                self.obj.user.save()
                 self.obj.name = self.display_name
                 self.obj.save()
                 logger.info("User saved. User id %i", self.obj.id)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mit-open/pull/513

### Description (What does it do?)
Resolves an issue that occurs when a SCIM POST request, to the /users/ endpoint, contains the `active` attribute.  The issue is caused by not creating a User object, associated with the Profile object used for SCIM, before accessing the User model's `is_active` attribute.


### How can this be tested?
SCIM POST request to `http://open.ol.local:8063/scim/v2/Users` with the body of:
```
{
    "schemas": [
        "urn:ietf:params:scim:schemas:core:2.0:User"
    ],
    "userName": "collinpreston",
    "name": {
        "givenName": "Collin",
        "familyName": "Preston"
    },
    "emails": [
        {
            "primary": true,
            "value": "collinp@mit.edu"
        }
    ],
    "externalId": "keycloakID",
    "active": true

}
```

### Additional Context
I caught this while testing the integration with Keycloak.  Previously, while testing locally, I did not include the `active` attribute in my SCIM requests.

