### PR TITLE
Remove all usages of pytz

### DIFF
--- a/learning_resources/etl/deduplication_test.py
+++ b/learning_resources/etl/deduplication_test.py
@@ -1,9 +1,8 @@
 """Tests for the deduplication ETL functions"""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
-import pytz
 
 from learning_resources.constants import AvailabilityType
 from learning_resources.etl.deduplication import get_most_relevant_run
@@ -17,12 +16,12 @@ def test_get_most_relevant_run():
 
     most_relevant_run = LearningResourceRunFactory.create(
         availability=AvailabilityType.archived.value,
-        start_date=datetime(2019, 10, 1, tzinfo=pytz.utc),
+        start_date=datetime(2019, 10, 1, tzinfo=UTC),
         run_id="1",
     )
     LearningResourceRunFactory.create(
         availability=AvailabilityType.archived.value,
-        start_date=datetime(2018, 10, 1, tzinfo=pytz.utc),
+        start_date=datetime(2018, 10, 1, tzinfo=UTC),
         run_id="2",
     )
 
@@ -33,13 +32,13 @@ def test_get_most_relevant_run():
 
     most_relevant_run = LearningResourceRunFactory.create(
         availability=AvailabilityType.upcoming.value,
-        start_date=datetime(2017, 10, 1, tzinfo=pytz.utc),
+        start_date=datetime(2017, 10, 1, tzinfo=UTC),
         run_id="3",
     )
 
     LearningResourceRunFactory.create(
         availability=AvailabilityType.upcoming.value,
-        start_date=datetime(2020, 10, 1, tzinfo=pytz.utc),
+        start_date=datetime(2020, 10, 1, tzinfo=UTC),
         run_id="4",
     )
 

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -3,9 +3,9 @@
 import copy
 import logging
 import re
+from datetime import UTC
 from urllib.parse import urljoin
 
-import pytz
 import requests
 from dateutil.parser import parse
 from django.conf import settings
@@ -35,7 +35,7 @@ def _parse_datetime(value):
     Returns:
         datetime: the parsed datetime
     """  # noqa: D401
-    return parse(value).replace(tzinfo=pytz.utc) if value else None
+    return parse(value).replace(tzinfo=UTC) if value else None
 
 
 def parse_page_attribute(

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -1,12 +1,11 @@
 """Next OCW ETL tests"""
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import boto3
 import pytest
-import pytz
 from moto import mock_s3
 
 from learning_resources.conftest import OCW_TEST_PREFIX, setup_s3_ocw
@@ -151,7 +150,7 @@ def test_transform_content_file_needs_text_update(
     )
 
     if modified_after_last_import:
-        ContentFile.objects.update(updated_on=datetime(2020, 12, 1, tzinfo=pytz.utc))
+        ContentFile.objects.update(updated_on=datetime(2020, 12, 1, tzinfo=UTC))
 
     content_data = transform_contentfile(
         s3_resource_object.key, resource_json, s3_resource, overwrite

--- a/learning_resources/etl/openedx.py
+++ b/learning_resources/etl/openedx.py
@@ -5,8 +5,8 @@ ETL extract and transformations for openedx
 import logging
 import re
 from collections import namedtuple
+from datetime import UTC
 
-import pytz
 import requests
 from dateutil.parser import parse
 from toolz import compose
@@ -99,7 +99,7 @@ def _parse_openedx_datetime(datetime_str):
     Returns:
         str: the parsed datetime
     """  # noqa: D401
-    return parse(datetime_str).astimezone(pytz.utc)
+    return parse(datetime_str).astimezone(UTC)
 
 
 def _get_course_marketing_url(config, course):

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -1,12 +1,11 @@
 """Tests for ETL pipelines"""
 
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from importlib import reload
 from unittest.mock import patch
 
 import pytest
-import pytz
 from moto import mock_s3
 
 from learning_resources.conftest import OCW_TEST_PREFIX, setup_s3_ocw
@@ -211,7 +210,7 @@ def test_ocw_courses_etl(settings, mocker, skip_content_files):
     pipelines.ocw_courses_etl(
         url_paths=[OCW_TEST_PREFIX],
         force_overwrite=True,
-        start_timestamp=datetime(2020, 12, 15, tzinfo=pytz.utc),
+        start_timestamp=datetime(2020, 12, 15, tzinfo=UTC),
         skip_content_files=skip_content_files,
     )
 
