### PR TITLE
Add channel url to topic, department, and offeror serializers

### DIFF
--- a/channels/factories.py
+++ b/channels/factories.py
@@ -108,7 +108,9 @@ class FieldChannelFactory(DjangoModelFactory):
 class ChannelTopicDetailFactory(DjangoModelFactory):
     """Factory for a channels.models.ChannelTopicDetail object"""
 
-    channel = factory.SubFactory(FieldChannelFactory, is_topic=True)
+    channel = factory.SubFactory(
+        FieldChannelFactory, is_topic=True, create_topic_detail=False
+    )
     topic = factory.SubFactory(LearningResourceTopicFactory)
 
     class Meta:
@@ -118,7 +120,9 @@ class ChannelTopicDetailFactory(DjangoModelFactory):
 class ChannelDepartmentDetailFactory(DjangoModelFactory):
     """Factory for a channels.models.ChannelDepartmentDetail object"""
 
-    channel = factory.SubFactory(FieldChannelFactory, is_department=True)
+    channel = factory.SubFactory(
+        FieldChannelFactory, is_department=True, create_department_detail=False
+    )
     department = factory.SubFactory(LearningResourceDepartmentFactory)
 
     class Meta:
@@ -128,7 +132,9 @@ class ChannelDepartmentDetailFactory(DjangoModelFactory):
 class ChannelOfferorDetailFactory(DjangoModelFactory):
     """Factory for a channels.models.ChannelOfferorDetail object"""
 
-    channel = factory.SubFactory(FieldChannelFactory, is_offeror=True)
+    channel = factory.SubFactory(
+        FieldChannelFactory, is_offeror=True, create_offeror_detail=False
+    )
     offeror = factory.SubFactory(LearningResourceOfferorFactory)
 
     class Meta:

--- a/channels/models.py
+++ b/channels/models.py
@@ -1,5 +1,8 @@
 """Models for channels"""
 
+from urllib.parse import urljoin
+
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.validators import RegexValidator
 from django.db import models
@@ -102,6 +105,11 @@ class FieldChannel(BaseChannel, TimestampedModel):
 
     class Meta:
         unique_together = ("name", "channel_type")
