### PR TITLE
Remove package manager config

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -1,7 +1,6 @@
 {
   "name": "api",
   "version": "workspace:*",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "sideEffects": false,
   "exports": {

--- a/frontends/github-pages/package.json
+++ b/frontends/github-pages/package.json
@@ -1,7 +1,6 @@
 {
   "name": "github-pages",
   "version": "0.1.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "dependencies": {
     "ol-components": "0.0.0",

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -1,7 +1,6 @@
 {
   "name": "mit-open",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "license": "BSD-3-Clause",
   "repository": {

--- a/frontends/ol-ckeditor/package.json
+++ b/frontends/ol-ckeditor/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-ckeditor",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "exports": {
     ".": "./src/index.ts",

--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-components",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "exports": {
     ".": "./src/index.ts",

--- a/frontends/ol-template/package.json
+++ b/frontends/ol-template/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-template",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "description": "Templates for the frontend.",
   "type": "module",

--- a/frontends/ol-test-utilities/package.json
+++ b/frontends/ol-test-utilities/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-test-utilities",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "exports": {
     ".": "./src/index.ts",

--- a/frontends/ol-utilities/package.json
+++ b/frontends/ol-utilities/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-utilities",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "exports": {
     ".": "./src/index.ts",

--- a/frontends/ol-widgets/package.json
+++ b/frontends/ol-widgets/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ol-widgets",
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "private": true,
   "main": "./src/index.ts",
   "dependencies": {

--- a/frontends/package.json
+++ b/frontends/package.json
@@ -39,7 +39,6 @@
     "build-storybook": "yarn workspace mit-open build-storybook"
   },
   "version": "0.0.0",
-  "packageManager": "yarn@4.1.1",
   "devDependencies": {
     "@swc/core": "^1.4.11",
     "@swc/jest": "^0.2.26",


### PR DESCRIPTION
Continuing [Deployment fixes for static frontend on Heroku #819](https://github.com/mitodl/mit-open/pull/819).

Aims to resolve most recent build issue on Heroku:

```
-----> Build
       Running build
       
       > heroku-entry@1.0.0 build
       > yarn --cwd frontends build
       
error This project's package.json defines "packageManager": "yarn@4.1.1". However the current global version of Yarn is 1.22.22.
Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
```