### PR TITLE
add userlist bookmark button and add to user list modal

### DIFF
--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -185,5 +185,14 @@ const invalidateResourceQueries = (
   })
 }
 
+const invalidateUserListQueries = (
+  queryClient: QueryClient,
+  userListId: UserList["id"],
+) => {
+  queryClient.invalidateQueries(
+    learningResources.userlists._ctx.detail(userListId).queryKey,
+  )
+}
+
 export default learningResources
-export { invalidateResourceQueries }
+export { invalidateResourceQueries, invalidateUserListQueries }

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -259,7 +259,7 @@ const learningPath: LearningResourceFactory<LearningPathResource> = (
 }
 const learningPaths = makePaginatedFactory(learningPath)
 
-const microRelationship: Factory<MicroLearningPathRelationship> = (
+const microLearningPathRelationship: Factory<MicroLearningPathRelationship> = (
   overrides = {},
 ) => {
   return {
@@ -273,7 +273,7 @@ const microRelationship: Factory<MicroLearningPathRelationship> = (
 const learningPathRelationship: Factory<LearningPathRelationship> = (
   overrides = {},
 ) => {
-  const micro = microRelationship()
+  const micro = microLearningPathRelationship()
   const resource = learningResource({
     id: micro.child,
     learning_path_parents: [micro],
@@ -410,7 +410,7 @@ export {
   learningResourceOfferors as offerors,
   learningPath,
   learningPaths,
-  microRelationship,
+  microLearningPathRelationship,
   learningPathRelationship,
   learningPathRelationships,
   program,

--- a/frontends/api/src/test-utils/factories/userLists.ts
+++ b/frontends/api/src/test-utils/factories/userLists.ts
@@ -24,7 +24,7 @@ const userList: Factory<UserList> = (overrides = {}) => {
 }
 const userLists = makePaginatedFactory(userList)
 
-const microRelationship: Factory<MicroUserListRelationship> = (
+const microUserListRelationship: Factory<MicroUserListRelationship> = (
   overrides = {},
 ) => {
   return {
@@ -38,7 +38,7 @@ const microRelationship: Factory<MicroUserListRelationship> = (
 const userListRelationship: Factory<UserListRelationship> = (
   overrides = {},
 ) => {
-  const micro = microRelationship()
+  const micro = microUserListRelationship()
   const resource = learningResource({
     id: micro.child,
     user_list_parents: [micro],
@@ -80,4 +80,10 @@ const userListRelationships = ({
   } satisfies PaginatedUserListRelationshipList
 }
 
-export { userList, userLists, userListRelationship, userListRelationships }
+export {
+  userList,
+  userLists,
+  userListRelationship,
+  userListRelationships,
+  microUserListRelationship,
+}

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker/locale/en"
 import * as NiceModal from "@ebay/nice-modal-react"
-import { AddToLearningPathDialog } from "./AddToListDialog"
+import { AddToLearningPathDialog, AddToUserListDialog } from "./AddToListDialog"
 
 import { setMockResponse, makeRequest, factories, urls } from "api/test-utils"
 
@@ -17,10 +17,14 @@ import {
   LearningPathRelationship,
   LearningPathResource,
   LearningResource,
+  UserList,
+  UserListRelationship,
 } from "api"
 import invariant from "tiny-invariant"
+import { ListType } from "api/constants"
 
-const factory = factories.learningResources
+const learningResourcesFactory = factories.learningResources
+const userListsFactory = factories.userLists
 
 jest.mock("@ebay/nice-modal-react", () => {
   const actual = jest.requireActual("@ebay/nice-modal-react")
@@ -34,53 +38,88 @@ type SetupOptions = {
   inLists: number[]
   dialogOpen: boolean
 }
-const setup = ({
+const setupLearningPaths = ({
   inLists = [],
   dialogOpen = true,
 }: Partial<SetupOptions> = {}) => {
-  const resource = factory.resource({ learning_path_parents: [] })
-  const paginatedLists = factory.learningPaths({ count: 3 })
-  const lists = paginatedLists.results
-  const parents = resource.learning_path_parents!
-
+  const resource = learningResourcesFactory.resource({
+    learning_path_parents: [],
+  })
+  const paginatedLearningPaths = learningResourcesFactory.learningPaths({
+    count: 3,
+  })
+  const learningPaths = paginatedLearningPaths.results
+  const learningPathParents = resource.learning_path_parents!
   inLists.forEach((index) => {
-    const list = lists[index]
-    parents.push(
-      factory.microRelationship({
-        parent: list.id,
+    const learningPath = learningPaths[index]
+    learningPathParents.push(
+      learningResourcesFactory.microLearningPathRelationship({
+        parent: learningPath.id,
         child: resource.id,
       }),
     )
-    list.learning_path.item_count += 1
+    learningPath.learning_path.item_count += 1
   })
-
   setMockResponse.get(
     urls.learningResources.details({ id: resource.id }),
     resource,
   )
-  setMockResponse.get(urls.learningPaths.list(), paginatedLists)
-
+  setMockResponse.get(urls.learningPaths.list(), paginatedLearningPaths)
   const view = renderWithProviders(null)
-
   if (dialogOpen) {
     act(() => {
       NiceModal.show(AddToLearningPathDialog, { resourceId: resource.id })
     })
   }
-
   return {
     view,
     resource,
-    lists,
-    parents,
+    lists: learningPaths,
+    parents: learningPathParents,
   }
 }
 
-const addToList = (
+const setupUserLists = ({
+  inLists = [],
+  dialogOpen = true,
+}: Partial<SetupOptions> = {}) => {
+  const resource = learningResourcesFactory.resource({ user_list_parents: [] })
+  const paginatedUserLists = userListsFactory.userLists({ count: 3 })
+  const userLists = paginatedUserLists.results
+  const userListParents = resource.user_list_parents!
+  inLists.forEach((index) => {
+    const userList = userLists[index]
+    userListParents.push(
+      userListsFactory.microUserListRelationship({
+        parent: userList.id,
+        child: resource.id,
+      }),
+    )
+  })
+  setMockResponse.get(
+    urls.learningResources.details({ id: resource.id }),
+    resource,
+  )
+  setMockResponse.get(urls.userLists.list(), paginatedUserLists)
+  const view = renderWithProviders(null)
+  if (dialogOpen) {
+    act(() => {
+      NiceModal.show(AddToUserListDialog, { resourceId: resource.id })
+    })
+  }
+  return {
+    view,
+    resource,
+    lists: userLists,
+    parents: userListParents,
+  }
+}
+
+const addToLearningPath = (
   resource: LearningResource,
   list: LearningPathResource,
 ): LearningPathRelationship => {
-  const member = factory.microRelationship({
+  const member = learningResourcesFactory.microLearningPathRelationship({
     parent: list.id,
     child: resource.id,
   })
@@ -88,115 +127,213 @@ const addToList = (
     ...resource,
     learning_path_parents: [...(resource.learning_path_parents ?? []), member],
   }
-  return factory.learningPathRelationship({
+  return learningResourcesFactory.learningPathRelationship({
     ...member,
     resource: modified,
   })
 }
 
-describe("AddToListDialog", () => {
-  test("List is checked iff resource is in list", async () => {
-    const index = faker.datatype.number({ min: 0, max: 2 })
-    setup({ inLists: [index] })
-
-    const checkboxes = await screen.findAllByRole<HTMLInputElement>("checkbox")
-    expect(checkboxes[0].checked).toBe(index === 0)
-    expect(checkboxes[1].checked).toBe(index === 1)
-    expect(checkboxes[2].checked).toBe(index === 2)
+const addToUserList = (
+  resource: LearningResource,
+  list: UserList,
+): UserListRelationship => {
+  const member = userListsFactory.microUserListRelationship({
+    parent: list.id,
+    child: resource.id,
   })
-
-  test("Clicking an unchecked list adds item to that list", async () => {
-    const { resource, lists } = setup()
-    const list = faker.helpers.arrayElement(lists)
-
-    const addToListUrl = urls.learningPaths.resources({
-      learning_resource_id: list.id,
-    })
-    const newRelationship = addToList(resource, list)
-    setMockResponse.post(addToListUrl, newRelationship)
-    setMockResponse.get(
-      urls.learningResources.details({ id: resource.id }),
-      resource,
-    )
-
-    const listButton = await screen.findByRole("button", { name: list.title })
-    const checkbox = within(listButton).getByRole<HTMLInputElement>("checkbox")
-
-    expect(checkbox.checked).toBe(false)
-    await user.click(listButton)
-
-    expect(makeRequest).toHaveBeenCalledWith(
-      "post",
-      addToListUrl,
-      expect.objectContaining({
-        parent: list.id,
-      }),
-    )
+  const modified = {
+    ...resource,
+    user_list_parents: [...(resource.user_list_parents ?? []), member],
+  }
+  return userListsFactory.userListRelationship({
+    ...member,
+    resource: modified,
   })
+}
 
-  test("Clicking a checked list removes item from that list", async () => {
-    const index = faker.datatype.number({ min: 0, max: 2 })
-    const { resource, lists, parents } = setup({ inLists: [index] })
-    const list = lists[index]
-    const relationship = parents.find(({ parent }) => parent === list.id)
-    invariant(relationship)
+describe.each([ListType.LearningPath, ListType.UserList])(
+  "AddToListDialog",
+  (listType: string) => {
+    test("List is checked iff resource is in list", async () => {
+      const index = faker.datatype.number({ min: 0, max: 2 })
+      if (listType === ListType.LearningPath) {
+        setupLearningPaths({ inLists: [index] })
+      } else if (listType === ListType.UserList) {
+        setupUserLists({ inLists: [index] })
+      }
 
-    const removalUrl = urls.learningPaths.resourceDetails({
-      id: relationship.id,
-      learning_resource_id: relationship.parent,
-    })
-    setMockResponse.delete(removalUrl)
-    setMockResponse.get(
-      urls.learningResources.details({ id: resource.id }),
-      resource,
-    )
-
-    const listButton = await screen.findByRole("button", { name: list.title })
-    const checkbox = within(listButton).getByRole<HTMLInputElement>("checkbox")
-
-    expect(checkbox.checked).toBe(true)
-    await user.click(listButton)
-
-    expect(makeRequest).toHaveBeenCalledWith("delete", removalUrl, undefined)
-  })
-
-  test("Clicking 'Create a new list' opens the create list dialog", async () => {
-    // Don't actually open the 'Create List' modal, or we'll need to mock API responses.
-    const createList = jest
-      .spyOn(manageListDialogs, "upsertLearningPath")
-      .mockImplementationOnce(jest.fn())
-
-    setup()
-    const button = await screen.findByRole("button", {
-      name: "Create a new list",
+      const checkboxes =
+        await screen.findAllByRole<HTMLInputElement>("checkbox")
+      expect(checkboxes[0].checked).toBe(index === 0)
+      expect(checkboxes[1].checked).toBe(index === 1)
+      expect(checkboxes[2].checked).toBe(index === 2)
     })
 
-    expect(createList).not.toHaveBeenCalled()
-    await user.click(button)
-    expect(createList).toHaveBeenCalledWith()
-  })
+    test("Clicking an unchecked list adds item to that list", async () => {
+      let title = ""
+      let id = -1
+      let addToListUrl = ""
+      if (listType === ListType.LearningPath) {
+        const { resource, lists } = setupLearningPaths()
+        const list = faker.helpers.arrayElement(lists)
 
-  test("Opens and closes via NiceModal", async () => {
-    const { resource: resource1 } = setup()
-    const dialog1 = await screen.findByRole("dialog")
-    await within(dialog1).findByText(resource1.title, { exact: false })
+        addToListUrl = urls.learningPaths.resources({
+          learning_resource_id: list.id,
+        })
+        const newRelationship = addToLearningPath(resource, list)
+        setMockResponse.post(addToListUrl, newRelationship)
+        setMockResponse.get(
+          urls.learningResources.details({ id: resource.id }),
+          resource,
+        )
+        title = list.title
+        id = list.id
+      } else if (listType === ListType.UserList) {
+        const { resource, lists } = setupUserLists()
+        const list = faker.helpers.arrayElement(lists)
 
-    // Close the dialog
-    act(() => {
-      NiceModal.hide(AddToLearningPathDialog)
+        addToListUrl = urls.userLists.resources({
+          userlist_id: list.id,
+        })
+        const newRelationship = addToUserList(resource, list)
+        setMockResponse.post(addToListUrl, newRelationship)
+        setMockResponse.get(
+          urls.learningResources.details({ id: resource.id }),
+          resource,
+        )
+        title = list.title
+        id = list.id
+      }
+
+      const listButton = await screen.findByRole("button", { name: title })
+      const checkbox =
+        within(listButton).getByRole<HTMLInputElement>("checkbox")
+
+      expect(checkbox.checked).toBe(false)
+      await user.click(listButton)
+
+      expect(makeRequest).toHaveBeenCalledWith(
+        "post",
+        addToListUrl,
+        expect.objectContaining({
+          parent: id,
+        }),
+      )
     })
-    await waitForElementToBeRemoved(dialog1)
 
-    // Open it with a new resource
-    const resource2 = factory.resource()
-    setMockResponse.get(
-      urls.learningResources.details({ id: resource2.id }),
-      resource2,
-    )
-    act(() => {
-      NiceModal.show(AddToLearningPathDialog, { resourceId: resource2.id })
+    test("Clicking a checked list removes item from that list", async () => {
+      const index = faker.datatype.number({ min: 0, max: 2 })
+      let title = ""
+      let removalUrl = ""
+      if (listType === ListType.LearningPath) {
+        const { resource, lists, parents } = setupLearningPaths({
+          inLists: [index],
+        })
+        const list = lists[index]
+        const relationship = parents.find(({ parent }) => parent === list.id)
+        invariant(relationship)
+
+        title = list.title
+        removalUrl = urls.learningPaths.resourceDetails({
+          id: relationship.id,
+          learning_resource_id: relationship.parent,
+        })
+        setMockResponse.delete(removalUrl)
+        setMockResponse.get(
+          urls.learningResources.details({ id: resource.id }),
+          resource,
+        )
+      } else if (listType === ListType.UserList) {
+        const { resource, lists, parents } = setupUserLists({
+          inLists: [index],
+        })
+        const list = lists[index]
+        const relationship = parents.find(({ parent }) => parent === list.id)
+        invariant(relationship)
+
+        title = list.title
+        removalUrl = urls.userLists.resourceDetails({
+          id: relationship.id,
+          userlist_id: relationship.parent,
+        })
+        setMockResponse.delete(removalUrl)
+        setMockResponse.get(
+          urls.userLists.details({ id: resource.id }),
+          resource,
+        )
+      }
+
+      const listButton = await screen.findByRole("button", { name: title })
+      const checkbox =
+        within(listButton).getByRole<HTMLInputElement>("checkbox")
+
+      expect(checkbox.checked).toBe(true)
+      await user.click(listButton)
+
+      expect(makeRequest).toHaveBeenCalledWith("delete", removalUrl, undefined)
     })
-    const dialog2 = await screen.findByRole("dialog")
-    await within(dialog2).findByText(resource2.title, { exact: false })
-  })
-})
+
+    test("Clicking 'Create a new list' opens the create list dialog", async () => {
+      let createList = null
+      if (listType === ListType.LearningPath) {
+        // Don't actually open the 'Create List' modal, or we'll need to mock API responses.
+        createList = jest
+          .spyOn(manageListDialogs, "upsertLearningPath")
+          .mockImplementationOnce(jest.fn())
+        setupLearningPaths()
+      } else if (listType === ListType.UserList) {
+        // Don't actually open the 'Create List' modal, or we'll need to mock API responses.
+        createList = jest
+          .spyOn(manageListDialogs, "upsertUserList")
+          .mockImplementationOnce(jest.fn())
+        setupUserLists()
+      }
+      const button = await screen.findByRole("button", {
+        name: "Create a new list",
+      })
+      expect(createList).not.toHaveBeenCalled()
+      await user.click(button)
+      expect(createList).toHaveBeenCalledWith()
+    })
+
+    test("Opens and closes via NiceModal", async () => {
+      let title = ""
+      if (listType === ListType.LearningPath) {
+        const { resource: resource1 } = setupLearningPaths()
+        title = resource1.title
+      } else if (listType === ListType.UserList) {
+        const { resource: resource1 } = setupUserLists()
+        title = resource1.title
+      }
+
+      const dialog1 = await screen.findByRole("dialog")
+      await within(dialog1).findByText(title, { exact: false })
+
+      // Close the dialog
+      act(() => {
+        if (listType === ListType.LearningPath) {
+          NiceModal.hide(AddToLearningPathDialog)
+        } else if (listType === ListType.UserList) {
+          NiceModal.hide(AddToUserListDialog)
+        }
+      })
+      await waitForElementToBeRemoved(dialog1)
+
+      // Open it with a new resource
+      const resource2 = learningResourcesFactory.resource()
+      setMockResponse.get(
+        urls.learningResources.details({ id: resource2.id }),
+        resource2,
+      )
+      act(() => {
+        if (listType === ListType.LearningPath) {
+          NiceModal.show(AddToLearningPathDialog, { resourceId: resource2.id })
+        } else if (listType === ListType.UserList) {
+          NiceModal.show(AddToUserListDialog, { resourceId: resource2.id })
+        }
+      })
+      const dialog2 = await screen.findByRole("dialog")
+      await within(dialog2).findByText(resource2.title, { exact: false })
+    })
+  },
+)

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker/locale/en"
 import * as NiceModal from "@ebay/nice-modal-react"
-import AddToLearningPathDialog from "./AddToListDialog"
+import { AddToLearningPathDialog } from "./AddToListDialog"
 
 import { setMockResponse, makeRequest, factories, urls } from "api/test-utils"
 

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.test.tsx
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker/locale/en"
 import * as NiceModal from "@ebay/nice-modal-react"
-import AddToListDialog from "./AddToListDialog"
+import AddToLearningPathDialog from "./AddToListDialog"
 
 import { setMockResponse, makeRequest, factories, urls } from "api/test-utils"
 
@@ -64,7 +64,7 @@ const setup = ({
 
   if (dialogOpen) {
     act(() => {
-      NiceModal.show(AddToListDialog, { resourceId: resource.id })
+      NiceModal.show(AddToLearningPathDialog, { resourceId: resource.id })
     })
   }
 
@@ -183,7 +183,7 @@ describe("AddToListDialog", () => {
 
     // Close the dialog
     act(() => {
-      NiceModal.hide(AddToListDialog)
+      NiceModal.hide(AddToLearningPathDialog)
     })
     await waitForElementToBeRemoved(dialog1)
 
@@ -194,7 +194,7 @@ describe("AddToListDialog", () => {
       resource2,
     )
     act(() => {
-      NiceModal.show(AddToListDialog, { resourceId: resource2.id })
+      NiceModal.show(AddToLearningPathDialog, { resourceId: resource2.id })
     })
     const dialog2 = await screen.findByRole("dialog")
     await within(dialog2).findByText(resource2.title, { exact: false })

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -330,13 +330,22 @@ const UserListToggleList: React.FC<UserListToggleListProps> = ({
     const adding = isAdding(list)
     const removing = isRemoving(list)
     const disabled = adding || removing
+    const privateLevel = PrivacyLevelEnum.Private[0]
+      .toUpperCase()
+      .concat(PrivacyLevelEnum.Private.slice(1))
+    const unlistedLevel = PrivacyLevelEnum.Unlisted[0]
+      .toUpperCase()
+      .concat(PrivacyLevelEnum.Unlisted.slice(1))
+    const privacyLevel = list.privacy_level
+      ? list.privacy_level[0].toUpperCase().concat(list.privacy_level.slice(1))
+      : privateLevel
     return (
       <ListItem
         key={list.id}
         secondaryAction={
           <PrivacyChip
-            publicOption={PrivacyLevelEnum.Unlisted}
-            selectedOption={list.privacy_level}
+            publicOption={unlistedLevel}
+            selectedOption={privacyLevel}
           />
         }
       >

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -243,27 +243,38 @@ const AddToListDialogInner: React.FC<AddToListDialogInnerProps> = ({
           <Description>
             Adding <ResourceTitle>{resource?.title}</ResourceTitle>
           </Description>
-          <Listing>
-            {listType === ListType.LearningPath ? (
+          {listType === ListType.LearningPath ? (
+            <Listing>
               <LearningPathToggleList
                 resource={resource}
                 lists={lists as LearningPathResource[]}
               />
-            ) : (
+              <ListItem className="add-to-list-new">
+                <ListItemButton
+                  onClick={() => manageListDialogs.upsertLearningPath()}
+                >
+                  <AddIcon />
+                  <ListItemText primary="Create a new list" />
+                </ListItemButton>
+              </ListItem>
+            </Listing>
+          ) : null}
+          {listType === ListType.UserList ? (
+            <Listing>
               <UserListToggleList
                 resource={resource}
                 lists={lists as UserList[]}
               />
-            )}
-            <ListItem className="add-to-list-new">
-              <ListItemButton
-                onClick={() => manageListDialogs.upsertLearningPath()}
-              >
-                <AddIcon />
-                <ListItemText primary="Create a new list" />
-              </ListItemButton>
-            </ListItem>
-          </Listing>
+              <ListItem className="add-to-list-new">
+                <ListItemButton
+                  onClick={() => manageListDialogs.upsertUserList()}
+                >
+                  <AddIcon />
+                  <ListItemText primary="Create a new list" />
+                </ListItemButton>
+              </ListItem>
+            </Listing>
+          ) : null}
         </>
       ) : (
         <LoadingSpinner loading={!isReady} />

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -226,9 +226,15 @@ const AddToListDialogInner: React.FC<AddToListDialogInnerProps> = ({
   isReady,
 }) => {
   const modal = NiceModal.useModal()
+  let dialogTitle = "Add to list"
+  if (listType === ListType.LearningPath) {
+    dialogTitle = "Add to Learning List"
+  } else if (listType === ListType.UserList) {
+    dialogTitle = "Add to User List"
+  }
   return (
     <StyledBasicDialog
-      title="Add to Learning List"
+      title={dialogTitle}
       showFooter={false}
       {...NiceModal.muiDialogV5(modal)}
     >

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders, user, screen } from "../../test-utils"
 import type { User } from "../../test-utils"
 import LearningResourceCard from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
-import AddToLearningPathDialog from "./AddToListDialog"
+import { AddToLearningPathDialog } from "./AddToListDialog"
 import * as factories from "api/test-utils/factories"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders, user, screen } from "../../test-utils"
 import type { User } from "../../test-utils"
 import LearningResourceCard from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
-import AddToListDialog from "./AddToListDialog"
+import AddToLearningPathDialog from "./AddToListDialog"
 import * as factories from "api/test-utils/factories"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 
@@ -73,7 +73,7 @@ describe("LearningResourceCard", () => {
 
     expect(showModal).not.toHaveBeenCalled()
     await user.click(button)
-    expect(showModal).toHaveBeenCalledWith(AddToListDialog, {
+    expect(showModal).toHaveBeenCalledWith(AddToLearningPathDialog, {
       resourceId: resource.id,
     })
   })

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -4,7 +4,7 @@ import { renderWithProviders, user, screen } from "../../test-utils"
 import type { User } from "../../test-utils"
 import LearningResourceCard from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
-import { AddToLearningPathDialog } from "./AddToListDialog"
+import { AddToLearningPathDialog, AddToUserListDialog } from "./AddToListDialog"
 import * as factories from "api/test-utils/factories"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 
@@ -34,6 +34,7 @@ describe("LearningResourceCard", () => {
 
   const labels = {
     addToLearningPaths: "Add to Learning Path",
+    addToUserList: "Add to User List",
   }
 
   test("Applies className to the resource card", () => {
@@ -43,37 +44,59 @@ describe("LearningResourceCard", () => {
 
   test.each([
     {
-      userSettings: { is_learning_path_editor: false },
-      expectButton: false,
+      userSettings: { is_authenticated: true, is_learning_path_editor: false },
+      expectAddToLearningPathButton: false,
+      expectAddToUserListButton: true,
     },
     {
-      userSettings: { is_learning_path_editor: true },
-      expectButton: true,
+      userSettings: { is_authenticated: true, is_learning_path_editor: true },
+      expectAddToLearningPathButton: true,
+      expectAddToUserListButton: true,
+    },
+    {
+      userSettings: { is_authenticated: false },
+      expectAddToLearningPathButton: false,
+      expectAddToUserListButton: false,
     },
   ])(
-    "Shows LearningPaths button if and only if user has editing privileges",
-    async ({ userSettings, expectButton }) => {
+    "Shows add to list buttons if and only if user is authenticated and has editing privileges",
+    async ({
+      userSettings,
+      expectAddToLearningPathButton,
+      expectAddToUserListButton,
+    }) => {
       setup({ userSettings })
-      const button = screen.queryByRole("button", {
+      const addToLearningPathButton = screen.queryByRole("button", {
         name: labels.addToLearningPaths,
       })
-      expect(!!button).toBe(expectButton)
+      const addToUserListButton = screen.queryByRole("button", {
+        name: labels.addToUserList,
+      })
+      expect(!!addToLearningPathButton).toBe(expectAddToLearningPathButton)
+      expect(!!addToUserListButton).toBe(expectAddToUserListButton)
     },
   )
 
-  test("Clicking LearningPath button opens AddToListDialog", async () => {
+  test("Clicking add to list button opens AddToListDialog", async () => {
     const showModal = jest.mocked(NiceModal.show)
 
     const { resource } = setup({
-      userSettings: { is_learning_path_editor: true },
+      userSettings: { is_authenticated: true, is_learning_path_editor: true },
     })
-    const button = screen.getByRole("button", {
+    const addToLearningPathButton = screen.getByRole("button", {
       name: labels.addToLearningPaths,
+    })
+    const addToUserListButton = screen.getByRole("button", {
+      name: labels.addToUserList,
     })
 
     expect(showModal).not.toHaveBeenCalled()
-    await user.click(button)
-    expect(showModal).toHaveBeenCalledWith(AddToLearningPathDialog, {
+    await user.click(addToLearningPathButton)
+    expect(showModal).toHaveBeenLastCalledWith(AddToLearningPathDialog, {
+      resourceId: resource.id,
+    })
+    await user.click(addToUserListButton)
+    expect(showModal).toHaveBeenLastCalledWith(AddToUserListDialog, {
       resourceId: resource.id,
     })
   })

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -6,7 +6,8 @@ import type { LearningResourceCardTemplateProps } from "@/page-components/Learni
 import { imgConfigs } from "@/common/constants"
 import { IconButton } from "ol-components"
 import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd"
-import { AddToLearningPathDialog } from "./AddToListDialog"
+import BookmarkOutlinedIcon from "@mui/icons-material/BookmarkOutlined"
+import { AddToLearningPathDialog, AddToUserListDialog } from "./AddToListDialog"
 import { LearningResource } from "api"
 import { useOpenLearningResourceDrawer } from "../LearningResourceDrawer/LearningResourceDrawer"
 
@@ -36,6 +37,10 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
     NiceModal.show(AddToLearningPathDialog, { resourceId: resource.id })
     return
   }, [resource])
+  const showAddToUserListDialog = useCallback(() => {
+    NiceModal.show(AddToUserListDialog, { resourceId: resource.id })
+    return
+  }, [resource])
 
   const { user } = window.SETTINGS
   const openLRDrawer = useOpenLearningResourceDrawer()
@@ -60,6 +65,13 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
               <PlaylistAddIcon />
             </IconButton>
           )}
+          <IconButton
+            size="small"
+            aria-label="Add to Learning Path"
+            onClick={showAddToUserListDialog}
+          >
+            <BookmarkOutlinedIcon />
+          </IconButton>
         </div>
       }
     />

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -6,7 +6,7 @@ import type { LearningResourceCardTemplateProps } from "@/page-components/Learni
 import { imgConfigs } from "@/common/constants"
 import { IconButton } from "ol-components"
 import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd"
-import BookmarkOutlinedIcon from "@mui/icons-material/BookmarkOutlined"
+import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder"
 import { AddToLearningPathDialog, AddToUserListDialog } from "./AddToListDialog"
 import { LearningResource } from "api"
 import { useOpenLearningResourceDrawer } from "../LearningResourceDrawer/LearningResourceDrawer"
@@ -71,7 +71,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
               aria-label="Add to User List"
               onClick={showAddToUserListDialog}
             >
-              <BookmarkOutlinedIcon />
+              <BookmarkBorderIcon />
             </IconButton>
           )}
         </div>

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -65,13 +65,15 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
               <PlaylistAddIcon />
             </IconButton>
           )}
-          <IconButton
-            size="small"
-            aria-label="Add to Learning Path"
-            onClick={showAddToUserListDialog}
-          >
-            <BookmarkOutlinedIcon />
-          </IconButton>
+          {user.is_authenticated && (
+            <IconButton
+              size="small"
+              aria-label="Add to Learning Path"
+              onClick={showAddToUserListDialog}
+            >
+              <BookmarkOutlinedIcon />
+            </IconButton>
+          )}
         </div>
       }
     />

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -6,7 +6,7 @@ import type { LearningResourceCardTemplateProps } from "@/page-components/Learni
 import { imgConfigs } from "@/common/constants"
 import { IconButton } from "ol-components"
 import PlaylistAddIcon from "@mui/icons-material/PlaylistAdd"
-import AddToListDialog from "./AddToListDialog"
+import { AddToLearningPathDialog } from "./AddToListDialog"
 import { LearningResource } from "api"
 import { useOpenLearningResourceDrawer } from "../LearningResourceDrawer/LearningResourceDrawer"
 
@@ -33,7 +33,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   suppressImage,
 }) => {
   const showAddToLearningPathDialog = useCallback(() => {
-    NiceModal.show(AddToListDialog, { resourceId: resource.id })
+    NiceModal.show(AddToLearningPathDialog, { resourceId: resource.id })
     return
   }, [resource])
 

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -56,7 +56,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       onActivate={(r) => openLRDrawer(r.id)}
       footerActionSlot={
         <div>
-          {user.is_learning_path_editor && (
+          {user.is_authenticated && user.is_learning_path_editor && (
             <IconButton
               size="small"
               aria-label="Add to Learning Path"

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -68,7 +68,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
           {user.is_authenticated && (
             <IconButton
               size="small"
-              aria-label="Add to Learning Path"
+              aria-label="Add to User List"
               onClick={showAddToUserListDialog}
             >
               <BookmarkOutlinedIcon />


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/721

### Description (What does it do?)
This PR adds the bookmark button to the `LearningResourceCard` page component. Clicking this button displays the "Add to User List" modal. The `AddToListDialog` page component was modified to support adding a resource to `UserList` objects.

### Screenshots (if appropriate):
<img width="1916" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/0c8d7c51-4263-48ad-b3df-6e39a89bfd28">
<img width="1917" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/2f5dd254-6008-41a9-99e2-171acf040c00">
<img width="221" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/7bde06c4-0180-485b-b5dd-baddecb0b225">
<img width="220" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/4d61ffff-14b8-4fbd-8849-a1a622a2f026">

### How can this be tested?
 - Spin up `mit-open` locally on this branch
 - Visit the home page at http://localhost:8063
 - Click the bookmark icon on any of the courses under "Upcoming Courses"
 - This should bring up the "Add to User List" dialog
 - Click the "Create a new list" button at the bottom
 - This should open the "Create User List" dialog
 - Create a new User List by filling out the dialog fields and clicking Save
 - Check the box to save the Learning Resource to your User List
 - Click the X in the upper right to close the dialog
 - Click the bookmark icon on the same Learning Resource to bring the dialog back up
 - Ensure that the User List we added the Learning Resource to is still checked
 - Add a few more Learning Resources to your User List
 - Visit http://localhost:8063/userlists
 - Click the title of the User List you created and ensure that all the items you added are present
