### PR TITLE
Cc/button updates

### DIFF
--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -3,19 +3,22 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { Button, ActionButton, ButtonLink } from "./Button"
 import Grid from "@mui/material/Grid"
 import Stack from "@mui/material/Stack"
-import ArrowForwardIcon from "@mui/icons-material/ArrowForward"
-import ArrowBackIcon from "@mui/icons-material/ArrowBack"
-import DeleteIcon from "@mui/icons-material/Delete"
-import EditIcon from "@mui/icons-material/Edit"
+import {
+  RiArrowLeftLine,
+  RiArrowRightLine,
+  RiDeleteBinLine,
+  RiEditLine,
+} from "@remixicon/react"
+
 import { withRouter } from "storybook-addon-react-router-v6"
 import { fn } from "@storybook/test"
 
 const icons = {
   None: undefined,
-  ArrowForwardIcon: <ArrowForwardIcon />,
-  ArrowBackIcon: <ArrowBackIcon />,
-  DeleteIcon: <DeleteIcon />,
-  EditIcon: <EditIcon />,
+  ArrowForwardIcon: <RiArrowRightLine />,
+  ArrowBackIcon: <RiArrowLeftLine />,
+  DeleteIcon: <RiDeleteBinLine />,
+  EditIcon: <RiEditLine />,
 }
 
 const meta: Meta<typeof Button> = {
@@ -144,16 +147,16 @@ export const EdgeStory: Story = {
 export const WithIconStory: Story = {
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} startIcon={<ArrowBackIcon />}>
+      <Button {...args} startIcon={<RiArrowLeftLine />}>
         Back
       </Button>
-      <Button {...args} startIcon={<DeleteIcon />}>
+      <Button {...args} startIcon={<RiDeleteBinLine />}>
         Delete
       </Button>
-      <Button {...args} startIcon={<EditIcon />}>
+      <Button {...args} startIcon={<RiEditLine />}>
         Edit
       </Button>
-      <Button {...args} endIcon={<ArrowForwardIcon />}>
+      <Button {...args} endIcon={<RiArrowRightLine />}>
         Forward
       </Button>
     </Stack>
@@ -164,16 +167,16 @@ export const IconOnlyStory: Story = {
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
       <ActionButton {...args}>
-        <ArrowBackIcon />
+        <RiArrowLeftLine />
       </ActionButton>
       <ActionButton {...args}>
-        <ArrowForwardIcon />
+        <RiArrowRightLine />
       </ActionButton>
       <ActionButton {...args} variant="outlined">
-        <DeleteIcon />
+        <RiDeleteBinLine />
       </ActionButton>
       <ActionButton {...args} variant="outlined" edge="rounded">
-        <EditIcon />
+        <RiEditLine />
       </ActionButton>
     </Stack>
   ),
@@ -184,8 +187,8 @@ const EDGES = ["sharp", "rounded"] as const
 const VARIANTS = ["filled", "outlined", "text"] as const
 const EXTRA_PROPS = [
   {},
-  { startIcon: <ArrowBackIcon /> },
-  { endIcon: <ArrowForwardIcon /> },
+  { startIcon: <RiArrowLeftLine /> },
+  { endIcon: <RiArrowRightLine /> },
 ]
 
 export const LinkStory: Story = {
@@ -239,19 +242,19 @@ export const ButtonsShowcase: Story = {
 const COLORS = ["primary", "secondary"] as const
 const ICONS = [
   {
-    component: <ArrowBackIcon />,
+    component: <RiArrowLeftLine />,
     key: "back",
   },
   {
-    component: <DeleteIcon />,
+    component: <RiDeleteBinLine />,
     key: "delete",
   },
   {
-    component: <EditIcon />,
+    component: <RiEditLine />,
     key: "edit",
   },
   {
-    component: <ArrowForwardIcon />,
+    component: <RiArrowRightLine />,
     key: "forward",
   },
 ]

--- a/frontends/ol-components/src/components/Button/Button.test.tsx
+++ b/frontends/ol-components/src/components/Button/Button.test.tsx
@@ -1,0 +1,95 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
+import { ButtonLink, ActionButtonLink } from "./Button"
+import type { LinkProps } from "react-router-dom"
+
+// Mock react-router-dom's Link so we don't need to set up a Router
+jest.mock("react-router-dom", () => {
+  return {
+    Link: React.forwardRef<HTMLAnchorElement, LinkProps>(
+      jest.fn((props, ref) => {
+        if (typeof props.to !== "string") {
+          throw new Error("Expected to prop to be a string")
+        }
+        return (
+          <a
+            {...props}
+            ref={ref}
+            href={props.to} // otherwise the anchor won't have role link
+            data-prop-to={props.to}
+            data-react-component="react-router-dom-link"
+          />
+        )
+      }),
+    ),
+  }
+})
+
+describe("ButtonLink", () => {
+  test.each([
+    {
+      nativeAnchor: undefined,
+      reactRouter: true,
+      label: "Link",
+    },
+    {
+      nativeAnchor: false,
+      reactRouter: true,
+      label: "Link",
+    },
+    {
+      nativeAnchor: true,
+      reactRouter: false,
+      label: "Anchor",
+    },
+  ])(
+    "renders a $label when nativeAnchor is $nativeAnchor",
+    ({ nativeAnchor, reactRouter }) => {
+      render(
+        <ButtonLink href="/test" nativeAnchor={nativeAnchor}>
+          Link text here
+        </ButtonLink>,
+        { wrapper: ThemeProvider },
+      )
+      const link = screen.getByRole("link")
+      expect(link.dataset["reactComponent"] === "react-router-dom-link").toBe(
+        reactRouter,
+      )
+    },
+  )
+})
+
+describe("ActionButtonLink", () => {
+  test.each([
+    {
+      nativeAnchor: undefined,
+      reactRouter: true,
+      label: "Link",
+    },
+    {
+      nativeAnchor: false,
+      reactRouter: true,
+      label: "Link",
+    },
+    {
+      nativeAnchor: true,
+      reactRouter: false,
+      label: "Anchor",
+    },
+  ])(
+    "renders a $label when nativeAnchor is $nativeAnchor",
+    ({ nativeAnchor, reactRouter }) => {
+      render(
+        <ActionButtonLink href="/test" nativeAnchor={nativeAnchor}>
+          Link text here
+        </ActionButtonLink>,
+        { wrapper: ThemeProvider },
+      )
+      const link = screen.getByRole("link")
+      expect(link.dataset["reactComponent"] === "react-router-dom-link").toBe(
+        reactRouter,
+      )
+    },
+  )
+})

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -127,9 +127,9 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       "& .MuiSvgIcon-root": {
         fontSize: pxToRem(
           {
-            small: 16,
-            medium: 20,
-            large: 24,
+            small: 20,
+            medium: 24,
+            large: 32,
           }[size],
         ),
       },
@@ -137,11 +137,12 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
   ],
 )
 
-const LinkStyled = styled(ButtonStyled.withComponent(Link))({
+const AnchorStyled = styled(ButtonStyled.withComponent("a"))({
   ":hover": {
     textDecoration: "none",
   },
 })
+const LinkStyled = ButtonStyled.withComponent(Link)
 
 type ButtonProps = ButtonStyleProps & React.ComponentProps<"button">
 
@@ -175,17 +176,41 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 
 type ButtonLinkProps = ButtonStyleProps &
-  React.ComponentProps<"a"> & { href: string }
+  React.ComponentProps<"a"> & {
+    href: string
+    /**
+     * If true, the component will render a native anchor element rather than
+     * a react router Link.
+     *
+     * In general, we want to use Link. It:
+     *  - WILL NOT trigger a full page reload for internal links
+     *  - WILL trigger a full page reload for external links.
+     *
+     * However, there are some rare cases where an internal link might need a
+     * full page reload, e.g., linking to login or logout pages.
+     */
+    nativeAnchor?: boolean
+  }
 
 const ButtonLink: React.FC<ButtonLinkProps> = ({
   children,
   href,
+  nativeAnchor,
   ...props
-}) => (
-  <LinkStyled to={href} {...props}>
-    <ButtonInner {...props}>{children}</ButtonInner>
-  </LinkStyled>
-)
+}) => {
+  if (nativeAnchor) {
+    return (
+      <AnchorStyled href={href} {...props}>
+        <ButtonInner {...props}>{children}</ButtonInner>
+      </AnchorStyled>
+    )
+  }
+  return (
+    <LinkStyled to={href} {...props}>
+      <ButtonInner {...props}>{children}</ButtonInner>
+    </LinkStyled>
+  )
+}
 
 const ActionButtonDefaultProps: Required<
   Omit<ButtonStyleProps, "startIcon" | "endIcon">
@@ -223,5 +248,27 @@ const ActionButton = styled(
   }
 })
 
