### PR TITLE
News & Events API

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -40,6 +40,94 @@ import {
 } from "./base"
 
 /**
+ * Serializer for FeedImage
+ * @export
+ * @interface FeedImage
+ */
+export interface FeedImage {
+  /**
+   *
+   * @type {number}
+   * @memberof FeedImage
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof FeedImage
+   */
+  url?: string
+  /**
+   *
+   * @type {string}
+   * @memberof FeedImage
+   */
+  description?: string
+  /**
+   *
+   * @type {string}
+   * @memberof FeedImage
+   */
+  alt?: string
+}
+/**
+ * FeedSource serializer
+ * @export
+ * @interface FeedSource
+ */
+export interface FeedSource {
+  /**
+   *
+   * @type {number}
+   * @memberof FeedSource
+   */
+  id: number
+  /**
+   *
+   * @type {FeedImage}
+   * @memberof FeedSource
+   */
+  image: FeedImage
+  /**
+   *
+   * @type {string}
+   * @memberof FeedSource
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof FeedSource
+   */
+  url: string
+  /**
+   *
+   * @type {string}
+   * @memberof FeedSource
+   */
+  description?: string
+  /**
+   *
+   * @type {FeedTypeEnum}
+   * @memberof FeedSource
+   */
+  feed_type: FeedTypeEnum
+}
+
+/**
+ * * `news` - News * `events` - Events
+ * @export
+ * @enum {string}
+ */
+
+export const FeedTypeEnum = {
+  News: "news",
+  Events: "events",
+} as const
+
+export type FeedTypeEnum = (typeof FeedTypeEnum)[keyof typeof FeedTypeEnum]
+
+/**
  * Serializer for FieldChannel
  * @export
  * @interface FieldChannel
@@ -302,6 +390,37 @@ export interface LearningPathPreview {
    * @memberof LearningPathPreview
    */
   id: number
