### PR TITLE
Add a channel for every topic, department, offeror

### DIFF
--- a/channels/admin.py
+++ b/channels/admin.py
@@ -24,6 +24,8 @@ class FieldChannelAdmin(admin.ModelAdmin):
     model = FieldChannel
     exclude = ("widget_list",)
     search_fields = ("name", "title")
+    list_display = ("title", "name", "channel_type")
+    list_filter = ("channel_type",)
     readonly_fields = (
         "field_widget_list",
         "updated_on",

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -40,6 +40,18 @@ class ChannelPlugin:
         return topic_detail.channel, False
 
     @hookimpl
+    def topic_delete(self, topic):
+        """
+        Delete the topic and any existing channel for that topic
+
+        Args:
+            offeror(LearningResourceOfferor): The offeror to delete
+
+        """
+        FieldChannel.objects.filter(topic_detail__topic=topic).delete()
+        topic.delete()
+
+    @hookimpl
     def department_upserted(self, department):
         """
         Create a channel for the department if it doesn't already exist
@@ -63,6 +75,18 @@ class ChannelPlugin:
         return dept_detail.channel, False
 
     @hookimpl
+    def department_delete(self, department):
+        """
+        Delete the department and any existing channel for that department
+
+        Args:
+            department(LearningResourceDepartment): The department to delete
+
+        """
+        FieldChannel.objects.filter(department_detail__department=department).delete()
+        department.delete()
+
+    @hookimpl
     def offeror_upserted(self, offeror):
         """
         Create a channel for the offeror if it doesn't already exist
@@ -80,3 +104,15 @@ class ChannelPlugin:
             ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
             return channel, True
         return offeror_detail.channel, False
+
+    @hookimpl
+    def offeror_delete(self, offeror):
+        """
+        Delete the offeror and any existing channel for that offeror
+
+        Args:
+            offeror(LearningResourceOfferor): The offeror to delete
+
+        """
+        FieldChannel.objects.filter(offeror_detail__offeror=offeror).delete()
+        offeror.delete()

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -1,0 +1,82 @@
+"""Plugins for field channels"""
+
+from django.apps import apps
+from django.utils.text import slugify
+
+from channels.constants import ChannelType
+from channels.models import (
+    ChannelDepartmentDetail,
+    ChannelOfferorDetail,
+    ChannelTopicDetail,
+    FieldChannel,
+)
+
+
+class ChannelPlugin:
+    """Create/delete channels based on learning_resources models"""
+
+    hookimpl = apps.get_app_config("learning_resources").hookimpl
+
+    @hookimpl
+    def topic_upserted(self, topic):
+        """
+        Create a channel for the topic if it doesn't already exist
+
+        Args:
+            topic(LearningResourceTopic): The topic that was upserted
+
+        Returns:
+            tuple(FieldChannel, bool): Channel and "created" boolean
+        """
+        topic_detail = ChannelTopicDetail.objects.filter(topic=topic).first()
+        if not topic_detail:
+            channel, _ = FieldChannel.objects.get_or_create(
+                name=slugify(topic.name),
+                channel_type=ChannelType.topic.name,
+                title=topic.name,
+            )
+            ChannelTopicDetail.objects.create(channel=channel, topic=topic)
+            return channel, True
+        return topic_detail.channel, False
+
+    @hookimpl
+    def department_upserted(self, department):
+        """
+        Create a channel for the department if it doesn't already exist
+
+        Args:
+            department(LearningResourceDepartment): The department that was upserted
+        """
+        dept_detail = ChannelDepartmentDetail.objects.filter(
+            department=department
+        ).first()
+        if not dept_detail:
+            channel, _ = FieldChannel.objects.get_or_create(
+                name=slugify(department.name),
+                channel_type=ChannelType.department.name,
+                title=department.name,
+            )
+            ChannelDepartmentDetail.objects.create(
+                channel=channel, department=department
+            )
+            return channel, True
+        return dept_detail.channel, False
+
+    @hookimpl
+    def offeror_upserted(self, offeror):
+        """
+        Create a channel for the offeror if it doesn't already exist
+
+        Args:
+            offeror(LearningResourceOfferor): The offeror that was upserted
+        """
+        offeror_detail = ChannelOfferorDetail.objects.filter(offeror=offeror).first()
+        if not offeror_detail:
+            channel, _ = FieldChannel.objects.get_or_create(
+                name=offeror.code,
+                channel_type=ChannelType.offeror.name,
+                title=offeror.name,
+            )
+            ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
+            return channel, True
+        return offeror_detail, False

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -33,7 +33,7 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=slugify(topic.name),
                 channel_type=ChannelType.topic.name,
-                defaults={"title": topic.name},
+                defaults={"title": topic.name, "search_filter": f"topic={topic.name}"},
             )
             ChannelTopicDetail.objects.create(channel=channel, topic=topic)
             return channel, True
@@ -66,7 +66,10 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=slugify(department.name),
                 channel_type=ChannelType.department.name,
