### PR TITLE
Apply free filter to all resources

### DIFF
--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -106,9 +106,9 @@ class LearningResourceFilter(FilterSet):
 
     def filter_free(self, queryset, _, value):
         """Free cost filter for learning resources"""
-        queryset = queryset.exclude(runs__isnull=True)
         free_filter = (
-            Q(runs__prices__isnull=True)
+            Q(runs__isnull=True)
+            | Q(runs__prices__isnull=True)
             | Q(runs__prices=[])
             | Q(runs__prices__contains=[Decimal(0.00)])
         )

--- a/learning_resources/filters_test.py
+++ b/learning_resources/filters_test.py
@@ -193,10 +193,14 @@ def test_learning_resource_filter_free(client):
         learning_resource=free2pay_course, prices=[0.00, 100.00]
     )
 
+    always_free_podcast_episode = LearningResourceFactory.create(
+        is_podcast_episode=True
+    )
+
     results = client.get(f"{RESOURCE_API_URL}?free=true").json()["results"]
-    assert len(results) == 2
-    for course in [free_course, free2pay_course]:
-        assert course.id in [result["id"] for result in results]
+    assert len(results) == 3
+    for resource in [free_course, free2pay_course, always_free_podcast_episode]:
+        assert resource.id in [result["id"] for result in results]
     results = client.get(f"{RESOURCE_API_URL}?free=false").json()["results"]
     assert len(results) == 1
     assert results[0]["id"] == paid_course.id

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -69,6 +69,8 @@ def serialize_learning_resource_for_update(
     ]:
         prices = learning_resource_obj.prices
         serialized_data["free"] = Decimal(0.00) in prices or not prices or prices == []
+    else:
+        serialized_data["free"] = True
     if learning_resource_obj.resource_type == LearningResourceType.course.name:
         serialized_data["course"]["course_numbers"] = [
             SearchCourseNumberSerializer(instance=num).data

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -72,12 +72,10 @@ def test_serialize_learning_resource_for_bulk(resource_type):
     The "course" resource type is tested by `test_serialize_course_numbers_for_bulk` below.
     """
     resource = factories.LearningResourceFactory.create(resource_type=resource_type)
-    free_dict = (
-        {"free": False}
-        if resource_type
-        in [LearningResourceType.program.name, LearningResourceType.course.name]
-        else {}
-    )
+    free_dict = {
+        "free": resource_type
+        not in [LearningResourceType.program.name, LearningResourceType.course.name]
+    }
     assert serializers.serialize_learning_resource_for_bulk(resource) == {
         "_id": resource.id,
         "resource_relations": {"name": "resource"},


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4202


### Description (What does it do?)
Applies the `free` api/search filter to all learning resources even if they are always free, not just courses and programs.


### How can this be tested?
http://localhost:8063/api/v1/podcasts/?free=True should return the same results as http://localhost:8063/api/v1/podcasts/

http://localhost:8063/api/v1/podcasts/?free=False should return 0 results

http://localhost:8063/api/v1/learning_resources_search/?resource_type=podcast&free=True should return the same results as http://localhost:8063/api/v1/learning_resources_search/?resource_type=podcast

http://localhost:8063/api/v1/learning_resources_search/?resource_type=podcast&free=False should return 0 results
