### PR TITLE
First iteration of field pages

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -58,19 +58,19 @@ class ChannelAppearanceMixin(serializers.Serializer):
             return True
         return False
 
-    def get_avatar(self, channel) -> str:
+    def get_avatar(self, channel) -> str | None:
         """Get the avatar image URL"""
         return channel.avatar.url if channel.avatar else None
 
-    def get_avatar_small(self, channel) -> str:
+    def get_avatar_small(self, channel) -> str | None:
         """Get the avatar image small URL"""
         return channel.avatar_small.url if channel.avatar_small else None
 
-    def get_avatar_medium(self, channel) -> str:
+    def get_avatar_medium(self, channel) -> str | None:
         """Get the avatar image medium URL"""
         return channel.avatar_medium.url if channel.avatar_medium else None
 
-    def get_banner(self, channel) -> str:
+    def get_banner(self, channel) -> str | None:
         """Get the banner image URL"""
         return channel.banner.url if channel.banner else None
 
@@ -110,7 +110,10 @@ class FieldChannelSerializer(ChannelAppearanceMixin, serializers.ModelSerializer
 
     lists = serializers.SerializerMethodField()
     featured_list = LearningPathPreviewSerializer(
-        many=False, read_only=True, help_text="Learning path featured in this field."
+        allow_null=True,
+        many=False,
+        read_only=True,
+        help_text="Learning path featured in this field.",
     )
     subfields = SubfieldSerializer(many=True, read_only=True)
 

--- a/frontends/api/src/clients.ts
+++ b/frontends/api/src/clients.ts
@@ -6,6 +6,9 @@ import {
   ProgramLettersApi,
   LearningResourcesSearchApi,
 } from "./generated/v1/api"
+
+import { FieldsApi, WidgetListsApi } from "./generated/v0/api"
+
 import axiosInstance from "./axios"
 
 const BASE_PATH = ""
@@ -36,6 +39,10 @@ const programLettersApi = new ProgramLettersApi(
   BASE_PATH,
   axiosInstance,
 )
+
+const fieldsApi = new FieldsApi(undefined, BASE_PATH, axiosInstance)
+const widgetListsApi = new WidgetListsApi(undefined, BASE_PATH, axiosInstance)
+
 export {
   learningResourcesApi,
   learningpathsApi,
@@ -43,4 +50,6 @@ export {
   articlesApi,
   programLettersApi,
   learningResourcesSearchApi,
+  fieldsApi,
+  widgetListsApi,
 }

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -168,7 +168,7 @@ export interface FieldChannel {
    * @type {FieldChannelFeaturedList}
    * @memberof FieldChannel
    */
-  featured_list: FieldChannelFeaturedList
+  featured_list: FieldChannelFeaturedList | null
   /**
    *
    * @type {Array<LearningPathPreview>}
@@ -180,25 +180,25 @@ export interface FieldChannel {
    * @type {string}
    * @memberof FieldChannel
    */
-  avatar?: string
+  avatar?: string | null
   /**
    * Get the avatar image medium URL
    * @type {string}
    * @memberof FieldChannel
    */
-  avatar_medium: string
+  avatar_medium: string | null
   /**
    * Get the avatar image small URL
    * @type {string}
    * @memberof FieldChannel
    */
-  avatar_small: string
+  avatar_small: string | null
   /**
    * Get the banner image URL
    * @type {string}
    * @memberof FieldChannel
    */
-  banner?: string
+  banner?: string | null
   /**
    *
    * @type {number}
@@ -494,19 +494,32 @@ export interface PatchedFieldChannelWriteRequest {
    * @type {string}
    * @memberof PatchedFieldChannelWriteRequest
    */
-  avatar?: string
+  avatar?: string | null
   /**
    * Get the banner image URL
    * @type {string}
    * @memberof PatchedFieldChannelWriteRequest
    */
-  banner?: string
+  banner?: string | null
   /**
    *
    * @type {any}
    * @memberof PatchedFieldChannelWriteRequest
    */
   about?: any | null
+}
+/**
+ * Serializer for WidgetLists
+ * @export
+ * @interface PatchedWidgetListRequest
+ */
+export interface PatchedWidgetListRequest {
+  /**
+   *
+   * @type {Array<WidgetInstance>}
+   * @memberof PatchedWidgetListRequest
+   */
+  widgets?: Array<WidgetInstance> | null
 }
 /**
  * Serializer for Profile
@@ -643,6 +656,122 @@ export interface User {
    */
   profile: Profile
 }
+/**
+ * WidgetInstance serializer
+ * @export
+ * @interface WidgetInstance
+ */
+export interface WidgetInstance {
+  /**
+   *
+   * @type {number}
+   * @memberof WidgetInstance
+   */
+  id: number
+  /**
+   *
+   * @type {WidgetTypeEnum}
+   * @memberof WidgetInstance
+   */
+  widget_type: WidgetTypeEnum
+  /**
+   *
+   * @type {string}
+   * @memberof WidgetInstance
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof WidgetInstance
+   */
+  configuration?: string
+  /**
+   *
+   * @type {string}
+   * @memberof WidgetInstance
+   */
+  json: string
+}
+
+/**
+ * Serializer for WidgetLists
+ * @export
+ * @interface WidgetList
+ */
+export interface WidgetList {
+  /**
+   *
+   * @type {number}
+   * @memberof WidgetList
+   */
+  id: number
+  /**
+   *
+   * @type {Array<WidgetInstance>}
+   * @memberof WidgetList
+   */
+  widgets?: Array<WidgetInstance> | null
+  /**
+   *
+   * @type {Array<WidgetListAvailableWidgetsInner>}
+   * @memberof WidgetList
+   */
+  available_widgets: Array<WidgetListAvailableWidgetsInner>
+}
+/**
+ *
+ * @export
+ * @interface WidgetListAvailableWidgetsInner
+ */
+export interface WidgetListAvailableWidgetsInner {
+  /**
+   *
+   * @type {string}
+   * @memberof WidgetListAvailableWidgetsInner
+   */
+  widget_type?: string
+  /**
+   *
+   * @type {string}
+   * @memberof WidgetListAvailableWidgetsInner
+   */
+  description?: string
+  /**
+   *
+   * @type {object}
+   * @memberof WidgetListAvailableWidgetsInner
+   */
+  form_spec?: object
+}
+/**
+ * Serializer for WidgetLists
+ * @export
+ * @interface WidgetListRequest
+ */
+export interface WidgetListRequest {
+  /**
+   *
+   * @type {Array<WidgetInstance>}
+   * @memberof WidgetListRequest
+   */
+  widgets?: Array<WidgetInstance> | null
+}
+/**
+ * * `Markdown` - Markdown * `URL` - URL * `RSS Feed` - RSS Feed * `People` - People
+ * @export
+ * @enum {string}
+ */
+
+export const WidgetTypeEnum = {
+  Markdown: "Markdown",
+  Url: "URL",
+  RssFeed: "RSS Feed",
+  People: "People",
+} as const
+
+export type WidgetTypeEnum =
+  (typeof WidgetTypeEnum)[keyof typeof WidgetTypeEnum]
 
 /**
  * CkeditorApi - axios parameter creator
@@ -2669,6 +2798,453 @@ export class UsersApi extends BaseAPI {
   public usersMeRetrieve(options?: RawAxiosRequestConfig) {
     return UsersApiFp(this.configuration)
       .usersMeRetrieve(options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * WidgetListsApi - axios parameter creator
+ * @export
+ */
+export const WidgetListsApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {PatchedWidgetListRequest} [PatchedWidgetListRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsPartialUpdate: async (
+      id: number,
+      PatchedWidgetListRequest?: PatchedWidgetListRequest,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("widgetListsPartialUpdate", "id", id)
+      const localVarPath = `/api/v0/widget_lists/{id}/`.replace(
+        `{${"id"}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "PATCH",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      localVarHeaderParameter["Content-Type"] = "application/json"
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        PatchedWidgetListRequest,
+        localVarRequestOptions,
+        configuration,
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsRetrieve: async (
+      id: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("widgetListsRetrieve", "id", id)
+      const localVarPath = `/api/v0/widget_lists/{id}/`.replace(
+        `{${"id"}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {WidgetListRequest} [WidgetListRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsUpdate: async (
+      id: number,
+      WidgetListRequest?: WidgetListRequest,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("widgetListsUpdate", "id", id)
+      const localVarPath = `/api/v0/widget_lists/{id}/`.replace(
+        `{${"id"}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "PUT",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      localVarHeaderParameter["Content-Type"] = "application/json"
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        WidgetListRequest,
+        localVarRequestOptions,
+        configuration,
+      )
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * WidgetListsApi - functional programming interface
+ * @export
+ */
+export const WidgetListsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    WidgetListsApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {PatchedWidgetListRequest} [PatchedWidgetListRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async widgetListsPartialUpdate(
+      id: number,
+      PatchedWidgetListRequest?: PatchedWidgetListRequest,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<WidgetList>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.widgetListsPartialUpdate(
+          id,
+          PatchedWidgetListRequest,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["WidgetListsApi.widgetListsPartialUpdate"]?.[index]
+          ?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async widgetListsRetrieve(
+      id: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<WidgetList>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.widgetListsRetrieve(id, options)
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["WidgetListsApi.widgetListsRetrieve"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * API for managing widget lists
+     * @param {number} id A unique integer value identifying this widget list.
+     * @param {WidgetListRequest} [WidgetListRequest]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async widgetListsUpdate(
+      id: number,
+      WidgetListRequest?: WidgetListRequest,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<WidgetList>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.widgetListsUpdate(
+          id,
+          WidgetListRequest,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["WidgetListsApi.widgetListsUpdate"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * WidgetListsApi - factory interface
+ * @export
+ */
+export const WidgetListsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = WidgetListsApiFp(configuration)
+  return {
+    /**
+     * API for managing widget lists
+     * @param {WidgetListsApiWidgetListsPartialUpdateRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsPartialUpdate(
+      requestParameters: WidgetListsApiWidgetListsPartialUpdateRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<WidgetList> {
+      return localVarFp
+        .widgetListsPartialUpdate(
+          requestParameters.id,
+          requestParameters.PatchedWidgetListRequest,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * API for managing widget lists
+     * @param {WidgetListsApiWidgetListsRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsRetrieve(
+      requestParameters: WidgetListsApiWidgetListsRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<WidgetList> {
+      return localVarFp
+        .widgetListsRetrieve(requestParameters.id, options)
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * API for managing widget lists
+     * @param {WidgetListsApiWidgetListsUpdateRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    widgetListsUpdate(
+      requestParameters: WidgetListsApiWidgetListsUpdateRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<WidgetList> {
+      return localVarFp
+        .widgetListsUpdate(
+          requestParameters.id,
+          requestParameters.WidgetListRequest,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for widgetListsPartialUpdate operation in WidgetListsApi.
+ * @export
+ * @interface WidgetListsApiWidgetListsPartialUpdateRequest
+ */
+export interface WidgetListsApiWidgetListsPartialUpdateRequest {
+  /**
+   * A unique integer value identifying this widget list.
+   * @type {number}
+   * @memberof WidgetListsApiWidgetListsPartialUpdate
+   */
+  readonly id: number
+
+  /**
+   *
+   * @type {PatchedWidgetListRequest}
+   * @memberof WidgetListsApiWidgetListsPartialUpdate
+   */
+  readonly PatchedWidgetListRequest?: PatchedWidgetListRequest
+}
+
+/**
+ * Request parameters for widgetListsRetrieve operation in WidgetListsApi.
+ * @export
+ * @interface WidgetListsApiWidgetListsRetrieveRequest
+ */
+export interface WidgetListsApiWidgetListsRetrieveRequest {
+  /**
+   * A unique integer value identifying this widget list.
+   * @type {number}
+   * @memberof WidgetListsApiWidgetListsRetrieve
+   */
+  readonly id: number
+}
+
+/**
+ * Request parameters for widgetListsUpdate operation in WidgetListsApi.
+ * @export
+ * @interface WidgetListsApiWidgetListsUpdateRequest
+ */
+export interface WidgetListsApiWidgetListsUpdateRequest {
+  /**
+   * A unique integer value identifying this widget list.
+   * @type {number}
+   * @memberof WidgetListsApiWidgetListsUpdate
+   */
+  readonly id: number
+
+  /**
+   *
+   * @type {WidgetListRequest}
+   * @memberof WidgetListsApiWidgetListsUpdate
+   */
+  readonly WidgetListRequest?: WidgetListRequest
+}
+
+/**
+ * WidgetListsApi - object-oriented interface
+ * @export
+ * @class WidgetListsApi
+ * @extends {BaseAPI}
+ */
+export class WidgetListsApi extends BaseAPI {
+  /**
+   * API for managing widget lists
+   * @param {WidgetListsApiWidgetListsPartialUpdateRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof WidgetListsApi
+   */
+  public widgetListsPartialUpdate(
+    requestParameters: WidgetListsApiWidgetListsPartialUpdateRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return WidgetListsApiFp(this.configuration)
+      .widgetListsPartialUpdate(
+        requestParameters.id,
+        requestParameters.PatchedWidgetListRequest,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * API for managing widget lists
+   * @param {WidgetListsApiWidgetListsRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof WidgetListsApi
+   */
+  public widgetListsRetrieve(
+    requestParameters: WidgetListsApiWidgetListsRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return WidgetListsApiFp(this.configuration)
+      .widgetListsRetrieve(requestParameters.id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * API for managing widget lists
+   * @param {WidgetListsApiWidgetListsUpdateRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof WidgetListsApi
+   */
+  public widgetListsUpdate(
+    requestParameters: WidgetListsApiWidgetListsUpdateRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return WidgetListsApiFp(this.configuration)
+      .widgetListsUpdate(
+        requestParameters.id,
+        requestParameters.WidgetListRequest,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 }

--- a/frontends/api/src/hooks/fields/index.ts
+++ b/frontends/api/src/hooks/fields/index.ts
@@ -1,0 +1,49 @@
+import {
+  UseQueryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
+
+import { fieldsApi } from "../../clients"
+import type {
+  FieldsApiFieldsListRequest as FieldsApiListRequest,
+  PatchedFieldChannelWriteRequest,
+} from "../../generated/v0"
+import fields from "./keyFactory"
+
+const useFieldsList = (
+  params: FieldsApiListRequest = {},
+  opts: Pick<UseQueryOptions, "enabled"> = {},
+) => {
+  return useQuery({
+    ...fields.list(params),
+    ...opts,
+  })
+}
+
+const useFieldDetail = (fieldName: string | undefined) => {
+  return useQuery({
+    ...fields.detail(fieldName ?? ""),
+  })
+}
+
+const useFieldPartialUpdate = () => {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (
+      data: PatchedFieldChannelWriteRequest & { field_name: string },
+    ) =>
+      fieldsApi
+        .fieldsPartialUpdate({
+          field_name: data.field_name,
+          PatchedFieldChannelWriteRequest: data,
+        })
+        .then((response) => response.data),
+    onSuccess: (_data) => {
+      client.invalidateQueries(fields._def)
+    },
+  })
+}
+
+export { useFieldDetail, useFieldsList, useFieldPartialUpdate }

--- a/frontends/api/src/hooks/fields/keyFactory.ts
+++ b/frontends/api/src/hooks/fields/keyFactory.ts
@@ -1,0 +1,20 @@
+import { fieldsApi } from "../../clients"
+import type { FieldsApiFieldsListRequest as FieldsApiListRequest } from "../../generated/v0"
+import { createQueryKeys } from "@lukemorales/query-key-factory"
+
+const fields = createQueryKeys("field", {
+  detail: (fieldName: string) => ({
+    queryKey: [fieldName],
+    queryFn: () => {
+      return fieldsApi
+        .fieldsRetrieve({ field_name: fieldName })
+        .then((res) => res.data)
+    },
+  }),
+  list: (params: FieldsApiListRequest) => ({
+    queryKey: [params],
+    queryFn: () => fieldsApi.fieldsList(params).then((res) => res.data),
+  }),
+})
+
+export default fields

--- a/frontends/api/src/hooks/widget_lists/index.ts
+++ b/frontends/api/src/hooks/widget_lists/index.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { widgetListsApi } from "../../clients"
+import widgetLists from "./keyFactory"
+import { WidgetInstance } from "api/v0"
+/**
+ * Query is diabled if id is undefined.
+ */
+const useWidgetList = (id: number | undefined) => {
+  return useQuery({
+    ...widgetLists.detail(id ?? -1),
+    enabled: id !== undefined,
+  })
+}
+
+const useMutateWidgetsList = (id: number) => {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (data: WidgetInstance[]) =>
+      widgetListsApi
+        .widgetListsPartialUpdate({
+          id: id,
+          PatchedWidgetListRequest: { widgets: data as WidgetInstance[] },
+        })
+        .then((response) => response.data),
+
+    onSuccess: (_data) => {
+      client.invalidateQueries(widgetLists._def)
+    },
+  })
+}
+
+export { useWidgetList, useMutateWidgetsList }

--- a/frontends/api/src/hooks/widget_lists/keyFactory.ts
+++ b/frontends/api/src/hooks/widget_lists/keyFactory.ts
@@ -1,0 +1,14 @@
+import { widgetListsApi } from "../../clients"
+import { createQueryKeys } from "@lukemorales/query-key-factory"
+
+const widgetLists = createQueryKeys("widgetLists", {
+  detail: (id: number) => ({
+    queryKey: [id],
+    queryFn: () => {
+      if (id < 0) return Promise.reject("Invalid ID")
+      return widgetListsApi.widgetListsRetrieve({ id }).then((res) => res.data)
+    },
+  }),
+})
+
+export default widgetLists

--- a/frontends/api/src/test-utils/factories/fields.ts
+++ b/frontends/api/src/test-utils/factories/fields.ts
@@ -1,0 +1,29 @@
+import { faker } from "@faker-js/faker/locale/en"
+import { makePaginatedFactory } from "ol-test-utilities"
+import type { Factory } from "ol-test-utilities"
+import type { FieldChannel } from "../../generated/v0"
+
+const field: Factory<FieldChannel> = (overrides = {}) => ({
+  name: faker.helpers.unique(faker.lorem.slug),
+  about: faker.lorem.paragraph(),
+  title: faker.lorem.words(faker.datatype.number({ min: 1, max: 4 })),
+  public_description: faker.lorem.paragraph(),
+  banner: new URL(faker.internet.url()).toString(),
+  avatar_small: new URL(faker.internet.url()).toString(),
+  avatar_medium: new URL(faker.internet.url()).toString(),
+  avatar: new URL(faker.internet.url()).toString(),
+  is_moderator: faker.datatype.boolean(),
+  widget_list: faker.datatype.number(),
+  subfields: [],
+  featured_list: null,
+  lists: [],
+  updated_on: faker.date.recent().toString(),
+  created_on: faker.date.recent().toString(),
+  id: faker.datatype.number(),
+  ga_tracking_id: faker.lorem.slug(),
+  ...overrides,
+})
+
+const fields = makePaginatedFactory(field)
+
+export { fields, field }

--- a/frontends/api/src/test-utils/factories/index.ts
+++ b/frontends/api/src/test-utils/factories/index.ts
@@ -2,3 +2,4 @@ export * as learningResources from "./learningResources"
 
 export * as articles from "./articles"
 export * as letters from "./programLetters"
+export * as fields from "./fields"

--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -63,6 +63,14 @@ const articles = {
   details: (id: number) => `/api/v1/articles/${id}/`,
 }
 
+const fields = {
+  details: (fieldName: string) => `/api/v0/fields/${fieldName}/`,
+}
+
+const widgetLists = {
+  details: (id: number) => `/api/v0/widget_lists/${id}/`,
+}
+
 const programLetters = {
   details: (id: string) => `/api/v1/program_letters/${id}/`,
 }
@@ -78,4 +86,6 @@ export {
   articles,
   search,
   programLetters,
+  fields,
+  widgetLists,
 }

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -18,6 +18,16 @@ export const articlesView = (id: number) =>
 export const articlesEditView = (id: number) =>
   generatePath(ARTICLES_EDIT, { id: String(id) })
 
+export const FIELD_VIEW = "/fields/:name/" as const
+export const FIELD_EDIT = "/fields/:name/manage/" as const
+export const FIELD_EDIT_WIDGETS = "/fields/:name/manage/widgets/" as const
+export const makeFieldViewPath = (name: string) =>
+  generatePath(FIELD_VIEW, { name })
+export const makeFieldEditPath = (name: string) =>
+  generatePath(FIELD_EDIT, { name })
+export const makeFieldManageWidgetsPath = (name: string) =>
+  generatePath(FIELD_EDIT_WIDGETS, { name })
+
 export const LOGIN = "/login/ol-oidc/"
 export const LOGOUT = "/logout/"
 

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.test.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.test.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+
+import { fields as factory } from "api/test-utils/factories"
+import FieldAvatar from "./FieldAvatar"
+
+describe("Avatar", () => {
+  it("Displays a small avatar image for the field", async () => {
+    const field = factory.field()
+    render(<FieldAvatar field={field} imageSize="small" />)
+    const img = screen.getByRole("img")
+    expect(img.getAttribute("alt")).toBe(null) // should be empty unless meaningful
+    expect(img.getAttribute("src")).toEqual(field.avatar_small)
+  })
+  it("Displays a medium avatar image by default", async () => {
+    const field = factory.field()
+    render(<FieldAvatar field={field} />)
+    const img = screen.getByRole("img")
+    expect(img.getAttribute("alt")).toBe(null) // should be empty unless meaningful
+    expect(img.getAttribute("src")).toEqual(field.avatar_medium)
+  })
+  it("Displays initials if no avatar image exists", async () => {
+    const field = factory.field({
+      title: "Test Title",
+      avatar: null,
+      avatar_small: null,
+      avatar_medium: null,
+    })
+    render(<FieldAvatar field={field} />)
+    const img = screen.queryByRole("img")
+    expect(img).toBeNull()
+    await screen.findByText("TT")
+  })
+})

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -1,0 +1,96 @@
+import React from "react"
+
+import type { FieldChannel } from "api/v0"
+import { styled } from "ol-components"
+export const AVATAR_SMALL = "small" as const
+export const AVATAR_MEDIUM = "medium" as const
+export const AVATAR_LARGE = "large" as const
+
+type ImageSize =
+  | typeof AVATAR_SMALL
+  | typeof AVATAR_MEDIUM
+  | typeof AVATAR_LARGE
+
+type AvatarProps = {
+  imageSize?: ImageSize
+  field: FieldChannel
+  editable?: boolean
+  formImageUrl?: string | null
+  name?: string
+}
+
+const initials = (title: string): string => {
+  return title
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((item) => (item[0] ?? "").toUpperCase())
+    .join("")
+}
+
+const getImage = (field: FieldChannel, imageSize: ImageSize | undefined) => {
+  switch (imageSize) {
+    case AVATAR_LARGE:
+      return field.avatar
+    case AVATAR_SMALL:
+      return field.avatar_small
+    default:
+      return field.avatar_medium
+  }
+}
+
+const IMG_SIZES = {
+  small: "22px",
+  medium: "57px",
+  large: "90px",
+}
+const FONT_SIZES = {
+  small: "15px",
+  medium: "32px",
+  large: "50px",
+}
+
+type AvatarStyleProps = Required<Pick<AvatarProps, "imageSize">>
+const AvatarContainer = styled.div<AvatarStyleProps>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: ${({ imageSize }) => IMG_SIZES[imageSize]};
+  height: ${({ imageSize }) => IMG_SIZES[imageSize]};
+`
+const AvatarImg = styled.img<AvatarStyleProps>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  min-height: 0;
+  min-width: 0;
+  border-radius: 15px;
+  width: ${({ imageSize }) => IMG_SIZES[imageSize]};
+  height: ${({ imageSize }) => IMG_SIZES[imageSize]};
+`
+const AvatarInitials = styled(AvatarImg.withComponent("div"))`
+  font-size: ${({ imageSize = "medium" }) => FONT_SIZES[imageSize]};
+  font-weight: 600;
+  color: white;
+`
+
+const FieldAvatar: React.FC<AvatarProps> = (props) => {
+  const { field, formImageUrl, imageSize = "medium" } = props
+
+  const imageUrl = formImageUrl || getImage(field, imageSize)
+
+  return (
+    <AvatarContainer imageSize={imageSize}>
+      {!imageUrl ? (
+        <AvatarInitials imageSize={imageSize}>
+          {initials(field.title)}
+        </AvatarInitials>
+      ) : (
+        <AvatarImg src={imageUrl} imageSize={imageSize} />
+      )}
+    </AvatarContainer>
+  )
+}
+
+export default FieldAvatar

--- a/frontends/mit-open/src/components/FieldMenu/FieldMenu.test.tsx
+++ b/frontends/mit-open/src/components/FieldMenu/FieldMenu.test.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { BrowserRouter } from "react-router-dom"
+
+import FieldMenu from "./FieldMenu"
+import { urls } from "api/test-utils"
+import { setMockResponse, user } from "../../test-utils"
+import { fields as factory } from "api/test-utils/factories"
+
+describe("FieldMenu", () => {
+  it("Includes links to field management and widget management", async () => {
+    const field = factory.field()
+    setMockResponse.get(urls.fields.details(field.name), field)
+
+    render(
+      <BrowserRouter>
+        <FieldMenu fieldName={field.name} />
+      </BrowserRouter>,
+    )
+    const dropdown = await screen.findByRole("button")
+    await user.click(dropdown)
+
+    const item1 = screen.getByRole("menuitem", { name: "Field Settings" })
+    expect((item1 as HTMLAnchorElement).href).toContain(
+      `/fields/${field.name}/manage`,
+    )
+
+    const item2 = screen.getByRole("menuitem", { name: "Manage Widgets" })
+    expect((item2 as HTMLAnchorElement).href).toContain(
+      `/fields/${field.name}/manage/widgets`,
+    )
+  })
+})

--- a/frontends/mit-open/src/components/FieldMenu/FieldMenu.tsx
+++ b/frontends/mit-open/src/components/FieldMenu/FieldMenu.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from "react"
+import * as routes from "../../common/urls"
+import { SimpleMenu, IconButton } from "ol-components"
+import type { SimpleMenuItem } from "ol-components"
+import SettingsIcon from "@mui/icons-material/Settings"
+
+const FieldMenu: React.FC<{ fieldName: string }> = ({ fieldName }) => {
+  const items: SimpleMenuItem[] = useMemo(() => {
+    return [
+      {
+        key: "settings",
+        label: "Field Settings",
+        href: routes.makeFieldEditPath(fieldName),
+      },
+      {
+        key: "widget",
+        label: "Manage Widgets",
+        href: routes.makeFieldManageWidgetsPath(fieldName),
+      },
+    ]
+  }, [fieldName])
+  return (
+    <SimpleMenu
+      items={items}
+      trigger={
+        <IconButton sx={{ color: "white" }}>
+          <SettingsIcon />
+        </IconButton>
+      }
+    />
+  )
+}
+
+export default FieldMenu

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.test.tsx
@@ -1,0 +1,90 @@
+import {
+  renderTestApp,
+  screen,
+  fireEvent,
+  user,
+  waitFor,
+} from "../../test-utils"
+import { fields as factory } from "api/test-utils/factories"
+import { urls, setMockResponse } from "api/test-utils"
+import { makeFieldViewPath, makeFieldEditPath } from "@/common/urls"
+import { makeWidgetListResponse } from "ol-widgets/src/factories"
+import type { FieldChannel } from "api/v0"
+
+const setupApis = (fieldOverrides: Partial<FieldChannel>) => {
+  const field = factory.field({ is_moderator: true, ...fieldOverrides })
+  setMockResponse.get(urls.fields.details(field.name), field)
+  setMockResponse.get(
+    urls.widgetLists.details(field.widget_list || -1),
+    makeWidgetListResponse({}, { count: 0 }),
+  )
+  return field
+}
+
+describe("EditFieldAppearanceForm", () => {
+  it("Displays the field title, appearance inputs with current field values", async () => {
+    const field = setupApis({})
+    expect(field.is_moderator).toBeTruthy()
+    renderTestApp({ url: `${makeFieldEditPath(field.name)}/#appearance` })
+    const descInput = (await screen.findByLabelText(
+      "Description",
+    )) as HTMLInputElement
+    const titleInput = (await screen.findByLabelText(
+      "Title",
+    )) as HTMLInputElement
+    expect(titleInput.value).toEqual(field.title)
+    expect(descInput.value).toEqual(field.public_description)
+  })
+
+  it("Shows an error if a required field is blank", async () => {
+    const field = setupApis({})
+    renderTestApp({ url: `${makeFieldEditPath(field.name)}/#appearance` })
+    const titleInput = await screen.findByLabelText("Title")
+    const titleError = screen.queryByText("Title is required.")
+    expect(titleError).toBeNull()
+    fireEvent.change(titleInput, {
+      target: { value: "" },
+    })
+    fireEvent.blur(titleInput)
+    await screen.findByText("Title is required.")
+  })
+
+  it("updates field values on form submission", async () => {
+    const field = setupApis({
+      featured_list: null, // so we don't have to mock userList responses
+      lists: [],
+    })
+    const newTitle = "New Title"
+    const newDesc = "New Description"
+    // Initial field values
+    const updatedValues = {
+      ...field,
+      title: newTitle,
+      public_description: newDesc,
+    }
+    setMockResponse.patch(urls.fields.details(field.name), updatedValues)
+    const { location } = renderTestApp({
+      url: `${makeFieldEditPath(field.name)}/#appearance`,
+    })
+    const titleInput = (await screen.findByLabelText(
+      "Title",
+    )) as HTMLInputElement
+    const descInput = (await screen.findByLabelText(
+      "Description",
+    )) as HTMLInputElement
+    const submitBtn = await screen.findByText("Save")
+    titleInput.setSelectionRange(0, titleInput.value.length)
+    await user.type(titleInput, newTitle)
+    descInput.setSelectionRange(0, descInput.value.length)
+    await user.type(descInput, newDesc)
+    // Expected field values after submit
+    setMockResponse.get(urls.fields.details(field.name), updatedValues)
+    await user.click(submitBtn)
+
+    await waitFor(() => {
+      expect(location.current.pathname).toBe(makeFieldViewPath(field.name))
+    })
+    await screen.findByText(newTitle)
+    await screen.findByText(newDesc)
+  })
+})

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.tsx
@@ -1,0 +1,91 @@
+import React, { useCallback } from "react"
+import { useNavigate } from "react-router-dom"
+import { useFormik } from "formik"
+import { Button, TextField } from "ol-components"
+import * as Yup from "yup"
+
+import type { FieldChannel } from "api/v0"
+import { makeFieldViewPath } from "@/common/urls"
+import { useFieldPartialUpdate } from "api/hooks/fields"
+
+type FormProps = {
+  field: FieldChannel
+}
+
+const postSchema = Yup.object().shape({
+  title: Yup.string().default("").required("Title is required."),
+  public_description: Yup.string()
+    .default("")
+    .required("Description is required."),
+})
+type FormData = Yup.InferType<typeof postSchema>
+
+const EditFieldAppearanceForm = (props: FormProps): JSX.Element => {
+  const { field } = props
+  const fieldName = field.name
+  const editField = useFieldPartialUpdate()
+  const navigate = useNavigate()
+
+  const handleSubmit = useCallback(
+    async (e: FormData) => {
+      const data = await editField.mutateAsync({ field_name: fieldName, ...e })
+      if (data) {
+        navigate(makeFieldViewPath(data.name))
+      }
+      return data
+    },
+    [navigate, fieldName, editField],
+  )
+
+  const formik = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      title: field.title,
+      public_description: field.public_description,
+    },
+    validationSchema: postSchema,
+    onSubmit: handleSubmit,
+  })
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <TextField
+        className="form-row"
+        name="title"
+        label="Title"
+        placeholder="List Title"
+        value={formik.values.title}
+        error={!!formik.errors.title}
+        helperText={formik.errors.title}
+        onChange={formik.handleChange}
+        fullWidth
+      />
+      <TextField
+        className="form-row"
+        label="Description"
+        name="public_description"
+        placeholder="List Description"
+        value={formik.values.public_description}
+        error={!!formik.errors.public_description}
+        helperText={formik.errors.public_description}
+        onChange={formik.handleChange}
+        fullWidth
+        multiline
+      />
+
+      <div className="form-row actions">
+        <Button
+          className="cancel"
+          onClick={() => navigate(makeFieldViewPath(field.name))}
+        >
+          Cancel
+        </Button>
+        <Button type="submit" className="save-changes">
+          Save
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default EditFieldAppearanceForm

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldPage.test.tsx
@@ -1,0 +1,35 @@
+import { renderTestApp, screen } from "../../test-utils"
+import { fields as factory } from "api/test-utils/factories"
+import { setMockResponse, urls as apiUrls } from "api/test-utils"
+import { makeFieldEditPath } from "@/common/urls"
+
+describe("EditFieldPage", () => {
+  const setup = () => {
+    const field = factory.field({ is_moderator: true })
+    setMockResponse.get(apiUrls.fields.details(field.name), field)
+    return field
+  }
+
+  it("Displays 2 tabs for moderators", async () => {
+    const field = setup()
+    renderTestApp({ url: `${makeFieldEditPath(field.name)}/` })
+    const tabs = screen.queryAllByRole("tab")
+    expect(tabs.length).toEqual(0)
+  })
+
+  it("Displays message and no tabs for non-moderators", async () => {
+    const field = factory.field({ is_moderator: false })
+    setMockResponse.get(apiUrls.fields.details(field.name), field)
+    renderTestApp({ url: `${makeFieldEditPath(field.name)}/` })
+    await screen.findByText("You do not have permission to access this page.")
+    const tabs = screen.queryAllByRole("tab")
+    expect(tabs.length).toEqual(0)
+  })
+
+  it("Displays the correct tab and form for the #appearance hash", async () => {
+    const field = setup()
+    renderTestApp({ url: `${makeFieldEditPath(field.name)}/#appearance` })
+    await screen.findByLabelText("Description")
+    await screen.findByLabelText("Appearance")
+  })
+})

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldPage.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldPage.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback } from "react"
+import { useNavigate, useLocation, useParams } from "react-router"
+import { Link } from "react-router-dom"
+import { Container, TabList, Tab, TabContext, TabPanel } from "ol-components"
+
+import { MetaTags } from "ol-utilities"
+
+import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
+import { useFieldDetail } from "api/hooks/fields"
+import EditFieldAppearanceForm from "./EditFieldAppearanceForm"
+import FieldPageSkeleton from "./FieldPageSkeleton"
+type RouteParams = {
+  name: string
+}
+
+const keyFromHash = (hash: string) => {
+  const keys = ["appearance", "moderators"]
+  const match = keys.find((key) => `#${key}` === hash)
+  return match ?? "appearance"
+}
+
+const EditFieldPage: React.FC = () => {
+  const { name } = useParams<RouteParams>()
+  const navigate = useNavigate()
+  const { hash } = useLocation()
+  const tabValue = keyFromHash(hash)
+  const field = useFieldDetail(name)
+  const handleChange = useCallback(
+    (event: React.SyntheticEvent, newValue: string) => {
+      navigate({ hash: newValue }, { replace: true })
+    },
+    [navigate],
+  )
+
+  return field.data ? (
+    <FieldPageSkeleton name={name || ""}>
+      <MetaTags>
+        <title>Edit {field.data.title} Channel</title>
+      </MetaTags>
+      {field.data.is_moderator ? (
+        <TabContext value={tabValue}>
+          <div className="page-subbanner">
+            <Container className="page-nav-container">
+              <GridContainer>
+                <GridColumn variant="main-2">
+                  <TabList className="page-nav" onChange={handleChange}>
+                    <Tab
+                      component={Link}
+                      to="#appearance"
+                      label="Appearance"
+                      value="appearance"
+                    />
+                    <Tab
+                      component={Link}
+                      to="#moderators"
+                      label="Moderators"
+                      value="moderators"
+                    />
+                  </TabList>
+                </GridColumn>
+              </GridContainer>
+            </Container>
+          </div>
+          <Container>
+            <GridContainer className="edit-channel">
+              <GridColumn variant="main-2">
+                <TabPanel value="appearance" className="page-nav-content">
+                  <div>
+                    <EditFieldAppearanceForm field={field.data} />
+                  </div>
+                </TabPanel>
+                <TabPanel value="moderators" className="page-nav-content">
+                  Moderators placeholder
+                </TabPanel>
+              </GridColumn>
+            </GridContainer>
+          </Container>
+        </TabContext>
+      ) : (
+        <Container>
+          <GridContainer>
+            <GridColumn variant="main-2">
+              <div className="row">
+                You do not have permission to access this page.
+              </div>
+            </GridColumn>
+          </GridContainer>
+        </Container>
+      )}
+    </FieldPageSkeleton>
+  ) : null
+}
+
+export default EditFieldPage

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -1,0 +1,113 @@
+import { assertInstanceOf } from "ol-utilities"
+import { urls } from "api/test-utils"
+import type { FieldChannel } from "api/v0"
+import { fields as factory } from "api/test-utils/factories"
+import WidgetList from "./WidgetsList"
+import {
+  renderTestApp,
+  screen,
+  setMockResponse,
+  within,
+  user,
+  waitFor,
+} from "../../test-utils"
+import { makeWidgetListResponse } from "ol-widgets/src/factories"
+import { makeFieldViewPath } from "@/common/urls"
+
+jest.mock("./WidgetsList", () => {
+  const actual = jest.requireActual("./WidgetsList")
+  return {
+    __esModule: true,
+    default: jest.fn(actual.default),
+  }
+})
+const mockWidgetList = jest.mocked(WidgetList)
+
+const setupApis = (fieldPatch?: Partial<FieldChannel>) => {
+  const field = factory.field(fieldPatch)
+
+  setMockResponse.get(urls.fields.details(field.name), field)
+
+  const widgetsList = makeWidgetListResponse()
+  setMockResponse.get(
+    urls.widgetLists.details(field.widget_list || -1),
+    widgetsList,
+  )
+
+  return {
+    field,
+    widgets: widgetsList.widgets,
+  }
+}
+
+describe("FieldPage", () => {
+  it("Displays the field title, banner, and avatar", async () => {
+    const { field } = setupApis()
+    renderTestApp({ url: `/fields/${field.name}` })
+
+    const title = await screen.findByText(field.title)
+    const header = title.closest("header")
+    assertInstanceOf(header, HTMLElement)
+    const images = within(header).getAllByRole("img") as HTMLImageElement[]
+
+    expect(images[0].src).toBe(field.banner)
+    expect(images).toEqual([
+      /**
+       * Unless it is meaningful, the alt text should be an empty string, and
+       * the channel header already has a title.
+       */
+      expect.objectContaining({ src: field.banner, alt: "" }),
+      expect.objectContaining({ src: field.avatar_medium, alt: "" }),
+    ])
+  })
+
+  it.each([
+    {
+      getUrl: (field: FieldChannel) => `/fields/${field.name}`,
+      isEditing: false,
+      urlDesc: "/fields/:name/",
+    },
+    {
+      getUrl: (field: FieldChannel) => `/fields/${field.name}/manage/widgets/`,
+      isEditing: true,
+      urlDesc: "/fields/:name/manage/widgets/",
+    },
+  ])(
+    "Renders readonly WidgetList at $urlDesc",
+    async ({ getUrl, isEditing }) => {
+      const { field, widgets } = setupApis()
+      const url = getUrl(field)
+      renderTestApp({ url })
+
+      // below we check the FC was called correctly
+      // but let's check that it is still visible, too.
+      await screen.findByText(widgets[0].title)
+      expect(field.widget_list).toEqual(expect.any(Number))
+
+      const expectedProps = expect.objectContaining({
+        widgetListId: field.widget_list,
+        isEditing: isEditing,
+      })
+      const expectedContext = expect.anything()
+      expect(mockWidgetList).toHaveBeenLastCalledWith(
+        expectedProps,
+        expectedContext,
+      )
+    },
+  )
+
+  it.each([{ btnName: "Done" }, { btnName: "Cancel" }])(
+    "When managing widgets, $text returns to field page",
+    async ({ btnName }) => {
+      const { field } = setupApis()
+      const url = `/fields/${field.name}/manage/widgets/`
+      const { location } = renderTestApp({ url })
+      // click done without an edit
+      await user.click(await screen.findByRole("button", { name: btnName }))
+
+      await waitFor(() => {
+        expect(location.current.pathname).toBe(makeFieldViewPath(field.name))
+      })
+    },
+  )
+})

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from "react"
+import { useParams, useLocation, useNavigate } from "react-router"
+import { Tab, TabContext, TabList, TabPanel, Container } from "ol-components"
+import { Link } from "react-router-dom"
+import FieldPageSkeleton from "./FieldPageSkeleton"
+import { useFieldDetail } from "api/hooks/fields"
+import WidgetsList from "./WidgetsList"
+import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
+import { makeFieldViewPath } from "@/common/urls"
+
+type RouteParams = {
+  name: string
+}
+
+const keyFromHash = (hash: string) => {
+  const keys = ["home", "about"]
+  const match = keys.find((key) => `#${key}` === hash)
+  return match ?? "home"
+}
+
+const MANAGE_WIDGETS_SUFFIX = "manage/widgets"
+
+const FieldPage: React.FC = () => {
+  const { name } = useParams<RouteParams>()
+  const navigate = useNavigate()
+  const { hash, pathname } = useLocation()
+  const fieldQuery = useFieldDetail(name)
+  const handleChange = useCallback(
+    (_event: React.SyntheticEvent, newValue: string) => {
+      navigate({ hash: newValue }, { replace: true })
+    },
+    [navigate],
+  )
+
+  const isEditingWidgets = pathname
+    .replace(/\/$/, "")
+    .endsWith(MANAGE_WIDGETS_SUFFIX)
+  const tabValue = keyFromHash(hash)
+
+  const leaveWidgetManagement = useCallback(() => {
+    navigate(makeFieldViewPath(name || ""))
+  }, [navigate, name])
+
+  return (
+    <FieldPageSkeleton name={name || ""}>
+      <TabContext value={tabValue}>
+        <div>
+          <Container>
+            <GridContainer>
+              <GridColumn variant="main-2-wide-main">
+                <TabList onChange={handleChange}>
+                  <Tab component={Link} to="#" label="Home" value="home" />
+                  <Tab
+                    component={Link}
+                    to="#about"
+                    label="About"
+                    value="about"
+                  />
+                </TabList>
+              </GridColumn>
+              <GridColumn variant="sidebar-2-wide-main" />
+            </GridContainer>
+          </Container>
+        </div>
+        <Container>
+          <GridContainer>
+            <GridColumn variant="main-2-wide-main">
+              <TabPanel value="home">
+                <p>{fieldQuery.data?.public_description}</p>
+              </TabPanel>
+              <TabPanel value="about"></TabPanel>
+            </GridColumn>
+            <GridColumn variant="sidebar-2-wide-main">
+              {fieldQuery.data?.widget_list && (
+                <WidgetsList
+                  widgetListId={fieldQuery.data.widget_list}
+                  isEditing={isEditingWidgets}
+                  onFinishEditing={leaveWidgetManagement}
+                />
+              )}
+            </GridColumn>
+          </GridContainer>
+        </Container>
+      </TabContext>
+    </FieldPageSkeleton>
+  )
+}
+
+export default FieldPage

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -1,0 +1,80 @@
+import React from "react"
+import { Link } from "react-router-dom"
+import * as routes from "../../common/urls"
+import { BannerPage, styled, Container } from "ol-components"
+import { useFieldDetail } from "api/hooks/fields"
+import FieldMenu from "@/components/FieldMenu/FieldMenu"
+import FieldAvatar from "@/components/FieldAvatar/FieldAvatar"
+
+export const FieldTitleRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  h1 a {
+    margin-left: 1em;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+`
+
+export const FieldControls = styled.div`
+  position: relative;
+  flex-grow: 0.95;
+  justify-content: flex-end;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+`
+
+interface FieldSkeletonProps {
+  children: React.ReactNode
+  name: string
+}
+
+/**
+ * Common structure for field-oriented pages.
+ *
+ * Renders the field title and avatar in a banner.
+ */
+const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
+  children,
+  name,
+}) => {
+  const field = useFieldDetail(name)
+
+  return (
+    <BannerPage
+      src={field.data?.banner ?? ""}
+      alt=""
+      omitBackground={field.isLoading}
+      bannerContent={
+        <Container>
+          <FieldTitleRow>
+            {field.data && (
+              <>
+                <FieldAvatar field={field.data} imageSize="medium" />
+                <h1>
+                  <Link to={routes.makeFieldViewPath(field.data.name)}>
+                    {field.data.title}
+                  </Link>
+                </h1>
+                <FieldControls>
+                  {field.data?.is_moderator ? (
+                    <FieldMenu fieldName={field.data.name} />
+                  ) : null}
+                </FieldControls>
+              </>
+            )}
+          </FieldTitleRow>
+        </Container>
+      }
+    >
+      {children}
+    </BannerPage>
+  )
+}
+
+export default FieldSkeletonProps

--- a/frontends/mit-open/src/pages/FieldPage/WidgetsList.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/WidgetsList.test.tsx
@@ -1,0 +1,119 @@
+import React from "react"
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  expectProps,
+  user,
+  expectLastProps,
+  setMockResponse,
+} from "../../test-utils"
+import { Widget, WidgetsListEditable } from "ol-widgets"
+import { makeWidgetListResponse } from "ol-widgets/src/factories"
+import WidgetsList from "./WidgetsList"
+import { urls } from "api/test-utils"
+import { makeRequest } from "../../test-utils/mockAxios"
+
+jest.mock("ol-widgets", () => {
+  const actual = jest.requireActual("ol-widgets")
+  return {
+    __esModule: true,
+    ...actual,
+    Widget: jest.fn(actual.Widget),
+    WidgetsListEditable: jest.fn(actual.WidgetsListEditable),
+  }
+})
+const spyWidget = jest.mocked(Widget)
+const spyWidgetsListEditable = jest.mocked(WidgetsListEditable)
+
+const setupApis = ({ widgets = 3 } = {}) => {
+  const widgetsList = makeWidgetListResponse({}, { count: widgets })
+  setMockResponse.get(urls.widgetLists.details(widgetsList.id), widgetsList)
+  return { widgetsList }
+}
+
+describe("Viewing widgets with WidgetsList", () => {
+  test("Renders widgets", async () => {
+    const { widgetsList } = setupApis({ widgets: 3 })
+    renderWithProviders(
+      <WidgetsList isEditing={false} widgetListId={widgetsList.id} />,
+    )
+
+    /**
+     * Check that widget components are still on-screen
+     */
+    const { widgets } = widgetsList
+    const w1 = await screen.findByRole("heading", { name: widgets[0].title })
+    const w2 = await screen.findByRole("heading", { name: widgets[1].title })
+    const w3 = await screen.findByRole("heading", { name: widgets[2].title })
+
+    const { DOCUMENT_POSITION_FOLLOWING } = Node
+    expect(w1.compareDocumentPosition(w2)).toBe(DOCUMENT_POSITION_FOLLOWING)
+    expect(w2.compareDocumentPosition(w3)).toBe(DOCUMENT_POSITION_FOLLOWING)
+
+    /**
+     * Check that the Widget component was called with correct props
+     */
+    expectProps(spyWidget, { widget: widgets.at(-1) })
+    expectProps(spyWidget, { widget: widgets.at(-2) })
+    expectProps(spyWidget, { widget: widgets.at(-3) })
+  })
+})
+
+describe("Editing widgets with WidgetsList", () => {
+  it("renders WidgetsListEditable with expected stuff", async () => {
+    const { widgetsList } = setupApis({ widgets: 3 })
+    renderWithProviders(
+      <WidgetsList isEditing={true} widgetListId={widgetsList.id} />,
+    )
+
+    /**
+     * Check that widget components are still on-screen
+     */
+    const { widgets } = widgetsList
+    await waitFor(() => {
+      screen.getByRole("heading", { name: widgets[0].title })
+      screen.getByRole("heading", { name: widgets[1].title })
+      screen.getByRole("heading", { name: widgets[2].title })
+    })
+    expectLastProps(spyWidgetsListEditable, { widgetsList })
+  })
+
+  it("makes the expected API call when WidgetsListEditable is edited+submitted", async () => {
+    const { widgetsList } = setupApis({ widgets: 3 })
+    renderWithProviders(
+      <WidgetsList isEditing={true} widgetListId={widgetsList.id} />,
+    )
+    const deleteBtns = await screen.findAllByRole("button", { name: /Delete/ })
+    expect(deleteBtns.length).toBe(3)
+    await user.click(deleteBtns[0])
+    const modified = {
+      ...widgetsList,
+      widgets: widgetsList.widgets.slice(1),
+    }
+    setMockResponse.patch(urls.widgetLists.details(widgetsList.id), modified)
+    await user.click(screen.getByRole("button", { name: "Done" }))
+    expect(makeRequest).toHaveBeenCalledWith(
+      "patch",
+      urls.widgetLists.details(widgetsList.id),
+      expect.objectContaining({
+        widgets: modified.widgets,
+      }),
+    )
+  })
+
+  it("Does not make an API call if widget list not edited", async () => {
+    const { widgetsList } = setupApis({ widgets: 3 })
+    renderWithProviders(
+      <WidgetsList isEditing={true} widgetListId={widgetsList.id} />,
+    )
+    // Wait for the widgets to have loaded
+    const deleteBtns = await screen.findAllByRole("button", { name: /Delete/ })
+    expect(deleteBtns.length).toBe(3)
+    // click done without an edit
+    const callCount = makeRequest.mock.calls.length
+    await user.click(await screen.findByRole("button", { name: "Done" }))
+    // call count should be same as before
+    expect(makeRequest).toHaveBeenCalledTimes(callCount)
+  })
+})

--- a/frontends/mit-open/src/pages/FieldPage/WidgetsList.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/WidgetsList.tsx
@@ -1,0 +1,106 @@
+import React, { useCallback } from "react"
+import {
+  Widget,
+  WidgetsListEditable,
+  WidgetsListEditableProps,
+  WidgetDialogClasses,
+  AnonymousWidget,
+  WidgetListResponse,
+} from "ol-widgets"
+import { WidgetInstance } from "api/v0"
+import { useMutateWidgetsList, useWidgetList } from "api/hooks/widget_lists"
+import { styled } from "ol-components"
+
+interface WidgetsListProps {
+  isEditing: boolean
+  widgetListId: number
+  className?: string
+  onFinishEditing?: () => void
+}
+
+const dialogClasses: WidgetDialogClasses = {
+  dialog: "ic-widget-editing-dialog",
+  field: "form-field",
+  error: "validation-message",
+  label: "field-label",
+  detail: "field-detail",
+  fieldGroup: "form-item",
+}
+
+export const WidgetListStyles = styled.div`
+  .ic-widget {
+    .ol-markdown {
+      a {
+        word-break: break-word;
+        color: theme.$link-blue;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    margin-bottom: 5px;
+  }
+
+  .ic-widget-editing-header {
+    h4 {
+      margin-top: 0;
+    }
+  }
+`
+
+const WidgetsList: React.FC<WidgetsListProps> = ({
+  widgetListId,
+  isEditing,
+  onFinishEditing,
+  className,
+}) => {
+  const widgetsQuery = useWidgetList(widgetListId)
+  const mutation = useMutateWidgetsList(widgetListId)
+  const widgets = widgetsQuery.data?.widgets ?? []
+  const onSubmit: WidgetsListEditableProps["onSubmit"] = useCallback(
+    (event) => {
+      if (event.touched) {
+        mutation.mutate(event.widgets as WidgetInstance[], {
+          onSuccess: () => {
+            if (onFinishEditing) onFinishEditing()
+          },
+        })
+      } else {
+        if (onFinishEditing) onFinishEditing()
+      }
+    },
+    [onFinishEditing, mutation],
+  )
+  const onCancel: WidgetsListEditableProps["onCancel"] = useCallback(() => {
+    if (onFinishEditing) onFinishEditing()
+  }, [onFinishEditing])
+  return (
+    <WidgetListStyles>
+      <section className={className}>
+        {isEditing
+          ? widgetsQuery.data && (
+              <WidgetsListEditable
+                widgetsList={widgetsQuery.data as WidgetListResponse}
+                onSubmit={onSubmit}
+                onCancel={onCancel}
+                headerClassName="ic-widget-editing-header"
+                widgetClassName="ic-widget"
+                dialogClasses={dialogClasses}
+              />
+            )
+          : widgets.map((widget) => (
+              <Widget
+                key={widget.id}
+                widget={widget as AnonymousWidget}
+                isEditing={false}
+                className="ic-widget"
+              />
+            ))}
+      </section>
+    </WidgetListStyles>
+  )
+}
+
+export default WidgetsList

--- a/frontends/mit-open/src/routes.tsx
+++ b/frontends/mit-open/src/routes.tsx
@@ -4,6 +4,9 @@ import HomePage from "@/pages/HomePage/HomePage"
 import RestrictedRoute from "@/components/RestrictedRoute/RestrictedRoute"
 import LearningPathListingPage from "@/pages/LearningPathListingPage/LearningPathListingPage"
 import LearningPathDetailsPage from "@/pages/LearningPathDetailsPage/LearningPathDetailsPage"
+import FieldPage from "@/pages/FieldPage/FieldPage"
+import EditFieldPage from "@/pages/FieldPage/EditFieldPage"
+
 import ArticleDetailsPage from "@/pages/ArticleDetailsPage/ArticleDetailsPage"
 import { ArticleCreatePage, ArticleEditPage } from "@/pages/ArticleUpsertPages"
 import ProgramLetterPage from "@/pages/ProgramLetterPage/ProgramLetterPage"
@@ -52,6 +55,18 @@ const routes: RouteObject[] = [
       {
         path: urls.SEARCH,
         element: <SearchPage />,
+      },
+      {
+        path: urls.FIELD_VIEW,
+        element: <FieldPage />,
+      },
+      {
+        path: urls.FIELD_EDIT_WIDGETS,
+        element: <FieldPage />,
+      },
+      {
+        path: urls.FIELD_EDIT,
+        element: <EditFieldPage />,
       },
       {
         element: <RestrictedRoute requires={Permissions.ArticleEditor} />,

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -104,6 +104,9 @@ export type { FormLabelProps } from "@mui/material/FormLabel"
 export { default as Pagination } from "@mui/material/Pagination"
 export type { PaginationProps } from "@mui/material/Pagination"
 
+export { default as Menu } from "@mui/material/Menu"
+export { default as MenuItem } from "@mui/material/MenuItem"
+
 export * from "./components/BasicDialog/BasicDialog"
 export * from "./components/BannerPage/BannerPage"
 export * from "./components/ButtonLink/ButtonLink"

--- a/main/urls.py
+++ b/main/urls.py
@@ -53,6 +53,7 @@ urlpatterns = [  # noqa: RUF005
     re_path(r"^articles/", index, name="articles"),
     re_path(r"^dashboard/", index, name="dashboard"),
     re_path(r"^program_letter/", index, name="programletter"),
+    re_path(r"^fields/", index, name="fields"),
     # Hijack
     re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
     re_path(r"", include("news_events.urls")),

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -346,6 +346,86 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
           description: ''
+  /api/v0/widget_lists/{id}/:
+    get:
+      operationId: widget_lists_retrieve
+      description: API for managing widget lists
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this widget list.
+        required: true
+      tags:
+      - widget_lists
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetList'
+          description: ''
+    put:
+      operationId: widget_lists_update
+      description: API for managing widget lists
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this widget list.
+        required: true
+      tags:
+      - widget_lists
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WidgetListRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/WidgetListRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/WidgetListRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetList'
+          description: ''
+    patch:
+      operationId: widget_lists_partial_update
+      description: API for managing widget lists
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this widget list.
+        required: true
+      tags:
+      - widget_lists
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedWidgetListRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedWidgetListRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedWidgetListRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WidgetList'
+          description: ''
 components:
   schemas:
     FeedImage:
@@ -425,6 +505,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/LearningPathPreview'
           readOnly: true
+          nullable: true
           description: Learning path featured in this field.
         lists:
           type: array
@@ -433,17 +514,21 @@ components:
           readOnly: true
         avatar:
           type: string
+          nullable: true
           description: Get the avatar image URL
         avatar_medium:
           type: string
+          nullable: true
           description: Get the avatar image medium URL
           readOnly: true
         avatar_small:
           type: string
+          nullable: true
           description: Get the avatar image small URL
           readOnly: true
         banner:
           type: string
+          nullable: true
           description: Get the banner image URL
         widget_list:
           type: integer
@@ -639,11 +724,22 @@ components:
           description: Learng paths in this field.
         avatar:
           type: string
+          nullable: true
           description: Get the avatar image URL
         banner:
           type: string
+          nullable: true
           description: Get the banner image URL
         about:
+          nullable: true
+    PatchedWidgetListRequest:
+      type: object
+      description: Serializer for WidgetLists
+      properties:
+        widgets:
+          type: array
+          items:
+            $ref: '#/components/schemas/WidgetInstance'
           nullable: true
     Profile:
       type: object
@@ -733,3 +829,73 @@ components:
       - id
       - profile
       - username
+    WidgetInstance:
+      type: object
+      description: WidgetInstance serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        widget_type:
+          $ref: '#/components/schemas/WidgetTypeEnum'
+        title:
+          type: string
+          maxLength: 200
+        configuration:
+          type: string
+        json:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - json
+      - title
+      - widget_type
+    WidgetList:
+      type: object
+      description: Serializer for WidgetLists
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        widgets:
+          type: array
+          items:
+            $ref: '#/components/schemas/WidgetInstance'
+          nullable: true
+        available_widgets:
+          type: array
+          items:
+            type: object
+            properties:
+              widget_type:
+                type: string
+              description:
+                type: string
+              form_spec:
+                type: object
+          readOnly: true
+      required:
+      - available_widgets
+      - id
+    WidgetListRequest:
+      type: object
+      description: Serializer for WidgetLists
+      properties:
+        widgets:
+          type: array
+          items:
+            $ref: '#/components/schemas/WidgetInstance'
+          nullable: true
+    WidgetTypeEnum:
+      enum:
+      - Markdown
+      - URL
+      - RSS Feed
+      - People
+      type: string
+      description: |-
+        * `Markdown` - Markdown
+        * `URL` - URL
+        * `RSS Feed` - RSS Feed
+        * `People` - People

--- a/widgets/urls.py
+++ b/widgets/urls.py
@@ -9,5 +9,5 @@ from widgets.views import WidgetListViewSet
 
 router = routers.DefaultRouter()
 router.register(r"widget_lists", WidgetListViewSet, basename="widget_list")
-
-urlpatterns = [re_path(r"^api/v0/", include(router.urls))]
+app_name = "widgets"
+urlpatterns = [re_path(r"^api/v0/", include((router.urls, "v0")))]

--- a/widgets/views_test.py
+++ b/widgets/views_test.py
@@ -127,7 +127,7 @@ def widget_list(user):
 
 def test_widget_list_get(client, widget_list):
     """Tests that you can get an existing list"""
-    url = reverse("widget_list-detail", kwargs={"pk": widget_list.id})
+    url = reverse("widgets:v0:widget_list-detail", kwargs={"pk": widget_list.id})
     resp = client.get(url)
 
     assert resp.status_code == status.HTTP_200_OK
@@ -140,7 +140,7 @@ def test_widget_list_get(client, widget_list):
 
 def test_widget_list_add_widget(widget_list, user_client):
     """Tests that you can add a widget to an existing list"""
-    url = reverse("widget_list-detail", kwargs={"pk": widget_list.id})
+    url = reverse("widgets:v0:widget_list-detail", kwargs={"pk": widget_list.id})
     resp = user_client.patch(
         url,
         {
@@ -173,7 +173,7 @@ def test_widget_list_add_widget(widget_list, user_client):
 def test_widget_list_update_widget(widget_list, user_client):
     """Tests that you can add a widget to an existing list"""
     widget_instance = WidgetInstanceFactory.create(widget_list=widget_list)
-    url = reverse("widget_list-detail", kwargs={"pk": widget_list.id})
+    url = reverse("widgets:v0:widget_list-detail", kwargs={"pk": widget_list.id})
     resp = user_client.patch(
         url,
         {
@@ -208,7 +208,7 @@ def test_widget_list_update_widget(widget_list, user_client):
 def test_widget_list_add_update_and_reorder_widgets(widget_list, user_client):
     """Tests that you can simultaneously update, reorder, and add a widget"""
     widget_instance = WidgetInstanceFactory.create(widget_list=widget_list)
-    url = reverse("widget_list-detail", kwargs={"pk": widget_list.id})
+    url = reverse("widgets:v0:widget_list-detail", kwargs={"pk": widget_list.id})
     resp = user_client.patch(
         url,
         {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/602

### Description (What does it do?)
This PR moves field functionality from open discussions to the new open UI. It does not include list functionality since we probably don't need it. 

### Screenshots (if appropriate):
<img width="1425" alt="Screenshot 2024-03-18 at 11 22 36 PM" src="https://github.com/mitodl/mit-open/assets/1934992/8e5f5ea9-511c-44b3-8b15-04b640013f11">
<img width="1419" alt="Screenshot 2024-03-18 at 11 23 03 PM" src="https://github.com/mitodl/mit-open/assets/1934992/a141061c-a204-443a-9da3-10e4b0ccfb1d">

<img width="1429" alt="Screenshot 2024-03-18 at 11 23 16 PM" src="https://github.com/mitodl/mit-open/assets/1934992/60a46e8d-8625-4d01-9bb7-b06b9950db1b">

### How can this be tested?
- If you don't have a field locally already, create one at http://localhost:8063/api/v1/fields/ 
- Go to http://localhost:8063/fields/<your field>/ you should see your field's name and description
- Go to http://localhost:8063/fields/<your field>/manage - if you are not logged in, you should see a message that you don't have permission to access the page
- Login and go back to  http://localhost:8063/fields/<your field>/. Click the gear at the right hand side of the banner to go to the field management page
-  You should be able to change the title and description in the "appearance" tab
- You should be able to add new widgets 

### Additional Context
There will be follow up tickets to clean up the documentation and api call structure for the field and widget_list api calls (https://github.com/mitodl/mit-open/issues/643 and https://github.com/mitodl/mit-open/issues/644)