+}
+/**
+ *
+ * @export
+ * @interface PaginatedFeedSourceList
+ */
+export interface PaginatedFeedSourceList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedFeedSourceList
+   */
+  count?: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedFeedSourceList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedFeedSourceList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<FeedSource>}
+   * @memberof PaginatedFeedSourceList
+   */
+  results?: Array<FeedSource>
 }
 /**
  *
@@ -1769,6 +1888,664 @@ export class FieldsApi extends BaseAPI {
       .then((request) => request(this.axios, this.basePath))
   }
 }
+
+/**
+ * NewsEventsApi - axios parameter creator
+ * @export
+ */
+export const NewsEventsApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * Get a paginated list of feed items.
+     * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsList: async (
+      feed_type?: Array<NewsEventsListFeedTypeEnum>,
+      limit?: number,
+      offset?: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/api/v0/news_events/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      if (feed_type) {
+        localVarQueryParameter["feed_type"] = feed_type
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter["limit"] = limit
+      }
+
+      if (offset !== undefined) {
+        localVarQueryParameter["offset"] = offset
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Retrieve a single feed item.
+     * @param {number} id A unique integer value identifying this feed item.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsRetrieve: async (
+      id: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("newsEventsRetrieve", "id", id)
+      const localVarPath = `/api/v0/news_events/{id}/`.replace(
+        `{${"id"}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * NewsEventsApi - functional programming interface
+ * @export
+ */
+export const NewsEventsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    NewsEventsApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * Get a paginated list of feed items.
+     * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async newsEventsList(
+      feed_type?: Array<NewsEventsListFeedTypeEnum>,
+      limit?: number,
+      offset?: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+    > {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.newsEventsList(
+        feed_type,
+        limit,
+        offset,
+        options,
+      )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["NewsEventsApi.newsEventsList"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * Retrieve a single feed item.
+     * @param {number} id A unique integer value identifying this feed item.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async newsEventsRetrieve(
+      id: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.newsEventsRetrieve(id, options)
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["NewsEventsApi.newsEventsRetrieve"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * NewsEventsApi - factory interface
+ * @export
+ */
+export const NewsEventsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = NewsEventsApiFp(configuration)
+  return {
+    /**
+     * Get a paginated list of feed items.
+     * @param {NewsEventsApiNewsEventsListRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsList(
+      requestParameters: NewsEventsApiNewsEventsListRequest = {},
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .newsEventsList(
+          requestParameters.feed_type,
+          requestParameters.limit,
+          requestParameters.offset,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Retrieve a single feed item.
+     * @param {NewsEventsApiNewsEventsRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsRetrieve(
+      requestParameters: NewsEventsApiNewsEventsRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<void> {
+      return localVarFp
+        .newsEventsRetrieve(requestParameters.id, options)
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for newsEventsList operation in NewsEventsApi.
+ * @export
+ * @interface NewsEventsApiNewsEventsListRequest
+ */
+export interface NewsEventsApiNewsEventsListRequest {
+  /**
+   * The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+   * @type {Array<'events' | 'news'>}
+   * @memberof NewsEventsApiNewsEventsList
+   */
+  readonly feed_type?: Array<NewsEventsListFeedTypeEnum>
+
+  /**
+   * Number of results to return per page.
+   * @type {number}
+   * @memberof NewsEventsApiNewsEventsList
+   */
+  readonly limit?: number
+
+  /**
+   * The initial index from which to return the results.
+   * @type {number}
+   * @memberof NewsEventsApiNewsEventsList
+   */
+  readonly offset?: number
+}
+
+/**
+ * Request parameters for newsEventsRetrieve operation in NewsEventsApi.
+ * @export
+ * @interface NewsEventsApiNewsEventsRetrieveRequest
+ */
+export interface NewsEventsApiNewsEventsRetrieveRequest {
+  /**
+   * A unique integer value identifying this feed item.
+   * @type {number}
+   * @memberof NewsEventsApiNewsEventsRetrieve
+   */
+  readonly id: number
+}
+
+/**
+ * NewsEventsApi - object-oriented interface
+ * @export
+ * @class NewsEventsApi
+ * @extends {BaseAPI}
+ */
+export class NewsEventsApi extends BaseAPI {
+  /**
+   * Get a paginated list of feed items.
+   * @param {NewsEventsApiNewsEventsListRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof NewsEventsApi
+   */
+  public newsEventsList(
+    requestParameters: NewsEventsApiNewsEventsListRequest = {},
+    options?: RawAxiosRequestConfig,
+  ) {
+    return NewsEventsApiFp(this.configuration)
+      .newsEventsList(
+        requestParameters.feed_type,
+        requestParameters.limit,
+        requestParameters.offset,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Retrieve a single feed item.
+   * @param {NewsEventsApiNewsEventsRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof NewsEventsApi
+   */
+  public newsEventsRetrieve(
+    requestParameters: NewsEventsApiNewsEventsRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return NewsEventsApiFp(this.configuration)
+      .newsEventsRetrieve(requestParameters.id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * @export
+ */
+export const NewsEventsListFeedTypeEnum = {
+  Events: "events",
+  News: "news",
+} as const
+export type NewsEventsListFeedTypeEnum =
+  (typeof NewsEventsListFeedTypeEnum)[keyof typeof NewsEventsListFeedTypeEnum]
+
+/**
+ * NewsEventsSourcesApi - axios parameter creator
+ * @export
+ */
+export const NewsEventsSourcesApiAxiosParamCreator = function (
+  configuration?: Configuration,
+) {
+  return {
+    /**
+     * Get a paginated list of news/event feed sources.
+     * @param {Array<NewsEventsSourcesListFeedTypeEnum>} [feed_type] The type of source  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsSourcesList: async (
+      feed_type?: Array<NewsEventsSourcesListFeedTypeEnum>,
+      limit?: number,
+      offset?: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/api/v0/news_events_sources/`
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      if (feed_type) {
+        localVarQueryParameter["feed_type"] = feed_type
+      }
+
+      if (limit !== undefined) {
+        localVarQueryParameter["limit"] = limit
+      }
+
+      if (offset !== undefined) {
+        localVarQueryParameter["offset"] = offset
+      }
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
+     * Retrieve a single news/event feed source.
+     * @param {number} id A unique integer value identifying this feed source.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsSourcesRetrieve: async (
+      id: number,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists("newsEventsSourcesRetrieve", "id", id)
+      const localVarPath = `/api/v0/news_events_sources/{id}/`.replace(
+        `{${"id"}}`,
+        encodeURIComponent(String(id)),
+      )
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+  }
+}
+
+/**
+ * NewsEventsSourcesApi - functional programming interface
+ * @export
+ */
+export const NewsEventsSourcesApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator =
+    NewsEventsSourcesApiAxiosParamCreator(configuration)
+  return {
+    /**
+     * Get a paginated list of news/event feed sources.
+     * @param {Array<NewsEventsSourcesListFeedTypeEnum>} [feed_type] The type of source  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+     * @param {number} [limit] Number of results to return per page.
+     * @param {number} [offset] The initial index from which to return the results.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async newsEventsSourcesList(
+      feed_type?: Array<NewsEventsSourcesListFeedTypeEnum>,
+      limit?: number,
+      offset?: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PaginatedFeedSourceList>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.newsEventsSourcesList(
+          feed_type,
+          limit,
+          offset,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["NewsEventsSourcesApi.newsEventsSourcesList"]?.[
+          index
+        ]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
+     * Retrieve a single news/event feed source.
+     * @param {number} id A unique integer value identifying this feed source.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async newsEventsSourcesRetrieve(
+      id: number,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedSource>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.newsEventsSourcesRetrieve(id, options)
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["NewsEventsSourcesApi.newsEventsSourcesRetrieve"]?.[
+          index
+        ]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+  }
+}
+
+/**
+ * NewsEventsSourcesApi - factory interface
+ * @export
+ */
+export const NewsEventsSourcesApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance,
+) {
+  const localVarFp = NewsEventsSourcesApiFp(configuration)
+  return {
+    /**
+     * Get a paginated list of news/event feed sources.
+     * @param {NewsEventsSourcesApiNewsEventsSourcesListRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsSourcesList(
+      requestParameters: NewsEventsSourcesApiNewsEventsSourcesListRequest = {},
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<PaginatedFeedSourceList> {
+      return localVarFp
+        .newsEventsSourcesList(
+          requestParameters.feed_type,
+          requestParameters.limit,
+          requestParameters.offset,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
+     * Retrieve a single news/event feed source.
+     * @param {NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    newsEventsSourcesRetrieve(
+      requestParameters: NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<FeedSource> {
+      return localVarFp
+        .newsEventsSourcesRetrieve(requestParameters.id, options)
+        .then((request) => request(axios, basePath))
+    },
+  }
+}
+
+/**
+ * Request parameters for newsEventsSourcesList operation in NewsEventsSourcesApi.
+ * @export
+ * @interface NewsEventsSourcesApiNewsEventsSourcesListRequest
+ */
+export interface NewsEventsSourcesApiNewsEventsSourcesListRequest {
+  /**
+   * The type of source  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
+   * @type {Array<'events' | 'news'>}
+   * @memberof NewsEventsSourcesApiNewsEventsSourcesList
+   */
+  readonly feed_type?: Array<NewsEventsSourcesListFeedTypeEnum>
+
+  /**
+   * Number of results to return per page.
+   * @type {number}
+   * @memberof NewsEventsSourcesApiNewsEventsSourcesList
+   */
+  readonly limit?: number
+
+  /**
+   * The initial index from which to return the results.
+   * @type {number}
+   * @memberof NewsEventsSourcesApiNewsEventsSourcesList
+   */
+  readonly offset?: number
+}
+
+/**
+ * Request parameters for newsEventsSourcesRetrieve operation in NewsEventsSourcesApi.
+ * @export
+ * @interface NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest
+ */
+export interface NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest {
+  /**
+   * A unique integer value identifying this feed source.
+   * @type {number}
+   * @memberof NewsEventsSourcesApiNewsEventsSourcesRetrieve
+   */
+  readonly id: number
+}
+
+/**
+ * NewsEventsSourcesApi - object-oriented interface
+ * @export
+ * @class NewsEventsSourcesApi
+ * @extends {BaseAPI}
+ */
+export class NewsEventsSourcesApi extends BaseAPI {
+  /**
+   * Get a paginated list of news/event feed sources.
+   * @param {NewsEventsSourcesApiNewsEventsSourcesListRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof NewsEventsSourcesApi
+   */
+  public newsEventsSourcesList(
+    requestParameters: NewsEventsSourcesApiNewsEventsSourcesListRequest = {},
+    options?: RawAxiosRequestConfig,
+  ) {
+    return NewsEventsSourcesApiFp(this.configuration)
+      .newsEventsSourcesList(
+        requestParameters.feed_type,
+        requestParameters.limit,
+        requestParameters.offset,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
+  /**
+   * Retrieve a single news/event feed source.
+   * @param {NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof NewsEventsSourcesApi
+   */
+  public newsEventsSourcesRetrieve(
+    requestParameters: NewsEventsSourcesApiNewsEventsSourcesRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return NewsEventsSourcesApiFp(this.configuration)
+      .newsEventsSourcesRetrieve(requestParameters.id, options)
+      .then((request) => request(this.axios, this.basePath))
+  }
+}
+
+/**
+ * @export
+ */
+export const NewsEventsSourcesListFeedTypeEnum = {
+  Events: "events",
+  News: "news",
+} as const
+export type NewsEventsSourcesListFeedTypeEnum =
+  (typeof NewsEventsSourcesListFeedTypeEnum)[keyof typeof NewsEventsSourcesListFeedTypeEnum]
 
 /**
  * UsersApi - axios parameter creator

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -2,16 +2,11 @@
 
 import logging
 
-from django.db.models import Q, QuerySet
 from django_filters import (
-    BaseInFilter,
-    CharFilter,
     ChoiceFilter,
     FilterSet,
     MultipleChoiceFilter,
-    NumberFilter,
 )
-from django_filters.rest_framework import DjangoFilterBackend
 
 from learning_resources.constants import (
     DEPARTMENTS,
@@ -22,62 +17,9 @@ from learning_resources.constants import (
     PlatformType,
 )
 from learning_resources.models import ContentFile, LearningResource
+from main.filters import CharInFilter, NumberInFilter, multi_or_filter
 
 log = logging.getLogger(__name__)
-
-
-def multi_or_filter(
-    queryset: QuerySet, attribute: str, values: list[str or list]
-) -> QuerySet:
-    """Filter attribute by value string with n comma-delimited values"""
-    query_or_filters = Q()
-    for query in [Q(**{attribute: value}) for value in values]:
-        query_or_filters |= query
-    return queryset.filter(query_or_filters)
-
-
-class CharInFilter(BaseInFilter, CharFilter):
-    """Filter that allows for multiple character values"""
-
-
-class NumberInFilter(BaseInFilter, NumberFilter):
-    """Filter that allows for multiple numeric values"""
-
-
-class MultipleOptionsFilterBackend(DjangoFilterBackend):
-    """
-    Custom filter backend that handles multiple values for the same key
-    in various formats
-    """
-
-    def get_filterset_kwargs(self, request, queryset, view):  # noqa: ARG002
-        """
-        Adjust the query parameters to handle multiple values for the same key,
-        regardless of whether they are in the form 'key=x&key=y' or 'key=x,y'
-        """
-        query_params = request.query_params.copy()
-        for key in query_params:
-            filter_key = request.parser_context[
-                "view"
-            ].filterset_class.base_filters.get(key)
-            if filter_key:
-                values = query_params.getlist(key)
-                if isinstance(filter_key, MultipleChoiceFilter):
-                    split_values = [
-                        value.split(",") for value in query_params.getlist(key)
-                    ]
-                    values = [value for val_list in split_values for value in val_list]
-                    query_params.setlist(key, values)
-                elif (isinstance(filter_key, CharInFilter | NumberInFilter)) and len(
-                    values
-                ) > 1:
-                    query_params[key] = ",".join(list(values))
-
-        return {
-            "data": query_params,
-            "queryset": queryset,
-            "request": request,
-        }
 
 
 class LearningResourceFilter(FilterSet):

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -34,7 +34,6 @@ from learning_resources.exceptions import WebhookException
 from learning_resources.filters import (
     ContentFileFilter,
     LearningResourceFilter,
-    MultipleOptionsFilterBackend,
 )
 from learning_resources.models import (
     ContentFile,
@@ -80,6 +79,7 @@ from learning_resources.utils import (
     resource_unpublished_actions,
 )
 from main.constants import VALID_HTTP_METHODS
+from main.filters import MultipleOptionsFilterBackend
 from main.permissions import (
     AnonymousAccessReadonlyPermission,
     is_admin_user,

--- a/main/filters.py
+++ b/main/filters.py
@@ -1,0 +1,59 @@
+"""Common filter classes and functions"""
+
+from django.db.models import Q, QuerySet
+from django_filters import BaseInFilter, CharFilter, MultipleChoiceFilter, NumberFilter
+from django_filters.rest_framework import DjangoFilterBackend
+
+
+def multi_or_filter(
+    queryset: QuerySet, attribute: str, values: list[str or list]
+) -> QuerySet:
+    """Filter attribute by value string with n comma-delimited values"""
+    query_or_filters = Q()
+    for query in [Q(**{attribute: value}) for value in values]:
+        query_or_filters |= query
+    return queryset.filter(query_or_filters)
+
+
+class CharInFilter(BaseInFilter, CharFilter):
+    """Filter that allows for multiple character values"""
+
+
+class NumberInFilter(BaseInFilter, NumberFilter):
+    """Filter that allows for multiple numeric values"""
+
+
+class MultipleOptionsFilterBackend(DjangoFilterBackend):
+    """
+    Custom filter backend that handles multiple values for the same key
+    in various formats
+    """
+
+    def get_filterset_kwargs(self, request, queryset, view):  # noqa: ARG002
+        """
+        Adjust the query parameters to handle multiple values for the same key,
+        regardless of whether they are in the form 'key=x&key=y' or 'key=x,y'
+        """
+        query_params = request.query_params.copy()
+        for key in query_params:
+            filter_key = request.parser_context[
+                "view"
+            ].filterset_class.base_filters.get(key)
+            if filter_key:
+                values = query_params.getlist(key)
+                if isinstance(filter_key, MultipleChoiceFilter):
+                    split_values = [
+                        value.split(",") for value in query_params.getlist(key)
+                    ]
+                    values = [value for val_list in split_values for value in val_list]
+                    query_params.setlist(key, values)
+                elif (isinstance(filter_key, CharInFilter | NumberInFilter)) and len(
+                    values
+                ) > 1:
+                    query_params[key] = ",".join(list(values))
+
+        return {
+            "data": query_params,
+            "queryset": queryset,
+            "request": request,
+        }

--- a/main/urls.py
+++ b/main/urls.py
@@ -55,6 +55,7 @@ urlpatterns = [  # noqa: RUF005
     re_path(r"^program_letter/", index, name="programletter"),
     # Hijack
     re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
+    re_path(r"", include("news_events.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:

--- a/news_events/factories.py
+++ b/news_events/factories.py
@@ -11,7 +11,7 @@ from news_events.constants import FeedType
 
 
 class FeedImageFactory(factory.django.DjangoModelFactory):
-    """Factory for images"""
+    """Factory for source/item images"""
 
     url = factory.Faker("url")
     description = factory.Faker("sentence")

--- a/news_events/factories.py
+++ b/news_events/factories.py
@@ -10,6 +10,17 @@ from news_events import models
 from news_events.constants import FeedType
 
 
+class FeedImageFactory(factory.django.DjangoModelFactory):
+    """Factory for images"""
+
+    url = factory.Faker("url")
+    description = factory.Faker("sentence")
+    alt = factory.Faker("sentence")
+
+    class Meta:
+        model = models.FeedImage
+
+
 class FeedSourceFactory(factory.django.DjangoModelFactory):
     """Factory for FeedSource model"""
 
@@ -17,6 +28,7 @@ class FeedSourceFactory(factory.django.DjangoModelFactory):
     url = factory.Faker("url")
     description = factory.Faker("paragraph")
     feed_type = FuzzyChoice([feed_type.name for feed_type in FeedType])
+    image = factory.SubFactory(FeedImageFactory)
 
     class Meta:
         model = models.FeedSource

--- a/news_events/filters.py
+++ b/news_events/filters.py
@@ -1,0 +1,34 @@
+"""API query filters for news & events"""
+
+from django_filters import FilterSet, MultipleChoiceFilter
+
+from news_events.constants import FeedType
+from news_events.models import FeedItem, FeedSource
+
+
+class FeedItemFilter(FilterSet):
+    """FeedItem filter"""
+
+    feed_type = MultipleChoiceFilter(
+        label="The type of item",
+        field_name="source__feed_type",
+        choices=(FeedType.as_list()),
+    )
+
+    class Meta:
+        model = FeedItem
+        fields = []
+
+
+class FeedSourceFilter(FilterSet):
+    """FeedSource filter"""
+
+    feed_type = MultipleChoiceFilter(
+        label="The type of source",
+        field_name="feed_type",
+        choices=(FeedType.as_list()),
+    )
+
+    class Meta:
+        model = FeedSource
+        fields = []

--- a/news_events/filters_test.py
+++ b/news_events/filters_test.py
@@ -1,0 +1,47 @@
+"""Tests for news_events filters"""
+
+import pytest
+
+from news_events.constants import FeedType
+from news_events.factories import FeedItemFactory, FeedSourceFactory
+
+SOURCE_API_URL = "/api/v0/news_events_sources/"
+ITEM_API_URL = "/api/v0/news_events/"
+
+
+@pytest.mark.parametrize(
+    "multifilter", ["feed_type={}&feed_type={}", "feed_type={},{}"]
+)
+def test_source_filter_feed_type(client, multifilter):
+    """Test that the feed type filter works for sources"""
+    sources = [
+        FeedSourceFactory.create(feed_type=feed_type) for feed_type in FeedType.names()
+    ]
+    FeedSourceFactory.create(feed_type="other")
+
+    type_filter = multifilter.format(FeedType.news.name, FeedType.events.name)
+    results = client.get(f"{SOURCE_API_URL}?{type_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["id"] for result in results]) == sorted(
+        [source.id for source in sources]
+    )
+
+
+@pytest.mark.parametrize(
+    "multifilter", ["feed_type={}&feed_type={}", "feed_type={},{}"]
+)
+def test_item_filter_feed_type(client, multifilter):
+    """Test that the feed type filter works for sources"""
+    sources = [
+        FeedSourceFactory.create(feed_type=feed_type) for feed_type in FeedType.names()
+    ]
+    items = [FeedItemFactory.create(source=source) for source in sources]
+    other_source = FeedSourceFactory.create(feed_type="other")
+    FeedItemFactory.create(source=other_source)
+
+    type_filter = multifilter.format(FeedType.news.name, FeedType.events.name)
+    results = client.get(f"{ITEM_API_URL}?{type_filter}").json()["results"]
+    assert len(results) == 2
+    assert sorted([result["id"] for result in results]) == sorted(
+        [item.id for item in items]
+    )

--- a/news_events/serializers.py
+++ b/news_events/serializers.py
@@ -1,0 +1,89 @@
+"""Serializers for news_events"""
+
+from rest_framework import serializers
+
+from news_events import models
+from news_events.constants import FeedType
+
+COMMON_IGNORED_FIELDS = ("created_on", "updated_on")
+
+
+class FeedImageSerializer(serializers.ModelSerializer):
+    """Serializer for FeedImage"""
+
+    class Meta:
+        model = models.FeedImage
+        exclude = COMMON_IGNORED_FIELDS
+
+
+class FeedSourceSerializer(serializers.ModelSerializer):
+    """FeedSource serializer"""
+
+    image = FeedImageSerializer()
+
+    class Meta:
+        model = models.FeedSource
+        exclude = COMMON_IGNORED_FIELDS
+
+
+class FeedEventDetailSerializer(serializers.ModelSerializer):
+    """FeedEventDetail serializer"""
+
+    class Meta:
+        model = models.FeedEventDetail
+        exclude = ("feed_item", *COMMON_IGNORED_FIELDS)
+
+
+class FeedNewsDetailSerializer(serializers.ModelSerializer):
+    """FeedNewsDetail serializer"""
+
+    class Meta:
+        model = models.FeedNewsDetail
+        exclude = ("feed_item", *COMMON_IGNORED_FIELDS)
+
+
+class FeedItemBaseSerializer(serializers.ModelSerializer):
+    """Base serializer for FeedItem"""
+
+    feed_type = serializers.CharField(source="source.feed_type")
+    image = FeedImageSerializer()
+
+    class Meta:
+        model = models.FeedItem
+        exclude = COMMON_IGNORED_FIELDS
+
+
+class FeedItemTypeField(serializers.ReadOnlyField):
+    """Field for FeedItem.feed_type"""
+
+
+class NewsFeedItemSerializer(FeedItemBaseSerializer):
+    """Serializer for News FeedItem"""
+
+    feed_type = FeedItemTypeField(default=FeedType.news.name)
+    news_details = FeedNewsDetailSerializer()
+
+
+class EventFeedItemSerializer(FeedItemBaseSerializer):
+    """Serializer for News FeedItem"""
+
+    feed_type = FeedItemTypeField(default=FeedType.events.name)
+    event_details = FeedEventDetailSerializer()
+
+
+class FeedItemSerializer(serializers.Serializer):
+    """Serializer for FeedItem"""
+
+    serializer_cls_mapping = {
+        serializer_cls().fields["feed_type"].default: serializer_cls
+        for serializer_cls in (
+            EventFeedItemSerializer,
+            NewsFeedItemSerializer,
+        )
+    }
+
+    def to_representation(self, instance):
+        """Serialize a FeedItem based on feed_type"""
+        serializer_cls = self.serializer_cls_mapping[instance.source.feed_type]
+
+        return serializer_cls(instance=instance, context=self.context).data

--- a/news_events/serializers_test.py
+++ b/news_events/serializers_test.py
@@ -1,0 +1,70 @@
+"""Tests for news_events serializers"""
+
+import pytest
+
+from main.test_utils import assert_json_equal
+from news_events import serializers
+from news_events.constants import FeedType
+from news_events.factories import FeedItemFactory, FeedSourceFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("feed_type", FeedType.names())
+def test_feed_source_serializer(feed_type):
+    """Test that the feed source serializer returns expected data"""
+    source = FeedSourceFactory.create(feed_type=feed_type)
+    serializer = serializers.FeedSourceSerializer(source)
+    assert_json_equal(
+        serializer.data,
+        {
+            "id": source.id,
+            "title": source.title,
+            "url": source.url,
+            "feed_type": source.feed_type,
+            "description": source.description,
+            "image": {
+                "id": source.image.id,
+                "url": source.image.url,
+                "description": source.image.description,
+                "alt": source.image.alt,
+            },
+        },
+    )
+
+
+@pytest.mark.parametrize("feed_type", FeedType.names())
+def test_feed_item_serializer(feed_type):
+    """Test that the feed source serializer returns expected data"""
+    is_news = feed_type == FeedType.news.name
+    item = FeedItemFactory.create(is_news=is_news, is_event=not is_news)
+    item_details_dict = (
+        {"news_details": serializers.FeedNewsDetailSerializer(item.news_details).data}
+        if is_news
+        else {
+            "event_details": serializers.FeedEventDetailSerializer(
+                item.event_details
+            ).data
+        }
+    )
+    serializer = serializers.FeedItemSerializer(item)
+    assert_json_equal(
+        serializer.data,
+        {
+            "id": item.id,
+            "guid": item.guid,
+            "title": item.title,
+            "url": item.url,
+            "feed_type": item.source.feed_type,
+            "summary": item.summary,
+            "content": item.content,
+            "source": item.source.id,
+            "image": {
+                "id": item.image.id,
+                "url": item.image.url,
+                "description": item.image.description,
+                "alt": item.image.alt,
+            },
+            **item_details_dict,
+        },
+    )

--- a/news_events/urls.py
+++ b/news_events/urls.py
@@ -1,0 +1,26 @@
+"""URLs for news_events"""
+
+from django.urls import include, re_path
+from rest_framework.routers import SimpleRouter
+
+from news_events import views
+
+router = SimpleRouter()
+router.register(
+    r"news_events",
+    views.FeedItemViewSet,
+    basename="news_events_items_api",
+)
+router.register(
+    r"news_events_sources", views.FeedSourceViewSet, basename="news_events_sources_api"
+)
+
+
+v0_urls = [
+    *router.urls,
+]
+
+app_name = "news_events"
+urlpatterns = [
+    re_path(r"^api/v0/", include((v0_urls, "v0"))),
+]

--- a/news_events/views.py
+++ b/news_events/views.py
@@ -1,0 +1,72 @@
+"""Views for news_events"""
+
+from drf_spectacular.utils import extend_schema, extend_schema_view
+from rest_framework import viewsets
+from rest_framework.pagination import LimitOffsetPagination
+
+from main.filters import MultipleOptionsFilterBackend
+from main.permissions import AnonymousAccessReadonlyPermission
+from news_events.filters import FeedItemFilter, FeedSourceFilter
+from news_events.models import FeedItem, FeedSource
+from news_events.serializers import FeedItemSerializer, FeedSourceSerializer
+
+
+class DefaultPagination(LimitOffsetPagination):
+    """
+    Pagination class for news/events viewsets which gets
+    default_limit and max_limit from settings
+    """
+
+    default_limit = 10
+    max_limit = 100
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="Get a paginated list of feed items.",
+    ),
+    retrieve=extend_schema(
+        description="Retrieve a single feed item.",
+    ),
+)
+class FeedItemViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for news and events
+    """
+
+    resource_type_name_plural = "News and Events"
+    serializer_class = FeedItemSerializer
+    permission_classes = (AnonymousAccessReadonlyPermission,)
+    pagination_class = DefaultPagination
+    filter_backends = [MultipleOptionsFilterBackend]
+    filterset_class = FeedItemFilter
+    queryset = (
+        FeedItem.objects.select_related(*FeedItem.related_selects)
+        .all()
+        .order_by(
+            "-news_details__publish_date",
+            "-event_details__event_datetime",
+        )
+    )
+
+
+@extend_schema_view(
+    list=extend_schema(
+        description="Get a paginated list of news/event feed sources.",
+    ),
+    retrieve=extend_schema(
+        description="Retrieve a single news/event feed source.",
+    ),
+)
+class FeedSourceViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for news and event sources
+    """
+
+    permission_classes = (AnonymousAccessReadonlyPermission,)
+    pagination_class = DefaultPagination
+    resource_type_name_plural = "News & Events Sources"
+    serializer_class = FeedSourceSerializer
+    filter_backends = [MultipleOptionsFilterBackend]
+    filterset_class = FeedSourceFilter
+    queryset = FeedSource.objects.all().order_by("id")

--- a/news_events/views_test.py
+++ b/news_events/views_test.py
@@ -1,0 +1,121 @@
+"""Tests for news_events views"""
+
+import pytest
+from django.urls import reverse
+
+from main.test_utils import assert_json_equal
+from news_events import factories, serializers
+from news_events.constants import FeedType
+
+
+def test_feed_source_viewset_list(client):
+    """Est that the feed sources list viewset returns data in expected format"""
+    sources = sorted(factories.FeedSourceFactory.create_batch(5), key=lambda x: x.id)
+    results = (
+        client.get(reverse("news_events:v0:news_events_sources_api-list"))
+        .json()
+        .get("results")
+    )
+    assert_json_equal(
+        results,
+        [serializers.FeedSourceSerializer(instance=source).data for source in sources],
+    )
+
+
+@pytest.mark.parametrize("feed_type", FeedType.names())
+def test_feed_source_viewset_list_filtered(client, feed_type):
+    """Test that the sources list viewset returns data filtered by feed type"""
+    is_news = feed_type == FeedType.news.name
+    filtered = sorted(
+        factories.FeedSourceFactory.create_batch(2, feed_type=feed_type),
+        key=lambda x: x.id,
+    )
+    # This should not be in results
+    factories.FeedSourceFactory.create(
+        feed_type=FeedType.events.name if is_news else FeedType.news.name
+    )
+    results = (
+        client.get(
+            reverse("news_events:v0:news_events_sources_api-list"),
+            {"feed_type": feed_type},
+        )
+        .json()
+        .get("results")
+    )
+    assert_json_equal(
+        results,
+        [serializers.FeedSourceSerializer(instance=source).data for source in filtered],
+    )
+
+
+def test_feed_source_viewset_detail(client):
+    """Test that the feed sources detail viewset returns data in expected format"""
+    source = factories.FeedSourceFactory.create()
+    result = client.get(
+        reverse(
+            "news_events:v0:news_events_sources_api-detail", kwargs={"pk": source.id}
+        )
+    ).json()
+    assert_json_equal(result, serializers.FeedSourceSerializer(instance=source).data)
+
+
+@pytest.mark.parametrize("is_news", [True, False])
+def test_feed_item_viewset_list(client, is_news):
+    """Est that the feed sources list viewset returns data in expected format"""
+    items = sorted(
+        factories.FeedItemFactory.create_batch(
+            5, is_news=is_news, is_event=not is_news
+        ),
+        key=lambda x: x.news_details.publish_date
+        if is_news
+        else x.event_details.event_datetime,
+        reverse=True,
+    )
+    results = (
+        client.get(reverse("news_events:v0:news_events_items_api-list"))
+        .json()
+        .get("results")
+    )
+    assert_json_equal(
+        [serializers.FeedItemSerializer(instance=item).data for item in items], results
+    )
+
+
+@pytest.mark.parametrize("feed_type", FeedType.names())
+def test_feed_item_viewset_list_filtered(client, feed_type):
+    """Test that the items list viewset returns data filtered by source feed type"""
+    is_news = feed_type == FeedType.news.name
+    filtered = sorted(
+        factories.FeedItemFactory.create_batch(
+            2, is_news=is_news, is_event=not is_news
+        ),
+        key=lambda x: x.news_details.publish_date
+        if is_news
+        else x.event_details.event_datetime,
+        reverse=True,
+    )
+    # This should not be in results
+    factories.FeedItemFactory.create(is_news=not is_news, is_event=is_news)
+    results = (
+        client.get(
+            reverse("news_events:v0:news_events_items_api-list"),
+            {"feed_type": feed_type},
+        )
+        .json()
+        .get("results")
+    )
+    assert_json_equal(
+        [serializers.FeedItemSerializer(instance=item).data for item in filtered],
+        results,
+    )
+
+
+@pytest.mark.parametrize("is_news", [True, False])
+def test_feed_item_viewset_detail(client, is_news):
+    """Test that the feed items detail viewset returns data in expected format"""
+    item = factories.FeedItemFactory.create(is_news=is_news, is_event=not is_news)
+    expected = serializers.FeedItemSerializer(instance=item).data
+    result = client.get(
+        reverse("news_events:v0:news_events_items_api-detail", kwargs={"pk": item.id})
+    ).json()
+    assert_json_equal(result, expected)

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -217,6 +217,122 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/v0/news_events/:
+    get:
+      operationId: news_events_list
+      description: Get a paginated list of feed items.
+      parameters:
+      - in: query
+        name: feed_type
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - events
+            - news
+        description: |-
+          The type of item
+
+          * `news` - News
+          * `events` - Events
+        explode: true
+        style: form
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - news_events
+      responses:
+        '200':
+          description: No response body
+  /api/v0/news_events/{id}/:
+    get:
+      operationId: news_events_retrieve
+      description: Retrieve a single feed item.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this feed item.
+        required: true
+      tags:
+      - news_events
+      responses:
+        '200':
+          description: No response body
+  /api/v0/news_events_sources/:
+    get:
+      operationId: news_events_sources_list
+      description: Get a paginated list of news/event feed sources.
+      parameters:
+      - in: query
+        name: feed_type
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - events
+            - news
+        description: |-
+          The type of source
+
+          * `news` - News
+          * `events` - Events
+        explode: true
+        style: form
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - news_events_sources
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedFeedSourceList'
+          description: ''
+  /api/v0/news_events_sources/{id}/:
+    get:
+      operationId: news_events_sources_retrieve
+      description: Retrieve a single news/event feed source.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this feed source.
+        required: true
+      tags:
+      - news_events_sources
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedSource'
+          description: ''
   /api/v0/users/me/:
     get:
       operationId: users_me_retrieve
@@ -232,6 +348,58 @@ paths:
           description: ''
 components:
   schemas:
+    FeedImage:
+      type: object
+      description: Serializer for FeedImage
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        url:
+          type: string
+          maxLength: 2048
+        description:
+          type: string
+          maxLength: 1024
+        alt:
+          type: string
+          maxLength: 1024
+      required:
+      - id
+    FeedSource:
+      type: object
+      description: FeedSource serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        image:
+          $ref: '#/components/schemas/FeedImage'
+        title:
+          type: string
+          maxLength: 255
+        url:
+          type: string
+          format: uri
+          maxLength: 200
+        description:
+          type: string
+        feed_type:
+          $ref: '#/components/schemas/FeedTypeEnum'
+      required:
+      - feed_type
+      - id
+      - image
+      - title
+      - url
+    FeedTypeEnum:
+      enum:
+      - news
+      - events
+      type: string
+      description: |-
+        * `news` - News
+        * `events` - Events
     FieldChannel:
       type: object
       description: Serializer for FieldChannel
@@ -404,6 +572,26 @@ components:
       required:
       - id
       - title
+    PaginatedFeedSourceList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedSource'
     PaginatedFieldChannelList:
       type: object
       properties:


### PR DESCRIPTION
### What are the relevant tickets?
Related to #611, based on PR #612 which should be merged first.

### Description (What does it do?)
- Adds API endpoints for news_events sources and items, filterable by feed_type ("news", "events")
- Moves some classes/functions from `learning_resources/filters.py` to `main/filters.py` because they might be useful for multiple API endpoints (and one is used for this new endpoint).


### How can this be tested?
- Run `./manage.py backpopulate_news_events` if you haven't already
- Try the following urls:
  - http://localhost:8063/api/v0/news_events_sources/ - should return 2 results
  -  http://localhost:8063/api/v0/news_events_sources/?feed_type=news,events - should return 2 results
  - http://localhost:8063/api/v0/news_events_sources/?feed_type=news - should return 1 result, with `{"feed_type": "news"}`
  - http://localhost:8063/api/v0/news_events_sources/?feed_type=events - should return 1 result, with `{"feed_type": "events"}`
  - http://localhost:8063/api/v0/news_events/ - should return multiple results for news and events.  Events should come before news, with all items sorted by `event_details.event_datetime` / `news_details.publish_date` in reverse order.
  - http://localhost:8063/api/v0/news_events/?feed_type=news - should return only news items, sorted by `news_details.publish_date` in reverse order
  - http://localhost:8063/api/v0/news_events/?feed_type=events - should return only event items, sorted by `event_details.event_datetime` in reverse order.
