### PR TITLE
Add Free, Certification, and Professional Facets to Search UI

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.0.9",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31",
+    "@mitodl/course-search-utils": "^3.1.0",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.tsx
@@ -225,7 +225,7 @@ const FieldSearch: React.FC<FeildSearchProps> = ({
         <GridContainer>
           <GridColumn variant="main-2-wide-main">
             <AvailableFacetsDropdowns
-              facetMap={facetManifest}
+              facetManifest={facetManifest}
               isLoading={isLoading}
               activeFacets={allParams as Facets & BooleanFacets}
               onFacetChange={setParamValue}

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -32,7 +32,7 @@ export type SingleFacetOptions = {
 export type FacetManifest = SingleFacetOptions[]
 
 interface FacetDisplayProps {
-  facetMap: FacetManifest
+  facetManifest: FacetManifest
   isLoading?: boolean
   /**
    * Returns the aggregation options for a given group.
@@ -75,7 +75,7 @@ const filteredResultsWithLabels = (
 const AvailableFacetsDropdowns: React.FC<
   Omit<FacetDisplayProps, "clearAllFilters">
 > = ({
-  facetMap,
+  facetManifest,
   isLoading,
   facetOptions,
   activeFacets,
@@ -84,7 +84,7 @@ const AvailableFacetsDropdowns: React.FC<
 }) => {
   return (
     <>
-      {facetMap.map((facetSetting, index) => {
+      {facetManifest.map((facetSetting, index) => {
         const facetItems = filteredResultsWithLabels(
           facetOptions(facetSetting.name) || [],
           facetSetting.labelFunction || null,

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -210,8 +210,11 @@ describe("SearchPage", () => {
       })
       const apiSearchParams = getLastApiSearchParams()
       expect(apiSearchParams.getAll("aggregations").sort()).toEqual([
+        "certification",
+        "free",
         "learning_format",
         "offered_by",
+        "professional",
         "resource_type",
         "topic",
       ])

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -47,22 +47,42 @@ const getFacetManifest = (
 ): FacetManifest => {
   return [
     {
+      type: "group",
+      facets: [
+        {
+          value: true,
+          name: "free",
+          label: "Free Courses",
+        },
+        {
+          value: true,
+          name: "certification",
+          label: "With Certificate",
+        },
+        {
+          value: true,
+          name: "professional",
+          label: "Professional Courses",
+        },
+      ],
+    },
+    {
       name: "topic",
       title: "Topics",
-      useFilterableFacet: true,
+      type: "filterable",
       expandedOnLoad: true,
     },
     {
       name: "offered_by",
       title: "Offered By",
-      useFilterableFacet: false,
+      type: "filterable",
       expandedOnLoad: true,
       labelFunction: (key) => offerors[key]?.name ?? key,
     },
     {
       name: "learning_format",
       title: "Format",
-      useFilterableFacet: false,
+      type: "filterable",
       expandedOnLoad: true,
       labelFunction: (key) =>
         key
@@ -73,15 +93,21 @@ const getFacetManifest = (
   ]
 }
 
-const FACET_NAMES = getFacetManifest({}).map(
-  (f) => f.name,
-) as UseResourceSearchParamsProps["facets"]
+const FACET_NAMES = getFacetManifest({}).flatMap((config) => {
+  if (config.type === "group") {
+    return config.facets.map((f) => f.name)
+  }
+  return config.name
+}) as UseResourceSearchParamsProps["facets"]
 
 const AGGREGATIONS: LRSearchRequest["aggregations"] = [
   "resource_type",
   "learning_format",
   "topic",
   "offered_by",
+  "certification",
+  "free",
+  "professional",
 ]
 
 const SORT_OPTIONS = [
@@ -398,9 +424,7 @@ const SearchPage: React.FC = () => {
                   facetMap={facetManifest}
                   activeFacets={params}
                   onFacetChange={toggleParamValue}
-                  facetOptions={(name) =>
-                    data?.metadata.aggregations?.[name] ?? []
-                  }
+                  facetOptions={data?.metadata.aggregations ?? {}}
                 />
               </FacetStyles>
             </GridColumn>

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -52,7 +52,7 @@ const getFacetManifest = (
         {
           value: true,
           name: "free",
-          label: "Free Courses",
+          label: "Free",
         },
         {
           value: true,
@@ -62,7 +62,7 @@ const getFacetManifest = (
         {
           value: true,
           name: "professional",
-          label: "Professional Courses",
+          label: "Professional",
         },
       ],
     },
@@ -421,7 +421,7 @@ const SearchPage: React.FC = () => {
               </FacetsTitleContainer>
               <FacetStyles>
                 <AvailableFacets
-                  facetMap={facetManifest}
+                  facetManifest={facetManifest}
                   activeFacets={params}
                   onFacetChange={toggleParamValue}
                   facetOptions={data?.metadata.aggregations ?? {}}

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -61,11 +61,6 @@ module.exports = (env, argv) => {
     mode,
     context: __dirname,
     devtool: "source-map",
-    snapshot: {
-      managedPaths: [
-        /^(.+?[\\/]node_modules)[\\/]((?!@mitodl\/course-search-utils)).*[\\/]*/,
-      ],
-    },
     entry: {
       root: "./src/App",
     },

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -61,6 +61,11 @@ module.exports = (env, argv) => {
     mode,
     context: __dirname,
     devtool: "source-map",
+    snapshot: {
+      managedPaths: [
+        /^(.+?[\\/]node_modules)[\\/]((?!@mitodl\/course-search-utils)).*[\\/]*/,
+      ],
+    },
     entry: {
       root: "./src/App",
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,13 +3606,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.0.9":
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31":
   version: 3.0.9
-  resolution: "@mitodl/course-search-utils@npm:3.0.9"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.5.6"
-    "@testing-library/react": "npm:12"
-    "@testing-library/user-event": "npm:^14.5.2"
     axios: "npm:^1.6.7"
     fuse.js: "npm:^7.0.0"
     query-string: "npm:^6.13.1"
@@ -3629,7 +3627,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/83bced0eaf513fc9778883dc8edcfc88266df1a8912d91c09d0b663023833873259861adadce03d3ca5f03be555582d51116d4cb38708329195f1967073c5a9d
+  checksum: 10/ba281c44ad4876071e615680243593c59c84d1c4ffea66c99c0125e13cea64c3961892a5c8bf0834afd948caef66c17708355397902618ca950668533c69de86
   languageName: node
   linkType: hard
 
@@ -5539,22 +5537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0":
-  version: 8.20.1
-  resolution: "@testing-library/dom@npm:8.20.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.10.4"
-    "@babel/runtime": "npm:^7.12.5"
-    "@types/aria-query": "npm:^5.0.1"
-    aria-query: "npm:5.1.3"
-    chalk: "npm:^4.1.0"
-    dom-accessibility-api: "npm:^0.5.9"
-    lz-string: "npm:^1.5.0"
-    pretty-format: "npm:^27.0.2"
-  checksum: 10/6c7a92fcc89931ef62a9a92dacec09b3e5ee5c3aba2171aa8de6c7504927b7c9364d73d2ed87b72447d6783108c1c92c207d16f788de64c69bc97059d7105e3c
-  languageName: node
-  linkType: hard
-
 "@testing-library/dom@npm:^9.0.0, @testing-library/dom@npm:^9.3.4":
   version: 9.3.4
   resolution: "@testing-library/dom@npm:9.3.4"
@@ -5601,20 +5583,6 @@ __metadata:
     vitest:
       optional: true
   checksum: 10/7ee1e51caffad032734a4a43a00bf72d49080cf1bbf53021b443e91c7fa3762a66f55ce68f1c6643590fe66fbc4df92142659b8cf17c92166a3fb22691987e0d
-  languageName: node
-  linkType: hard
-
-"@testing-library/react@npm:12":
-  version: 12.1.5
-  resolution: "@testing-library/react@npm:12.1.5"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-    "@testing-library/dom": "npm:^8.0.0"
-    "@types/react-dom": "npm:<18.0.0"
-  peerDependencies:
-    react: <18.0.0
-    react-dom: <18.0.0
-  checksum: 10/24ea6ed298ae65c374b3068974359371f551fa1ffdeb5de9853432856ff63b71576d8bbfa8ee1e45d4fa214c2135e49561bafc9b11528cecc8a7943e2a942255
   languageName: node
   linkType: hard
 
@@ -6258,15 +6226,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:<18.0.0":
-  version: 17.0.25
-  resolution: "@types/react-dom@npm:17.0.25"
-  dependencies:
-    "@types/react": "npm:^17"
-  checksum: 10/5854802aee0f23436e086b179360e93ac6db3387339f7e9359a786245a36bff5e4c36ff380e9ddb3c7c02d720a3bc9cbb3a3433906ecb4b48482f6e5462d1d22
-  languageName: node
-  linkType: hard
-
 "@types/react-dom@npm:^18.0.0":
   version: 18.3.0
   resolution: "@types/react-dom@npm:18.3.0"
@@ -6304,17 +6263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^17":
-  version: 17.0.80
-  resolution: "@types/react@npm:17.0.80"
-  dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:^0.16"
-    csstype: "npm:^3.0.2"
-  checksum: 10/f5dce5825e693313bb7f8db0199299a25be21d58a7f6eedea9dacd593d2b4013d664ed3d54e5fb241a43c7ebbdfeee41d5a500ed2979cc772a89d460aa40d8f4
-  languageName: node
-  linkType: hard
-
 "@types/resolve@npm:1.17.1":
   version: 1.17.1
   resolution: "@types/resolve@npm:1.17.1"
@@ -6342,13 +6290,6 @@ __metadata:
   version: 0.12.2
   resolution: "@types/retry@npm:0.12.2"
   checksum: 10/e5675035717b39ce4f42f339657cae9637cf0c0051cf54314a6a2c44d38d91f6544be9ddc0280587789b6afd056be5d99dbe3e9f4df68c286c36321579b1bf4a
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:^0.16":
-  version: 0.16.8
-  resolution: "@types/scheduler@npm:0.16.8"
-  checksum: 10/6c091b096daa490093bf30dd7947cd28e5b2cd612ec93448432b33f724b162587fed9309a0acc104d97b69b1d49a0f3fc755a62282054d62975d53d7fd13472d
   languageName: node
   linkType: hard
 
@@ -17398,7 +17339,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^7.3.0"
-    "@mitodl/course-search-utils": "npm:^3.0.9"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3606,9 +3606,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31":
-  version: 3.0.9
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31"
+"@mitodl/course-search-utils@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@mitodl/course-search-utils@npm:3.1.0"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.5.6"
     axios: "npm:^1.6.7"
@@ -3627,7 +3627,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/ba281c44ad4876071e615680243593c59c84d1c4ffea66c99c0125e13cea64c3961892a5c8bf0834afd948caef66c17708355397902618ca950668533c69de86
+  checksum: 10/98c745b0bc2da1177fcf7acb414a63c162d9b4512e11e97aa4d3276e30a9b95d2d89bbf121135773ad08af0fc56a3c574530168a41e311d238fd2ee2ef850517
   languageName: node
   linkType: hard
 
@@ -17339,7 +17339,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^7.3.0"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#a4efeaa70c4c4677d96d5a1a89e1e4b0eb64ae31"
+    "@mitodl/course-search-utils": "npm:^3.1.0"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
### What are the relevant tickets?
- Together with https://github.com/mitodl/course-search-utils/pull/106, this closes https://github.com/mitodl/hq/issues/4209

### Description (What does it do?)
Configures "Free", "With Certificate", and "Professional" boolean facets for the search page.

### Screenshots (if appropriate):
<img width="1616" alt="Screenshot 2024-05-19 at 4 04 00 PM" src="https://github.com/mitodl/mit-open/assets/9010790/34f376ad-7e3d-446a-9ec6-d09627a2b09a">


### How can this be tested?
1. On this branch, `docker compose watch build` and `docker compose up`.
2. Visit http://localhost:8063/search. Try out the 3 new facets, "Free", "With Certificate", and "Professional". They should function as expected, filtering courses.
    - You will need some courses/programs with truthy values. If you don't have certificate/professional courses, backpopulate xPRO. 

### Additional Context
Review with 
- https://github.com/mitodl/course-search-utils/pull/106

