### PR TITLE
Fix n+1 queries

### DIFF
--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -143,6 +143,7 @@ class LearningResource(TimestampedModel):
         "topics",
         "offered_by",
         "departments",
+        "departments__school",
         "content_tags",
         "runs",
         "runs__instructors",

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -60,7 +60,6 @@ def test_serialize_program_to_json():
     )
 
     serializer = serializers.ProgramSerializer(instance=program)
-
     assert_json_equal(
         serializer.data,
         {

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -211,7 +211,7 @@ def test_no_excess_queries(mocker, django_assert_num_queries, course_count):
 
     CourseFactory.create_batch(course_count)
 
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(10):
         view = CourseViewSet(request=mocker.Mock(query_params=[]))
         results = view.get_queryset().all()
         assert len(results) == course_count


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4082

### Description (What does it do?)
Modifies some view/serializer queries to avoid n+1 warnings.


### How can this be tested?
- If you don't already have mitxonline courses/programs, run `./manage.py backpopulate_mitxonline_data`
- Try the following urls, and look at the console output.  There will be `Potential unnecessary eager load detected` warnings but there should not be any `Potential n+1 query detected` warnings.
  - http://localhost:8063/api/v1/programs/?platform=mitxonline
  - http://localhost:8063/api/v1/courses/?platform=mitxonline
