### PR TITLE
Adds the /complete/ol-oidc route to Nginx to forward to the backend

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -28,7 +28,7 @@ server {
         return 204;
     }
 
-    location ~ ^/(api|login|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
+    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
         include uwsgi_params;
         uwsgi_pass web:8061;
         uwsgi_pass_request_headers on;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -75,7 +75,7 @@ http {
             return 204;
         }
 
-        location ~ ^/(api|login|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
+        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;
             uwsgi_param CONTENT_TYPE $content_type;


### PR DESCRIPTION
A previous [merge](jk/alert-ui-device) to use Nginx to serve the static frontend included path matching for the backend so that all non matched paths server the frontend app. This auth route was missed causing issues with login.