### PR TITLE
content file isn't a resource type

### DIFF
--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -14,14 +14,18 @@ from learning_resources_search.api import (
     generate_suggest_clause,
     relevant_indexes,
 )
-from learning_resources_search.constants import SOURCE_EXCLUDED_FIELDS
+from learning_resources_search.constants import (
+    CONTENT_FILE_TYPE,
+    LEARNING_RESOURCE,
+)
 
 
 @pytest.mark.parametrize(
-    ("resourse_types", "aggregations", "result"),
+    ("endpoint", "resourse_types", "aggregations", "result"),
     [
-        (["course"], [], ["testindex_course_default"]),
+        (LEARNING_RESOURCE, ["course"], [], ["testindex_course_default"]),
         (
+            LEARNING_RESOURCE,
             ["course"],
             ["resource_type"],
             [
@@ -34,12 +38,11 @@ from learning_resources_search.constants import SOURCE_EXCLUDED_FIELDS
                 "testindex_video_playlist_default",
             ],
         ),
-        (["content_file"], [], ["testindex_course_default"]),
-        (["content_file", "course"], [], ["testindex_course_default"]),
+        (CONTENT_FILE_TYPE, ["content_file"], [], ["testindex_course_default"]),
     ],
 )
-def test_relevant_indexes(resourse_types, aggregations, result):
-    assert list(relevant_indexes(resourse_types, aggregations)) == result
+def test_relevant_indexes(endpoint, resourse_types, aggregations, result):
+    assert list(relevant_indexes(resourse_types, aggregations, endpoint)) == result
 
 
 @pytest.mark.parametrize(
@@ -1003,7 +1006,7 @@ def test_generate_aggregation_clauses_with_same_filters_as_aggregation():
     assert generate_aggregation_clauses(params, filters) == result
 
 
-def test_execute_learn_search(opensearch):
+def test_execute_learn_search_for_learning_resource_query(opensearch):
     opensearch.conn.search.return_value = {
         "hits": {"total": {"value": 10, "relation": "eq"}}
     }
@@ -1014,13 +1017,13 @@ def test_execute_learn_search(opensearch):
         "limit": 1,
         "offset": 1,
         "sortby": "-readable_id",
+        "endpoint": LEARNING_RESOURCE,
     }
 
     query = {
-        "_source": {"excludes": SOURCE_EXCLUDED_FIELDS},
         "query": {
             "bool": {
-                "should": [
+                "must": [
                     {
                         "bool": {
                             "filter": [
@@ -1077,9 +1080,7 @@ def test_execute_learn_search(opensearch):
                                                             "wildcard": {
                                                                 "readable_id": {
                                                                     "value": "MATH*",
-                                                                    "rewrite": (
-                                                                        "constant_score"
-                                                                    ),
+                                                                    "rewrite": "constant_score",
                                                                 }
                                                             }
                                                         },
@@ -1090,7 +1091,7 @@ def test_execute_learn_search(opensearch):
                                                                     "multi_match": {
                                                                         "query": "math",
                                                                         "fields": [
-                                                                            "course.course_numbers.value",
+                                                                            "course.course_numbers.value"
                                                                         ],
                                                                     }
                                                                 },
@@ -1271,7 +1272,8 @@ def test_execute_learn_search(opensearch):
                             ],
                         }
                     }
-                ]
+                ],
+                "filter": [{"exists": {"field": "resource_type"}}],
             }
         },
         "post_filter": {
@@ -1340,17 +1342,14 @@ def test_execute_learn_search(opensearch):
             "offered_by": {
                 "aggs": {
                     "offered_by": {
+                        "nested": {"path": "offered_by"},
                         "aggs": {
                             "offered_by": {
-                                "terms": {
-                                    "field": "offered_by.code",
-                                    "size": 10000,
-                                },
+                                "terms": {"field": "offered_by.code", "size": 10000},
                                 "aggs": {"root": {"reverse_nested": {}}},
                             }
                         },
-                        "nested": {"path": "offered_by"},
-                    },
+                    }
                 },
                 "filter": {
                     "bool": {
@@ -1373,6 +1372,216 @@ def test_execute_learn_search(opensearch):
                     }
                 },
             }
