### PR TITLE
only show clear all if it would do something

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.0.5",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf",
     "@mui/icons-material": "^5.15.15",
     "@sentry/react": "^7.57.0",
     "@tanstack/react-query": "^4.36.1",

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf",
+    "@mitodl/course-search-utils": "^3.0.7",
     "@mui/icons-material": "^5.15.15",
     "@sentry/react": "^7.57.0",
     "@tanstack/react-query": "^4.36.1",

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -246,11 +246,13 @@ describe("SearchPage", () => {
     expect(chemistry).toBeChecked()
     // clear all
     await user.click(clearAll)
+    expect(clearAll).not.toBeVisible()
     expect(location.current.search).toBe("")
     expect(physics).not.toBeChecked()
     expect(chemistry).not.toBeChecked()
     // toggle physics
     await user.click(physics)
+    await screen.findByRole("button", { name: /clear all/i }) // Clear All shows again
     expect(physics).toBeChecked()
     expect(location.current.search).toBe("?topic=Physics")
   })

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -7,7 +7,6 @@ import {
   Card,
   CardContent,
   Grid,
-  Stack,
   Button,
   Typography,
 } from "ol-components"
@@ -197,9 +196,11 @@ const FilterTitle = styled.div`
 
 const FacetsTitleContainer = styled.div`
   display: flex;
-  flex-direction: column;
-  height: 48px;
-  justify-content: end;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  min-height: 40px;
+  padding-top: 8px;
 `
 
 const PaginationContainer = styled.div`
@@ -263,6 +264,7 @@ const SearchPage: React.FC = () => {
   }, [setPage])
   const {
     params,
+    hasFacets,
     clearAllFacets,
     patchParams,
     toggleParamValue,
@@ -320,23 +322,20 @@ const SearchPage: React.FC = () => {
           <ResourceTypeTabs.Context resourceType={params.resource_type?.[0]}>
             <GridColumn variant="sidebar-2-wide-main">
               <FacetsTitleContainer>
-                <Stack
-                  direction="row"
-                  alignItems="baseline"
-                  justifyContent="space-between"
-                >
-                  <FilterTitle>
-                    <Typography variant="h5">Filters </Typography>
-                    <TuneIcon fontSize="inherit" />
-                  </FilterTitle>
+                <FilterTitle>
+                  <Typography variant="h5">Filters</Typography>
+                  <TuneIcon fontSize="inherit" />
+                </FilterTitle>
+                {hasFacets ? (
                   <Button
                     variant="text"
                     color="secondary"
+                    size="small"
                     onClick={clearAllFacets}
                   >
                     Clear all
                   </Button>
-                </Stack>
+                ) : null}
               </FacetsTitleContainer>
               <FacetStyles>
                 <AvailableFacets

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,9 +3606,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf":
-  version: 3.0.6
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=2d82ea290c4a509cbed848ff2c3b9f4906abb3cf"
+"@mitodl/course-search-utils@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@mitodl/course-search-utils@npm:3.0.7"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.5.6"
     "@testing-library/react": "npm:12"
@@ -3630,7 +3630,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/d6832b5241584918d2b49a0b2f3bab55fadcc8a756d64f8eb409c913005bacd9c7fdd7ce514c77b58552b893876b90dc4f807a09310f0a337a1fcb3f4fadf7c1
+  checksum: 10/ee42113ac5bba2ddf84b73bdca15b2f4e82fd02c4949cf73d7cfd0c3b541acba933675008c7f753ac51e43af215c004bf254698e2e118be83abe25d808d5a0ae
   languageName: node
   linkType: hard
 
@@ -17365,7 +17365,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^7.3.0"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf"
+    "@mitodl/course-search-utils": "npm:^3.0.7"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@sentry/react": "npm:^7.57.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,11 +3606,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@mitodl/course-search-utils@npm:3.0.5"
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf":
+  version: 3.0.6
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=2d82ea290c4a509cbed848ff2c3b9f4906abb3cf"
   dependencies:
-    "@mitodl/open-api-axios": "npm:^2024.3.22"
+    "@mitodl/open-api-axios": "npm:^2024.5.6"
     "@testing-library/react": "npm:12"
     "@testing-library/user-event": "npm:^14.5.2"
     axios: "npm:^1.6.7"
@@ -3630,17 +3630,17 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/1d35c0ae9f90605b7a758122df0d6d48313c0b586ade6fa4886afb1e0aa08218c21535b2c21db9c7286a512ada59f937a67dd09479ebdcc3e25772975272d219
+  checksum: 10/d6832b5241584918d2b49a0b2f3bab55fadcc8a756d64f8eb409c913005bacd9c7fdd7ce514c77b58552b893876b90dc4f807a09310f0a337a1fcb3f4fadf7c1
   languageName: node
   linkType: hard
 
-"@mitodl/open-api-axios@npm:^2024.3.22":
-  version: 2024.3.22
-  resolution: "@mitodl/open-api-axios@npm:2024.3.22"
+"@mitodl/open-api-axios@npm:^2024.5.6":
+  version: 2024.5.6
+  resolution: "@mitodl/open-api-axios@npm:2024.5.6"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/b5eea9fdfe218a73f6b66084a2caccdcaec0c4f7781a4a9ee5514ea0aed29c36d85bb10ee7a49d8b79c0dfc7feb6eb0fc01af27943aa1ec58a5d27815dcd176a
+  checksum: 10/3349ca554644da05edc01efcddcc574f373894cf406dd119367537a993559c75ba2829eda53b9a809e390681a58a28a57ed07fc0171017f04276e032ce655be4
   languageName: node
   linkType: hard
 
@@ -17365,7 +17365,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^7.3.0"
-    "@mitodl/course-search-utils": "npm:^3.0.5"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2d82ea290c4a509cbed848ff2c3b9f4906abb3cf"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@sentry/react": "npm:^7.57.0"


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/3900
- related PR: https://github.com/mitodl/course-search-utils/pull/99

### Description (What does it do?)
Shows the "Clear All" button if and only if some facets are active.

### How can this be tested?
1. Checkout this branch and `docker compose build watch; docker compose restart watch` (Need to pick up the updated course-search-utils)
2. Visit the search page. 
    - With no facets active, "Clear All" should not appear.
    - With facets active, "Clear All" button should appear.

### Notes
Review together with https://github.com/mitodl/course-search-utils/pull/99