### PR TITLE
Fix schema documentation for news_events feed items

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -404,6 +404,124 @@ export type DepartmentChannelTypeEnum =
   (typeof DepartmentChannelTypeEnum)[keyof typeof DepartmentChannelTypeEnum]
 
 /**
+ * Serializer for News FeedItem
+ * @export
+ * @interface EventFeedItem
+ */
+export interface EventFeedItem {
+  /**
+   *
+   * @type {number}
+   * @memberof EventFeedItem
+   */
+  id: number
+  /**
+   *
+   * @type {EventFeedItemFeedTypeEnum}
+   * @memberof EventFeedItem
+   */
+  feed_type: EventFeedItemFeedTypeEnum
+  /**
+   *
+   * @type {FeedImage}
+   * @memberof EventFeedItem
+   */
+  image: FeedImage
+  /**
+   *
+   * @type {FeedEventDetail}
+   * @memberof EventFeedItem
+   */
+  event_details: FeedEventDetail
+  /**
+   *
+   * @type {string}
+   * @memberof EventFeedItem
+   */
+  guid: string
+  /**
+   *
+   * @type {string}
+   * @memberof EventFeedItem
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof EventFeedItem
+   */
+  url: string
+  /**
+   *
+   * @type {string}
+   * @memberof EventFeedItem
+   */
+  summary?: string
+  /**
+   *
+   * @type {string}
+   * @memberof EventFeedItem
+   */
+  content?: string
+  /**
+   *
+   * @type {number}
+   * @memberof EventFeedItem
+   */
+  source: number
+}
+
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const EventFeedItemFeedTypeEnum = {
+  Events: "events",
+} as const
+
+export type EventFeedItemFeedTypeEnum =
+  (typeof EventFeedItemFeedTypeEnum)[keyof typeof EventFeedItemFeedTypeEnum]
+
+/**
+ * FeedEventDetail serializer
+ * @export
+ * @interface FeedEventDetail
+ */
+export interface FeedEventDetail {
+  /**
+   *
+   * @type {number}
+   * @memberof FeedEventDetail
+   */
+  id: number
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof FeedEventDetail
+   */
+  audience: Array<string>
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof FeedEventDetail
+   */
+  location: Array<string>
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof FeedEventDetail
+   */
+  event_type: Array<string>
+  /**
+   *
+   * @type {string}
+   * @memberof FeedEventDetail
+   */
+  event_datetime: string
+}
+/**
  * Serializer for FeedImage
  * @export
  * @interface FeedImage
@@ -433,6 +551,45 @@ export interface FeedImage {
    * @memberof FeedImage
    */
   alt?: string
+}
+/**
+ * @type FeedItem
+ * @export
+ */
+export type FeedItem =
+  | ({ resource_type: "events" } & EventFeedItem)
+  | ({ resource_type: "news" } & NewsFeedItem)
+
+/**
+ * FeedNewsDetail serializer
+ * @export
+ * @interface FeedNewsDetail
+ */
+export interface FeedNewsDetail {
+  /**
+   *
+   * @type {number}
+   * @memberof FeedNewsDetail
+   */
+  id: number
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof FeedNewsDetail
+   */
+  authors?: Array<string>
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof FeedNewsDetail
+   */
+  topics?: Array<string>
+  /**
+   *
+   * @type {string}
+   * @memberof FeedNewsDetail
+   */
+  publish_date: string
 }
 /**
  * FeedSource serializer
@@ -472,10 +629,10 @@ export interface FeedSource {
   description?: string
   /**
    *
-   * @type {FeedTypeEnum}
+   * @type {FeedSourceFeedTypeEnum}
    * @memberof FeedSource
    */
-  feed_type: FeedTypeEnum
+  feed_type: FeedSourceFeedTypeEnum
 }
 
 /**
@@ -484,12 +641,13 @@ export interface FeedSource {
  * @enum {string}
  */
 
