### PR TITLE
Deployment fixes for static frontend on Heroku

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,23 +19,6 @@ jobs:
         with:
           ref: release
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18.18.2"
-          cache: yarn
-          cache-dependency-path: frontends/yarn.lock
-
-      - name: Setup environment
-        run: sudo apt-get install libelf1
-
-      - name: Install frontend dependencies
-        working-directory: frontends
-        run: yarn install --immutable
-
-      - name: Build frontend
-        working-directory: frontends
-        run: yarn run build
-
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,23 +19,6 @@ jobs:
         with:
           ref: release-candidate
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "18.18.2"
-          cache: yarn
-          cache-dependency-path: frontends/yarn.lock
-
-      - name: Setup environment
-        run: sudo apt-get install libelf1
-
-      - name: Install frontend dependencies
-        working-directory: frontends
-        run: yarn install --immutable
-
-      - name: Build frontend
-        working-directory: frontends
-        run: yarn run build
-
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -3,5 +3,5 @@
 # Syntax bin/compile <build-dir> <cache-dir>
 
 echo "-----> Writing out SOURCE_VERSION to frontends/build/static/hash ($SOURCE_VERSION)"
-mkdir -p /app/frontends/build/static
-echo $SOURCE_VERSION >/app/frontends/build/static/hash.txt
+mkdir -p $BUILD_DIR/frontends/build/static
+echo $SOURCE_VERSION >$BUILD_DIR/frontends/build/static/hash.txt

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -3,4 +3,5 @@
 # Syntax bin/compile <build-dir> <cache-dir>
 
 echo "-----> Writing out SOURCE_VERSION to frontends/build/static/hash ($SOURCE_VERSION)"
-echo $SOURCE_VERSION >$BUILD_DIR/frontends/build/static/hash.txt
+mkdir -p /app/frontends/build/static
+echo $SOURCE_VERSION >/app/frontends/build/static/hash.txt

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -78,7 +78,7 @@ module.exports = (env, argv) => {
             filename: "[name].js",
           }),
       publicPath: "/",
-      clean: true,
+      clean: !isProduction,
     },
     module: {
       rules: [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "heroku-entry",
+  "description": "Provides build entrypoint for heroku-buildpack-nodejs",
+  "version": "1.0.0",
+  "repository": "https://github.com/mitodl/mit-open.git",
+  "license": "MIT",
+  "scripts": {
+    "build": "yarn --cwd frontends build"
+  }
+}


### PR DESCRIPTION
- Provides a package.json at root providing a build script for the NodeJS Buildpack.
- Adds mkdir for https://github.com/mitodl/mit-open/pull/815 (frontend build paths not created at pre-compile).
- Removes release CI steps to build frontend.
- Configures Webpack to not clear the build directory in production mode (or would delete hash.txt).