### PR TITLE
Do not show unpublished runs in learning resource serializer data

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -346,7 +346,6 @@ def load_course(
         for course_run_data in runs_data:
             load_run(learning_resource, course_run_data)
 
-        unpublished_runs = []
         if config.prune:
             # mark runs no longer included here as unpublished
             for run in learning_resource.runs.exclude(
@@ -354,7 +353,6 @@ def load_course(
             ).filter(published=True):
                 run.published = False
                 run.save()
-                unpublished_runs.append(run.id)
 
         load_next_start_date(learning_resource)
         load_topics(learning_resource, topics_data)
@@ -478,7 +476,6 @@ def load_program(
         for run_data in runs_data:
             load_run(learning_resource, run_data)
 
-        unpublished_runs = []
         if config.prune:
             # mark runs no longer included here as unpublished
             for run in learning_resource.runs.exclude(
@@ -486,7 +483,6 @@ def load_program(
             ).filter(published=True):
                 run.published = False
                 run.save()
-                unpublished_runs.append(run.id)
 
         load_next_start_date(learning_resource)
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -494,6 +494,12 @@ class LearningResourceBaseSerializer(serializers.ModelSerializer, WriteableTopic
             learning_resource=instance
         ).count()
 
+    def to_representation(self, instance):
+        """Filter out unpublished runs"""
+        data = super().to_representation(instance)
+        data["runs"] = [run for run in data["runs"] if run["published"]]
+        return data
+
     class Meta:
         model = models.LearningResource
         read_only_fields = ["professional", "views"]

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -18,6 +18,8 @@ from learning_resources.constants import (
     LearningResourceType,
     PlatformType,
 )
+from learning_resources.factories import LearningResourceFactory
+from learning_resources.serializers import LearningResourceSerializer
 from main.test_utils import assert_json_equal, drf_datetime
 
 pytestmark = pytest.mark.django_db
@@ -245,6 +247,19 @@ def test_learning_resource_serializer(  # noqa: PLR0913
         ],
         "next_start_date": resource.next_start_date,
     }
+
+
+def test_learning_resource_serializer_published_runs_only():
+    """Only published runs should be in the serializer"""
+    resource = LearningResourceFactory.create(is_course=True)
+    assert resource.runs.count() == 2
+    assert len(LearningResourceSerializer(resource).data["runs"]) == 2
+    unpublished_run = resource.runs.last()
+    unpublished_run.published = False
+    unpublished_run.save()
+    updated_data = LearningResourceSerializer(resource).data
+    assert len(updated_data["runs"]) == 1
+    assert updated_data["runs"][0]["id"] != unpublished_run.id
 
 
 @pytest.mark.parametrize("has_context", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4218

### Description (What does it do?)
Filters out unpublished runs from the base LearningResourceSerializer data


### How can this be tested?
- In django admin, find a course with multiple runs, update one of them to `published=False`
- Go to the api url for that course: `http://localhost:8063/api/v1/courses/<resource_id>` and check that the unpublished run is not included in the `runs` field.

### Additional Context
I initially thought of turning `runs` into a SerializedMethodField and running a query to filter out the unpublished runs in the `get_runs` method, but that led to more n+1 queries.

Another option is to delete unpublished runs altogether, not sure if there's a point to keeping them around other than maybe for archival purposes.