+        },
+        "_source": {
+            "excludes": [
+                "course.course_numbers.sort_coursenum",
+                "course.course_numbers.primary",
+                "created_on",
+                "resource_relations",
+            ]
+        },
+    }
+
+    assert execute_learn_search(search_params) == opensearch.conn.search.return_value
+
+    opensearch.conn.search.assert_called_once_with(
+        body=query,
+        index=["testindex_course_default"],
+    )
+
+
+def test_execute_learn_search_for_content_file_query(opensearch):
+    opensearch.conn.search.return_value = {
+        "hits": {"total": {"value": 10, "relation": "eq"}}
+    }
+
+    search_params = {
+        "aggregations": ["offered_by"],
+        "q": "math",
+        "limit": 1,
+        "offset": 1,
+        "content_feature_type": ["Online Textbook"],
+        "endpoint": CONTENT_FILE_TYPE,
+    }
+
+    query = {
+        "query": {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "filter": [
+                                {
+                                    "bool": {
+                                        "must": [
+                                            {
+                                                "bool": {
+                                                    "should": [
+                                                        {
+                                                            "multi_match": {
+                                                                "query": "math",
+                                                                "fields": [
+                                                                    "content",
+                                                                    "title.english^3",
+                                                                    "short_description.english^2",
+                                                                    "content_feature_type",
+                                                                ],
+                                                            }
+                                                        },
+                                                        {
+                                                            "nested": {
+                                                                "path": "departments",
+                                                                "query": {
+                                                                    "multi_match": {
+                                                                        "query": "math",
+                                                                        "fields": [
+                                                                            "departments.department_id"
+                                                                        ],
+                                                                    }
+                                                                },
+                                                            }
+                                                        },
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            "should": [
+                                {
+                                    "multi_match": {
+                                        "query": "math",
+                                        "fields": [
+                                            "content",
+                                            "title.english^3",
+                                            "short_description.english^2",
+                                            "content_feature_type",
+                                        ],
+                                    }
+                                },
+                                {
+                                    "nested": {
+                                        "path": "departments",
+                                        "query": {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": ["departments.department_id"],
+                                            }
+                                        },
+                                    }
+                                },
+                            ],
+                        }
+                    }
+                ],
+                "filter": [{"exists": {"field": "content_type"}}],
+            }
+        },
+        "post_filter": {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "should": [
+                                {
+                                    "term": {
+                                        "content_feature_type": {
+                                            "value": "Online Textbook",
+                                            "case_insensitive": True,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "from": 1,
+        "size": 1,
+        "suggest": {
+            "text": "math",
+            "title.trigram": {
+                "phrase": {
+                    "field": "title.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "title.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+            "description.trigram": {
+                "phrase": {
+                    "field": "description.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "description.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+        },
+        "aggs": {
+            "offered_by": {
+                "aggs": {
+                    "offered_by": {
+                        "nested": {"path": "offered_by"},
+                        "aggs": {
+                            "offered_by": {
+                                "terms": {"field": "offered_by.code", "size": 10000},
+                                "aggs": {"root": {"reverse_nested": {}}},
+                            }
+                        },
+                    }
+                },
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "bool": {
+                                    "should": [
+                                        {
+                                            "term": {
+                                                "content_feature_type": {
+                                                    "value": "Online Textbook",
+                                                    "case_insensitive": True,
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+            }
+        },
+        "_source": {
+            "excludes": [
+                "course.course_numbers.sort_coursenum",
+                "course.course_numbers.primary",
+                "created_on",
+                "resource_relations",
+            ]
         },
     }
 

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -20,6 +20,8 @@ CURRENT_INDEX = "current_index"
 REINDEXING_INDEX = "reindexing_index"
 BOTH_INDEXES = "all_indexes"
 
+LEARNING_RESOURCE = "learning_resource"
+
 
 class IndexestoUpdate(Enum):
     """
@@ -235,7 +237,6 @@ CONTENT_FILE_MAP = {
     "resource_id": {"type": "long"},
     "resource_readable_id": {"type": "keyword"},
     "course_number": {"type": "keyword"},
-    "resource_type": {"type": "keyword"},
     "offered_by": {
         "type": "nested",
         "properties": {

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -276,7 +276,6 @@ class ContentFileSearchRequestSerializer(SearchRequestSerializer):
         help_text="Show resource counts by category",
         child=serializers.ChoiceField(choices=CONTENT_FILE_AGGREGATIONS),
     )
-    resource_type = serializers.ReadOnlyField(default=[CONTENT_FILE_TYPE])
     run_id = StringArrayField(
         required=False,
         child=serializers.IntegerField(),
@@ -446,7 +445,6 @@ def serialize_content_file_for_update(content_file_obj):
             "name": CONTENT_FILE_TYPE,
             "parent": content_file_obj.run.learning_resource_id,
         },
-        "resource_type": CONTENT_FILE_TYPE,
         **ContentFileSerializer(content_file_obj).data,
     }
 

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -155,7 +155,6 @@ def test_serialize_content_file_for_bulk():
             "name": "content_file",
             "parent": content_file.run.learning_resource_id,
         },
-        "resource_type": "content_file",
         **ContentFileSerializer(content_file).data,
     }
 
@@ -249,7 +248,6 @@ def test_content_file_search_request_serializer():
         "limit": 1,
         "id": [1],
         "sortby": "-id",
-        "resource_type": ["content_file"],
         "topic": ["Math"],
         "aggregations": ["topic"],
         "content_feature_type": ["Assignment"],

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 
 from authentication.decorators import blocked_ip_exempt
 from learning_resources_search.api import execute_learn_search
+from learning_resources_search.constants import CONTENT_FILE_TYPE, LEARNING_RESOURCE
 from learning_resources_search.serializers import (
     ContentFileeSearchResponseSerializer,
     ContentFileSearchRequestSerializer,
@@ -57,7 +58,9 @@ class LearningResourcesSearchView(ESView):
         request_data = LearningResourcesSearchRequestSerializer(data=request.GET)
 
         if request_data.is_valid():
-            response = execute_learn_search(request_data.data)
+            response = execute_learn_search(
+                request_data.data | {"endpoint": LEARNING_RESOURCE}
+            )
             return Response(
                 SearchResponseSerializer(response, context={"request": request}).data
             )
@@ -91,7 +94,9 @@ class ContentFileSearchView(ESView):
     def get(self, request):
         request_data = ContentFileSearchRequestSerializer(data=request.GET)
         if request_data.is_valid():
-            response = execute_learn_search(request_data.data)
+            response = execute_learn_search(
+                request_data.data | {"endpoint": CONTENT_FILE_TYPE}
+            )
             return Response(
                 SearchResponseSerializer(response, context={"request": request}).data
             )

--- a/learning_resources_search/views_test.py
+++ b/learning_resources_search/views_test.py
@@ -9,6 +9,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
+from learning_resources_search.constants import CONTENT_FILE_TYPE, LEARNING_RESOURCE
 from learning_resources_search.serializers import (
     ContentFileSearchRequestSerializer,
     LearningResourcesSearchRequestSerializer,
@@ -72,6 +73,7 @@ def test_learn_resources_search(mocker, client, learning_resources_search_view):
     resp = client.get(learning_resources_search_view.url, params)
     search_mock.assert_called_once_with(
         LearningResourcesSearchRequestSerializer(params).data
+        | {"endpoint": LEARNING_RESOURCE}
     )
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
         SearchResponseSerializer(FAKE_SEARCH_RESPONSE).data
@@ -214,7 +216,10 @@ def test_content_file_search(mocker, client, content_file_search_view):
     params = {"q": "text"}
     request = Request(request_factory.get(content_file_search_view.url, params))
     resp = client.get(content_file_search_view.url, params)
-    search_mock.assert_called_once_with(ContentFileSearchRequestSerializer(params).data)
+    search_mock.assert_called_once_with(
+        ContentFileSearchRequestSerializer(params).data
+        | {"endpoint": CONTENT_FILE_TYPE}
+    )
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
         SearchResponseSerializer(
             FAKE_SEARCH_RESPONSE, context={"request": request}


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/mit-open/issues/389

### Description (What does it do?)
This pr removes the learning_resource field from content files and fixes a bug that shows content file counts when a learning resource search  query has aggregation resource_type.


### How can this be tested?
Run docker-compose run web ./manage.py recreate_index --all

Verify that http://localhost:8063/api/v1/learning_resources_search/?aggregations=resource_type does not show content_type as a key

Verify that the document counts are the same at http://localhost:8063/api/v1/learning_resources_search/ and http://localhost:8063/api/v1/learning_resources/ and http://localhost:8063/api/v1/content_file_search/ and http://localhost:8063/api/v1/contentfiles/

Verify that both the content file search and the learning resource search behave normally in other ways
