### PR TITLE
E2E Test and fixture for login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,12 +220,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Debug OIDC endpoint
-        run: echo $SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT
-
-      - name: Debug OIDC key
-        run: echo $SOCIAL_AUTH_OL_OIDC_KEY
-
       - name: Build frontend
         run: NODE_ENV=production yarn build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Debug OIDC endpoint
+        run: echo $SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT
+
+      - name: Debug OIDC key
+        run: echo $SOCIAL_AUTH_OL_OIDC_KEY
+
       - name: Build frontend
         run: NODE_ENV=production yarn build
 

--- a/e2e_testing/.env
+++ b/e2e_testing/.env
@@ -2,3 +2,6 @@ BASE_URL=http://localhost:8063/
 # BASE_URL=http://nginx:8063/
 # BASE_URL=https://mit-open-rc.odl.mit.edu/
 # BASE_URL=https://mitopen.odl.mit.edu/
+
+TEST_USER_EMAIL=jonkafton+test1@gmail.com
+TEST_USER_PASSWORD=3edc5tgb # pragma: allowlist secret

--- a/e2e_testing/tests/003_login.spec.ts
+++ b/e2e_testing/tests/003_login.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "./fixtures"
+
+test.describe("User can log in @sanity", () => {
+  test("User is logged out - Authenticated page redirects to SSO login screen", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard")
+
+    await expect(page).toHaveURL(
+      /\/realms\/olapps\/protocol\/openid-connect\/auth/,
+    )
+  })
+
+  test("User logs in and can view authenticated page", async ({
+    authenticated: page,
+  }) => {
+    await page.goto("/")
+    await page.getByLabel("User Menu").click()
+    await page.getByRole("menuitem", { name: "Dashboard" }).click()
+
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible()
+  })
+
+  test("User logs out and authenticated page redirects to SSO login screen", async ({
+    authenticated: page,
+  }) => {
+    await page.getByLabel("User Menu").click()
+    await page.getByRole("menuitem", { name: "Log out" }).click()
+
+    // Sometimes we get an OIDC logout button, sometimes we go straight to "You are logged out"
+    const logoutButton = page.getByRole("button", { name: "Logout" })
+    if (await logoutButton.isVisible()) {
+      await logoutButton.click()
+    }
+
+    await page.goto("/dashboard")
+    await page.waitForURL(/\/realms\/olapps\/protocol\/openid-connect\/auth/)
+  })
+})

--- a/e2e_testing/tests/fixtures.ts
+++ b/e2e_testing/tests/fixtures.ts
@@ -1,0 +1,16 @@
+import { test as base, Page } from "@playwright/test"
+import { signInUser } from "./helpers/authentication"
+
+type Fixtures = {
+  authenticated: Page
+}
+
+export const test = base.extend<Fixtures>({
+  authenticated: async ({ browser }, use) => {
+    const page = await signInUser(browser)
+
+    await use(page)
+  },
+})
+
+export { expect } from "@playwright/test"

--- a/e2e_testing/tests/helpers/authentication.ts
+++ b/e2e_testing/tests/helpers/authentication.ts
@@ -1,0 +1,18 @@
+import type { Browser } from "@playwright/test"
+
+export const signInUser = async (browser: Browser) => {
+  const context = await browser.newContext({
+    storageState: "playwright/.auth/user.json",
+  })
+  const page = await context.newPage()
+
+  await page.goto("/login/ol-oidc")
+
+  await page.getByLabel("Email").fill(process.env.TEST_USER_EMAIL)
+  await page.getByRole("button", { name: "Next" }).click()
+
+  await page.getByLabel("Password").fill(process.env.TEST_USER_PASSWORD)
+  await page.getByRole("button", { name: "Next" }).click()
+
+  return page
+}


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/mit-open/issues/536

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Adds an E2E fixture that logs a user in via OIDC.
- Adds a test spec to log in and check authenticated and unauthenticated page access.

### How can this be tested?

- Tests should be pass locally against RC:

```bash
yarn workspace e2e_testing test:rc
```

- e2e-test CI job should run successfully (awaiting setup, see below).





### Additional Context

Putting up early for review. The linked issue assumes Keycloak is not configured for local login, but seems we do have setup for od.odl.local:8063 ([detail](https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit#heading=h.owvgv2h3odjp)).

We need to set up a test user on the CI OIDC before tests will pass on CI.

Do we have any test accounts set up? Ideally we'll use a test email address that we can set up in RC and Prod. 


