### PR TITLE
use neue-haas-grotesk font

### DIFF
--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
       },
     ],
     quotes: ["error", "double", { avoidEscape: true }],
+    "no-restricted-syntax": ["error", "Literal[value=fontWeight]"],
   },
   overrides: [
     {

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -87,6 +87,12 @@ module.exports = {
         message:
           "Do not specify `fontWeight` manually. Prefer spreading `theme.typography.subtitle1` or similar. If you MUST use a fontWeight, refer to `fontWeights` theme object.",
       },
+      {
+        selector:
+          "Property[key.name=fontFamily][value.raw=/Neue Haas/], TemplateElement[value.raw=/Neue Haas/]",
+        message:
+          "Do not specify `fontFamily` manually. Prefer spreading `theme.typography.subtitle1` or similar. If using neue-haas-grotesk-text, this is ThemeProvider's default fontFamily.",
+      },
     ],
   },
   overrides: [

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -79,7 +79,15 @@ module.exports = {
       },
     ],
     quotes: ["error", "double", { avoidEscape: true }],
-    "no-restricted-syntax": ["error", "Literal[value=fontWeight]"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        selector:
+          "Property[key.name=fontWeight][value.raw=/\\d+/], TemplateElement[value.raw=/font-weight: \\d+/]",
+        message:
+          "Do not specify `fontWeight` manually. Prefer spreading `theme.typography.subtitle1` or similar. If you MUST use a fontWeight, refer to `fontWeights` theme object.",
+      },
+    ],
   },
   overrides: [
     {

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -81,6 +81,12 @@ module.exports = {
     quotes: ["error", "double", { avoidEscape: true }],
     "no-restricted-syntax": [
       "error",
+      /**
+       * See https://eslint.org/docs/latest/rules/no-restricted-syntax
+       *
+       * The selectors use "ES Query", a css-like syntax for AST querying. A
+       * useful tool is  https://estools.github.io/esquery/
+       */
       {
         selector:
           "Property[key.name=fontWeight][value.raw=/\\d+/], TemplateElement[value.raw=/font-weight: \\d+/]",

--- a/frontends/mit-open/.storybook/preview-head.html
+++ b/frontends/mit-open/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<!--
+      Font files for Adobe Neue Haas Grotesk.
+      WARNING: This is linked to chudzick@mit.edu's Adobe account.
+  -->
+<link rel="stylesheet" href="https://use.typekit.net/lbk1xay.css" />

--- a/frontends/mit-open/public/index.html
+++ b/frontends/mit-open/public/index.html
@@ -3,16 +3,17 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,500,700"
-    />
+    <!--
+      Font files for Adobe Neue Haas Grotesk.
+      WARNING: This is linked to chudzick@mit.edu's Adobe account.
+  -->
+    <link rel="stylesheet" href="https://use.typekit.net/lbk1xay.css" />
     <link
       rel="stylesheet"
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
     />
   </head>
+
   <body>
     <div id="app-container"></div>
   </body>

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.test.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.test.tsx
@@ -1,20 +1,23 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 
+import { ThemeProvider } from "ol-components"
 import { fields as factory } from "api/test-utils/factories"
 import FieldAvatar from "./FieldAvatar"
 
 describe("Avatar", () => {
   it("Displays a small avatar image for the field", async () => {
     const field = factory.field()
-    render(<FieldAvatar field={field} imageSize="small" />)
+    render(<FieldAvatar field={field} imageSize="small" />, {
+      wrapper: ThemeProvider,
+    })
     const img = screen.getByRole("img")
     expect(img.getAttribute("alt")).toBe(null) // should be empty unless meaningful
     expect(img.getAttribute("src")).toEqual(field.avatar_small)
   })
   it("Displays a medium avatar image by default", async () => {
     const field = factory.field()
-    render(<FieldAvatar field={field} />)
+    render(<FieldAvatar field={field} />, { wrapper: ThemeProvider })
     const img = screen.getByRole("img")
     expect(img.getAttribute("alt")).toBe(null) // should be empty unless meaningful
     expect(img.getAttribute("src")).toEqual(field.avatar_medium)
@@ -26,7 +29,7 @@ describe("Avatar", () => {
       avatar_small: null,
       avatar_medium: null,
     })
-    render(<FieldAvatar field={field} />)
+    render(<FieldAvatar field={field} />, { wrapper: ThemeProvider })
     const img = screen.queryByRole("img")
     expect(img).toBeNull()
     await screen.findByText("TT")

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -44,11 +44,11 @@ const IMG_SIZES = {
   medium: "57px",
   large: "90px",
 }
-const FONT_SIZES = {
-  small: "15px",
-  medium: "32px",
-  large: "50px",
-}
+const FONT_STYLES = {
+  small: "subtitle1",
+  medium: "h3",
+  large: "h2",
+} as const
 
 type AvatarStyleProps = Required<Pick<AvatarProps, "imageSize">>
 const AvatarContainer = styled.div<AvatarStyleProps>`
@@ -69,11 +69,12 @@ const AvatarImg = styled.img<AvatarStyleProps>`
   width: ${({ imageSize }) => IMG_SIZES[imageSize]};
   height: ${({ imageSize }) => IMG_SIZES[imageSize]};
 `
-const AvatarInitials = styled(AvatarImg.withComponent("div"))`
-  font-size: ${({ imageSize = "medium" }) => FONT_SIZES[imageSize]};
-  font-weight: 600;
-  color: white;
-`
+const AvatarInitials = styled(AvatarImg.withComponent("div"))(
+  ({ theme, imageSize = "medium" }) => ({
+    ...theme.typography[FONT_STYLES[imageSize]],
+    color: "white",
+  }),
+)
 
 const FieldAvatar: React.FC<AvatarProps> = (props) => {
   const { field, formImageUrl, imageSize = "medium" } = props

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -13,6 +13,7 @@ import {
   Skeleton,
   SimpleSelect,
   truncateText,
+  css,
 } from "ol-components"
 import { MetaTags, capitalize } from "ol-utilities"
 
@@ -136,8 +137,7 @@ const FacetStyles = styled.div`
   }
 
   .filter-section-button {
-    font-size: ${({ theme }) => theme.typography.subtitle1.fontSize};
-    font-weight: 600;
+    ${({ theme }) => css({ ...theme.typography.subtitle1 })};
     padding-left: 0;
     background-color: transparent;
     display: flex;

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -31,7 +31,7 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     ...defaultProps,
     ...props,
   }
-  const { palette } = theme
+  const { palette, typography } = theme
   return [
     {
       // font
@@ -55,17 +55,17 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     size === "large" && {
       padding: "0px 24px",
       height: `calc(48px - 16px + ${pxToRem(16)})`, // 48px at default base font size
-      fontSize: pxToRem(16),
+      ...typography.buttonLarge,
     },
     size === "medium" && {
       padding: "0px 16px",
       height: `calc(40px - 14px + ${pxToRem(14)})`, // 40px at default base font size
-      fontSize: pxToRem(14),
+      ...typography.button,
     },
     size === "small" && {
       padding: "0px 12px",
       height: `calc(32px - 12px + ${pxToRem(12)})`, // 32px at default base font size
-      fontSize: pxToRem(12),
+      ...typography.buttonSmall,
     },
     // variant
     variant === "filled" && {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -34,10 +34,6 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
   const { palette, typography } = theme
   return [
     {
-      // font
-      lineHeight: 1,
-      fontFamily: theme.typography.fontFamily,
-      fontWeight: 500,
       color: theme.palette.text.primary,
       // display
       display: "flex",

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -92,9 +92,7 @@ const Input = styled(InputBase)(({
 
 const AdornmentButtonStyled = styled("button")(({ theme }) => ({
   // font
-  lineHeight: 1,
-  fontFamily: theme.typography.fontFamily,
-  fontWeight: 500,
+  ...theme.typography.button,
   // display
   display: "flex",
   justifyContent: "center",

--- a/frontends/ol-components/src/components/ThemeProvider/typography.ts
+++ b/frontends/ol-components/src/components/ThemeProvider/typography.ts
@@ -1,9 +1,11 @@
 import type { ThemeOptions } from "@mui/material/styles"
 import { createTheme } from "@mui/material/styles"
 
-const neueHaasWeights = {
+const fontWeights = {
   /**
-   * ALERT! These weights are based on the stylesheet provided by Adobe.
+   * ALERT! These weights are based on the stylesheet provided by Adobe and are
+   * specific to the neue-haas-grotesk font family.
+   *
    * They may not match the weights shown in Figma, which can be incorrect.
    */
   display: {
@@ -36,112 +38,112 @@ const globalSettings: ThemeOptions["typography"] = {
   fontFamily: "neue-haas-grotesk-text, sans-serif",
   h1: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",
-    fontWeight: neueHaasWeights.display.bold,
+    fontWeight: fontWeights.display.bold,
     fontStyle: "normal",
     fontSize: pxToRem(56),
     lineHeight: pxToRem(64),
   },
   h2: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",
-    fontWeight: neueHaasWeights.display.bold,
+    fontWeight: fontWeights.display.bold,
     fontStyle: "normal",
     fontSize: pxToRem(40),
     lineHeight: pxToRem(48),
   },
   h3: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",
-    fontWeight: neueHaasWeights.display.bold,
+    fontWeight: fontWeights.display.bold,
     fontStyle: "normal",
     fontSize: pxToRem(32),
     lineHeight: pxToRem(40),
   },
   h4: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",
-    fontWeight: neueHaasWeights.display.bold,
+    fontWeight: fontWeights.display.bold,
     fontStyle: "normal",
     fontSize: pxToRem(24),
     lineHeight: pxToRem(30),
   },
   h5: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",
-    fontWeight: neueHaasWeights.display.medium,
+    fontWeight: fontWeights.display.medium,
     fontStyle: "normal",
     fontSize: pxToRem(20),
     lineHeight: pxToRem(26),
   },
   subtitle1: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(16),
     lineHeight: pxToRem(20),
   },
   subtitle2: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(18),
   },
   subtitle3: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(12),
     lineHeight: pxToRem(16),
   },
   subtitle4: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(10),
     lineHeight: pxToRem(14),
   },
   body1: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.roman,
+    fontWeight: fontWeights.text.roman,
     fontStyle: "normal",
     fontSize: pxToRem(16),
     lineHeight: pxToRem(20),
   },
   body2: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.roman,
+    fontWeight: fontWeights.text.roman,
     fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(18),
   },
   body3: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.roman,
+    fontWeight: fontWeights.text.roman,
     fontStyle: "normal",
     fontSize: pxToRem(12),
     lineHeight: pxToRem(16),
   },
   body4: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.roman,
+    fontWeight: fontWeights.text.roman,
     fontStyle: "normal",
     fontSize: pxToRem(10),
     lineHeight: pxToRem(14),
   },
   buttonLarge: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(16),
     lineHeight: pxToRem(16),
   },
   button: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(14),
   },
   buttonSmall: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",
-    fontWeight: neueHaasWeights.text.medium,
+    fontWeight: fontWeights.text.medium,
     fontStyle: "normal",
     fontSize: pxToRem(12),
     lineHeight: pxToRem(12),

--- a/frontends/ol-components/src/components/ThemeProvider/typography.ts
+++ b/frontends/ol-components/src/components/ThemeProvider/typography.ts
@@ -35,6 +35,7 @@ const fontWeights = {
 const pxToRem = (px: number) => `${px / 16}rem`
 
 const globalSettings: ThemeOptions["typography"] = {
+  // Note: Figma calls this "Neue Haas Grotesk Text", but that is incorrect based on Adobe's font family.
   fontFamily: "neue-haas-grotesk-text, sans-serif",
   h1: {
     fontFamily: "neue-haas-grotesk-display, sans-serif",

--- a/frontends/ol-components/src/components/ThemeProvider/typography.ts
+++ b/frontends/ol-components/src/components/ThemeProvider/typography.ts
@@ -1,6 +1,23 @@
 import type { ThemeOptions } from "@mui/material/styles"
 import { createTheme } from "@mui/material/styles"
 
+const neueHaasWeights = {
+  /**
+   * ALERT! These weights are based on the stylesheet provided by Adobe.
+   * They may not match the weights shown in Figma, which can be incorrect.
+   */
+  display: {
+    roman: 500,
+    medium: 600,
+    bold: 700,
+  },
+  text: {
+    roman: 400,
+    medium: 500,
+    bold: 700,
+  },
+}
+
 /**
  * This function converts from pixels to rems, assuming a base font size of 16px
  * (which is the default for most modern browsers).
@@ -16,70 +33,118 @@ import { createTheme } from "@mui/material/styles"
 const pxToRem = (px: number) => `${px / 16}rem`
 
 const globalSettings: ThemeOptions["typography"] = {
-  fontFamily: ['"Helvetica Neue"', "Arial", "sans-serif"].join(","),
+  fontFamily: "neue-haas-grotesk-text, sans-serif",
   h1: {
-    fontWeight: 700,
+    fontFamily: "neue-haas-grotesk-display, sans-serif",
+    fontWeight: neueHaasWeights.display.bold,
+    fontStyle: "normal",
     fontSize: pxToRem(56),
     lineHeight: pxToRem(64),
   },
   h2: {
-    fontWeight: 700,
+    fontFamily: "neue-haas-grotesk-display, sans-serif",
+    fontWeight: neueHaasWeights.display.bold,
+    fontStyle: "normal",
     fontSize: pxToRem(40),
     lineHeight: pxToRem(48),
   },
   h3: {
-    fontWeight: 700,
+    fontFamily: "neue-haas-grotesk-display, sans-serif",
+    fontWeight: neueHaasWeights.display.bold,
+    fontStyle: "normal",
     fontSize: pxToRem(32),
     lineHeight: pxToRem(40),
   },
   h4: {
-    fontWeight: 700,
+    fontFamily: "neue-haas-grotesk-display, sans-serif",
+    fontWeight: neueHaasWeights.display.bold,
+    fontStyle: "normal",
     fontSize: pxToRem(24),
     lineHeight: pxToRem(30),
   },
   h5: {
-    fontWeight: 500,
+    fontFamily: "neue-haas-grotesk-display, sans-serif",
+    fontWeight: neueHaasWeights.display.medium,
+    fontStyle: "normal",
     fontSize: pxToRem(20),
     lineHeight: pxToRem(26),
   },
   subtitle1: {
-    fontWeight: 500,
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
     fontSize: pxToRem(16),
     lineHeight: pxToRem(20),
   },
   subtitle2: {
-    fontWeight: 500,
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(18),
   },
   subtitle3: {
-    fontWeight: 500,
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
     fontSize: pxToRem(12),
     lineHeight: pxToRem(16),
   },
   subtitle4: {
-    fontWeight: 500,
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
     fontSize: pxToRem(10),
     lineHeight: pxToRem(14),
   },
   body1: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.roman,
+    fontStyle: "normal",
     fontSize: pxToRem(16),
     lineHeight: pxToRem(20),
   },
   body2: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.roman,
+    fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(18),
   },
   body3: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.roman,
+    fontStyle: "normal",
     fontSize: pxToRem(12),
     lineHeight: pxToRem(16),
   },
   body4: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.roman,
+    fontStyle: "normal",
     fontSize: pxToRem(10),
     lineHeight: pxToRem(14),
   },
+  buttonLarge: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
+    fontSize: pxToRem(16),
+    lineHeight: pxToRem(16),
+  },
   button: {
-    textTransform: "none",
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
+    fontSize: pxToRem(14),
+    lineHeight: pxToRem(14),
+  },
+  buttonSmall: {
+    fontFamily: "neue-haas-grotesk-text, sans-serif",
+    fontWeight: neueHaasWeights.text.medium,
+    fontStyle: "normal",
+    fontSize: pxToRem(12),
+    lineHeight: pxToRem(12),
   },
 }
 const component: NonNullable<ThemeOptions["components"]>["MuiTypography"] = {

--- a/frontends/ol-components/src/types/typography.d.ts
+++ b/frontends/ol-components/src/types/typography.d.ts
@@ -15,7 +15,9 @@ declare module "@mui/material/styles" {
     subtitle2: React.CSSProperties
     subtitle3: React.CSSProperties
     subtitle4: React.CSSProperties
+    buttonLarge: React.CSSProperties
     button: React.CSSProperties
+    buttonSmall: React.CSSProperties
   }
   interface TypographyVariantsOptions {
     h1: React.CSSProperties
@@ -31,7 +33,9 @@ declare module "@mui/material/styles" {
     subtitle2: React.CSSProperties
     subtitle3: React.CSSProperties
     subtitle4: React.CSSProperties
+    buttonLarge: React.CSSProperties
     button: React.CSSProperties
+    buttonSmall: React.CSSProperties
   }
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4205

### Description (What does it do?)
Adds Neue Haas Grotest fonts to MIT Open.

### Screenshots (if appropriate):
See https://ordinary-kitty.surge.sh/?path=/docs/smoot-design-typography--docs

### How can this be tested?

**NOTES:** 



1. Look around the site. It should look similar but should be using a new font.
2. In particular, check that the search page looks good.
3.  You could check that the fonts in http://localhost:6006/?path=/docs/smoot-design-typography--docs match https://www.figma.com/file/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?type=design&node-id=104-822&mode=design&t=6B5Qy7dacJnxYeVE-0
4. Try adding `{ fontWeight: 500 }` (the value can be any number) to an object. You should get an ESLint warning.

### Other Notes

1. Browsers resolve fonts by matching font descriptors (e.g., `font-family`, `font-weight`, and `font-style`) to font declarations. Generally, normal and bold-weight fonts are separate fonts, not the same character set with different thicknesses. To see the actual font being rendered by Chrome, you can use the "Computed" panel in the "Elements" tab:
 
    <img width="934" alt="Screenshot 2024-05-13 at 11 49 51 AM" src="https://github.com/mitodl/mit-open/assets/9010790/8297f143-d020-4db8-82b8-fa37347081fc">
2. **Figma:** Does not show the actual font for designs (e.g., "Neue Haas Grotesk Display Pro 75 Bold  -  56px") but instead shows
    1. The "name" if it is a named style (e.g., H1, S3, or Body2).
    2. CSS properties. _Except, these are inaccurate for font weight. See note on `.eslintrc`._