### PR TITLE
Move hash.txt location to frontend build directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,8 @@ jobs:
           || { echo "OpenAPI spec is out of date. Please regenerate via ./scripts/generate_openapi.sh"; exit 1; }
 
   e2e-tests:
+    # Disabling the E2E tests for now
+    if: false
     runs-on: ubuntu-latest
 
     steps:

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -2,5 +2,5 @@
 
 # Syntax bin/compile <build-dir> <cache-dir>
 
-echo "-----> Writing out SOURCE_VERSION to static/hash ($SOURCE_VERSION)"
-echo $SOURCE_VERSION >$BUILD_DIR/static/hash.txt
+echo "-----> Writing out SOURCE_VERSION to frontends/build/static/hash ($SOURCE_VERSION)"
+echo $SOURCE_VERSION >$BUILD_DIR/frontends/build/static/hash.txt


### PR DESCRIPTION
Relates to [CI and deployment config for decoupled front end #629](https://github.com/mitodl/mit-open/issues/629) (interim deployment).

We write the SOURCE_VERSION to a hash.txt file for doof to determine release.

This PR updates the path to the new static directory location, missed on previous commit.

Assumes that `$BUILD_DIR` is `/app` on Heroku (and that the new CI steps to build the frontend and push to Heroku are working correctly).

Also disables the E2E test job as these are not in use.
