### PR TITLE
Corrects the hash.txt path

### DIFF
--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -2,6 +2,6 @@
 
 # Syntax bin/compile <build-dir> <cache-dir>
 
-echo "-----> Writing out SOURCE_VERSION to frontends/build/static/hash ($SOURCE_VERSION)"
-mkdir -p $BUILD_DIR/frontends/build/static
-echo $SOURCE_VERSION >$BUILD_DIR/frontends/build/static/hash.txt
+echo "-----> Writing out SOURCE_VERSION ($SOURCE_VERSION) to $BUILD_DIR/frontends/mit-open/build/static"
+mkdir -p $BUILD_DIR/frontends/mit-open/build/static
+echo $SOURCE_VERSION >$BUILD_DIR/frontends/mit-open/build/static/hash.txt


### PR DESCRIPTION
The hash.txt for verifying releases is written to an incorrect path on previous commit. This corrects.