### PR TITLE
fixing readonly exception in migration

### DIFF
--- a/profiles/migrations/0022_fill_programcertificate_record_hash.py
+++ b/profiles/migrations/0022_fill_programcertificate_record_hash.py
@@ -2,25 +2,28 @@
 
 import uuid
 
+from django.conf import settings
 from django.db import migrations, models, transaction
 
 
-def gen_uuid(apps, schema_editor):
+def generate_program_certificate_uuid(apps, schema_editor):
     ProgramCertificate = apps.get_model("profiles", "ProgramCertificate")
     while ProgramCertificate.objects.filter(record_hash__isnull=True).exists():
         with transaction.atomic():
+            external = list(settings.EXTERNAL_MODELS)
+            settings.EXTERNAL_MODELS = []
             for row in ProgramCertificate.objects.filter(record_hash__isnull=True):
                 row.record_hash = str(uuid.uuid4())
                 row.save()
+        settings.EXTERNAL_MODELS = external
 
 
 class Migration(migrations.Migration):
     dependencies = [
         ("profiles", "0021_programcertificate_record_hash"),
     ]
-
     operations = [
-        migrations.RunPython(gen_uuid),
+        migrations.RunPython(generate_program_certificate_uuid),
         migrations.RemoveField(
             model_name="programcertificate",
             name="id",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes #738 


### Description (What does it do?)
This fixes an issue where the program certificate migration fails if there are pre-existing records when the migration runs. In order to switch from "id" to "record_hash" as the primary key, we need to backfill existing records with something so we can make it non-nullable. This pr has changes that temporarily sets the EXTERNAL_MODELS table to empty before proceeding with the backfill.


### How can this be tested?

These are the steps to repro/validate this. Try first on main to see it fail and then repeat on this branch to confirm it works
1. remove migrations that add the record hash
```
rm profiles/migrations/0021_programcertificate_record_hash.py
rm profiles/migrations/0022_fill_programcertificate_record_hash.py
```
2. comment out the record_hash field from the ProgramCertificate model in profiles/models.py
3. run ```docker-compose down``` and ```docker-compose up```
4. get into the django shell and create some program certificates:
```
from profiles.models import ProgramCertificate
from django.conf import settings
settings.EXTERNAL_MODELS = []
ProgramCertificate.objects.create(user_email='test@test.com',program_title='test')
ProgramCertificate.objects.create(user_email='test2@test.com',program_title='test2')
ProgramCertificate.objects.create(user_email='test3@test.com',program_title='test3')
```
5. Add the record_hash field back to the ProgramCertificate model in profiles/models.py
6. git checkout profiles/migrations -> this adds the record_hash migrations back in.
7. run migrate -> on main this will fail with the read only error. In this branch it should run successfully and if you inspect the ProgramCertificates we created earlier, they should have record_hashes