-export const FeedTypeEnum = {
+export const FeedSourceFeedTypeEnum = {
   News: "news",
   Events: "events",
 } as const
 
-export type FeedTypeEnum = (typeof FeedTypeEnum)[keyof typeof FeedTypeEnum]
+export type FeedSourceFeedTypeEnum =
+  (typeof FeedSourceFeedTypeEnum)[keyof typeof FeedSourceFeedTypeEnum]
 
 /**
  * @type FieldChannel
@@ -668,6 +826,87 @@ export interface LearningPathPreview {
    */
   id: number
 }
+/**
+ * Serializer for News FeedItem
+ * @export
+ * @interface NewsFeedItem
+ */
+export interface NewsFeedItem {
+  /**
+   *
+   * @type {number}
+   * @memberof NewsFeedItem
+   */
+  id: number
+  /**
+   *
+   * @type {NewsFeedItemFeedTypeEnum}
+   * @memberof NewsFeedItem
+   */
+  feed_type: NewsFeedItemFeedTypeEnum
+  /**
+   *
+   * @type {FeedImage}
+   * @memberof NewsFeedItem
+   */
+  image: FeedImage
+  /**
+   *
+   * @type {FeedNewsDetail}
+   * @memberof NewsFeedItem
+   */
+  news_details: FeedNewsDetail
+  /**
+   *
+   * @type {string}
+   * @memberof NewsFeedItem
+   */
+  guid: string
+  /**
+   *
+   * @type {string}
+   * @memberof NewsFeedItem
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof NewsFeedItem
+   */
+  url: string
+  /**
+   *
+   * @type {string}
+   * @memberof NewsFeedItem
+   */
+  summary?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NewsFeedItem
+   */
+  content?: string
+  /**
+   *
+   * @type {number}
+   * @memberof NewsFeedItem
+   */
+  source: number
+}
+
+/**
+ *
+ * @export
+ * @enum {string}
+ */
+
+export const NewsFeedItemFeedTypeEnum = {
+  News: "news",
+} as const
+
+export type NewsFeedItemFeedTypeEnum =
+  (typeof NewsFeedItemFeedTypeEnum)[keyof typeof NewsFeedItemFeedTypeEnum]
+
 /**
  * Serializer for Channel model of type offeror
  * @export
@@ -851,6 +1090,37 @@ export interface PaginatedAttestationList {
    * @memberof PaginatedAttestationList
    */
   results: Array<Attestation>
+}
+/**
+ *
+ * @export
+ * @interface PaginatedFeedItemList
+ */
+export interface PaginatedFeedItemList {
+  /**
+   *
+   * @type {number}
+   * @memberof PaginatedFeedItemList
+   */
+  count: number
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedFeedItemList
+   */
+  next?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof PaginatedFeedItemList
+   */
+  previous?: string | null
+  /**
+   *
+   * @type {Array<FeedItem>}
+   * @memberof PaginatedFeedItemList
+   */
+  results: Array<FeedItem>
 }
 /**
  *
@@ -1567,6 +1837,20 @@ export interface ProgramCertificate {
    */
   program_completion_timestamp?: string | null
 }
