### PR TITLE
fix flaky test

### DIFF
--- a/learning_resources/views_learningpath_test.py
+++ b/learning_resources/views_learningpath_test.py
@@ -370,12 +370,11 @@ def test_get_resource_learning_paths(user_client, user, is_editor):
         factories.LearningPathRelationshipFactory.create_batch(
             3, child=course.learning_resource
         ),
-        key=lambda item: item.position,
+        key=lambda item: item.id,
     )
     resp = user_client.get(
         reverse("lr:v1:courses_api-detail", args=[course.learning_resource.id])
     )
-
     expected = (
         [
             {
@@ -388,5 +387,7 @@ def test_get_resource_learning_paths(user_client, user, is_editor):
         if is_editor
         else []
     )
-
-    assert resp.data.get("learning_path_parents") == expected
+    response_data = sorted(
+        resp.data.get("learning_path_parents"), key=lambda item: item["id"]
+    )
+    assert response_data == expected


### PR DESCRIPTION
### What are the relevant tickets?

Fixes #609 


### Description (What does it do?)
Fixes a flaky test by standardizing the order of results


### How can this be tested?
to simulate flaky test runs, apply the following patch to the learning_resources/views_learningpath_test.py file:
[test.patch](https://github.com/mitodl/mit-open/files/14653071/test.patch) and run the loaders test via  pytest learning_resources/views_learningpath_test.py -vvv -k test_get_resource_learning_paths -x --no-cov -s --pdb - it should not fail throughout its hundreds of runs (it will fail on main branch at some point).
