### PR TITLE
Populate prices for mitxonline programs

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -82,6 +82,20 @@ def extract_courses():
     return []
 
 
+def parse_program_prices(program_data: dict) -> list[float]:
+    """Return a list of unique prices for a program"""
+    prices = [program_data.get("current_price") or 0.00]
+    price_string = parse_page_attribute(program_data, "price")
+    if price_string:
+        prices.extend(
+            [
+                float(price.replace(",", ""))
+                for price in re.findall(r"[\d\.,]+", price_string)
+            ]
+        )
+    return sorted(set(prices))
+
+
 def _transform_image(mitxonline_data: dict) -> dict:
     """
     Transforms an image into our normalized data structure
@@ -225,6 +239,7 @@ def transform_programs(programs):
                     "url": parse_page_attribute(program, "page_url", is_url=True),
                     "image": _transform_image(program),
                     "description": parse_page_attribute(program, "description"),
+                    "prices": parse_program_prices(program),
                 }
             ],
             "courses": [


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4077

### Description (What does it do?)
Adjusts the ETL code for mitxonline to save program prices.


### How can this be tested?
- Set the following .env variables:
  ```
  MITX_ONLINE_BASE_URL=https://mitxonline.mit.edu/
  MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/courses/
  MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/programs/
  ```
- Run `./manage.py backpopulate_mitxonline_data`
- Go to http://localhost:8063/api/v1/programs/?platform=mitxonline and check that the `prices` field for each program run (ignore the child courses/runs) is an array with numeric values.
