### PR TITLE
Ab sort dropdown

### DIFF
--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -221,7 +221,7 @@ describe("FieldSearch", () => {
         "Topic",
         "Certification",
       ]) {
-        if (dropdownName in displayedFacets) {
+        if ((displayedFacets as string[]).includes(dropdownName as string)) {
           await screen.findByText(dropdownName)
         } else {
           expect(screen.queryByText(dropdownName)).toBeNull()

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -8,7 +8,9 @@ import type {
   BooleanFacetKey,
 } from "@mitodl/course-search-utils"
 import { BOOLEAN_FACET_NAMES } from "@mitodl/course-search-utils"
-import { FormControl, Select, MenuItem, Skeleton, styled } from "ol-components"
+import { Skeleton, styled } from "ol-components"
+import { StyledDropdown } from "../SearchPage/SearchPage"
+
 export type KeyWithLabel = { key: string; label: string }
 
 const StyledSkeleton = styled(Skeleton)`
@@ -110,45 +112,22 @@ const AvailableFacetsDropdowns: React.FC<
           displayValue = activeFacets[facetSetting.name as FacetKey] || []
         }
 
+        if (!isMultiple) {
+          facetItems.unshift({ key: "", label: "no selection" })
+        }
+
         return (
           facetItems.length && (
-            <FormControl key={facetSetting.name}>
-              <Select
-                multiple={isMultiple}
-                displayEmpty
-                value={displayValue}
-                renderValue={() => {
-                  return facetSetting.title
-                }}
-                onChange={(e) =>
-                  onFacetChange(facetSetting.name, e.target.value)
-                }
-                sx={{ m: 1, minWidth: 140 }}
-              >
-                {!isMultiple ? (
-                  <MenuItem
-                    value=""
-                    key={facetSetting.name.concat(":", "unselect")}
-                  >
-                    no selection
-                  </MenuItem>
-                ) : (
-                  ""
-                )}
-                {filteredResultsWithLabels(
-                  facetOptions(facetSetting.name) || [],
-                  facetSetting.labelFunction || null,
-                  constantSearchParams[facetSetting.name as FacetKey] || null,
-                ).map((facet) => (
-                  <MenuItem
-                    value={facet.key}
-                    key={facetSetting.name.concat(":", facet.key)}
-                  >
-                    {facet.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <StyledDropdown
+              key={facetSetting.name}
+              initialValue={displayValue}
+              isMultiple={isMultiple}
+              onChange={(e) => onFacetChange(facetSetting.name, e.target.value)}
+              renderValue={() => {
+                return facetSetting.title
+              }}
+              options={facetItems}
+            />
           )
         )
       })}

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -303,6 +303,42 @@ test("Facet 'Offered By' uses API response for names", async () => {
   expect(offeror2).toBeVisible()
 })
 
+test("Set sort", async () => {
+  setMockApiResponses({ search: { count: 137 } })
+
+  const { location } = renderWithProviders(<SearchPage />)
+
+  let sortDropdown = await screen.findByText("Sort by: Relevance")
+
+  await user.click(sortDropdown)
+
+  const noneSelect = await screen.findByRole("option", {
+    name: "Relevance",
+  })
+
+  expect(noneSelect).toHaveAttribute("aria-selected", "true")
+
+  let popularitySelect = await screen.findByRole("option", {
+    name: /Popular/i,
+  })
+
+  expect(popularitySelect).toHaveAttribute("aria-selected", "false")
+
+  await user.click(popularitySelect)
+
+  expect(location.current.search).toBe("?sortby=-views")
+
+  sortDropdown = await screen.findByText("Sort by: Popular")
+
+  await user.click(sortDropdown)
+
+  popularitySelect = await screen.findByRole("option", {
+    name: /Popular/i,
+  })
+
+  expect(popularitySelect).toHaveAttribute("aria-selected", "true")
+})
+
 test("Clearing text updates URL", async () => {
   setMockApiResponses({})
   const { location } = renderWithProviders(<SearchPage />, { url: "?q=meow" })

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
   PlainList,
   Skeleton,
+  SimpleSelect,
 } from "ol-components"
 import { MetaTags } from "ol-utilities"
 
@@ -69,6 +70,25 @@ const AGGREGATIONS: LRSearchRequest["aggregations"] = [
   "offered_by",
 ]
 
+const SORT_OPTIONS = [
+  {
+    label: "Relevance",
+    key: "",
+  },
+  {
+    label: "New",
+    key: "new",
+  },
+  {
+    label: "Popular",
+    key: "-views",
+  },
+  {
+    label: "Upcoming",
+    key: "upcoming",
+  },
+]
+
 const ColoredHeader = styled.div`
   background-color: #394357;
   height: 150px;
@@ -80,6 +100,17 @@ const SearchField = styled(SearchInput)`
   width: 100%;
 `
 
+export const StyledDropdown = styled(SimpleSelect)`
+  margin: 8px;
+  min-width: 140px;
+`
+
+const SortContainer = styled.div`
+  ${({ theme }) => theme.breakpoints.up("sm")} {
+    float: right;
+    padding-right: 12px;
+  }
+`
 const FacetStyles = styled.div`
   * {
     color: ${({ theme }) => theme.palette.secondary.main};
@@ -263,7 +294,6 @@ const SearchPage: React.FC = () => {
     },
     [setSearchParams],
   )
-
   const facetManifest = useFacetManifest()
   const onFacetsChange = useCallback(() => {
     setPage(1)
@@ -278,6 +308,7 @@ const SearchPage: React.FC = () => {
     currentText,
     setCurrentText,
     setCurrentTextAndQuery,
+    setParamValue,
   } = useResourceSearchParams({
     searchParams,
     setSearchParams,
@@ -357,6 +388,20 @@ const SearchPage: React.FC = () => {
               </FacetStyles>
             </GridColumn>
             <GridColumn variant="main-2-wide-main">
+              <SortContainer>
+                <StyledDropdown
+                  initialValue={params.sortby || ""}
+                  isMultiple={false}
+                  onChange={(e) => setParamValue("sortby", e.target.value)}
+                  options={SORT_OPTIONS}
+                  renderValue={(value) => {
+                    const opt = SORT_OPTIONS.find(
+                      (option) => option.key === value,
+                    )
+                    return `Sort by: ${opt?.label}`
+                  }}
+                />
+              </SortContainer>
               <ResourceTypeTabs.TabList
                 patchParams={patchParams}
                 tabs={TABS}

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import { SimpleSelect, SimpleSelectProps } from "./SimpleSelect"
+import type { SelectChangeEvent } from "@mui/material/Select"
+
+function StateWrapper(props: SimpleSelectProps) {
+  const [value, setValue] = useState(props.initialValue)
+
+  const handleChange = (event: SelectChangeEvent<string | string[]>) => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <SimpleSelect {...props} initialValue={value} onChange={handleChange} />
+  )
+}
+
+const meta: Meta<typeof SimpleSelect> = {
+  title: "ol-components/SimpleSelect",
+  component: StateWrapper,
+  argTypes: {
+    isMultiple: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof SimpleSelect>
+const options = [
+  {
+    key: "bagel",
+    label: "Bagel",
+  },
+  {
+    key: "bacon",
+    label: "Bacon",
+  },
+  {
+    key: "french_toast",
+    label: "French Toast",
+  },
+  {
+    key: "eggs",
+    label: "Eggs",
+  },
+  {
+    key: "belgian_waffles",
+    label: "Belgian Waffles",
+  },
+]
+
+export const SingleSelect: Story = {
+  args: {
+    initialValue: "bagel",
+    isMultiple: false,
+    options: options,
+  },
+}
+
+export const MultipleSelect: Story = {
+  args: {
+    initialValue: ["bagel", "bacon"],
+    isMultiple: true,
+    options: options,
+  },
+}

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { Select } from "../SelectField/SelectField"
+import MenuItem from "@mui/material/MenuItem"
+import type { SelectChangeEvent } from "@mui/material/Select"
+
+interface SimpleSelectProps {
+  /**
+   * Value of initial selection for the dropdown
+   */
+  initialValue: string | string[]
+  /**
+   * Whether the dropdown allows multiple selections
+   */
+  isMultiple: boolean
+  /**
+  The function that runs when there is a selection from the dropdown
+   */
+  onChange: (event: SelectChangeEvent<string[] | string>) => void
+  /**
+   * The options for the dropdown
+   */
+  options: SimpleSelectOptionProps[]
+  /**
+   * Function that controls the display for the dropdown
+   */
+  renderValue?: (selected: string | string[] | void) => string
+  /**
+   * class name for the dropdown and base for key for dropdown options
+   */
+  className?: string
+}
+
+interface SimpleSelectOptionProps {
+  /**
+   * value for the dropdown option
+   */
+  key: string
+  /**
+   * label for the dropdown option
+   */
+  label: string
+}
+
+const SimpleSelect: React.FC<SimpleSelectProps> = ({
+  className,
+  initialValue,
+  isMultiple,
+  onChange,
+  options,
+  renderValue,
+}) => {
+  return (
+    <Select
+      multiple={isMultiple}
+      displayEmpty
+      value={initialValue}
+      onChange={onChange}
+      className={className}
+      renderValue={renderValue}
+    >
+      {options.map((option) => (
+        <MenuItem value={option.key.toString()} key={option.key.toString()}>
+          {option.label}
+        </MenuItem>
+      ))}
+    </Select>
+  )
+}
+
+export { SimpleSelect }
+export type { SimpleSelectProps, SimpleSelectOptionProps }

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -133,6 +133,12 @@ export * from "./components/RadioChoiceField/RadioChoiceField"
 export { Input, AdornmentButton } from "./components/Input/Input"
 export type { InputProps, AdornmentButtonProps } from "./components/Input/Input"
 export { TextField } from "./components/TextField/TextField"
+export { SimpleSelect } from "./components/SimpleSelect/SimpleSelect"
+export type {
+  SimpleSelectProps,
+  SimpleSelectOptionProps,
+} from "./components/SimpleSelect/SimpleSelect"
+
 export type { TextFieldProps } from "./components/TextField/TextField"
 export { Select, SelectField } from "./components/SelectField/SelectField"
 export type {

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -34,6 +34,7 @@ from learning_resources_search.utils import (
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
+DEFAULT_SORT = "-created_on"
 
 
 def gen_content_file_id(content_file_id):
@@ -81,6 +82,7 @@ def generate_sort_clause(search_params):
         dict or String: either a dictionary with the sort clause for
             nested sort params or just sort parameter
     """
+
     sort = (
         LEARNING_RESOURCE_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
         .get("sort")
@@ -541,8 +543,9 @@ def construct_search(search_params):
 
     if search_params.get("sortby"):
         sort = generate_sort_clause(search_params)
-
         search = search.sort(sort)
+    elif not search_params.get("q"):
+        search = search.sort(DEFAULT_SORT)
 
     if search_params.get("endpoint") == CONTENT_FILE_TYPE:
         query_type_query = {"exists": {"field": "content_type"}}

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -9,6 +9,7 @@ from opensearch_dsl.query import Percolate
 from learning_resources.factories import LearningResourceFactory
 from learning_resources_search.api import (
     Search,
+    construct_search,
     execute_learn_search,
     generate_aggregation_clause,
     generate_aggregation_clauses,
@@ -1754,3 +1755,25 @@ def test_document_percolation(opensearch, mocker):
         lr.id,
         list(PercolateQuery.objects.filter(id__in=[p["id"] for p in percolate_hits])),
     )
+
+
+@pytest.mark.parametrize(
+    ("sortby", "q", "result"),
+    [
+        ("-views", None, [{"views": {"order": "desc"}}]),
+        ("-views", "text", [{"views": {"order": "desc"}}]),
+        (None, None, [{"created_on": {"order": "desc"}}]),
+        (None, "text", None),
+    ],
+)
+def test_default_sort(sortby, q, result):
+    search_params = {
+        "aggregations": [],
+        "q": q,
+        "limit": 1,
+        "offset": 1,
+        "sortby": sortby,
+        "endpoint": LEARNING_RESOURCE,
+    }
+
+    assert construct_search(search_params).to_dict().get("sort") == result


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4128

### Description (What does it do?)
This pr adds a dropdown for sort to the search ui. It also extracts dropdown code into a component so we can style all dropdowns togather

### Screenshots (if appropriate):

<img width="1708" alt="Screenshot 2024-05-09 at 11 26 36 AM" src="https://github.com/mitodl/mit-open/assets/1934992/feed2b72-c6fc-4415-b6ba-9fcf49ef2d33">
<img width="390" alt="Screenshot 2024-05-09 at 11 27 15 AM" src="https://github.com/mitodl/mit-open/assets/1934992/ceccb946-bdb9-493e-8fc8-567857694b57">

<img width="1216" alt="Screenshot 2024-05-09 at 11 29 13 AM" src="https://github.com/mitodl/mit-open/assets/1934992/858db50e-f878-4fd6-b2ad-51c7f49e3fc9">
<img width="392" alt="Screenshot 2024-05-09 at 11 29 01 AM" src="https://github.com/mitodl/mit-open/assets/1934992/629c9e51-13dd-42c1-9907-2ceacce8d863">


### How can this be tested?
- Go to http://localhost:8063/search verify that you can use the sort dropdown to change the order of the items 
- Go to a channel page with search enabled (search_filter set in the database/admin), for example http://localhost:8063/c/department/biology. Verify that all dropdowns also still work