### PR TITLE
Filter channels api by channel_type

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -137,8 +137,11 @@ class FieldChannelBaseSerializer(ChannelAppearanceMixin, serializers.ModelSerial
         """Return the field's list of LearningPaths"""
         return [
             LearningPathPreviewSerializer(field_list.field_list).data
-            for field_list in instance.lists.all()
-            .prefetch_related("field_list")
+            for field_list in FieldList.objects.filter(field_channel=instance)
+            .prefetch_related(
+                "field_list", "field_channel__lists", "field_channel__featured_list"
+            )
+            .all()
             .order_by("position")
         ]
 

--- a/channels/views.py
+++ b/channels/views.py
@@ -3,6 +3,7 @@
 import logging
 
 from django.contrib.auth.models import User
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import mixins, viewsets
 from rest_framework.generics import ListCreateAPIView, get_object_or_404
@@ -67,11 +68,19 @@ class FieldChannelViewSet(
     http_method_names = VALID_HTTP_METHODS
     lookup_field = "id"
     lookup_url_kwarg = "id"
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["channel_type"]
 
     def get_queryset(self):
         """Return a queryset"""
-        return FieldChannel.objects.all().prefetch_related(
-            "subfields", "subfields__field_channel"
+        return (
+            FieldChannel.objects.prefetch_related(
+                "lists", "subfields", "subfields__field_channel"
+            )
+            .select_related(
+                "featured_list", "topic_detail", "department_detail", "offeror_detail"
+            )
+            .all()
         )
 
     def get_serializer_class(self):

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -369,7 +369,7 @@ def test_no_excess_queries(user_client, django_assert_num_queries, related_count
     subfields / lists.
     """
     # This isn't too important; we care it does not scale with number of related items
-    expected_query_count = 9
+    expected_query_count = 11
 
     field_channel = FieldChannelFactory.create()
     FieldListFactory.create_batch(related_count, field_channel=field_channel)

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -371,13 +371,13 @@ def test_no_excess_queries(user_client, django_assert_num_queries, related_count
     # This isn't too important; we care it does not scale with number of related items
     expected_query_count = 11
 
-    field_channel = FieldChannelFactory.create()
-    FieldListFactory.create_batch(related_count, field_channel=field_channel)
-    SubfieldFactory.create_batch(related_count, parent_channel=field_channel)
+    topic_channel = FieldChannelFactory.create(is_topic=True)
+    FieldListFactory.create_batch(related_count, field_channel=topic_channel)
+    SubfieldFactory.create_batch(related_count, parent_channel=topic_channel)
 
     url = reverse(
         "channels:v0:field_channels_api-detail",
-        kwargs={"id": field_channel.id},
+        kwargs={"id": topic_channel.id},
     )
     with django_assert_num_queries(expected_query_count):
         user_client.get(url)

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -1581,12 +1581,14 @@ export const ChannelsApiAxiosParamCreator = function (
     /**
      * CRUD Operations related to FieldChannels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
      * @summary List
+     * @param {ChannelsListChannelTypeEnum} [channel_type] * &#x60;topic&#x60; - Topic * &#x60;department&#x60; - Department * &#x60;offeror&#x60; - Offeror * &#x60;pathway&#x60; - Pathway
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     channelsList: async (
+      channel_type?: ChannelsListChannelTypeEnum,
       limit?: number,
       offset?: number,
       options: RawAxiosRequestConfig = {},
@@ -1606,6 +1608,10 @@ export const ChannelsApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
+
+      if (channel_type !== undefined) {
+        localVarQueryParameter["channel_type"] = channel_type
+      }
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
@@ -2007,12 +2013,14 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
     /**
      * CRUD Operations related to FieldChannels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
      * @summary List
+     * @param {ChannelsListChannelTypeEnum} [channel_type] * &#x60;topic&#x60; - Topic * &#x60;department&#x60; - Department * &#x60;offeror&#x60; - Offeror * &#x60;pathway&#x60; - Pathway
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async channelsList(
+      channel_type?: ChannelsListChannelTypeEnum,
       limit?: number,
       offset?: number,
       options?: RawAxiosRequestConfig,
@@ -2023,6 +2031,7 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<PaginatedFieldChannelList>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.channelsList(
+        channel_type,
         limit,
         offset,
         options,
@@ -2278,6 +2287,7 @@ export const ChannelsApiFactory = function (
     ): AxiosPromise<PaginatedFieldChannelList> {
       return localVarFp
         .channelsList(
+          requestParameters.channel_type,
           requestParameters.limit,
           requestParameters.offset,
           options,
@@ -2426,6 +2436,13 @@ export interface ChannelsApiChannelsDestroyRequest {
  * @interface ChannelsApiChannelsListRequest
  */
 export interface ChannelsApiChannelsListRequest {
+  /**
+   * * &#x60;topic&#x60; - Topic * &#x60;department&#x60; - Department * &#x60;offeror&#x60; - Offeror * &#x60;pathway&#x60; - Pathway
+   * @type {'department' | 'offeror' | 'pathway' | 'topic'}
+   * @memberof ChannelsApiChannelsList
+   */
+  readonly channel_type?: ChannelsListChannelTypeEnum
+
   /**
    * Number of results to return per page.
    * @type {number}
@@ -2607,7 +2624,12 @@ export class ChannelsApi extends BaseAPI {
     options?: RawAxiosRequestConfig,
   ) {
     return ChannelsApiFp(this.configuration)
-      .channelsList(requestParameters.limit, requestParameters.offset, options)
+      .channelsList(
+        requestParameters.channel_type,
+        requestParameters.limit,
+        requestParameters.offset,
+        options,
+      )
       .then((request) => request(this.axios, this.basePath))
   }
 
@@ -2728,6 +2750,18 @@ export class ChannelsApi extends BaseAPI {
       .then((request) => request(this.axios, this.basePath))
   }
 }
+
+/**
+ * @export
+ */
+export const ChannelsListChannelTypeEnum = {
+  Department: "department",
+  Offeror: "offeror",
+  Pathway: "pathway",
+  Topic: "topic",
+} as const
+export type ChannelsListChannelTypeEnum =
+  (typeof ChannelsListChannelTypeEnum)[keyof typeof ChannelsListChannelTypeEnum]
 
 /**
  * CkeditorApi - axios parameter creator

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -12,6 +12,20 @@ paths:
         or organizations at MIT and are a high-level categorization of content.
       summary: List
       parameters:
+      - in: query
+        name: channel_type
+        schema:
+          type: string
+          enum:
+          - department
+          - offeror
+          - pathway
+          - topic
+        description: |-
+          * `topic` - Topic
+          * `department` - Department
+          * `offeror` - Offeror
+          * `pathway` - Pathway
       - name: limit
         required: false
         in: query


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/3973


### Description (What does it do?)
- Adds a `channel_type` filter option to the channels API
- Removes some n+1 queries from the channels API view


### How can this be tested?
If you haven't already, run `./manage.py backpopulate_field_channels`

The following should work, and filter appropriately:
- http://localhost:8063/api/v0/channels/?channel_type=offeror
- http://localhost:8063/api/v0/channels/?channel_type=department
- http://localhost:8063/api/v0/channels/?channel_type=topic
- http://localhost:8063/api/v0/channels/
