### PR TITLE
Null start dates for OCW course runs

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -36,7 +36,6 @@ from learning_resources.utils import (
     get_s3_object_and_read,
     parse_instructors,
     safe_load_json,
-    semester_year_to_date,
 )
 
 log = logging.getLogger(__name__)
@@ -254,7 +253,6 @@ def transform_run(course_data: dict) -> dict:
                 .get("image-alt")
             ),
         },
-        "start_date": semester_year_to_date(semester, year),
         "level": transform_levels(course_data.get("level", [])),
         "last_modified": course_data.get("last_modified"),
         "title": course_data.get("course_title"),

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -21,7 +21,6 @@ from learning_resources.models import ContentFile
 from learning_resources.utils import (
     get_s3_object_and_read,
     safe_load_json,
-    semester_year_to_date,
 )
 from main.utils import now_in_utc
 
@@ -217,9 +216,6 @@ def test_transform_course(  # noqa: PLR0913
         assert transformed_json["runs"][0]["level"] == ["undergraduate", "high_school"]
         assert transformed_json["runs"][0]["semester"] == (term if term else None)
         assert transformed_json["runs"][0]["year"] == (year if year else None)
-        assert transformed_json["runs"][0]["start_date"] == semester_year_to_date(
-            term or None, year or None
-        )
         assert (
             transformed_json["image"]["url"]
             == "http://test.edu/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg"

--- a/learning_resources/migrations/0048_null_ocw_start_dates.py
+++ b/learning_resources/migrations/0048_null_ocw_start_dates.py
@@ -1,0 +1,27 @@
+# Manually generated
+
+from django.db import migrations
+
+from learning_resources.etl.constants import ETLSource
+
+
+def depopulate_ocw_start_dates(apps, schema_editor):
+    """
+    Make all OCW run start dates null
+    """
+    LearningResourceRun = apps.get_model("learning_resources", "LearningResourceRun")
+    LearningResourceRun.objects.filter(
+        learning_resource__etl_source=ETLSource.ocw.name
+    ).update(start_date=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0047_add_nestable_topics"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            depopulate_ocw_start_dates, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -3,7 +3,6 @@
 import json
 import logging
 import re
-from datetime import UTC, datetime
 from pathlib import Path
 
 import rapidjson
@@ -89,30 +88,6 @@ def get_year_and_semester(course_run):
             semester = None
             year = course_run.get("start")[:4] if course_run.get("start") else None
     return year, semester
-
-
-def semester_year_to_date(semester, year):
-    """
-    Convert semester and year to a rough date
-
-    Args:
-        semester (str): Semester ("Fall", "Spring", etc)
-        year (int): Year
-
-    Returns:
-        datetime: The rough date of the course
-    """
-    if year is None:
-        return None
-    if semester is None:
-        month_day = "01-01"
-    elif semester.lower() == "fall":
-        month_day = "09-01"
-    elif semester.lower() == "summer":
-        month_day = "06-01"
-    else:
-        month_day = "01-01"
-    return datetime.strptime(f"{year}-{month_day}", "%Y-%m-%d").replace(tzinfo=UTC)
 
 
 def load_course_blocklist():

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -3,7 +3,6 @@ Test learning_resources utils
 """
 
 import json
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
@@ -54,32 +53,6 @@ def fixture_test_instructors_data():
     """
     with open("./test_json/test_instructors_data.json") as test_data:  # noqa: PTH123
         return json.load(test_data)["instructors"]
-
-
-@pytest.mark.parametrize(
-    ("semester", "year", "expected"),
-    [
-        ("Spring", 2020, "2020-01-01"),
-        ("Fall", 2020, "2020-09-01"),
-        ("fall", 2020, "2020-09-01"),
-        ("summer", 2021, "2021-06-01"),
-        ("Summer", 2021, "2021-06-01"),
-        ("spring", None, None),
-        (None, 2020, "2020-01-01"),
-        ("something", 2020, "2020-01-01"),
-        ("January IAP", 2018, "2018-01-01"),
-    ],
-)
-def test_semester_year_to_date(semester, year, expected):
-    """
-    Test that a correct rough date is returned for semester and year
-    """
-    if expected is None:
-        assert utils.semester_year_to_date(semester, year) is None
-    else:
-        assert utils.semester_year_to_date(semester, year) == datetime.strptime(
-            expected, "%Y-%m-%d"
-        ).replace(tzinfo=UTC)
 
 
 @pytest.mark.parametrize("url", [None, "http://test.me"])


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4154

### Description (What does it do?)
Makes start date null for OCW courses


### How can this be tested?
If you have existing OCW resources, they should all have a null start date after the migration is run.
If you run `./manage.py backpopulate_ocw_data --course-name <ocw_course> --skip-contentfiles`, that course should still have a null start date afterward.

