### PR TITLE
Additional routes to the Django app

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -20,6 +20,10 @@ server {
         try_files /static$uri $uri @index;
     }
 
+    location ~ ^/program_letter/([0-9]+)/view$ {
+        try_files /index.html =404;
+    }
+
     location @index {
         try_files /index.html =404;
     }
@@ -28,7 +32,7 @@ server {
         return 204;
     }
 
-    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
+    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|program_letter/([0-9]+)/) {
         include uwsgi_params;
         uwsgi_pass web:8061;
         uwsgi_pass_request_headers on;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ server {
         return 204;
     }
 
-    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|program_letter/([0-9]+)/) {
+    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|profile/program_letter/([0-9]+)/) {
         include uwsgi_params;
         uwsgi_pass web:8061;
         uwsgi_pass_request_headers on;

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -32,7 +32,7 @@ server {
         return 204;
     }
 
-    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|program_letter/([0-9]+)/) {
+    location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|program_letter/([0-9]+)/) {
         include uwsgi_params;
         uwsgi_pass web:8061;
         uwsgi_pass_request_headers on;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -80,7 +80,7 @@ http {
             return 204;
         }
 
-        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|program_letter/([0-9]+)/) {
+        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|program_letter/([0-9]+)/) {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;
             uwsgi_param CONTENT_TYPE $content_type;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -66,6 +66,11 @@ http {
             try_files /frontends/mit-open/build/static$uri /frontends/mit-open/build$uri @index;
         }
 
+        location ~ ^/program_letter/([0-9]+)/view$ {
+            expires 1m;
+            try_files /frontends/mit-open/build/index.html =404;
+        }
+
         location @index {
             expires 1m;
             try_files /frontends/mit-open/build/index.html =404;
@@ -75,7 +80,7 @@ http {
             return 204;
         }
 
-        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_features) {
+        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|program_letter/([0-9]+)/) {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;
             uwsgi_param CONTENT_TYPE $content_type;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -80,7 +80,7 @@ http {
             return 204;
         }
 
-        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|program_letter/([0-9]+)/) {
+        location ~ ^/(api|login|complete/ol-oidc|logout|admin|static/admin|static/rest_framework|static/hijack|_/features/|scim/|o/|disconnect/|podcasts/rss_feed|__debug__/|media/|profile/|program_letter/([0-9]+)/) {
             uwsgi_param QUERY_STRING $query_string;
             uwsgi_param REQUEST_METHOD $request_method;
             uwsgi_param CONTENT_TYPE $content_type;


### PR DESCRIPTION
Adds additional routes for Nginx to forward to the Django backend:

- `/_/features/`
- `/scim/`
- `/o/`
- `/disconnect/`
- `/podcasts/rss_feed`
- `/__debug__/`
- `/program_letter/([0-9]+)/`

This matches for front end handling of the view route:
- `/program_letter/([0-9]+)/view`