### PR TITLE
#629 Build front end during release CI

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,11 +19,22 @@ jobs:
         with:
           ref: release
 
-      - name: Download frontend build
-        uses: actions/download-artifact@v4
+      - uses: actions/setup-node@v4
         with:
-          name: frontend-build
-          path: frontends/mit-open/build
+          node-version: "18.18.2"
+          cache: yarn
+          cache-dependency-path: frontends/yarn.lock
+
+      - name: Setup environment
+        run: sudo apt-get install libelf1
+
+      - name: Install frontend dependencies
+        working-directory: frontends
+        run: yarn install --immutable
+
+      - name: Build frontend
+        working-directory: frontends
+        run: yarn run build
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,11 +19,22 @@ jobs:
         with:
           ref: release-candidate
 
-      - name: Download frontend build
-        uses: actions/download-artifact@v4
+      - uses: actions/setup-node@v4
         with:
-          name: frontend-build
-          path: frontends/mit-open/build
+          node-version: "18.18.2"
+          cache: yarn
+          cache-dependency-path: frontends/yarn.lock
+
+      - name: Setup environment
+        run: sudo apt-get install libelf1
+
+      - name: Install frontend dependencies
+        working-directory: frontends
+        run: yarn install --immutable
+
+      - name: Build frontend
+        working-directory: frontends
+        run: yarn run build
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:


### PR DESCRIPTION
For [Load session from API and configure decoupled frontend for local development #616](https://github.com/mitodl/mit-open/issues/616) we are serving the static content with Nginx on Heroku.

This commit attempted to download the frontend build artifact from the previous CI workflow, but failed to do so.

This PR builds the front end during release workflows.

This is an interim solution as we will ultimately deploy the front end separately for [CI and deployment config for decoupled front end #629](https://github.com/mitodl/mit-open/issues/629).