### PR TITLE
Group Renovate CKEditor PRs 

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
       "enabled": false
     },
     {
-      "matchSourceUrls": ["https://github.com/ckeditor/ckeditor5"]
+      "matchSourceUrlPrefixes": ["https://github.com/ckeditor/ckeditor5/"],
+      "groupName": "ckeditor5"
     }
   ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
#317 

### Description (What does it do?)
Try grouping by [`matchSourceUrlPrefixes`](https://docs.renovatebot.com/configuration-options/#matchsourceurlprefixes) instead of `matchSourceUrl`.


### How can this be tested?
You could run `npx --package renovate renovate-config-validator` in the git repo.

### Additional Context
I'm not sure why `matchSourceUrl` hasn't been working, but it clearly hasn't been grouping the ckeditor PRs.