-export { Button, ButtonLink, ActionButton }
-export type { ButtonProps, ButtonLinkProps }
+type ActionButtonLinkProps = ActionButtonProps &
+  React.ComponentProps<"a"> & {
+    href: string
+    nativeAnchor?: boolean
+  }
+
+const ActionButtonLink = ActionButton.withComponent(
+  React.forwardRef<HTMLAnchorElement, ActionButtonLinkProps>(
+    ({ href, nativeAnchor, ...props }, ref) => {
+      if (nativeAnchor) {
+        return <AnchorStyled ref={ref} href={href} {...props} />
+      }
+      return <LinkStyled ref={ref} to={href} {...props} />
+    },
+  ),
+)
+
+export { Button, ButtonLink, ActionButton, ActionButtonLink }
+export type {
+  ButtonProps,
+  ButtonLinkProps,
+  ActionButtonProps,
+  ActionButtonLinkProps,
+}

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -167,6 +167,9 @@ const ButtonInner: React.FC<
   )
 }
 
+/**
+ * Our styled button. If you need a link that looks like a button, use ButtonLink
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ children, ...props }, ref) => (
     <ButtonStyled ref={ref} type="button" {...props}>
@@ -223,6 +226,11 @@ const ActionButtonDefaultProps: Required<
 
 type ActionButtonProps = Omit<ButtonStyleProps, "startIcon" | "endIcon"> &
   React.ComponentProps<"button">
+
+/**
+ * A button that should contain a remixicon icon and nothing else.
+ * For a variant that functions as a link, see ActionButtonLink.
+ */
 const ActionButton = styled(
   React.forwardRef<HTMLButtonElement, ActionButtonProps>((props, ref) => (
     <ButtonStyled ref={ref} type="button" {...props} />

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -124,12 +124,14 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       marginRight: "-4px",
     },
     {
-      "& .MuiSvgIcon-root": {
+      "& svg, & .MuiSvgIcon-root": {
+        width: "1em",
+        height: "1em",
         fontSize: pxToRem(
           {
-            small: 20,
-            medium: 24,
-            large: 32,
+            small: 16,
+            medium: 20,
+            large: 24,
           }[size],
         ),
       },
@@ -244,12 +246,14 @@ const ActionButton = styled(
       medium: "40px",
       large: "48px",
     }[size],
-    "& .MuiSvgIcon-root": {
+    "& svg, & .MuiSvgIcon-root": {
+      width: "1em",
+      height: "1em",
       fontSize: pxToRem(
         {
-          small: 16,
-          medium: 20,
-          large: 24,
+          small: 20,
+          medium: 24,
+          large: 32,
         }[size],
       ),
     },


### PR DESCRIPTION
### What are the relevant tickets?
None—Motivated by a conversation with Steve and Carey's work on header.

### Description (What does it do?)
Updates our Button component a little bit:
- ButtonLink can now be used with a native anchor
- ActionButton icons are a little bigger and supports an ActionButtonLink version.
    - Not sure if the figma changed or if i got the icon sizes wrong in original PR.

### How can this be tested?
1. Buttons on the app should function normally.
2. Check the icons at http://localhost:6006/?path=/story/smoot-design-button--action-buttons-showcase ... They should have width/height 20px, 24px, 32px for small/medium/large variants.


