### PR TITLE
Assign topics to videos and playlists

### DIFF
--- a/learning_resources/admin.py
+++ b/learning_resources/admin.py
@@ -105,6 +105,7 @@ class VideoPlaylistInline(TabularInline):
     model = models.VideoPlaylist
     extra = 0
     show_change_link = True
+    fields = ("channel",)
 
 
 class ProgramInline(TabularInline):

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -861,9 +861,10 @@ def load_video_channels(video_channels_data: iter) -> list[VideoChannel]:
         list of VideoChannel: the loaded video channels
     """
     video_channels = []
-
+    channel_ids = []
     for video_channel_data in video_channels_data:
         channel_id = video_channel_data["channel_id"]
+        channel_ids.append(channel_id)
         try:
             video_channel = load_video_channel(video_channel_data)
         except ExtractException:
@@ -879,7 +880,6 @@ def load_video_channels(video_channels_data: iter) -> list[VideoChannel]:
         else:
             video_channels.append(video_channel)
 
-    channel_ids = [video_channel.channel_id for video_channel in video_channels]
     VideoChannel.objects.exclude(channel_id__in=channel_ids).update(published=False)
 
     # Unpublish any video playlists not included in published channels

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -17,6 +17,7 @@ from learning_resources.etl.constants import (
 )
 from learning_resources.etl.deduplication import get_most_relevant_run
 from learning_resources.etl.exceptions import ExtractException
+from learning_resources.etl.utils import most_common_topics
 from learning_resources.models import (
     ContentFile,
     Course,
@@ -45,6 +46,7 @@ from learning_resources.utils import (
     resource_run_upserted_actions,
     resource_unpublished_actions,
     resource_upserted_actions,
+    similar_topics_action,
 )
 
 log = logging.getLogger()
@@ -722,6 +724,8 @@ def load_video(video_data: dict) -> LearningResource:
             learning_resource=learning_resource, defaults=video_fields
         )
         load_image(learning_resource, image_data)
+        if not topics_data:
+            topics_data = similar_topics_action(learning_resource)
         load_topics(learning_resource, topics_data)
         load_offered_by(learning_resource, offered_by_data)
 
@@ -776,6 +780,7 @@ def load_playlist(video_channel: VideoChannel, playlist_data: dict) -> LearningR
         )
         load_offered_by(playlist_resource, offered_bys_data)
         video_resources = load_videos(videos_data)
+        load_topics(playlist_resource, most_common_topics(video_resources))
         playlist_resource.resources.clear()
         for idx, video in enumerate(video_resources):
             playlist_resource.resources.add(

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -7,6 +7,7 @@ import mimetypes
 import os
 import re
 import uuid
+from collections import Counter
 from collections.abc import Generator
 from datetime import datetime
 from hashlib import md5
@@ -38,6 +39,7 @@ from learning_resources.etl.constants import CourseNumberType, ETLSource
 from learning_resources.models import (
     ContentFile,
     Course,
+    LearningResource,
     LearningResourceRun,
 )
 
@@ -627,3 +629,23 @@ def update_course_numbers_json(course: Course):
         is_ocw=is_ocw,
     )
     course.save()
+
+
+def most_common_topics(
+    resources: list[LearningResource], max_topics: int = settings.OPEN_VIDEO_MAX_TOPICS
+) -> list[dict]:
+    """
+    Get the most common topics from a list of resources
+
+    Args:
+        resources (list[LearningResource]): resources to get topics from
+        max_topics (int): The maximum number of topics to return
+
+    Returns:
+        list: The most common topic names as a dict
+    """
+    counter = Counter(
+        list({topic.name for resource in resources for topic in resource.topics.all()})
+    )
+    common_topics = dict(counter.most_common(max_topics)).keys()
+    return [{"name": topic} for topic in common_topics]

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -645,7 +645,7 @@ def most_common_topics(
         list: The most common topic names as a dict
     """
     counter = Counter(
-        list({topic.name for resource in resources for topic in resource.topics.all()})
+        [topic.name for resource in resources for topic in resource.topics.all()]
     )
     common_topics = dict(counter.most_common(max_topics)).keys()
     return [{"name": topic} for topic in common_topics]

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -642,7 +642,7 @@ def most_common_topics(
         max_topics (int): The maximum number of topics to return
 
     Returns:
-        list: The most common topic names as a dict
+        list of dict: The most common topic names
     """
     counter = Counter(
         [topic.name for resource in resources for topic in resource.topics.all()]

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -24,6 +24,10 @@ class LearningResourceHooks:
         """Trigger actions after a learning resource is unpublished"""
 
     @hookspec
+    def resource_similar_topics(self, resource) -> dict:
+        """Get similar topics for a learning resource"""
+
+    @hookspec
     def bulk_resources_unpublished(self, resource_ids, resource_type):
         """Trigger actions after multiple learning resources are unpublished"""
 

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -24,7 +24,7 @@ class LearningResourceHooks:
         """Trigger actions after a learning resource is unpublished"""
 
     @hookspec
-    def resource_similar_topics(self, resource) -> dict:
+    def resource_similar_topics(self, resource) -> list[dict]:
         """Get similar topics for a learning resource"""
 
     @hookspec

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -111,7 +111,6 @@ class LearningResource(TimestampedModel):
         "runs__image",
         "children__child",
         "children__child__runs",
-        "children__child__parents",
         "children__child__runs__instructors",
         "children__child__departments",
         "children__child__platform",

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -111,16 +111,15 @@ class LearningResource(TimestampedModel):
         "runs__image",
         "children__child",
         "children__child__runs",
+        "children__child__parents",
         "children__child__runs__instructors",
-        "children__child__course",
-        "children__child__program",
-        "children__child__learning_path",
         "children__child__departments",
         "children__child__platform",
         "children__child__topics",
         "children__child__image",
         "children__child__offered_by",
         "children__child__content_tags",
+        *[f"children__child__{item.name}" for item in LearningResourceType],
     ]
 
     related_selects = [

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -331,6 +331,17 @@ def resource_unpublished_actions(resource: LearningResource):
     hook.resource_unpublished(resource=resource)
 
 
+def similar_topics_action(resource: LearningResource) -> dict:
+    """
+    Trigger plugins to get similar topics for a resource
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    topics = hook.resource_similar_topics(resource=resource)
+    # The plugin returns the list wrapped in another list for some reason
+    return topics[0] if topics else []
+
+
 def resource_delete_actions(resource: LearningResource):
     """
     Trigger plugin to handle learning resource deletion

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -333,7 +333,7 @@ def resource_unpublished_actions(resource: LearningResource):
 
 def similar_topics_action(resource: LearningResource) -> dict:
     """
-    Trigger plugins to get similar topics for a resource
+    Trigger plugin to get similar topics for a resource
     """
     pm = get_plugin_manager()
     hook = pm.hook

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -212,6 +212,18 @@ def test_resource_upserted_actions(mock_plugin_manager, fixture_resource):
     )
 
 
+def test_similar_topics_action(mock_plugin_manager, fixture_resource) -> dict:
+    """
+    similar_topics_action should trigger plugin hook's resource_similar_topics function
+    """
+    mock_topics = [{"name": "Biology"}, {"name": "Chemistry"}]
+    mock_plugin_manager.hook.resource_similar_topics.return_value = [mock_topics]
+    assert utils.similar_topics_action(fixture_resource) == mock_topics
+    mock_plugin_manager.hook.resource_similar_topics.assert_called_once_with(
+        resource=fixture_resource
+    )
+
+
 def test_resource_unpublished_actions(mock_plugin_manager, fixture_resource):
     """
     resource_unpublished_actions function should trigger plugin hook's resource_unpublished function

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1,8 +1,10 @@
 """API for general search-related functionality"""
 
 import re
+from collections import Counter
 
 from opensearch_dsl import Search
+from opensearch_dsl.query import MoreLikeThis
 
 from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
 from learning_resources_search.connection import get_default_alias_name
@@ -515,3 +517,49 @@ def execute_learn_search(search_params):
         search = search.extra(aggs=aggregation_clauses)
 
     return search.execute().to_dict()
+
+
+def get_similar_topics(
+    value_doc: dict, num_topics: int, min_term_freq: int, min_doc_freq: int
+) -> list[str]:
+    """
+    Get a list of similar topics based on text values
+
+    Args:
+        value_doc (dict):
+            a document representing the data fields we want to search with
+        num_topics (int):
+            number of topics to return
+        min_term_freq (int):
+            minimum times a term needs to show up in input
+        min_doc_freq (int):
+            minimum times a term needs to show up in docs
+
+    Returns:
+        list of str:
+            list of topic values
+    """
+    indexes = relevant_indexes([COURSE_TYPE], [])
+    search = Search(index=",".join(indexes))
+    search = search.filter("term", resource_type=COURSE_TYPE)
+    search = search.query(
+        MoreLikeThis(
+            like=[{"doc": value_doc, "fields": list(value_doc.keys())}],
+            fields=[
+                "course.course_numbers.value",
+                "title",
+                "description",
+                "full_description",
+            ],
+            min_term_freq=min_term_freq,
+            min_doc_freq=min_doc_freq,
+        )
+    )
+    search = search.source(includes="topics")
+
+    response = search.execute()
+
+    topics = [topic.to_dict()["name"] for hit in response.hits for topic in hit.topics]
+
+    counter = Counter(topics)
+    return dict(counter.most_common(num_topics)).keys()

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -562,4 +562,4 @@ def get_similar_topics(
     topics = [topic.to_dict()["name"] for hit in response.hits for topic in hit.topics]
 
     counter = Counter(topics)
-    return dict(counter.most_common(num_topics)).keys()
+    return list(dict(counter.most_common(num_topics)).keys())

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -13,6 +13,7 @@ from learning_resources_search.constants import (
     COURSE_QUERY_FIELDS,
     COURSE_TYPE,
     DEPARTMENT_QUERY_FIELDS,
+    LEARNING_RESOURCE,
     LEARNING_RESOURCE_QUERY_FIELDS,
     LEARNING_RESOURCE_SEARCH_FILTERS,
     LEARNING_RESOURCE_TYPES,
@@ -539,7 +540,7 @@ def get_similar_topics(
         list of str:
             list of topic values
     """
-    indexes = relevant_indexes([COURSE_TYPE], [])
+    indexes = relevant_indexes([COURSE_TYPE], [], endpoint=LEARNING_RESOURCE)
     search = Search(index=",".join(indexes))
     search = search.filter("term", resource_type=COURSE_TYPE)
     search = search.query(

--- a/learning_resources_search/plugins_test.py
+++ b/learning_resources_search/plugins_test.py
@@ -117,3 +117,26 @@ def test_search_index_plugin_resource_run_delete(mock_search_index_helpers):
         False,  # noqa: FBT003
     )
     assert LearningResourceRun.objects.filter(id=run_id).exists() is False
+
+
+@pytest.mark.django_db()
+def test_resource_similar_topics(mocker, settings):
+    """The plugin function should return expected topics for a resource"""
+    expected_topics = ["topic1", "topic2"]
+    mock_similar_topics = mocker.patch(
+        "learning_resources_search.plugins.get_similar_topics",
+        return_value=expected_topics,
+    )
+    resource = LearningResourceFactory.create()
+    topics = SearchIndexPlugin().resource_similar_topics(resource)
+    assert topics == [{"name": topic} for topic in expected_topics]
+    mock_similar_topics.assert_called_once_with(
+        {
+            "title": resource.title,
+            "description": resource.description,
+            "full_description": resource.full_description,
+        },
+        settings.OPEN_VIDEO_MAX_TOPICS,
+        settings.OPEN_VIDEO_MIN_TERM_FREQ,
+        settings.OPEN_VIDEO_MIN_DOC_FREQ,
+    )


### PR DESCRIPTION
### What are the relevant tickets?
Closes #579

### Description (What does it do?)
For videos, runs an opensearch course query for each video to guesstimate the covered topics based on the video title & description fields, and assigns the 3 most common topics from the results.  (Port of open-discussions functionality).
For video playlists, assigns the 3 most common topics from the videos in the playlist. 


### How can this be tested?
Follow testing instructions for PR #558.  Everything should work the same, except that most video and video playlist resources should now have up to 3 topics assigned to them after the ETL pipeline is complete.   This assumes you already have a decent amount of courses available with topics.  If you don't, run `./manage.py backpopulate_ocw_data --skip-contentfiles` first, it will likely take 20-30 minutes or so.