@@ -245,7 +244,7 @@ def test_ocw_courses_etl_no_data(settings, mocker):
     pipelines.ocw_courses_etl(
         url_paths=[s3_path],
         force_overwrite=True,
-        start_timestamp=datetime(2020, 12, 15, tzinfo=pytz.utc),
+        start_timestamp=datetime(2020, 12, 15, tzinfo=UTC),
     )
     mock_log.assert_called_once_with("No course data found for %s", s3_path)
 
@@ -264,7 +263,7 @@ def test_ocw_courses_etl_exception(settings, mocker):
         pipelines.ocw_courses_etl(
             url_paths=url_paths,
             force_overwrite=True,
-            start_timestamp=datetime(2020, 12, 15, tzinfo=pytz.utc),
+            start_timestamp=datetime(2020, 12, 15, tzinfo=UTC),
         )
     assert str(ex.value) == "Some OCW urls raised errors: %s" % ",".join(url_paths)
     for path in url_paths:

--- a/learning_resources/etl/podcast_test.py
+++ b/learning_resources/etl/podcast_test.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 from urllib.parse import urljoin
 
 import pytest
-import pytz
 import yaml
 from bs4 import BeautifulSoup as bs  # noqa: N813
 from dateutil.tz import tzutc
@@ -258,9 +257,9 @@ def test_generate_aggregate_podcast_rss():
     resource_2 = PodcastEpisodeFactory.create(
         rss="<item>rss2</item>",
     ).learning_resource
-    resource_1.last_modified = datetime.datetime(2020, 2, 1, tzinfo=pytz.UTC)
+    resource_1.last_modified = datetime.datetime(2020, 2, 1, tzinfo=datetime.UTC)
     resource_1.save()
-    resource_2.last_modified = datetime.datetime(2020, 1, 1, tzinfo=pytz.UTC)
+    resource_2.last_modified = datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC)
     resource_2.save()
 
     podcasts_url = urljoin(settings.SITE_BASE_URL, "podcasts")

--- a/learning_resources/etl/prolearn.py
+++ b/learning_resources/etl/prolearn.py
@@ -2,11 +2,10 @@
 
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from urllib.parse import urljoin, urlparse
 
-import pytz
 import requests
 from django.conf import settings
 
