### PR TITLE
Alert UI component

### DIFF
--- a/frontends/ol-components/src/components/Alert/Alert.stories.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Alert> = {
   component: Alert,
   argTypes: {
     severity: {
-      options: ["success", "info", "warning", "error"],
+      options: ["info", "success", "warning", "error"],
       control: {
         type: "select",
       },
@@ -30,7 +30,7 @@ export default meta
 
 type Story = StoryObj<typeof Alert>
 
-export const Plain: Story = {
+export const Basic: Story = {
   args: {
     severity: "info",
   },

--- a/frontends/ol-components/src/components/Alert/Alert.stories.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import { Alert } from "./Alert"
+import Stack from "@mui/material/Stack"
+
+const meta: Meta<typeof Alert> = {
+  title: "smoot-design/Alert",
+  component: Alert,
+  argTypes: {
+    severity: {
+      options: ["success", "info", "warning", "error"],
+      control: {
+        type: "select",
+      },
+    },
+    visible: {
+      control: {
+        type: "boolean",
+      },
+    },
+    closeable: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Alert>
+
+export const Plain: Story = {
+  args: {
+    severity: "success",
+  },
+  render: (args) => (
+    <Alert {...args}>Alert with severity "{args.severity}"</Alert>
+  ),
+}
+
+export const Closable: Story = {
+  args: {
+    severity: "success",
+    closeable: true,
+  },
+  render: (args) => (
+    <Alert {...args}>Closable alert with severity "{args.severity}"</Alert>
+  ),
+}
+
+export const Variants: Story = {
+  render: (args) => (
+    <Stack direction="column" gap={2} sx={{ my: 2 }}>
+      <Alert {...args} severity="success">
+        Alert with severity "success"
+      </Alert>
+      <Alert {...args} severity="info">
+        Alert with severity "info"
+      </Alert>
+      <Alert {...args} severity="warning">
+        Alert with severity "warning"
+      </Alert>
+      <Alert {...args} severity="error">
+        Alert with severity "error"
+      </Alert>
+      <Alert {...args} closeable severity="success">
+        Closeable alert with severity "success"
+      </Alert>
+      <Alert {...args} closeable severity="info">
+        Closeable alert with severity "info"
+      </Alert>
+      <Alert {...args} closeable severity="warning">
+        Closeable alert with severity "warning"
+      </Alert>
+      <Alert {...args} closeable severity="error">
+        Closeable alert with severity "error"
+      </Alert>
+    </Stack>
+  ),
+}

--- a/frontends/ol-components/src/components/Alert/Alert.stories.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof Alert>
 
 export const Plain: Story = {
   args: {
-    severity: "success",
+    severity: "info",
   },
   render: (args) => (
     <Alert {...args}>Alert with severity "{args.severity}"</Alert>
@@ -41,7 +41,7 @@ export const Plain: Story = {
 
 export const Closable: Story = {
   args: {
-    severity: "success",
+    severity: "warning",
     closeable: true,
   },
   render: (args) => (
@@ -50,28 +50,40 @@ export const Closable: Story = {
 }
 
 export const Variants: Story = {
+  argTypes: {
+    severity: {
+      table: {
+        disable: true,
+      },
+    },
+    closeable: {
+      table: {
+        disable: true,
+      },
+    },
+  },
   render: (args) => (
     <Stack direction="column" gap={2} sx={{ my: 2 }}>
-      <Alert {...args} severity="success">
-        Alert with severity "success"
-      </Alert>
       <Alert {...args} severity="info">
         Alert with severity "info"
-      </Alert>
-      <Alert {...args} severity="warning">
-        Alert with severity "warning"
-      </Alert>
-      <Alert {...args} severity="error">
-        Alert with severity "error"
-      </Alert>
-      <Alert {...args} closeable severity="success">
-        Closeable alert with severity "success"
       </Alert>
       <Alert {...args} closeable severity="info">
         Closeable alert with severity "info"
       </Alert>
+      <Alert {...args} severity="success">
+        Alert with severity "success"
+      </Alert>
+      <Alert {...args} closeable severity="success">
+        Closeable alert with severity "success"
+      </Alert>
+      <Alert {...args} severity="warning">
+        Alert with severity "warning"
+      </Alert>
       <Alert {...args} closeable severity="warning">
         Closeable alert with severity "warning"
+      </Alert>
+      <Alert {...args} severity="error">
+        Alert with severity "error"
       </Alert>
       <Alert {...args} closeable severity="error">
         Closeable alert with severity "error"

--- a/frontends/ol-components/src/components/Alert/Alert.stories.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.stories.tsx
@@ -18,7 +18,7 @@ const meta: Meta<typeof Alert> = {
         type: "boolean",
       },
     },
-    closeable: {
+    closable: {
       control: {
         type: "boolean",
       },
@@ -42,7 +42,7 @@ export const Basic: Story = {
 export const Closable: Story = {
   args: {
     severity: "warning",
-    closeable: true,
+    closable: true,
   },
   render: (args) => (
     <Alert {...args}>Closable alert with severity "{args.severity}"</Alert>
@@ -56,7 +56,7 @@ export const Variants: Story = {
         disable: true,
       },
     },
-    closeable: {
+    closable: {
       table: {
         disable: true,
       },
@@ -67,26 +67,26 @@ export const Variants: Story = {
       <Alert {...args} severity="info">
         Alert with severity "info"
       </Alert>
-      <Alert {...args} closeable severity="info">
-        Closeable alert with severity "info"
+      <Alert {...args} closable severity="info">
+        Closable alert with severity "info"
       </Alert>
       <Alert {...args} severity="success">
         Alert with severity "success"
       </Alert>
-      <Alert {...args} closeable severity="success">
-        Closeable alert with severity "success"
+      <Alert {...args} closable severity="success">
+        Closable alert with severity "success"
       </Alert>
       <Alert {...args} severity="warning">
         Alert with severity "warning"
       </Alert>
-      <Alert {...args} closeable severity="warning">
-        Closeable alert with severity "warning"
+      <Alert {...args} closable severity="warning">
+        Closable alert with severity "warning"
       </Alert>
       <Alert {...args} severity="error">
         Alert with severity "error"
       </Alert>
-      <Alert {...args} closeable severity="error">
-        Closeable alert with severity "error"
+      <Alert {...args} closable severity="error">
+        Closable alert with severity "error"
       </Alert>
     </Stack>
   ),

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -1,7 +1,57 @@
 import React, { useEffect } from "react"
-import { default as MuiAlert } from "@mui/material/Alert"
-
+import styled from "@emotion/styled"
+import { default as MuiAlert, AlertColor } from "@mui/material/Alert"
+import { theme } from "../ThemeProvider/ThemeProvider"
 import type { AlertProps as MuiAlertProps } from "@mui/material/Alert"
+import { pxToRem } from "../ThemeProvider/typography"
+
+type Colors = {
+  [Severity in AlertColor]: string
+}
+
+const COLORS: Colors = {
+  info: theme.custom.colors.blue,
+  success: theme.custom.colors.green,
+  warning: theme.custom.colors.orange,
+  error: theme.custom.colors.lightRed,
+}
+
+type AlertStyleProps = {
+  severity: AlertColor
+}
+
+const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ severity }) => ({
+  padding: "11px 16px",
+  borderRadius: 4,
+  borderWidth: 2,
+  borderStyle: "solid",
+  borderColor: COLORS[severity],
+  background: "#FFF",
+  ".MuiAlert-message": {
+    lineHeight: pxToRem(22),
+    verticalAlign: "middle",
+    fontSize: pxToRem(14),
+    color: theme.custom.colors.darkGray2,
+  },
+  "> div": {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  ".MuiAlert-icon": {
+    marginRight: 8,
+    svg: {
+      width: 16,
+      fill: COLORS[severity],
+    },
+  },
+  button: {
+    padding: 0,
+    ":hover": {
+      margin: 0,
+      background: "none",
+    },
+  },
+}))
 
 type AlertProps = { visible?: boolean; closeable?: boolean } & Pick<
   MuiAlertProps,
@@ -31,12 +81,14 @@ const Alert: React.FC<AlertProps> = ({
   }
 
   return (
-    <MuiAlert
-      severity={severity}
+    <AlertStyled
+      severity={severity!}
       onClose={closeable ? onCloseClick : undefined}
+      role="alert"
+      aria-description={`${severity} message`}
     >
       {children}
-    </MuiAlert>
+    </AlertStyled>
   )
 }
 

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect } from "react"
+import { default as MuiAlert } from "@mui/material/Alert"
+
+import type { AlertProps as MuiAlertProps } from "@mui/material/Alert"
+
+type AlertProps = { visible?: boolean; closeable?: boolean } & Pick<
+  MuiAlertProps,
+  "severity" | "children"
+>
+
+const Alert: React.FC<AlertProps> = ({
+  visible,
+  severity,
+  closeable,
+  children,
+}) => {
+  visible = typeof visible === "undefined" || visible
+
+  const [open, setOpen] = React.useState(visible)
+
+  const onCloseClick = () => {
+    setOpen(false)
+  }
+
+  useEffect(() => {
+    setOpen(visible)
+  }, [visible])
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <MuiAlert
+      severity={severity}
+      onClose={closeable ? onCloseClick : undefined}
+    >
+      {children}
+    </MuiAlert>
+  )
+}
+
+export { Alert }
+export type { AlertProps }

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -60,14 +60,12 @@ type AlertProps = {
 } & Pick<MuiAlertProps, "severity" | "children">
 
 const Alert: React.FC<AlertProps> = ({
-  visible,
+  visible = true,
   severity = "info",
   closeable,
   children,
   className,
 }) => {
-  visible = typeof visible === "undefined" || visible
-
   const [open, setOpen] = React.useState(visible)
 
   const onCloseClick = () => {

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -55,14 +55,14 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ severity }) => ({
 
 type AlertProps = {
   visible?: boolean
-  closeable?: boolean
+  closable?: boolean
   className?: string
 } & Pick<MuiAlertProps, "severity" | "children">
 
 const Alert: React.FC<AlertProps> = ({
   visible = true,
   severity = "info",
-  closeable,
+  closable,
   children,
   className,
 }) => {
@@ -83,7 +83,7 @@ const Alert: React.FC<AlertProps> = ({
   return (
     <AlertStyled
       severity={severity!}
-      onClose={closeable ? onCloseClick : undefined}
+      onClose={closable ? onCloseClick : undefined}
       role="alert"
       aria-description={`${severity} message`}
       className={className}

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled"
 import { default as MuiAlert, AlertColor } from "@mui/material/Alert"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import type { AlertProps as MuiAlertProps } from "@mui/material/Alert"
-import { pxToRem } from "../ThemeProvider/typography"
 
 type Colors = {
   [Severity in AlertColor]: string
@@ -28,9 +27,7 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ severity }) => ({
   borderColor: COLORS[severity],
   background: "#FFF",
   ".MuiAlert-message": {
-    lineHeight: pxToRem(22),
-    verticalAlign: "middle",
-    fontSize: pxToRem(14),
+    ...theme.typography.body2,
     color: theme.custom.colors.darkGray2,
   },
   "> div": {
@@ -66,17 +63,17 @@ const Alert: React.FC<AlertProps> = ({
   children,
   className,
 }) => {
-  const [open, setOpen] = React.useState(visible)
+  const [_visible, setVisible] = React.useState(visible)
 
   const onCloseClick = () => {
-    setOpen(false)
+    setVisible(false)
   }
 
   useEffect(() => {
-    setOpen(visible)
+    setVisible(visible)
   }, [visible])
 
-  if (!open) {
+  if (!_visible) {
     return null
   }
 

--- a/frontends/ol-components/src/components/Alert/Alert.tsx
+++ b/frontends/ol-components/src/components/Alert/Alert.tsx
@@ -53,16 +53,18 @@ const AlertStyled = styled(MuiAlert)<AlertStyleProps>(({ severity }) => ({
   },
 }))
 
-type AlertProps = { visible?: boolean; closeable?: boolean } & Pick<
-  MuiAlertProps,
-  "severity" | "children"
->
+type AlertProps = {
+  visible?: boolean
+  closeable?: boolean
+  className?: string
+} & Pick<MuiAlertProps, "severity" | "children">
 
 const Alert: React.FC<AlertProps> = ({
   visible,
-  severity,
+  severity = "info",
   closeable,
   children,
+  className,
 }) => {
   visible = typeof visible === "undefined" || visible
 
@@ -86,6 +88,7 @@ const Alert: React.FC<AlertProps> = ({
       onClose={closeable ? onCloseClick : undefined}
       role="alert"
       aria-description={`${severity} message`}
+      className={className}
     >
       {children}
     </AlertStyled>

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -9,8 +9,6 @@
  *  - we don't need to implement ref-forwarding, which is important for some
  *    functionality.
  */
-export { default as Alert } from "@mui/material/Alert"
-export type { AlertProps } from "@mui/material/Alert"
 
 export { default as Avatar } from "@mui/material/Avatar"
 export type { AvatarProps } from "@mui/material/Avatar"
@@ -112,6 +110,7 @@ export type { TypographyProps } from "@mui/material/Typography"
 export { default as Menu } from "@mui/material/Menu"
 export { default as MenuItem } from "@mui/material/MenuItem"
 
+export * from "./components/Alert/Alert"
 export * from "./components/BasicDialog/BasicDialog"
 export * from "./components/BannerPage/BannerPage"
 export * from "./components/ButtonLink/ButtonLink"


### PR DESCRIPTION
### What are the relevant tickets?

[Design System: Alerts #4053](https://github.com/mitodl/hq/issues/4053)

### Description (What does it do?)

Creates an Alert component in `ol-components`.

https://www.figma.com/file/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=104%3A1894&mode=dev

### Screenshots (if appropriate):
 
<img width="1377" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/8b314feb-0a69-4999-bb10-93492e0b6426">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Run storybook:
```bash
cd frontends && yarn run storybook
```

Navigate to http://localhost:6006/?path=/story/smoot-design-alert--plain.

If testing the component in situ:

```
import { Alert, styled } from "ol-components" 

...

/* Basic alert. Severity in ["info", "success", "warning", "error"] */
<Alert severity="info">Alert message</Alert>

/* Closable alert (close buttons removes from page) */
<Alert severity="warning" closable>Alert message</Alert>

/*  Show/hide can be controlled by props */
<Alert severity="success" visible={visible}>Alert message</Alert>

/* Can be styled externally */
const StyledAlert = styled(Alert)`
  position: fixed;
  bottom: 0;
  left: 0;
  margin: 20px;
  width: calc(100% - 40px);
  z-index: 1200;
`
<StyledAlert severity="info" visible={visible}>Alert message</StyledAlert>
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Currently this provides a plain alert device. Positioning is the responsibility of the parent. Any timers to fade/remove, alert queueing, stacking on page and deduping to be handled by an accompanying AlertQueue component if the need arises.

As a suggestion, I think it's more fitting to call these "notifications". "Alert" implies something heavier to me - e.g. the user must acknowledge to clear.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
