### PR TITLE
Update MITx Online ETL to not parse the readable ID for departments

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -72,16 +72,10 @@ def parse_page_attribute(
     return default_value
 
 
-def map_mxo_depts_to_open(departments):
+def parse_mitxonline_departments(departments):
     """Map the MITx Online departments to Open ones"""
 
-    return (
-        LearningResourceDepartment.objects.filter(
-            name__in=[mxo_dept["name"] for mxo_dept in departments]
-        )
-        .values_list("name", flat=True)
-        .all()
-    )
+    return [mxo_dept["name"] for mxo_dept in departments]
 
 
 def extract_programs():
@@ -183,7 +177,7 @@ def _transform_course(course):
         "title": course["title"],
         "offered_by": copy.deepcopy(OFFERED_BY),
         "topics": transform_topics(course.get("topics", [])),
-        "departments": map_mxo_depts_to_open(course["departments"]),
+        "departments": parse_mitxonline_departments(course["departments"]),
         "runs": [
             _transform_run(course_run, course) for course_run in course["courseruns"]
         ],
@@ -230,7 +224,7 @@ def transform_programs(programs):
             "offered_by": OFFERED_BY,
             "etl_source": ETLSource.mitxonline.name,
             "resource_type": LearningResourceType.program.name,
-            "departments": map_mxo_depts_to_open(program["departments"]),
+            "departments": parse_mitxonline_departments(program["departments"]),
             "platform": PlatformType.mitxonline.name,
             "professional": False,
             "certification": bool(parse_page_attribute(program, "page_url")),

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -18,11 +18,11 @@ from learning_resources.constants import (
 )
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.utils import (
-    extract_valid_department_from_id,
     generate_course_numbers_json,
     parse_certification,
     transform_topics,
 )
+from learning_resources.models import LearningResourceDepartment
 
 log = logging.getLogger(__name__)
 
@@ -70,6 +70,18 @@ def parse_page_attribute(
             urljoin(settings.MITX_ONLINE_BASE_URL, attribute) if is_url else attribute
         )
     return default_value
+
+
+def map_mxo_depts_to_open(departments):
+    """Map the MITx Online departments to Open ones"""
+
+    return (
+        LearningResourceDepartment.objects.filter(
+            name__in=[mxo_dept["name"] for mxo_dept in departments]
+        )
+        .values_list("name", flat=True)
+        .all()
+    )
 
 
 def extract_programs():
@@ -171,7 +183,7 @@ def _transform_course(course):
         "title": course["title"],
         "offered_by": copy.deepcopy(OFFERED_BY),
         "topics": transform_topics(course.get("topics", [])),
-        "departments": extract_valid_department_from_id(course["readable_id"]),
+        "departments": map_mxo_depts_to_open(course["departments"]),
         "runs": [
             _transform_run(course_run, course) for course_run in course["courseruns"]
         ],
@@ -218,7 +230,7 @@ def transform_programs(programs):
             "offered_by": OFFERED_BY,
             "etl_source": ETLSource.mitxonline.name,
             "resource_type": LearningResourceType.program.name,
-            "departments": extract_valid_department_from_id(program["readable_id"]),
+            "departments": map_mxo_depts_to_open(program["departments"]),
             "platform": PlatformType.mitxonline.name,
             "professional": False,
             "certification": bool(parse_page_attribute(program, "page_url")),

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -22,6 +22,7 @@ from learning_resources.etl.mitxonline import (
     _transform_image,
     extract_courses,
     extract_programs,
+    parse_mitxonline_departments,
     parse_page_attribute,
     parse_program_prices,
     transform_courses,
@@ -29,7 +30,6 @@ from learning_resources.etl.mitxonline import (
 )
 from learning_resources.etl.utils import (
     UCC_TOPIC_MAPPINGS,
-    extract_valid_department_from_id,
     parse_certification,
 )
 from main.test_utils import any_instance_of
@@ -162,8 +162,8 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                     "resource_type": LearningResourceType.course.name,
                     "professional": False,
                     "etl_source": ETLSource.mitxonline.value,
-                    "departments": extract_valid_department_from_id(
-                        course_data["readable_id"]
+                    "departments": parse_mitxonline_departments(
+                        course_data["departments"]
                     ),
                     "title": course_data["title"],
                     "image": _transform_image(course_data),
@@ -247,7 +247,7 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
             "platform": PlatformType.mitxonline.name,
             "etl_source": ETLSource.mitxonline.name,
             "resource_type": LearningResourceType.course.name,
-            "departments": extract_valid_department_from_id(course_data["readable_id"]),
+            "departments": parse_mitxonline_departments(course_data["departments"]),
             "title": course_data["title"],
             "image": _transform_image(course_data),
             "description": course_data.get("page", {}).get("description", None),

--- a/test_json/mitxonline_courses.json
+++ b/test_json/mitxonline_courses.json
@@ -1,20 +1,50 @@
 [
   {
-    "id": 3,
-    "title": "Data Analysis for Social Scientists",
-    "readable_id": "course-v1:MITxT+14.310x",
+    "id": 1,
+    "title": "Microeconomics",
+    "readable_id": "course-v1:MITxT+14.100x",
+    "next_run_id": 246,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
+      "page_url": "/courses/course-v1:MITxT+14.100x/",
+      "description": "Use economic models to learn how prices and markets benefit society in the face of scarcity.",
+      "live": true,
+      "length": "14 weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Jonathan Gruber",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
     "courseruns": [
       {
-        "title": "Data Analysis for Social Scientists",
+        "title": "Microeconomics",
         "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
+        "end_date": "2023-06-24T19:20:00Z",
         "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
+        "enrollment_end": "2022-10-07T23:59:00Z",
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.310x+3T2022",
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.100x+3T2022",
+        "certificate_available_date": "2023-06-25T00:00:00Z",
+        "upgrade_deadline": "2022-12-25T19:20:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
         "run_tag": "3T2022",
-        "id": 36,
+        "id": 35,
+        "live": true,
+        "course_number": "14.100x",
         "products": [
           {
             "id": 22,
@@ -34,42 +64,1157 @@
             }
           }
         ],
-        "page": {
-          "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-          "page_url": "/courses/course-v1:MITxT+14.310x/",
-          "financial_assistance_form_url": ""
-        }
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2023-09-12T15:00:00Z",
+        "end_date": "2024-02-18T15:00:00Z",
+        "enrollment_start": "2023-06-27T15:00:00Z",
+        "enrollment_end": "2023-10-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+14.100x+3T2023",
+        "certificate_available_date": "2024-02-19T00:00:00Z",
+        "upgrade_deadline": "2023-11-03T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 185,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 164,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2023-05-30T15:00:00Z",
+        "end_date": "2024-02-01T15:00:00Z",
+        "enrollment_start": "2022-10-11T15:00:00Z",
+        "enrollment_end": "2023-06-27T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100x+2T2023",
+        "courseware_id": "course-v1:MITxT+14.100x+2T2023",
+        "certificate_available_date": "2024-02-02T00:00:00Z",
+        "upgrade_deadline": "2023-07-18T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2023",
+        "id": 143,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 108,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-04T00:00:00Z",
+        "enrollment_start": "2023-10-10T15:00:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+14.100x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 225,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 200,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2024-05-14T15:00:00Z",
+        "end_date": "2024-08-21T15:00:00Z",
+        "enrollment_start": "2024-02-13T23:59:00Z",
+        "enrollment_end": "2024-06-11T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+14.100x+2T2024",
+        "certificate_available_date": "2024-09-18T00:00:00Z",
+        "upgrade_deadline": "2024-06-25T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 246,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 217,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2017-09-26T15:00:00Z",
+        "end_date": "2017-12-22T15:00:00Z",
+        "enrollment_start": "2017-07-03T15:00:00Z",
+        "enrollment_end": "2017-10-24T03:21:39Z",
+        "expiration_date": "2017-12-23T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2017",
+        "courseware_id": "course-v1:MITx+14.100x+3T2017",
+        "certificate_available_date": "2017-12-22T15:00:00Z",
+        "upgrade_deadline": "2017-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2017",
+        "id": 63,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 26,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+3T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2017-02-06T15:00:00Z",
+        "end_date": "2017-05-05T15:00:00Z",
+        "enrollment_start": "2016-12-05T05:00:00Z",
+        "enrollment_end": "2017-03-06T14:00:00Z",
+        "expiration_date": "2017-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2017",
+        "courseware_id": "course-v1:MITx+14.100x+1T2017",
+        "certificate_available_date": "2017-05-05T15:00:00Z",
+        "upgrade_deadline": "2017-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2017",
+        "id": 119,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 84,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+1T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2017-06-05T15:00:00Z",
+        "end_date": "2017-08-28T15:00:00Z",
+        "enrollment_start": "2017-03-06T14:00:00Z",
+        "enrollment_end": "2017-07-03T15:00:00Z",
+        "expiration_date": "2017-08-29T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2017",
+        "courseware_id": "course-v1:MITx+14.100x+2T2017",
+        "certificate_available_date": "2017-08-28T15:00:00Z",
+        "upgrade_deadline": "2017-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2017",
+        "id": 120,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 85,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2018-02-06T15:00:00Z",
+        "end_date": "2018-05-05T15:00:00Z",
+        "enrollment_start": "2017-10-24T15:00:00Z",
+        "enrollment_end": "2018-03-06T04:00:00Z",
+        "expiration_date": "2018-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2018",
+        "courseware_id": "course-v1:MITx+14.100x+1T2018",
+        "certificate_available_date": "2018-05-05T15:00:00Z",
+        "upgrade_deadline": "2018-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2018",
+        "id": 121,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 86,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+1T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2018-06-05T15:00:00Z",
+        "end_date": "2018-08-21T03:30:00Z",
+        "enrollment_start": "2018-03-06T15:00:00Z",
+        "enrollment_end": "2018-07-03T15:00:00Z",
+        "expiration_date": "2018-08-22T03:30:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2018",
+        "courseware_id": "course-v1:MITx+14.100x+2T2018",
+        "certificate_available_date": "2018-08-21T03:30:00Z",
+        "upgrade_deadline": "2018-08-21T03:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2018",
+        "id": 122,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 87,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2020",
+        "courseware_id": "course-v1:MITx+14.100x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 108,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 73,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2016-09-16T04:00:00Z",
+        "end_date": "2016-12-15T15:00:00Z",
+        "enrollment_start": "2016-09-16T04:00:00Z",
+        "enrollment_end": "2016-12-04T04:00:00Z",
+        "expiration_date": "2016-12-16T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2016",
+        "courseware_id": "course-v1:MITx+14.100x+3T2016",
+        "certificate_available_date": "2016-12-15T15:00:00Z",
+        "upgrade_deadline": "2016-12-15T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2016",
+        "id": 118,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 83,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+3T2016",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2018-09-11T15:00:00Z",
+        "end_date": "2018-11-28T03:00:00Z",
+        "enrollment_start": "2018-07-03T15:00:00Z",
+        "enrollment_end": "2018-10-09T15:00:00Z",
+        "expiration_date": "2018-11-29T03:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2018",
+        "courseware_id": "course-v1:MITx+14.100x+3T2018",
+        "certificate_available_date": "2018-11-28T03:00:00Z",
+        "upgrade_deadline": "2018-11-28T03:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2018",
+        "id": 123,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 88,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+3T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2019-02-05T15:00:00Z",
+        "end_date": "2019-04-23T15:00:00Z",
+        "enrollment_start": "2018-10-09T15:00:00Z",
+        "enrollment_end": "2019-03-03T15:00:00Z",
+        "expiration_date": "2019-04-24T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2019",
+        "courseware_id": "course-v1:MITx+14.100x+1T2019",
+        "certificate_available_date": "2019-04-23T15:00:00Z",
+        "upgrade_deadline": "2019-04-23T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2019",
+        "id": 124,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 89,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+1T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2019-05-21T15:00:00Z",
+        "end_date": "2019-08-06T15:00:00Z",
+        "enrollment_start": "2019-03-04T15:02:19Z",
+        "enrollment_end": "2019-06-18T15:00:00Z",
+        "expiration_date": "2019-08-07T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2019",
+        "courseware_id": "course-v1:MITx+14.100x+2T2019",
+        "certificate_available_date": "2019-08-06T15:00:00Z",
+        "upgrade_deadline": "2019-08-06T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019",
+        "id": 125,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 90,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-06-18T15:00:00Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2019a",
+        "courseware_id": "course-v1:MITx+14.100x+2T2019a",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019a",
+        "id": 126,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 91,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2019a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-02T17:28:24Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2020",
+        "courseware_id": "course-v1:MITx+14.100x+1T2020",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020",
+        "id": 127,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 92,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+1T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:28Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2020",
+        "courseware_id": "course-v1:MITx+14.100x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 128,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 93,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2021",
+        "courseware_id": "course-v1:MITx+14.100x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 129,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 94,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2021-06-01T15:00:00Z",
+        "end_date": "2021-08-17T23:59:00Z",
+        "enrollment_start": "2021-03-13T23:59:00Z",
+        "enrollment_end": "2021-07-07T15:00:00Z",
+        "expiration_date": "2021-08-18T23:59:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2021",
+        "courseware_id": "course-v1:MITx+14.100x+2T2021",
+        "certificate_available_date": "2021-08-17T23:59:00Z",
+        "upgrade_deadline": "2021-08-17T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2021",
+        "id": 130,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 95,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.100x+2T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2021-10-05T15:00:00Z",
+        "end_date": "2021-12-22T15:00:00Z",
+        "enrollment_start": null,
+        "enrollment_end": "2021-11-02T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+14.100x+3T2021",
+        "certificate_available_date": "2021-12-23T23:30:00Z",
+        "upgrade_deadline": "2021-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2021",
+        "id": 2,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 9,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics",
+        "start_date": "2022-05-31T15:00:00Z",
+        "end_date": "2022-08-16T23:30:00Z",
+        "enrollment_start": "2021-11-02T23:59:00Z",
+        "enrollment_end": "2022-07-06T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.100x+2T2022",
+        "certificate_available_date": "2022-08-18T15:00:00Z",
+        "upgrade_deadline": "2022-08-16T23:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 9,
+        "live": true,
+        "course_number": "14.100x",
+        "products": [
+          {
+            "id": 5,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.100x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
       }
-    ],
-    "next_run_id": 36,
-    "topics": []
+    ]
   },
   {
     "id": 2,
     "title": "Designing and Running Randomized Evaluations",
     "readable_id": "course-v1:MITxT+JPAL102x",
+    "next_run_id": 248,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
     "page": {
       "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
       "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-      "financial_assistance_form_url": ""
+      "description": "This course equips students with the practical skills for running evaluations in the field. Students will learn the foundations of randomizations and research design, as well as practical tips and skills for collecting high quality, reliable data in the field.",
+      "live": true,
+      "length": "14 Weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Esther Duflo",
+          "description": ""
+        },
+        {
+          "name": "Rachel Glennerster",
+          "description": ""
+        }
+      ]
     },
+    "programs": null,
     "courseruns": [
       {
         "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2017-06-05T15:00:00Z",
+        "end_date": "2017-08-28T15:00:00Z",
+        "enrollment_start": "2017-03-06T23:30:00Z",
+        "enrollment_end": "2017-07-03T23:30:00Z",
+        "expiration_date": "2017-08-29T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2017",
+        "courseware_id": "course-v1:MITx+JPAL102x+2T2017",
+        "certificate_available_date": "2017-08-28T15:00:00Z",
+        "upgrade_deadline": "2017-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2017",
+        "id": 67,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 32,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+2T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2017-09-26T15:00:00Z",
+        "end_date": "2017-12-22T15:00:00Z",
+        "enrollment_start": "2017-07-03T15:00:00Z",
+        "enrollment_end": "2017-10-24T03:25:53Z",
+        "expiration_date": "2017-12-23T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2017",
+        "courseware_id": "course-v1:MITx+JPAL102x+3T2017",
+        "certificate_available_date": "2017-12-22T15:00:00Z",
+        "upgrade_deadline": "2017-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2017",
+        "id": 68,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 33,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+3T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-02T00:00:00Z",
+        "enrollment_start": "2023-10-10T23:59:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+JPAL102x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 223,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 198,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2024-09-10T15:00:00Z",
+        "end_date": "2024-12-17T15:00:00Z",
+        "enrollment_start": "2024-02-13T23:59:00Z",
+        "enrollment_end": "2024-10-08T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2024/course",
+        "courseware_id": "course-v1:MITxT+JPAL102x+3T2024",
+        "certificate_available_date": "2025-01-14T00:00:00Z",
+        "upgrade_deadline": "2024-10-22T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2024",
+        "id": 248,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 219,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+3T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2023-09-12T15:00:00Z",
+        "end_date": "2024-01-19T15:00:00Z",
+        "enrollment_start": "2023-03-07T23:59:00Z",
+        "enrollment_end": "2023-10-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+JPAL102x+3T2023",
+        "certificate_available_date": "2024-01-20T00:00:00Z",
+        "upgrade_deadline": "2023-11-03T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 171,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 150,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2022-02-01T15:00:00Z",
+        "end_date": "2022-04-20T15:00:00Z",
+        "enrollment_start": "2021-11-02T23:59:00Z",
+        "enrollment_end": "2022-03-08T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+JPAL102x+1T2022",
+        "certificate_available_date": "2022-04-21T15:00:00Z",
+        "upgrade_deadline": "2022-04-20T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 8,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 16,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+1T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2021-10-05T15:00:00Z",
+        "end_date": "2021-12-22T15:00:00Z",
+        "enrollment_start": null,
+        "enrollment_end": "2021-11-02T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+JPAL102x+3T2021",
+        "certificate_available_date": "2021-12-23T23:30:00Z",
+        "upgrade_deadline": "2021-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2021",
+        "id": 4,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 17,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
         "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
+        "end_date": "2024-01-03T19:20:00Z",
         "enrollment_start": "2022-03-08T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
+        "enrollment_end": "2022-10-07T23:59:00Z",
         "expiration_date": null,
         "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2022/course/",
         "courseware_id": "course-v1:MITxT+JPAL102x+3T2022",
+        "certificate_available_date": "2024-01-04T00:00:00Z",
+        "upgrade_deadline": "2023-12-24T19:20:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
         "run_tag": "3T2022",
         "id": 22,
+        "live": true,
+        "course_number": "JPAL102x",
         "products": [
           {
-            "id": 22,
-            "price": "2000.00",
-            "description": "course-v2:MITxT+15.100x+3T2023",
+            "id": 8,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+3T2022",
             "is_active": true,
             "product_flexible_price": {
               "amount": null,
@@ -83,108 +1228,461 @@
               "expiration_date": null
             }
           }
-        ]
-      }
-    ],
-    "next_run_id": 22,
-    "topics": []
-  },
-  {
-    "id": 5,
-    "title": "Foundations of Development Policy",
-    "readable_id": "course-v1:MITxT+14.740x",
-    "courseruns": [
+        ],
+        "approved_flexible_price_exists": false
+      },
       {
-        "title": "Foundations of Development Policy",
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2017-02-06T15:00:00Z",
+        "end_date": "2017-05-05T15:00:00Z",
+        "enrollment_start": "2016-12-05T05:00:00Z",
+        "enrollment_end": "2017-03-06T14:00:00Z",
+        "expiration_date": "2017-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2017",
+        "courseware_id": "course-v1:MITx+JPAL102x+1T2017",
+        "certificate_available_date": "2017-05-05T15:00:00Z",
+        "upgrade_deadline": "2017-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2017",
+        "id": 64,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 29,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+1T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2018-06-05T15:00:00Z",
+        "end_date": "2018-08-21T03:30:00Z",
+        "enrollment_start": "2018-03-06T15:00:00Z",
+        "enrollment_end": "2018-07-03T15:00:00Z",
+        "expiration_date": "2018-08-22T03:30:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2018",
+        "courseware_id": "course-v1:MITx+JPAL102x+2T2018",
+        "certificate_available_date": "2018-08-21T03:30:00Z",
+        "upgrade_deadline": "2018-08-21T03:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2018",
+        "id": 69,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 34,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+2T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2018-02-06T15:00:00Z",
+        "end_date": "2018-05-05T15:00:00Z",
+        "enrollment_start": "2017-10-25T15:00:00Z",
+        "enrollment_end": "2018-03-06T15:00:00Z",
+        "expiration_date": "2018-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2018",
+        "courseware_id": "course-v1:MITx+JPAL102x+1T2018",
+        "certificate_available_date": "2018-05-05T15:00:00Z",
+        "upgrade_deadline": "2018-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2018",
+        "id": 78,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 43,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+1T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2018-09-11T15:00:00Z",
+        "end_date": "2018-11-28T03:00:00Z",
+        "enrollment_start": "2018-07-03T15:00:00Z",
+        "enrollment_end": "2018-10-09T15:00:00Z",
+        "expiration_date": "2018-11-29T03:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2018",
+        "courseware_id": "course-v1:MITx+JPAL102x+3T2018",
+        "certificate_available_date": "2018-11-28T03:00:00Z",
+        "upgrade_deadline": "2018-11-28T03:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2018",
+        "id": 88,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 53,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+3T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:21Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2020",
+        "courseware_id": "course-v1:MITx+JPAL102x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 117,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 82,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2019-02-05T15:00:00Z",
+        "end_date": "2019-04-23T15:00:00Z",
+        "enrollment_start": "2018-10-09T15:00:00Z",
+        "enrollment_end": "2019-03-03T15:00:00Z",
+        "expiration_date": "2019-04-24T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2019",
+        "courseware_id": "course-v1:MITx+JPAL102x+1T2019",
+        "certificate_available_date": "2019-04-23T15:00:00Z",
+        "upgrade_deadline": "2019-04-23T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2019",
+        "id": 131,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 96,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+1T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2019-05-21T15:00:00Z",
+        "end_date": "2019-08-06T15:00:00Z",
+        "enrollment_start": "2019-03-04T15:02:13Z",
+        "enrollment_end": "2019-06-18T15:00:00Z",
+        "expiration_date": "2019-08-07T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2019",
+        "courseware_id": "course-v1:MITx+JPAL102x+2T2019",
+        "certificate_available_date": "2019-08-06T15:00:00Z",
+        "upgrade_deadline": "2019-08-06T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019",
+        "id": 132,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 97,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+2T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-06-18T15:00:00Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2019a",
+        "courseware_id": "course-v1:MITx+JPAL102x+2T2019a",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019a",
+        "id": 133,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 98,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+2T2019a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-02T18:15:02Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2020a",
+        "courseware_id": "course-v1:MITx+JPAL102x+1T2020a",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020a",
+        "id": 134,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 99,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+1T2020a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2020",
+        "courseware_id": "course-v1:MITx+JPAL102x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 135,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 100,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2021",
+        "courseware_id": "course-v1:MITx+JPAL102x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 136,
+        "live": true,
+        "course_number": "JPAL102x",
+        "products": [
+          {
+            "id": 101,
+            "price": "1000.00",
+            "description": "course-v1:MITx+JPAL102x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations",
         "start_date": "2023-01-31T15:00:00Z",
-        "end_date": "2023-04-19T15:00:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
+        "end_date": "2023-08-12T15:00:00Z",
+        "enrollment_start": "2022-10-11T15:00:00Z",
         "enrollment_end": "2023-03-07T23:59:00Z",
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2023/course/",
-        "courseware_id": "course-v1:MITxT+14.740x+1T2023",
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2023/course/",
+        "courseware_id": "course-v1:MITxT+JPAL102x+1T2023",
+        "certificate_available_date": "2023-09-01T00:00:00Z",
+        "upgrade_deadline": "2023-03-16T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
         "run_tag": "1T2023",
-        "id": 37,
-        "products": []
-      }
-    ],
-    "next_run_id": 37,
-    "topics": []
-  },
-  {
-    "id": 16,
-    "title": "Good Economics for Hard Times",
-    "readable_id": "course-v1:MITxT+14.009x",
-    "courseruns": [
-      {
-        "title": "Good Economics for Hard Times",
-        "start_date": "2023-05-30T15:00:00Z",
-        "end_date": "2023-08-16T15:00:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2023-07-04T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2023/course/",
-        "courseware_id": "course-v1:MITxT+14.009x+2T2023",
-        "run_tag": "2T2023",
-        "id": 38,
-        "products": []
-      }
-    ],
-    "next_run_id": 38,
-    "topics": []
-  },
-  {
-    "id": 1,
-    "title": "Microeconomics",
-    "readable_id": "course-v1:MITxT+14.100x",
-    "page": {
-      "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-      "page_url": "/courses/course-v1:MITxT+14.100x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Microeconomics",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T23:30:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.100x+3T2022",
-        "run_tag": "3T2022",
-        "id": 35,
-        "products": []
-      }
-    ],
-    "next_run_id": 35,
-    "topics": []
-  },
-  {
-    "id": 6,
-    "title": "Political Economy and Economic Development",
-    "readable_id": "course-v1:MITxT+14.750x",
-    "page": {
-      "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
-      "page_url": "/courses/course-v1:MITxT+14.750x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Political Economy and Economic Development",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
-        "enrollment_start": "2021-11-02T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.750x+3T2022",
-        "run_tag": "3T2022",
-        "id": 10,
+        "id": 58,
+        "live": true,
+        "course_number": "JPAL102x",
         "products": [
           {
-            "id": 22,
-            "description": "course-v4:MITxT+16.100x+3T2023",
+            "id": 24,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+JPAL102x+1T2023",
             "is_active": true,
             "product_flexible_price": {
               "amount": null,
@@ -198,558 +1696,3460 @@
               "expiration_date": null
             }
           }
-        ]
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 3,
+    "title": "Data Analysis for Social Scientists",
+    "readable_id": "course-v1:MITxT+14.310x",
+    "next_run_id": 247,
+    "departments": [
+      {
+        "name": "Economics"
       }
     ],
-    "next_run_id": 10,
-    "topics": []
+    "page": {
+      "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
+      "page_url": "/courses/course-v1:MITxT+14.310x/",
+      "description": "Learn methods for harnessing and analyzing data to answer questions of cultural, social, economic, and policy interest.",
+      "live": true,
+      "length": "14 Weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Esther Duflo",
+          "description": ""
+        },
+        {
+          "name": "Sara Fisher Ellison",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2023-09-12T15:00:00Z",
+        "end_date": "2024-02-18T15:00:00Z",
+        "enrollment_start": "2023-06-27T23:59:00Z",
+        "enrollment_end": "2023-10-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+14.310x+3T2023",
+        "certificate_available_date": "2024-02-19T00:00:00Z",
+        "upgrade_deadline": "2023-12-31T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 183,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 162,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2022-05-31T15:00:00Z",
+        "end_date": "2022-08-16T23:30:00Z",
+        "enrollment_start": "2022-03-08T23:59:00Z",
+        "enrollment_end": "2022-08-16T23:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.310x+2T2022",
+        "certificate_available_date": "2022-08-22T00:00:00Z",
+        "upgrade_deadline": "2022-08-16T23:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 20,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 3,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2023-05-30T15:00:00Z",
+        "end_date": "2024-02-01T15:00:00Z",
+        "enrollment_start": "2023-03-07T23:59:00Z",
+        "enrollment_end": "2023-06-27T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2023/course",
+        "courseware_id": "course-v1:MITxT+14.310x+2T2023",
+        "certificate_available_date": "2024-02-02T00:00:00Z",
+        "upgrade_deadline": "2023-07-24T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2023",
+        "id": 170,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 149,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2023-01-31T15:00:00Z",
+        "end_date": "2023-05-20T15:00:00Z",
+        "enrollment_start": "2022-10-11T15:00:00Z",
+        "enrollment_end": "2023-03-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2023/course/",
+        "courseware_id": "course-v1:MITxT+14.310x+1T2023",
+        "certificate_available_date": "2023-05-22T00:00:00Z",
+        "upgrade_deadline": "2023-03-16T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2023",
+        "id": 55,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 23,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+1T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2022-02-01T15:00:00Z",
+        "end_date": "2022-04-20T15:00:00Z",
+        "enrollment_start": "2021-11-02T23:59:00Z",
+        "enrollment_end": "2022-03-08T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.310x+1T2022",
+        "certificate_available_date": "2022-04-21T15:00:00Z",
+        "upgrade_deadline": "2022-04-20T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 7,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 6,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+1T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2024-05-14T15:00:00Z",
+        "end_date": "2024-08-21T15:00:00Z",
+        "enrollment_start": "2024-02-13T23:59:00Z",
+        "enrollment_end": "2024-06-11T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+14.310x+2T2024",
+        "certificate_available_date": "2024-09-18T00:00:00Z",
+        "upgrade_deadline": "2024-06-25T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 247,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 218,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2018-02-06T15:00:00Z",
+        "end_date": "2018-05-05T15:00:00Z",
+        "enrollment_start": "2017-10-24T15:00:00Z",
+        "enrollment_end": "2018-03-06T15:00:00Z",
+        "expiration_date": "2018-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2018",
+        "courseware_id": "course-v1:MITx+14.310x+1T2018",
+        "certificate_available_date": "2018-05-05T15:00:00Z",
+        "upgrade_deadline": "2018-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2018",
+        "id": 65,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 30,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+1T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2017-02-06T15:00:00Z",
+        "end_date": "2017-05-05T15:00:00Z",
+        "enrollment_start": "2016-12-05T05:00:00Z",
+        "enrollment_end": "2017-03-06T14:00:00Z",
+        "expiration_date": "2017-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2017",
+        "courseware_id": "course-v1:MITx+14.310x+1T2017",
+        "certificate_available_date": "2017-05-05T15:00:00Z",
+        "upgrade_deadline": "2017-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2017",
+        "id": 70,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 35,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+1T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2017-06-05T14:00:00Z",
+        "end_date": "2017-08-28T15:00:00Z",
+        "enrollment_start": "2017-03-06T14:00:00Z",
+        "enrollment_end": "2017-07-03T15:00:00Z",
+        "expiration_date": "2017-08-29T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2017",
+        "courseware_id": "course-v1:MITx+14.310x+2T2017",
+        "certificate_available_date": "2017-08-28T15:00:00Z",
+        "upgrade_deadline": "2017-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2017",
+        "id": 71,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 36,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2017-09-26T15:00:00Z",
+        "end_date": "2017-12-22T15:00:00Z",
+        "enrollment_start": "2017-07-03T15:00:00Z",
+        "enrollment_end": "2017-10-24T03:25:47Z",
+        "expiration_date": "2017-12-23T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2017",
+        "courseware_id": "course-v1:MITx+14.310x+3T2017",
+        "certificate_available_date": "2017-12-22T15:00:00Z",
+        "upgrade_deadline": "2017-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2017",
+        "id": 72,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 37,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+3T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2018-09-11T15:00:00Z",
+        "end_date": "2018-11-28T03:00:00Z",
+        "enrollment_start": "2018-07-03T15:00:00Z",
+        "enrollment_end": "2018-10-09T15:00:00Z",
+        "expiration_date": "2018-11-29T03:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2018",
+        "courseware_id": "course-v1:MITx+14.310x+3T2018",
+        "certificate_available_date": "2018-11-28T03:00:00Z",
+        "upgrade_deadline": "2018-11-28T03:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2018",
+        "id": 79,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 44,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+3T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2019-05-21T15:00:00Z",
+        "end_date": "2019-08-06T15:00:00Z",
+        "enrollment_start": "2019-03-04T15:02:09Z",
+        "enrollment_end": "2019-06-18T15:00:00Z",
+        "expiration_date": "2019-08-07T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2019",
+        "courseware_id": "course-v1:MITx+14.310x+2T2019",
+        "certificate_available_date": "2019-08-06T15:00:00Z",
+        "upgrade_deadline": "2019-08-06T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019",
+        "id": 80,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 45,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2021",
+        "courseware_id": "course-v1:MITx+14.310x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 81,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 46,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2016-09-16T15:00:00Z",
+        "end_date": "2016-12-18T00:00:00Z",
+        "enrollment_start": "2016-09-16T04:00:00Z",
+        "enrollment_end": "2016-12-04T15:00:00Z",
+        "expiration_date": "2016-12-19T00:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2016",
+        "courseware_id": "course-v1:MITx+14.310x+3T2016",
+        "certificate_available_date": "2016-12-18T00:00:00Z",
+        "upgrade_deadline": "2016-12-18T00:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2016",
+        "id": 89,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 54,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+3T2016",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2018-06-05T15:00:00Z",
+        "end_date": "2018-08-21T03:30:00Z",
+        "enrollment_start": "2018-03-06T15:00:00Z",
+        "enrollment_end": "2018-07-03T15:00:00Z",
+        "expiration_date": "2018-08-22T03:30:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2018",
+        "courseware_id": "course-v1:MITx+14.310x+2T2018",
+        "certificate_available_date": "2018-08-21T03:30:00Z",
+        "upgrade_deadline": "2018-08-21T03:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2018",
+        "id": 90,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 55,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2019-02-05T15:00:00Z",
+        "end_date": "2019-04-23T15:00:00Z",
+        "enrollment_start": "2018-10-09T15:00:00Z",
+        "enrollment_end": "2019-03-03T15:00:00Z",
+        "expiration_date": "2019-04-24T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2019",
+        "courseware_id": "course-v1:MITx+14.310x+1T2019",
+        "certificate_available_date": "2019-04-23T15:00:00Z",
+        "upgrade_deadline": "2019-04-23T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2019",
+        "id": 91,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 56,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+1T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-02T17:32:14Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2020",
+        "courseware_id": "course-v1:MITx+14.310x+1T2020",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020",
+        "id": 96,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 61,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+1T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-06-18T15:00:00Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2019a",
+        "courseware_id": "course-v1:MITx+14.310x+2T2019a",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019a",
+        "id": 100,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 65,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2019a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2020",
+        "courseware_id": "course-v1:MITx+14.310x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 101,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 66,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2021-06-01T15:00:00Z",
+        "end_date": "2021-08-17T15:00:00Z",
+        "enrollment_start": "2021-03-13T04:59:59Z",
+        "enrollment_end": "2021-07-07T15:00:00Z",
+        "expiration_date": "2021-08-18T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2021",
+        "courseware_id": "course-v1:MITx+14.310x+2T2021",
+        "certificate_available_date": "2021-08-17T15:00:00Z",
+        "upgrade_deadline": "2021-08-17T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2021",
+        "id": 109,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 74,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+2T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:17Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2020",
+        "courseware_id": "course-v1:MITx+14.310x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 137,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 102,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.310x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2021-10-05T15:00:00Z",
+        "end_date": "2021-12-22T15:00:00Z",
+        "enrollment_start": null,
+        "enrollment_end": "2021-11-02T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+14.310x+3T2021",
+        "certificate_available_date": "2021-12-23T23:30:00Z",
+        "upgrade_deadline": "2021-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2021",
+        "id": 1,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 10,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-02T00:00:00Z",
+        "enrollment_start": "2023-10-10T23:59:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+14.310x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 222,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 197,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists",
+        "start_date": "2022-09-06T15:00:00Z",
+        "end_date": "2023-01-04T19:20:00Z",
+        "enrollment_start": "2022-07-06T23:59:00Z",
+        "enrollment_end": "2022-10-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.310x+3T2022",
+        "certificate_available_date": "2023-04-22T00:00:00Z",
+        "upgrade_deadline": "2022-12-25T19:20:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2022",
+        "id": 36,
+        "live": true,
+        "course_number": "14.310x",
+        "products": [
+          {
+            "id": 19,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.310x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
   },
   {
     "id": 4,
     "title": "The Challenges of Global Poverty",
     "readable_id": "course-v1:MITxT+14.73x",
+    "next_run_id": 249,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
     "page": {
       "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
       "page_url": "/courses/course-v1:MITxT+14.73x/",
-      "financial_assistance_form_url": ""
+      "description": "A course for those who are interested in the challenge posed by massive and persistent world poverty.",
+      "live": true,
+      "length": "14 weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Abhijit Vinayak Banerjee",
+          "description": ""
+        },
+        {
+          "name": "Esther Duflo",
+          "description": ""
+        },
+        {
+          "name": "Frank Schilbach",
+          "description": ""
+        }
+      ]
     },
+    "programs": null,
     "courseruns": [
       {
         "title": "The Challenges of Global Poverty",
+        "start_date": "2023-09-12T15:00:00Z",
+        "end_date": "2024-02-18T15:00:00Z",
+        "enrollment_start": "2023-03-07T23:59:00Z",
+        "enrollment_end": "2023-10-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+14.73x+3T2023",
+        "certificate_available_date": "2024-02-19T00:00:00Z",
+        "upgrade_deadline": "2023-11-03T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 169,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 148,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2023-01-31T15:00:00Z",
+        "end_date": "2023-05-12T15:00:00Z",
+        "enrollment_start": "2022-10-11T15:00:00Z",
+        "enrollment_end": "2023-03-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2023/course/",
+        "courseware_id": "course-v1:MITxT+14.73x+1T2023",
+        "certificate_available_date": "2023-05-22T00:00:00Z",
+        "upgrade_deadline": "2023-03-16T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2023",
+        "id": 56,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 20,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+1T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2021-10-05T15:00:00Z",
+        "end_date": "2021-12-22T15:00:00Z",
+        "enrollment_start": null,
+        "enrollment_end": "2021-11-02T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+14.73x+3T2021",
+        "certificate_available_date": "2021-12-23T23:30:00Z",
+        "upgrade_deadline": "2021-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2021",
+        "id": 3,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 12,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2014-02-04T15:00:00Z",
+        "end_date": "2014-05-11T15:00:00Z",
+        "enrollment_start": "2013-12-13T04:00:00Z",
+        "enrollment_end": "2014-05-11T04:00:00Z",
+        "expiration_date": "2014-05-12T15:00:00Z",
+        "courseware_url": null,
+        "courseware_id": "MITx/14_73x/1T2014",
+        "certificate_available_date": "2014-05-11T15:00:00Z",
+        "upgrade_deadline": "2014-05-11T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2014",
+        "id": 60,
+        "live": true,
+        "course_number": "14_73x",
+        "products": [
+          {
+            "id": 27,
+            "price": "1000.00",
+            "description": "MITx/14_73x/1T2014",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2015-02-03T15:00:00Z",
+        "end_date": "2015-05-03T04:00:00Z",
+        "enrollment_start": "2014-10-20T15:00:00Z",
+        "enrollment_end": "2015-05-03T04:00:00Z",
+        "expiration_date": "2015-05-04T04:00:00Z",
+        "courseware_url": null,
+        "courseware_id": "MITx/14.73x_1/1T2015",
+        "certificate_available_date": "2015-05-03T04:00:00Z",
+        "upgrade_deadline": "2015-05-03T04:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2015",
+        "id": 62,
+        "live": true,
+        "course_number": "14.73x_1",
+        "products": [
+          {
+            "id": 25,
+            "price": "1000.00",
+            "description": "MITx/14.73x_1/1T2015",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2024-09-10T15:00:00Z",
+        "end_date": "2024-12-17T15:00:00Z",
+        "enrollment_start": "2024-02-13T23:59:00Z",
+        "enrollment_end": "2024-10-08T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2024/course",
+        "courseware_id": "course-v1:MITxT+14.73x+3T2024",
+        "certificate_available_date": "2025-01-14T00:00:00Z",
+        "upgrade_deadline": "2024-10-22T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2024",
+        "id": 249,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 220,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+3T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2022-02-01T15:00:00Z",
+        "end_date": "2022-04-20T15:00:00Z",
+        "enrollment_start": "2021-11-02T23:59:00Z",
+        "enrollment_end": "2022-03-08T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.73x+1T2022",
+        "certificate_available_date": "2022-04-21T15:00:00Z",
+        "upgrade_deadline": "2022-04-20T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 11,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 11,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+1T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2013-02-12T15:00:00Z",
+        "end_date": "2013-05-11T15:00:00Z",
+        "enrollment_start": "2013-02-12T15:00:00Z",
+        "enrollment_end": "2016-12-04T04:00:00Z",
+        "expiration_date": "2013-05-12T15:00:00Z",
+        "courseware_url": null,
+        "courseware_id": "MITx/14.73x/2013_Spring",
+        "certificate_available_date": "2013-05-11T15:00:00Z",
+        "upgrade_deadline": "2013-05-11T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2013_Spring",
+        "id": 61,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 28,
+            "price": "1000.00",
+            "description": "MITx/14.73x/2013_Spring",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2016-02-22T15:00:00Z",
+        "end_date": "2016-05-15T15:00:00Z",
+        "enrollment_start": "2015-12-30T15:00:00Z",
+        "enrollment_end": "2016-12-04T04:00:00Z",
+        "expiration_date": "2016-05-16T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x_1+1T2016",
+        "courseware_id": "course-v1:MITx+14.73x_1+1T2016",
+        "certificate_available_date": "2016-05-15T15:00:00Z",
+        "upgrade_deadline": "2016-05-15T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2016",
+        "id": 73,
+        "live": true,
+        "course_number": "14.73x_1",
+        "products": [
+          {
+            "id": 38,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x_1+1T2016",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2016-09-16T04:00:00Z",
+        "end_date": "2016-12-11T15:00:00Z",
+        "enrollment_start": "2016-09-16T04:00:00Z",
+        "enrollment_end": "2016-12-04T04:00:00Z",
+        "expiration_date": "2016-12-12T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2016",
+        "courseware_id": "course-v1:MITx+14.73x+3T2016",
+        "certificate_available_date": "2016-12-11T15:00:00Z",
+        "upgrade_deadline": "2016-12-11T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2016",
+        "id": 74,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 39,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+3T2016",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2019-02-05T15:00:00Z",
+        "end_date": "2019-04-23T15:00:00Z",
+        "enrollment_start": "2018-10-09T15:00:00Z",
+        "enrollment_end": "2019-03-03T15:00:00Z",
+        "expiration_date": "2019-04-24T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2019",
+        "courseware_id": "course-v1:MITx+14.73x+1T2019",
+        "certificate_available_date": "2019-04-23T15:00:00Z",
+        "upgrade_deadline": "2019-04-23T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2019",
+        "id": 75,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 40,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+1T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2019-05-21T15:00:00Z",
+        "end_date": "2019-08-06T15:00:00Z",
+        "enrollment_start": "2019-03-04T15:02:22Z",
+        "enrollment_end": "2019-06-18T15:00:00Z",
+        "expiration_date": "2019-08-07T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019",
+        "courseware_id": "course-v1:MITx+14.73x+2T2019",
+        "certificate_available_date": "2019-08-06T15:00:00Z",
+        "upgrade_deadline": "2019-08-06T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019",
+        "id": 76,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 41,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+2T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2017-02-06T15:00:00Z",
+        "end_date": "2017-05-05T15:00:00Z",
+        "enrollment_start": "2016-12-05T05:00:00Z",
+        "enrollment_end": "2017-03-06T14:00:00Z",
+        "expiration_date": "2017-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2017",
+        "courseware_id": "course-v1:MITx+14.73x+1T2017",
+        "certificate_available_date": "2017-05-05T15:00:00Z",
+        "upgrade_deadline": "2017-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2017",
+        "id": 82,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 47,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+1T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of World Poverty",
+        "start_date": "2017-06-05T15:00:00Z",
+        "end_date": "2017-08-28T15:00:00Z",
+        "enrollment_start": "2017-03-06T14:00:00Z",
+        "enrollment_end": "2017-07-03T23:30:00Z",
+        "expiration_date": "2017-08-29T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2017",
+        "courseware_id": "course-v1:MITx+14.73x+2T2017",
+        "certificate_available_date": "2017-08-28T15:00:00Z",
+        "upgrade_deadline": "2017-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2017",
+        "id": 83,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 48,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+2T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of World Poverty",
+        "start_date": "2017-09-26T15:00:00Z",
+        "end_date": "2017-12-22T15:00:00Z",
+        "enrollment_start": "2017-07-03T15:00:00Z",
+        "enrollment_end": "2017-10-24T03:26:14Z",
+        "expiration_date": "2017-12-23T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2017",
+        "courseware_id": "course-v1:MITx+14.73x+3T2017",
+        "certificate_available_date": "2017-12-22T15:00:00Z",
+        "upgrade_deadline": "2017-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2017",
+        "id": 84,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 49,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+3T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of World Poverty",
+        "start_date": "2018-02-06T15:00:00Z",
+        "end_date": "2018-05-05T15:00:00Z",
+        "enrollment_start": "2017-10-24T15:00:00Z",
+        "enrollment_end": "2018-03-06T15:00:00Z",
+        "expiration_date": "2018-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2018",
+        "courseware_id": "course-v1:MITx+14.73x+1T2018",
+        "certificate_available_date": "2018-05-05T15:00:00Z",
+        "upgrade_deadline": "2018-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2018",
+        "id": 97,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 62,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+1T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-06-18T15:00:00Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019a",
+        "courseware_id": "course-v1:MITx+14.73x+2T2019a",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019a",
+        "id": 102,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 67,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+2T2019a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-02T17:34:22Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019a",
+        "courseware_id": "course-v1:MITx+14.73x+1T2020a",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020a",
+        "id": 103,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 68,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+1T2020a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2020",
+        "courseware_id": "course-v1:MITx+14.73x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 110,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 75,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:33Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2020",
+        "courseware_id": "course-v1:MITx+14.73x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 111,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 76,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2018-06-05T15:00:00Z",
+        "end_date": "2018-08-21T03:30:00Z",
+        "enrollment_start": "2018-03-06T15:00:00Z",
+        "enrollment_end": "2018-07-03T15:00:00Z",
+        "expiration_date": "2018-08-22T03:30:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2018",
+        "courseware_id": "course-v1:MITx+14.73x+2T2018",
+        "certificate_available_date": "2018-08-21T03:30:00Z",
+        "upgrade_deadline": "2018-08-21T03:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2018",
+        "id": 138,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 103,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+2T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2018-09-11T15:00:00Z",
+        "end_date": "2018-11-28T03:00:00Z",
+        "enrollment_start": "2018-07-03T15:00:00Z",
+        "enrollment_end": "2018-10-09T15:00:00Z",
+        "expiration_date": "2018-11-29T03:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2018",
+        "courseware_id": "course-v1:MITx+14.73x+3T2018",
+        "certificate_available_date": "2018-11-28T03:00:00Z",
+        "upgrade_deadline": "2018-11-28T03:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2018",
+        "id": 139,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 104,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+3T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2021",
+        "courseware_id": "course-v1:MITx+14.73x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 140,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 105,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.73x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "The Challenges of Global Poverty",
         "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
+        "end_date": "2024-01-03T19:20:00Z",
         "enrollment_start": "2022-03-08T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
+        "enrollment_end": "2022-10-07T23:59:00Z",
         "expiration_date": null,
         "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2022/course/",
         "courseware_id": "course-v1:MITxT+14.73x+3T2022",
+        "certificate_available_date": "2024-01-04T00:00:00Z",
+        "upgrade_deadline": "2023-12-24T19:20:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
         "run_tag": "3T2022",
         "id": 21,
-        "products": []
-      }
-    ],
-    "next_run_id": 21,
-    "topics": []
-  },
-  {
-    "id": 22,
-    "title": "Bringing Workers Voice into Technology and Employment Strategies",
-    "readable_id": "course-v1:MITxT+15.699x",
-    "page": {
-      "feature_image_src": "/media/original_images/negative-space-female-factory-worker-engine-hard-hat-yellow-chevanon-photo.jpg?v=fcf6e582d2d28a8c7c4b34b82759e145a2306269",
-      "page_url": "/courses/course-v1:MITxT+15.699x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 15,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
       {
-        "title": "Bringing Workers Voice into Technology and Employment Strategies",
-        "start_date": "2022-09-07T16:00:00Z",
-        "end_date": "2022-10-19T16:00:00Z",
-        "enrollment_start": "2022-06-09T00:00:00Z",
-        "enrollment_end": "2022-09-19T16:00:00Z",
+        "title": "The Challenges of Global Poverty",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-03T00:00:00Z",
+        "enrollment_start": "2023-10-10T23:59:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+15.699x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+15.699x+3T2022",
-        "run_tag": "3T2022",
-        "id": 31,
-        "products": []
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+14.73x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 224,
+        "live": true,
+        "course_number": "14.73x",
+        "products": [
+          {
+            "id": 199,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.73x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
       }
-    ],
-    "next_run_id": 31,
-    "topics": []
+    ]
   },
   {
-    "id": 9,
-    "title": "Cellular Solids 1: Structures, Properties and Engineering Applications",
-    "readable_id": "course-v1:MITxT+3.054x",
-    "page": {
-      "feature_image_src": "/media/original_images/3054AboutPageImage_Final_resized.png?v=8486faa001525f1d3350f87de992acbcb3cc70ba",
-      "page_url": "/courses/course-v1:MITxT+3.054x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+    "id": 5,
+    "title": "Foundations of Development Policy",
+    "readable_id": "course-v1:MITxT+14.740x",
+    "next_run_id": 188,
+    "departments": [
       {
-        "title": "Cellular Solids: Structure, Properties and Applications",
-        "start_date": "2022-05-04T05:30:00Z",
-        "end_date": "2023-05-03T00:00:00Z",
-        "enrollment_start": "2022-04-25T00:00:00Z",
-        "enrollment_end": "2023-05-03T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.054x+3T2021/course/",
-        "courseware_id": "course-v1:MITxT+3.054x+3T2021",
-        "run_tag": "3T2021",
-        "id": 14,
-        "products": []
+        "name": "Economics"
       }
     ],
-    "next_run_id": 14,
-    "topics": []
-  },
-  {
-    "id": 19,
-    "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
-    "readable_id": "course-v1:MITxT+11.S952x",
-    "page": {
-      "feature_image_src": "/media/original_images/11.S952x_Course_Image.png?v=faba2ccb0ebef1badccda77298e5829b9eb9dd04",
-      "page_url": "/courses/course-v1:MITxT+11.S952x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
-        "start_date": "2022-08-29T16:00:00Z",
-        "end_date": "2023-04-14T16:00:00Z",
-        "enrollment_start": "2022-08-01T00:00:00Z",
-        "enrollment_end": "2023-03-15T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+11.S952x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+11.S952x+2T2022",
-        "run_tag": "2T2022",
-        "id": 28,
-        "products": []
-      }
-    ],
-    "next_run_id": 28,
-    "topics": []
-  },
-  {
-    "id": 10,
-    "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.310PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-      "page_url": "/courses/course-v1:MITxT+14.310PEx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T15:00:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.310PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.310PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 50,
-        "products": []
-      }
-    ],
-    "next_run_id": 50,
-    "topics": []
-  },
-  {
-    "id": 11,
-    "title": "Designing and Running Randomized Evaluations - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+JPAL102PEx",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 30,
-    "title": "Electrical, Optical & Magnetic Materials and Devices",
-    "readable_id": "course-v1:MITxT+3.15x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.15x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Electrical, Optical & Magnetic Materials and Devices",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.15x+2T2022",
-        "courseware_id": "course-v1:MITxT+3.15x+2T2022",
-        "run_tag": "2T2022",
-        "id": 43,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 29,
-    "title": "Electronic, Optical, and Magnetic Properties of Materials",
-    "readable_id": "course-v1:MITxT+3.024x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.024x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Electronic, Optical, and Magnetic Properties of Materials Course Navigation",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.024x+2T2022",
-        "courseware_id": "course-v1:MITxT+3.024x+2T2022",
-        "run_tag": "2T2022",
-        "id": 42,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 18,
-    "title": "Evaluating Social Programs",
-    "readable_id": "course-v1:MITxT+JPAL_RCT101x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+JPAL_RCT101x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Evaluating Social Programs (RCT101x)",
-        "start_date": "2022-04-13T15:00:00Z",
-        "end_date": "2030-05-08T04:00:00Z",
-        "enrollment_start": "2022-04-13T05:00:00Z",
-        "enrollment_end": "2030-04-05T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL_RCT101x+1T2022/course/",
-        "courseware_id": "course-v1:MITxT+JPAL_RCT101x+1T2022",
-        "run_tag": "1T2022",
-        "id": 27,
-        "products": []
-      }
-    ],
-    "next_run_id": 27,
-    "topics": []
-  },
-  {
-    "id": 12,
-    "title": "Foundations of Development Policy - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.740PEx",
     "page": {
       "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
-      "page_url": "/courses/course-v1:MITxT+14.740PEx/",
-      "financial_assistance_form_url": ""
+      "page_url": "/courses/course-v1:MITxT+14.740x/",
+      "description": "Examine the different facets of human development, including education, health, gender, the family, land relations, risk, public policy, and institutions. At the same time, discover modern empirical methods in economics while working with real data.",
+      "live": true,
+      "length": "14 weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Abhijit Vinayak Banerjee",
+          "description": ""
+        },
+        {
+          "name": "Esther Duflo",
+          "description": ""
+        },
+        {
+          "name": "Benjamin Olken",
+          "description": ""
+        }
+      ]
     },
+    "programs": null,
     "courseruns": [
       {
-        "title": "Foundations of Development Policy - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2016-09-16T04:00:00Z",
+        "end_date": "2016-12-11T23:59:00Z",
+        "enrollment_start": "2016-09-16T04:00:00Z",
+        "enrollment_end": "2016-12-04T04:00:00Z",
+        "expiration_date": "2016-12-12T23:59:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2016",
+        "courseware_id": "course-v1:MITx+14.740x+3T2016",
+        "certificate_available_date": "2016-12-11T23:59:00Z",
+        "upgrade_deadline": "2016-12-11T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2016",
+        "id": 66,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 31,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+3T2016",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-02T00:00:00Z",
+        "enrollment_start": "2023-07-24T23:59:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.740PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.740PEx+2T2022",
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+14.740x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 194,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 173,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.740x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-06-18T15:00:00Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2019a",
+        "courseware_id": "course-v1:MITx+14.740x+2T2019a",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019a",
+        "id": 87,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 52,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2019a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2024-05-14T15:00:00Z",
+        "end_date": "2024-08-21T15:00:00Z",
+        "enrollment_start": "2023-06-27T23:59:00Z",
+        "enrollment_end": "2024-06-11T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+14.740x+2T2024",
+        "certificate_available_date": "2024-09-18T00:00:00Z",
+        "upgrade_deadline": "2024-06-25T23:59:59Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 188,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 167,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.740x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2022-05-31T15:00:00Z",
+        "end_date": "2023-07-16T23:30:00Z",
+        "enrollment_start": "2021-10-05T15:00:00Z",
+        "enrollment_end": "2022-07-05T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.740x+2T2022",
+        "certificate_available_date": "2023-07-18T00:00:00Z",
+        "upgrade_deadline": "2022-08-16T23:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
         "run_tag": "2T2022",
-        "id": 49,
-        "products": []
+        "id": 6,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 7,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.740x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2017-06-05T15:00:00Z",
+        "end_date": "2017-08-28T15:00:00Z",
+        "enrollment_start": "2017-03-06T23:30:00Z",
+        "enrollment_end": "2017-07-03T15:00:00Z",
+        "expiration_date": "2017-08-29T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2017",
+        "courseware_id": "course-v1:MITx+14.740x+2T2017",
+        "certificate_available_date": "2017-08-28T15:00:00Z",
+        "upgrade_deadline": "2017-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2017",
+        "id": 85,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 50,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2017-09-26T15:00:00Z",
+        "end_date": "2017-12-22T15:00:00Z",
+        "enrollment_start": "2017-07-03T15:00:00Z",
+        "enrollment_end": "2017-10-24T03:26:02Z",
+        "expiration_date": "2017-12-23T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2017",
+        "courseware_id": "course-v1:MITx+14.740x+3T2017",
+        "certificate_available_date": "2017-12-22T15:00:00Z",
+        "upgrade_deadline": "2017-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2017",
+        "id": 86,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 51,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+3T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2015-09-21T15:00:00Z",
+        "end_date": "2015-12-10T15:00:00Z",
+        "enrollment_start": "2015-07-20T15:00:00Z",
+        "enrollment_end": "2015-12-10T15:00:00Z",
+        "expiration_date": "2015-12-11T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.74x+3T2015",
+        "courseware_id": "course-v1:MITx+14.74x+3T2015",
+        "certificate_available_date": "2015-12-10T15:00:00Z",
+        "upgrade_deadline": "2015-12-10T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2015",
+        "id": 92,
+        "live": true,
+        "course_number": "14.74x",
+        "products": [
+          {
+            "id": 57,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.74x+3T2015",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2017-02-06T15:00:00Z",
+        "end_date": "2017-05-05T15:00:00Z",
+        "enrollment_start": "2016-12-05T15:00:00Z",
+        "enrollment_end": "2017-03-06T14:00:00Z",
+        "expiration_date": "2017-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2017",
+        "courseware_id": "course-v1:MITx+14.740x+1T2017",
+        "certificate_available_date": "2017-05-05T15:00:00Z",
+        "upgrade_deadline": "2017-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2017",
+        "id": 93,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 58,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+1T2017",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2018-02-06T15:00:00Z",
+        "end_date": "2018-05-05T15:00:00Z",
+        "enrollment_start": "2017-10-24T15:00:00Z",
+        "enrollment_end": "2018-03-06T15:00:00Z",
+        "expiration_date": "2018-05-06T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2018",
+        "courseware_id": "course-v1:MITx+14.740x+1T2018",
+        "certificate_available_date": "2018-05-05T15:00:00Z",
+        "upgrade_deadline": "2018-05-05T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2018",
+        "id": 94,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 59,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+1T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy: Advanced Development Economics",
+        "start_date": "2018-06-05T15:00:00Z",
+        "end_date": "2018-08-21T03:30:00Z",
+        "enrollment_start": "2018-03-06T15:00:00Z",
+        "enrollment_end": "2018-07-03T15:00:00Z",
+        "expiration_date": "2018-08-22T03:30:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2018",
+        "courseware_id": "course-v1:MITx+14.740x+2T2018",
+        "certificate_available_date": "2018-08-21T03:30:00Z",
+        "upgrade_deadline": "2018-08-21T03:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2018",
+        "id": 95,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 60,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2018-09-11T15:00:00Z",
+        "end_date": "2018-11-28T03:00:00Z",
+        "enrollment_start": "2018-07-03T15:00:00Z",
+        "enrollment_end": "2018-10-09T15:00:00Z",
+        "expiration_date": "2018-11-29T03:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2018",
+        "courseware_id": "course-v1:MITx+14.740x+3T2018",
+        "certificate_available_date": "2018-11-28T03:00:00Z",
+        "upgrade_deadline": "2018-11-28T03:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2018",
+        "id": 98,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 63,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+3T2018",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2019-05-21T15:00:00Z",
+        "end_date": "2019-08-06T15:00:00Z",
+        "enrollment_start": "2019-03-04T15:02:16Z",
+        "enrollment_end": "2019-06-18T15:00:00Z",
+        "expiration_date": "2019-08-07T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2019",
+        "courseware_id": "course-v1:MITx+14.740x+2T2019",
+        "certificate_available_date": "2019-08-06T15:00:00Z",
+        "upgrade_deadline": "2019-08-06T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2019",
+        "id": 99,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 64,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2019-02-05T15:00:00Z",
+        "end_date": "2019-04-23T15:00:00Z",
+        "enrollment_start": "2018-10-09T15:00:00Z",
+        "enrollment_end": "2019-03-03T15:00:00Z",
+        "expiration_date": "2019-04-24T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2019",
+        "courseware_id": "course-v1:MITx+14.740x+1T2019",
+        "certificate_available_date": "2019-04-23T15:00:00Z",
+        "upgrade_deadline": "2019-04-23T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2019",
+        "id": 104,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 69,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+1T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-02T18:13:07Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2020a",
+        "courseware_id": "course-v1:MITx+14.740x+1T2020a",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020a",
+        "id": 105,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 70,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+1T2020a",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2021",
+        "courseware_id": "course-v1:MITx+14.740x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 112,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 77,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2020",
+        "courseware_id": "course-v1:MITx+14.740x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 113,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 78,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:24Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2020",
+        "courseware_id": "course-v1:MITx+14.740x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 114,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 79,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2021-06-01T15:00:00Z",
+        "end_date": "2021-08-17T15:00:00Z",
+        "enrollment_start": "2021-03-13T23:59:00Z",
+        "enrollment_end": "2021-07-07T23:59:00Z",
+        "expiration_date": "2021-08-18T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2021",
+        "courseware_id": "course-v1:MITx+14.740x+2T2021",
+        "certificate_available_date": "2021-08-17T15:00:00Z",
+        "upgrade_deadline": "2021-08-17T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2021",
+        "id": 141,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 106,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.740x+2T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2023-01-31T15:00:00Z",
+        "end_date": "2023-08-12T15:00:00Z",
+        "enrollment_start": "2022-07-06T23:59:00Z",
+        "enrollment_end": "2023-03-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2023/course/",
+        "courseware_id": "course-v1:MITxT+14.740x+1T2023",
+        "certificate_available_date": "2023-08-20T00:00:00Z",
+        "upgrade_deadline": "2023-03-16T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2023",
+        "id": 37,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 21,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.740x+1T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Foundations of Development Policy",
+        "start_date": "2023-05-30T15:00:00Z",
+        "end_date": "2023-09-15T15:00:00Z",
+        "enrollment_start": "2023-03-07T23:59:00Z",
+        "enrollment_end": "2023-06-27T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2023/course",
+        "courseware_id": "course-v1:MITxT+14.740x+2T2023",
+        "certificate_available_date": "2023-09-25T00:00:00Z",
+        "upgrade_deadline": "2023-07-18T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2023",
+        "id": 165,
+        "live": true,
+        "course_number": "14.740x",
+        "products": [
+          {
+            "id": 146,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.740x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
       }
-    ],
-    "next_run_id": 49,
-    "topics": []
+    ]
   },
   {
-    "id": 34,
-    "title": "Good Economics for Hard Times - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.009PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-      "page_url": "/courses/course-v1:MITxT+14.009PEx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+    "id": 6,
+    "title": "Political Economy and Economic Development",
+    "readable_id": "course-v1:MITxT+14.750x",
+    "next_run_id": 220,
+    "departments": [
       {
-        "title": "Good Economics for Hard Times - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.009PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.009PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 47,
-        "products": []
+        "name": "Economics"
       }
     ],
-    "next_run_id": 47,
-    "topics": []
-  },
-  {
-    "id": 27,
-    "title": "How Language Works",
-    "readable_id": "course-v1:MITxT+24.900x",
     "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+24.900x/",
-      "financial_assistance_form_url": ""
+      "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
+      "page_url": "/courses/course-v1:MITxT+14.750x/",
+      "description": "Explore why and how political institutions affect economic development, and apply key theories and empirical techniques to real-world examples ranging from voting and corruption to the role of the media.",
+      "live": true,
+      "length": "14 weeks",
+      "effort": "12–14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Abhijit Vinayak Banerjee",
+          "description": ""
+        },
+        {
+          "name": "Benjamin Olken",
+          "description": ""
+        }
+      ]
     },
+    "programs": null,
     "courseruns": [
       {
-        "title": "How Language Works",
-        "start_date": null,
-        "end_date": null,
+        "title": "Political Economy and Economic Development",
+        "start_date": "2024-05-14T15:00:00Z",
+        "end_date": "2024-08-21T15:00:00Z",
+        "enrollment_start": "2023-10-10T23:59:00Z",
+        "enrollment_end": "2024-06-11T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+14.750x+2T2024",
+        "certificate_available_date": "2024-09-18T00:00:00Z",
+        "upgrade_deadline": "2024-06-25T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 220,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 195,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy and Economic Development",
+        "start_date": "2022-09-06T15:00:00Z",
+        "end_date": "2023-06-24T19:20:00Z",
+        "enrollment_start": "2021-11-02T23:59:00Z",
+        "enrollment_end": "2022-10-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.750x+3T2022",
+        "certificate_available_date": "2023-06-25T00:00:00Z",
+        "upgrade_deadline": "2022-12-25T19:20:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2022",
+        "id": 10,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 13,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy and Economic Development",
+        "start_date": "2021-10-05T15:00:00Z",
+        "end_date": "2021-12-22T15:00:00Z",
         "enrollment_start": null,
+        "enrollment_end": "2021-11-02T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+14.750x+3T2021",
+        "certificate_available_date": "2021-12-23T23:30:00Z",
+        "upgrade_deadline": "2021-12-22T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2021",
+        "id": 5,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 4,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy & Economic Development",
+        "start_date": "2020-02-04T15:00:00Z",
+        "end_date": "2020-04-21T15:00:00Z",
+        "enrollment_start": "2019-10-01T15:00:00Z",
+        "enrollment_end": "2020-03-03T15:00:00Z",
+        "expiration_date": "2020-04-22T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+1T2020",
+        "courseware_id": "course-v1:MITx+14.750x+1T2020",
+        "certificate_available_date": "2020-04-21T15:00:00Z",
+        "upgrade_deadline": "2020-04-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2020",
+        "id": 77,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 42,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.750x+1T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy & Economic Development",
+        "start_date": "2019-09-03T15:00:00Z",
+        "end_date": "2019-11-19T15:00:00Z",
+        "enrollment_start": "2019-07-29T15:18:12Z",
+        "enrollment_end": "2019-10-01T15:00:00Z",
+        "expiration_date": "2019-11-20T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+3T2019",
+        "courseware_id": "course-v1:MITx+14.750x+3T2019",
+        "certificate_available_date": "2019-11-19T15:00:00Z",
+        "upgrade_deadline": "2019-11-19T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2019",
+        "id": 106,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 71,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.750x+3T2019",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy & Economic Development",
+        "start_date": "2021-02-09T15:00:00Z",
+        "end_date": "2021-04-27T15:00:00Z",
+        "enrollment_start": "2020-10-06T15:00:00Z",
+        "enrollment_end": "2021-03-12T15:00:00Z",
+        "expiration_date": "2021-04-28T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+1T2021",
+        "courseware_id": "course-v1:MITx+14.750x+1T2021",
+        "certificate_available_date": "2021-04-27T15:00:00Z",
+        "upgrade_deadline": "2021-04-27T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2021",
+        "id": 107,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 72,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.750x+1T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy & Economic Development",
+        "start_date": "2020-06-02T15:00:00Z",
+        "end_date": "2020-08-18T15:00:00Z",
+        "enrollment_start": "2020-03-03T15:00:00Z",
+        "enrollment_end": "2020-07-01T15:00:00Z",
+        "expiration_date": "2020-08-19T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+2T2020",
+        "courseware_id": "course-v1:MITx+14.750x+2T2020",
+        "certificate_available_date": "2020-08-18T15:00:00Z",
+        "upgrade_deadline": "2020-08-18T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2020",
+        "id": 115,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 80,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.750x+2T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy & Economic Development",
+        "start_date": "2020-09-08T15:00:00Z",
+        "end_date": "2020-11-24T15:00:00Z",
+        "enrollment_start": "2020-07-17T14:42:30Z",
+        "enrollment_end": "2020-10-06T15:00:00Z",
+        "expiration_date": "2020-11-25T15:00:00Z",
+        "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+3T2020",
+        "courseware_id": "course-v1:MITx+14.750x+3T2020",
+        "certificate_available_date": "2020-11-24T15:00:00Z",
+        "upgrade_deadline": "2020-11-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2020",
+        "id": 116,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 81,
+            "price": "1000.00",
+            "description": "course-v1:MITx+14.750x+3T2020",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy and Economic Development",
+        "start_date": "2023-01-31T15:00:00Z",
+        "end_date": "2023-08-12T15:00:00Z",
+        "enrollment_start": "2022-10-11T15:00:00Z",
+        "enrollment_end": "2023-03-07T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+1T2023/course/",
+        "courseware_id": "course-v1:MITxT+14.750x+1T2023",
+        "certificate_available_date": "2023-09-01T00:00:00Z",
+        "upgrade_deadline": "2023-03-16T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2023",
+        "id": 142,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 107,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+1T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy and Economic Development",
+        "start_date": "2023-09-12T15:00:00Z",
+        "end_date": "2024-02-18T15:00:00Z",
+        "enrollment_start": "2023-06-27T23:59:00Z",
+        "enrollment_end": "2023-10-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+14.750x+3T2023",
+        "certificate_available_date": "2024-02-19T00:00:00Z",
+        "upgrade_deadline": "2023-11-03T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 186,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 165,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Political Economy and Economic Development",
+        "start_date": "2023-05-30T15:00:00Z",
+        "end_date": "2023-11-01T15:00:00Z",
+        "enrollment_start": "2023-03-07T23:59:00Z",
+        "enrollment_end": "2023-06-27T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+2T2023/course",
+        "courseware_id": "course-v1:MITxT+14.750x+2T2023",
+        "certificate_available_date": "2023-11-02T00:00:00Z",
+        "upgrade_deadline": "2023-07-14T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2023",
+        "id": 168,
+        "live": true,
+        "course_number": "14.750x",
+        "products": [
+          {
+            "id": 147,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.750x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 7,
+    "title": "Qualitative Research Methods: Conversational Interviewing",
+    "readable_id": "course-v1:MITxT+21A.819.1x",
+    "next_run_id": 228,
+    "departments": [
+      {
+        "name": "Anthropology"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/21A.819x_CourseImage_1134p-675p.jpg?v=430c765ca446c319a4c920aa1846bf918599328a",
+      "page_url": "/courses/course-v1:MITxT+21A.819.1x/",
+      "description": "A short course that will teach you how to prepare for and conduct conversational interviews, that will produce rich qualitative data.",
+      "live": true,
+      "length": "4 weeks",
+      "effort": "2-3 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": 49,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Qualitative Research Methods: Conversational Interviewing",
+        "start_date": "2023-10-31T16:00:00Z",
+        "end_date": "2024-10-29T16:00:00Z",
+        "enrollment_start": "2023-10-10T16:00:00Z",
         "enrollment_end": null,
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+24.900x+3T2022",
-        "courseware_id": "course-v1:MITxT+24.900x+3T2022",
-        "run_tag": "3T2022",
-        "id": 40,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 23,
-    "title": "Mechanics: Kinematics and Dynamics",
-    "readable_id": "course-v1:MITxT+8.01.1x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.1x_Image_2022_MITxO.png?v=593cb814d4e22283198eceb20855662bf41704d8",
-      "page_url": "/courses/course-v1:MITxT+8.01.1x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.1x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+21A.819.1x+3T2023",
+        "certificate_available_date": "2024-10-29T16:00:00Z",
+        "upgrade_deadline": "2023-10-31T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 228,
+        "live": true,
+        "course_number": "21A.819.1x",
+        "products": [
+          {
+            "id": 202,
+            "price": "49.00",
+            "description": "course-v1:MITxT+21A.819.1x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
       {
-        "title": "Mechanics: Kinematics and Dynamics",
-        "start_date": "2022-09-22T16:00:00Z",
-        "end_date": "2023-04-13T16:00:00Z",
-        "enrollment_start": null,
+        "title": "Qualitative Research Methods: Conversational Interviewing",
+        "start_date": "2022-11-01T15:00:00Z",
+        "end_date": "2023-11-02T17:00:00Z",
+        "enrollment_start": "2022-11-01T15:00:00Z",
         "enrollment_end": null,
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.1x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+8.01.1x+3T2022",
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+21A.819.1x+3T2022",
+        "courseware_id": "course-v1:MITxT+21A.819.1x+3T2022",
+        "certificate_available_date": "2023-11-02T17:00:00Z",
+        "upgrade_deadline": "2023-10-23T17:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": true,
         "run_tag": "3T2022",
-        "id": 32,
-        "products": []
-      }
-    ],
-    "next_run_id": 32,
-    "topics": []
-  },
-  {
-    "id": 31,
-    "title": "Mechanics: Momentum and Energy",
-    "readable_id": "course-v1:MITxT+8.01.2x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.2x_courseImage_435p-244p.png?v=50a30ec2256f4ebb8ae26b8904f1fab41fd36650",
-      "page_url": "/courses/course-v1:MITxT+8.01.2x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+        "id": 145,
+        "live": true,
+        "course_number": "21A.819.1x",
+        "products": [
+          {
+            "id": 128,
+            "price": "49.00",
+            "description": "course-v1:MITxT+21A.819.1x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
       {
-        "title": "Mechanics: Momentum and Energy",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
+        "title": "Qualitative Research Methods: Conversational Interviewing",
+        "start_date": "2021-11-17T16:00:00Z",
+        "end_date": "2022-10-27T16:00:00Z",
+        "enrollment_start": "2021-10-10T16:00:00Z",
         "enrollment_end": null,
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.2x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.2x+3T2022",
-        "run_tag": "3T2022",
-        "id": 44,
-        "products": []
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.1x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+21A.819.1x+3T2021",
+        "certificate_available_date": "2022-10-27T16:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "3T2021",
+        "id": 12,
+        "live": true,
+        "course_number": "21A.819.1x",
+        "products": [],
+        "approved_flexible_price_exists": false
       }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 32,
-    "title": "Mechanics: Rotational Dynamics",
-    "readable_id": "course-v1:MITxT+8.01.3x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+8.01.3x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Rotational Dynamics",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.3x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.3x+3T2022",
-        "run_tag": "3T2022",
-        "id": 45,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 33,
-    "title": "Mechanics: Simple Harmonic Motion",
-    "readable_id": "course-v1:MITxT+8.01.4x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.4x_courseimage01_435p-244p.jpg?v=0a2fac7fe3be47df2d6b0651b7e57e2871f901ad",
-      "page_url": "/courses/course-v1:MITxT+8.01.4x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Simple Harmonic Motion",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.4x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.4x+3T2022",
-        "run_tag": "3T2022",
-        "id": 46,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 13,
-    "title": "Microeconomics - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.100PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.100x_xGKvQiK.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-      "page_url": "/courses/course-v1:MITxT+14.100PEx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Microeconomics - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.100PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 48,
-        "products": []
-      }
-    ],
-    "next_run_id": 48,
-    "topics": []
-  },
-  {
-    "id": 21,
-    "title": "Minds and Machines",
-    "readable_id": "course-v1:MITxT+24.09x",
-    "page": {
-      "feature_image_src": "/media/original_images/2409x_FL15_Thumbnail.jpeg?v=cc95c149b6f5f3597bd83079320b347cd03da6ef",
-      "page_url": "/courses/course-v1:MITxT+24.09x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Minds and Machines",
-        "start_date": "2022-06-08T17:00:00Z",
-        "end_date": "2022-08-31T17:00:00Z",
-        "enrollment_start": "2022-05-30T16:00:00Z",
-        "enrollment_end": "2022-08-31T16:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.09x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.09x+2T2022",
-        "run_tag": "2T2022",
-        "id": 30,
-        "products": []
-      }
-    ],
-    "next_run_id": 30,
-    "topics": []
-  },
-  {
-    "id": 24,
-    "title": "Moral Problems and the Good Life",
-    "readable_id": "course-v1:MITxT+24.02x",
-    "page": {
-      "feature_image_src": "/media/original_images/24.02x_course_image_01.jpg?v=a6b6b81b428417cddb6966a998a9dcb4ca7867eb",
-      "page_url": "/courses/course-v1:MITxT+24.02x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Moral Problems and the Good Life",
-        "start_date": "2022-11-17T16:00:00Z",
-        "end_date": "2023-02-02T16:00:00Z",
-        "enrollment_start": "2022-06-17T00:00:00Z",
-        "enrollment_end": "2023-01-26T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.02x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.02x+3T2022",
-        "run_tag": "3T2022",
-        "id": 33,
-        "products": []
-      }
-    ],
-    "next_run_id": 33,
-    "topics": []
-  },
-  {
-    "id": 20,
-    "title": "Paradox and Infinity",
-    "readable_id": "course-v1:MITxT+24.118x",
-    "page": {
-      "feature_image_src": "/media/original_images/24.118x_CourseImage_20170926_sm.png?v=5f596811c909028fcbc4361d295c0122e0d791b5",
-      "page_url": "/courses/course-v1:MITxT+24.118x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Paradox and Infinity",
-        "start_date": "2022-06-29T16:00:00Z",
-        "end_date": "2022-08-31T16:00:00Z",
-        "enrollment_start": "2022-06-20T16:00:00Z",
-        "enrollment_end": "2022-08-31T16:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.118x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.118x+2T2022",
-        "run_tag": "2T2022",
-        "id": 29,
-        "products": []
-      }
-    ],
-    "next_run_id": 29,
-    "topics": []
-  },
-  {
-    "id": 14,
-    "title": "Political Economy and Economic Development - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.750PEx",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 25,
-    "title": "Problems of Philosophy",
-    "readable_id": "course-v1:MITxT+24.10x",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
+    ]
   },
   {
     "id": 8,
-    "title": "Qualitative Research Methods: Analyzing Data",
+    "title": "Qualitative Research Methods: Data Coding and Analysis",
     "readable_id": "course-v1:MITxT+21A.819.2x",
+    "next_run_id": 229,
+    "departments": [
+      {
+        "name": "Anthropology"
+      }
+    ],
     "page": {
       "feature_image_src": "/media/original_images/21A.819.2x_courseImage_1134p-675p.jpg?v=b7305a970e6cdaff78231fbf31853c9dc70d9cac",
       "page_url": "/courses/course-v1:MITxT+21A.819.2x/",
-      "financial_assistance_form_url": ""
+      "description": "A short course that will teach you how to analyze qualitative data.",
+      "live": true,
+      "length": "4 weeks",
+      "effort": "2-3 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": 49,
+      "instructors": []
     },
+    "programs": null,
     "courseruns": [
       {
         "title": "Qualitative Research Methods: Analyzing Data",
@@ -760,101 +5160,2407 @@
         "expiration_date": null,
         "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.2x+3T2021/course/",
         "courseware_id": "course-v1:MITxT+21A.819.2x+3T2021",
+        "certificate_available_date": "2022-10-27T17:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": false,
+        "is_self_paced": true,
         "run_tag": "3T2021",
         "id": 13,
-        "products": []
-      }
-    ],
-    "next_run_id": 13,
-    "topics": []
-  },
-  {
-    "id": 7,
-    "title": "Qualitative Research Methods: Conversational Interviewing",
-    "readable_id": "course-v1:MITxT+21A.819.1x",
-    "page": {
-      "feature_image_src": "/media/original_images/21A.819x_CourseImage_1134p-675p.jpg?v=430c765ca446c319a4c920aa1846bf918599328a",
-      "page_url": "/courses/course-v1:MITxT+21A.819.1x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+        "live": true,
+        "course_number": "21A.819.2x",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
       {
-        "title": "Qualitative Research Methods: Conversational Interviewing",
-        "start_date": "2021-11-17T15:30:00Z",
-        "end_date": "2022-10-27T17:00:00Z",
-        "enrollment_start": "2021-11-17T15:00:00Z",
-        "enrollment_end": "2022-10-20T17:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.1x+3T2021/course/",
-        "courseware_id": "course-v1:MITxT+21A.819.1x+3T2021",
-        "run_tag": "3T2021",
-        "id": 12,
-        "products": []
-      }
-    ],
-    "next_run_id": 12,
-    "topics": []
-  },
-  {
-    "id": 26,
-    "title": "Quantum Mechanics: A First Course",
-    "readable_id": "course-v1:MITxT+8.04x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.04x_replacement_20200917_DiIr66w.png?v=aa4947564bf5b8228085ee3139c62c873d21a66d",
-      "page_url": "/courses/course-v1:MITxT+8.04x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Quantum Mechanics: A First Course",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
+        "title": "Qualitative Research Methods: Data Coding and Analysis",
+        "start_date": "2023-10-31T16:00:00Z",
+        "end_date": "2024-10-29T16:00:00Z",
+        "enrollment_start": "2023-10-10T16:00:00Z",
         "enrollment_end": null,
         "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.04x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.04x+3T2022",
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.2x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+21A.819.2x+3T2023",
+        "certificate_available_date": "2022-10-29T17:00:00Z",
+        "upgrade_deadline": "2023-10-31T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 229,
+        "live": true,
+        "course_number": "21A.819.2x",
+        "products": [
+          {
+            "id": 203,
+            "price": "49.00",
+            "description": "course-v1:MITxT+21A.819.2x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Qualitative Research Methods: Data Coding and Analysis",
+        "start_date": "2022-11-01T15:30:00Z",
+        "end_date": "2023-11-02T17:00:00Z",
+        "enrollment_start": "2022-10-01T15:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+21A.819.2x+3T2022/home",
+        "courseware_id": "course-v1:MITxT+21A.819.2x+3T2022",
+        "certificate_available_date": "2023-11-02T17:00:00Z",
+        "upgrade_deadline": "2023-10-23T17:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": true,
         "run_tag": "3T2022",
-        "id": 39,
-        "products": []
+        "id": 148,
+        "live": true,
+        "course_number": "21A.819.2x",
+        "products": [
+          {
+            "id": 127,
+            "price": "49.00",
+            "description": "course-v1:MITxT+21A.819.2x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
       }
-    ],
-    "next_run_id": null,
-    "topics": []
+    ]
   },
   {
-    "id": 28,
-    "title": "Structure of Materials",
-    "readable_id": "course-v1:MITxT+3.012Sx",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.012Sx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
+    "id": 9,
+    "title": "Cellular Solids",
+    "readable_id": "course-v1:MITxT+3.054x",
+    "next_run_id": 239,
+    "departments": [
       {
-        "title": "Structure of Materials",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.012Sx+2T2022",
-        "courseware_id": "course-v1:MITxT+3.012Sx+2T2022",
-        "run_tag": "2T2022",
-        "id": 41,
-        "products": []
+        "name": "Materials Science and Engineering"
       }
     ],
+    "page": {
+      "feature_image_src": "/media/original_images/3054AboutPageImage_Final_resized.png?v=8486faa001525f1d3350f87de992acbcb3cc70ba",
+      "page_url": "/courses/course-v1:MITxT+3.054x/",
+      "description": "Learn how to model the mechanical properties of honeycombs and foams and to apply the models to material selection in engineering design.",
+      "live": true,
+      "length": "15 weeks",
+      "effort": "8-12 hours per week",
+      "financial_assistance_form_url": "/courses/course-v1:MITxT+3.054x/3054x-financial-assistance-request/",
+      "current_price": 149,
+      "instructors": [
+        {
+          "name": "Lorna Gibson",
+          "description": ""
+        },
+        {
+          "name": "Jessica Sandland",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Cellular Solids: Structure, Properties and Applications",
+        "start_date": "2022-05-04T05:30:00Z",
+        "end_date": "2023-11-01T00:00:00Z",
+        "enrollment_start": "2022-04-25T00:00:00Z",
+        "enrollment_end": "2023-11-01T00:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.054x+3T2021/course/",
+        "courseware_id": "course-v1:MITxT+3.054x+3T2021",
+        "certificate_available_date": "2023-11-01T00:00:00Z",
+        "upgrade_deadline": "2023-10-22T00:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2021",
+        "id": 14,
+        "live": true,
+        "course_number": "3.054x",
+        "products": [
+          {
+            "id": 114,
+            "price": "149.00",
+            "description": "course-v1:MITxT+3.054x+3T2021",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Cellular Solids: Structure, Properties and Applications",
+        "start_date": "2024-01-31T16:00:00Z",
+        "end_date": "2025-01-29T16:00:00Z",
+        "enrollment_start": "2024-01-14T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.054x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+3.054x+1T2024",
+        "certificate_available_date": "2025-01-29T16:00:00Z",
+        "upgrade_deadline": "2025-01-19T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "1T2024",
+        "id": 239,
+        "live": true,
+        "course_number": "3.054x",
+        "products": [
+          {
+            "id": 210,
+            "price": "149.00",
+            "description": "course-v1:MITxT+3.054x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 10,
+    "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+14.310PEx",
     "next_run_id": null,
-    "topics": []
+    "departments": [],
+    "page": null,
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
+        "start_date": "2022-04-20T15:00:00Z",
+        "end_date": "2022-05-16T16:00:00Z",
+        "enrollment_start": "2022-04-20T15:00:00Z",
+        "enrollment_end": "2022-04-29T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310PEx+1T2022a/course/",
+        "courseware_id": "course-v1:MITxT+14.310PEx+1T2022a",
+        "certificate_available_date": "2022-01-26T16:00:00Z",
+        "upgrade_deadline": "2022-05-06T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022a",
+        "id": 24,
+        "live": true,
+        "course_number": "14.310PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
+        "start_date": "2022-01-03T15:00:00Z",
+        "end_date": "2022-01-24T16:00:00Z",
+        "enrollment_start": "2022-01-03T15:00:00Z",
+        "enrollment_end": "2022-01-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310PEx+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.310PEx+1T2022",
+        "certificate_available_date": "2022-01-21T16:00:00Z",
+        "upgrade_deadline": "2022-01-24T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 19,
+        "live": true,
+        "course_number": "14.310PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
+        "start_date": "2022-08-17T15:00:00Z",
+        "end_date": "2022-09-07T15:00:00Z",
+        "enrollment_start": "2022-08-17T15:00:00Z",
+        "enrollment_end": "2022-08-26T15:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.310PEx+2T2022",
+        "courseware_id": "course-v1:MITxT+14.310PEx+2T2022",
+        "certificate_available_date": "2022-01-26T16:00:00Z",
+        "upgrade_deadline": "2022-08-28T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 50,
+        "live": true,
+        "course_number": "14.310PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 11,
+    "title": "Designing and Running Randomized Evaluations - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+JPAL102PEx",
+    "next_run_id": null,
+    "departments": [],
+    "page": {
+      "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
+      "page_url": "/courses/course-v1:MITxT+JPAL102PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Designing and Running Randomized Evaluations - PROCTORED EXAM",
+        "start_date": "2022-01-03T15:00:00Z",
+        "end_date": "2022-01-27T16:00:00Z",
+        "enrollment_start": "2022-01-03T15:00:00Z",
+        "enrollment_end": "2022-01-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102PEx+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+JPAL102PEx+1T2022",
+        "certificate_available_date": "2022-01-21T16:00:00Z",
+        "upgrade_deadline": "2022-01-27T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 18,
+        "live": true,
+        "course_number": "JPAL102PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Designing and Running Randomized Evaluations - PROCTORED EXAM",
+        "start_date": "2022-04-20T15:00:00Z",
+        "end_date": "2022-05-15T16:00:00Z",
+        "enrollment_start": "2022-04-20T15:00:00Z",
+        "enrollment_end": "2022-04-29T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102PEx+1T2022a/course/",
+        "courseware_id": "course-v1:MITxT+JPAL102PEx+1T2022a",
+        "certificate_available_date": "2022-01-29T16:00:00Z",
+        "upgrade_deadline": "2022-05-05T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022a",
+        "id": 26,
+        "live": true,
+        "course_number": "JPAL102PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 12,
+    "title": "Foundations of Development Policy - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+14.740PEx",
+    "next_run_id": null,
+    "departments": [],
+    "page": {
+      "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
+      "page_url": "/courses/course-v1:MITxT+14.740PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Foundations of Development Policy - PROCTORED EXAM",
+        "start_date": "2022-08-17T15:00:00Z",
+        "end_date": "2022-09-08T15:00:00Z",
+        "enrollment_start": "2022-08-17T13:30:00Z",
+        "enrollment_end": "2022-08-26T15:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.740PEx+2T2022",
+        "courseware_id": "course-v1:MITxT+14.740PEx+2T2022",
+        "certificate_available_date": "2022-09-09T15:00:00Z",
+        "upgrade_deadline": "2022-08-29T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 49,
+        "live": true,
+        "course_number": "14.740PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 13,
+    "title": "14.100x - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+14.100PEx",
+    "next_run_id": null,
+    "departments": [],
+    "page": {
+      "feature_image_src": "/media/original_images/14.100x_xGKvQiK.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
+      "page_url": "/courses/course-v1:MITxT+14.100PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Microeconomics - PROCTORED EXAM",
+        "start_date": "2022-08-17T15:00:00Z",
+        "end_date": "2022-09-08T15:00:00Z",
+        "enrollment_start": "2022-08-17T13:30:00Z",
+        "enrollment_end": "2022-08-26T15:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100PEx+2T2022",
+        "courseware_id": "course-v1:MITxT+14.100PEx+2T2022",
+        "certificate_available_date": "2022-01-21T15:00:00Z",
+        "upgrade_deadline": "2022-08-29T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 48,
+        "live": true,
+        "course_number": "14.100PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Microeconomics - PROCTORED EXAM",
+        "start_date": "2022-01-03T15:00:00Z",
+        "end_date": "2022-01-24T15:00:00Z",
+        "enrollment_start": "2022-01-03T15:00:00Z",
+        "enrollment_end": "2022-01-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100PEx+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.100PEx+1T2022",
+        "certificate_available_date": "2022-01-21T15:00:00Z",
+        "upgrade_deadline": "2022-01-24T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 16,
+        "live": true,
+        "course_number": "14.100PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 14,
+    "title": "Political Economy and Economic Development - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+14.750PEx",
+    "next_run_id": null,
+    "departments": [],
+    "page": {
+      "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
+      "page_url": "/courses/course-v1:MITxT+14.750PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Political Economy & Economic Development - PROCTORED EXAM",
+        "start_date": "2022-01-03T15:00:00Z",
+        "end_date": "2022-01-24T16:00:00Z",
+        "enrollment_start": "2022-01-03T15:00:00Z",
+        "enrollment_end": "2022-01-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750PEx+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.750PEx+1T2022",
+        "certificate_available_date": "2022-01-21T16:00:00Z",
+        "upgrade_deadline": "2022-01-24T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 17,
+        "live": true,
+        "course_number": "14.750PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
   },
   {
     "id": 15,
     "title": "The Challenges of Global Poverty - PROCTORED EXAM",
     "readable_id": "course-v1:MITxT+14.73PEx",
-    "courseruns": [],
     "next_run_id": null,
-    "topics": []
+    "departments": [],
+    "page": {
+      "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
+      "page_url": "/courses/course-v1:MITxT+14.73PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Challenges of Global Poverty - PROCTORED EXAM",
+        "start_date": "2022-04-20T15:00:00Z",
+        "end_date": "2022-05-16T16:00:00Z",
+        "enrollment_start": "2022-04-20T15:00:00Z",
+        "enrollment_end": "2022-04-29T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73PEx+1T2022a/course/",
+        "courseware_id": "course-v1:MITxT+14.73PEx+1T2022a",
+        "certificate_available_date": "2022-01-26T16:00:00Z",
+        "upgrade_deadline": "2022-05-06T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022a",
+        "id": 25,
+        "live": true,
+        "course_number": "14.73PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Challenges of Global Poverty - PROCTORED EXAM",
+        "start_date": "2022-01-03T15:00:00Z",
+        "end_date": "2022-01-24T16:00:00Z",
+        "enrollment_start": "2022-01-03T15:00:00Z",
+        "enrollment_end": "2022-01-10T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73PEx+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.73PEx+1T2022",
+        "certificate_available_date": "2022-01-21T16:00:00Z",
+        "upgrade_deadline": "2022-01-24T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2022",
+        "id": 15,
+        "live": true,
+        "course_number": "14.73PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 16,
+    "title": "Good Economics for Hard Times",
+    "readable_id": "course-v1:MITxT+14.009x",
+    "next_run_id": 245,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
+      "page_url": "/courses/course-v1:MITxT+14.009x/",
+      "description": "Learn how current applied economics uses data to tackle some of the toughest problems facing society. Taught by Nobel-prize winning MIT professors Abhijit Banerjee and Esther Duflo and based on their book Good Economics for Hard Times, the course specifically addresses today’s most pressing issues in the United States and other advanced economies.",
+      "live": true,
+      "length": "14 weeks",
+      "effort": "12-14 hours per week",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "current_price": 1000,
+      "instructors": [
+        {
+          "name": "Esther Duflo",
+          "description": ""
+        },
+        {
+          "name": "Abhijit Vinayak Banerjee",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Good Economics for Hard Times",
+        "start_date": "2024-01-16T15:00:00Z",
+        "end_date": "2024-05-03T00:00:00Z",
+        "enrollment_start": "2023-06-27T23:59:00Z",
+        "enrollment_end": "2024-02-13T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+14.009x+1T2024",
+        "certificate_available_date": "2024-05-15T00:00:00Z",
+        "upgrade_deadline": "2024-02-28T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "1T2024",
+        "id": 187,
+        "live": true,
+        "course_number": "14.009x",
+        "products": [
+          {
+            "id": 166,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.009x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Good Economics for Hard Times",
+        "start_date": "2023-05-30T15:00:00Z",
+        "end_date": "2023-09-11T15:00:00Z",
+        "enrollment_start": "2022-07-04T23:59:00Z",
+        "enrollment_end": "2023-06-27T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2023/course/",
+        "courseware_id": "course-v1:MITxT+14.009x+2T2023",
+        "certificate_available_date": "2023-09-25T00:00:00Z",
+        "upgrade_deadline": "2023-07-14T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2023",
+        "id": 38,
+        "live": true,
+        "course_number": "14.009x",
+        "products": [
+          {
+            "id": 18,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.009x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Good Economics for Hard Times",
+        "start_date": "2024-05-14T15:00:00Z",
+        "end_date": "2024-08-21T15:00:00Z",
+        "enrollment_start": "2024-02-13T23:59:00Z",
+        "enrollment_end": "2024-06-11T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+14.009x+2T2024",
+        "certificate_available_date": "2024-09-18T00:00:00Z",
+        "upgrade_deadline": "2024-06-25T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 245,
+        "live": true,
+        "course_number": "14.009x",
+        "products": [
+          {
+            "id": 216,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.009x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Good Economics for Hard Times",
+        "start_date": "2022-05-31T15:00:00Z",
+        "end_date": "2023-05-16T23:30:00Z",
+        "enrollment_start": "2022-04-01T15:00:00Z",
+        "enrollment_end": "2022-07-06T23:59:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+14.009x+2T2022",
+        "certificate_available_date": "2023-05-17T00:00:00Z",
+        "upgrade_deadline": "2022-08-16T23:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 23,
+        "live": true,
+        "course_number": "14.009x",
+        "products": [
+          {
+            "id": 14,
+            "price": "1000.00",
+            "description": "course-v1:MITxT+14.009x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 18,
+    "title": "Evaluating Social Programs",
+    "readable_id": "course-v1:MITxT+JPAL_RCT101x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
+      "page_url": "/courses/course-v1:MITxT+JPAL_RCT101x/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Evaluating Social Programs (RCT101x)",
+        "start_date": "2022-04-13T15:00:00Z",
+        "end_date": "2024-01-16T04:00:00Z",
+        "enrollment_start": "2022-04-13T05:00:00Z",
+        "enrollment_end": "2023-12-13T17:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL_RCT101x+1T2022/course/",
+        "courseware_id": "course-v1:MITxT+JPAL_RCT101x+1T2022",
+        "certificate_available_date": "2024-01-16T04:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "1T2022",
+        "id": 27,
+        "live": true,
+        "course_number": "JPAL_RCT101x",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 19,
+    "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
+    "readable_id": "course-v1:MITxT+11.S952x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Urban Studies and Planning"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/11.S952x_Course_Image.png?v=faba2ccb0ebef1badccda77298e5829b9eb9dd04",
+      "page_url": "/courses/course-v1:MITxT+11.S952x/",
+      "description": "Learn how COVID-19 has impacted the world’s most vulnerable populations, across the Global South, and understand the varied responses and governance issues in self-organized, self-built urban poor communities.",
+      "live": true,
+      "length": "4-6 Weeks",
+      "effort": "2-3 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Caesar McDowell",
+          "description": ""
+        },
+        {
+          "name": "Karenna Groff",
+          "description": ""
+        },
+        {
+          "name": "Amelia Seabold",
+          "description": ""
+        },
+        {
+          "name": "Daniela Beltrame",
+          "description": ""
+        },
+        {
+          "name": "Joaquin Benitez",
+          "description": ""
+        },
+        {
+          "name": "Marcelle Mardon",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
+        "start_date": "2022-09-12T16:00:00Z",
+        "end_date": "2023-04-28T16:00:00Z",
+        "enrollment_start": "2022-08-01T00:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+11.S952x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+11.S952x+2T2022",
+        "certificate_available_date": "2023-04-28T16:00:00Z",
+        "upgrade_deadline": "2023-04-18T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "2T2022",
+        "id": 28,
+        "live": true,
+        "course_number": "11.S952x",
+        "products": [
+          {
+            "id": 109,
+            "price": "29.00",
+            "description": "course-v1:MITxT+11.S952x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 20,
+    "title": "Paradox and Infinity",
+    "readable_id": "course-v1:MITxT+24.118x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Linguistics and Philosophy"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/24.118x_CourseImage_20170926_sm.png?v=5f596811c909028fcbc4361d295c0122e0d791b5",
+      "page_url": "/courses/course-v1:MITxT+24.118x/",
+      "description": "This is a class about awe-inspiring issues at the intersection between philosophy and mathematics.",
+      "live": true,
+      "length": "12 weeks",
+      "effort": "5-6 per week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Agustín Rayo",
+          "description": ""
+        },
+        {
+          "name": "David Balcarras",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Paradox and Infinity",
+        "start_date": "2022-06-29T16:00:00Z",
+        "end_date": "2022-08-31T16:00:00Z",
+        "enrollment_start": "2022-06-20T16:00:00Z",
+        "enrollment_end": "2022-08-31T00:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.118x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+24.118x+2T2022",
+        "certificate_available_date": "2022-09-09T00:00:00Z",
+        "upgrade_deadline": "2022-08-21T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 29,
+        "live": true,
+        "course_number": "24.118x",
+        "products": [
+          {
+            "id": 113,
+            "price": "99.00",
+            "description": "course-v1:MITxT+24.118x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Paradox and Infinity",
+        "start_date": "2023-11-09T16:00:00Z",
+        "end_date": "2024-01-25T16:00:00Z",
+        "enrollment_start": "2023-08-30T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.118x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+24.118x+3T2023",
+        "certificate_available_date": "2024-01-26T00:00:00Z",
+        "upgrade_deadline": "2024-01-15T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 205,
+        "live": true,
+        "course_number": "24.118x",
+        "products": [
+          {
+            "id": 184,
+            "price": "99.00",
+            "description": "course-v1:MITxT+24.118x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 21,
+    "title": "Minds and Machines",
+    "readable_id": "course-v1:MITxT+24.09x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Linguistics and Philosophy"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/2409x_FL15_Thumbnail.jpeg?v=cc95c149b6f5f3597bd83079320b347cd03da6ef",
+      "page_url": "/courses/course-v1:MITxT+24.09x/",
+      "description": "An introduction to philosophy of mind, exploring consciousness, reality, AI, and more. The most in-depth philosophy course available online.",
+      "live": true,
+      "length": "12 weeks",
+      "effort": "4-6 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Alex Byrne",
+          "description": ""
+        },
+        {
+          "name": "David Balcarras",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Minds and Machines",
+        "start_date": "2023-11-07T16:00:00Z",
+        "end_date": "2024-01-31T16:00:00Z",
+        "enrollment_start": "2023-08-30T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.09x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+24.09x+3T2023",
+        "certificate_available_date": "2024-02-02T00:00:00Z",
+        "upgrade_deadline": "2024-01-21T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2023",
+        "id": 206,
+        "live": true,
+        "course_number": "24.09x",
+        "products": [
+          {
+            "id": 185,
+            "price": "49.00",
+            "description": "course-v1:MITxT+24.09x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Minds and Machines",
+        "start_date": "2022-06-08T17:00:00Z",
+        "end_date": "2022-08-31T17:00:00Z",
+        "enrollment_start": "2022-05-30T16:00:00Z",
+        "enrollment_end": "2022-08-31T00:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.09x+2T2022/course/",
+        "courseware_id": "course-v1:MITxT+24.09x+2T2022",
+        "certificate_available_date": "2022-09-01T00:00:00Z",
+        "upgrade_deadline": "2022-08-21T17:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 30,
+        "live": true,
+        "course_number": "24.09x",
+        "products": [
+          {
+            "id": 112,
+            "price": "49.00",
+            "description": "course-v1:MITxT+24.09x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 22,
+    "title": "Bringing Worker Voices into Technology and Employment Strategies",
+    "readable_id": "course-v1:MITxT+15.699x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Management"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/negative-space-female-factory-worker-engine-hard-hat-yellow-chevanon-photo.jpg?v=fcf6e582d2d28a8c7c4b34b82759e145a2306269",
+      "page_url": "/courses/course-v1:MITxT+15.699x/",
+      "description": "Course exploring ways in which worker representatives can negotiate with employers and vendors to shape new technology entering the workplace to benefit workers",
+      "live": true,
+      "length": "6 weeks",
+      "effort": "3-4 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Bringing Workers Voice into Technology and Employment Strategies",
+        "start_date": "2022-09-07T16:00:00Z",
+        "end_date": "2023-01-31T16:00:00Z",
+        "enrollment_start": "2022-06-09T00:00:00Z",
+        "enrollment_end": "2023-01-31T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+15.699x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+15.699x+3T2022",
+        "certificate_available_date": "2023-01-31T16:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 31,
+        "live": true,
+        "course_number": "15.699x",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Bringing Workers Voice into Technology and Employment Strategies",
+        "start_date": "2023-06-20T00:00:00Z",
+        "end_date": "2023-11-21T16:00:00Z",
+        "enrollment_start": "2023-06-01T00:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+15.699x+2T2023/course",
+        "courseware_id": "course-v1:MITxT+15.699x+2T2023",
+        "certificate_available_date": "2023-11-21T16:00:00Z",
+        "upgrade_deadline": "2023-11-11T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "2T2023",
+        "id": 181,
+        "live": true,
+        "course_number": "15.699x",
+        "products": [
+          {
+            "id": 160,
+            "price": "49.00",
+            "description": "course-v1:MITxT+15.699x+2T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 23,
+    "title": "Mechanics: Kinematics and Dynamics",
+    "readable_id": "course-v1:MITxT+8.01.1x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Physics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.1x_Image_2022_MITxO.png?v=593cb814d4e22283198eceb20855662bf41704d8",
+      "page_url": "/courses/course-v1:MITxT+8.01.1x/",
+      "description": "Learn about kinematics and dynamics in this calculus-based physics course.",
+      "live": true,
+      "length": "5 weeks",
+      "effort": "10-12 hours/week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Krishna Rajagopal",
+          "description": ""
+        },
+        {
+          "name": "Peter Dourmaskin",
+          "description": ""
+        },
+        {
+          "name": "Analia Barrantes",
+          "description": ""
+        },
+        {
+          "name": "Saif Rayyan",
+          "description": ""
+        },
+        {
+          "name": "Michelle Tomasik",
+          "description": ""
+        },
+        {
+          "name": "George Stephans",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Mechanics: Kinematics and Dynamics",
+        "start_date": "2022-09-22T16:00:00Z",
+        "end_date": "2023-04-13T16:00:00Z",
+        "enrollment_start": "2022-07-27T00:00:00Z",
+        "enrollment_end": "2023-04-13T00:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.1x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+8.01.1x+3T2022",
+        "certificate_available_date": "2023-04-13T16:00:00Z",
+        "upgrade_deadline": "2023-03-24T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 32,
+        "live": true,
+        "course_number": "8.01.1x",
+        "products": [
+          {
+            "id": 115,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.1x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Mechanics: Kinematics and Dynamics",
+        "start_date": "2023-09-27T16:00:00Z",
+        "end_date": "2024-04-17T16:00:00Z",
+        "enrollment_start": "2022-07-27T00:00:00Z",
+        "enrollment_end": "2024-03-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.1x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+8.01.1x+3T2023",
+        "certificate_available_date": "2024-04-17T16:00:00Z",
+        "upgrade_deadline": "2024-03-20T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2023",
+        "id": 208,
+        "live": true,
+        "course_number": "8.01.1x",
+        "products": [
+          {
+            "id": 186,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.1x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 24,
+    "title": "Moral Problems and the Good Life",
+    "readable_id": "course-v1:MITxT+24.02x",
+    "next_run_id": 253,
+    "departments": [
+      {
+        "name": "Linguistics and Philosophy"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/24.02x_course_image_01.jpg?v=a6b6b81b428417cddb6966a998a9dcb4ca7867eb",
+      "page_url": "/courses/course-v1:MITxT+24.02x/",
+      "description": "A rigorous introduction to ethics. We’ll think about well-being, objectivity, key historical figures and approaches, what we owe to others, and more.",
+      "live": true,
+      "length": "10 weeks",
+      "effort": "5-7 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": 99,
+      "instructors": [
+        {
+          "name": "Caspar Hare",
+          "description": ""
+        },
+        {
+          "name": "Tamar Schapiro",
+          "description": ""
+        },
+        {
+          "name": "Kieran Setiya",
+          "description": ""
+        },
+        {
+          "name": "David Balcarras",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Moral Problems and the Good Life",
+        "start_date": "2022-11-17T16:00:00Z",
+        "end_date": "2023-02-02T16:00:00Z",
+        "enrollment_start": "2022-06-17T00:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.02x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+24.02x+3T2022",
+        "certificate_available_date": "2023-02-03T00:00:00Z",
+        "upgrade_deadline": "2023-01-23T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2022",
+        "id": 33,
+        "live": true,
+        "course_number": "24.02x",
+        "products": [
+          {
+            "id": 111,
+            "price": "99.00",
+            "description": "course-v1:MITxT+24.02x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Moral Problems and the Good Life",
+        "start_date": "2024-06-13T16:00:00Z",
+        "end_date": "2024-08-28T16:00:00Z",
+        "enrollment_start": "2024-04-29T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.02x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+24.02x+2T2024",
+        "certificate_available_date": "2024-08-31T00:00:00Z",
+        "upgrade_deadline": "2024-08-18T16:00:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 253,
+        "live": true,
+        "course_number": "24.02x",
+        "products": [
+          {
+            "id": 224,
+            "price": "99.00",
+            "description": "course-v1:MITxT+24.02x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 25,
+    "title": "Problems of Philosophy",
+    "readable_id": "course-v1:MITxT+24.10x",
+    "next_run_id": 254,
+    "departments": [
+      {
+        "name": "Linguistics and Philosophy"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/24.10x_-_course_Image.jpg?v=6854692b199940a6d43965a020d8bc12d29d4e41",
+      "page_url": "/courses/course-v1:MITxT+24.10x/",
+      "description": "A tour through the big questions of philosophy. Does God exist? Do we have free will? Is morality objective? What is knowledge? What is the meaning of life?",
+      "live": true,
+      "length": "12 weeks",
+      "effort": "3-5 hours per week",
+      "financial_assistance_form_url": "",
+      "current_price": 139,
+      "instructors": [
+        {
+          "name": "Alex Byrne",
+          "description": ""
+        },
+        {
+          "name": "David Balcarras",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Problems of Philosophy",
+        "start_date": "2022-11-17T14:00:00Z",
+        "end_date": "2023-02-09T14:00:00Z",
+        "enrollment_start": "2022-09-26T14:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.10x+3T2022/course/",
+        "courseware_id": "course-v1:MITxT+24.10x+3T2022",
+        "certificate_available_date": "2023-02-04T14:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "3T2022",
+        "id": 34,
+        "live": true,
+        "course_number": "24.10x",
+        "products": [],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Problems of Philosophy",
+        "start_date": "2024-06-04T16:00:00Z",
+        "end_date": "2024-08-27T16:00:00Z",
+        "enrollment_start": "2024-04-29T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.10x+2T2024/course",
+        "courseware_id": "course-v1:MITxT+24.10x+2T2024",
+        "certificate_available_date": "2024-08-30T00:00:00Z",
+        "upgrade_deadline": "2024-08-17T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": false,
+        "run_tag": "2T2024",
+        "id": 254,
+        "live": true,
+        "course_number": "24.10x",
+        "products": [
+          {
+            "id": 225,
+            "price": "139.00",
+            "description": "course-v1:MITxT+24.10x+2T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 26,
+    "title": "Quantum Mechanics: A First Course",
+    "readable_id": "course-v1:MITxT+8.04x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Physics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.04x_replacement_20200917_DiIr66w.png?v=aa4947564bf5b8228085ee3139c62c873d21a66d",
+      "page_url": "/courses/course-v1:MITxT+8.04x/",
+      "description": "Learn about wavefunctions and their probabilistic interpretation, how to solve the Schrödinger equation for a particle moving in one-dimensional potentials, scattering, central potentials, and the hydrogen atom.",
+      "live": false,
+      "length": "17 Weeks",
+      "effort": "10-15 Hours/Week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Quantum Mechanics: A First Course",
+        "start_date": "2022-10-13T16:00:00Z",
+        "end_date": "2023-02-09T17:00:00Z",
+        "enrollment_start": "2022-07-29T16:00:00Z",
+        "enrollment_end": "2022-12-19T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.04x+3T2022",
+        "courseware_id": "course-v1:MITxT+8.04x+3T2022",
+        "certificate_available_date": "2023-02-09T17:00:00Z",
+        "upgrade_deadline": "2023-01-30T17:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "3T2022",
+        "id": 39,
+        "live": true,
+        "course_number": "8.04x",
+        "products": [
+          {
+            "id": 119,
+            "price": "149.00",
+            "description": "course-v1:MITxT+8.04x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 27,
+    "title": "How Language Works",
+    "readable_id": "course-v1:MITxT+24.900x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Linguistics and Philosophy"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
+      "page_url": "/courses/course-v1:MITxT+24.900x/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "How Language Works",
+        "start_date": "2024-08-01T16:00:00Z",
+        "end_date": "2024-09-01T16:00:00Z",
+        "enrollment_start": "2024-06-01T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+24.900x+3T2022",
+        "courseware_id": "course-v1:MITxT+24.900x+3T2022",
+        "certificate_available_date": "2024-09-01T16:00:00Z",
+        "upgrade_deadline": null,
+        "is_upgradable": true,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 40,
+        "live": true,
+        "course_number": "24.900x",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 28,
+    "title": "Structure of Materials",
+    "readable_id": "course-v1:MITxT+3.012Sx",
+    "next_run_id": 201,
+    "departments": [
+      {
+        "name": "Materials Science and Engineering"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/3012_Part3_Image.jpg?v=e7d597d18e48dad875b363686066012a30990889",
+      "page_url": "/courses/course-v1:MITxT+3.012Sx/",
+      "description": "Discover the structure of the materials that make up our modern world and learn how this underlying structure influences the properties and performance of these materials.",
+      "live": true,
+      "length": "16 weeks",
+      "effort": "6–8 hours per week",
+      "financial_assistance_form_url": "/courses/course-v1:MITxT+3.012Sx/3012Sx-Financial-Assistance-Request/",
+      "current_price": 150,
+      "instructors": [
+        {
+          "name": "Silvija Gradečak",
+          "description": ""
+        },
+        {
+          "name": "Jessica Sandland",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Structure of Materials",
+        "start_date": "2023-09-06T16:00:00Z",
+        "end_date": "2024-08-28T16:00:00Z",
+        "enrollment_start": "2023-08-17T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.012Sx+3T2023/course",
+        "courseware_id": "course-v1:MITxT+3.012Sx+3T2023",
+        "certificate_available_date": "2024-08-28T16:00:00Z",
+        "upgrade_deadline": "2024-08-01T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "3T2023",
+        "id": 201,
+        "live": true,
+        "course_number": "3.012Sx",
+        "products": [
+          {
+            "id": 180,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.012Sx+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Structure of Materials",
+        "start_date": "2022-10-25T10:00:00Z",
+        "end_date": "2023-08-31T15:00:00Z",
+        "enrollment_start": "2022-08-31T10:00:00Z",
+        "enrollment_end": "2023-08-17T00:30:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.012Sx+2T2022",
+        "courseware_id": "course-v1:MITxT+3.012Sx+2T2022",
+        "certificate_available_date": "2023-08-31T15:00:00Z",
+        "upgrade_deadline": "2023-08-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "2T2022",
+        "id": 41,
+        "live": true,
+        "course_number": "3.012Sx",
+        "products": [
+          {
+            "id": 124,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.012Sx+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 29,
+    "title": "Electronic, Optical and Magnetic Properties of Materials",
+    "readable_id": "course-v1:MITxT+3.024x",
+    "next_run_id": 202,
+    "departments": [
+      {
+        "name": "Materials Science and Engineering"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/3.024x_SP18_CourseImage_resized.jpg?v=9a9f6c7b40b975b8490dcc60c4233d23dd2a7785",
+      "page_url": "/courses/course-v1:MITxT+3.024x/",
+      "description": "Discover the physical principles behind diodes, light-emitting devices, and memories.",
+      "live": true,
+      "length": "15 weeks",
+      "effort": "11-13 hours per week",
+      "financial_assistance_form_url": "/courses/course-v1:MITxT+3.024x/3024x-Financial-Assistance-Request/",
+      "current_price": 150,
+      "instructors": [
+        {
+          "name": "Polina Anikeeva",
+          "description": ""
+        },
+        {
+          "name": "Jessica Sandland",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Electronic, Optical, and Magnetic Properties of Materials",
+        "start_date": "2022-11-15T16:00:00Z",
+        "end_date": "2023-08-31T16:00:00Z",
+        "enrollment_start": "2022-08-21T00:00:00Z",
+        "enrollment_end": "2023-08-17T00:30:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.024x+2T2022",
+        "courseware_id": "course-v1:MITxT+3.024x+2T2022",
+        "certificate_available_date": "2023-08-31T16:00:00Z",
+        "upgrade_deadline": "2023-08-21T16:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "2T2022",
+        "id": 42,
+        "live": true,
+        "course_number": "3.024x",
+        "products": [
+          {
+            "id": 129,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.024x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Electronic, Optical, and Magnetic Properties of Materials",
+        "start_date": "2023-09-06T16:00:00Z",
+        "end_date": "2024-08-28T16:00:00Z",
+        "enrollment_start": "2023-08-17T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.024x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+3.024x+3T2023",
+        "certificate_available_date": "2024-08-28T16:00:00Z",
+        "upgrade_deadline": "2024-08-01T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "3T2023",
+        "id": 202,
+        "live": true,
+        "course_number": "3.024x",
+        "products": [
+          {
+            "id": 181,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.024x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 30,
+    "title": "Electrical, Optical & Magnetic Materials and Devices",
+    "readable_id": "course-v1:MITxT+3.15x",
+    "next_run_id": 203,
+    "departments": [
+      {
+        "name": "Materials Science and Engineering"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/3.15x_course_image.jpg?v=61d2d710e71eac2070ec3b8ad06236fac1e409c9",
+      "page_url": "/courses/course-v1:MITxT+3.15x/",
+      "description": "In 3.15x we will explore the electrical, optical, and magnetic properties of materials and learn how electronic devices are designed to exploit these properties.",
+      "live": true,
+      "length": "16 weeks",
+      "effort": "8-12 hours per week",
+      "financial_assistance_form_url": "/courses/course-v1:MITxT+3.15x/315x-Financial-Assistance-Request/",
+      "current_price": 150,
+      "instructors": [
+        {
+          "name": "Caroline Ross",
+          "description": ""
+        },
+        {
+          "name": "Jessica Sandland",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Electrical, Optical & Magnetic Materials and Devices",
+        "start_date": "2022-11-29T15:00:00Z",
+        "end_date": "2023-08-31T15:00:00Z",
+        "enrollment_start": "2022-08-31T00:00:00Z",
+        "enrollment_end": "2023-08-17T00:30:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.15x+2T2022",
+        "courseware_id": "course-v1:MITxT+3.15x+2T2022",
+        "certificate_available_date": "2023-08-31T15:00:00Z",
+        "upgrade_deadline": "2023-08-21T15:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "2T2022",
+        "id": 43,
+        "live": true,
+        "course_number": "3.15x",
+        "products": [
+          {
+            "id": 125,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.15x+2T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Electrical, Optical & Magnetic Materials and Devices",
+        "start_date": "2023-09-06T16:00:00Z",
+        "end_date": "2024-08-28T16:00:00Z",
+        "enrollment_start": "2023-08-17T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.15x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+3.15x+3T2023",
+        "certificate_available_date": "2024-08-28T16:00:00Z",
+        "upgrade_deadline": "2024-08-01T23:59:00Z",
+        "is_upgradable": true,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "3T2023",
+        "id": 203,
+        "live": true,
+        "course_number": "3.15x",
+        "products": [
+          {
+            "id": 182,
+            "price": "150.00",
+            "description": "course-v1:MITxT+3.15x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 31,
+    "title": "Mechanics: Momentum and Energy",
+    "readable_id": "course-v1:MITxT+8.01.2x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Physics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.2x_courseImage_435p-244p.png?v=50a30ec2256f4ebb8ae26b8904f1fab41fd36650",
+      "page_url": "/courses/course-v1:MITxT+8.01.2x/",
+      "description": "This online physics course is the second in the xSeries in Introduction to Mechanics that covers calculus-based mechanics. In this course, you will learn about the concepts of momentum, impulse, energy, and work, as well as the powerful idea of conservation laws. You will apply these concepts as techniques to solve interesting mechanics problems such as collisions and rockets.",
+      "live": true,
+      "length": "6 weeks",
+      "effort": "10-12 hours/week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Krishna Rajagopal",
+          "description": ""
+        },
+        {
+          "name": "Peter Dourmaskin",
+          "description": ""
+        },
+        {
+          "name": "Analia Barrantes",
+          "description": ""
+        },
+        {
+          "name": "Saif Rayyan",
+          "description": ""
+        },
+        {
+          "name": "Michelle Tomasik",
+          "description": ""
+        },
+        {
+          "name": "George Stephans",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Mechanics: Momentum and Energy",
+        "start_date": "2022-10-20T16:00:00Z",
+        "end_date": "2023-04-13T16:00:00Z",
+        "enrollment_start": "2022-07-27T00:00:00Z",
+        "enrollment_end": "2023-04-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.2x+3T2022",
+        "courseware_id": "course-v1:MITxT+8.01.2x+3T2022",
+        "certificate_available_date": "2023-04-13T16:00:00Z",
+        "upgrade_deadline": "2023-03-28T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 44,
+        "live": true,
+        "course_number": "8.01.2x",
+        "products": [
+          {
+            "id": 116,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.2x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Mechanics: Momentum and Energy",
+        "start_date": "2023-11-08T16:00:00Z",
+        "end_date": "2024-04-17T16:00:00Z",
+        "enrollment_start": "2022-07-27T00:00:00Z",
+        "enrollment_end": "2024-03-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.2x+3T2023/course",
+        "courseware_id": "course-v1:MITxT+8.01.2x+3T2023",
+        "certificate_available_date": "2024-04-17T16:00:00Z",
+        "upgrade_deadline": "2024-03-20T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2023",
+        "id": 210,
+        "live": true,
+        "course_number": "8.01.2x",
+        "products": [
+          {
+            "id": 188,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.2x+3T2023",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 32,
+    "title": "Introduction to Mechanics: Rotational Dynamics",
+    "readable_id": "course-v1:MITxT+8.01.3x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Physics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
+      "page_url": "/courses/course-v1:MITxT+8.01.3x/",
+      "description": "Learn about rotational dynamics in this calculus-based physics course.",
+      "live": true,
+      "length": "4 weeks",
+      "effort": "10-12 hours/week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Deepto Chakrabarty",
+          "description": ""
+        },
+        {
+          "name": "Peter Dourmaskin",
+          "description": ""
+        },
+        {
+          "name": "Analia Barrantes",
+          "description": ""
+        },
+        {
+          "name": "Saif Rayyan",
+          "description": ""
+        },
+        {
+          "name": "Michelle Tomasik",
+          "description": ""
+        },
+        {
+          "name": "George Stephans",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Mechanics: Rotational Dynamics",
+        "start_date": "2022-11-17T18:00:00Z",
+        "end_date": "2023-04-13T17:00:00Z",
+        "enrollment_start": "2022-11-01T00:00:00Z",
+        "enrollment_end": "2023-04-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.3x+3T2022",
+        "courseware_id": "course-v1:MITxT+8.01.3x+3T2022",
+        "certificate_available_date": "2023-04-13T17:00:00Z",
+        "upgrade_deadline": "2023-03-28T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 45,
+        "live": true,
+        "course_number": "8.01.3x",
+        "products": [
+          {
+            "id": 117,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.3x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Mechanics: Rotational Dynamics",
+        "start_date": "2024-01-03T18:00:00Z",
+        "end_date": "2024-04-17T18:00:00Z",
+        "enrollment_start": "2023-08-28T16:00:00Z",
+        "enrollment_end": "2024-03-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.3x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+8.01.3x+1T2024",
+        "certificate_available_date": "2024-04-17T18:00:00Z",
+        "upgrade_deadline": "2024-04-07T18:00:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "1T2024",
+        "id": 209,
+        "live": true,
+        "course_number": "8.01.3x",
+        "products": [
+          {
+            "id": 187,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.3x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 33,
+    "title": "Introduction to Mechanics: Simple Harmonic Motion and Non-Inertial Reference Frames",
+    "readable_id": "course-v1:MITxT+8.01.4x",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Physics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/8.01.4x_courseimage01_435p-244p.jpg?v=0a2fac7fe3be47df2d6b0651b7e57e2871f901ad",
+      "page_url": "/courses/course-v1:MITxT+8.01.4x/",
+      "description": "Learn how to solve and understand simple harmonic motion in this calculus-based physics course. ",
+      "live": true,
+      "length": "4 weeks",
+      "effort": "10-12 hours/ week",
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": [
+        {
+          "name": "Deepto Chakrabarty",
+          "description": ""
+        },
+        {
+          "name": "Peter Dourmaskin",
+          "description": ""
+        },
+        {
+          "name": "Analia Barrantes",
+          "description": ""
+        },
+        {
+          "name": "Saif Rayyan",
+          "description": ""
+        },
+        {
+          "name": "Michelle Tomasik",
+          "description": ""
+        },
+        {
+          "name": "George Stephans",
+          "description": ""
+        }
+      ]
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Mechanics: Simple Harmonic Motion and Rotating Reference Frames",
+        "start_date": "2024-02-07T16:00:00Z",
+        "end_date": "2024-04-17T16:00:00Z",
+        "enrollment_start": "2022-07-29T16:00:00Z",
+        "enrollment_end": null,
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.4x+1T2024/course",
+        "courseware_id": "course-v1:MITxT+8.01.4x+1T2024",
+        "certificate_available_date": "2024-04-17T16:00:00Z",
+        "upgrade_deadline": "2024-04-06T23:59:00Z",
+        "is_upgradable": false,
+        "is_enrollable": true,
+        "is_self_paced": true,
+        "run_tag": "1T2024",
+        "id": 211,
+        "live": true,
+        "course_number": "8.01.4x",
+        "products": [
+          {
+            "id": 189,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.4x+1T2024",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      },
+      {
+        "title": "Mechanics: Simple Harmonic Motion and Rotating Reference Frames",
+        "start_date": "2022-12-15T16:00:00Z",
+        "end_date": "2023-04-13T16:00:00Z",
+        "enrollment_start": "2022-07-29T16:00:00Z",
+        "enrollment_end": "2023-04-13T16:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.4x+3T2022",
+        "courseware_id": "course-v1:MITxT+8.01.4x+3T2022",
+        "certificate_available_date": "2023-04-13T16:00:00Z",
+        "upgrade_deadline": "2023-03-28T23:59:59Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": true,
+        "run_tag": "3T2022",
+        "id": 46,
+        "live": true,
+        "course_number": "8.01.4x",
+        "products": [
+          {
+            "id": 118,
+            "price": "49.00",
+            "description": "course-v1:MITxT+8.01.4x+3T2022",
+            "is_active": true,
+            "product_flexible_price": {
+              "amount": null,
+              "automatic": false,
+              "discount_type": null,
+              "redemption_type": null,
+              "max_redemptions": null,
+              "discount_code": "",
+              "payment_type": null,
+              "activation_date": null,
+              "expiration_date": null
+            }
+          }
+        ],
+        "approved_flexible_price_exists": false
+      }
+    ]
+  },
+  {
+    "id": 34,
+    "title": "Good Economics for Hard Times - PROCTORED EXAM",
+    "readable_id": "course-v1:MITxT+14.009PEx",
+    "next_run_id": null,
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
+      "page_url": "/courses/course-v1:MITxT+14.009PEx/",
+      "description": "do not publish",
+      "live": false,
+      "length": "do not publish",
+      "effort": null,
+      "financial_assistance_form_url": "",
+      "current_price": null,
+      "instructors": []
+    },
+    "programs": null,
+    "courseruns": [
+      {
+        "title": "Good Economics for Hard Times - PROCTORED EXAM",
+        "start_date": "2022-08-17T15:00:00Z",
+        "end_date": "2022-09-07T23:30:00Z",
+        "enrollment_start": "2022-08-17T13:30:00Z",
+        "enrollment_end": "2022-08-26T15:00:00Z",
+        "expiration_date": null,
+        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.009PEx+2T2022",
+        "courseware_id": "course-v1:MITxT+14.009PEx+2T2022",
+        "certificate_available_date": "2022-09-09T15:00:00Z",
+        "upgrade_deadline": "2022-08-28T23:30:00Z",
+        "is_upgradable": false,
+        "is_enrollable": false,
+        "is_self_paced": false,
+        "run_tag": "2T2022",
+        "id": 47,
+        "live": true,
+        "course_number": "14.009PEx",
+        "products": [],
+        "approved_flexible_price_exists": false
+      }
+    ]
   }
 ]

--- a/test_json/mitxonline_programs.json
+++ b/test_json/mitxonline_programs.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Data, Economics and Development Policy",
+    "title": "Data, Economics, and Design of Policy: International Development",
     "readable_id": "program-v1:MITx+DEDP",
     "id": 1,
     "courses": [
@@ -8,233 +8,4034 @@
         "id": 1,
         "title": "Microeconomics",
         "readable_id": "course-v1:MITxT+14.100x",
+        "next_run_id": 246,
+        "departments": [
+          {
+            "name": "Economics"
+          }
+        ],
         "page": {
           "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
           "page_url": "/courses/course-v1:MITxT+14.100x/",
-          "financial_assistance_form_url": ""
+          "description": "Use economic models to learn how prices and markets benefit society in the face of scarcity.",
+          "live": true,
+          "length": "14 weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Jonathan Gruber",
+              "description": ""
+            }
+          ]
         },
+        "programs": null,
         "courseruns": [
           {
             "title": "Microeconomics",
             "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T23:30:00Z",
+            "end_date": "2023-06-24T19:20:00Z",
             "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
+            "enrollment_end": "2022-10-07T23:59:00Z",
             "expiration_date": null,
             "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2022/course/",
             "courseware_id": "course-v1:MITxT+14.100x+3T2022",
+            "certificate_available_date": "2023-06-25T00:00:00Z",
+            "upgrade_deadline": "2022-12-25T19:20:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
             "run_tag": "3T2022",
             "id": 35,
+            "live": true,
+            "course_number": "14.100x",
             "products": [
               {
                 "id": 22,
+                "price": "1000.00",
                 "description": "course-v1:MITxT+14.100x+3T2022",
                 "is_active": true,
-                "product_flexible_price": {
-                  "amount": null,
-                  "automatic": false,
-                  "discount_type": null,
-                  "redemption_type": null,
-                  "max_redemptions": null,
-                  "discount_code": "",
-                  "payment_type": null,
-                  "activation_date": null,
-                  "expiration_date": null
-                }
+                "product_flexible_price": null
               }
-            ]
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2023-09-12T15:00:00Z",
+            "end_date": "2024-02-18T15:00:00Z",
+            "enrollment_start": "2023-06-27T15:00:00Z",
+            "enrollment_end": "2023-10-10T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2023/course",
+            "courseware_id": "course-v1:MITxT+14.100x+3T2023",
+            "certificate_available_date": "2024-02-19T00:00:00Z",
+            "upgrade_deadline": "2023-11-03T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2023",
+            "id": 185,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 164,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+3T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2023-05-30T15:00:00Z",
+            "end_date": "2024-02-01T15:00:00Z",
+            "enrollment_start": "2022-10-11T15:00:00Z",
+            "enrollment_end": "2023-06-27T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100x+2T2023",
+            "courseware_id": "course-v1:MITxT+14.100x+2T2023",
+            "certificate_available_date": "2024-02-02T00:00:00Z",
+            "upgrade_deadline": "2023-07-18T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2023",
+            "id": 143,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 108,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+2T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2024-01-16T15:00:00Z",
+            "end_date": "2024-05-04T00:00:00Z",
+            "enrollment_start": "2023-10-10T15:00:00Z",
+            "enrollment_end": "2024-02-13T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+1T2024/course",
+            "courseware_id": "course-v1:MITxT+14.100x+1T2024",
+            "certificate_available_date": "2024-05-15T00:00:00Z",
+            "upgrade_deadline": "2024-02-28T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2024",
+            "id": 225,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 200,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+1T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2024-05-14T15:00:00Z",
+            "end_date": "2024-08-21T15:00:00Z",
+            "enrollment_start": "2024-02-13T23:59:00Z",
+            "enrollment_end": "2024-06-11T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+2T2024/course",
+            "courseware_id": "course-v1:MITxT+14.100x+2T2024",
+            "certificate_available_date": "2024-09-18T00:00:00Z",
+            "upgrade_deadline": "2024-06-25T23:59:00Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "2T2024",
+            "id": 246,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 217,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+2T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2017-09-26T15:00:00Z",
+            "end_date": "2017-12-22T15:00:00Z",
+            "enrollment_start": "2017-07-03T15:00:00Z",
+            "enrollment_end": "2017-10-24T03:21:39Z",
+            "expiration_date": "2017-12-23T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2017",
+            "courseware_id": "course-v1:MITx+14.100x+3T2017",
+            "certificate_available_date": "2017-12-22T15:00:00Z",
+            "upgrade_deadline": "2017-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2017",
+            "id": 63,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 26,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+3T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2017-02-06T15:00:00Z",
+            "end_date": "2017-05-05T15:00:00Z",
+            "enrollment_start": "2016-12-05T05:00:00Z",
+            "enrollment_end": "2017-03-06T14:00:00Z",
+            "expiration_date": "2017-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2017",
+            "courseware_id": "course-v1:MITx+14.100x+1T2017",
+            "certificate_available_date": "2017-05-05T15:00:00Z",
+            "upgrade_deadline": "2017-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2017",
+            "id": 119,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 84,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+1T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2017-06-05T15:00:00Z",
+            "end_date": "2017-08-28T15:00:00Z",
+            "enrollment_start": "2017-03-06T14:00:00Z",
+            "enrollment_end": "2017-07-03T15:00:00Z",
+            "expiration_date": "2017-08-29T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2017",
+            "courseware_id": "course-v1:MITx+14.100x+2T2017",
+            "certificate_available_date": "2017-08-28T15:00:00Z",
+            "upgrade_deadline": "2017-08-28T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2017",
+            "id": 120,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 85,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2018-02-06T15:00:00Z",
+            "end_date": "2018-05-05T15:00:00Z",
+            "enrollment_start": "2017-10-24T15:00:00Z",
+            "enrollment_end": "2018-03-06T04:00:00Z",
+            "expiration_date": "2018-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2018",
+            "courseware_id": "course-v1:MITx+14.100x+1T2018",
+            "certificate_available_date": "2018-05-05T15:00:00Z",
+            "upgrade_deadline": "2018-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2018",
+            "id": 121,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 86,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+1T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2018-06-05T15:00:00Z",
+            "end_date": "2018-08-21T03:30:00Z",
+            "enrollment_start": "2018-03-06T15:00:00Z",
+            "enrollment_end": "2018-07-03T15:00:00Z",
+            "expiration_date": "2018-08-22T03:30:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2018",
+            "courseware_id": "course-v1:MITx+14.100x+2T2018",
+            "certificate_available_date": "2018-08-21T03:30:00Z",
+            "upgrade_deadline": "2018-08-21T03:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2018",
+            "id": 122,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 87,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2020",
+            "courseware_id": "course-v1:MITx+14.100x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 108,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 73,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2016-09-16T04:00:00Z",
+            "end_date": "2016-12-15T15:00:00Z",
+            "enrollment_start": "2016-09-16T04:00:00Z",
+            "enrollment_end": "2016-12-04T04:00:00Z",
+            "expiration_date": "2016-12-16T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2016",
+            "courseware_id": "course-v1:MITx+14.100x+3T2016",
+            "certificate_available_date": "2016-12-15T15:00:00Z",
+            "upgrade_deadline": "2016-12-15T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2016",
+            "id": 118,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 83,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+3T2016",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2018-09-11T15:00:00Z",
+            "end_date": "2018-11-28T03:00:00Z",
+            "enrollment_start": "2018-07-03T15:00:00Z",
+            "enrollment_end": "2018-10-09T15:00:00Z",
+            "expiration_date": "2018-11-29T03:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2018",
+            "courseware_id": "course-v1:MITx+14.100x+3T2018",
+            "certificate_available_date": "2018-11-28T03:00:00Z",
+            "upgrade_deadline": "2018-11-28T03:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2018",
+            "id": 123,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 88,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+3T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2019-02-05T15:00:00Z",
+            "end_date": "2019-04-23T15:00:00Z",
+            "enrollment_start": "2018-10-09T15:00:00Z",
+            "enrollment_end": "2019-03-03T15:00:00Z",
+            "expiration_date": "2019-04-24T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2019",
+            "courseware_id": "course-v1:MITx+14.100x+1T2019",
+            "certificate_available_date": "2019-04-23T15:00:00Z",
+            "upgrade_deadline": "2019-04-23T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2019",
+            "id": 124,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 89,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+1T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2019-05-21T15:00:00Z",
+            "end_date": "2019-08-06T15:00:00Z",
+            "enrollment_start": "2019-03-04T15:02:19Z",
+            "enrollment_end": "2019-06-18T15:00:00Z",
+            "expiration_date": "2019-08-07T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2019",
+            "courseware_id": "course-v1:MITx+14.100x+2T2019",
+            "certificate_available_date": "2019-08-06T15:00:00Z",
+            "upgrade_deadline": "2019-08-06T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019",
+            "id": 125,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 90,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-06-18T15:00:00Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2019a",
+            "courseware_id": "course-v1:MITx+14.100x+2T2019a",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019a",
+            "id": 126,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 91,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2019a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-02T17:28:24Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2020",
+            "courseware_id": "course-v1:MITx+14.100x+1T2020",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020",
+            "id": 127,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 92,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+1T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:28Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+3T2020",
+            "courseware_id": "course-v1:MITx+14.100x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 128,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 93,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+1T2021",
+            "courseware_id": "course-v1:MITx+14.100x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 129,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 94,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2021-06-01T15:00:00Z",
+            "end_date": "2021-08-17T23:59:00Z",
+            "enrollment_start": "2021-03-13T23:59:00Z",
+            "enrollment_end": "2021-07-07T15:00:00Z",
+            "expiration_date": "2021-08-18T23:59:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.100x+2T2021",
+            "courseware_id": "course-v1:MITx+14.100x+2T2021",
+            "certificate_available_date": "2021-08-17T23:59:00Z",
+            "upgrade_deadline": "2021-08-17T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2021",
+            "id": 130,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 95,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.100x+2T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2021-10-05T15:00:00Z",
+            "end_date": "2021-12-22T15:00:00Z",
+            "enrollment_start": null,
+            "enrollment_end": "2021-11-02T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2021/course/",
+            "courseware_id": "course-v1:MITxT+14.100x+3T2021",
+            "certificate_available_date": "2021-12-23T23:30:00Z",
+            "upgrade_deadline": "2021-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2021",
+            "id": 2,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 9,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+3T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Microeconomics",
+            "start_date": "2022-05-31T15:00:00Z",
+            "end_date": "2022-08-16T23:30:00Z",
+            "enrollment_start": "2021-11-02T23:59:00Z",
+            "enrollment_end": "2022-07-06T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+2T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.100x+2T2022",
+            "certificate_available_date": "2022-08-18T15:00:00Z",
+            "upgrade_deadline": "2022-08-16T23:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2022",
+            "id": 9,
+            "live": true,
+            "course_number": "14.100x",
+            "products": [
+              {
+                "id": 5,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.100x+2T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
           }
         ],
-        "next_run_id": 35,
-        "topics": [],
         "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
         "page_url": "/courses/course-v1:MITxT+14.100x/",
-        "financial_assistance_form_url": ""
+        "description": "Use economic models to learn how prices and markets benefit society in the face of scarcity.",
+        "live": true,
+        "length": "14 weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
+          {
+            "name": "Jonathan Gruber",
+            "description": ""
+          }
+        ]
       },
       {
         "id": 2,
         "title": "Designing and Running Randomized Evaluations",
         "readable_id": "course-v1:MITxT+JPAL102x",
+        "next_run_id": 248,
+        "departments": [
+          {
+            "name": "Economics"
+          }
+        ],
         "page": {
           "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
           "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-          "financial_assistance_form_url": ""
+          "description": "This course equips students with the practical skills for running evaluations in the field. Students will learn the foundations of randomizations and research design, as well as practical tips and skills for collecting high quality, reliable data in the field.",
+          "live": true,
+          "length": "14 Weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Esther Duflo",
+              "description": ""
+            },
+            {
+              "name": "Rachel Glennerster",
+              "description": ""
+            }
+          ]
         },
+        "programs": null,
         "courseruns": [
           {
             "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2017-06-05T15:00:00Z",
+            "end_date": "2017-08-28T15:00:00Z",
+            "enrollment_start": "2017-03-06T23:30:00Z",
+            "enrollment_end": "2017-07-03T23:30:00Z",
+            "expiration_date": "2017-08-29T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2017",
+            "courseware_id": "course-v1:MITx+JPAL102x+2T2017",
+            "certificate_available_date": "2017-08-28T15:00:00Z",
+            "upgrade_deadline": "2017-08-28T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2017",
+            "id": 67,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 32,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+2T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2017-09-26T15:00:00Z",
+            "end_date": "2017-12-22T15:00:00Z",
+            "enrollment_start": "2017-07-03T15:00:00Z",
+            "enrollment_end": "2017-10-24T03:25:53Z",
+            "expiration_date": "2017-12-23T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2017",
+            "courseware_id": "course-v1:MITx+JPAL102x+3T2017",
+            "certificate_available_date": "2017-12-22T15:00:00Z",
+            "upgrade_deadline": "2017-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2017",
+            "id": 68,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 33,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+3T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2024-01-16T15:00:00Z",
+            "end_date": "2024-05-02T00:00:00Z",
+            "enrollment_start": "2023-10-10T23:59:00Z",
+            "enrollment_end": "2024-02-13T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2024/course",
+            "courseware_id": "course-v1:MITxT+JPAL102x+1T2024",
+            "certificate_available_date": "2024-05-15T00:00:00Z",
+            "upgrade_deadline": "2024-02-28T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2024",
+            "id": 223,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 198,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+1T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2024-09-10T15:00:00Z",
+            "end_date": "2024-12-17T15:00:00Z",
+            "enrollment_start": "2024-02-13T23:59:00Z",
+            "enrollment_end": "2024-10-08T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2024/course",
+            "courseware_id": "course-v1:MITxT+JPAL102x+3T2024",
+            "certificate_available_date": "2025-01-14T00:00:00Z",
+            "upgrade_deadline": "2024-10-22T23:59:00Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "3T2024",
+            "id": 248,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 219,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+3T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2023-09-12T15:00:00Z",
+            "end_date": "2024-01-19T15:00:00Z",
+            "enrollment_start": "2023-03-07T23:59:00Z",
+            "enrollment_end": "2023-10-10T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2023/course",
+            "courseware_id": "course-v1:MITxT+JPAL102x+3T2023",
+            "certificate_available_date": "2024-01-20T00:00:00Z",
+            "upgrade_deadline": "2023-11-03T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2023",
+            "id": 171,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 150,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+3T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2022-02-01T15:00:00Z",
+            "end_date": "2022-04-20T15:00:00Z",
+            "enrollment_start": "2021-11-02T23:59:00Z",
+            "enrollment_end": "2022-03-08T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2022/course/",
+            "courseware_id": "course-v1:MITxT+JPAL102x+1T2022",
+            "certificate_available_date": "2022-04-21T15:00:00Z",
+            "upgrade_deadline": "2022-04-20T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2022",
+            "id": 8,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 16,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+1T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2021-10-05T15:00:00Z",
+            "end_date": "2021-12-22T15:00:00Z",
+            "enrollment_start": null,
+            "enrollment_end": "2021-11-02T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2021/course/",
+            "courseware_id": "course-v1:MITxT+JPAL102x+3T2021",
+            "certificate_available_date": "2021-12-23T23:30:00Z",
+            "upgrade_deadline": "2021-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2021",
+            "id": 4,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 17,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+3T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
             "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
+            "end_date": "2024-01-03T19:20:00Z",
             "enrollment_start": "2022-03-08T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
+            "enrollment_end": "2022-10-07T23:59:00Z",
             "expiration_date": null,
             "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2022/course/",
             "courseware_id": "course-v1:MITxT+JPAL102x+3T2022",
+            "certificate_available_date": "2024-01-04T00:00:00Z",
+            "upgrade_deadline": "2023-12-24T19:20:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
             "run_tag": "3T2022",
             "id": 22,
-            "products": []
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 8,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+3T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2017-02-06T15:00:00Z",
+            "end_date": "2017-05-05T15:00:00Z",
+            "enrollment_start": "2016-12-05T05:00:00Z",
+            "enrollment_end": "2017-03-06T14:00:00Z",
+            "expiration_date": "2017-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2017",
+            "courseware_id": "course-v1:MITx+JPAL102x+1T2017",
+            "certificate_available_date": "2017-05-05T15:00:00Z",
+            "upgrade_deadline": "2017-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2017",
+            "id": 64,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 29,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+1T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2018-06-05T15:00:00Z",
+            "end_date": "2018-08-21T03:30:00Z",
+            "enrollment_start": "2018-03-06T15:00:00Z",
+            "enrollment_end": "2018-07-03T15:00:00Z",
+            "expiration_date": "2018-08-22T03:30:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2018",
+            "courseware_id": "course-v1:MITx+JPAL102x+2T2018",
+            "certificate_available_date": "2018-08-21T03:30:00Z",
+            "upgrade_deadline": "2018-08-21T03:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2018",
+            "id": 69,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 34,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+2T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2018-02-06T15:00:00Z",
+            "end_date": "2018-05-05T15:00:00Z",
+            "enrollment_start": "2017-10-25T15:00:00Z",
+            "enrollment_end": "2018-03-06T15:00:00Z",
+            "expiration_date": "2018-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2018",
+            "courseware_id": "course-v1:MITx+JPAL102x+1T2018",
+            "certificate_available_date": "2018-05-05T15:00:00Z",
+            "upgrade_deadline": "2018-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2018",
+            "id": 78,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 43,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+1T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2018-09-11T15:00:00Z",
+            "end_date": "2018-11-28T03:00:00Z",
+            "enrollment_start": "2018-07-03T15:00:00Z",
+            "enrollment_end": "2018-10-09T15:00:00Z",
+            "expiration_date": "2018-11-29T03:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2018",
+            "courseware_id": "course-v1:MITx+JPAL102x+3T2018",
+            "certificate_available_date": "2018-11-28T03:00:00Z",
+            "upgrade_deadline": "2018-11-28T03:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2018",
+            "id": 88,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 53,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+3T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:21Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+3T2020",
+            "courseware_id": "course-v1:MITx+JPAL102x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 117,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 82,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2019-02-05T15:00:00Z",
+            "end_date": "2019-04-23T15:00:00Z",
+            "enrollment_start": "2018-10-09T15:00:00Z",
+            "enrollment_end": "2019-03-03T15:00:00Z",
+            "expiration_date": "2019-04-24T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2019",
+            "courseware_id": "course-v1:MITx+JPAL102x+1T2019",
+            "certificate_available_date": "2019-04-23T15:00:00Z",
+            "upgrade_deadline": "2019-04-23T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2019",
+            "id": 131,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 96,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+1T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2019-05-21T15:00:00Z",
+            "end_date": "2019-08-06T15:00:00Z",
+            "enrollment_start": "2019-03-04T15:02:13Z",
+            "enrollment_end": "2019-06-18T15:00:00Z",
+            "expiration_date": "2019-08-07T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2019",
+            "courseware_id": "course-v1:MITx+JPAL102x+2T2019",
+            "certificate_available_date": "2019-08-06T15:00:00Z",
+            "upgrade_deadline": "2019-08-06T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019",
+            "id": 132,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 97,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+2T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-06-18T15:00:00Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2019a",
+            "courseware_id": "course-v1:MITx+JPAL102x+2T2019a",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019a",
+            "id": 133,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 98,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+2T2019a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-02T18:15:02Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2020a",
+            "courseware_id": "course-v1:MITx+JPAL102x+1T2020a",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020a",
+            "id": 134,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 99,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+1T2020a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+2T2020",
+            "courseware_id": "course-v1:MITx+JPAL102x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 135,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 100,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+JPAL102x+1T2021",
+            "courseware_id": "course-v1:MITx+JPAL102x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 136,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 101,
+                "price": "1000.00",
+                "description": "course-v1:MITx+JPAL102x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Designing and Running Randomized Evaluations",
+            "start_date": "2023-01-31T15:00:00Z",
+            "end_date": "2023-08-12T15:00:00Z",
+            "enrollment_start": "2022-10-11T15:00:00Z",
+            "enrollment_end": "2023-03-07T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+1T2023/course/",
+            "courseware_id": "course-v1:MITxT+JPAL102x+1T2023",
+            "certificate_available_date": "2023-09-01T00:00:00Z",
+            "upgrade_deadline": "2023-03-16T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2023",
+            "id": 58,
+            "live": true,
+            "course_number": "JPAL102x",
+            "products": [
+              {
+                "id": 24,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+JPAL102x+1T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
           }
         ],
-        "next_run_id": 22,
-        "topics": [],
         "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
         "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-        "financial_assistance_form_url": ""
+        "description": "This course equips students with the practical skills for running evaluations in the field. Students will learn the foundations of randomizations and research design, as well as practical tips and skills for collecting high quality, reliable data in the field.",
+        "live": true,
+        "length": "14 Weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
+          {
+            "name": "Esther Duflo",
+            "description": ""
+          },
+          {
+            "name": "Rachel Glennerster",
+            "description": ""
+          }
+        ]
       },
       {
         "id": 3,
         "title": "Data Analysis for Social Scientists",
         "readable_id": "course-v1:MITxT+14.310x",
+        "next_run_id": 247,
+        "departments": [
+          {
+            "name": "Economics"
+          }
+        ],
         "page": {
           "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
           "page_url": "/courses/course-v1:MITxT+14.310x/",
-          "financial_assistance_form_url": ""
+          "description": "Learn methods for harnessing and analyzing data to answer questions of cultural, social, economic, and policy interest.",
+          "live": true,
+          "length": "14 Weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Esther Duflo",
+              "description": ""
+            },
+            {
+              "name": "Sara Fisher Ellison",
+              "description": ""
+            }
+          ]
         },
+        "programs": null,
         "courseruns": [
           {
             "title": "Data Analysis for Social Scientists",
+            "start_date": "2023-09-12T15:00:00Z",
+            "end_date": "2024-02-18T15:00:00Z",
+            "enrollment_start": "2023-06-27T23:59:00Z",
+            "enrollment_end": "2023-10-10T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2023/course",
+            "courseware_id": "course-v1:MITxT+14.310x+3T2023",
+            "certificate_available_date": "2024-02-19T00:00:00Z",
+            "upgrade_deadline": "2023-12-31T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2023",
+            "id": 183,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 162,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+3T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2022-05-31T15:00:00Z",
+            "end_date": "2022-08-16T23:30:00Z",
+            "enrollment_start": "2022-03-08T23:59:00Z",
+            "enrollment_end": "2022-08-16T23:00:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.310x+2T2022",
+            "certificate_available_date": "2022-08-22T00:00:00Z",
+            "upgrade_deadline": "2022-08-16T23:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2022",
+            "id": 20,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 3,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+2T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2023-05-30T15:00:00Z",
+            "end_date": "2024-02-01T15:00:00Z",
+            "enrollment_start": "2023-03-07T23:59:00Z",
+            "enrollment_end": "2023-06-27T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2023/course",
+            "courseware_id": "course-v1:MITxT+14.310x+2T2023",
+            "certificate_available_date": "2024-02-02T00:00:00Z",
+            "upgrade_deadline": "2023-07-24T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2023",
+            "id": 170,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 149,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+2T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2023-01-31T15:00:00Z",
+            "end_date": "2023-05-20T15:00:00Z",
+            "enrollment_start": "2022-10-11T15:00:00Z",
+            "enrollment_end": "2023-03-07T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2023/course/",
+            "courseware_id": "course-v1:MITxT+14.310x+1T2023",
+            "certificate_available_date": "2023-05-22T00:00:00Z",
+            "upgrade_deadline": "2023-03-16T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2023",
+            "id": 55,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 23,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+1T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2022-02-01T15:00:00Z",
+            "end_date": "2022-04-20T15:00:00Z",
+            "enrollment_start": "2021-11-02T23:59:00Z",
+            "enrollment_end": "2022-03-08T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.310x+1T2022",
+            "certificate_available_date": "2022-04-21T15:00:00Z",
+            "upgrade_deadline": "2022-04-20T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2022",
+            "id": 7,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 6,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+1T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2024-05-14T15:00:00Z",
+            "end_date": "2024-08-21T15:00:00Z",
+            "enrollment_start": "2024-02-13T23:59:00Z",
+            "enrollment_end": "2024-06-11T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+2T2024/course",
+            "courseware_id": "course-v1:MITxT+14.310x+2T2024",
+            "certificate_available_date": "2024-09-18T00:00:00Z",
+            "upgrade_deadline": "2024-06-25T23:59:00Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "2T2024",
+            "id": 247,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 218,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+2T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2018-02-06T15:00:00Z",
+            "end_date": "2018-05-05T15:00:00Z",
+            "enrollment_start": "2017-10-24T15:00:00Z",
+            "enrollment_end": "2018-03-06T15:00:00Z",
+            "expiration_date": "2018-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2018",
+            "courseware_id": "course-v1:MITx+14.310x+1T2018",
+            "certificate_available_date": "2018-05-05T15:00:00Z",
+            "upgrade_deadline": "2018-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2018",
+            "id": 65,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 30,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+1T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2017-02-06T15:00:00Z",
+            "end_date": "2017-05-05T15:00:00Z",
+            "enrollment_start": "2016-12-05T05:00:00Z",
+            "enrollment_end": "2017-03-06T14:00:00Z",
+            "expiration_date": "2017-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2017",
+            "courseware_id": "course-v1:MITx+14.310x+1T2017",
+            "certificate_available_date": "2017-05-05T15:00:00Z",
+            "upgrade_deadline": "2017-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2017",
+            "id": 70,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 35,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+1T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2017-06-05T14:00:00Z",
+            "end_date": "2017-08-28T15:00:00Z",
+            "enrollment_start": "2017-03-06T14:00:00Z",
+            "enrollment_end": "2017-07-03T15:00:00Z",
+            "expiration_date": "2017-08-29T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2017",
+            "courseware_id": "course-v1:MITx+14.310x+2T2017",
+            "certificate_available_date": "2017-08-28T15:00:00Z",
+            "upgrade_deadline": "2017-08-28T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2017",
+            "id": 71,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 36,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2017-09-26T15:00:00Z",
+            "end_date": "2017-12-22T15:00:00Z",
+            "enrollment_start": "2017-07-03T15:00:00Z",
+            "enrollment_end": "2017-10-24T03:25:47Z",
+            "expiration_date": "2017-12-23T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2017",
+            "courseware_id": "course-v1:MITx+14.310x+3T2017",
+            "certificate_available_date": "2017-12-22T15:00:00Z",
+            "upgrade_deadline": "2017-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2017",
+            "id": 72,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 37,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+3T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2018-09-11T15:00:00Z",
+            "end_date": "2018-11-28T03:00:00Z",
+            "enrollment_start": "2018-07-03T15:00:00Z",
+            "enrollment_end": "2018-10-09T15:00:00Z",
+            "expiration_date": "2018-11-29T03:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2018",
+            "courseware_id": "course-v1:MITx+14.310x+3T2018",
+            "certificate_available_date": "2018-11-28T03:00:00Z",
+            "upgrade_deadline": "2018-11-28T03:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2018",
+            "id": 79,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 44,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+3T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2019-05-21T15:00:00Z",
+            "end_date": "2019-08-06T15:00:00Z",
+            "enrollment_start": "2019-03-04T15:02:09Z",
+            "enrollment_end": "2019-06-18T15:00:00Z",
+            "expiration_date": "2019-08-07T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2019",
+            "courseware_id": "course-v1:MITx+14.310x+2T2019",
+            "certificate_available_date": "2019-08-06T15:00:00Z",
+            "upgrade_deadline": "2019-08-06T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019",
+            "id": 80,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 45,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2021",
+            "courseware_id": "course-v1:MITx+14.310x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 81,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 46,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2016-09-16T15:00:00Z",
+            "end_date": "2016-12-18T00:00:00Z",
+            "enrollment_start": "2016-09-16T04:00:00Z",
+            "enrollment_end": "2016-12-04T15:00:00Z",
+            "expiration_date": "2016-12-19T00:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2016",
+            "courseware_id": "course-v1:MITx+14.310x+3T2016",
+            "certificate_available_date": "2016-12-18T00:00:00Z",
+            "upgrade_deadline": "2016-12-18T00:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2016",
+            "id": 89,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 54,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+3T2016",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2018-06-05T15:00:00Z",
+            "end_date": "2018-08-21T03:30:00Z",
+            "enrollment_start": "2018-03-06T15:00:00Z",
+            "enrollment_end": "2018-07-03T15:00:00Z",
+            "expiration_date": "2018-08-22T03:30:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2018",
+            "courseware_id": "course-v1:MITx+14.310x+2T2018",
+            "certificate_available_date": "2018-08-21T03:30:00Z",
+            "upgrade_deadline": "2018-08-21T03:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2018",
+            "id": 90,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 55,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2019-02-05T15:00:00Z",
+            "end_date": "2019-04-23T15:00:00Z",
+            "enrollment_start": "2018-10-09T15:00:00Z",
+            "enrollment_end": "2019-03-03T15:00:00Z",
+            "expiration_date": "2019-04-24T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2019",
+            "courseware_id": "course-v1:MITx+14.310x+1T2019",
+            "certificate_available_date": "2019-04-23T15:00:00Z",
+            "upgrade_deadline": "2019-04-23T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2019",
+            "id": 91,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 56,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+1T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-02T17:32:14Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+1T2020",
+            "courseware_id": "course-v1:MITx+14.310x+1T2020",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020",
+            "id": 96,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 61,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+1T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-06-18T15:00:00Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2019a",
+            "courseware_id": "course-v1:MITx+14.310x+2T2019a",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019a",
+            "id": 100,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 65,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2019a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2020",
+            "courseware_id": "course-v1:MITx+14.310x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 101,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 66,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2021-06-01T15:00:00Z",
+            "end_date": "2021-08-17T15:00:00Z",
+            "enrollment_start": "2021-03-13T04:59:59Z",
+            "enrollment_end": "2021-07-07T15:00:00Z",
+            "expiration_date": "2021-08-18T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+2T2021",
+            "courseware_id": "course-v1:MITx+14.310x+2T2021",
+            "certificate_available_date": "2021-08-17T15:00:00Z",
+            "upgrade_deadline": "2021-08-17T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2021",
+            "id": 109,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 74,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+2T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:17Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.310x+3T2020",
+            "courseware_id": "course-v1:MITx+14.310x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 137,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 102,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.310x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2021-10-05T15:00:00Z",
+            "end_date": "2021-12-22T15:00:00Z",
+            "enrollment_start": null,
+            "enrollment_end": "2021-11-02T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2021/course/",
+            "courseware_id": "course-v1:MITxT+14.310x+3T2021",
+            "certificate_available_date": "2021-12-23T23:30:00Z",
+            "upgrade_deadline": "2021-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2021",
+            "id": 1,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 10,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+3T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
+            "start_date": "2024-01-16T15:00:00Z",
+            "end_date": "2024-05-02T00:00:00Z",
+            "enrollment_start": "2023-10-10T23:59:00Z",
+            "enrollment_end": "2024-02-13T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+1T2024/course",
+            "courseware_id": "course-v1:MITxT+14.310x+1T2024",
+            "certificate_available_date": "2024-05-15T00:00:00Z",
+            "upgrade_deadline": "2024-02-28T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2024",
+            "id": 222,
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 197,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+1T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Data Analysis for Social Scientists",
             "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
+            "end_date": "2023-01-04T19:20:00Z",
             "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
+            "enrollment_end": "2022-10-07T23:59:00Z",
             "expiration_date": null,
             "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2022/course/",
             "courseware_id": "course-v1:MITxT+14.310x+3T2022",
+            "certificate_available_date": "2023-04-22T00:00:00Z",
+            "upgrade_deadline": "2022-12-25T19:20:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
             "run_tag": "3T2022",
             "id": 36,
-            "products": []
+            "live": true,
+            "course_number": "14.310x",
+            "products": [
+              {
+                "id": 19,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.310x+3T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
           }
         ],
-        "next_run_id": 36,
-        "topics": [],
         "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
         "page_url": "/courses/course-v1:MITxT+14.310x/",
-        "financial_assistance_form_url": ""
-      },
-      {
-        "id": 4,
-        "title": "The Challenges of Global Poverty",
-        "readable_id": "course-v1:MITxT+14.73x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
-          "page_url": "/courses/course-v1:MITxT+14.73x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
+        "description": "Learn methods for harnessing and analyzing data to answer questions of cultural, social, economic, and policy interest.",
+        "live": true,
+        "length": "14 Weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
           {
-            "title": "The Challenges of Global Poverty",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
-            "enrollment_start": "2022-03-08T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+14.73x+3T2022",
-            "run_tag": "3T2022",
-            "id": 21,
-            "products": []
+            "name": "Esther Duflo",
+            "description": ""
+          },
+          {
+            "name": "Sara Fisher Ellison",
+            "description": ""
           }
-        ],
-        "next_run_id": 21,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
-        "page_url": "/courses/course-v1:MITxT+14.73x/",
-        "financial_assistance_form_url": ""
+        ]
       },
       {
         "id": 5,
         "title": "Foundations of Development Policy",
         "readable_id": "course-v1:MITxT+14.740x",
+        "next_run_id": 188,
+        "departments": [
+          {
+            "name": "Economics"
+          }
+        ],
         "page": {
           "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
           "page_url": "/courses/course-v1:MITxT+14.740x/",
-          "financial_assistance_form_url": ""
+          "description": "Examine the different facets of human development, including education, health, gender, the family, land relations, risk, public policy, and institutions. At the same time, discover modern empirical methods in economics while working with real data.",
+          "live": true,
+          "length": "14 weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Abhijit Vinayak Banerjee",
+              "description": ""
+            },
+            {
+              "name": "Esther Duflo",
+              "description": ""
+            },
+            {
+              "name": "Benjamin Olken",
+              "description": ""
+            }
+          ]
         },
+        "programs": null,
         "courseruns": [
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2016-09-16T04:00:00Z",
+            "end_date": "2016-12-11T23:59:00Z",
+            "enrollment_start": "2016-09-16T04:00:00Z",
+            "enrollment_end": "2016-12-04T04:00:00Z",
+            "expiration_date": "2016-12-12T23:59:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2016",
+            "courseware_id": "course-v1:MITx+14.740x+3T2016",
+            "certificate_available_date": "2016-12-11T23:59:00Z",
+            "upgrade_deadline": "2016-12-11T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2016",
+            "id": 66,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 31,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+3T2016",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2024-01-16T15:00:00Z",
+            "end_date": "2024-05-02T00:00:00Z",
+            "enrollment_start": "2023-07-24T23:59:00Z",
+            "enrollment_end": "2024-02-13T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2024/course",
+            "courseware_id": "course-v1:MITxT+14.740x+1T2024",
+            "certificate_available_date": "2024-05-15T00:00:00Z",
+            "upgrade_deadline": "2024-02-28T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2024",
+            "id": 194,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 173,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.740x+1T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-06-18T15:00:00Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2019a",
+            "courseware_id": "course-v1:MITx+14.740x+2T2019a",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019a",
+            "id": 87,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 52,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2019a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2024-05-14T15:00:00Z",
+            "end_date": "2024-08-21T15:00:00Z",
+            "enrollment_start": "2023-06-27T23:59:00Z",
+            "enrollment_end": "2024-06-11T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2024/course",
+            "courseware_id": "course-v1:MITxT+14.740x+2T2024",
+            "certificate_available_date": "2024-09-18T00:00:00Z",
+            "upgrade_deadline": "2024-06-25T23:59:59Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "2T2024",
+            "id": 188,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 167,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.740x+2T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2022-05-31T15:00:00Z",
+            "end_date": "2023-07-16T23:30:00Z",
+            "enrollment_start": "2021-10-05T15:00:00Z",
+            "enrollment_end": "2022-07-05T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.740x+2T2022",
+            "certificate_available_date": "2023-07-18T00:00:00Z",
+            "upgrade_deadline": "2022-08-16T23:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2022",
+            "id": 6,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 7,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.740x+2T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2017-06-05T15:00:00Z",
+            "end_date": "2017-08-28T15:00:00Z",
+            "enrollment_start": "2017-03-06T23:30:00Z",
+            "enrollment_end": "2017-07-03T15:00:00Z",
+            "expiration_date": "2017-08-29T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2017",
+            "courseware_id": "course-v1:MITx+14.740x+2T2017",
+            "certificate_available_date": "2017-08-28T15:00:00Z",
+            "upgrade_deadline": "2017-08-28T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2017",
+            "id": 85,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 50,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2017-09-26T15:00:00Z",
+            "end_date": "2017-12-22T15:00:00Z",
+            "enrollment_start": "2017-07-03T15:00:00Z",
+            "enrollment_end": "2017-10-24T03:26:02Z",
+            "expiration_date": "2017-12-23T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2017",
+            "courseware_id": "course-v1:MITx+14.740x+3T2017",
+            "certificate_available_date": "2017-12-22T15:00:00Z",
+            "upgrade_deadline": "2017-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2017",
+            "id": 86,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 51,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+3T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2015-09-21T15:00:00Z",
+            "end_date": "2015-12-10T15:00:00Z",
+            "enrollment_start": "2015-07-20T15:00:00Z",
+            "enrollment_end": "2015-12-10T15:00:00Z",
+            "expiration_date": "2015-12-11T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.74x+3T2015",
+            "courseware_id": "course-v1:MITx+14.74x+3T2015",
+            "certificate_available_date": "2015-12-10T15:00:00Z",
+            "upgrade_deadline": "2015-12-10T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2015",
+            "id": 92,
+            "live": true,
+            "course_number": "14.74x",
+            "products": [
+              {
+                "id": 57,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.74x+3T2015",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2017-02-06T15:00:00Z",
+            "end_date": "2017-05-05T15:00:00Z",
+            "enrollment_start": "2016-12-05T15:00:00Z",
+            "enrollment_end": "2017-03-06T14:00:00Z",
+            "expiration_date": "2017-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2017",
+            "courseware_id": "course-v1:MITx+14.740x+1T2017",
+            "certificate_available_date": "2017-05-05T15:00:00Z",
+            "upgrade_deadline": "2017-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2017",
+            "id": 93,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 58,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+1T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2018-02-06T15:00:00Z",
+            "end_date": "2018-05-05T15:00:00Z",
+            "enrollment_start": "2017-10-24T15:00:00Z",
+            "enrollment_end": "2018-03-06T15:00:00Z",
+            "expiration_date": "2018-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2018",
+            "courseware_id": "course-v1:MITx+14.740x+1T2018",
+            "certificate_available_date": "2018-05-05T15:00:00Z",
+            "upgrade_deadline": "2018-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2018",
+            "id": 94,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 59,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+1T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy: Advanced Development Economics",
+            "start_date": "2018-06-05T15:00:00Z",
+            "end_date": "2018-08-21T03:30:00Z",
+            "enrollment_start": "2018-03-06T15:00:00Z",
+            "enrollment_end": "2018-07-03T15:00:00Z",
+            "expiration_date": "2018-08-22T03:30:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2018",
+            "courseware_id": "course-v1:MITx+14.740x+2T2018",
+            "certificate_available_date": "2018-08-21T03:30:00Z",
+            "upgrade_deadline": "2018-08-21T03:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2018",
+            "id": 95,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 60,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2018-09-11T15:00:00Z",
+            "end_date": "2018-11-28T03:00:00Z",
+            "enrollment_start": "2018-07-03T15:00:00Z",
+            "enrollment_end": "2018-10-09T15:00:00Z",
+            "expiration_date": "2018-11-29T03:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2018",
+            "courseware_id": "course-v1:MITx+14.740x+3T2018",
+            "certificate_available_date": "2018-11-28T03:00:00Z",
+            "upgrade_deadline": "2018-11-28T03:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2018",
+            "id": 98,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 63,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+3T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2019-05-21T15:00:00Z",
+            "end_date": "2019-08-06T15:00:00Z",
+            "enrollment_start": "2019-03-04T15:02:16Z",
+            "enrollment_end": "2019-06-18T15:00:00Z",
+            "expiration_date": "2019-08-07T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2019",
+            "courseware_id": "course-v1:MITx+14.740x+2T2019",
+            "certificate_available_date": "2019-08-06T15:00:00Z",
+            "upgrade_deadline": "2019-08-06T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019",
+            "id": 99,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 64,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2019-02-05T15:00:00Z",
+            "end_date": "2019-04-23T15:00:00Z",
+            "enrollment_start": "2018-10-09T15:00:00Z",
+            "enrollment_end": "2019-03-03T15:00:00Z",
+            "expiration_date": "2019-04-24T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2019",
+            "courseware_id": "course-v1:MITx+14.740x+1T2019",
+            "certificate_available_date": "2019-04-23T15:00:00Z",
+            "upgrade_deadline": "2019-04-23T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2019",
+            "id": 104,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 69,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+1T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-02T18:13:07Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2020a",
+            "courseware_id": "course-v1:MITx+14.740x+1T2020a",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020a",
+            "id": 105,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 70,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+1T2020a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+1T2021",
+            "courseware_id": "course-v1:MITx+14.740x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 112,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 77,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2020",
+            "courseware_id": "course-v1:MITx+14.740x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 113,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 78,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:24Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+3T2020",
+            "courseware_id": "course-v1:MITx+14.740x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 114,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 79,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2021-06-01T15:00:00Z",
+            "end_date": "2021-08-17T15:00:00Z",
+            "enrollment_start": "2021-03-13T23:59:00Z",
+            "enrollment_end": "2021-07-07T23:59:00Z",
+            "expiration_date": "2021-08-18T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.740x+2T2021",
+            "courseware_id": "course-v1:MITx+14.740x+2T2021",
+            "certificate_available_date": "2021-08-17T15:00:00Z",
+            "upgrade_deadline": "2021-08-17T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2021",
+            "id": 141,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 106,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.740x+2T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
           {
             "title": "Foundations of Development Policy",
             "start_date": "2023-01-31T15:00:00Z",
-            "end_date": "2023-04-19T15:00:00Z",
+            "end_date": "2023-08-12T15:00:00Z",
             "enrollment_start": "2022-07-06T23:59:00Z",
             "enrollment_end": "2023-03-07T23:59:00Z",
             "expiration_date": null,
             "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2023/course/",
             "courseware_id": "course-v1:MITxT+14.740x+1T2023",
+            "certificate_available_date": "2023-08-20T00:00:00Z",
+            "upgrade_deadline": "2023-03-16T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
             "run_tag": "1T2023",
             "id": 37,
-            "products": []
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 21,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.740x+1T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Foundations of Development Policy",
+            "start_date": "2023-05-30T15:00:00Z",
+            "end_date": "2023-09-15T15:00:00Z",
+            "enrollment_start": "2023-03-07T23:59:00Z",
+            "enrollment_end": "2023-06-27T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+2T2023/course",
+            "courseware_id": "course-v1:MITxT+14.740x+2T2023",
+            "certificate_available_date": "2023-09-25T00:00:00Z",
+            "upgrade_deadline": "2023-07-18T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2023",
+            "id": 165,
+            "live": true,
+            "course_number": "14.740x",
+            "products": [
+              {
+                "id": 146,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.740x+2T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
           }
         ],
-        "next_run_id": 37,
-        "topics": [],
         "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
         "page_url": "/courses/course-v1:MITxT+14.740x/",
-        "financial_assistance_form_url": ""
+        "description": "Examine the different facets of human development, including education, health, gender, the family, land relations, risk, public policy, and institutions. At the same time, discover modern empirical methods in economics while working with real data.",
+        "live": true,
+        "length": "14 weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
+          {
+            "name": "Abhijit Vinayak Banerjee",
+            "description": ""
+          },
+          {
+            "name": "Esther Duflo",
+            "description": ""
+          },
+          {
+            "name": "Benjamin Olken",
+            "description": ""
+          }
+        ]
       },
       {
         "id": 6,
         "title": "Political Economy and Economic Development",
         "readable_id": "course-v1:MITxT+14.750x",
+        "next_run_id": 220,
+        "departments": [
+          {
+            "name": "Economics"
+          }
+        ],
         "page": {
           "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
           "page_url": "/courses/course-v1:MITxT+14.750x/",
-          "financial_assistance_form_url": ""
+          "description": "Explore why and how political institutions affect economic development, and apply key theories and empirical techniques to real-world examples ranging from voting and corruption to the role of the media.",
+          "live": true,
+          "length": "14 weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Abhijit Vinayak Banerjee",
+              "description": ""
+            },
+            {
+              "name": "Benjamin Olken",
+              "description": ""
+            }
+          ]
         },
+        "programs": null,
         "courseruns": [
           {
             "title": "Political Economy and Economic Development",
+            "start_date": "2024-05-14T15:00:00Z",
+            "end_date": "2024-08-21T15:00:00Z",
+            "enrollment_start": "2023-10-10T23:59:00Z",
+            "enrollment_end": "2024-06-11T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+2T2024/course",
+            "courseware_id": "course-v1:MITxT+14.750x+2T2024",
+            "certificate_available_date": "2024-09-18T00:00:00Z",
+            "upgrade_deadline": "2024-06-25T23:59:00Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "2T2024",
+            "id": 220,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 195,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+2T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy and Economic Development",
             "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
+            "end_date": "2023-06-24T19:20:00Z",
             "enrollment_start": "2021-11-02T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
+            "enrollment_end": "2022-10-07T23:59:00Z",
             "expiration_date": null,
             "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2022/course/",
             "courseware_id": "course-v1:MITxT+14.750x+3T2022",
+            "certificate_available_date": "2023-06-25T00:00:00Z",
+            "upgrade_deadline": "2022-12-25T19:20:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
             "run_tag": "3T2022",
             "id": 10,
-            "products": []
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 13,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+3T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy and Economic Development",
+            "start_date": "2021-10-05T15:00:00Z",
+            "end_date": "2021-12-22T15:00:00Z",
+            "enrollment_start": null,
+            "enrollment_end": "2021-11-02T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2021/course/",
+            "courseware_id": "course-v1:MITxT+14.750x+3T2021",
+            "certificate_available_date": "2021-12-23T23:30:00Z",
+            "upgrade_deadline": "2021-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2021",
+            "id": 5,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 4,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+3T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy & Economic Development",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-01T15:00:00Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+1T2020",
+            "courseware_id": "course-v1:MITx+14.750x+1T2020",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020",
+            "id": 77,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 42,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.750x+1T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy & Economic Development",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-07-29T15:18:12Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+3T2019",
+            "courseware_id": "course-v1:MITx+14.750x+3T2019",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2019",
+            "id": 106,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 71,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.750x+3T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy & Economic Development",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+1T2021",
+            "courseware_id": "course-v1:MITx+14.750x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 107,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 72,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.750x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy & Economic Development",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+2T2020",
+            "courseware_id": "course-v1:MITx+14.750x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 115,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 80,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.750x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy & Economic Development",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:30Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.750x+3T2020",
+            "courseware_id": "course-v1:MITx+14.750x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 116,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 81,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.750x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy and Economic Development",
+            "start_date": "2023-01-31T15:00:00Z",
+            "end_date": "2023-08-12T15:00:00Z",
+            "enrollment_start": "2022-10-11T15:00:00Z",
+            "enrollment_end": "2023-03-07T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+1T2023/course/",
+            "courseware_id": "course-v1:MITxT+14.750x+1T2023",
+            "certificate_available_date": "2023-09-01T00:00:00Z",
+            "upgrade_deadline": "2023-03-16T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2023",
+            "id": 142,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 107,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+1T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy and Economic Development",
+            "start_date": "2023-09-12T15:00:00Z",
+            "end_date": "2024-02-18T15:00:00Z",
+            "enrollment_start": "2023-06-27T23:59:00Z",
+            "enrollment_end": "2023-10-10T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2023/course",
+            "courseware_id": "course-v1:MITxT+14.750x+3T2023",
+            "certificate_available_date": "2024-02-19T00:00:00Z",
+            "upgrade_deadline": "2023-11-03T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2023",
+            "id": 186,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 165,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+3T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Political Economy and Economic Development",
+            "start_date": "2023-05-30T15:00:00Z",
+            "end_date": "2023-11-01T15:00:00Z",
+            "enrollment_start": "2023-03-07T23:59:00Z",
+            "enrollment_end": "2023-06-27T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+2T2023/course",
+            "courseware_id": "course-v1:MITxT+14.750x+2T2023",
+            "certificate_available_date": "2023-11-02T00:00:00Z",
+            "upgrade_deadline": "2023-07-14T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2023",
+            "id": 168,
+            "live": true,
+            "course_number": "14.750x",
+            "products": [
+              {
+                "id": 147,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.750x+2T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
           }
         ],
-        "next_run_id": 10,
-        "topics": [],
         "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
         "page_url": "/courses/course-v1:MITxT+14.750x/",
-        "financial_assistance_form_url": ""
+        "description": "Explore why and how political institutions affect economic development, and apply key theories and empirical techniques to real-world examples ranging from voting and corruption to the role of the media.",
+        "live": true,
+        "length": "14 weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
+          {
+            "name": "Abhijit Vinayak Banerjee",
+            "description": ""
+          },
+          {
+            "name": "Benjamin Olken",
+            "description": ""
+          }
+        ]
       },
       {
-        "id": 16,
-        "title": "Good Economics for Hard Times",
-        "readable_id": "course-v1:MITxT+14.009x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-          "page_url": "/courses/course-v1:MITxT+14.009x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
+        "id": 4,
+        "title": "The Challenges of Global Poverty",
+        "readable_id": "course-v1:MITxT+14.73x",
+        "next_run_id": 249,
+        "departments": [
           {
-            "title": "Good Economics for Hard Times",
-            "start_date": "2023-05-30T15:00:00Z",
-            "end_date": "2023-08-16T15:00:00Z",
-            "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2023-07-04T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2023/course/",
-            "courseware_id": "course-v1:MITxT+14.009x+2T2023",
-            "run_tag": "2T2023",
-            "id": 38,
-            "products": []
+            "name": "Economics"
           }
         ],
-        "next_run_id": 38,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-        "page_url": "/courses/course-v1:MITxT+14.009x/",
-        "financial_assistance_form_url": ""
+        "page": {
+          "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
+          "page_url": "/courses/course-v1:MITxT+14.73x/",
+          "description": "A course for those who are interested in the challenge posed by massive and persistent world poverty.",
+          "live": true,
+          "length": "14 weeks",
+          "effort": "12–14 hours per week",
+          "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+          "current_price": 1000.0,
+          "instructors": [
+            {
+              "name": "Abhijit Vinayak Banerjee",
+              "description": ""
+            },
+            {
+              "name": "Esther Duflo",
+              "description": ""
+            },
+            {
+              "name": "Frank Schilbach",
+              "description": ""
+            }
+          ]
+        },
+        "programs": null,
+        "courseruns": [
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2023-09-12T15:00:00Z",
+            "end_date": "2024-02-18T15:00:00Z",
+            "enrollment_start": "2023-03-07T23:59:00Z",
+            "enrollment_end": "2023-10-10T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2023/course",
+            "courseware_id": "course-v1:MITxT+14.73x+3T2023",
+            "certificate_available_date": "2024-02-19T00:00:00Z",
+            "upgrade_deadline": "2023-11-03T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2023",
+            "id": 169,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 148,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+3T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2023-01-31T15:00:00Z",
+            "end_date": "2023-05-12T15:00:00Z",
+            "enrollment_start": "2022-10-11T15:00:00Z",
+            "enrollment_end": "2023-03-07T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2023/course/",
+            "courseware_id": "course-v1:MITxT+14.73x+1T2023",
+            "certificate_available_date": "2023-05-22T00:00:00Z",
+            "upgrade_deadline": "2023-03-16T23:59:59Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2023",
+            "id": 56,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 20,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+1T2023",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2021-10-05T15:00:00Z",
+            "end_date": "2021-12-22T15:00:00Z",
+            "enrollment_start": null,
+            "enrollment_end": "2021-11-02T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2021/course/",
+            "courseware_id": "course-v1:MITxT+14.73x+3T2021",
+            "certificate_available_date": "2021-12-23T23:30:00Z",
+            "upgrade_deadline": "2021-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2021",
+            "id": 3,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 12,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+3T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2014-02-04T15:00:00Z",
+            "end_date": "2014-05-11T15:00:00Z",
+            "enrollment_start": "2013-12-13T04:00:00Z",
+            "enrollment_end": "2014-05-11T04:00:00Z",
+            "expiration_date": "2014-05-12T15:00:00Z",
+            "courseware_url": null,
+            "courseware_id": "MITx/14_73x/1T2014",
+            "certificate_available_date": "2014-05-11T15:00:00Z",
+            "upgrade_deadline": "2014-05-11T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2014",
+            "id": 60,
+            "live": true,
+            "course_number": "14_73x",
+            "products": [
+              {
+                "id": 27,
+                "price": "1000.00",
+                "description": "MITx/14_73x/1T2014",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2015-02-03T15:00:00Z",
+            "end_date": "2015-05-03T04:00:00Z",
+            "enrollment_start": "2014-10-20T15:00:00Z",
+            "enrollment_end": "2015-05-03T04:00:00Z",
+            "expiration_date": "2015-05-04T04:00:00Z",
+            "courseware_url": null,
+            "courseware_id": "MITx/14.73x_1/1T2015",
+            "certificate_available_date": "2015-05-03T04:00:00Z",
+            "upgrade_deadline": "2015-05-03T04:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2015",
+            "id": 62,
+            "live": true,
+            "course_number": "14.73x_1",
+            "products": [
+              {
+                "id": 25,
+                "price": "1000.00",
+                "description": "MITx/14.73x_1/1T2015",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2024-09-10T15:00:00Z",
+            "end_date": "2024-12-17T15:00:00Z",
+            "enrollment_start": "2024-02-13T23:59:00Z",
+            "enrollment_end": "2024-10-08T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2024/course",
+            "courseware_id": "course-v1:MITxT+14.73x+3T2024",
+            "certificate_available_date": "2025-01-14T00:00:00Z",
+            "upgrade_deadline": "2024-10-22T23:59:00Z",
+            "is_upgradable": true,
+            "is_enrollable": true,
+            "is_self_paced": false,
+            "run_tag": "3T2024",
+            "id": 249,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 220,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+3T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2022-02-01T15:00:00Z",
+            "end_date": "2022-04-20T15:00:00Z",
+            "enrollment_start": "2021-11-02T23:59:00Z",
+            "enrollment_end": "2022-03-08T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.73x+1T2022",
+            "certificate_available_date": "2022-04-21T15:00:00Z",
+            "upgrade_deadline": "2022-04-20T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2022",
+            "id": 11,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 11,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+1T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2013-02-12T15:00:00Z",
+            "end_date": "2013-05-11T15:00:00Z",
+            "enrollment_start": "2013-02-12T15:00:00Z",
+            "enrollment_end": "2016-12-04T04:00:00Z",
+            "expiration_date": "2013-05-12T15:00:00Z",
+            "courseware_url": null,
+            "courseware_id": "MITx/14.73x/2013_Spring",
+            "certificate_available_date": "2013-05-11T15:00:00Z",
+            "upgrade_deadline": "2013-05-11T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2013_Spring",
+            "id": 61,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 28,
+                "price": "1000.00",
+                "description": "MITx/14.73x/2013_Spring",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2016-02-22T15:00:00Z",
+            "end_date": "2016-05-15T15:00:00Z",
+            "enrollment_start": "2015-12-30T15:00:00Z",
+            "enrollment_end": "2016-12-04T04:00:00Z",
+            "expiration_date": "2016-05-16T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x_1+1T2016",
+            "courseware_id": "course-v1:MITx+14.73x_1+1T2016",
+            "certificate_available_date": "2016-05-15T15:00:00Z",
+            "upgrade_deadline": "2016-05-15T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2016",
+            "id": 73,
+            "live": true,
+            "course_number": "14.73x_1",
+            "products": [
+              {
+                "id": 38,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x_1+1T2016",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2016-09-16T04:00:00Z",
+            "end_date": "2016-12-11T15:00:00Z",
+            "enrollment_start": "2016-09-16T04:00:00Z",
+            "enrollment_end": "2016-12-04T04:00:00Z",
+            "expiration_date": "2016-12-12T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2016",
+            "courseware_id": "course-v1:MITx+14.73x+3T2016",
+            "certificate_available_date": "2016-12-11T15:00:00Z",
+            "upgrade_deadline": "2016-12-11T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2016",
+            "id": 74,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 39,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+3T2016",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2019-02-05T15:00:00Z",
+            "end_date": "2019-04-23T15:00:00Z",
+            "enrollment_start": "2018-10-09T15:00:00Z",
+            "enrollment_end": "2019-03-03T15:00:00Z",
+            "expiration_date": "2019-04-24T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2019",
+            "courseware_id": "course-v1:MITx+14.73x+1T2019",
+            "certificate_available_date": "2019-04-23T15:00:00Z",
+            "upgrade_deadline": "2019-04-23T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2019",
+            "id": 75,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 40,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+1T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2019-05-21T15:00:00Z",
+            "end_date": "2019-08-06T15:00:00Z",
+            "enrollment_start": "2019-03-04T15:02:22Z",
+            "enrollment_end": "2019-06-18T15:00:00Z",
+            "expiration_date": "2019-08-07T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019",
+            "courseware_id": "course-v1:MITx+14.73x+2T2019",
+            "certificate_available_date": "2019-08-06T15:00:00Z",
+            "upgrade_deadline": "2019-08-06T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019",
+            "id": 76,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 41,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+2T2019",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2017-02-06T15:00:00Z",
+            "end_date": "2017-05-05T15:00:00Z",
+            "enrollment_start": "2016-12-05T05:00:00Z",
+            "enrollment_end": "2017-03-06T14:00:00Z",
+            "expiration_date": "2017-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2017",
+            "courseware_id": "course-v1:MITx+14.73x+1T2017",
+            "certificate_available_date": "2017-05-05T15:00:00Z",
+            "upgrade_deadline": "2017-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2017",
+            "id": 82,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 47,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+1T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of World Poverty",
+            "start_date": "2017-06-05T15:00:00Z",
+            "end_date": "2017-08-28T15:00:00Z",
+            "enrollment_start": "2017-03-06T14:00:00Z",
+            "enrollment_end": "2017-07-03T23:30:00Z",
+            "expiration_date": "2017-08-29T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2017",
+            "courseware_id": "course-v1:MITx+14.73x+2T2017",
+            "certificate_available_date": "2017-08-28T15:00:00Z",
+            "upgrade_deadline": "2017-08-28T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2017",
+            "id": 83,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 48,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+2T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of World Poverty",
+            "start_date": "2017-09-26T15:00:00Z",
+            "end_date": "2017-12-22T15:00:00Z",
+            "enrollment_start": "2017-07-03T15:00:00Z",
+            "enrollment_end": "2017-10-24T03:26:14Z",
+            "expiration_date": "2017-12-23T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2017",
+            "courseware_id": "course-v1:MITx+14.73x+3T2017",
+            "certificate_available_date": "2017-12-22T15:00:00Z",
+            "upgrade_deadline": "2017-12-22T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2017",
+            "id": 84,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 49,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+3T2017",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of World Poverty",
+            "start_date": "2018-02-06T15:00:00Z",
+            "end_date": "2018-05-05T15:00:00Z",
+            "enrollment_start": "2017-10-24T15:00:00Z",
+            "enrollment_end": "2018-03-06T15:00:00Z",
+            "expiration_date": "2018-05-06T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2018",
+            "courseware_id": "course-v1:MITx+14.73x+1T2018",
+            "certificate_available_date": "2018-05-05T15:00:00Z",
+            "upgrade_deadline": "2018-05-05T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2018",
+            "id": 97,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 62,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+1T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2019-09-03T15:00:00Z",
+            "end_date": "2019-11-19T15:00:00Z",
+            "enrollment_start": "2019-06-18T15:00:00Z",
+            "enrollment_end": "2019-10-01T15:00:00Z",
+            "expiration_date": "2019-11-20T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019a",
+            "courseware_id": "course-v1:MITx+14.73x+2T2019a",
+            "certificate_available_date": "2019-11-19T15:00:00Z",
+            "upgrade_deadline": "2019-11-19T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2019a",
+            "id": 102,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 67,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+2T2019a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2020-02-04T15:00:00Z",
+            "end_date": "2020-04-21T15:00:00Z",
+            "enrollment_start": "2019-10-02T17:34:22Z",
+            "enrollment_end": "2020-03-03T15:00:00Z",
+            "expiration_date": "2020-04-22T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2019a",
+            "courseware_id": "course-v1:MITx+14.73x+1T2020a",
+            "certificate_available_date": "2020-04-21T15:00:00Z",
+            "upgrade_deadline": "2020-04-21T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2020a",
+            "id": 103,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 68,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+1T2020a",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2020-06-02T15:00:00Z",
+            "end_date": "2020-08-18T15:00:00Z",
+            "enrollment_start": "2020-03-03T15:00:00Z",
+            "enrollment_end": "2020-07-01T15:00:00Z",
+            "expiration_date": "2020-08-19T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2020",
+            "courseware_id": "course-v1:MITx+14.73x+2T2020",
+            "certificate_available_date": "2020-08-18T15:00:00Z",
+            "upgrade_deadline": "2020-08-18T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2020",
+            "id": 110,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 75,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+2T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2020-09-08T15:00:00Z",
+            "end_date": "2020-11-24T15:00:00Z",
+            "enrollment_start": "2020-07-17T14:42:33Z",
+            "enrollment_end": "2020-10-06T15:00:00Z",
+            "expiration_date": "2020-11-25T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2020",
+            "courseware_id": "course-v1:MITx+14.73x+3T2020",
+            "certificate_available_date": "2020-11-24T15:00:00Z",
+            "upgrade_deadline": "2020-11-24T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2020",
+            "id": 111,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 76,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+3T2020",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2018-06-05T15:00:00Z",
+            "end_date": "2018-08-21T03:30:00Z",
+            "enrollment_start": "2018-03-06T15:00:00Z",
+            "enrollment_end": "2018-07-03T15:00:00Z",
+            "expiration_date": "2018-08-22T03:30:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+2T2018",
+            "courseware_id": "course-v1:MITx+14.73x+2T2018",
+            "certificate_available_date": "2018-08-21T03:30:00Z",
+            "upgrade_deadline": "2018-08-21T03:30:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "2T2018",
+            "id": 138,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 103,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+2T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2018-09-11T15:00:00Z",
+            "end_date": "2018-11-28T03:00:00Z",
+            "enrollment_start": "2018-07-03T15:00:00Z",
+            "enrollment_end": "2018-10-09T15:00:00Z",
+            "expiration_date": "2018-11-29T03:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+3T2018",
+            "courseware_id": "course-v1:MITx+14.73x+3T2018",
+            "certificate_available_date": "2018-11-28T03:00:00Z",
+            "upgrade_deadline": "2018-11-28T03:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2018",
+            "id": 139,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 104,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+3T2018",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "Challenges of Global Poverty",
+            "start_date": "2021-02-09T15:00:00Z",
+            "end_date": "2021-04-27T15:00:00Z",
+            "enrollment_start": "2020-10-06T15:00:00Z",
+            "enrollment_end": "2021-03-12T15:00:00Z",
+            "expiration_date": "2021-04-28T15:00:00Z",
+            "courseware_url": "https://courses.edx.org/courses/course-v1:MITx+14.73x+1T2021",
+            "courseware_id": "course-v1:MITx+14.73x+1T2021",
+            "certificate_available_date": "2021-04-27T15:00:00Z",
+            "upgrade_deadline": "2021-04-27T15:00:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2021",
+            "id": 140,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 105,
+                "price": "1000.00",
+                "description": "course-v1:MITx+14.73x+1T2021",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2022-09-06T15:00:00Z",
+            "end_date": "2024-01-03T19:20:00Z",
+            "enrollment_start": "2022-03-08T23:59:00Z",
+            "enrollment_end": "2022-10-07T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2022/course/",
+            "courseware_id": "course-v1:MITxT+14.73x+3T2022",
+            "certificate_available_date": "2024-01-04T00:00:00Z",
+            "upgrade_deadline": "2023-12-24T19:20:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "3T2022",
+            "id": 21,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 15,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+3T2022",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          },
+          {
+            "title": "The Challenges of Global Poverty",
+            "start_date": "2024-01-16T15:00:00Z",
+            "end_date": "2024-05-03T00:00:00Z",
+            "enrollment_start": "2023-10-10T23:59:00Z",
+            "enrollment_end": "2024-02-13T23:59:00Z",
+            "expiration_date": null,
+            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+1T2024/course",
+            "courseware_id": "course-v1:MITxT+14.73x+1T2024",
+            "certificate_available_date": "2024-05-15T00:00:00Z",
+            "upgrade_deadline": "2024-02-28T23:59:00Z",
+            "is_upgradable": false,
+            "is_enrollable": false,
+            "is_self_paced": false,
+            "run_tag": "1T2024",
+            "id": 224,
+            "live": true,
+            "course_number": "14.73x",
+            "products": [
+              {
+                "id": 199,
+                "price": "1000.00",
+                "description": "course-v1:MITxT+14.73x+1T2024",
+                "is_active": true,
+                "product_flexible_price": null
+              }
+            ],
+            "approved_flexible_price_exists": false
+          }
+        ],
+        "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
+        "page_url": "/courses/course-v1:MITxT+14.73x/",
+        "description": "A course for those who are interested in the challenge posed by massive and persistent world poverty.",
+        "live": true,
+        "length": "14 weeks",
+        "effort": "12–14 hours per week",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "current_price": 1000.0,
+        "instructors": [
+          {
+            "name": "Abhijit Vinayak Banerjee",
+            "description": ""
+          },
+          {
+            "name": "Esther Duflo",
+            "description": ""
+          },
+          {
+            "name": "Frank Schilbach",
+            "description": ""
+          }
+        ]
       }
     ],
-    "start_date": "2021-10-05T15:00:00Z",
-    "end_date": "2023-08-16T15:00:00Z",
-    "enrollment_start": "2021-10-05T15:00:00Z",
-    "topics": []
+    "requirements": {
+      "required": [
+        1,
+        2,
+        3
+      ],
+      "electives": [
+        5,
+        6,
+        4
+      ]
+    },
+    "req_tree": [
+      {
+        "data": {
+          "node_type": "program_root",
+          "operator": null,
+          "operator_value": null,
+          "program": 1,
+          "course": null,
+          "title": "",
+          "elective_flag": false
+        },
+        "id": 1,
+        "children": [
+          {
+            "data": {
+              "node_type": "operator",
+              "operator": "all_of",
+              "operator_value": null,
+              "program": 1,
+              "course": null,
+              "title": "Required Courses",
+              "elective_flag": false
+            },
+            "id": 2,
+            "children": [
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 1,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 4
+              },
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 2,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 5
+              },
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 3,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 6
+              }
+            ]
+          },
+          {
+            "data": {
+              "node_type": "operator",
+              "operator": "min_number_of",
+              "operator_value": "2",
+              "program": 1,
+              "course": null,
+              "title": "Elective Courses",
+              "elective_flag": true
+            },
+            "id": 3,
+            "children": [
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 5,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 7
+              },
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 6,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 8
+              },
+              {
+                "data": {
+                  "node_type": "course",
+                  "operator": null,
+                  "operator_value": null,
+                  "program": 1,
+                  "course": 4,
+                  "title": null,
+                  "elective_flag": false
+                },
+                "id": 20
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "page": {
+      "feature_image_src": "/media/original_images/InternationalDevelopment-track_image_1134.jpg?v=32d70d0ad6a7b87b4cfbc4717e20177d601afb42",
+      "page_url": "/programs/program-v1:MITx+DEDP/",
+      "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+      "description": "<p data-block-key=\"s6wzo\">Grapple with some of the world’s most pressing problems from a rigorous, data-driven perspective developed by Nobel prize winners Esther Duflo and Abhijit Banerjee. Complete three core courses and two out of three electives plus proctored exams to earn your credential. You may then apply to the Master’s degree offered by MIT’s #1 world-ranked Economics Department.</p>",
+      "live": true,
+      "length": "3 terms (12 months)",
+      "effort": "12-14 hours per week",
+      "price": "$250 - $1000"
+    },
+    "program_type": "MicroMasters®",
+    "departments": [
+      {
+        "name": "Economics"
+      }
+    ],
+    "live": true
   }
 ]


### PR DESCRIPTION
This is not done yet - [draft PR per request for work in progress](https://github.com/mitodl/hq/discussions/4225#discussioncomment-9426021).

### What are the relevant tickets?

Closes mitodl/hq#4164

### Description (What does it do?)

MITx Online's API for courses and programs specifies the departments these objects belong to, so the ETL tasks for these should use that rather than trying to parse the department out of the course readable ID. 

### How can this be tested?

Automated tests should pass.