+
+    @property
+    def channel_url(self) -> str:
+        """Return the channel url"""
+        return urljoin(settings.SITE_BASE_URL, f"/c/{self.channel_type}/{self.name}/")
 
 
 class ChannelTopicDetail(TimestampedModel):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -124,6 +124,7 @@ class FieldChannelBaseSerializer(ChannelAppearanceMixin, serializers.ModelSerial
     """Serializer for FieldChannel"""
 
     lists = serializers.SerializerMethodField()
+    channel_url = serializers.SerializerMethodField(read_only=True)
     featured_list = LearningPathPreviewSerializer(
         allow_null=True,
         many=False,
@@ -144,6 +145,10 @@ class FieldChannelBaseSerializer(ChannelAppearanceMixin, serializers.ModelSerial
             .all()
             .order_by("position")
         ]
+
+    def get_channel_url(self, instance):
+        """Get the URL for the channel"""
+        return instance.channel_url
 
     class Meta:
         model = FieldChannel

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -1,8 +1,10 @@
 """Tests for channels.serializers"""
 
 from types import SimpleNamespace
+from urllib.parse import urljoin
 
 import pytest
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from channels.constants import FIELD_ROLE_MODERATORS, ChannelType
@@ -120,6 +122,9 @@ def test_serialize_field_channel(  # pylint: disable=too-many-arguments
         "updated_on": mocker.ANY,
         "created_on": mocker.ANY,
         "id": channel.id,
+        "channel_url": urljoin(
+            settings.SITE_BASE_URL, f"/c/{channel.channel_type}/{channel.name}/"
+        ),
         "lists": [
             LearningPathPreviewSerializer(field_list.field_list).data
             for field_list in sorted(

--- a/channels/views.py
+++ b/channels/views.py
@@ -97,7 +97,9 @@ class FieldChannelViewSet(
 
 
 @extend_schema_view(
-    get=extend_schema(summary="FieldChannel Detail Lookup by channel type and name"),
+    retrieve=extend_schema(
+        summary="FieldChannel Detail Lookup by channel type and name"
+    ),
 )
 class ChannelByTypeNameDetailView(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     """

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -199,6 +199,12 @@ export interface DepartmentChannel {
   lists: Array<LearningPathPreview>
   /**
    *
+   * @type {string}
+   * @memberof DepartmentChannel
+   */
+  channel_url: string
+  /**
+   *
    * @type {DepartmentChannelFeaturedList}
    * @memberof DepartmentChannel
    */
@@ -636,6 +642,12 @@ export interface OfferorChannel {
   lists: Array<LearningPathPreview>
   /**
    *
+   * @type {string}
+   * @memberof OfferorChannel
+   */
+  channel_url: string
+  /**
+   *
    * @type {DepartmentChannelFeaturedList}
    * @memberof OfferorChannel
    */
@@ -956,6 +968,12 @@ export interface PathwayChannel {
   lists: Array<LearningPathPreview>
   /**
    *
+   * @type {string}
+   * @memberof PathwayChannel
+   */
+  channel_url: string
+  /**
+   *
    * @type {DepartmentChannelFeaturedList}
    * @memberof PathwayChannel
    */
@@ -1205,6 +1223,12 @@ export interface TopicChannel {
    * @memberof TopicChannel
    */
   lists: Array<LearningPathPreview>
+  /**
+   *
+   * @type {string}
+   * @memberof TopicChannel
+   */
+  channel_url: string
   /**
    *
    * @type {DepartmentChannelFeaturedList}
@@ -1895,6 +1919,7 @@ export const ChannelsApiAxiosParamCreator = function (
     },
     /**
      * View for retrieving an individual field channel by type and name
+     * @summary FieldChannel Detail Lookup by channel type and name
      * @param {string} channel_type
      * @param {string} name
      * @param {*} [options] Override http request option.
@@ -2201,6 +2226,7 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
     },
     /**
      * View for retrieving an individual field channel by type and name
+     * @summary FieldChannel Detail Lookup by channel type and name
      * @param {string} channel_type
      * @param {string} name
      * @param {*} [options] Override http request option.
@@ -2383,6 +2409,7 @@ export const ChannelsApiFactory = function (
     },
     /**
      * View for retrieving an individual field channel by type and name
+     * @summary FieldChannel Detail Lookup by channel type and name
      * @param {ChannelsApiChannelsTypeRetrieveRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -2732,6 +2759,7 @@ export class ChannelsApi extends BaseAPI {
 
   /**
    * View for retrieving an individual field channel by type and name
+   * @summary FieldChannel Detail Lookup by channel type and name
    * @param {ChannelsApiChannelsTypeRetrieveRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -994,6 +994,12 @@ export interface LearningResourceDepartment {
    * @memberof LearningResourceDepartment
    */
   name: string
+  /**
+   * Get the channel url for the department if it exists
+   * @type {string}
+   * @memberof LearningResourceDepartment
+   */
+  channel_url: string | null
 }
 /**
  * Serializer for LearningResourceDepartment
@@ -1144,6 +1150,12 @@ export interface LearningResourceOfferor {
    * @memberof LearningResourceOfferor
    */
   name: string
+  /**
+   * Get the channel url for the offeror if it exists
+   * @type {string}
+   * @memberof LearningResourceOfferor
+   */
+  channel_url: string | null
 }
 /**
  * Serializer for LearningResourceOfferor
@@ -1607,6 +1619,12 @@ export interface LearningResourceTopic {
    * @memberof LearningResourceTopic
    */
   name: string
+  /**
+   * Get the channel url for the topic if it exists
+   * @type {string}
+   * @memberof LearningResourceTopic
+   */
+  channel_url: string | null
 }
 /**
  * Serializer containing only parent and child ids for a learning path relationship

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -69,6 +69,7 @@ const learningResourceDepartment: Factory<LearningResourceDepartment> = (
   return {
     department_id: faker.helpers.unique(faker.lorem.words),
     name: faker.lorem.word(),
+    channel_url: faker.internet.url(),
     ...overrides,
   }
 }
@@ -89,6 +90,7 @@ const learningResourceOfferor: Factory<LearningResourceOfferor> = (
   return {
     code: faker.helpers.unique(faker.lorem.words),
     name: faker.helpers.unique(faker.lorem.words),
+    channel_url: faker.internet.url(),
     ...overrides,
   }
 }
@@ -129,6 +131,7 @@ const learningResourceTopic: Factory<LearningResourceTopic> = (
   const topic: LearningResourceTopic = {
     id: faker.helpers.unique(faker.datatype.number),
     name: faker.helpers.unique(faker.lorem.words),
+    channel_url: faker.internet.url(),
     ...overrides,
   }
   return topic

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -61,6 +61,7 @@ const learningPathFormSchema = Yup.object().shape({
       Yup.object().shape({
         id: Yup.number().required(),
         name: Yup.string().required(),
+        channel_url: Yup.string().nullable().required(),
       }),
     )
     .min(1, "Select between 1 and 3 subjects.")

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -11,6 +11,7 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from channels.models import FieldChannel
 from learning_resources import constants, models
 from learning_resources.constants import LearningResourceType, LevelType
 from learning_resources.etl.loaders import update_index
@@ -34,9 +35,16 @@ class LearningResourceTopicSerializer(serializers.ModelSerializer):
     Serializer for LearningResourceTopic model
     """
 
+    channel_url = serializers.SerializerMethodField(read_only=True, allow_null=True)
+
+    def get_channel_url(self, instance: models.LearningResourceTopic) -> str or None:
+        """Get the channel url for the topic if it exists"""
+        channel = FieldChannel.objects.filter(topic_detail__topic=instance).first()
+        return channel.channel_url if channel else None
+
     class Meta:
         model = models.LearningResourceTopic
-        fields = ["id", "name"]
+        fields = ["id", "name", "channel_url"]
 
 
 class WriteableTopicsMixin(serializers.Serializer):
@@ -80,9 +88,16 @@ class LearningResourceTypeField(serializers.ReadOnlyField):
 class LearningResourceOfferorSerializer(serializers.ModelSerializer):
     """Serializer for LearningResourceOfferor"""
 
+    channel_url = serializers.SerializerMethodField(read_only=True, allow_null=True)
+
+    def get_channel_url(self, instance: models.LearningResourceOfferor) -> str or None:
+        """Get the channel url for the offeror if it exists"""
+        channel = FieldChannel.objects.filter(offeror_detail__offeror=instance).first()
+        return channel.channel_url if channel else None
+
     class Meta:
         model = models.LearningResourceOfferor
-        fields = ("code", "name")
+        fields = ("code", "name", "channel_url")
 
 
 @extend_schema_field({"type": "array", "items": {"type": "string"}})
@@ -105,9 +120,20 @@ class LearningResourcePlatformSerializer(serializers.ModelSerializer):
 class LearningResourceDepartmentSerializer(serializers.ModelSerializer):
     """Serializer for LearningResourceDepartment"""
 
+    channel_url = serializers.SerializerMethodField(read_only=True, allow_null=True)
+
+    def get_channel_url(
+        self, instance: models.LearningResourceDepartment
+    ) -> str or None:
+        """Get the channel url for the department if it exists"""
+        channel = FieldChannel.objects.filter(
+            department_detail__department=instance
+        ).first()
+        return channel.channel_url if channel else None
+
     class Meta:
         model = models.LearningResourceDepartment
-        fields = ["department_id", "name"]
+        fields = ["department_id", "name", "channel_url"]
 
 
 class LearningResourceContentTagSerializer(serializers.ModelSerializer):

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -126,6 +126,7 @@ LEARNING_RESOURCE_MAP = {
         "properties": {
             "department_id": {"type": "keyword"},
             "name": {"type": "keyword"},
+            "channel_url": {"type": "keyword"},
         },
     },
     "professional": {"type": "boolean"},
@@ -135,6 +136,7 @@ LEARNING_RESOURCE_MAP = {
         "properties": {
             "id": {"type": "long"},
             "name": {"type": "keyword"},
+            "channel_url": {"type": "keyword"},
         },
     },
     "offered_by": {
@@ -142,6 +144,7 @@ LEARNING_RESOURCE_MAP = {
         "properties": {
             "code": {"type": "keyword"},
             "name": {"type": "keyword"},
+            "channel_url": {"type": "keyword"},
         },
     },
     "course_feature": {"type": "keyword"},
@@ -156,6 +159,7 @@ LEARNING_RESOURCE_MAP = {
                         "properties": {
                             "department_id": {"type": "keyword"},
                             "name": {"type": "keyword"},
+                            "channel_url": {"type": "keyword"},
                         }
                     },
                     "primary": {"type": "boolean"},

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -229,6 +229,7 @@ paths:
     get:
       operationId: channels_type_retrieve
       description: View for retrieving an individual field channel by type and name
+      summary: FieldChannel Detail Lookup by channel type and name
       parameters:
       - in: path
         name: channel_type
@@ -573,6 +574,9 @@ components:
           items:
             $ref: '#/components/schemas/LearningPathPreview'
           readOnly: true
+        channel_url:
+          type: string
+          readOnly: true
         featured_list:
           allOf:
           - $ref: '#/components/schemas/LearningPathPreview'
@@ -625,6 +629,7 @@ components:
       - avatar_medium
       - avatar_small
       - channel_type
+      - channel_url
       - created_on
       - department_detail
       - featured_list
@@ -848,6 +853,9 @@ components:
           items:
             $ref: '#/components/schemas/LearningPathPreview'
           readOnly: true
+        channel_url:
+          type: string
+          readOnly: true
         featured_list:
           allOf:
           - $ref: '#/components/schemas/LearningPathPreview'
@@ -900,6 +908,7 @@ components:
       - avatar_medium
       - avatar_small
       - channel_type
+      - channel_url
       - created_on
       - featured_list
       - id
@@ -1064,6 +1073,9 @@ components:
           items:
             $ref: '#/components/schemas/LearningPathPreview'
           readOnly: true
+        channel_url:
+          type: string
+          readOnly: true
         featured_list:
           allOf:
           - $ref: '#/components/schemas/LearningPathPreview'
@@ -1114,6 +1126,7 @@ components:
       - avatar_medium
       - avatar_small
       - channel_type
+      - channel_url
       - created_on
       - featured_list
       - id
@@ -1233,6 +1246,9 @@ components:
           items:
             $ref: '#/components/schemas/LearningPathPreview'
           readOnly: true
+        channel_url:
+          type: string
+          readOnly: true
         featured_list:
           allOf:
           - $ref: '#/components/schemas/LearningPathPreview'
@@ -1285,6 +1301,7 @@ components:
       - avatar_medium
       - avatar_small
       - channel_type
+      - channel_url
       - created_on
       - featured_list
       - id

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -8478,7 +8478,13 @@ components:
         name:
           type: string
           maxLength: 256
+        channel_url:
+          type: string
+          description: Get the channel url for the department if it exists
+          readOnly: true
+          nullable: true
       required:
+      - channel_url
       - department_id
       - name
     LearningResourceDepartmentRequest:
@@ -8582,7 +8588,13 @@ components:
         name:
           type: string
           maxLength: 256
+        channel_url:
+          type: string
+          description: Get the channel url for the offeror if it exists
+          readOnly: true
+          nullable: true
       required:
+      - channel_url
       - code
       - name
     LearningResourceOfferorRequest:
@@ -8955,7 +8967,13 @@ components:
         name:
           type: string
           maxLength: 128
+        channel_url:
+          type: string
+          description: Get the channel url for the topic if it exists
+          readOnly: true
+          nullable: true
       required:
+      - channel_url
       - id
       - name
     MicroLearningPathRelationship:


### PR DESCRIPTION


### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4011

### Description (What does it do?)
Adds a `channel_url` field to the topic, department, and offeror serializers


### How can this be tested?
- If you haven't already, run `./manage.py backpopulate_field_channels`
- Run `manage.py recreate_index --all`
- Go to the following urls, each entity should have a populated `channel_url` field, and the urls should work.
  - http://localhost:8063/api/v1/topics/
  - http://localhost:8063/api/v1/departments/
  - http://localhost:8063/api/v1/offerors/
  - http://localhost:8063/api/v0/channels/
- Go to http://localhost:8063/learningpaths (as an admin user) and created/edit some channels, adding/updating the topics.  The functionality should still work.

