### PR TITLE
add UserList modals and wire up buttons

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -223,14 +223,10 @@ const useUserListsDetail = (id: number) => {
   return useQuery(learningResources.userlists._ctx.detail(id))
 }
 
-type UserListCreateRequest = Omit<
-  ULCreateRequest["UserListRequest"],
-  "readable_id" | "resource_type"
->
 const useUserListCreate = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (params: UserListCreateRequest) =>
+    mutationFn: (params: ULCreateRequest["UserListRequest"]) =>
       userListsApi.userlistsCreate({
         UserListRequest: params,
       }),

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -19,8 +19,11 @@ import type {
   LearningResource,
   LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest as LRSearchRequest,
   UserlistsApiUserlistsListRequest as ULListRequest,
+  UserlistsApiUserlistsCreateRequest as ULCreateRequest,
+  UserlistsApiUserlistsDestroyRequest as ULDestroyRequest,
   UserlistsApiUserlistsItemsListRequest as ULItemsListRequest,
   OfferorsApiOfferorsListRequest,
+  UserList,
 } from "../../generated/v1"
 import learningResources, { invalidateResourceQueries } from "./keyFactory"
 import { ListType } from "../../common/constants"
@@ -220,6 +223,47 @@ const useUserListsDetail = (id: number) => {
   return useQuery(learningResources.userlists._ctx.detail(id))
 }
 
