### PR TITLE
Add Format as a facet to the search page

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.0.7",
+    "@mitodl/course-search-utils": "^3.0.8",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -210,6 +210,7 @@ describe("SearchPage", () => {
       })
       const apiSearchParams = getLastApiSearchParams()
       expect(apiSearchParams.getAll("aggregations").sort()).toEqual([
+        "learning_format",
         "offered_by",
         "resource_type",
         "topic",

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -13,7 +13,7 @@ import {
   Skeleton,
   SimpleSelect,
 } from "ol-components"
-import { MetaTags } from "ol-utilities"
+import { MetaTags, capitalize } from "ol-utilities"
 
 import { ResourceTypeEnum } from "api"
 import type {
@@ -57,6 +57,17 @@ const getFacetManifest = (
       expandedOnLoad: true,
       labelFunction: (key) => offerors[key]?.name ?? key,
     },
+    {
+      name: "learning_format",
+      title: "Format",
+      useFilterableFacet: false,
+      expandedOnLoad: true,
+      labelFunction: (key) =>
+        key
+          .split("_")
+          .map((word) => capitalize(word))
+          .join("-"),
+    },
   ]
 }
 
@@ -66,6 +77,7 @@ const FACET_NAMES = getFacetManifest({}).map(
 
 const AGGREGATIONS: LRSearchRequest["aggregations"] = [
   "resource_type",
+  "learning_format",
   "topic",
   "offered_by",
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,9 +3606,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@mitodl/course-search-utils@npm:3.0.7"
+"@mitodl/course-search-utils@npm:^3.0.8":
+  version: 3.0.8
+  resolution: "@mitodl/course-search-utils@npm:3.0.8"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.5.6"
     "@testing-library/react": "npm:12"
@@ -3630,17 +3630,17 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/ee42113ac5bba2ddf84b73bdca15b2f4e82fd02c4949cf73d7cfd0c3b541acba933675008c7f753ac51e43af215c004bf254698e2e118be83abe25d808d5a0ae
+  checksum: 10/59d01c31b060e33dc0b35dbc4a7be13769c534e7948c7e863681b57685c32a9351ca8cf8beb1f4961285199249b55534d6ab8cbfca0ef5efce665546c8aa0ed2
   languageName: node
   linkType: hard
 
 "@mitodl/open-api-axios@npm:^2024.5.6":
-  version: 2024.5.6
-  resolution: "@mitodl/open-api-axios@npm:2024.5.6"
+  version: 2024.5.9
+  resolution: "@mitodl/open-api-axios@npm:2024.5.9"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/3349ca554644da05edc01efcddcc574f373894cf406dd119367537a993559c75ba2829eda53b9a809e390681a58a28a57ed07fc0171017f04276e032ce655be4
+  checksum: 10/b3ce799c35773475b1a3b4520d271f3ed218d6f1c2260e2addbea07f3811d4f38c2f2b644dfa6f0c4260da9b4c2077c0be17047ebb07af798f8ebf48c046617e
   languageName: node
   linkType: hard
 
@@ -6176,7 +6176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.11.19":
+"@types/node@npm:*":
   version: 20.12.7
   resolution: "@types/node@npm:20.12.7"
   dependencies:
@@ -6191,6 +6191,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10/654194d4f3cc5867e5525a39647773a12c0c7175972bc4d288cdc74991fc969be2a9689267a3dc1cc5c5c7617e8f7c4769ac4829525726cd3e2f60eb238c1ff4
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^20.11.19":
+  version: 20.12.11
+  resolution: "@types/node@npm:20.12.11"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10/c6afe7c2c4504a4f488814d7b306ebad16bf42cbb43bf9db9fe1aed8c5fb99235593c3be5088979a64526b106cf022256688e2f002811be8273d87dc2e0d484f
   languageName: node
   linkType: hard
 
@@ -17374,7 +17383,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^7.3.0"
-    "@mitodl/course-search-utils": "npm:^3.0.7"
+    "@mitodl/course-search-utils": "npm:^3.0.8"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4166

### Description (What does it do?)
This pr adds format as a facet to the search page

### Screenshots (if appropriate):
<img width="1705" alt="Screenshot 2024-05-09 at 4 34 54 PM" src="https://github.com/mitodl/mit-open/assets/1934992/99d74e33-4a1b-415c-8242-49971a419377">
<img width="388" alt="Screenshot 2024-05-09 at 4 35 18 PM" src="https://github.com/mitodl/mit-open/assets/1934992/6317e735-203e-4218-b790-8775095e6a38">

### How can this be tested?
Go to http://localhost:8063/search. Verify that you see "Format" as a facet and can filter to a format

### Additional Context
https://github.com/mitodl/course-search-utils/pull/101 needs to be merged before this, otherwise typecheck breaks