-                defaults={"title": department.name},
+                defaults={
+                    "title": department.name,
+                    "search_filter": f"department={department.department_id}",
+                },
             )
             ChannelDepartmentDetail.objects.create(
                 channel=channel, department=department
@@ -99,7 +102,10 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=offeror.code,
                 channel_type=ChannelType.offeror.name,
-                defaults={"title": offeror.name},
+                defaults={
+                    "title": offeror.name,
+                    "search_filter": f"offeror={offeror.code}",
+                },
             )
             ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
             return channel, True

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -18,24 +18,25 @@ class ChannelPlugin:
     hookimpl = apps.get_app_config("learning_resources").hookimpl
 
     @hookimpl
-    def topic_upserted(self, topic):
+    def topic_upserted(self, topic, overwrite):
         """
         Create a channel for the topic if it doesn't already exist
 
         Args:
             topic(LearningResourceTopic): The topic that was upserted
+            overwrite(bool): Whether to overwrite the existing channel
 
         Returns:
-            tuple(FieldChannel, bool): Channel and "created" boolean
+            tuple(FieldChannel, bool): Channel and "upserted" boolean
         """
         topic_detail = ChannelTopicDetail.objects.filter(topic=topic).first()
-        if not topic_detail:
-            channel, _ = FieldChannel.objects.get_or_create(
+        if overwrite or not topic_detail:
+            channel, _ = FieldChannel.objects.update_or_create(
                 name=slugify(topic.name),
                 channel_type=ChannelType.topic.name,
                 defaults={"title": topic.name, "search_filter": f"topic={topic.name}"},
             )
-            ChannelTopicDetail.objects.create(channel=channel, topic=topic)
+            ChannelTopicDetail.objects.update_or_create(channel=channel, topic=topic)
             return channel, True
         return topic_detail.channel, False
 
@@ -52,18 +53,23 @@ class ChannelPlugin:
         topic.delete()
 
     @hookimpl
-    def department_upserted(self, department):
+    def department_upserted(self, department, overwrite):
         """
         Create a channel for the department if it doesn't already exist
 
         Args:
             department(LearningResourceDepartment): The department that was upserted
+            overwrite(bool): Whether to overwrite the existing channel
+
+
+        Returns:
+            tuple(FieldChannel, bool): Channel and "upserted" boolean
         """
         dept_detail = ChannelDepartmentDetail.objects.filter(
             department=department
         ).first()
-        if not dept_detail:
-            channel, _ = FieldChannel.objects.get_or_create(
+        if overwrite or not dept_detail:
+            channel, _ = FieldChannel.objects.update_or_create(
                 name=slugify(department.name),
                 channel_type=ChannelType.department.name,
                 defaults={
@@ -71,7 +77,7 @@ class ChannelPlugin:
                     "search_filter": f"department={department.department_id}",
                 },
             )
-            ChannelDepartmentDetail.objects.create(
+            ChannelDepartmentDetail.objects.update_or_create(
                 channel=channel, department=department
             )
             return channel, True
@@ -90,24 +96,30 @@ class ChannelPlugin:
         department.delete()
 
     @hookimpl
-    def offeror_upserted(self, offeror):
+    def offeror_upserted(self, offeror, overwrite):
         """
         Create a channel for the offeror if it doesn't already exist
 
         Args:
             offeror(LearningResourceOfferor): The offeror that was upserted
+            overwrite(bool): Whether to overwrite the existing channel
+
+        Returns:
+            tuple(FieldChannel, bool): Channel and "upserted" boolean
         """
         offeror_detail = ChannelOfferorDetail.objects.filter(offeror=offeror).first()
-        if not offeror_detail:
-            channel, _ = FieldChannel.objects.get_or_create(
+        if overwrite or not offeror_detail:
+            channel, _ = FieldChannel.objects.update_or_create(
                 name=offeror.code,
                 channel_type=ChannelType.offeror.name,
                 defaults={
                     "title": offeror.name,
-                    "search_filter": f"offeror={offeror.code}",
+                    "search_filter": f"offered_by={offeror.code}",
                 },
             )
-            ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
+            ChannelOfferorDetail.objects.update_or_create(
+                channel=channel, offeror=offeror
+            )
             return channel, True
         return offeror_detail.channel, False
 

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -79,4 +79,4 @@ class ChannelPlugin:
             )
             ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
             return channel, True
-        return offeror_detail, False
+        return offeror_detail.channel, False

--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -33,7 +33,7 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=slugify(topic.name),
                 channel_type=ChannelType.topic.name,
-                title=topic.name,
+                defaults={"title": topic.name},
             )
             ChannelTopicDetail.objects.create(channel=channel, topic=topic)
             return channel, True
@@ -66,7 +66,7 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=slugify(department.name),
                 channel_type=ChannelType.department.name,
-                title=department.name,
+                defaults={"title": department.name},
             )
             ChannelDepartmentDetail.objects.create(
                 channel=channel, department=department
@@ -99,7 +99,7 @@ class ChannelPlugin:
             channel, _ = FieldChannel.objects.get_or_create(
                 name=offeror.code,
                 channel_type=ChannelType.offeror.name,
-                title=offeror.name,
+                defaults={"title": offeror.name},
             )
             ChannelOfferorDetail.objects.create(channel=channel, offeror=offeror)
             return channel, True

--- a/channels/plugins_test.py
+++ b/channels/plugins_test.py
@@ -3,11 +3,18 @@
 import pytest
 
 from channels.constants import ChannelType
+from channels.factories import FieldChannelFactory
+from channels.models import FieldChannel
 from channels.plugins import ChannelPlugin
 from learning_resources.factories import (
     LearningResourceDepartmentFactory,
     LearningResourceOfferorFactory,
     LearningResourceTopicFactory,
+)
+from learning_resources.models import (
+    LearningResourceDepartment,
+    LearningResourceOfferor,
+    LearningResourceTopic,
 )
 
 
@@ -26,6 +33,17 @@ def test_search_index_plugin_topic_upserted():
 
 
 @pytest.mark.django_db()
+def test_search_index_plugin_topic_delete():
+    """The plugin function should delete a topic and associated channel"""
+    channel = FieldChannelFactory.create(is_topic=True)
+    topic = channel.topic_detail.topic
+    assert topic is not None
+    ChannelPlugin().topic_delete(topic)
+    assert FieldChannel.objects.filter(id=channel.id).exists() is False
+    assert LearningResourceTopic.objects.filter(id=topic.id).exists() is False
+
+
+@pytest.mark.django_db()
 def test_search_index_plugin_department_upserted():
     """The plugin function should create a department channel"""
     department = LearningResourceDepartmentFactory.create()
@@ -39,6 +57,22 @@ def test_search_index_plugin_department_upserted():
 
 
 @pytest.mark.django_db()
+def test_search_index_plugin_department_delete():
+    """The plugin function should delete a department and associated channel"""
+    channel = FieldChannelFactory.create(is_department=True)
+    department = channel.department_detail.department
+    assert department is not None
+    ChannelPlugin().department_delete(department)
+    assert FieldChannel.objects.filter(id=channel.id).exists() is False
+    assert (
+        LearningResourceDepartment.objects.filter(
+            department_id=department.department_id
+        ).exists()
+        is False
+    )
+
+
+@pytest.mark.django_db()
 def test_search_index_plugin_offeror_upserted():
     """The plugin function should create an offeror channel"""
     offeror = LearningResourceOfferorFactory.create()
@@ -49,3 +83,14 @@ def test_search_index_plugin_offeror_upserted():
     same_channel, created = ChannelPlugin().offeror_upserted(offeror)
     assert channel == same_channel
     assert created is False
+
+
+@pytest.mark.django_db()
+def test_search_index_plugin_offeror_delete():
+    """The plugin function should delete an offeror and associated channel"""
+    channel = FieldChannelFactory.create(is_offeror=True)
+    offeror = channel.offeror_detail.offeror
+    assert offeror is not None
+    ChannelPlugin().offeror_delete(offeror)
+    assert FieldChannel.objects.filter(id=channel.id).exists() is False
+    assert LearningResourceOfferor.objects.filter(code=offeror.code).exists() is False

--- a/channels/plugins_test.py
+++ b/channels/plugins_test.py
@@ -27,6 +27,7 @@ def test_search_index_plugin_topic_upserted():
     assert channel.topic_detail.topic == topic
     assert channel.title == topic.name
     assert channel.channel_type == ChannelType.topic.name
+    assert channel.search_filter == f"topic={topic.name}"
     same_channel, created = ChannelPlugin().topic_upserted(topic)
     assert channel == same_channel
     assert created is False
@@ -51,6 +52,7 @@ def test_search_index_plugin_department_upserted():
     assert channel.department_detail.department == department
     assert channel.title == department.name
     assert channel.channel_type == ChannelType.department.name
+    assert channel.search_filter == f"department={department.department_id}"
     same_channel, created = ChannelPlugin().department_upserted(department)
     assert channel == same_channel
     assert created is False
@@ -80,6 +82,7 @@ def test_search_index_plugin_offeror_upserted():
     assert channel.offeror_detail.offeror == offeror
     assert channel.title == offeror.name
     assert channel.channel_type == ChannelType.offeror.name
+    assert channel.search_filter == f"offeror={offeror.code}"
     same_channel, created = ChannelPlugin().offeror_upserted(offeror)
     assert channel == same_channel
     assert created is False

--- a/channels/plugins_test.py
+++ b/channels/plugins_test.py
@@ -1,0 +1,51 @@
+"""Tests for channels plugins"""
+
+import pytest
+
+from channels.constants import ChannelType
+from channels.plugins import ChannelPlugin
+from learning_resources.factories import (
+    LearningResourceDepartmentFactory,
+    LearningResourceOfferorFactory,
+    LearningResourceTopicFactory,
+)
+
+
+@pytest.mark.django_db()
+def test_search_index_plugin_topic_upserted():
+    """The plugin function should create a topic channel"""
+    topic = LearningResourceTopicFactory.create()
+    channel, created = ChannelPlugin().topic_upserted(topic)
+    assert created is True
+    assert channel.topic_detail.topic == topic
+    assert channel.title == topic.name
+    assert channel.channel_type == ChannelType.topic.name
+    same_channel, created = ChannelPlugin().topic_upserted(topic)
+    assert channel == same_channel
+    assert created is False
+
+
+@pytest.mark.django_db()
+def test_search_index_plugin_department_upserted():
+    """The plugin function should create a department channel"""
+    department = LearningResourceDepartmentFactory.create()
+    channel, created = ChannelPlugin().department_upserted(department)
+    assert channel.department_detail.department == department
+    assert channel.title == department.name
+    assert channel.channel_type == ChannelType.department.name
+    same_channel, created = ChannelPlugin().department_upserted(department)
+    assert channel == same_channel
+    assert created is False
+
+
+@pytest.mark.django_db()
+def test_search_index_plugin_offeror_upserted():
+    """The plugin function should create an offeror channel"""
+    offeror = LearningResourceOfferorFactory.create()
+    channel, created = ChannelPlugin().offeror_upserted(offeror)
+    assert channel.offeror_detail.offeror == offeror
+    assert channel.title == offeror.name
+    assert channel.channel_type == ChannelType.offeror.name
+    same_channel, created = ChannelPlugin().offeror_upserted(offeror)
+    assert channel == same_channel
+    assert created is False

--- a/channels/plugins_test.py
+++ b/channels/plugins_test.py
@@ -19,18 +19,19 @@ from learning_resources.models import (
 
 
 @pytest.mark.django_db()
-def test_search_index_plugin_topic_upserted():
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_search_index_plugin_topic_upserted(overwrite):
     """The plugin function should create a topic channel"""
     topic = LearningResourceTopicFactory.create()
-    channel, created = ChannelPlugin().topic_upserted(topic)
+    channel, created = ChannelPlugin().topic_upserted(topic, overwrite)
     assert created is True
     assert channel.topic_detail.topic == topic
     assert channel.title == topic.name
     assert channel.channel_type == ChannelType.topic.name
     assert channel.search_filter == f"topic={topic.name}"
-    same_channel, created = ChannelPlugin().topic_upserted(topic)
+    same_channel, upserted = ChannelPlugin().topic_upserted(topic, overwrite)
     assert channel == same_channel
-    assert created is False
+    assert upserted is overwrite
 
 
 @pytest.mark.django_db()
@@ -45,17 +46,18 @@ def test_search_index_plugin_topic_delete():
 
 
 @pytest.mark.django_db()
-def test_search_index_plugin_department_upserted():
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_search_index_plugin_department_upserted(overwrite):
     """The plugin function should create a department channel"""
     department = LearningResourceDepartmentFactory.create()
-    channel, created = ChannelPlugin().department_upserted(department)
+    channel, created = ChannelPlugin().department_upserted(department, overwrite)
     assert channel.department_detail.department == department
     assert channel.title == department.name
     assert channel.channel_type == ChannelType.department.name
     assert channel.search_filter == f"department={department.department_id}"
-    same_channel, created = ChannelPlugin().department_upserted(department)
+    same_channel, upserted = ChannelPlugin().department_upserted(department, overwrite)
     assert channel == same_channel
-    assert created is False
+    assert upserted is overwrite
 
 
 @pytest.mark.django_db()
@@ -75,17 +77,18 @@ def test_search_index_plugin_department_delete():
 
 
 @pytest.mark.django_db()
-def test_search_index_plugin_offeror_upserted():
+@pytest.mark.parametrize("overwrite", [True, False])
+def test_search_index_plugin_offeror_upserted(overwrite):
     """The plugin function should create an offeror channel"""
     offeror = LearningResourceOfferorFactory.create()
-    channel, created = ChannelPlugin().offeror_upserted(offeror)
+    channel, created = ChannelPlugin().offeror_upserted(offeror, overwrite)
     assert channel.offeror_detail.offeror == offeror
     assert channel.title == offeror.name
     assert channel.channel_type == ChannelType.offeror.name
-    assert channel.search_filter == f"offeror={offeror.code}"
-    same_channel, created = ChannelPlugin().offeror_upserted(offeror)
+    assert channel.search_filter == f"offered_by={offeror.code}"
+    same_channel, upserted = ChannelPlugin().offeror_upserted(offeror, overwrite)
     assert channel == same_channel
-    assert created is False
+    assert upserted is overwrite
 
 
 @pytest.mark.django_db()

--- a/channels/urls.py
+++ b/channels/urls.py
@@ -15,7 +15,7 @@ v0_router.register(r"channels", FieldChannelViewSet, basename="field_channels_ap
 
 v0_urls = [
     re_path(
-        r"^channels/type/(?P<channel_type>[A-Za-z0-9_]+)/(?P<name>[A-Za-z0-9_]+)/$",
+        r"^channels/type/(?P<channel_type>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9_\-]+)/$",
         ChannelByTypeNameDetailView.as_view({"get": "retrieve"}),
         name="field_by_type_name_api-detail",
     ),

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -75,10 +75,11 @@ def load_topics(resource, topics_data):
         topics = []
 
         for topic_data in topics_data:
-            topic, _ = LearningResourceTopic.objects.get_or_create(
+            topic, created = LearningResourceTopic.objects.get_or_create(
                 name=topic_data["name"]
             )
-            topic_upserted_actions(topic)
+            if created:
+                topic_upserted_actions(topic)
             topics.append(topic)
 
         resource.topics.set(topics)

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -47,6 +47,7 @@ from learning_resources.utils import (
     resource_unpublished_actions,
     resource_upserted_actions,
     similar_topics_action,
+    topic_upserted_actions,
 )
 
 log = logging.getLogger()
@@ -77,6 +78,7 @@ def load_topics(resource, topics_data):
             topic, _ = LearningResourceTopic.objects.get_or_create(
                 name=topic_data["name"]
             )
+            topic_upserted_actions(topic)
             topics.append(topic)
 
         resource.topics.set(topics)

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -553,7 +553,7 @@ def test_load_topics(mocker, parent_factory, topics_exist):
     load_topics(parent.learning_resource, [{"name": topic.name} for topic in topics])
 
     assert parent.learning_resource.topics.count() == len(topics)
-    assert mock_pluggy.call_count == len(topics)
+    assert mock_pluggy.call_count == (0 if topics_exist else len(topics))
 
     load_topics(parent.learning_resource, None)
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -535,8 +535,9 @@ def test_load_run(run_exists):
 
 @pytest.mark.parametrize("parent_factory", [CourseFactory, ProgramFactory])
 @pytest.mark.parametrize("topics_exist", [True, False])
-def test_load_topics(parent_factory, topics_exist):
+def test_load_topics(mocker, parent_factory, topics_exist):
     """Test that load_topics creates and/or assigns topics to the parent object"""
+    mock_pluggy = mocker.patch("learning_resources.etl.loaders.topic_upserted_actions")
     topics = (
         LearningResourceTopicFactory.create_batch(3)
         if topics_exist
@@ -547,10 +548,12 @@ def test_load_topics(parent_factory, topics_exist):
     load_topics(parent.learning_resource, [])
 
     assert parent.learning_resource.topics.count() == 0
+    mock_pluggy.assert_not_called()
 
     load_topics(parent.learning_resource, [{"name": topic.name} for topic in topics])
 
     assert parent.learning_resource.topics.count() == len(topics)
+    assert mock_pluggy.call_count == len(topics)
 
     load_topics(parent.learning_resource, None)
 

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -61,12 +61,24 @@ class LearningResourceHooks:
         """Trigger actions after a learning resource topic is created or updated"""
 
     @hookspec
+    def topic_delete(self, topic):
+        """Trigger actions to delete a learning resource topic"""
+
+    @hookspec
     def department_upserted(self, department):
         """Trigger actions after a learning resource department is created or updated"""
 
     @hookspec
+    def department_delete(self, department):
+        """Trigger actions to delete a learning resource department"""
+
+    @hookspec
     def offeror_upserted(self, offeror):
         """Trigger actions after a learning resource offeror is created or updated"""
+
+    @hookspec
+    def offeror_delete(self, offeror):
+        """Trigger actions to delete a learning resource offeror"""
 
 
 def get_plugin_manager():

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -57,7 +57,7 @@ class LearningResourceHooks:
         """Trigger actions to remove a learning resource run"""
 
     @hookspec
-    def topic_upserted(self, topic):
+    def topic_upserted(self, topic, overwrite):
         """Trigger actions after a learning resource topic is created or updated"""
 
     @hookspec
@@ -65,7 +65,7 @@ class LearningResourceHooks:
         """Trigger actions to delete a learning resource topic"""
 
     @hookspec
-    def department_upserted(self, department):
+    def department_upserted(self, department, overwrite):
         """Trigger actions after a learning resource department is created or updated"""
 
     @hookspec
@@ -73,7 +73,7 @@ class LearningResourceHooks:
         """Trigger actions to delete a learning resource department"""
 
     @hookspec
-    def offeror_upserted(self, offeror):
+    def offeror_upserted(self, offeror, overwrite):
         """Trigger actions after a learning resource offeror is created or updated"""
 
     @hookspec

--- a/learning_resources/hooks.py
+++ b/learning_resources/hooks.py
@@ -56,6 +56,18 @@ class LearningResourceHooks:
     def resource_run_delete(self, run):
         """Trigger actions to remove a learning resource run"""
 
+    @hookspec
+    def topic_upserted(self, topic):
+        """Trigger actions after a learning resource topic is created or updated"""
+
+    @hookspec
+    def department_upserted(self, department):
+        """Trigger actions after a learning resource department is created or updated"""
+
+    @hookspec
+    def offeror_upserted(self, offeror):
+        """Trigger actions after a learning resource offeror is created or updated"""
+
 
 def get_plugin_manager():
     """Return the plugin manager for learning_resources hooks"""

--- a/learning_resources/management/commands/backpopulate_resource_channels.py
+++ b/learning_resources/management/commands/backpopulate_resource_channels.py
@@ -1,0 +1,71 @@
+"""Management command to create channels for topics, departments, offerors"""
+
+from django.core.management import BaseCommand
+
+from channels.constants import ChannelType
+from learning_resources.hooks import get_plugin_manager
+from learning_resources.models import (
+    LearningResourceDepartment,
+    LearningResourceOfferor,
+    LearningResourceTopic,
+)
+from main.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Management command to create channels for topics, departments, offerors"""
+
+    help = "Management command to create channels for topics, departments, offerors"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--all",
+            dest="all",
+            action="store_true",
+            help="Create channels for all types",
+        )
+
+        for channeL_type in [
+            ChannelType.topic.name,
+            ChannelType.department.name,
+            ChannelType.offeror.name,
+        ]:
+            parser.add_argument(
+                f"--{channeL_type}",
+                dest=channeL_type,
+                action="store_true",
+                help=f"Create {channeL_type} channels",
+            )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Create channels for topics, departments, offerors"""
+        start = now_in_utc()
+        pm = get_plugin_manager()
+        hook = pm.hook
+
+        if options["all"] or options[ChannelType.department.name]:
+            created = 0
+            self.stdout.write("Creating department channels")
+            for dept in LearningResourceDepartment.objects.all():
+                if hook.department_upserted(department=dept)[0][1]:
+                    created += 1
+            self.stdout.write(f"Created channels for {created} departments")
+        if options["all"] or options[ChannelType.offeror.name]:
+            created = 0
+            self.stdout.write("Creating offeror channels")
+            for offeror in LearningResourceOfferor.objects.all():
+                if hook.offeror_upserted(offeror=offeror)[0][1]:
+                    created += 1
+            self.stdout.write(f"Finished creating channels for {created} offerors")
+        if options["all"] or options[ChannelType.topic.name]:
+            created = 0
+            self.stdout.write("Creating topic channels")
+            for topic in LearningResourceTopic.objects.all():
+                if hook.topic_upserted(topic=topic)[0][1]:
+                    created += 1
+            self.stdout.write(f"Finished creating channels for {created} topics")
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            f"Creation of channels finished, took {total_seconds} seconds"
+        )

--- a/learning_resources/management/commands/backpopulate_resource_channels.py
+++ b/learning_resources/management/commands/backpopulate_resource_channels.py
@@ -26,6 +26,14 @@ class Command(BaseCommand):
             help="Create channels for all types",
         )
 
+        parser.add_argument(
+            "--overwrite",
+            dest="overwrite",
+            action="store_true",
+            default=False,
+            help="Overwrite existing channels",
+        )
+
         for channeL_type in [
             ChannelType.topic.name,
             ChannelType.department.name,
@@ -44,18 +52,20 @@ class Command(BaseCommand):
         start = now_in_utc()
         pm = get_plugin_manager()
         hook = pm.hook
+        overwrite = options["overwrite"]
+        self.stdout.write(f"Overwriting existing channels?: {overwrite}")
         if options["all"] or options[ChannelType.department.name]:
             created = 0
             self.stdout.write("Creating department channels")
             for dept in LearningResourceDepartment.objects.all():
-                if hook.department_upserted(department=dept)[0][1]:
+                if hook.department_upserted(department=dept, overwrite=overwrite)[0][1]:
                     created += 1
             self.stdout.write(f"Created channels for {created} departments")
         if options["all"] or options[ChannelType.offeror.name]:
             created = 0
             self.stdout.write("Creating offeror channels")
             for offeror in LearningResourceOfferor.objects.all():
-                if hook.offeror_upserted(offeror=offeror)[0][1]:
+                if hook.offeror_upserted(offeror=offeror, overwrite=overwrite)[0][1]:
                     created += 1
             self.stdout.write(f"Finished creating channels for {created} offerors")
         if options["all"] or options[ChannelType.topic.name]:
@@ -64,7 +74,7 @@ class Command(BaseCommand):
             for topic in LearningResourceTopic.objects.filter(
                 learningresource__isnull=False
             ):
-                if hook.topic_upserted(topic=topic)[0][1]:
+                if hook.topic_upserted(topic=topic, overwrite=overwrite)[0][1]:
                     created += 1
             # Remove topics and channels without any associated learning resources
             for topic in LearningResourceTopic.objects.filter(

--- a/learning_resources/management/commands/backpopulate_resource_channels.py
+++ b/learning_resources/management/commands/backpopulate_resource_channels.py
@@ -22,6 +22,7 @@ class Command(BaseCommand):
             "--all",
             dest="all",
             action="store_true",
+            default=True,
             help="Create channels for all types",
         )
 
@@ -43,7 +44,6 @@ class Command(BaseCommand):
         start = now_in_utc()
         pm = get_plugin_manager()
         hook = pm.hook
-
         if options["all"] or options[ChannelType.department.name]:
             created = 0
             self.stdout.write("Creating department channels")

--- a/learning_resources/management/commands/update_departments.py
+++ b/learning_resources/management/commands/update_departments.py
@@ -5,6 +5,7 @@ from django.db import transaction
 
 from learning_resources.constants import DEPARTMENTS
 from learning_resources.models import LearningResourceDepartment
+from learning_resources.utils import department_upserted_actions
 from main.utils import now_in_utc
 
 
@@ -21,10 +22,11 @@ class Command(BaseCommand):
         departments = []
         with transaction.atomic():
             for department_id, name in DEPARTMENTS.items():
-                LearningResourceDepartment.objects.update_or_create(
+                dept, _ = LearningResourceDepartment.objects.update_or_create(
                     department_id=department_id,
                     defaults={"name": name},
                 )
+                department_upserted_actions(dept)
                 departments.append(department_id)
             LearningResourceDepartment.objects.exclude(
                 department_id__in=departments

--- a/learning_resources/management/commands/update_departments.py
+++ b/learning_resources/management/commands/update_departments.py
@@ -5,7 +5,10 @@ from django.db import transaction
 
 from learning_resources.constants import DEPARTMENTS
 from learning_resources.models import LearningResourceDepartment
-from learning_resources.utils import department_upserted_actions
+from learning_resources.utils import (
+    department_delete_actions,
+    department_upserted_actions,
+)
 from main.utils import now_in_utc
 
 
@@ -28,9 +31,11 @@ class Command(BaseCommand):
                 )
                 department_upserted_actions(dept)
                 departments.append(department_id)
-            LearningResourceDepartment.objects.exclude(
+            invalid_departments = LearningResourceDepartment.objects.exclude(
                 department_id__in=departments
-            ).delete()
+            )
+            for department in invalid_departments:
+                department_delete_actions(department)
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
             f"Update of departments finished, took {total_seconds} seconds"

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -22,9 +22,11 @@ from learning_resources.constants import (
 from learning_resources.hooks import get_plugin_manager
 from learning_resources.models import (
     LearningResource,
+    LearningResourceDepartment,
     LearningResourceOfferor,
     LearningResourcePlatform,
     LearningResourceRun,
+    LearningResourceTopic,
 )
 from main.utils import generate_filepath
 
@@ -285,10 +287,11 @@ def upsert_offered_by_data():
         with transaction.atomic():
             for offeror in offered_by_json:
                 offeror_fields = offeror["fields"]
-                LearningResourceOfferor.objects.update_or_create(
+                offered_by, _ = LearningResourceOfferor.objects.update_or_create(
                     name=offeror_fields["name"],
                     defaults=offeror_fields,
                 )
+                offeror_upserted_actions(offered_by)
                 offerors.append(offeror_fields["name"])
             LearningResourceOfferor.objects.exclude(name__in=offerors).delete()
 
@@ -386,3 +389,30 @@ def resource_run_delete_actions(run: LearningResourceRun):
     pm = get_plugin_manager()
     hook = pm.hook
     hook.resource_run_delete(run=run)
+
+
+def topic_upserted_actions(topic: LearningResourceTopic):
+    """
+    Trigger plugins when a LearningResourceTopic is created or updated
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.topic_upserted(topic=topic)
+
+
+def department_upserted_actions(department: LearningResourceDepartment):
+    """
+    Trigger plugins when a LearningResourceDepartment is created or updated
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.department_upserted(department=department)
+
+
+def offeror_upserted_actions(offeror: LearningResourceOfferor):
+    """
+    Trigger plugins when a LearningResourceOfferor is created or updated
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.offeror_upserted(offeror=offeror)

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -395,13 +395,13 @@ def resource_run_delete_actions(run: LearningResourceRun):
     hook.resource_run_delete(run=run)
 
 
-def topic_upserted_actions(topic: LearningResourceTopic):
+def topic_upserted_actions(topic: LearningResourceTopic, *, overwrite: bool = False):
     """
     Trigger plugins when a LearningResourceTopic is created or updated
     """
     pm = get_plugin_manager()
     hook = pm.hook
-    hook.topic_upserted(topic=topic)
+    hook.topic_upserted(topic=topic, overwrite=overwrite)
 
 
 def topic_delete_actions(topic: LearningResourceTopic):
@@ -413,13 +413,15 @@ def topic_delete_actions(topic: LearningResourceTopic):
     hook.topic_delete(topic=topic)
 
 
-def department_upserted_actions(department: LearningResourceDepartment):
+def department_upserted_actions(
+    department: LearningResourceDepartment, *, overwrite: bool = False
+):
     """
     Trigger plugins when a LearningResourceDepartment is created or updated
     """
     pm = get_plugin_manager()
     hook = pm.hook
-    hook.department_upserted(department=department)
+    hook.department_upserted(department=department, overwrite=overwrite)
 
 
 def department_delete_actions(department: LearningResourceDepartment):
@@ -431,13 +433,15 @@ def department_delete_actions(department: LearningResourceDepartment):
     hook.department_delete(department=department)
 
 
-def offeror_upserted_actions(offeror: LearningResourceOfferor):
+def offeror_upserted_actions(
+    offeror: LearningResourceOfferor, *, overwrite: bool = False
+):
     """
     Trigger plugins when a LearningResourceOfferor is created or updated
     """
     pm = get_plugin_manager()
     hook = pm.hook
-    hook.offeror_upserted(offeror=offeror)
+    hook.offeror_upserted(offeror=offeror, overwrite=overwrite)
 
 
 def offeror_delete_actions(offeror: LearningResourceOfferor):

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -293,7 +293,11 @@ def upsert_offered_by_data():
                 )
                 offeror_upserted_actions(offered_by)
                 offerors.append(offeror_fields["name"])
-            LearningResourceOfferor.objects.exclude(name__in=offerors).delete()
+            invalid_offerors = LearningResourceOfferor.objects.exclude(
+                name__in=offerors
+            )
+            for offeror in invalid_offerors:
+                offeror_delete_actions(offeror)
 
 
 def upsert_platform_data():
@@ -400,6 +404,15 @@ def topic_upserted_actions(topic: LearningResourceTopic):
     hook.topic_upserted(topic=topic)
 
 
+def topic_delete_actions(topic: LearningResourceTopic):
+    """
+    Trigger plugin function to delete a LearningResourceTopic
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.topic_delete(topic=topic)
+
+
 def department_upserted_actions(department: LearningResourceDepartment):
     """
     Trigger plugins when a LearningResourceDepartment is created or updated
@@ -409,6 +422,15 @@ def department_upserted_actions(department: LearningResourceDepartment):
     hook.department_upserted(department=department)
 
 
+def department_delete_actions(department: LearningResourceDepartment):
+    """
+    Trigger plugin function to delete a LearningResourceDepartment
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.department_delete(department=department)
+
+
 def offeror_upserted_actions(offeror: LearningResourceOfferor):
     """
     Trigger plugins when a LearningResourceOfferor is created or updated
@@ -416,3 +438,12 @@ def offeror_upserted_actions(offeror: LearningResourceOfferor):
     pm = get_plugin_manager()
     hook = pm.hook
     hook.offeror_upserted(offeror=offeror)
+
+
+def offeror_delete_actions(offeror: LearningResourceOfferor):
+    """
+    Trigger plugin function to delete a LearningResourceOfferor
+    """
+    pm = get_plugin_manager()
+    hook = pm.hook
+    hook.offeror_delete(offeror=offeror)

--- a/main/settings_pluggy.py
+++ b/main/settings_pluggy.py
@@ -6,5 +6,5 @@ MITOPEN_AUTHENTICATION_PLUGINS = get_string(
 )
 MITOPEN_LEARNING_RESOURCES_PLUGINS = get_string(
     "MITOPEN_LEARNING_RESOURCES_PLUGINS",
-    "learning_resources_search.plugins.SearchIndexPlugin",
+    "learning_resources_search.plugins.SearchIndexPlugin,channels.plugins.ChannelPlugin",
 )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -220,13 +220,13 @@ paths:
         name: channel_type
         schema:
           type: string
-          pattern: ^[A-Za-z0-9_]+$
+          pattern: ^[A-Za-z0-9_\-]+$
         required: true
       - in: path
         name: name
         schema:
           type: string
-          pattern: ^[A-Za-z0-9_]+$
+          pattern: ^[A-Za-z0-9_\-]+$
         required: true
       tags:
       - channels


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3978

### Description (What does it do?)
- Adds a `ChannelPlugin` class with functions to create channels of the appropriate type  (topic, department, or offeror).
- Calls the plugin topic function when a new topic is created in `learning_resources.etl.load_topics()`
- Calls the plugin offeror & department functions as part of the `updated_offered_by` and `update_departments` management commands respectively.
- Adds a new `backpopulate_resource_channels` that will create channels of the appropriate type for all the above, or just the specified type via options.



### How can this be tested?
- In django admin, delete the "Linear Algebra" `LearningResourceTopic` if it exists, then run `./manage.py backpopulate_ocw_data --course-name 18-700-linear-algebra-fall-2013
- Once done, the topic should exist again, and there should be a new `FieldChannel` with `channel_type=topic`, `name=linear-algebra`, `title=Linear Algebra`, and an associated `ChannelTopicDetail` with `topic=<id of the topic>`
- Run `./manage.py update_departments`.   Once complete, there should be a  `FieldChannel` with `channel_type=department` for each `LearningResourceDepartment` with relevant `name`, `title` and `ChannelDepartmentDetail` for each.
- Run `./manage.py update_offered_by`.   Once complete, there should be a  `FieldChannel` with `channel_type=offeror` for each `LearningResourceOfferor` with relevant `name`, `title` and `ChannelOfefrorDetail` for each.
- Delete all the new field channels via django admin.
- Run `./manage.py backpopulate_resource_channels`.  When done, there should be a `FieldChannel` for every department, offeror, and topic.

Try these urls, they should work and show appropriately filtered search results:

- http://localhost:8063/c/department/civil-and-environmental-engineering
- http://localhost:8063/c/topic/systems-engineering
- http://localhost:8063/c/offeror/ocw

