### PR TITLE
Endpoint for user program certificate info and program letter links

### DIFF
--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -3020,6 +3020,12 @@ export interface ProgramCertificate {
   id: number
   /**
    *
+   * @type {string}
+   * @memberof ProgramCertificate
+   */
+  program_letter_url: string
+  /**
+   *
    * @type {number}
    * @memberof ProgramCertificate
    */

--- a/frontends/api/src/generated/api.ts
+++ b/frontends/api/src/generated/api.ts
@@ -3023,7 +3023,13 @@ export interface ProgramCertificate {
    * @type {string}
    * @memberof ProgramCertificate
    */
-  program_letter_url: string
+  program_letter_generate_url: string
+  /**
+   *
+   * @type {string}
+   * @memberof ProgramCertificate
+   */
+  program_letter_share_url: string
   /**
    *
    * @type {number}

--- a/frontends/api/src/test-utils/factories/programLetters.ts
+++ b/frontends/api/src/test-utils/factories/programLetters.ts
@@ -39,7 +39,8 @@ const programLetter: Factory<ProgramLetter> = (overrides = {}) => ({
     user_first_name: faker.name.firstName(),
     user_last_name: faker.name.lastName(),
     user_full_name: faker.name.fullName(),
-    program_letter_url: new URL(faker.internet.url()).toString(),
+    program_letter_generate_url: new URL(faker.internet.url()).toString(),
+    program_letter_share_url: new URL(faker.internet.url()).toString(),
   },
   ...overrides,
 })

--- a/frontends/api/src/test-utils/factories/programLetters.ts
+++ b/frontends/api/src/test-utils/factories/programLetters.ts
@@ -39,6 +39,7 @@ const programLetter: Factory<ProgramLetter> = (overrides = {}) => ({
     user_first_name: faker.name.firstName(),
     user_last_name: faker.name.lastName(),
     user_full_name: faker.name.fullName(),
+    program_letter_url: new URL(faker.internet.url()).toString(),
   },
   ...overrides,
 })

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -9765,7 +9765,10 @@ components:
         id:
           type: integer
           readOnly: true
-        program_letter_url:
+        program_letter_generate_url:
+          type: string
+          readOnly: true
+        program_letter_share_url:
           type: string
           readOnly: true
         user_edxorg_id:
@@ -9831,7 +9834,8 @@ components:
           nullable: true
       required:
       - id
-      - program_letter_url
+      - program_letter_generate_url
+      - program_letter_share_url
       - program_title
       - user_email
     ProgramLetter:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -9765,6 +9765,9 @@ components:
         id:
           type: integer
           readOnly: true
+        program_letter_url:
+          type: string
+          readOnly: true
         user_edxorg_id:
           type: integer
           maximum: 2147483647
@@ -9828,6 +9831,7 @@ components:
           nullable: true
       required:
       - id
+      - program_letter_url
       - program_title
       - user_email
     ProgramLetter:

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -59,6 +59,7 @@ class UserWebsiteFactory(DjangoModelFactory):
 class ProgramCertificateFactory(DjangoModelFactory):
     user_full_name = Faker("name")
     user_email = Faker("email")
+    micromasters_program_id = Faker("random_int")
 
     class Meta:
         model = ProgramCertificate

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -260,12 +260,29 @@ class ProgramCertificateSerializer(serializers.ModelSerializer):
     Serializer for Program Certificates
     """
 
-    program_letter_url = serializers.SerializerMethodField()
+    program_letter_generate_url = serializers.SerializerMethodField()
+    program_letter_share_url = serializers.SerializerMethodField()
 
-    def get_program_letter_url(self, instance):
-        return reverse(
+    def get_program_letter_generate_url(self, instance):
+        request = self.context.get("request")
+        letter_url = reverse(
             "profile:program-letter-intercept", args=[instance.micromasters_program_id]
         )
+        if request:
+            return request.build_absolute_uri(letter_url)
+        return letter_url
+
+    def get_program_letter_share_url(self, instance):
+        request = self.context.get("request")
+
+        user = User.objects.get(email=instance.user_email)
+        letter, created = ProgramLetter.objects.get_or_create(
+            user=user, certificate=instance
+        )
+        letter_url = letter.get_absolute_url()
+        if request:
+            return request.build_absolute_uri(letter_url)
+        return letter_url
 
     class Meta:
         model = ProgramCertificate

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -7,6 +7,7 @@ import re
 import ulid
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.urls import reverse
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -258,6 +259,13 @@ class ProgramCertificateSerializer(serializers.ModelSerializer):
     """
     Serializer for Program Certificates
     """
+
+    program_letter_url = serializers.SerializerMethodField()
+
+    def get_program_letter_url(self, instance):
+        return reverse(
+            "profile:program-letter-intercept", args=[instance.micromasters_program_id]
+        )
 
     class Meta:
         model = ProgramCertificate

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -7,6 +7,7 @@ from profiles.views import (
     CurrentUserRetrieveViewSet,
     ProfileViewSet,
     ProgramLetterInterceptView,
+    UserProgramCertificateViewSet,
     UserViewSet,
     UserWebsiteViewSet,
     name_initials_avatar_view,
@@ -16,6 +17,11 @@ router = DefaultRouter()
 router.register(r"users", UserViewSet, basename="user_api")
 router.register(r"profiles", ProfileViewSet, basename="profile_api")
 router.register(r"websites", UserWebsiteViewSet, basename="user_websites_api")
+router.register(
+    r"program_certificates",
+    UserProgramCertificateViewSet,
+    basename="user_program_certificates_api",
+)
 
 
 v0_urls = [

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -126,7 +126,7 @@ class UserProgramCertificateViewSet(viewsets.ViewSet):
     def list(self, request):
         queryset = ProgramCertificate.objects.filter(user_email=request.user.email)
         serializer = ProgramCertificateSerializer(
-            self.filter_queryset(queryset), many=True
+            self.filter_queryset(queryset), many=True, context={"request": request}
         )
         return Response(serializer.data)
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -22,6 +22,7 @@ from profiles.models import Profile, ProgramCertificate, ProgramLetter, UserWebs
 from profiles.permissions import HasEditPermission, HasSiteEditPermission
 from profiles.serializers import (
     ProfileSerializer,
+    ProgramCertificateSerializer,
     ProgramLetterSerializer,
     UserSerializer,
     UserWebsiteSerializer,
@@ -107,6 +108,22 @@ class UserWebsiteViewSet(
     permission_classes = (IsAuthenticated, HasSiteEditPermission)
     serializer_class = UserWebsiteSerializer
     queryset = UserWebsite.objects.select_related("profile__user")
+
+
+@extend_schema(exclude=True)
+class UserProgramCertificateViewSet(viewsets.ViewSet):
+    """
+    View for listing program certificates for a user
+    (includes program letter links)
+    """
+
+    permission_classes = (IsAuthenticated,)
+    serializer_class = ProgramCertificateSerializer
+
+    def list(self, request):
+        queryset = ProgramCertificate.objects.filter(user_email=request.user.email)
+        serializer = ProgramCertificateSerializer(queryset, many=True)
+        return Response(serializer.data)
 
 
 @cache_page(60 * 60 * 24)

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -11,7 +11,7 @@ from rest_framework import status
 
 from profiles.factories import ProgramCertificateFactory, ProgramLetterFactory
 from profiles.models import ProgramLetter
-from profiles.serializers import ProgramLetterSerializer
+from profiles.serializers import ProgramCertificateSerializer, ProgramLetterSerializer
 from profiles.utils import DEFAULT_PROFILE_IMAGE, make_temp_image_file
 
 pytestmark = [pytest.mark.django_db]
@@ -413,3 +413,23 @@ def test_program_letter_api_view_returns_404_for_invalid_id(
         )
     )
     assert response.status_code == 404
+
+
+@pytest.mark.parametrize("is_anonymous", [True, False])
+def test_list_user_program_certificates(mocker, client, user, is_anonymous):
+    """
+    Test listing program certificates for a user
+    """
+    if not is_anonymous:
+        client.force_login(user)
+        certs = ProgramCertificateFactory.create_batch(
+            3,
+            user_email=user.email,
+        )
+    url = reverse("profile:v0:user_program_certificates_api-list")
+    resp = client.get(url)
+    if not is_anonymous:
+        assert resp.status_code == 200
+        assert resp.json() == ProgramCertificateSerializer(certs, many=True).data
+    else:
+        assert resp.status_code == 403

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -9,6 +9,7 @@ from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework import status
 
+from learning_resources_search.serializers_test import get_request_object
 from profiles.factories import ProgramCertificateFactory, ProgramLetterFactory
 from profiles.models import ProgramLetter
 from profiles.serializers import ProgramCertificateSerializer, ProgramLetterSerializer
@@ -429,7 +430,13 @@ def test_list_user_program_certificates(mocker, client, user, is_anonymous):
     url = reverse("profile:v0:user_program_certificates_api-list")
     resp = client.get(url)
     if not is_anonymous:
+        request = get_request_object(url)
         assert resp.status_code == 200
-        assert resp.json() == ProgramCertificateSerializer(certs, many=True).data
+        assert (
+            resp.json()
+            == ProgramCertificateSerializer(
+                certs, many=True, context={"request": request}
+            ).data
+        )
     else:
         assert resp.status_code == 403


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #556 
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This Pr adds an api endpoint (/api/v0/program_certificates) to retrieve program certificates along with program letter urls for an authenticated user. The idea is that when a user goes to a program specific dashboard, we will call this endpoint to get a list of program letter urls to display.


### How can this be tested?
1. checkout this branch and generate some program certificates via 
<pre><code>
from profiles.models import ProgramCertificate
ProgramCertificate.objects.get_or_create(user_full_name='john doe',user_email=<b>'your@email.here'</b>, micromasters_program_id=1, program_title='Supply Chain Management')
ProgramCertificate.objects.get_or_create(user_full_name='john doe',user_email=<b>'your@email.here'</b>, micromasters_program_id=18, program_title='Statistics and Data Science')
ProgramCertificate.objects.get_or_create(user_full_name='john doe',user_email=<b>'your@email.here'</b>, micromasters_program_id=2, program_title='Data, Economics, and Development Policy')
</code></pre>
2. visit endpoint http://localhost:8063/api/v0/program_certificates/ and confirm they your program certificates are listed there along with the program_letter_urls 


