### PR TITLE
fix OpenAPI response for content_file_search

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -222,11 +222,11 @@ export interface ContentFile {
    */
   resource_readable_id: string
   /**
-   *
-   * @type {string}
+   * Extract the course number(s) from the associated course
+   * @type {Array<string>}
    * @memberof ContentFile
    */
-  course_number: string
+  course_number: Array<string>
   /**
    *
    * @type {string}
@@ -253,6 +253,85 @@ export interface ContentFile {
   run_readable_id: string
 }
 
+/**
+ * SearchResponseSerializer with OpenAPI annotations for Content Files search
+ * @export
+ * @interface ContentFileeSearchResponse
+ */
+export interface ContentFileeSearchResponse {
+  /**
+   *
+   * @type {number}
+   * @memberof ContentFileeSearchResponse
+   */
+  count: number
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFileeSearchResponse
+   */
+  next: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFileeSearchResponse
+   */
+  previous: string | null
+  /**
+   *
+   * @type {Array<ContentFile>}
+   * @memberof ContentFileeSearchResponse
+   */
+  results: Array<ContentFile>
+  /**
+   *
+   * @type {ContentFileeSearchResponseMetadata}
+   * @memberof ContentFileeSearchResponse
+   */
+  metadata: ContentFileeSearchResponseMetadata
+}
+/**
+ *
+ * @export
+ * @interface ContentFileeSearchResponseMetadata
+ */
+export interface ContentFileeSearchResponseMetadata {
+  /**
+   *
+   * @type {{ [key: string]: Array<ContentFileeSearchResponseMetadataAggregationsValueInner>; }}
+   * @memberof ContentFileeSearchResponseMetadata
+   */
+  aggregations: {
+    [
+      key: string
+    ]: Array<ContentFileeSearchResponseMetadataAggregationsValueInner>
+  }
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof ContentFileeSearchResponseMetadata
+   */
+  suggestions: Array<string>
+}
+/**
+ *
+ * @export
+ * @interface ContentFileeSearchResponseMetadataAggregationsValueInner
+ */
+export interface ContentFileeSearchResponseMetadataAggregationsValueInner {
+  /**
+   *
+   * @type {string}
+   * @memberof ContentFileeSearchResponseMetadataAggregationsValueInner
+   */
+  key: string
+  /**
+   *
+   * @type {number}
+   * @memberof ContentFileeSearchResponseMetadataAggregationsValueInner
+   */
+  doc_count: number
+}
 /**
  * * `page` - page * `file` - file * `vertical` - vertical
  * @export
@@ -1468,6 +1547,43 @@ export interface LearningResourceRunRequest {
    * @memberof LearningResourceRunRequest
    */
   checksum?: string | null
+}
+/**
+ * SearchResponseSerializer with OpenAPI annotations for Learning Resources search
+ * @export
+ * @interface LearningResourceSearchResponse
+ */
+export interface LearningResourceSearchResponse {
+  /**
+   *
+   * @type {number}
+   * @memberof LearningResourceSearchResponse
+   */
+  count: number
+  /**
+   *
+   * @type {string}
+   * @memberof LearningResourceSearchResponse
+   */
+  next: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof LearningResourceSearchResponse
+   */
+  previous: string | null
+  /**
+   *
+   * @type {Array<LearningResource>}
+   * @memberof LearningResourceSearchResponse
+   */
+  results: Array<LearningResource>
+  /**
+   *
+   * @type {ContentFileeSearchResponseMetadata}
+   * @memberof LearningResourceSearchResponse
+   */
+  metadata: ContentFileeSearchResponseMetadata
 }
 /**
  * Serializer for LearningResourceTopic model
@@ -3077,83 +3193,6 @@ export type ResourceTypeEnum =
   (typeof ResourceTypeEnum)[keyof typeof ResourceTypeEnum]
 
 /**
- *
- * @export
- * @interface SearchResponse
- */
-export interface SearchResponse {
-  /**
-   *
-   * @type {number}
-   * @memberof SearchResponse
-   */
-  count: number
-  /**
-   *
-   * @type {string}
-   * @memberof SearchResponse
-   */
-  next: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof SearchResponse
-   */
-  previous: string | null
-  /**
-   *
-   * @type {Array<LearningResource>}
-   * @memberof SearchResponse
-   */
-  results: Array<LearningResource>
-  /**
-   *
-   * @type {SearchResponseMetadata}
-   * @memberof SearchResponse
-   */
-  metadata: SearchResponseMetadata
-}
-/**
- *
- * @export
- * @interface SearchResponseMetadata
- */
-export interface SearchResponseMetadata {
-  /**
-   *
-   * @type {{ [key: string]: Array<SearchResponseMetadataAggregationsValueInner>; }}
-   * @memberof SearchResponseMetadata
-   */
-  aggregations: {
-    [key: string]: Array<SearchResponseMetadataAggregationsValueInner>
-  }
-  /**
-   *
-   * @type {Array<string>}
-   * @memberof SearchResponseMetadata
-   */
-  suggestions: Array<string>
-}
-/**
- *
- * @export
- * @interface SearchResponseMetadataAggregationsValueInner
- */
-export interface SearchResponseMetadataAggregationsValueInner {
-  /**
-   *
-   * @type {string}
-   * @memberof SearchResponseMetadataAggregationsValueInner
-   */
-  key: string
-  /**
-   *
-   * @type {number}
-   * @memberof SearchResponseMetadataAggregationsValueInner
-   */
-  doc_count: number
-}
-/**
  * Simplified serializer for UserList model.
  * @export
  * @interface UserList
@@ -4161,7 +4200,10 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
       topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponse>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<ContentFileeSearchResponse>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.contentFileSearchRetrieve(
@@ -4216,7 +4258,7 @@ export const ContentFileSearchApiFactory = function (
     contentFileSearchRetrieve(
       requestParameters: ContentFileSearchApiContentFileSearchRetrieveRequest = {},
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<SearchResponse> {
+    ): AxiosPromise<ContentFileeSearchResponse> {
       return localVarFp
         .contentFileSearchRetrieve(
           requestParameters.aggregations,
@@ -9979,7 +10021,10 @@ export const LearningResourcesSearchApiFp = function (
       topic?: Array<string>,
       options?: RawAxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<SearchResponse>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<LearningResourceSearchResponse>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningResourcesSearchRetrieve(
@@ -10037,7 +10082,7 @@ export const LearningResourcesSearchApiFactory = function (
     learningResourcesSearchRetrieve(
       requestParameters: LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest = {},
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<SearchResponse> {
+    ): AxiosPromise<LearningResourceSearchResponse> {
       return localVarFp
         .learningResourcesSearchRetrieve(
           requestParameters.aggregations,

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -583,7 +583,7 @@ class ContentFileSerializer(serializers.ModelSerializer):
         source="run.learning_resource.platform"
     )
 
-    def get_course_number(self, instance):
+    def get_course_number(self, instance) -> list[str]:
         """Extract the course number(s) from the associated course"""
         if hasattr(instance.run.learning_resource, LearningResourceType.course.name):
             return [

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -406,7 +406,6 @@ class SearchResponseSerializer(serializers.Serializer):
     def get_count(self, instance) -> int:
         return instance.get("hits", {}).get("total", {}).get("value")
 
-    @extend_schema_field(LearningResourceSerializer(many=True))
     def get_results(self, instance):
         hits = instance.get("hits", {}).get("hits", [])
         return (hit.get("_source") for hit in hits)
@@ -416,6 +415,27 @@ class SearchResponseSerializer(serializers.Serializer):
             "aggregations": _transform_aggregations(instance.get("aggregations", {})),
             "suggest": _transform_search_results_suggest(instance),
         }
+
+
+class LearningResourceSearchResponseSerializer(SearchResponseSerializer):
+    """
+    SearchResponseSerializer with OpenAPI annotations for Learning Resources
+    search
+    """
+
+    @extend_schema_field(LearningResourceSerializer(many=True))
+    def get_results():
+        return super().get_results()
+
+
+class ContentFileeSearchResponseSerializer(SearchResponseSerializer):
+    """
+    SearchResponseSerializer with OpenAPI annotations for Content Files search
+    """
+
+    @extend_schema_field(ContentFileSerializer(many=True))
+    def get_results():
+        return super().get_results()
 
 
 def serialize_content_file_for_update(content_file_obj):

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -13,7 +13,9 @@ from rest_framework.views import APIView
 from authentication.decorators import blocked_ip_exempt
 from learning_resources_search.api import execute_learn_search
 from learning_resources_search.serializers import (
+    ContentFileeSearchResponseSerializer,
     ContentFileSearchRequestSerializer,
+    LearningResourceSearchResponseSerializer,
     LearningResourcesSearchRequestSerializer,
     SearchResponseSerializer,
 )
@@ -39,7 +41,7 @@ class ESView(APIView):
 @extend_schema_view(
     get=extend_schema(
         parameters=[LearningResourcesSearchRequestSerializer()],
-        responses=SearchResponseSerializer(),
+        responses=LearningResourceSearchResponseSerializer(),
     ),
 )
 @action(methods=["GET"], detail=False, name="Search Learning Resources")
@@ -73,7 +75,7 @@ class LearningResourcesSearchView(ESView):
 @extend_schema_view(
     get=extend_schema(
         parameters=[ContentFileSearchRequestSerializer()],
-        responses=SearchResponseSerializer(),
+        responses=ContentFileeSearchResponseSerializer(),
     ),
 )
 @action(methods=["GET"], detail=False, name="Search Content Files")

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -307,7 +307,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SearchResponse'
+                $ref: '#/components/schemas/ContentFileeSearchResponse'
           description: ''
   /api/v1/contentfiles/:
     get:
@@ -3095,7 +3095,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SearchResponse'
+                $ref: '#/components/schemas/LearningResourceSearchResponse'
           description: ''
   /api/v1/learningpaths/:
     get:
@@ -5742,7 +5742,10 @@ components:
         resource_readable_id:
           type: string
         course_number:
-          type: string
+          type: array
+          items:
+            type: string
+          description: Extract the course number(s) from the associated course
           readOnly: true
         file_type:
           type: string
@@ -5770,6 +5773,58 @@ components:
       - semester
       - topics
       - year
+    ContentFileeSearchResponse:
+      type: object
+      description: SearchResponseSerializer with OpenAPI annotations for Content Files
+        search
+      properties:
+        count:
+          type: integer
+          readOnly: true
+        next:
+          type: string
+          nullable: true
+          readOnly: true
+        previous:
+          type: string
+          nullable: true
+          readOnly: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ContentFile'
+          readOnly: true
+        metadata:
+          type: object
+          properties:
+            aggregations:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    doc_count:
+                      type: integer
+                  required:
+                  - doc_count
+                  - key
+            suggestions:
+              type: array
+              items:
+                type: string
+          required:
+          - aggregations
+          - suggestions
+          readOnly: true
+      required:
+      - count
+      - metadata
+      - next
+      - previous
+      - results
     ContentTypeEnum:
       enum:
       - page
@@ -6670,6 +6725,59 @@ components:
       - level
       - run_id
       - title
+    LearningResourceSearchResponse:
+      type: object
+      description: |-
+        SearchResponseSerializer with OpenAPI annotations for Learning Resources
+        search
+      properties:
+        count:
+          type: integer
+          readOnly: true
+        next:
+          type: string
+          nullable: true
+          readOnly: true
+        previous:
+          type: string
+          nullable: true
+          readOnly: true
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResource'
+          readOnly: true
+        metadata:
+          type: object
+          properties:
+            aggregations:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    key:
+                      type: string
+                    doc_count:
+                      type: integer
+                  required:
+                  - doc_count
+                  - key
+            suggestions:
+              type: array
+              items:
+                type: string
+          required:
+          - aggregations
+          - suggestions
+          readOnly: true
+      required:
+      - count
+      - metadata
+      - next
+      - previous
+      - results
     LearningResourceTopic:
       type: object
       description: Serializer for LearningResourceTopic model
@@ -7800,56 +7908,6 @@ components:
         * `learning_path` - learning_path
         * `podcast` - podcast
         * `podcast_episode` - podcast_episode
-    SearchResponse:
-      type: object
-      properties:
-        count:
-          type: integer
-          readOnly: true
-        next:
-          type: string
-          nullable: true
-          readOnly: true
-        previous:
-          type: string
-          nullable: true
-          readOnly: true
-        results:
-          type: array
-          items:
-            $ref: '#/components/schemas/LearningResource'
-          readOnly: true
-        metadata:
-          type: object
-          properties:
-            aggregations:
-              type: object
-              additionalProperties:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    key:
-                      type: string
-                    doc_count:
-                      type: integer
-                  required:
-                  - doc_count
-                  - key
-            suggestions:
-              type: array
-              items:
-                type: string
-          required:
-          - aggregations
-          - suggestions
-          readOnly: true
-      required:
-      - count
-      - metadata
-      - next
-      - previous
-      - results
     UserList:
       type: object
       description: Simplified serializer for UserList model.


### PR DESCRIPTION
### What are the relevant tickets?
Closes #533 

### Description (What does it do?)
Annotates the `/api/v1/content_file_search/` endpoint for drf-spectacular / OpenAPI generation.

### How can this be tested?
1. View schema at http://localhost:8063/api/v1/schema/redoc/#tag/content_file_search; `response.results` should be an array of contentfiles. 

