### PR TITLE
Don't initialize PostHog if it's disabled

### DIFF
--- a/main/features.py
+++ b/main/features.py
@@ -31,17 +31,18 @@ def configure():
     The posthog library normally takes care of this but it doesn't
     expose all the client config options.
     """
-    posthog.default_client = posthog.Client(
-        api_key=settings.POSTHOG_PROJECT_API_KEY,
-        host=settings.POSTHOG_API_HOST,
-        debug=settings.DEBUG,
-        on_error=None,
-        send=None,
-        sync_mode=False,
-        poll_interval=30,
-        disable_geoip=True,
-        feature_flags_request_timeout_seconds=3,
-    )
+    if settings.POSTHOG_ENABLED:
+        posthog.default_client = posthog.Client(
+            api_key=settings.POSTHOG_PROJECT_API_KEY,
+            host=settings.POSTHOG_API_HOST,
+            debug=settings.DEBUG,
+            on_error=None,
+            send=None,
+            sync_mode=False,
+            poll_interval=30,
+            disable_geoip=True,
+            feature_flags_request_timeout_seconds=3,
+        )
 
 
 def default_unique_id() -> str:


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

This PR updates `main.features.configure()` to checks to see if `POSTHOG_ENABLED` is set to True before attempting to initialize PostHog. This should resolve the issue noted by @gumaerc - if you disable PostHog in the `.env` file (and notably don't have any of the other settings set, like the project key), you get errors relating to initialization failing, and the app doesn't work. 

### How can this be tested?

Automated tests should pass.

If `POSTHOG_ENABLED=False` is set in `.env`, and (importantly) there are _no other PostHog settings set_, the app should start and work successfully. 
