### PR TITLE
Correct path to webpack stats file

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -76,7 +76,7 @@ WEBPACK_LOADER = {
         "CACHE": not DEBUG,
         "BUNDLE_DIR_NAME": "mit-open/",
         "STATS_FILE": os.path.join(  # noqa: PTH118
-            BASE_DIR, "webpack-stats/mit-open.json"
+            BASE_DIR, "frontends/mit-open/webpack-stats.json"
         ),
         "POLL_INTERVAL": 0.1,
         "TIMEOUT": None,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Fixes an error we are seeing due to the WebPack stats file having moved during [Self contained front end and fixes for building on Heroku #829](https://github.com/mitodl/mit-open/pull/829) by correcting the path.

```
Error reading /app/webpack-stats/mit-open.json.
Are you sure webpack has generated the file and the path is correct?
```

