### PR TITLE
allow Button to hold a ref

### DIFF
--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -170,10 +170,12 @@ const ButtonInner: React.FC<
   )
 }
 
-const Button: React.FC<ButtonProps> = ({ children, ...props }) => (
-  <ButtonStyled type="button" {...props}>
-    <ButtonInner {...props}>{children}</ButtonInner>
-  </ButtonStyled>
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, ...props }, ref) => (
+    <ButtonStyled ref={ref} type="button" {...props}>
+      <ButtonInner {...props}>{children}</ButtonInner>
+    </ButtonStyled>
+  ),
 )
 
 type ButtonLinkProps = ButtonStyleProps &
@@ -200,7 +202,7 @@ const iconButtonDefaultProps: Required<
 
 type IconButtonProps = Omit<ButtonStyleProps, "startIcon" | "endIcon"> &
   React.ComponentProps<"button">
-const IconButton: React.FC<IconButtonProps> = styled(ButtonStyled)((props) => {
+const IconButton = styled(ButtonStyled)((props: IconButtonProps) => {
   const { size = iconButtonDefaultProps.size } = props
   return {
     padding: 0,


### PR DESCRIPTION
### What are the relevant tickets?
None; related to a suggestion I'm going to make for #878 

### Description (What does it do?)
Allows `Button` to take a ref.

### How can this be tested?
You should see `ref` as an available prop on ButtonProps

<img width="740" alt="Screenshot 2024-05-08 at 11 12 43 AM" src="https://github.com/mitodl/mit-open/assets/9010790/d1c3bce4-6c4f-4ca4-b5c2-670d9f9f25e9">
