### PR TITLE
Avoid duplicate courses

### DIFF
--- a/learning_resources/etl/constants.py
+++ b/learning_resources/etl/constants.py
@@ -10,6 +10,8 @@ COMMON_HEADERS = {
     "User-Agent": f"CourseCatalogBot/{settings.VERSION} ({settings.SITE_BASE_URL})"
 }
 
+DEFAULT_UNIQUE_KEY = "readable_id"
+
 MIT_OWNER_KEYS = ["MITx", "MITx_PRO"]
 
 

--- a/learning_resources/etl/constants.py
+++ b/learning_resources/etl/constants.py
@@ -10,7 +10,7 @@ COMMON_HEADERS = {
     "User-Agent": f"CourseCatalogBot/{settings.VERSION} ({settings.SITE_BASE_URL})"
 }
 
-DEFAULT_UNIQUE_KEY = "readable_id"
+READABLE_ID_FIELD = "readable_id"
 
 MIT_OWNER_KEYS = ["MITx", "MITx_PRO"]
 

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -290,16 +290,14 @@ def load_course(
         if unique_field_name != DEFAULT_UNIQUE_KEY:
             # Some dupes may result, so we need to unpublish resources
             # with matching unique values and different readable_ids
-            dupe_resources = LearningResource.objects.filter(
+            for resource in LearningResource.objects.filter(
                 **{unique_field_name: unique_field_value},
                 platform=platform,
                 resource_type=LearningResourceType.course.name,
-            ).exclude(readable_id=resource_id)
-            if dupe_resources.count() > 0:
-                bulk_resources_unpublished_actions(
-                    [resource.id for resource in dupe_resources],
-                    LearningResourceType.course.name,
-                )
+            ).exclude(readable_id=resource_id):
+                resource.published = False
+                resource.save()
+                resource_unpublished_actions(resource)
         (
             learning_resource,
             created,

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -12,7 +12,7 @@ from learning_resources.constants import (
     PlatformType,
 )
 from learning_resources.etl.constants import (
-    DEFAULT_UNIQUE_KEY,
+    READABLE_ID_FIELD,
     CourseLoaderConfig,
     ProgramLoaderConfig,
 )
@@ -277,7 +277,7 @@ def load_course(
                 duplicate_resource.save()
                 resource_unpublished_actions(duplicate_resource)
 
-        unique_field_name = resource_data.pop("unique_field", DEFAULT_UNIQUE_KEY)
+        unique_field_name = resource_data.pop("unique_field", READABLE_ID_FIELD)
         unique_field_value = resource_data.get(unique_field_name)
 
         log.info(
@@ -287,7 +287,7 @@ def load_course(
             unique_field_value,
         )
         resource_id = deduplicated_course_id or readable_id
-        if unique_field_name != DEFAULT_UNIQUE_KEY:
+        if unique_field_name != READABLE_ID_FIELD:
             # Some dupes may result, so we need to unpublish resources
             # with matching unique values and different readable_ids
             for resource in LearningResource.objects.filter(

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -12,10 +12,10 @@ from learning_resources.constants import (
     PlatformType,
 )
 from learning_resources.etl.constants import (
+    DEFAULT_UNIQUE_KEY,
     CourseLoaderConfig,
     ProgramLoaderConfig,
 )
-from learning_resources.etl.deduplication import get_most_relevant_run
 from learning_resources.etl.exceptions import ExtractException
 from learning_resources.etl.utils import most_common_topics
 from learning_resources.models import (
@@ -212,7 +212,7 @@ def load_run(
     return learning_resource_run
 
 
-def load_course(  # noqa: C901
+def load_course(
     resource_data: dict,
     blocklist: list[str],
     duplicates: list[dict],
@@ -237,7 +237,6 @@ def load_course(  # noqa: C901
             the created/updated course
     """
     platform_name = resource_data.pop("platform")
-    readable_id = resource_data.pop("readable_id")
     runs_data = resource_data.pop("runs", [])
     topics_data = resource_data.pop("topics", None)
     offered_bys_data = resource_data.pop("offered_by", None)
@@ -246,6 +245,7 @@ def load_course(  # noqa: C901
     department_data = resource_data.pop("departments", [])
     content_tags_data = resource_data.pop("content_tags", [])
 
+    readable_id = resource_data.pop("readable_id")
     if readable_id in blocklist or not runs_data:
         resource_data["published"] = False
 
@@ -268,37 +268,47 @@ def load_course(  # noqa: C901
             )
             return None
 
-        if deduplicated_course_id:
-            # intentionally not updating if the course doesn't exist
-            (
-                learning_resource,
-                created,
-            ) = LearningResource.objects.select_for_update().get_or_create(
-                platform=platform,
-                readable_id=deduplicated_course_id,
-                resource_type=LearningResourceType.course.name,
-                defaults=resource_data,
-            )
+        if readable_id != deduplicated_course_id:
+            duplicate_resource = LearningResource.objects.filter(
+                platform=platform, readable_id=readable_id
+            ).first()
+            if duplicate_resource:
+                duplicate_resource.published = False
+                duplicate_resource.save()
+                resource_unpublished_actions(duplicate_resource)
 
-            if readable_id != deduplicated_course_id:
-                duplicate_resource = LearningResource.objects.filter(
-                    platform=platform, readable_id=readable_id
-                ).first()
-                if duplicate_resource:
-                    duplicate_resource.published = False
-                    duplicate_resource.save()
-                    resource_unpublished_actions(duplicate_resource)
+        unique_field_name = resource_data.pop("unique_field", DEFAULT_UNIQUE_KEY)
+        unique_field_value = resource_data.get(unique_field_name)
 
-        else:
-            (
-                learning_resource,
-                created,
-            ) = LearningResource.objects.select_for_update().update_or_create(
+        log.info(
+            "Loading course: %s:%s=%s",
+            readable_id,
+            unique_field_name,
+            unique_field_value,
+        )
+        resource_id = deduplicated_course_id or readable_id
+        if unique_field_name != DEFAULT_UNIQUE_KEY:
+            # Some dupes may result, so we need to unpublish resources
+            # with matching unique values and different readable_ids
+            dupe_resources = LearningResource.objects.filter(
+                **{unique_field_name: unique_field_value},
                 platform=platform,
-                readable_id=readable_id,
                 resource_type=LearningResourceType.course.name,
-                defaults=resource_data,
-            )
+            ).exclude(readable_id=resource_id)
+            if dupe_resources.count() > 0:
+                bulk_resources_unpublished_actions(
+                    [resource.id for resource in dupe_resources],
+                    LearningResourceType.course.name,
+                )
+        (
+            learning_resource,
+            created,
+        ) = LearningResource.objects.select_for_update().update_or_create(
+            readable_id=resource_id,
+            platform=platform,
+            resource_type=LearningResourceType.course.name,
+            defaults=resource_data,
+        )
 
         Course.objects.get_or_create(
             learning_resource=learning_resource, defaults=course_data
@@ -308,14 +318,6 @@ def load_course(  # noqa: C901
 
         for course_run_data in runs_data:
             load_run(learning_resource, course_run_data)
-
-        if deduplicated_course_id and not created:
-            most_relevent_run = get_most_relevant_run(learning_resource.runs.all())
-
-            if most_relevent_run.run_id in run_ids_to_update_or_create:
-                for attr, val in resource_data.items():
-                    setattr(learning_resource, attr, val)
-                learning_resource.save()
 
         unpublished_runs = []
         if config.prune:

--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -43,6 +43,7 @@ log = logging.getLogger(__name__)
 
 OFFERED_BY = {"code": OfferedBy.ocw.name}
 PRIMARY_COURSE_ID = "primary_course_number"
+UNIQUE_FIELD = "url"
 
 
 def transform_content_files(
@@ -344,6 +345,7 @@ def transform_course(course_data: dict) -> dict:
         "topics": topics,
         "runs": [transform_run(course_data)],
         "resource_type": LearningResourceType.course.name,
+        "unique_field": UNIQUE_FIELD,
     }
 
 

--- a/learning_resources/etl/prolearn_test.py
+++ b/learning_resources/etl/prolearn_test.py
@@ -10,6 +10,7 @@ import pytz
 from learning_resources.etl import prolearn
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.prolearn import (
+    UNIQUE_FIELD,
     get_offered_by,
     parse_date,
     parse_image,
@@ -164,6 +165,7 @@ def test_prolearn_transform_programs(mock_csail_programs_data):
                 }
                 for course_id in sorted(program["field_related_courses_programs"])
             ],
+            "unique_field": UNIQUE_FIELD,
         }
         for program in extracted_data
     ]
@@ -212,6 +214,7 @@ def test_prolearn_transform_courses(mock_mitpe_courses_data):
                 )
             ],
             "course": {"course_numbers": []},
+            "unique_field": UNIQUE_FIELD,
         }
         for course in extracted_data
     ]

--- a/learning_resources/etl/prolearn_test.py
+++ b/learning_resources/etl/prolearn_test.py
@@ -3,13 +3,16 @@
 import json
 from datetime import datetime
 from decimal import Decimal
+from urllib.parse import urljoin, urlparse
 
 import pytest
 import pytz
 
+from learning_resources.constants import OfferedBy, PlatformType
 from learning_resources.etl import prolearn
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.prolearn import (
+    PROLEARN_BASE_URL,
     UNIQUE_FIELD,
     get_offered_by,
     parse_date,
@@ -124,16 +127,16 @@ def test_prolearn_transform_programs(mock_csail_programs_data):
     result = prolearn.transform_programs(extracted_data)
     expected = [
         {
-            "readable_id": program["nid"],
+            "readable_id": f"prolearn-{PlatformType.csail.name}-{program['nid']}",
             "title": program["title"],
             "url": (
                 program["course_link"]
                 or program["course_application_url"]
-                or program["url"]
+                or urljoin(PROLEARN_BASE_URL, program["url"])
             ),
             "image": parse_image(program),
-            "platform": "csail",
-            "offered_by": {"name": "CSAIL"},
+            "platform": PlatformType.csail.name,
+            "offered_by": {"name": OfferedBy.csail.value},
             "etl_source": ETLSource.prolearn.name,
             "professional": True,
             "runs": [
@@ -162,6 +165,7 @@ def test_prolearn_transform_programs(mock_csail_programs_data):
                             "run_id": course_id,
                         }
                     ],
+                    "unique_field": UNIQUE_FIELD,
                 }
                 for course_id in sorted(program["field_related_courses_programs"])
             ],
@@ -178,9 +182,9 @@ def test_prolearn_transform_courses(mock_mitpe_courses_data):
     result = list(prolearn.transform_courses(extracted_data))
     expected = [
         {
-            "readable_id": course["nid"],
-            "platform": "mitpe",
-            "offered_by": {"name": "Professional Education"},
+            "readable_id": f"prolearn-{PlatformType.mitpe.name}-{course['nid']}",
+            "platform": PlatformType.mitpe.name,
+            "offered_by": {"name": OfferedBy.mitpe.value},
             "etl_source": ETLSource.prolearn.name,
             "title": course["title"],
             "image": parse_image(course),
@@ -188,10 +192,11 @@ def test_prolearn_transform_courses(mock_mitpe_courses_data):
             "published": True,
             "professional": True,
             "topics": parse_topic(course),
-            "url": (
-                course["course_link"]
-                or course["course_application_url"]
-                or course["url"]
+            "url": course["course_link"]
+            if urlparse(course["course_link"]).path
+            else (
+                course["course_application_url"]
+                or urljoin(PROLEARN_BASE_URL, course["url"])
             ),
             "runs": [
                 {


### PR DESCRIPTION
### What are the relevant tickets?
Closes #473 

### Description (What does it do?)
- Adjusts the `load_course` ETL function to check for an optional data param ("unique_field") that if different from the default `readable_id`, unpublishes all other course resources with the same field value and platform.
- Adjusts the prolearn readable_id value to be more than just a number
- Changes the url used by prolearn (ignores the "course_link" field if there is no path in it).


### How can this be tested?
- If you haven't loaded prolearn courses already, do so on the main branch (set `PROLEARN_CATALOG_API_URL=https://prolearn.mit.edu/graphql` and then run `./manage.py backpopulate_prolearn_data`).
- Via django admin, check how many published courses there are from that source: http://localhost:8063/admin/learning_resources/learningresource/?etl_source=prolearn&published__exact=1&resource_type__exact=course
- If you search for "Accelerating Digital Transformation" you will get multiple results: http://localhost:8063/api/v1//learning_resources_search/?q=%22Accelerating%20Digital%20Transformation%22
- Switch to this branch and run the management command again.  
- Now the count of published courses from [this source should be lower](http://localhost:8063/admin/learning_resources/learningresource/?etl_source=prolearn&published__exact=1&resource_type__exact=course), and there should be only one search result for "[Accelerating Digital Transformation](http://localhost:8063/api/v1//learning_resources_search/?q=%22Accelerating%20Digital%20Transformation%22)".