@@ -99,7 +98,7 @@ def parse_date(num) -> datetime:
         datetime: start or end date
     """
     if num:
-        return datetime.fromtimestamp(num, tz=pytz.UTC)
+        return datetime.fromtimestamp(num, tz=UTC)
     return None
 
 

--- a/learning_resources/etl/prolearn_test.py
+++ b/learning_resources/etl/prolearn_test.py
@@ -1,12 +1,11 @@
 """Tests for prolearn etl functions"""
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from decimal import Decimal
 from urllib.parse import urljoin, urlparse
 
 import pytest
-import pytz
 
 from learning_resources.constants import OfferedBy, PlatformType
 from learning_resources.etl import prolearn
@@ -229,7 +228,7 @@ def test_prolearn_transform_courses(mock_mitpe_courses_data):
 @pytest.mark.parametrize(
     ("date_int", "expected_dt"),
     [
-        [1670932800, datetime(2022, 12, 13, 12, 0, tzinfo=pytz.UTC)],  # noqa: PT007
+        [1670932800, datetime(2022, 12, 13, 12, 0, tzinfo=UTC)],  # noqa: PT007
         [None, None],  # noqa: PT007
     ],
 )

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -9,7 +9,7 @@ import re
 import uuid
 from collections import Counter
 from collections.abc import Generator
-from datetime import datetime
+from datetime import UTC, datetime
 from hashlib import md5
 from itertools import chain
 from pathlib import Path
@@ -17,7 +17,6 @@ from subprocess import check_call
 from tempfile import TemporaryDirectory
 
 import boto3
-import pytz
 import rapidjson
 import requests
 from django.conf import settings
@@ -257,33 +256,33 @@ def parse_dates(date_string, hour=12):
         start_date = datetime.strptime(
             f"{match.group('start_m')} {match.group('start_d')} {match.group('year')}",
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         end_date = datetime.strptime(
             f"{match.group('start_m')} {match.group('end_d')} {match.group('year')}",
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         return start_date, end_date
     match = re.match(pattern_1_year, date_string)
     if match:
         start_date = datetime.strptime(
             f"{match.group('start_m')} {match.group('start_d')} {match.group('year')}",
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         end_date = datetime.strptime(
             f"{match.group('end_m')} {match.group('end_d')} {match.group('year')}",
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         return start_date, end_date
     match = re.match(pattern_2_years, date_string)
     if match:
         start_date = datetime.strptime(
             f"{match.group('start_m')} {match.group('start_d')} {match.group('start_y')}",  # noqa: E501
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         end_date = datetime.strptime(
             f"{match.group('end_m')} {match.group('end_d')} {match.group('end_y')}",
             "%b %d %Y",
-        ).replace(hour=hour, tzinfo=pytz.utc)
+        ).replace(hour=hour, tzinfo=UTC)
         return start_date, end_date
     return None
 

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -8,7 +8,6 @@ from tempfile import TemporaryDirectory
 from unittest.mock import ANY
 
 import pytest
-import pytz
 from lxml import etree
 
 from learning_resources.constants import (
@@ -148,18 +147,18 @@ def test_parse_dates():
     """Test that parse_dates returns correct dates"""
     for datestring in ("May 13-30, 2020", "May 13 - 30,2020"):
         assert utils.parse_dates(datestring) == (
-            datetime.datetime(2020, 5, 13, 12, tzinfo=pytz.utc),
-            datetime.datetime(2020, 5, 30, 12, tzinfo=pytz.utc),
+            datetime.datetime(2020, 5, 13, 12, tzinfo=datetime.UTC),
+            datetime.datetime(2020, 5, 30, 12, tzinfo=datetime.UTC),
         )
     for datestring in ("Jun 24-Aug 11, 2020", "Jun  24 -  Aug 11,    2020"):
         assert utils.parse_dates(datestring) == (
-            datetime.datetime(2020, 6, 24, 12, tzinfo=pytz.utc),
-            datetime.datetime(2020, 8, 11, 12, tzinfo=pytz.utc),
+            datetime.datetime(2020, 6, 24, 12, tzinfo=datetime.UTC),
+            datetime.datetime(2020, 8, 11, 12, tzinfo=datetime.UTC),
         )
     for datestring in ("Nov 25, 2020-Jan 26, 2021", "Nov 25,2020  -Jan   26,2021"):
         assert utils.parse_dates(datestring) == (
-            datetime.datetime(2020, 11, 25, 12, tzinfo=pytz.utc),
-            datetime.datetime(2021, 1, 26, 12, tzinfo=pytz.utc),
+            datetime.datetime(2020, 11, 25, 12, tzinfo=datetime.UTC),
+            datetime.datetime(2021, 1, 26, 12, tzinfo=datetime.UTC),
         )
     assert utils.parse_dates("This is not a date") is None
 

--- a/learning_resources/etl/xpro.py
+++ b/learning_resources/etl/xpro.py
@@ -2,8 +2,8 @@
 
 import copy
 import logging
+from datetime import UTC
 
-import pytz
 import requests
 from dateutil.parser import parse
 from django.conf import settings
@@ -37,7 +37,7 @@ def _parse_datetime(value):
     Returns:
         datetime: the parsed datetime
     """  # noqa: D401
-    return parse(value).replace(tzinfo=pytz.utc) if value else None
+    return parse(value).replace(tzinfo=UTC) if value else None
 
 
 def extract_programs():

--- a/learning_resources/etl/youtube_test.py
+++ b/learning_resources/etl/youtube_test.py
@@ -3,13 +3,12 @@
 # pylint: disable=redefined-outer-name
 import json
 from collections import defaultdict
-from datetime import datetime
+from datetime import UTC, datetime
 from glob import glob
 from os.path import basename
 from unittest.mock import Mock
 
 import pytest