+type UserListCreateRequest = Omit<
+  ULCreateRequest["UserListRequest"],
+  "readable_id" | "resource_type"
+>
+const useUserListCreate = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: UserListCreateRequest) =>
+      userListsApi.userlistsCreate({
+        UserListRequest: params,
+      }),
+    onSettled: () => {
+      queryClient.invalidateQueries(learningResources.userlists._ctx.list._def)
+    },
+  })
+}
+const useUserListUpdate = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: Pick<UserList, "id"> & Partial<UserList>) =>
+      userListsApi.userlistsPartialUpdate({
+        id: params.id,
+        PatchedUserListRequest: params,
+      }),
+    onSettled: (_data, _err, vars) => {
+      invalidateResourceQueries(queryClient, vars.id)
+    },
+  })
+}
+
+const useUserListDestroy = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (params: ULDestroyRequest) =>
+      learningpathsApi.learningpathsDestroy(params),
+    onSettled: (_data, _err, vars) => {
+      invalidateResourceQueries(queryClient, vars.id)
+    },
+  })
+}
+
 const useInfiniteUserListItems = (
   params: ULItemsListRequest,
   options: Pick<UseQueryOptions, "enabled"> = {},
@@ -306,6 +350,9 @@ export {
   useLearningResourcesSearch,
   useUserListList,
   useUserListsDetail,
+  useUserListCreate,
+  useUserListUpdate,
+  useUserListDestroy,
   useInfiniteUserListItems,
   useOfferorsList,
   useListItemMove,

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -257,7 +257,7 @@ const useUserListDestroy = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (params: ULDestroyRequest) =>
-      learningpathsApi.learningpathsDestroy(params),
+      userListsApi.userlistsDestroy(params),
     onSettled: (_data, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.id)
     },

--- a/frontends/api/src/test-utils/factories/userLists.ts
+++ b/frontends/api/src/test-utils/factories/userLists.ts
@@ -2,6 +2,7 @@ import { Factory, makePaginatedFactory } from "ol-test-utilities"
 import {
   MicroUserListRelationship,
   PaginatedUserListRelationshipList,
+  PrivacyLevelEnum,
   UserList,
   UserListRelationship,
 } from "api"
@@ -12,6 +13,8 @@ const userList: Factory<UserList> = (overrides = {}) => {
   const list: UserList = {
     id: faker.helpers.unique(faker.datatype.number),
     title: faker.helpers.unique(faker.lorem.words),
+    description: faker.helpers.unique(faker.lorem.paragraph),
+    privacy_level: PrivacyLevelEnum.Private,
     item_count: 4,
     image: {},
     author: faker.helpers.unique(faker.datatype.number),

--- a/frontends/api/src/test-utils/factories/userLists.ts
+++ b/frontends/api/src/test-utils/factories/userLists.ts
@@ -14,7 +14,7 @@ const userList: Factory<UserList> = (overrides = {}) => {
     id: faker.helpers.unique(faker.datatype.number),
     title: faker.helpers.unique(faker.lorem.words),
     description: faker.helpers.unique(faker.lorem.paragraph),
-    privacy_level: PrivacyLevelEnum.Private,
+    privacy_level: faker.helpers.arrayElement(Object.values(PrivacyLevelEnum)),
     item_count: 4,
     image: {},
     author: faker.helpers.unique(faker.datatype.number),

--- a/frontends/mit-open/src/GlobalStyles.tsx
+++ b/frontends/mit-open/src/GlobalStyles.tsx
@@ -63,7 +63,7 @@ const formCss = css`
 
   form .form-row,
   .form-header .form-row {
-    margin: 10px 0 24px 0;
+    margin: 10px 0 24px;
   }
 
   .MuiDialogContent-root {

--- a/frontends/mit-open/src/GlobalStyles.tsx
+++ b/frontends/mit-open/src/GlobalStyles.tsx
@@ -63,7 +63,7 @@ const formCss = css`
 
   form .form-row,
   .form-header .form-row {
-    margin: 10px 10px 24px 0;
+    margin: 10px 0px 24px 0;
   }
 
   .MuiDialogContent-root {

--- a/frontends/mit-open/src/GlobalStyles.tsx
+++ b/frontends/mit-open/src/GlobalStyles.tsx
@@ -63,7 +63,7 @@ const formCss = css`
 
   form .form-row,
   .form-header .form-row {
-    margin: 10px 0px 24px 0;
+    margin: 10px 0 24px 0;
   }
 
   .MuiDialogContent-root {

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
@@ -11,7 +11,7 @@ import {
   within,
   act,
 } from "../../test-utils"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import { waitForElementToBeRemoved } from "@testing-library/react"
 import {
   LearningPathRelationship,
@@ -163,7 +163,7 @@ describe("AddToListDialog", () => {
   test("Clicking 'Create a new list' opens the create list dialog", async () => {
     // Don't actually open the 'Create List' modal, or we'll need to mock API responses.
     const createList = jest
-      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
+      .spyOn(manageListDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
 
     setup()

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
@@ -163,7 +163,7 @@ describe("AddToListDialog", () => {
   test("Clicking 'Create a new list' opens the create list dialog", async () => {
     // Don't actually open the 'Create List' modal, or we'll need to mock API responses.
     const createList = jest
-      .spyOn(manageLearningPathDialogs, "upsert")
+      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
 
     setup()

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -189,7 +189,7 @@ const AddToListDialogInner: React.FC<AddToListDialogProps> = ({
             })}
             <ListItem className="add-to-list-new">
               <ListItemButton
-                onClick={() => manageLearningPathDialogs.upsert()}
+                onClick={() => manageLearningPathDialogs.upsertLearningPath()}
               >
                 <AddIcon />
                 <ListItemText primary="Create a new list" />

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -25,7 +25,7 @@ import {
   useLearningpathRelationshipCreate,
   useLearningpathRelationshipDestroy,
 } from "api/hooks/learningResources"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 type AddToListDialogProps = {
   resourceId: number
@@ -189,7 +189,7 @@ const AddToListDialogInner: React.FC<AddToListDialogProps> = ({
             })}
             <ListItem className="add-to-list-new">
               <ListItemButton
-                onClick={() => manageLearningPathDialogs.upsertLearningPath()}
+                onClick={() => manageListDialogs.upsertLearningPath()}
               >
                 <AddIcon />
                 <ListItemText primary="Create a new list" />

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -70,7 +70,7 @@ describe("manageListDialogs.upsert", () => {
     renderWithProviders(null, opts)
 
     act(() => {
-      manageLearningPathDialogs.upsert(resource)
+      manageLearningPathDialogs.upsertLearningPath(resource)
     })
 
     return { topics }
@@ -216,7 +216,7 @@ describe("manageListDialogs.destroy", () => {
     const resource = factories.learningResources.learningPath()
     renderWithProviders(null)
     act(() => {
-      manageLearningPathDialogs.destroy(resource)
+      manageLearningPathDialogs.destroyLearningPath(resource)
     })
     return { resource }
   }

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -1,8 +1,10 @@
 import { faker } from "@faker-js/faker/locale/en"
 import { factories, urls, makeRequest } from "api/test-utils"
-import type {
-  LearningPathResource,
-  PaginatedLearningResourceTopicList,
+import {
+  PrivacyLevelEnum,
+  type LearningPathResource,
+  type PaginatedLearningResourceTopicList,
+  type UserList,
 } from "api"
 import { allowConsoleErrors, getDescriptionFor } from "ol-test-utilities"
 import { manageLearningPathDialogs } from "./ManageListDialogs"
@@ -39,6 +41,11 @@ const inputs = {
     const element = screen.getByLabelText(value ? "Public" : "Private")
     return element as HTMLInputElement
   },
+  privacy_level: (value?: string) => {
+    invariant(value !== undefined)
+    const element = screen.getByDisplayValue(value)
+    return element as HTMLInputElement
+  },
   title: () => screen.getByLabelText("Title", { exact: false }),
   description: () => screen.getByLabelText("Description", { exact: false }),
   topics: () => screen.getByLabelText("Subjects", { exact: false }),
@@ -47,7 +54,7 @@ const inputs = {
   delete: () => screen.getByRole("button", { name: "Yes, delete" }),
 }
 
-describe("manageListDialogs.upsert", () => {
+describe("manageListDialogs.upsertLearningPath", () => {
   const setup = ({
     resource,
     topics = factories.learningResources.topics({ count: 10 }),
@@ -211,7 +218,140 @@ describe("manageListDialogs.upsert", () => {
   })
 })
 
-describe("manageListDialogs.destroy", () => {
+describe("manageListDialogs.upsertUserList", () => {
+  const setup = ({
+    userList,
+    opts = {
+      user: { is_authenticated: true },
+    },
+  }: {
+    userList?: UserList
+    opts?: Partial<TestAppOptions>
+  } = {}) => {
+    renderWithProviders(null, opts)
+
+    act(() => {
+      manageLearningPathDialogs.upsertUserList(userList)
+    })
+  }
+
+  test.each([
+    {
+      userList: undefined,
+      expectedTitle: "Create User List",
+    },
+    {
+      userList: factories.userLists.userList(),
+      expectedTitle: "Edit User List",
+    },
+  ])(
+    "Dialog title is $expectedTitle when userList=$userList",
+    async ({ userList, expectedTitle }) => {
+      setup({ userList })
+      const dialog = screen.getByRole("heading", { name: expectedTitle })
+      expect(dialog).toBeVisible()
+    },
+  )
+
+  test("'Cancel' closes dialog (and does not make request)", async () => {
+    // behavior does not depend on stafflist / userlist, so just pick one
+    setup({
+      userList: factories.userLists.userList(),
+    })
+    const dialog = screen.getByRole("dialog")
+    await user.click(inputs.cancel())
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      "patch",
+      expect.anything(),
+      expect.anything(),
+    )
+    await waitForElementToBeRemoved(dialog)
+  })
+
+  test("Validates required fields", async () => {
+    setup()
+    await user.click(inputs.submit())
+
+    const titleInput = inputs.title()
+    const titleFeedback = getDescriptionFor(titleInput)
+    expect(titleInput).toBeInvalid()
+    expect(titleFeedback).toHaveTextContent("Title is required.")
+
+    const descriptionInput = inputs.description()
+    const descriptionFeedback = getDescriptionFor(descriptionInput)
+    expect(descriptionInput).toBeInvalid()
+    expect(descriptionFeedback).toHaveTextContent("Description is required.")
+  })
+
+  test("Form defaults are set", () => {
+    setup()
+    expect(inputs.title()).toHaveValue("")
+    expect(inputs.description()).toHaveValue("")
+    expect(inputs.privacy_level(PrivacyLevelEnum.Private).checked).toBe(true)
+    expect(inputs.privacy_level(PrivacyLevelEnum.Unlisted).checked).toBe(false)
+  })
+
+  test("Editing form values", async () => {
+    const userList = factories.userLists.userList()
+    setup({ userList: userList })
+    const patch = {
+      title: faker.lorem.words(),
+      description: faker.lorem.paragraph(),
+      privacy_level: PrivacyLevelEnum.Unlisted,
+    }
+
+    // Title
+    expect(inputs.title()).toHaveValue(userList.title)
+    await user.click(inputs.title())
+    await user.clear(inputs.title())
+    await user.paste(patch.title)
+
+    // Description
+    expect(inputs.description()).toHaveValue(userList.description)
+    await user.click(inputs.description())
+    await user.clear(inputs.description())
+    await user.paste(patch.description)
+
+    // Privacy Level
+    expect(inputs.privacy_level(PrivacyLevelEnum.Private).checked).toBe(true)
+    expect(inputs.privacy_level(PrivacyLevelEnum.Unlisted).checked).toBe(false)
+    await user.click(inputs.privacy_level(patch.privacy_level))
+
+    // Submit
+    const patchUrl = urls.userLists.details({ id: userList.id })
+    setMockResponse.patch(patchUrl, { ...userList, ...patch })
+    await user.click(inputs.submit())
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      "patch",
+      patchUrl,
+      expect.objectContaining({ ...patch }),
+    )
+  })
+
+  test("Displays overall error if form validates but API call fails", async () => {
+    allowConsoleErrors()
+    const userList = factories.userLists.userList()
+    await setup({ userList: userList })
+
+    const patchUrl = urls.userLists.details({ id: userList.id })
+    setMockResponse.patch(patchUrl, {}, { code: 408 })
+    await user.click(inputs.submit())
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      "patch",
+      patchUrl,
+      expect.anything(),
+    )
+    const alertMessage = await screen.findByRole("alert")
+
+    expect(alertMessage).toHaveTextContent(
+      "There was a problem saving your list.",
+    )
+  })
+})
+
+describe("manageListDialogs.destroyLearningPath", () => {
   const setup = () => {
     const resource = factories.learningResources.learningPath()
     renderWithProviders(null)

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -389,3 +389,42 @@ describe("manageListDialogs.destroyLearningPath", () => {
     await waitForElementToBeRemoved(dialog)
   })
 })
+
+describe("manageListDialogs.destroyUserList", () => {
+  const setup = () => {
+    const userList = factories.userLists.userList()
+    renderWithProviders(null)
+    act(() => {
+      manageLearningPathDialogs.destroyUserList(userList)
+    })
+    return { userList: userList }
+  }
+
+  test("Dialog title is 'Delete list'", async () => {
+    setup()
+    const dialog = screen.getByRole("heading", { name: "Delete User List" })
+    expect(dialog).toBeVisible()
+  })
+
+  test("Deleting a $label calls correct API", async () => {
+    const { userList } = setup()
+
+    const dialog = screen.getByRole("dialog")
+    const url = urls.userLists.details({ id: userList.id })
+    setMockResponse.delete(url, undefined)
+    await user.click(inputs.delete())
+
+    expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
+    await waitForElementToBeRemoved(dialog)
+  })
+
+  test("Clicking cancel does not delete list", async () => {
+    setup()
+
+    const dialog = screen.getByRole("dialog")
+    await user.click(inputs.cancel())
+
+    expect(makeRequest).not.toHaveBeenCalled()
+    await waitForElementToBeRemoved(dialog)
+  })
+})

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -7,7 +7,7 @@ import {
   type UserList,
 } from "api"
 import { allowConsoleErrors, getDescriptionFor } from "ol-test-utilities"
-import { manageLearningPathDialogs } from "./ManageListDialogs"
+import { manageListDialogs } from "./ManageListDialogs"
 import {
   screen,
   renderWithProviders,
@@ -77,7 +77,7 @@ describe("manageListDialogs.upsertLearningPath", () => {
     renderWithProviders(null, opts)
 
     act(() => {
-      manageLearningPathDialogs.upsertLearningPath(resource)
+      manageListDialogs.upsertLearningPath(resource)
     })
 
     return { topics }
@@ -231,7 +231,7 @@ describe("manageListDialogs.upsertUserList", () => {
     renderWithProviders(null, opts)
 
     act(() => {
-      manageLearningPathDialogs.upsertUserList(userList)
+      manageListDialogs.upsertUserList(userList)
     })
   }
 
@@ -356,7 +356,7 @@ describe("manageListDialogs.destroyLearningPath", () => {
     const resource = factories.learningResources.learningPath()
     renderWithProviders(null)
     act(() => {
-      manageLearningPathDialogs.destroyLearningPath(resource)
+      manageListDialogs.destroyLearningPath(resource)
     })
     return { resource }
   }
@@ -395,7 +395,7 @@ describe("manageListDialogs.destroyUserList", () => {
     const userList = factories.userLists.userList()
     renderWithProviders(null)
     act(() => {
-      manageLearningPathDialogs.destroyUserList(userList)
+      manageListDialogs.destroyUserList(userList)
     })
     return { userList: userList }
   }

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -390,7 +390,7 @@ const DeleteUserListDialog = NiceModal.create(
   },
 )
 
-const manageLearningPathDialogs = {
+const manageListDialogs = {
   upsertLearningPath: (resource?: LearningPathResource) => {
     const title = resource ? "Edit Learning Path" : "Create Learning Path"
     NiceModal.show(UpsertLearningPathDialog, { title, resource })
@@ -405,4 +405,4 @@ const manageLearningPathDialogs = {
     NiceModal.show(DeleteUserListDialog, { userList }),
 }
 
-export { manageLearningPathDialogs }
+export { manageListDialogs }

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -9,15 +9,19 @@ import {
   FormDialog,
   BasicDialog,
   styled,
+  RadioChoiceField,
 } from "ol-components"
 import * as Yup from "yup"
-import type { LearningPathResource } from "api"
+import { PrivacyLevelEnum, type LearningPathResource, UserList } from "api"
 
 import {
   useLearningpathCreate,
   useLearningpathUpdate,
   useLearningpathDestroy,
   useLearningResourceTopics,
+  useUserListCreate,
+  useUserListUpdate,
+  useUserListDestroy,
 } from "api/hooks/learningResources"
 
 /*
@@ -66,7 +70,16 @@ const learningPathFormSchema = Yup.object().shape({
     .required(),
 })
 
-const PRIVACY_CHOICES = [
+const userListFormSchema = Yup.object().shape({
+  privacy_level: Yup.string()
+    .oneOf(Object.values(PrivacyLevelEnum))
+    .default(PrivacyLevelEnum.Private)
+    .required("Privacy Level is required"),
+  title: Yup.string().default("").required("Title is required."),
+  description: Yup.string().default("").required("Description is required."),
+})
+
+const LEARNING_PATH_PRIVACY_CHOICES = [
   {
     value: false,
     label: "Private",
@@ -79,17 +92,31 @@ const PRIVACY_CHOICES = [
   },
 ]
 
-type FormValues = Yup.InferType<typeof learningPathFormSchema>
+const USER_LIST_PRIVACY_CHOICES = [
+  {
+    value: PrivacyLevelEnum.Private,
+    label: "Private",
+    className: "radio-option",
+  },
+  {
+    value: PrivacyLevelEnum.Unlisted,
+    label: "Unlisted",
+    className: "radio-option",
+  },
+]
+
+type LearningPathFormValues = Yup.InferType<typeof learningPathFormSchema>
+type UserListFormValues = Yup.InferType<typeof userListFormSchema>
 
 const variantProps = { InputLabelProps: { shrink: true } }
 
-interface UpsertListDialogProps {
+interface UpsertLearningPathDialogProps {
   title: string
   resource?: LearningPathResource | null
 }
 
-const UpsertListDialog = NiceModal.create(
-  ({ resource, title }: UpsertListDialogProps) => {
+const UpsertLearningPathDialog = NiceModal.create(
+  ({ resource, title }: UpsertLearningPathDialogProps) => {
     const modal = NiceModal.useModal()
     const topicsQuery = useLearningResourceTopics(undefined, {
       enabled: modal.visible,
@@ -98,7 +125,7 @@ const UpsertListDialog = NiceModal.create(
     const updateList = useLearningpathUpdate()
     const mutation = resource?.id ? updateList : createList
     const handleSubmit: FormikConfig<
-      LearningPathResource | FormValues
+      LearningPathResource | LearningPathFormValues
     >["onSubmit"] = useCallback(
       async (values) => {
         if (resource?.id) {
@@ -114,7 +141,8 @@ const UpsertListDialog = NiceModal.create(
     const formik = useFormik({
       enableReinitialize: true,
       initialValues:
-        resource ?? (learningPathFormSchema.getDefault() as FormValues),
+        resource ??
+        (learningPathFormSchema.getDefault() as LearningPathFormValues),
       validationSchema: learningPathFormSchema,
       onSubmit: handleSubmit,
       validateOnChange: false,
@@ -199,7 +227,7 @@ const UpsertListDialog = NiceModal.create(
           className="form-row"
           name="published"
           label="Privacy"
-          choices={PRIVACY_CHOICES}
+          choices={LEARNING_PATH_PRIVACY_CHOICES}
           value={formik.values.published}
           row
           onChange={(e) => formik.setFieldValue(e.name, e.value)}
@@ -209,12 +237,107 @@ const UpsertListDialog = NiceModal.create(
   },
 )
 
-type DeleteListDialogProps = {
+interface UpsertUserListDialogProps {
+  title: string
+  userList?: UserList | null
+}
+
+const UpsertUserListDialog = NiceModal.create(
+  ({ userList, title }: UpsertUserListDialogProps) => {
+    const modal = NiceModal.useModal()
+    const createList = useUserListCreate()
+    const updateList = useUserListUpdate()
+    const mutation = userList?.id ? updateList : createList
+    const handleSubmit: FormikConfig<
+      UserList | UserListFormValues
+    >["onSubmit"] = useCallback(
+      async (values) => {
+        if (userList?.id) {
+          await updateList.mutateAsync({ ...values, id: userList.id })
+        } else {
+          await createList.mutateAsync(values)
+        }
+        modal.hide()
+      },
+      [userList, createList, updateList, modal],
+    )
+
+    const formik = useFormik({
+      enableReinitialize: true,
+      initialValues:
+        userList ?? (userListFormSchema.getDefault() as UserListFormValues),
+      validationSchema: learningPathFormSchema,
+      onSubmit: handleSubmit,
+      validateOnChange: false,
+      validateOnBlur: false,
+    })
+
+    return (
+      <StyledFormDialog
+        {...NiceModal.muiDialogV5(modal)}
+        title={title}
+        fullWidth
+        formClassName="manage-list-form"
+        onReset={formik.resetForm}
+        onSubmit={formik.handleSubmit}
+        noValidate
+        footerContent={
+          mutation.isError &&
+          !formik.isSubmitting && (
+            <Alert severity="error">
+              There was a problem saving your list. Please try again later.
+            </Alert>
+          )
+        }
+      >
+        <TextField
+          required
+          className="form-row"
+          name="title"
+          label="Title"
+          placeholder="List Title"
+          value={formik.values.title}
+          error={!!formik.errors.title}
+          helperText={formik.errors.title}
+          onChange={formik.handleChange}
+          {...variantProps}
+          fullWidth
+        />
+        <TextField
+          required
+          className="form-row"
+          label="Description"
+          name="description"
+          placeholder="List Description"
+          value={formik.values.description}
+          error={!!formik.errors.description}
+          helperText={formik.errors.description}
+          onChange={formik.handleChange}
+          {...variantProps}
+          fullWidth
+          multiline
+          minRows={3}
+        />
+        <RadioChoiceField
+          className="form-row"
+          name="published"
+          label="Privacy"
+          choices={USER_LIST_PRIVACY_CHOICES}
+          value={formik.values.privacy_level}
+          row
+          onChange={(e) => formik.setFieldValue(e.target.name, e.target.value)}
+        />
+      </StyledFormDialog>
+    )
+  },
+)
+
+type DeleteLearningPathDialogProps = {
   resource: LearningPathResource
 }
 
-const DeleteListDialog = NiceModal.create(
-  ({ resource }: DeleteListDialogProps) => {
+const DeleteLearningPathDialog = NiceModal.create(
+  ({ resource }: DeleteLearningPathDialogProps) => {
     const modal = NiceModal.useModal()
     const hideModal = modal.hide
     const destroyList = useLearningpathDestroy()
@@ -238,13 +361,48 @@ const DeleteListDialog = NiceModal.create(
   },
 )
 
-const manageLearningPathDialogs = {
-  upsert: (resource?: LearningPathResource) => {
-    const title = resource ? "Edit Learning Path" : "Create Learning Path"
-    NiceModal.show(UpsertListDialog, { title, resource })
+type DeleteUserListDialogProps = {
+  userList: UserList
+}
+
+const DeleteUserListDialog = NiceModal.create(
+  ({ userList }: DeleteUserListDialogProps) => {
+    const modal = NiceModal.useModal()
+    const hideModal = modal.hide
+    const destroyList = useUserListDestroy()
+
+    const handleConfirm = useCallback(async () => {
+      await destroyList.mutateAsync({
+        id: userList.id,
+      })
+      hideModal()
+    }, [destroyList, hideModal, userList])
+    return (
+      <BasicDialog
+        {...NiceModal.muiDialogV5(modal)}
+        onConfirm={handleConfirm}
+        title="Delete User List"
+        confirmText="Yes, delete"
+      >
+        Are you sure you want to delete this list?
+      </BasicDialog>
+    )
   },
-  destroy: (resource: LearningPathResource) =>
-    NiceModal.show(DeleteListDialog, { resource }),
+)
+
+const manageLearningPathDialogs = {
+  upsertLearningPath: (resource?: LearningPathResource) => {
+    const title = resource ? "Edit Learning Path" : "Create Learning Path"
+    NiceModal.show(UpsertLearningPathDialog, { title, resource })
+  },
+  destroyLearningPath: (resource: LearningPathResource) =>
+    NiceModal.show(DeleteLearningPathDialog, { resource }),
+  upsertUserList: (userList?: UserList) => {
+    const title = userList ? "Edit User List" : "Create User List"
+    NiceModal.show(UpsertUserListDialog, { title, userList })
+  },
+  destroyUserList: (userList: UserList) =>
+    NiceModal.show(DeleteUserListDialog, { userList }),
 }
 
 export { manageLearningPathDialogs }

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -266,7 +266,7 @@ const UpsertUserListDialog = NiceModal.create(
       enableReinitialize: true,
       initialValues:
         userList ?? (userListFormSchema.getDefault() as UserListFormValues),
-      validationSchema: learningPathFormSchema,
+      validationSchema: userListFormSchema,
       onSubmit: handleSubmit,
       validateOnChange: false,
       validateOnBlur: false,

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -320,7 +320,7 @@ const UpsertUserListDialog = NiceModal.create(
         />
         <RadioChoiceField
           className="form-row"
-          name="published"
+          name="privacy_level"
           label="Privacy"
           choices={USER_LIST_PRIVACY_CHOICES}
           value={formik.values.privacy_level}

--- a/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
+++ b/frontends/mit-open/src/page-components/UserListCardTemplate/UserListCardTemplate.tsx
@@ -16,6 +16,7 @@ type UserListCardTemplateProps<U extends UserList = UserList> = {
   className?: string
   imgConfig: EmbedlyConfig
   onActivate?: OnActivateCard
+  footerActionSlot?: React.ReactNode
 }
 
 const UserListCardTemplate = <U extends UserList>({
@@ -25,6 +26,7 @@ const UserListCardTemplate = <U extends UserList>({
   imgConfig,
   sortable,
   onActivate,
+  footerActionSlot,
 }: UserListCardTemplateProps<U>) => {
   const handleActivate = useCallback(
     () => onActivate?.(userList),
@@ -50,6 +52,7 @@ const UserListCardTemplate = <U extends UserList>({
           {userList.item_count} {pluralize("item", userList.item_count)}
         </span>
       }
+      footerActionSlot={footerActionSlot}
     ></CardTemplate>
   )
 }

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { faker } from "@faker-js/faker/locale/en"
 import { factories, urls } from "api/test-utils"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import LearningResourceCardTemplate from "@/page-components/LearningResourceCardTemplate/LearningResourceCardTemplate"
 import LearningPathListingPage from "./LearningPathListingPage"
 import {
@@ -100,7 +100,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking edit -> Edit on opens the editing dialog", async () => {
     const editList = jest
-      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
+      .spyOn(manageListDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -118,7 +118,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking edit -> Delete opens the deletion dialog", async () => {
     const deleteList = jest
-      .spyOn(manageLearningPathDialogs, "destroyLearningPath")
+      .spyOn(manageListDialogs, "destroyLearningPath")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -138,7 +138,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking new list opens the creation dialog", async () => {
     const createList = jest
-      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
+      .spyOn(manageListDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
     setup()
     const newListButton = await screen.findByRole("button", {

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
@@ -100,7 +100,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking edit -> Edit on opens the editing dialog", async () => {
     const editList = jest
-      .spyOn(manageLearningPathDialogs, "upsert")
+      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -118,7 +118,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking edit -> Delete opens the deletion dialog", async () => {
     const deleteList = jest
-      .spyOn(manageLearningPathDialogs, "destroy")
+      .spyOn(manageLearningPathDialogs, "destroyLearningPath")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -138,7 +138,7 @@ describe("LearningPathListingPage", () => {
 
   test("Clicking new list opens the creation dialog", async () => {
     const createList = jest
-      .spyOn(manageLearningPathDialogs, "upsert")
+      .spyOn(manageLearningPathDialogs, "upsertLearningPath")
       .mockImplementationOnce(jest.fn())
     setup()
     const newListButton = await screen.findByRole("button", {

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
@@ -24,7 +24,7 @@ import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
 import LearningResourceCardTemplate from "@/page-components/LearningResourceCardTemplate/LearningResourceCardTemplate"
 
 import { imgConfigs } from "@/common/constants"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import CardRowList from "@/components/CardRowList/CardRowList"
 import * as urls from "@/common/urls"
 
@@ -44,13 +44,13 @@ const EditListMenu: React.FC<EditListMenuProps> = ({ resource }) => {
         key: "edit",
         label: "Edit",
         icon: <EditIcon />,
-        onClick: () => manageLearningPathDialogs.upsertLearningPath(resource),
+        onClick: () => manageListDialogs.upsertLearningPath(resource),
       },
       {
         key: "delete",
         label: "Delete",
         icon: <DeleteIcon />,
-        onClick: () => manageLearningPathDialogs.destroyLearningPath(resource),
+        onClick: () => manageListDialogs.destroyLearningPath(resource),
       },
     ],
     [resource],
@@ -96,7 +96,7 @@ const LearningPathListingPage: React.FC = () => {
     [navigate],
   )
   const handleCreate = useCallback(() => {
-    manageLearningPathDialogs.upsertLearningPath()
+    manageListDialogs.upsertLearningPath()
   }, [])
 
   const canEdit = window.SETTINGS.user.is_learning_path_editor

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
@@ -44,13 +44,13 @@ const EditListMenu: React.FC<EditListMenuProps> = ({ resource }) => {
         key: "edit",
         label: "Edit",
         icon: <EditIcon />,
-        onClick: () => manageLearningPathDialogs.upsert(resource),
+        onClick: () => manageLearningPathDialogs.upsertLearningPath(resource),
       },
       {
         key: "delete",
         label: "Delete",
         icon: <DeleteIcon />,
-        onClick: () => manageLearningPathDialogs.destroy(resource),
+        onClick: () => manageLearningPathDialogs.destroyLearningPath(resource),
       },
     ],
     [resource],
@@ -96,7 +96,7 @@ const LearningPathListingPage: React.FC = () => {
     [navigate],
   )
   const handleCreate = useCallback(() => {
-    manageLearningPathDialogs.upsert()
+    manageLearningPathDialogs.upsertLearningPath()
   }, [])
 
   const canEdit = window.SETTINGS.user.is_learning_path_editor

--- a/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
@@ -32,7 +32,9 @@ const LearningPathDetailsPage: React.FC = () => {
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() => manageLearningPathDialogs.upsert(pathQuery.data)}
+      handleEdit={() =>
+        manageLearningPathDialogs.upsertLearningPath(pathQuery.data)
+      }
     />
   )
 }

--- a/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
@@ -8,7 +8,7 @@ import {
 } from "api/hooks/learningResources"
 
 import ListDetailsPage from "./ListDetailsPage"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import { ListType } from "api/constants"
 
 type RouteParams = {
@@ -32,9 +32,7 @@ const LearningPathDetailsPage: React.FC = () => {
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() =>
-        manageLearningPathDialogs.upsertLearningPath(pathQuery.data)
-      }
+      handleEdit={() => manageListDialogs.upsertLearningPath(pathQuery.data)}
     />
   )
 }

--- a/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
+++ b/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
@@ -141,7 +141,7 @@ describe("ListDetailsPage", () => {
     setup({ path, userSettings: { is_learning_path_editor: true } })
     const editButton = await screen.findByRole("button", { name: "Edit" })
 
-    const editList = jest.spyOn(manageLearningPathDialogs, "upsert")
+    const editList = jest.spyOn(manageLearningPathDialogs, "upsertLearningPath")
     editList.mockImplementationOnce(jest.fn())
 
     expect(editList).not.toHaveBeenCalled()

--- a/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
+++ b/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
@@ -4,7 +4,7 @@ import type {
   LearningPathResource,
   PaginatedLearningPathRelationshipList,
 } from "api"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import ItemsListing from "./ItemsListing"
 import { learningPathsView } from "@/common/urls"
 import {
@@ -141,7 +141,7 @@ describe("ListDetailsPage", () => {
     setup({ path, userSettings: { is_learning_path_editor: true } })
     const editButton = await screen.findByRole("button", { name: "Edit" })
 
-    const editList = jest.spyOn(manageLearningPathDialogs, "upsertLearningPath")
+    const editList = jest.spyOn(manageListDialogs, "upsertLearningPath")
     editList.mockImplementationOnce(jest.fn())
 
     expect(editList).not.toHaveBeenCalled()

--- a/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
@@ -9,7 +9,7 @@ import {
 
 import { ListType } from "api/constants"
 import ListDetailsPage from "./ListDetailsPage"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 type RouteParams = {
   id: string
@@ -32,9 +32,7 @@ const UserListDetailsPage: React.FC = () => {
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() =>
-        manageLearningPathDialogs.upsertUserList(pathQuery.data)
-      }
+      handleEdit={() => manageListDialogs.upsertUserList(pathQuery.data)}
     />
   )
 }

--- a/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
@@ -9,6 +9,7 @@ import {
 
 import { ListType } from "api/constants"
 import ListDetailsPage from "./ListDetailsPage"
+import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 type RouteParams = {
   id: string
@@ -31,7 +32,9 @@ const UserListDetailsPage: React.FC = () => {
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() => {}}
+      handleEdit={() =>
+        manageLearningPathDialogs.upsertUserList(pathQuery.data)
+      }
     />
   )
 }

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.test.tsx
@@ -12,7 +12,7 @@ import {
 import type { User } from "../../types/settings"
 import UserListListingPage from "./UserListListingPage"
 import UserListCardTemplate from "@/page-components/UserListCardTemplate/UserListCardTemplate"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 jest.mock(
   "../../page-components/UserListCardTemplate/UserListCardTemplate",
@@ -75,7 +75,7 @@ describe("UserListListingPage", () => {
 
   test("Clicking edit -> Edit on opens the editing dialog", async () => {
     const editList = jest
-      .spyOn(manageLearningPathDialogs, "upsertUserList")
+      .spyOn(manageListDialogs, "upsertUserList")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -93,7 +93,7 @@ describe("UserListListingPage", () => {
 
   test("Clicking edit -> Delete opens the deletion dialog", async () => {
     const deleteList = jest
-      .spyOn(manageLearningPathDialogs, "destroyUserList")
+      .spyOn(manageListDialogs, "destroyUserList")
       .mockImplementationOnce(jest.fn())
 
     const { paths } = setup()
@@ -113,7 +113,7 @@ describe("UserListListingPage", () => {
 
   test("Clicking new list opens the creation dialog", async () => {
     const createList = jest
-      .spyOn(manageLearningPathDialogs, "upsertUserList")
+      .spyOn(manageListDialogs, "upsertUserList")
       .mockImplementationOnce(jest.fn())
     setup()
     const newListButton = await screen.findByRole("button", {

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -19,6 +19,7 @@ import UserListCardTemplate from "@/page-components/UserListCardTemplate/UserLis
 import { useNavigate } from "react-router"
 import * as urls from "@/common/urls"
 import { imgConfigs } from "@/common/constants"
+import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 const ListHeaderGrid = styled(Grid)`
   margin-top: 1rem;
@@ -53,6 +54,9 @@ const UserListListingPage: React.FC = () => {
     },
     [navigate],
   )
+  const handleCreate = useCallback(() => {
+    manageLearningPathDialogs.upsertUserList()
+  }, [])
 
   return (
     <BannerPage
@@ -76,7 +80,9 @@ const UserListListingPage: React.FC = () => {
                 alignItems="center"
                 display="flex"
               >
-                <Button variant="contained">Create new list</Button>
+                <Button variant="contained" onClick={handleCreate}>
+                  Create new list
+                </Button>
               </Grid>
             </ListHeaderGrid>
             <section>

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -25,7 +25,7 @@ import UserListCardTemplate from "@/page-components/UserListCardTemplate/UserLis
 import { useNavigate } from "react-router"
 import * as urls from "@/common/urls"
 import { imgConfigs } from "@/common/constants"
-import { manageLearningPathDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
 const ListHeaderGrid = styled(Grid)`
   margin-top: 1rem;
@@ -43,13 +43,13 @@ const EditUserListMenu: React.FC<EditUserListMenuProps> = ({ userList }) => {
         key: "edit",
         label: "Edit",
         icon: <EditIcon />,
-        onClick: () => manageLearningPathDialogs.upsertUserList(userList),
+        onClick: () => manageListDialogs.upsertUserList(userList),
       },
       {
         key: "delete",
         label: "Delete",
         icon: <DeleteIcon />,
-        onClick: () => manageLearningPathDialogs.destroyUserList(userList),
+        onClick: () => manageListDialogs.destroyUserList(userList),
       },
     ],
     [userList],
@@ -96,7 +96,7 @@ const UserListListingPage: React.FC = () => {
     [navigate],
   )
   const handleCreate = useCallback(() => {
-    manageLearningPathDialogs.upsertUserList()
+    manageListDialogs.upsertUserList()
   }, [])
 
   return (

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react"
+import React, { useCallback, useMemo } from "react"
 import {
   Button,
   Grid,
@@ -6,7 +6,13 @@ import {
   BannerPage,
   Container,
   styled,
+  SimpleMenuItem,
+  SimpleMenu,
+  IconButton,
 } from "ol-components"
+import EditIcon from "@mui/icons-material/Edit"
+import MoreVertIcon from "@mui/icons-material/MoreVert"
+import DeleteIcon from "@mui/icons-material/Delete"
 
 import { MetaTags } from "ol-utilities"
 import type { UserList } from "api"
@@ -26,6 +32,40 @@ const ListHeaderGrid = styled(Grid)`
   margin-bottom: 1rem;
 `
 
+type EditUserListMenuProps = {
+  userList: UserList
+}
+
+const EditUserListMenu: React.FC<EditUserListMenuProps> = ({ userList }) => {
+  const items: SimpleMenuItem[] = useMemo(
+    () => [
+      {
+        key: "edit",
+        label: "Edit",
+        icon: <EditIcon />,
+        onClick: () => manageLearningPathDialogs.upsertUserList(userList),
+      },
+      {
+        key: "delete",
+        label: "Delete",
+        icon: <DeleteIcon />,
+        onClick: () => manageLearningPathDialogs.destroyUserList(userList),
+      },
+    ],
+    [userList],
+  )
+  return (
+    <SimpleMenu
+      trigger={
+        <IconButton size="small" aria-label={`Edit list ${userList.title}`}>
+          <MoreVertIcon fontSize="inherit" />
+        </IconButton>
+      }
+      items={items}
+    />
+  )
+}
+
 type ListCardProps = {
   list: UserList
   onActivate: (userList: UserList) => void
@@ -39,6 +79,7 @@ const ListCard: React.FC<ListCardProps> = ({ list, onActivate }) => {
       className="ic-resource-card"
       imgConfig={imgConfigs["row-reverse-small"]}
       onActivate={onActivate}
+      footerActionSlot={<EditUserListMenu userList={list} />}
     />
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/715

### Description (What does it do?)
This PR adds the appropriate modals for creating, editing and deleting a `UserList`. The modals were wired up to buttons in the appropriate places:

 - "Create new list" button in `UserListListingPage`
 - A context menu was added to the cards displayed on `UserListListingPage` containing edit and delete buttons
 - Edit button on `UserListDetailsPage`

### Screenshots (if appropriate):
<img width="959" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/fe32f186-0768-419b-b007-0dd2dc02e1ee">
<img width="959" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/3ecb3dd7-4afd-4044-9305-52f04861b0dc">
<img width="959" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/b78a2557-5540-4a58-8e90-095312e65498">
<img width="959" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/60a867f1-5737-4b33-8702-76eba8404e6a">
<img width="959" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/f4fe74d7-8bd0-495b-8c64-80d061224f4d">

<img width="146" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/9975af37-d706-4738-b990-e225dc417287">
<img width="147" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/27953106-206a-417d-8481-c35fb4bd1da8">
<img width="148" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/c2f093a3-6867-45e6-9d2e-05b42088d625">
<img width="147" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/f4fa56fc-2bcd-4ebe-a393-23dfca2e4b6c">

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Visit http://localhost:8063/userlists/
 - Click the "Create new list" button to create a new list
 - Fill out the form and hit save
 - Verify that your new User List shows up in the listing page
 - Click the title of your new User List to enter the details page
 - Verify that the title and description are appropriately rendered
 - Click the Edit button in the upper right
 - Change the title and description and hit save
 - Verify that your changes are reflected on the details page
 - Navigate back to the listing page and verify once again that the changes to the title and description are reflected
 - Click the 3 dots on the card for your new User List and click the Edit button
 - Verify once again that editing the title and description reflects your changes on both the listing and details pages
 - Click the 3 dots again and click Delete, then click "Yes, Delete"
 - Verify that your User List is now gone from the listing page
