### PR TITLE
fix learningpath invalidation

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -273,7 +273,6 @@ describe("LearningPath CRUD", () => {
     setMockResponse.post(url, relationship)
 
     const { wrapper, queryClient } = setupReactQueryTest()
-    jest.spyOn(queryClient, "invalidateQueries")
     const { result } = renderHook(useLearningpathRelationshipCreate, {
       wrapper,
     })
@@ -281,12 +280,14 @@ describe("LearningPath CRUD", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
-      keys.relationshipListing,
-    )
+
     expect(invalidateResourceQueries).toHaveBeenCalledWith(
       queryClient,
       relationship.child,
+    )
+    expect(invalidateResourceQueries).toHaveBeenCalledWith(
+      queryClient,
+      relationship.parent,
     )
 
     // Check patches cached result

--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -303,7 +303,6 @@ describe("LearningPath CRUD", () => {
     setMockResponse.delete(url, null)
     const { wrapper, queryClient } = setupReactQueryTest()
     queryClient.setQueryData(keys.childResource, relationship.resource)
-    jest.spyOn(queryClient, "invalidateQueries")
     const { result } = renderHook(useLearningpathRelationshipDestroy, {
       wrapper,
     })
@@ -312,12 +311,13 @@ describe("LearningPath CRUD", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
-      keys.relationshipListing,
-    )
     expect(invalidateResourceQueries).toHaveBeenCalledWith(
       queryClient,
       relationship.child,
+    )
+    expect(invalidateResourceQueries).toHaveBeenCalledWith(
+      queryClient,
+      relationship.parent,
     )
 
     // Patched existing resource

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -185,12 +185,9 @@ const useLearningpathRelationshipDestroy = () => {
         },
       )
     },
-    onSettled: (response, _err, vars) => {
+    onSettled: (_response, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.child)
-      queryClient.invalidateQueries(
-        learningResources.learningpaths._ctx.detail(vars.parent)._ctx
-          .infiniteItems._def,
-      )
+      invalidateResourceQueries(queryClient, vars.parent)
     },
   })
 }

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -158,10 +158,7 @@ const useLearningpathRelationshipCreate = () => {
     },
     onSettled: (response, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.child)
-      queryClient.invalidateQueries(
-        learningResources.learningpaths._ctx.detail(vars.parent)._ctx
-          .infiniteItems._def,
-      )
+      invalidateResourceQueries(queryClient, vars.parent)
     },
   })
 }


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/mit-open/issues/636

### Description (What does it do?)
Invalidates learningpath queries after adding/removing items to a learningpath.



### How can this be tested?

Watch this video to observe the bug on RC. Note that the learning path says "4 items" even after removing items.

https://github.com/mitodl/mit-open/assets/9010790/9373ac0c-4d75-4f5b-a555-0e6233d0356b


1. Log in as an admin
2. Create a learning path and add a few items.
    - you can add items via the homepage carousel or the search page
3. Visit the "details" page for the learning path (top right dropdown --> learningpaths --> click the learningpath).
4. Repeat the steps in video above. The item count should be accurate at all points.
5. Do any other add/remove manipulations you want. The API results should stay up-to-date.
    - Note: In general, if you want to reproduce this sort of bug, avoid full page reloads. Instead, navigate via in-app links.