### PR TITLE
fix for test failure in main

### DIFF
--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -5,6 +5,7 @@ import json
 from os.path import basename, splitext
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.urls import reverse
 from rest_framework import status
@@ -422,6 +423,8 @@ def test_list_user_program_certificates(mocker, client, user, is_anonymous):
     """
     Test listing program certificates for a user
     """
+    settings.DATABASE_ROUTERS = []
+    settings.EXTERNAL_MODELS = []
     if not is_anonymous:
         client.force_login(user)
         certs = ProgramCertificateFactory.create_batch(


### PR DESCRIPTION
### What are the relevant tickets?
fixes test failure on main https://github.com/mitodl/mit-open/actions/runs/8332224748/job/22800891647?pr=630

### Description (What does it do?)
sets external models setting to empty so test can create programcertficate objects


### How can this be tested?
Tests should succeed

### Additional Context
PR https://github.com/mitodl/mit-open/pull/617 locks down programcertficate tables as readonly. this PR was merged in after another PR that had tests for programcertificates

