### PR TITLE
Fix 500 error loading attestations without a cover image

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -70,11 +70,11 @@ export interface Attestation {
    */
   avatar_medium: string
   /**
-   *
+   * Get the cover image URL
    * @type {string}
    * @memberof Attestation
    */
-  cover: string
+  cover: string | null
   /**
    *
    * @type {string}

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -552,7 +552,9 @@ components:
           format: uri
         cover:
           type: string
-          format: uri
+          nullable: true
+          description: Get the cover image URL
+          readOnly: true
         created_on:
           type: string
           format: date-time

--- a/testimonials/serializers.py
+++ b/testimonials/serializers.py
@@ -11,7 +11,11 @@ class AttestationSerializer(serializers.ModelSerializer):
     avatar = serializers.URLField(source="avatar.url")
     avatar_small = serializers.URLField(source="avatar_small.url")
     avatar_medium = serializers.URLField(source="avatar_medium.url")
-    cover = serializers.URLField(source="cover.url")
+    cover = serializers.SerializerMethodField()
+
+    def get_cover(self, attestation) -> str | None:
+        """Get the cover image URL"""
+        return attestation.cover.url if attestation.cover else None
 
     class Meta:
         """Meta options for the serializer"""


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4249

### Description (What does it do?)

The cover image field used a `URLField` in the serializer, but the field is optional; if the field is None, this generates an error. This update moves that back to a `SerializerMethodField` so we can return None if there's no cover image.

### How can this be tested?

Automated tests should pass. 

The testing scenario in 4249 should also work (i.e., create an attestation without a cover image and try to load it). 