### PR TITLE
create exported components bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,9 @@ jobs:
       - name: Build frontend
         run: NODE_ENV=production yarn build
 
+      - name: Build exported components
+        run: NODE_ENV=production yarn workspace mit-open build-exports
+
       - name: Build services
         run: docker compose -f docker-compose-e2e-tests.yml build
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 .Python
 env/
 build/
+build-exports/
 develop-eggs/
 dist/
 downloads/

--- a/README.md
+++ b/README.md
@@ -207,6 +207,42 @@ Personal API keys only need read permission to Query. When creating a personal A
 
 Once these are set (and you've restarted the app), you should see events flowing into the PostHog dashboard.
 
+## Exported Components
+
+A Javascript bundle of exported frontend components can be generated for use in external websites that have CORS allowance into a given instance of `mit-open`. There are a few settings you might want to change in order to get the expected results.
+
+- `MITOPEN_AXIOS_WITH_CREDENTIALS` - This sets `withCredentials: true` when initializing the Axios API, which tells the end user's browser to send along any browser level cookies for the current domain when making CORS requests
+- `MITOPEN_AXIOS_BASE_PATH` - This sets the base path used for API requests, which will need to be set to a fully qualified url pointing to an instance of `mit-open` (i.e. https://mitopen.odl.mit.edu) in order for requests from the external site to reach the proper destination
+- `CORS_ALLOWED_ORIGINS`, `CSRF_TRUSTED_ORIGINS` - On the instance of `mit-open` that the externally hosted components will access via the API, the domains of any sites that need CORS access need to be here as a list of strings
+
+To build the bundle of exported components, run:
+
+```
+yarn workspace mit-open build-exports
+```
+
+The bundle will build out to `frontends/mit-open/build-exports/`
+
+### `initMitOpenDom`
+
+This function takes an argument of an `HTMLElement` with which `mit-open` components will mount into.
+
+### `openAddToUserListDialog`
+
+This function opens a modal for adding a given `LearningResource` to a `UserList`, given the `readable_id` of the `LearningResource` object. Given a div with an ID of `mit-open-components` and a button with the ID for `add-to-user-list-button`, you would use it in combination with `initMitOpenDom` like this:
+
+```javascript
+import { initMitOpenDom, openAddToUserListDialog } from "mit-open-components"
+
+$("#add-to-user-list-button").on("click", async (event) => {
+  event.preventDefault()
+  await initMitOpenDom($("#mit-open-components"))
+  await openAddToUserListDialog("18.700+fall_2013")
+})
+```
+
+This is just an example, and you could input any `readable_id` to bring up a dialog to add any given `LearningResource` object to a `UserList`.
+
 ## GitHub Pages
 
 A static site for this repo with developer resources publishes to https://mitodl.github.io/mit-open/ during CI runs.

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
           "**/test-utils/**",
           "**/test-utils/**",
           "**/webpack.config.js",
+          "**/webpack.exports.js",
           "**/postcss.config.js",
           "**/*.stories.ts",
           "**/*.stories.tsx",

--- a/frontends/api/src/axios.ts
+++ b/frontends/api/src/axios.ts
@@ -9,6 +9,5 @@ const instance = axios.create({
   withCredentials:
     APP_SETTINGS.axios_with_credentials?.toLowerCase() === "true",
 })
-instance.defaults.withCredentials = true
 
 export default instance

--- a/frontends/api/src/axios.ts
+++ b/frontends/api/src/axios.ts
@@ -9,5 +9,6 @@ const instance = axios.create({
   withCredentials:
     APP_SETTINGS.axios_with_credentials?.toLowerCase() === "true",
 })
+instance.defaults.withCredentials = true
 
 export default instance

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -12,6 +12,7 @@
     "watch:docker": "API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
     "watch:rc": "API_BASE_URL=https://mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
+    "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build --output-dir build/storybook"
   },

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -48,7 +48,8 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-middleware": "^7.2.1",
     "webpack-dev-server": "^5.0.4",
-    "webpack-hot-middleware": "^2.26.1"
+    "webpack-hot-middleware": "^2.26.1",
+    "webpack-merge": "^5.10.0"
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",

--- a/frontends/mit-open/src/ExportedComponentProviders.tsx
+++ b/frontends/mit-open/src/ExportedComponentProviders.tsx
@@ -5,9 +5,6 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
 import { ThemeProvider } from "ol-components"
 import GlobalStyles from "./GlobalStyles"
-import { PostHogProvider } from "posthog-js/react"
-
-import type { PostHogSettings } from "./types/settings"
 
 interface ExportedComponentProps {
   queryClient: QueryClient
@@ -19,19 +16,6 @@ interface ExportedComponentProps {
 const ExportedComponentProviders: React.FC<ExportedComponentProps> = ({
   queryClient,
 }) => {
-  const phSettings: PostHogSettings = APP_SETTINGS.posthog?.enabled
-    ? APP_SETTINGS.posthog
-    : {
-        api_key: "",
-        enabled: false,
-      }
-  const phOptions = {
-    feature_flag_request_timeout_ms: phSettings.timeout || 3000,
-    bootstrap: {
-      featureFlags: phSettings.bootstrap_flags,
-    },
-  }
-
   const interiorElements = (
     <ThemeProvider>
       <GlobalStyles />
@@ -47,15 +31,7 @@ const ExportedComponentProviders: React.FC<ExportedComponentProps> = ({
     </ThemeProvider>
   )
 
-  return phSettings.enabled ? (
-    <StrictMode>
-      <PostHogProvider apiKey={phSettings.api_key} options={phOptions}>
-        {interiorElements}
-      </PostHogProvider>
-    </StrictMode>
-  ) : (
-    <StrictMode>{interiorElements}</StrictMode>
-  )
+  return <StrictMode>{interiorElements}</StrictMode>
 }
 
 export default ExportedComponentProviders

--- a/frontends/mit-open/src/ExportedComponentProviders.tsx
+++ b/frontends/mit-open/src/ExportedComponentProviders.tsx
@@ -1,0 +1,61 @@
+import React, { StrictMode } from "react"
+import { HelmetProvider } from "react-helmet-async"
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
+import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
+import { ThemeProvider } from "ol-components"
+import GlobalStyles from "./GlobalStyles"
+import { PostHogProvider } from "posthog-js/react"
+
+import type { PostHogSettings } from "./types/settings"
+
+interface ExportedComponentProps {
+  queryClient: QueryClient
+}
+
+/**
+ * Renders child with Router, QueryClientProvider, and other such context provides.
+ */
+const ExportedComponentProviders: React.FC<ExportedComponentProps> = ({
+  queryClient,
+}) => {
+  const phSettings: PostHogSettings = APP_SETTINGS.posthog?.enabled
+    ? APP_SETTINGS.posthog
+    : {
+        api_key: "",
+        enabled: false,
+      }
+  const phOptions = {
+    feature_flag_request_timeout_ms: phSettings.timeout || 3000,
+    bootstrap: {
+      featureFlags: phSettings.bootstrap_flags,
+    },
+  }
+
+  const interiorElements = (
+    <ThemeProvider>
+      <GlobalStyles />
+      <QueryClientProvider client={queryClient}>
+        <HelmetProvider>
+          <NiceModalProvider></NiceModalProvider>
+        </HelmetProvider>
+        <ReactQueryDevtools
+          initialIsOpen={false}
+          toggleButtonProps={{ style: { opacity: 0.5 } }}
+        />
+      </QueryClientProvider>
+    </ThemeProvider>
+  )
+
+  return phSettings.enabled ? (
+    <StrictMode>
+      <PostHogProvider apiKey={phSettings.api_key} options={phOptions}>
+        {interiorElements}
+      </PostHogProvider>
+    </StrictMode>
+  ) : (
+    <StrictMode>{interiorElements}</StrictMode>
+  )
+}
+
+export default ExportedComponentProviders

--- a/frontends/mit-open/src/ExportedComponentProviders.tsx
+++ b/frontends/mit-open/src/ExportedComponentProviders.tsx
@@ -1,10 +1,8 @@
 import React, { StrictMode } from "react"
-import { HelmetProvider } from "react-helmet-async"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
 import { ThemeProvider } from "ol-components"
-import GlobalStyles from "./GlobalStyles"
 
 interface ExportedComponentProps {
   queryClient: QueryClient
@@ -18,11 +16,8 @@ const ExportedComponentProviders: React.FC<ExportedComponentProps> = ({
 }) => {
   const interiorElements = (
     <ThemeProvider>
-      <GlobalStyles />
       <QueryClientProvider client={queryClient}>
-        <HelmetProvider>
-          <NiceModalProvider></NiceModalProvider>
-        </HelmetProvider>
+        <NiceModalProvider></NiceModalProvider>
         <ReactQueryDevtools
           initialIsOpen={false}
           toggleButtonProps={{ style: { opacity: 0.5 } }}

--- a/frontends/mit-open/src/ExportedComponents.tsx
+++ b/frontends/mit-open/src/ExportedComponents.tsx
@@ -1,25 +1,38 @@
 import React from "react"
 import { createRoot } from "react-dom/client"
-import { AddToUserListDialog } from "@/page-components/LearningResourceCard/AddToListDialog"
+import { AddToUserListDialogInner } from "@/page-components/LearningResourceCard/AddToListDialog"
 import NiceModal from "@ebay/nice-modal-react"
 import { createQueryClient } from "@/services/react-query/react-query"
 import ExportedComponentProviders from "@/ExportedComponentProviders"
+import { useLearningResourcesList } from "api/hooks/learningResources"
 
-const prepareModals = (container: HTMLElement) => {
+const initMitOpenDom = (container: HTMLElement) => {
   const root = createRoot(container)
-
   const queryClient = createQueryClient()
-
-  root.render(<ExportedComponentProviders queryClient={queryClient} />)
+  return root.render(<ExportedComponentProviders queryClient={queryClient} />)
 }
 
-const openAddToListDialog = (resourceId: number) => {
-  NiceModal.show(AddToUserListDialog, { resourceId })
+type ExportedDialogProps = {
+  readableId: string
 }
 
-// // @ts-expect-error
-// window.prepareModals = prepareModals
-// // @ts-expect-error
-// window.openAddToListDialog = openAddToListDialog
+const AddToUserListDialogComponent: React.FC<ExportedDialogProps> = ({
+  readableId,
+}) => {
+  const resourcesQuery = useLearningResourcesList({ readable_id: [readableId] })
+  const response = resourcesQuery.data ?? null
+  if (response === null) return null
+  const resourceId = response.results[0].id
+  return (
+    <AddToUserListDialogInner
+      resourceId={resourceId}
+    ></AddToUserListDialogInner>
+  )
+}
 
-export { prepareModals, openAddToListDialog }
+const openAddToUserListDialog = (readableId: string) => {
+  const addToUserListDialog = NiceModal.create(AddToUserListDialogComponent)
+  NiceModal.show(addToUserListDialog, { readableId })
+}
+
+export { initMitOpenDom, openAddToUserListDialog }

--- a/frontends/mit-open/src/ExportedComponents.tsx
+++ b/frontends/mit-open/src/ExportedComponents.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { createRoot } from "react-dom/client"
+import { AddToUserListDialog } from "@/page-components/LearningResourceCard/AddToListDialog"
+import NiceModal from "@ebay/nice-modal-react"
+import { createQueryClient } from "@/services/react-query/react-query"
+import ExportedComponentProviders from "@/ExportedComponentProviders"
+
+const prepareModals = (container: HTMLElement) => {
+  const root = createRoot(container)
+
+  const queryClient = createQueryClient()
+
+  root.render(<ExportedComponentProviders queryClient={queryClient} />)
+}
+
+const openAddToListDialog = (resourceId: number) => {
+  NiceModal.show(AddToUserListDialog, { resourceId })
+}
+
+// // @ts-expect-error
+// window.prepareModals = prepareModals
+// // @ts-expect-error
+// window.openAddToListDialog = openAddToListDialog
+
+export { prepareModals, openAddToListDialog }

--- a/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/AddToListDialog.tsx
@@ -422,4 +422,8 @@ const AddToUserListDialogInner: React.FC<AddToListDialogProps> = ({
 const AddToLearningPathDialog = NiceModal.create(AddToLearningPathDialogInner)
 const AddToUserListDialog = NiceModal.create(AddToUserListDialogInner)
 
-export { AddToLearningPathDialog, AddToUserListDialog }
+export {
+  AddToLearningPathDialog,
+  AddToUserListDialog,
+  AddToUserListDialogInner,
+}

--- a/frontends/mit-open/tsconfig.json
+++ b/frontends/mit-open/tsconfig.json
@@ -5,8 +5,7 @@
     "target": "es2020",
     "declaration": true,
     "outDir": "./build",
-    // "rootDirs": ["./src", "./.storybook"],
-    "rootDir": "../../",
+    "rootDirs": ["./src", "./.storybook"],
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]

--- a/frontends/mit-open/tsconfig.json
+++ b/frontends/mit-open/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "module": "es2020",
-    "target": "es2020",
     "declaration": true,
     "outDir": "./build",
     "rootDirs": ["./src", "./.storybook"],

--- a/frontends/mit-open/tsconfig.json
+++ b/frontends/mit-open/tsconfig.json
@@ -1,8 +1,12 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "es2020",
+    "target": "es2020",
+    "declaration": true,
     "outDir": "./build",
-    "rootDirs": ["./src", "./.storybook"],
+    // "rootDirs": ["./src", "./.storybook"],
+    "rootDir": "../../",
     "baseUrl": "./src",
     "paths": {
       "@/*": ["./*"]

--- a/frontends/mit-open/webpack.exports.js
+++ b/frontends/mit-open/webpack.exports.js
@@ -1,5 +1,4 @@
 const path = require("path")
-// eslint-disable-next-line import/no-extraneous-dependencies
 const webpackMerge = require("webpack-merge")
 const config = require("./webpack.config")
 

--- a/frontends/mit-open/webpack.exports.js
+++ b/frontends/mit-open/webpack.exports.js
@@ -1,0 +1,27 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const webpackMerge = require("webpack-merge")
+const config = require("./webpack.config")
+
+const exportOverrides = {
+  entry: {
+    exports: "./src/ExportedComponents",
+  },
+  output: {
+    library: {
+      type: "module",
+    },
+  },
+  optimization: {
+    usedExports: true,
+  },
+  experiments: {
+    outputModule: true,
+  },
+}
+
+module.exports = (_env, argv) => {
+  argv.mode = process.env.NODE_ENV || "production"
+  const defaultConfig = config(_env, argv)
+  delete defaultConfig.entry.root
+  return webpackMerge.merge(defaultConfig, exportOverrides)
+}

--- a/frontends/mit-open/webpack.exports.js
+++ b/frontends/mit-open/webpack.exports.js
@@ -1,12 +1,14 @@
+const path = require("path")
 // eslint-disable-next-line import/no-extraneous-dependencies
 const webpackMerge = require("webpack-merge")
 const config = require("./webpack.config")
 
 const exportOverrides = {
   entry: {
-    exports: "./src/ExportedComponents",
+    "mit-open-components": "./src/ExportedComponents",
   },
   output: {
+    path: path.resolve(__dirname, "build-exports"),
     library: {
       type: "module",
     },

--- a/main/settings.py
+++ b/main/settings.py
@@ -165,6 +165,8 @@ CORS_ALLOWED_ORIGINS = get_list_of_str("CORS_ALLOWED_ORIGINS", [])
 CORS_ALLOWED_ORIGIN_REGEXES = get_list_of_str("CORS_ALLOWED_ORIGIN_REGEXES", [])
 CORS_ALLOW_CREDENTIALS = True
 
+CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
+
 # enable the nplusone profiler only in debug mode
 if DEBUG:
     INSTALLED_APPS += ("nplusone.ext.django",)

--- a/yarn.lock
+++ b/yarn.lock
@@ -17417,6 +17417,7 @@ __metadata:
     webpack-dev-middleware: "npm:^7.2.1"
     webpack-dev-server: "npm:^5.0.4"
     webpack-hot-middleware: "npm:^2.26.1"
+    webpack-merge: "npm:^5.10.0"
     yup: "npm:^1.2.0"
   languageName: unknown
   linkType: soft
@@ -24990,7 +24991,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
+"webpack-merge@npm:^5.10.0, webpack-merge@npm:^5.7.3, webpack-merge@npm:^5.8.0":
   version: 5.10.0
   resolution: "webpack-merge@npm:5.10.0"
   dependencies:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/864

### Description (What does it do?)
This PR adds a separate Webpack configuration designed to output a Javascript bundle of reusable components from `mit-open`. For now this only contains `AddToUserListDialog`, the modal used for adding a `LearningResource` to a `UserList`. A more detailed description of how to build and use the exported components is included in a README update. 

### How can this be tested?
 - In your `.env` file, set the following values:
```
MITOPEN_AXIOS_WITH_CREDENTIALS=True
MITOPEN_AXIOS_BASE_PATH=https://mitopen-rc.odl.mit.edu/
```
 - Run the following:
```
yarn workspace mit-open install
yarn workspace mit-open build-exports
```
 - In your `frontends/mit-open/` folder you should now see a `build-exports` folder with contents similar to the following:

<img width="361" alt="image" src="https://github.com/mitodl/mit-open/assets/12089658/be25f357-f549-46b7-8174-9c60c8f17779">

 - You won't be able to test importing and using the bundle locally when built like this, because https://mitopen-rc.odl.mit.edu/ only contains a CORS allowance for OCW RC, but you can see an example of how this would be implemented in this branch of `ocw-hugo-themes`: https://github.com/mitodl/ocw-hugo-themes/tree/cg/mit-open-login-button-testing. Of particular note is `course-v2/assets/js/userlist_modal.ts`. Here you can see `AddToUserListDialog` being utilized with a given `readable_id`. 

### Additional Context
This functionality is being added in the pursuit of allowing external sites to implement UI controls built here in `mit-open` using a CORS approach, building a "batteries included" bundle of components you can bring into any Javascript project using the `import` syntax for use in your site.
