### PR TITLE
Add botocore to ignored deprecation warnings, remove old python 3.7 ignore line

### DIFF
--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -34,15 +34,10 @@ def warnings_as_errors():  # noqa: PT004
         warnings.filterwarnings("ignore", category=InsecureRequestWarning)
         warnings.filterwarnings("ignore", category=PytestMockWarning)
         warnings.filterwarnings("ignore", category=ResourceWarning)
-        warnings.filterwarnings(
-            "ignore",
-            message="'async' and 'await' will become reserved keywords in Python 3.7",
-            category=DeprecationWarning,
-        )
         # Ignore deprecation warnings in third party libraries
         warnings.filterwarnings(
             "ignore",
-            module=".*(api_jwt|api_jws|rest_framework_jwt|astroid|celery|factory).*",
+            module=".*(api_jwt|api_jws|rest_framework_jwt|astroid|celery|factory|botocore).*",
             category=DeprecationWarning,
         )
         yield


### PR DESCRIPTION
### What are the relevant tickets?
Hopefully gets tests to pass on #349

### Description (What does it do?)
Adds `botocore` to 3rd-party deprecation warning ignore list
Removes an old ignore line for a deprecation warning related to python 3.7


### How can this be tested?
- Tests should pass
- If you apply this change locally to #349 (after rebuilding docker containers), tests should pass there too.


PS I initially tried upgrading boto3 and moto to the latest versions on the PR 349 branch, but the deprecation warning was still present.