+/**
+ * * `news` - news * `events` - events
+ * @export
+ * @enum {string}
+ */
+
+export const ResourceTypeEnum = {
+  News: "news",
+  Events: "events",
+} as const
+
+export type ResourceTypeEnum =
+  (typeof ResourceTypeEnum)[keyof typeof ResourceTypeEnum]
+
 /**
  * * `facebook` - facebook * `linkedin` - linkedin * `personal` - personal * `twitter` - twitter
  * @export
@@ -3558,7 +3842,10 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
       offset?: number,
       options?: RawAxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<PaginatedFeedItemList>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.newsEventsList(
         feed_type,
@@ -3587,7 +3874,7 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
       id: number,
       options?: RawAxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<FeedItem>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.newsEventsRetrieve(id, options)
@@ -3625,7 +3912,7 @@ export const NewsEventsApiFactory = function (
     newsEventsList(
       requestParameters: NewsEventsApiNewsEventsListRequest = {},
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<void> {
+    ): AxiosPromise<PaginatedFeedItemList> {
       return localVarFp
         .newsEventsList(
           requestParameters.feed_type,
@@ -3644,7 +3931,7 @@ export const NewsEventsApiFactory = function (
     newsEventsRetrieve(
       requestParameters: NewsEventsApiNewsEventsRetrieveRequest,
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<void> {
+    ): AxiosPromise<FeedItem> {
       return localVarFp
         .newsEventsRetrieve(requestParameters.id, options)
         .then((request) => request(axios, basePath))

--- a/news_events/apps.py
+++ b/news_events/apps.py
@@ -5,3 +5,6 @@ from django.apps import AppConfig
 
 class ExternalFeedsConfig(AppConfig):
     name = "news_events"
+
+    def ready(self):
+        from news_events import schema  # noqa: F401

--- a/news_events/schema.py
+++ b/news_events/schema.py
@@ -1,0 +1,78 @@
+"""Extensions to drf-spectacular schema"""
+
+from drf_spectacular.extensions import (
+    OpenApiSerializerExtension,
+    OpenApiSerializerFieldExtension,
+)
+from drf_spectacular.plumbing import ResolvedComponent
+
+from news_events import constants, serializers
+
+
+class FeedItemTypeFieldConstant(OpenApiSerializerFieldExtension):
+    target_class = "news_events.serializers.FeedItemTypeField"
+
+    def map_serializer_field(self, auto_schema, direction):  # noqa: ARG002
+        return {
+            "type": "string",
+            "default": self.target.default,
+            "enum": [self.target.default],
+        }
+
+
+class FeedItemSerializerExtension(OpenApiSerializerExtension):
+    target_class = "news_events.serializers.FeedItemSerializer"
+
+    def _map_feed_item_base(self, auto_schema, direction):
+        # this will only be generated on return of map_serializer so mock it for now
+        return ResolvedComponent(
+            name=auto_schema._get_serializer_name(  # noqa: SLF001
+                self.target, direction
+            ),
+            type=ResolvedComponent.SCHEMA,
+            object=self.target,
+            schema=auto_schema._map_basic_serializer(  # noqa: SLF001
+                serializers.FeedItemBaseSerializer, direction
+            ),
+        )
+
+    def map_serializer(self, auto_schema, direction):
+        sub_serializers = serializers.FeedItemBaseSerializer.__subclasses__()
+
+        resolved_sub_serializers = [
+            (
+                sub().fields["feed_type"].default,
+                auto_schema.resolve_serializer(sub, direction).ref,
+            )
+            for sub in sub_serializers
+        ]
+
+        # manually register this enum with the schema
+        # it otherwise doesn't automatically get picked up
+        # because of how LearningResourceTypeFieldConstant works
+        resource_type_enum = ResolvedComponent(
+            name="ResourceTypeEnum",
+            object="ResourceTypeEnum",
+            type=ResolvedComponent.SCHEMA,
+            schema={
+                "enum": constants.FeedType.names(),
+                "type": "string",
+                "description": "\n".join(
+                    [
+                        f"* `{lr_type}` - {lr_type}"
+                        for lr_type in constants.FeedType.names()
+                    ]
+                ),
+            },
+        )
+        auto_schema.registry.register_on_missing(resource_type_enum)
+
+        return {
+            "oneOf": [ref for (_, ref) in resolved_sub_serializers],
+            "discriminator": {
+                "propertyName": "resource_type",
+                "mapping": {
+                    name: ref["$ref"] for (name, ref) in resolved_sub_serializers
+                },
+            },
+        }

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -302,7 +302,11 @@ paths:
       - news_events
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedFeedItemList'
+          description: ''
   /api/v0/news_events/{id}/:
     get:
       operationId: news_events_retrieve
@@ -318,7 +322,11 @@ paths:
       - news_events
       responses:
         '200':
-          description: No response body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedItem'
+          description: ''
   /api/v0/news_events_sources/:
     get:
       operationId: news_events_sources_list
@@ -1063,6 +1071,82 @@ components:
       - department
       type: string
       description: '* `department` - Department'
+    EventFeedItem:
+      type: object
+      description: Serializer for News FeedItem
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        feed_type:
+          allOf:
+          - $ref: '#/components/schemas/EventFeedItemFeedTypeEnum'
+          default: events
+          readOnly: true
+        image:
+          $ref: '#/components/schemas/FeedImage'
+        event_details:
+          $ref: '#/components/schemas/FeedEventDetail'
+        guid:
+          type: string
+          maxLength: 2048
+        title:
+          type: string
+          maxLength: 255
+        url:
+          type: string
+          format: uri
+          maxLength: 200
+        summary:
+          type: string
+        content:
+          type: string
+        source:
+          type: integer
+      required:
+      - event_details
+      - feed_type
+      - guid
+      - id
+      - image
+      - source
+      - title
+      - url
+    EventFeedItemFeedTypeEnum:
+      type: string
+      enum:
+      - events
+    FeedEventDetail:
+      type: object
+      description: FeedEventDetail serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        audience:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        location:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        event_type:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        event_datetime:
+          type: string
+          format: date-time
+      required:
+      - audience
+      - event_datetime
+      - event_type
+      - id
+      - location
     FeedImage:
       type: object
       description: Serializer for FeedImage
@@ -1081,6 +1165,38 @@ components:
           maxLength: 1024
       required:
       - id
+    FeedItem:
+      oneOf:
+      - $ref: '#/components/schemas/NewsFeedItem'
+      - $ref: '#/components/schemas/EventFeedItem'
+      discriminator:
+        propertyName: resource_type
+        mapping:
+          news: '#/components/schemas/NewsFeedItem'
+          events: '#/components/schemas/EventFeedItem'
+    FeedNewsDetail:
+      type: object
+      description: FeedNewsDetail serializer
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        authors:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        topics:
+          type: array
+          items:
+            type: string
+            maxLength: 255
+        publish_date:
+          type: string
+          format: date-time
+      required:
+      - id
+      - publish_date
     FeedSource:
       type: object
       description: FeedSource serializer
@@ -1100,14 +1216,14 @@ components:
         description:
           type: string
         feed_type:
-          $ref: '#/components/schemas/FeedTypeEnum'
+          $ref: '#/components/schemas/FeedSourceFeedTypeEnum'
       required:
       - feed_type
       - id
       - image
       - title
       - url
-    FeedTypeEnum:
+    FeedSourceFeedTypeEnum:
       enum:
       - news
       - events
@@ -1239,6 +1355,51 @@ components:
       required:
       - id
       - title
+    NewsFeedItem:
+      type: object
+      description: Serializer for News FeedItem
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        feed_type:
+          allOf:
+          - $ref: '#/components/schemas/NewsFeedItemFeedTypeEnum'
+          default: news
+          readOnly: true
+        image:
+          $ref: '#/components/schemas/FeedImage'
+        news_details:
+          $ref: '#/components/schemas/FeedNewsDetail'
+        guid:
+          type: string
+          maxLength: 2048
+        title:
+          type: string
+          maxLength: 255
+        url:
+          type: string
+          format: uri
+          maxLength: 200
+        summary:
+          type: string
+        content:
+          type: string
+        source:
+          type: integer
+      required:
+      - feed_type
+      - guid
+      - id
+      - image
+      - news_details
+      - source
+      - title
+      - url
+    NewsFeedItemFeedTypeEnum:
+      type: string
+      enum:
+      - news
     OfferorChannel:
       type: object
       description: Serializer for Channel model of type offeror
@@ -1369,6 +1530,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Attestation'
+    PaginatedFeedItemList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/FeedItem'
     PaginatedFeedSourceList:
       type: object
       required:
@@ -1849,6 +2033,14 @@ components:
       - program_title
       - record_hash
       - user_email
+    ResourceTypeEnum:
+      enum:
+      - news
+      - events
+      type: string
+      description: |-
+        * `news` - news
+        * `events` - events
     SiteTypeEnum:
       enum:
       - facebook


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4268

### Description (What does it do?)
Generates correct schema for news_events feed items

### Screenshots (if appropriate):

![Screenshot_16-5-2024_152711_localhost](https://github.com/mitodl/mit-open/assets/187676/af451109-9c71-4b33-ba07-9617eb9036a3)

### How can this be tested?
Go to http://localhost:8063/api/v0/schema/swagger-ui/#/news_events/news_events_list, you should see the response body schema as shown in the  screenshot above.
