### PR TITLE
remove depricated ACL setting

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -488,7 +488,6 @@ if MITOPEN_USE_S3 and (
     raise ImproperlyConfigured(msg)
 if MITOPEN_USE_S3:
     DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-    AWS_DEFAULT_ACL = "public-read"
 
 IMAGEKIT_SPEC_CACHEFILE_NAMER = "imagekit.cachefiles.namers.source_name_dot_hash"
 IMAGEKIT_CACHEFILE_DIR = get_string("IMAGEKIT_CACHEFILE_DIR", "")


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/mit-open/issues/219

### Description (What does it do?)
S3 settings have changed and AWS_DEFAULT_ACL no longer does anything

### How can this be tested?
Tests should pass