### PR TITLE
fix spacing between department groups

### DIFF
--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -189,10 +189,8 @@ const SchoolDepartments: React.FC<SchoolDepartmentProps> = ({
 const SchoolList = styled(PlainList)(({ theme }) => ({
   "> li": {
     marginTop: "40px",
-    marginBottom: "40px",
     [theme.breakpoints.down("sm")]: {
       marginTop: "30px",
-      marginBottom: "30px",
     },
   },
 }))

--- a/frontends/ol-components/src/components/PlainList/PlainList.tsx
+++ b/frontends/ol-components/src/components/PlainList/PlainList.tsx
@@ -25,10 +25,13 @@ const PlainList = styled.ul<PlainListProps>(
       marginBottom: 0,
       "> li": {
         listStyle: "none",
+        marginTop: 0,
+        marginBottom: 0,
       },
+    },
+    itemSpacing && {
       "> li + li": {
-        marginTop: theme.spacing(itemSpacing ?? 0),
-        marginBottom: theme.spacing(itemSpacing ?? 0),
+        marginTop: theme.spacing(itemSpacing),
       },
     },
     disabled && { opacity: 0.5 },


### PR DESCRIPTION
### What are the relevant tickets?
A follow to https://github.com/mitodl/mit-open/pull/865 that fixes spacing between the department groups.

### Screenshots (if appropriate):

BEFORE / AFTER
<img width="400" alt="Screenshot 2024-05-07 at 4 46 56 PM" src="https://github.com/mitodl/mit-open/assets/9010790/af175626-a8ab-4f09-941d-0a97606a8716"> <img width="400" alt="Screenshot 2024-05-07 at 4 46 31 PM" src="https://github.com/mitodl/mit-open/assets/9010790/2a99bdaa-8cd5-4992-b40d-4661a63ac408">


### How can this be tested?
View http://localhost:8063/departments


