### PR TITLE
add certification as facet to field search

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.0.4",
+    "@mitodl/course-search-utils": "^3.0.5",
     "@mui/icons-material": "^5.14.19",
     "@sentry/react": "^7.57.0",
     "@tanstack/react-query": "^4.36.1",

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
@@ -8,7 +8,11 @@ import WidgetsList from "./WidgetsList"
 import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
 import { makeFieldViewPath } from "@/common/urls"
 import FieldSearch from "./FieldSearch"
-import type { Facets, FacetKey } from "@mitodl/course-search-utils"
+import type {
+  Facets,
+  FacetKey,
+  BooleanFacets,
+} from "@mitodl/course-search-utils"
 import { ChannelTypeEnum } from "api/v0"
 
 type RouteParams = {
@@ -45,7 +49,7 @@ const FieldPage: React.FC = () => {
     navigate(makeFieldViewPath(String(channelType), String(name)))
   }, [navigate, channelType, name])
 
-  const searchParams: Facets = {}
+  const searchParams: Facets & BooleanFacets = {}
 
   if (fieldQuery.data?.search_filter) {
     const urlParams = new URLSearchParams(fieldQuery.data.search_filter)

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -149,15 +149,27 @@ describe("FieldSearch", () => {
   test.each([
     {
       fieldType: ChannelTypeEnum.Topic,
-      displayedFacets: ["Resource Type", "Offered By", "Department", "Level"],
+      displayedFacets: [
+        "Resource Type",
+        "Offered By",
+        "Department",
+        "Level",
+        "Certification",
+      ],
     },
     {
       fieldType: ChannelTypeEnum.Department,
-      displayedFacets: ["Resource Type", "Offered By", "Topic", "Level"],
+      displayedFacets: [
+        "Resource Type",
+        "Offered By",
+        "Topic",
+        "Level",
+        "Certification",
+      ],
     },
     {
       fieldType: ChannelTypeEnum.Offeror,
-      displayedFacets: ["Resource Type", "Topic", "Platform"],
+      displayedFacets: ["Resource Type", "Topic", "Platform", "Certification"],
     },
     {
       fieldType: ChannelTypeEnum.Pathway,
@@ -181,6 +193,7 @@ describe("FieldSearch", () => {
               resource_type: [{ key: "course", doc_count: 100 }],
               platform: [{ key: "ocw", doc_count: 100 }],
               offered_by: [{ key: "ocw", doc_count: 100 }],
+              certification: [{ key: "true", doc_count: 100 }],
             },
             suggestions: [],
           },
@@ -200,6 +213,7 @@ describe("FieldSearch", () => {
         "Offered By",
         "Platforn",
         "Topic",
+        "Certification",
       ]) {
         if (dropdownName in displayedFacets) {
           await screen.findByText(dropdownName)
@@ -210,7 +224,7 @@ describe("FieldSearch", () => {
     },
   )
 
-  test("Selected Facets should be displayed and toggleable", async () => {
+  test("Multi-select facets should be displayed and toggleable", async () => {
     const { field } = setMockApiResponses({
       fieldPatch: {
         channel_type: ChannelTypeEnum.Department,
@@ -267,5 +281,101 @@ describe("FieldSearch", () => {
     courseSelect = await screen.findByText("Course")
 
     expect(courseSelect).toHaveAttribute("aria-selected", "false")
+  })
+
+  test("Boolean facets should be displayed and toggleable", async () => {
+    const { field } = setMockApiResponses({
+      fieldPatch: {
+        channel_type: ChannelTypeEnum.Department,
+        search_filter: "offered_by=ocw",
+      },
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            certification: [
+              { key: "true", doc_count: 100 },
+              { key: "false", doc_count: 100 },
+            ],
+          },
+          suggestions: [],
+        },
+        results: [],
+      },
+    })
+
+    const { location } = renderTestApp({
+      url: `/c/${field.channel_type}/${field.name}/`,
+    })
+    expect(location.current.search).toBe("")
+    await waitFor(() => {
+      expect(makeRequest.mock.calls.length > 0).toBe(true)
+    })
+
+    let certificationDropdown = await screen.findByText("Certification")
+
+    await user.click(certificationDropdown)
+
+    let noneSelect = await screen.findByRole("option", {
+      name: "no selection",
+    })
+
+    expect(noneSelect).toHaveAttribute("aria-selected", "true")
+
+    let trueSelect = await screen.findByRole("option", {
+      name: /true/i,
+    })
+
+    expect(trueSelect).toHaveAttribute("aria-selected", "false")
+
+    await user.click(trueSelect)
+
+    expect(location.current.search).toBe("?certification=true")
+
+    certificationDropdown = await screen.findByText("Certification")
+
+    await user.click(certificationDropdown)
+
+    trueSelect = await screen.findByRole("option", {
+      name: /true/i,
+    })
+
+    expect(trueSelect).toHaveAttribute("aria-selected", "true")
+
+    let falseSelect = await screen.findByRole("option", {
+      name: /false/i,
+    })
+
+    expect(falseSelect).toHaveAttribute("aria-selected", "false")
+
+    await user.click(falseSelect)
+
+    expect(location.current.search).toBe("?certification=false")
+
+    certificationDropdown = await screen.findByText("Certification")
+
+    await user.click(certificationDropdown)
+
+    falseSelect = await screen.findByRole("option", {
+      name: /false/i,
+    })
+
+    expect(falseSelect).toHaveAttribute("aria-selected", "true")
+
+    trueSelect = await screen.findByRole("option", {
+      name: /true/i,
+    })
+
+    expect(trueSelect).toHaveAttribute("aria-selected", "false")
+
+    noneSelect = await screen.findByRole("option", {
+      name: /no selection/i,
+    })
+
+    expect(noneSelect).toHaveAttribute("aria-selected", "false")
+
+    await user.click(noneSelect)
+
+    expect(location.current.search).toBe("")
   })
 })

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
@@ -28,7 +28,7 @@ import {
   getDepartmentName,
   getLevelName,
 } from "@mitodl/course-search-utils"
-import type { Facets } from "@mitodl/course-search-utils"
+import type { Facets, BooleanFacets } from "@mitodl/course-search-utils"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
 import LearningResourceCard from "@/page-components/LearningResourceCard/LearningResourceCard"
 import CardRowList from "@/components/CardRowList/CardRowList"
@@ -46,14 +46,21 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
     "offered_by",
     "department",
     "level",
+    "certification",
   ],
   [ChannelTypeEnum.Department]: [
     "resource_type",
     "offered_by",
     "topic",
     "level",
+    "certification",
   ],
-  [ChannelTypeEnum.Offeror]: ["resource_type", "topic", "Platform"],
+  [ChannelTypeEnum.Offeror]: [
+    "resource_type",
+    "topic",
+    "platform",
+    "certification",
+  ],
   [ChannelTypeEnum.Pathway]: [],
 }
 
@@ -94,6 +101,10 @@ const getFacetManifest = (
       title: "Offered By",
       labelFunction: (key: string) => offerors[key]?.name ?? key,
     },
+    {
+      name: "certification",
+      title: "Certification",
+    },
   ].filter(
     (facetSetting: SingleFacetOptions) =>
       !Object.keys(constantSearchParams).includes(facetSetting.name) &&
@@ -126,7 +137,7 @@ export const FieldSearchControls = styled.div`
 const PAGE_SIZE = 10
 
 interface FeildSearchProps {
-  constantSearchParams: Facets
+  constantSearchParams: Facets & BooleanFacets
   channelType: ChannelTypeEnum
 }
 
@@ -177,7 +188,7 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
 
   const {
     params,
-    toggleParamValue,
+    setParamValue,
     currentText,
     setCurrentText,
     setCurrentTextAndQuery,
@@ -200,7 +211,7 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
       aggregations: facetNames as LRSearchRequest["aggregations"],
       offset: (page - 1) * PAGE_SIZE,
     },
-    { keepPreviousData: false },
+    { keepPreviousData: true },
   )
 
   return (
@@ -210,8 +221,8 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
           <GridColumn variant="main-2-wide-main">
             <AvailableFacetsDropdowns
               facetMap={facetManifest}
-              activeFacets={allParams}
-              onFacetChange={toggleParamValue}
+              activeFacets={allParams as Facets & BooleanFacets}
+              onFacetChange={setParamValue}
               facetOptions={(name) => data?.metadata.aggregations?.[name] ?? []}
               constantSearchParams={constantSearchParams}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,9 +3755,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "@mitodl/course-search-utils@npm:3.0.4"
+"@mitodl/course-search-utils@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@mitodl/course-search-utils@npm:3.0.5"
   dependencies:
     "@mitodl/open-api-axios": ^2024.3.22
     "@testing-library/react": 12
@@ -3779,7 +3779,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 65a3e2424296add21b2fe182a00e08ed8679cf770f93b538af71e36251641e6c1aa244ba03a6d1520d0aad4c6443b344b56b2ed435441662768b97b893494746
+  checksum: 429bf80dbfa4b08a513d10c9a1221569aa96b071d166131fdebb8e6bdab53a1a607a4541ed21ba2ca830860722b02e69d25f915b850b6aa1a7e7c52cb86a86a0
   languageName: node
   linkType: hard
 
@@ -17473,7 +17473,7 @@ __metadata:
     "@emotion/react": ^11.11.1
     "@emotion/styled": ^11.11.0
     "@faker-js/faker": ^7.3.0
-    "@mitodl/course-search-utils": ^3.0.4
+    "@mitodl/course-search-utils": ^3.0.5
     "@mui/icons-material": ^5.14.19
     "@sentry/react": ^7.57.0
     "@storybook/addon-essentials": ^8.0.6


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/mit-open/issues/745
also closes https://github.com/mitodl/mit-open/issues/750

### Description (What does it do?)
This pr adds certification as a facet for topic, department or offeror channels

### Screenshots (if appropriate):
<img width="1719" alt="Screenshot 2024-04-23 at 8 15 56 AM" src="https://github.com/mitodl/mit-open/assets/1934992/d1d66b51-9195-4e5a-845a-ec3e1a674d84">


### How can this be tested?
- find or create a   topic, department or offeror  channel. Make sure that a search filter is set
- go to http://localhost:8063/c/channel-type/channel-name/ 
- verify that you see a dropdown for certification and are able to use it to filter the results