### PR TITLE
Remove dupe line from learning_resources/urls.py file

### DIFF
--- a/learning_resources/urls.py
+++ b/learning_resources/urls.py
@@ -81,7 +81,6 @@ router.register(
 )
 
 router.register(r"contentfiles", views.ContentFileViewSet, basename="contentfiles_api")
-router.register(r"topics", views.TopicViewSet, basename="topics_api")
 router.register(r"userlists", views.UserListViewSet, basename="userlists_api")
 nested_userlist_router = NestedSimpleRouter(router, r"userlists", lookup="userlist")
 nested_userlist_router.register(


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #729

### Description (What does it do?)
Removes a dupe line



### How can this be tested?
Tests should pass
The url http://localhost:8063/api/v1/topics/ should still work
