### PR TITLE
Display loading view for search page

### DIFF
--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
@@ -6,6 +6,7 @@ import {
   Card,
   CardContent,
   PlainList,
+  Skeleton,
 } from "ol-components"
 import { getReadableResourceType } from "ol-utilities"
 
@@ -134,6 +135,10 @@ export const FieldSearchControls = styled.div`
   margin-top: 30px;
 `
 
+const StyledSkeleton = styled(Skeleton)`
+  border-radius: 4px;
+`
+
 const PAGE_SIZE = 10
 
 interface FeildSearchProps {
@@ -205,7 +210,7 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
 
   const page = +(searchParams.get("page") ?? "1")
 
-  const { data } = useLearningResourcesSearch(
+  const { data, isLoading } = useLearningResourcesSearch(
     {
       ...(allParams as LRSearchRequest),
       aggregations: facetNames as LRSearchRequest["aggregations"],
@@ -221,6 +226,7 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
           <GridColumn variant="main-2-wide-main">
             <AvailableFacetsDropdowns
               facetMap={facetManifest}
+              isLoading={isLoading}
               activeFacets={allParams as Facets & BooleanFacets}
               onFacetChange={setParamValue}
               facetOptions={(name) => data?.metadata.aggregations?.[name] ?? []}
@@ -243,7 +249,17 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
         </GridContainer>
       </FieldSearchControls>
       <div>
-        {data && data.count > 0 ? (
+        {isLoading ? (
+          <PlainList itemSpacing={3}>
+            {Array(PAGE_SIZE)
+              .fill(null)
+              .map((a, index) => (
+                <li key={index}>
+                  <StyledSkeleton variant="rectangular" height={162} />
+                </li>
+              ))}
+          </PlainList>
+        ) : data && data?.count > 0 ? (
           <PlainList itemSpacing={3}>
             {data.results.map((resource) => (
               <li key={resource.id}>

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -15,7 +15,6 @@ const StyledSkeleton = styled(Skeleton)`
   display: inline-flex;
   position: relative;
   transform: none;
-  margin: 8px 10px;
   width: 138px;
   height: 40px;
   margin: 8px 10px;

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -8,8 +8,19 @@ import type {
   BooleanFacetKey,
 } from "@mitodl/course-search-utils"
 import { BOOLEAN_FACET_NAMES } from "@mitodl/course-search-utils"
-import { FormControl, Select, MenuItem } from "ol-components"
+import { FormControl, Select, MenuItem, Skeleton, styled } from "ol-components"
 export type KeyWithLabel = { key: string; label: string }
+
+const StyledSkeleton = styled(Skeleton)`
+  display: inline-flex;
+  position: relative;
+  transform: none;
+  margin: 8px 10px;
+  width: 138px;
+  height: 40px;
+  margin: 8px 10px;
+  border-radius: 4px;
+`
 
 export type SingleFacetOptions = {
   name: string
@@ -21,6 +32,7 @@ export type FacetManifest = SingleFacetOptions[]
 
 interface FacetDisplayProps {
   facetMap: FacetManifest
+  isLoading?: boolean
   /**
    * Returns the aggregation options for a given group.
    *
@@ -63,6 +75,7 @@ const AvailableFacetsDropdowns: React.FC<
   Omit<FacetDisplayProps, "clearAllFilters">
 > = ({
   facetMap,
+  isLoading,
   facetOptions,
   activeFacets,
   onFacetChange,
@@ -70,12 +83,16 @@ const AvailableFacetsDropdowns: React.FC<
 }) => {
   return (
     <>
-      {facetMap.map((facetSetting) => {
+      {facetMap.map((facetSetting, index) => {
         const facetItems = filteredResultsWithLabels(
           facetOptions(facetSetting.name) || [],
           facetSetting.labelFunction || null,
           constantSearchParams[facetSetting.name as FacetKey] || null,
         )
+
+        if (isLoading) {
+          return <StyledSkeleton key={index} />
+        }
 
         const isMultiple = BOOLEAN_FACET_NAMES.includes(facetSetting.name)
           ? false
@@ -95,7 +112,7 @@ const AvailableFacetsDropdowns: React.FC<
         }
 
         return (
-          facetItems.length > 0 && (
+          facetItems.length && (
             <FormControl key={facetSetting.name}>
               <Select
                 multiple={isMultiple}

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   Typography,
   PlainList,
+  Skeleton,
 } from "ol-components"
 import { MetaTags } from "ol-utilities"
 
@@ -57,6 +58,7 @@ const getFacetManifest = (
     },
   ]
 }
+
 const FACET_NAMES = getFacetManifest({}).map(
   (f) => f.name,
 ) as UseResourceSearchParamsProps["facets"]
@@ -208,6 +210,10 @@ const PaginationContainer = styled.div`
   justify-content: end;
 `
 
+const StyledSkeleton = styled(Skeleton)`
+  border-radius: 4px;
+`
+
 const PAGE_SIZE = 10
 const MAX_PAGE = 50
 
@@ -262,6 +268,7 @@ const SearchPage: React.FC = () => {
   const onFacetsChange = useCallback(() => {
     setPage(1)
   }, [setPage])
+
   const {
     params,
     hasFacets,
@@ -277,11 +284,12 @@ const SearchPage: React.FC = () => {
     facets: FACET_NAMES,
     onFacetsChange,
   })
+
   const page = +(searchParams.get("page") ?? "1")
 
   const resourceType = params.resource_type
 
-  const { data } = useLearningResourcesSearch(
+  const { data, isLoading } = useLearningResourcesSearch(
     {
       ...(params as LRSearchRequest),
       aggregations: AGGREGATIONS,
@@ -356,7 +364,17 @@ const SearchPage: React.FC = () => {
                 onTabChange={() => setPage(1)}
               />
               <ResourceTypeTabs.TabPanels tabs={TABS}>
-                {data && data.count > 0 ? (
+                {isLoading ? (
+                  <PlainList itemSpacing={3}>
+                    {Array(PAGE_SIZE)
+                      .fill(null)
+                      .map((a, index) => (
+                        <li key={index}>
+                          <StyledSkeleton variant="rectangular" height={162} />
+                        </li>
+                      ))}
+                  </PlainList>
+                ) : data && data.count > 0 ? (
                   <PlainList itemSpacing={3}>
                     {data.results.map((resource) => (
                       <li key={resource.id}>

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -58,7 +58,8 @@ const Input = styled(InputBase)(({
         marginRight: `-${buttonPadding.medium}px`,
       },
       "&:hover:not(.Mui-disabled), &.Mui-focused": {
-        paddingLeft: "15px",
+        paddingLeft: "11px",
+        paddingRight: "11px",
       },
     },
     size === "medium" &&
@@ -79,6 +80,7 @@ const Input = styled(InputBase)(({
       },
       "&:hover:not(.Mui-disabled), &.Mui-focused": {
         paddingLeft: "15px",
+        paddingRight: "15px",
       },
     },
     size === "hero" &&

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -57,6 +57,9 @@ const Input = styled(InputBase)(({
       "&.MuiInputBase-adornedEnd": {
         marginRight: `-${buttonPadding.medium}px`,
       },
+      "&:hover:not(.Mui-disabled), &.Mui-focused": {
+        paddingLeft: "15px",
+      },
     },
     size === "medium" &&
       !multiline && {
@@ -73,6 +76,9 @@ const Input = styled(InputBase)(({
       },
       "&.MuiInputBase-adornedEnd": {
         marginRight: `-${buttonPadding.hero}px`,
+      },
+      "&:hover:not(.Mui-disabled), &.Mui-focused": {
+        paddingLeft: "15px",
       },
     },
     size === "hero" &&

--- a/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
+++ b/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
@@ -55,7 +55,6 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
     <Input
       fullWidth={props.fullWidth}
       size={props.size}
-      aria-label="foooo"
       inputProps={muiInputProps}
       autoFocus={props.autoFocus}
       className={props.className}


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/4131.

### Description (What does it do?)
<!--- Describe your changes in detail -->

Adds a skeleton view while search page and field search results initially load.

A small change also included to offset the padding on the text input component so the contents don't shift on hover as we increase the border width (testable on the home page hero search).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Navigate to `/search`. The page should briefly display the loading state:

<img width="1291" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/31241bb7-f879-4772-aef6-d08b1f2ec84f">

Navigate to a departments page, e.g. `/c/department/media-arts-and-sciences/`. The page should briefly display the loading state:

<img width="1397" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/9aeb819e-999a-4ff5-84d6-acf7275a6fbc">



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

- We may want to give similar treatment to the Facet Display as it can display the filter topics and "offered by" title and search inputs up front with skeleton aggregation results for a gentler page update on load (though this lives in course-search-utils).

- The loading view is only displayed on initial load and not while making additional searches. This may be ok as the previous content is displayed while the new content is loaded. For this we'd need to return an `isLoading` flag from `useResourceSearchParams` (also in course-search-utils).
