### PR TITLE
fix flaky test in ManageListDialogs

### DIFF
--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -313,8 +313,12 @@ describe("manageListDialogs.upsertUserList", () => {
     await user.paste(patch.description)
 
     // Privacy Level
-    expect(inputs.privacy_level(PrivacyLevelEnum.Private).checked).toBe(true)
-    expect(inputs.privacy_level(PrivacyLevelEnum.Unlisted).checked).toBe(false)
+    expect(inputs.privacy_level(PrivacyLevelEnum.Private).checked).toBe(
+      userList.privacy_level === PrivacyLevelEnum.Private,
+    )
+    expect(inputs.privacy_level(PrivacyLevelEnum.Unlisted).checked).toBe(
+      userList.privacy_level === PrivacyLevelEnum.Unlisted,
+    )
     await user.click(inputs.privacy_level(patch.privacy_level))
 
     // Submit


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-open/issues/715

### Description (What does it do?)
In https://github.com/mitodl/mit-open/issues/715, some tests were added to `ManageListDialogs.test.tsx` to test `UserList` functionality. One of these tests the `privacy_level` setting. Based on a recommendation before merging the PR, the factory that generates the test `UserList` was modified to use `faker.helpers.arrayElement`. The test was set up to specifically expect an initial `privacy_level` of "private," but the helper is generating a random value every time. The test was modified to take this into account.

### How can this be tested?
 - Make sure you are set up to run `mit-open` locally and spin it up on this branch
 - Run the JS tests with `docker compose exec watch yarn test` multiple times
 - Ensure that the tests pass