### PR TITLE
fixing compose mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
       - opensearch-node-mitopen
       - redis
     volumes:
+      - .:/src
       - django_media:/var/media
 
   watch:


### PR DESCRIPTION
### Description (What does it do?)
Adds the local src mount for the web container


### How can this be tested?
do a ```docker-compose down``` followed by ```docker-compose up``` . make a change to some python file. then get into the web container via ```docker-compose exec -ti web /bin/bash``` and see that whatever change that was made persists in the container.

