### PR TITLE
display image and description in userlists

### DIFF
--- a/frontends/mit-open/src/page-components/CardTemplate/CardTemplate.test.tsx
+++ b/frontends/mit-open/src/page-components/CardTemplate/CardTemplate.test.tsx
@@ -1,11 +1,20 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import CardTemplate from "./CardTemplate"
+import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
+import { makeImgConfig } from "ol-utilities/test-utils/factories"
 
 describe("CardTemplate", () => {
   it("renders title and cover image", () => {
     const title = "Test Title"
-    render(<CardTemplate variant="column" title={title} />)
+    render(
+      <CardTemplate
+        variant="column"
+        imgUrl={DEFAULT_RESOURCE_IMG}
+        imgConfig={makeImgConfig()}
+        title={title}
+      />,
+    )
     const heading = screen.getByRole("heading", { name: title })
     expect(heading).toHaveAccessibleName(title)
   })

--- a/frontends/mit-open/src/page-components/CardTemplate/CardTemplate.tsx
+++ b/frontends/mit-open/src/page-components/CardTemplate/CardTemplate.tsx
@@ -1,8 +1,13 @@
 import React from "react"
 import Dotdotdot from "react-dotdotdot"
 import invariant from "tiny-invariant"
-import { Card, CardContent, styled } from "ol-components"
+import { Card, CardContent, CardMedia, styled } from "ol-components"
 import DragIndicatorIcon from "@mui/icons-material/DragIndicator"
+import {
+  DEFAULT_RESOURCE_IMG,
+  EmbedlyConfig,
+  embedlyThumbnail,
+} from "ol-utilities"
 
 type CardVariant = "column" | "row" | "row-reverse"
 type OnActivateCard = () => void
@@ -11,15 +16,17 @@ type CardTemplateProps = {
    * Whether the course picture and info display as a column or row.
    */
   variant: CardVariant
-  sortable?: boolean
   className?: string
   handleActivate?: OnActivateCard
   extraDetails?: React.ReactNode
-  imageSlot?: React.ReactNode
+  imgUrl: string
+  imgConfig: EmbedlyConfig
   title?: string
   bodySlot?: React.ReactNode
   footerSlot?: React.ReactNode
   footerActionSlot?: React.ReactNode
+  sortable?: boolean
+  suppressImage?: boolean
 }
 
 const LIGHT_TEXT_COLOR = "#8c8c8c"
@@ -126,28 +133,79 @@ const DragHandle = styled.div`
   margin-right: 16px;
 `
 
+const CardMediaImage = styled(CardMedia)<{
+  variant: CardVariant
+  component: string
+  alt: string
+}>`
+  ${({ variant }) =>
+    variant === "row"
+      ? "margin-right: 16px;"
+      : variant === "row-reverse"
+        ? "margin-left: 16px;"
+        : ""}
+`
+
+type ImageProps = Pick<
+  CardTemplateProps,
+  "imgUrl" | "imgConfig" | "suppressImage" | "variant"
+>
+const CardImage: React.FC<ImageProps> = ({
+  imgUrl,
+  imgConfig,
+  suppressImage,
+  variant,
+}) => {
+  if (suppressImage) return null
+  const dims =
+    variant === "column"
+      ? { height: imgConfig.height }
+      : { width: imgConfig.width, height: imgConfig.height }
+
+  return (
+    <CardMediaImage
+      component="img"
+      variant={variant}
+      sx={dims}
+      src={embedlyThumbnail(imgUrl ?? DEFAULT_RESOURCE_IMG, imgConfig)}
+      alt=""
+    />
+  )
+}
+
 const CardTemplate = ({
   variant,
   className,
   handleActivate,
   extraDetails,
-  imageSlot,
+  imgUrl,
+  imgConfig,
   title,
   bodySlot,
   footerSlot,
   footerActionSlot,
   sortable = false,
+  suppressImage = false,
 }: CardTemplateProps) => {
   invariant(
     !sortable || variant === "row-reverse",
     "sortable only supported for variant='row-reverse'",
   )
 
+  const image = (
+    <CardImage
+      variant={variant}
+      imgUrl={imgUrl}
+      imgConfig={imgConfig}
+      suppressImage={suppressImage}
+    />
+  )
+
   return (
     <StyledCard className={className}>
-      {variant === "column" ? imageSlot : null}
+      {variant === "column" ? image : null}
       <StyledCardContent variant={variant} sortable={sortable}>
-        {variant !== "column" ? imageSlot : null}
+        {variant !== "column" ? image : null}
         <Details>
           {extraDetails}
           {handleActivate ? (

--- a/frontends/mit-open/src/page-components/LearningResourceCardTemplate/LearningResourceCardTemplate.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCardTemplate/LearningResourceCardTemplate.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback } from "react"
 import { ResourceTypeEnum, type LearningResource } from "api"
-import { Chip, CardMedia, styled } from "ol-components"
+import { Chip, styled } from "ol-components"
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday"
 import {
   formatDate,
   pluralize,
-  resourceThumbnailSrc,
   getReadableResourceType,
   findBestRun,
+  DEFAULT_RESOURCE_IMG,
 } from "ol-utilities"
 import type { EmbedlyConfig } from "ol-utilities"
 import CardTemplate from "../CardTemplate/CardTemplate"
@@ -71,46 +71,6 @@ const ResourceFooterDetails: React.FC<
   return <CalendarChip avatar={<CalendarTodayIcon />} label={formattedDate} />
 }
 
-const CardMediaImage = styled(CardMedia)<{
-  variant: CardVariant
-  component: string
-  alt: string
-}>`
-  ${({ variant }) =>
-    variant === "row"
-      ? "margin-right: 16px;"
-      : variant === "row-reverse"
-        ? "margin-left: 16px;"
-        : ""}
-`
-
-type LRCImageProps = Pick<
-  LearningResourceCardTemplateProps,
-  "resource" | "imgConfig" | "suppressImage" | "variant"
->
-const LRCImage: React.FC<LRCImageProps> = ({
-  resource,
-  imgConfig,
-  suppressImage,
-  variant,
-}) => {
-  if (suppressImage) return null
-  const dims =
-    variant === "column"
-      ? { height: imgConfig.height }
-      : { width: imgConfig.width, height: imgConfig.height }
-
-  return (
-    <CardMediaImage
-      component="img"
-      variant={variant}
-      sx={dims}
-      src={resourceThumbnailSrc(resource.image ?? null, imgConfig)}
-      alt=""
-    />
-  )
-}
-
 const OfferedByText = styled.span`
   color: ${LIGHT_TEXT_COLOR};
   padding-right: 0.25em;
@@ -162,14 +122,7 @@ const LearningResourceCardTemplate = <R extends LearningResource>({
     [resource, onActivate],
   )
 
-  const image = (
-    <LRCImage
-      variant={variant}
-      suppressImage={suppressImage}
-      resource={resource}
-      imgConfig={imgConfig}
-    />
-  )
+  const imgUrl = resource.image?.url ?? DEFAULT_RESOURCE_IMG
   const extraDetails = (
     <TypeRow>
       <span>{getReadableResourceType(resource)}</span>
@@ -190,15 +143,18 @@ const LearningResourceCardTemplate = <R extends LearningResource>({
       className={className}
       handleActivate={handleActivate}
       extraDetails={extraDetails}
-      imageSlot={image}
+      imgUrl={imgUrl}
+      imgConfig={imgConfig}
       title={resource.title}
       bodySlot={body}
       footerSlot={footer}
       footerActionSlot={footerActionSlot}
       sortable={sortable}
+      suppressImage={suppressImage}
     ></CardTemplate>
   )
 }
 
 export default LearningResourceCardTemplate
+export { TypeRow }
 export type { LearningResourceCardTemplateProps }

--- a/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.test.tsx
+++ b/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.test.tsx
@@ -2,13 +2,21 @@ import React from "react"
 import { render, screen } from "@testing-library/react"
 import UserListCardTemplate from "./UserListCardTemplate"
 import * as factories from "api/test-utils/factories"
+import { makeImgConfig } from "ol-utilities/test-utils/factories"
 
 const userListFactory = factories.userLists
 
 describe("UserListCard", () => {
   it("renders title and cover image", () => {
     const userList = userListFactory.userList()
-    render(<UserListCardTemplate variant="column" userList={userList} />)
+    const imgConfig = makeImgConfig()
+    render(
+      <UserListCardTemplate
+        variant="column"
+        userList={userList}
+        imgConfig={imgConfig}
+      />,
+    )
     const heading = screen.getByRole("heading", { name: userList.title })
     expect(heading).toHaveAccessibleName(userList.title)
   })

--- a/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
+++ b/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from "react"
 import CardTemplate from "../CardTemplate/CardTemplate"
 import { UserList } from "api"
+import { EmbedlyConfig } from "ol-utilities"
+import { TypeRow } from "../LearningResourceCardTemplate/LearningResourceCardTemplate"
 
 type CardVariant = "column" | "row" | "row-reverse"
 type OnActivateCard = (userList: UserList) => void
@@ -12,6 +14,7 @@ type UserListCardTemplateProps<U extends UserList = UserList> = {
   userList: U
   sortable?: boolean
   className?: string
+  imgConfig: EmbedlyConfig
   onActivate?: OnActivateCard
 }
 
@@ -19,6 +22,7 @@ const UserListCardTemplate = <U extends UserList>({
   variant,
   userList,
   className,
+  imgConfig,
   sortable,
   onActivate,
 }: UserListCardTemplateProps<U>) => {
@@ -26,11 +30,19 @@ const UserListCardTemplate = <U extends UserList>({
     () => onActivate?.(userList),
     [userList, onActivate],
   )
+  const extraDetails = (
+    <TypeRow>
+      <span>{userList.description}</span>
+    </TypeRow>
+  )
   return (
     <CardTemplate
       variant={variant}
       className={className}
+      imgUrl={userList.image?.url}
+      imgConfig={imgConfig}
       title={userList.title}
+      extraDetails={extraDetails}
       sortable={sortable}
       handleActivate={handleActivate}
     ></CardTemplate>

--- a/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
+++ b/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from "react"
 import CardTemplate from "../CardTemplate/CardTemplate"
 import { UserList } from "api"
-import { EmbedlyConfig } from "ol-utilities"
+import { EmbedlyConfig, pluralize } from "ol-utilities"
 import { TypeRow } from "../LearningResourceCardTemplate/LearningResourceCardTemplate"
 
 type CardVariant = "column" | "row" | "row-reverse"
@@ -45,6 +45,11 @@ const UserListCardTemplate = <U extends UserList>({
       extraDetails={extraDetails}
       sortable={sortable}
       handleActivate={handleActivate}
+      footerSlot={
+        <span>
+          {userList.item_count} {pluralize("item", userList.item_count)}
+        </span>
+      }
     ></CardTemplate>
   )
 }

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -18,6 +18,7 @@ import CardRowList from "@/components/CardRowList/CardRowList"
 import UserListCardTemplate from "@/page-components/UserListCardTemplate/UserListCardTemplate"
 import { useNavigate } from "react-router"
 import * as urls from "@/common/urls"
+import { imgConfigs } from "@/common/constants"
 
 const ListHeaderGrid = styled(Grid)`
   margin-top: 1rem;
@@ -35,6 +36,7 @@ const ListCard: React.FC<ListCardProps> = ({ list, onActivate }) => {
       variant="row-reverse"
       userList={list}
       className="ic-resource-card"
+      imgConfig={imgConfigs["row-reverse-small"]}
       onActivate={onActivate}
     />
   )

--- a/frontends/ol-utilities/src/learning-resources/learning-resources.ts
+++ b/frontends/ol-utilities/src/learning-resources/learning-resources.ts
@@ -94,5 +94,11 @@ const findBestRun = (
   return past[0] ?? sorted[0]
 }
 
-export { resourceThumbnailSrc, getReadableResourceType, findBestRun }
+export {
+  DEFAULT_RESOURCE_IMG,
+  embedlyThumbnail,
+  resourceThumbnailSrc,
+  getReadableResourceType,
+  findBestRun,
+}
 export type { EmbedlyConfig }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/694

### Description (What does it do?)
This PR adds images and descriptions to `UserList` cards. The `LRCImage` component from `LearningResourceCardTemplate` was moved to `CardTemplate` and renamed to `CardImage`. Instead of passing a `LearningResource` object to `CardTemplate`, you simply pass the image URL instead. In `LearningResourceCardTemplate`, the `LearningResource` image URL is used, and in `UserListCardTemplate` the `UserList` image URL is used.

### Screenshots (if appropriate):
<img width="720" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/93b11e0a-28fa-4c19-b65c-cd0445fd9354">
<img width="146" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/6d3fe54f-ef38-4b71-b403-b6b8c3df93ae">

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Make sure you have some `UserList`s in your database, and if not go to http://localhost:8063/api/v1/userlists and create some (making sure you enter a description), then visit http://localhost:8063/api/v1/userlists/x/items/ where x is the ID of your `UserList` to add some items to the lists
 - Visit http://localhost:8063/userlists/
 - For each `UserList`, you should see the title, description and either the default image if the list is empty or the image of the first `LearningResource` in the list