-import pytz
 from googleapiclient.errors import HttpError
 from youtube_transcript_api import NoTranscriptFound
 
@@ -516,9 +515,7 @@ def test_get_youtube_transcripts(mocker):
 
 @pytest.mark.django_db()
 @pytest.mark.parametrize("overwrite", [True, False])
-@pytest.mark.parametrize(
-    "created_after", [datetime(2019, 10, 4, tzinfo=pytz.utc), None]
-)
+@pytest.mark.parametrize("created_after", [datetime(2019, 10, 4, tzinfo=UTC), None])
 @pytest.mark.parametrize("created_minutes", [2000, None])
 def test_get_youtube_videos_for_transcripts_job(
     overwrite, created_after, created_minutes
@@ -528,16 +525,16 @@ def test_get_youtube_videos_for_transcripts_job(
     video1 = VideoFactory.create(transcript="saved already").learning_resource
     video2 = VideoFactory.create(transcript="").learning_resource
     video3 = VideoFactory.create(transcript="saved already").learning_resource
-    video3.created_on = datetime(2019, 10, 1, tzinfo=pytz.utc)
+    video3.created_on = datetime(2019, 10, 1, tzinfo=UTC)
     video3.save()
     video4 = VideoFactory.create(transcript="").learning_resource
-    video4.created_on = datetime(2019, 10, 1, tzinfo=pytz.utc)
+    video4.created_on = datetime(2019, 10, 1, tzinfo=UTC)
     video4.save()
     video5 = VideoFactory.create(transcript="saved already").learning_resource
-    video5.created_on = datetime(2019, 10, 5, tzinfo=pytz.utc)
+    video5.created_on = datetime(2019, 10, 5, tzinfo=UTC)
     video5.save()
     video6 = VideoFactory.create(transcript="").learning_resource
-    video6.created_on = datetime(2019, 10, 5, tzinfo=pytz.utc)
+    video6.created_on = datetime(2019, 10, 5, tzinfo=UTC)
     video6.save()
 
     result = youtube.get_youtube_videos_for_transcripts_job(

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -2,10 +2,9 @@
 
 import decimal
 import random
-from datetime import timedelta
+from datetime import UTC, timedelta
 
 import factory
-import pytz
 from factory import Faker
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyText
@@ -164,7 +163,7 @@ class LearningResourceFactory(DjangoModelFactory):
     full_description = factory.Faker("text")
     url = factory.Faker("url")
     languages = factory.List(random.choices(["en", "es"]))  # noqa: S311
-    last_modified = factory.Faker("date_time", tzinfo=pytz.utc)
+    last_modified = factory.Faker("date_time", tzinfo=UTC)
     image = factory.SubFactory(LearningResourceImageFactory)
     platform = factory.SubFactory(LearningResourcePlatformFactory)
     offered_by = factory.SubFactory(LearningResourceOfferorFactory)
@@ -414,7 +413,7 @@ class LearningResourceRunFactory(DjangoModelFactory):
             constants.AvailabilityType.archived.value,
         )
     )
-    enrollment_start = factory.Faker("date_time", tzinfo=pytz.utc)
+    enrollment_start = factory.Faker("date_time", tzinfo=UTC)
     enrollment_end = factory.LazyAttribute(
         lambda obj: (
             (obj.enrollment_start + timedelta(days=45))
@@ -458,12 +457,12 @@ class LearningResourceRunFactory(DjangoModelFactory):
 
         in_past = factory.Trait(
             enrollment_start=factory.Faker(
-                "date_time_between", end_date="-270d", tzinfo=pytz.utc
+                "date_time_between", end_date="-270d", tzinfo=UTC
             )
         )
         in_future = factory.Trait(
             enrollment_start=factory.Faker(
-                "date_time_between", start_date="+15d", tzinfo=pytz.utc
+                "date_time_between", start_date="+15d", tzinfo=UTC
             )
         )
 

--- a/learning_resources/management/commands/backpopulate_youtube_data.py
+++ b/learning_resources/management/commands/backpopulate_youtube_data.py
@@ -1,8 +1,7 @@
 """Management command for populating youtube course data"""
 
-from datetime import datetime
+from datetime import UTC, datetime
 
-import pytz
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
@@ -96,7 +95,7 @@ class Command(BaseCommand):
             if created_after:
                 try:
                     created_after = datetime.strptime(created_after, ISOFORMAT).replace(
-                        tzinfo=pytz.UTC
+                        tzinfo=UTC
                     )
                 except ValueError:
                     self.stdout.write("Invalid date format")

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -3,12 +3,11 @@ learning_resources tasks
 """
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 import boto3
 import celery
-import pytz
 from django.conf import settings
 
 from learning_resources.etl import pipelines, youtube
@@ -181,7 +180,7 @@ def get_ocw_courses(
         utc_start_timestamp = datetime.strptime(  # noqa: DTZ007
             utc_start_timestamp, ISOFORMAT
         )
-        utc_start_timestamp = utc_start_timestamp.replace(tzinfo=pytz.UTC)
+        utc_start_timestamp = utc_start_timestamp.replace(tzinfo=UTC)
 
     ocw_courses_etl(
         url_paths=url_paths,

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -3,10 +3,9 @@
 import json
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
-import pytz
 import rapidjson
 import requests
 import yaml
@@ -110,7 +109,7 @@ def semester_year_to_date(semester, year):
         month_day = "06-01"
     else:
         month_day = "01-01"
-    return datetime.strptime(f"{year}-{month_day}", "%Y-%m-%d").replace(tzinfo=pytz.UTC)
+    return datetime.strptime(f"{year}-{month_day}", "%Y-%m-%d").replace(tzinfo=UTC)
 
 
 def load_course_blocklist():

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -3,11 +3,10 @@ Test learning_resources utils
 """
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-import pytz
 
 from learning_resources import utils
 from learning_resources.constants import (
@@ -72,7 +71,7 @@ def test_semester_year_to_date(semester, year, expected):
     else:
         assert utils.semester_year_to_date(semester, year) == datetime.strptime(
             expected, "%Y-%m-%d"
-        ).replace(tzinfo=pytz.UTC)
+        ).replace(tzinfo=UTC)
 
 
 @pytest.mark.parametrize("url", [None, "http://test.me"])

--- a/main/utils.py
+++ b/main/utils.py
@@ -7,7 +7,6 @@ from enum import Flag, auto
 from itertools import islice
 
 import markdown2
-import pytz
 from bs4 import BeautifulSoup
 from django.conf import settings
 
@@ -38,7 +37,7 @@ def is_near_now(time):
         bool:
             True if near now, false otherwise
     """  # noqa: D401
-    now = datetime.datetime.now(tz=pytz.UTC)
+    now = datetime.datetime.now(tz=datetime.UTC)
     five_seconds = datetime.timedelta(0, 5)
     return now - five_seconds < time < now + five_seconds
 
@@ -49,7 +48,7 @@ def now_in_utc():
     Returns:
         datetime.datetime: A datetime object for the current time
     """
-    return datetime.datetime.now(tz=pytz.UTC)
+    return datetime.datetime.now(tz=datetime.UTC)
 
 
 def normalize_to_start_of_day(dt):

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -5,7 +5,6 @@ from math import ceil
 from tempfile import NamedTemporaryFile
 
 import pytest
-import pytz
 from django.contrib.auth import get_user_model
 
 from main.factories import UserFactory
@@ -31,14 +30,14 @@ def test_now_in_utc():
     """now_in_utc() should return the current time set to the UTC time zone"""
     now = now_in_utc()
     assert is_near_now(now)
-    assert now.tzinfo == pytz.UTC
+    assert now.tzinfo == datetime.UTC
 
 
 def test_is_near_now():
     """
     Test is_near_now for now
     """
-    now = datetime.datetime.now(tz=pytz.UTC)
+    now = datetime.datetime.now(tz=datetime.UTC)
     assert is_near_now(now) is True
     later = now + datetime.timedelta(0, 6)
     assert is_near_now(later) is False


### PR DESCRIPTION
### What are the relevant tickets?
Closes #645 

### Description (What does it do?)
Removes all usages of pytz and uses native timezone functionality instead.


### How can this be tested?
Unit tests should pass

### Additional Context
Once merged, should fix test failures on #628

