### PR TITLE
Set engines on package.json to instruct Heroku to install yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "version": "1.0.0",
   "repository": "https://github.com/mitodl/mit-open.git",
   "license": "MIT",
+  "engines": {
+    "node": "^20.12.2",
+    "yarn": "^1.22.11"
+  },
   "scripts": {
     "build": "yarn --cwd frontends build"
   }


### PR DESCRIPTION
Ongoing from [Deployment fixes for static frontend on Heroku](https://github.com/mitodl/mit-open/pull/819) - adding fix for current error:

```
-----> Build
       Running build
       
       > heroku-entry@1.0.0 build
       > yarn --cwd frontends build
       
sh: 1: yarn: not found
```