### PR TITLE
Fix schema issue that was breaking redoc

### DIFF
--- a/channels/schema.py
+++ b/channels/schema.py
@@ -9,21 +9,65 @@ from drf_spectacular.plumbing import ResolvedComponent
 from channels import constants, serializers
 
 
+def _create_channel_type_enum_component(prefix, channel_types, auto_schema):
+    """
+    Create and register a channel type enum
+    """
+    # manually register this enum with the schema
+    # it otherwise doesn't automatically get picked up
+    # because of how ChannelTypeFieldConstant works
+    channel_type_enum = ResolvedComponent(
+        name=f"{prefix.capitalize()}ChannelTypeEnum",
+        object=f"{prefix.capitalize()}ChannelTypeEnum",
+        type=ResolvedComponent.SCHEMA,
+        schema={
+            "enum": [name for name, _ in channel_types],
+            "type": "string",
+            "description": "\n".join(
+                [f"* `{name}` - {value}" for name, value in channel_types]
+            ),
+        },
+    )
+    auto_schema.registry.register_on_missing(channel_type_enum)
+
+    return channel_type_enum
+
+
 class ChannelTypeChoiceFieldExtension(OpenApiSerializerFieldExtension):
     target_class = "channels.serializers.ChannelTypeChoiceField"
+    priority = 100
 
     def map_serializer_field(self, auto_schema, direction):  # noqa: ARG002
-        return {"allOf": [{"$ref": "ChannelTypeEnum"}]}
+        channel_type_enum = _create_channel_type_enum_component(
+            "", constants.ChannelType.as_tuple(), auto_schema
+        )
+
+        return {
+            "type": "string",
+            "allOf": [channel_type_enum.ref],
+        }
 
 
 class ChannelTypeConstantFieldExtension(OpenApiSerializerFieldExtension):
     target_class = "channels.serializers.ChannelTypeConstantField"
+    priority = 100
 
     def map_serializer_field(self, auto_schema, direction):  # noqa: ARG002
+        channel_type = self.target.default
+        channel_type_enum = _create_channel_type_enum_component(
+            channel_type,
+            [
+                (name, value)
+                for name, value in constants.ChannelType.as_tuple()
+                if name == channel_type
+            ],
+            auto_schema,
+        )
+
         return {
             "type": "string",
             "default": self.target.default,
-            "enum": [self.target.default],
+            "allOf": [channel_type_enum.ref],
         }
 
 
@@ -53,26 +97,6 @@ class FieldChannelSerializerExtension(OpenApiSerializerExtension):
             )
             for sub in sub_serializers
         ]
-
-        # manually register this enum with the schema
-        # it otherwise doesn't automatically get picked up
-        # because of how ChannelTypeFieldConstant works
-        channel_type_enum = ResolvedComponent(
-            name="ChannelTypeEnum",
-            object="ChannelTypeEnum",
-            type=ResolvedComponent.SCHEMA,
-            schema={
-                "enum": constants.ChannelType.names(),
-                "type": "string",
-                "description": "\n".join(
-                    [
-                        f"* `{channel_type}` - {channel_type}"
-                        for channel_type in constants.ChannelType.names()
-                    ]
-                ),
-            },
-        )
-        auto_schema.registry.register_on_missing(channel_type_enum)
 
         return {
             "oneOf": [ref for (_, ref) in resolved_sub_serializers],

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -210,7 +210,7 @@ export interface ChannelTopicDetailRequest {
   topic?: number | null
 }
 /**
- * * `topic` - topic * `department` - department * `offeror` - offeror * `pathway` - pathway
+ * * `topic` - Topic * `department` - Department * `offeror` - Offeror * `pathway` - Pathway
  * @export
  * @enum {string}
  */
@@ -293,10 +293,10 @@ export interface DepartmentChannel {
   subfields: Array<Subfield>
   /**
    *
-   * @type {DepartmentChannelChannelTypeEnum}
+   * @type {DepartmentChannelTypeEnum}
    * @memberof DepartmentChannel
    */
-  channel_type: DepartmentChannelChannelTypeEnum
+  channel_type: DepartmentChannelTypeEnum
   /**
    *
    * @type {ChannelDepartmentDetail}
@@ -366,19 +366,6 @@ export interface DepartmentChannel {
 }
 
 /**
- *
- * @export
- * @enum {string}
- */
-
-export const DepartmentChannelChannelTypeEnum = {
-  Department: "department",
-} as const
-
-export type DepartmentChannelChannelTypeEnum =
-  (typeof DepartmentChannelChannelTypeEnum)[keyof typeof DepartmentChannelChannelTypeEnum]
-
-/**
  * Learning path featured in this field.
  * @export
  * @interface DepartmentChannelFeaturedList
@@ -403,6 +390,19 @@ export interface DepartmentChannelFeaturedList {
    */
   id: number
 }
+/**
+ * * `department` - Department
+ * @export
+ * @enum {string}
+ */
+
+export const DepartmentChannelTypeEnum = {
+  Department: "department",
+} as const
+
+export type DepartmentChannelTypeEnum =
+  (typeof DepartmentChannelTypeEnum)[keyof typeof DepartmentChannelTypeEnum]
+
 /**
  * Serializer for FeedImage
  * @export
@@ -736,10 +736,10 @@ export interface OfferorChannel {
   subfields: Array<Subfield>
   /**
    *
-   * @type {OfferorChannelChannelTypeEnum}
+   * @type {OfferorChannelTypeEnum}
    * @memberof OfferorChannel
    */
-  channel_type: OfferorChannelChannelTypeEnum
+  channel_type: OfferorChannelTypeEnum
   /**
    *
    * @type {ChannelOfferorDetail}
@@ -809,17 +809,17 @@ export interface OfferorChannel {
 }
 
 /**
- *
+ * * `offeror` - Offeror
  * @export
  * @enum {string}
  */
 
-export const OfferorChannelChannelTypeEnum = {
+export const OfferorChannelTypeEnum = {
   Offeror: "offeror",
 } as const
 
-export type OfferorChannelChannelTypeEnum =
-  (typeof OfferorChannelChannelTypeEnum)[keyof typeof OfferorChannelChannelTypeEnum]
+export type OfferorChannelTypeEnum =
+  (typeof OfferorChannelTypeEnum)[keyof typeof OfferorChannelTypeEnum]
 
 /**
  *
@@ -1191,10 +1191,10 @@ export interface PathwayChannel {
   subfields: Array<Subfield>
   /**
    *
-   * @type {PathwayChannelChannelTypeEnum}
+   * @type {PathwayChannelTypeEnum}
    * @memberof PathwayChannel
    */
-  channel_type: PathwayChannelChannelTypeEnum
+  channel_type: PathwayChannelTypeEnum
   /**
    *
    * @type {string}
@@ -1258,17 +1258,17 @@ export interface PathwayChannel {
 }
 
 /**
- *
+ * * `pathway` - Pathway
  * @export
  * @enum {string}
  */
 
-export const PathwayChannelChannelTypeEnum = {
+export const PathwayChannelTypeEnum = {
   Pathway: "pathway",
 } as const
 
-export type PathwayChannelChannelTypeEnum =
-  (typeof PathwayChannelChannelTypeEnum)[keyof typeof PathwayChannelChannelTypeEnum]
+export type PathwayChannelTypeEnum =
+  (typeof PathwayChannelTypeEnum)[keyof typeof PathwayChannelTypeEnum]
 
 /**
  * Serializer for Profile
@@ -1675,10 +1675,10 @@ export interface TopicChannel {
   subfields: Array<Subfield>
   /**
    *
-   * @type {TopicChannelChannelTypeEnum}
+   * @type {TopicChannelTypeEnum}
    * @memberof TopicChannel
    */
-  channel_type: TopicChannelChannelTypeEnum
+  channel_type: TopicChannelTypeEnum
   /**
    *
    * @type {ChannelTopicDetail}
@@ -1748,17 +1748,17 @@ export interface TopicChannel {
 }
 
 /**
- *
+ * * `topic` - Topic
  * @export
  * @enum {string}
  */
 
-export const TopicChannelChannelTypeEnum = {
+export const TopicChannelTypeEnum = {
   Topic: "topic",
 } as const
 
-export type TopicChannelChannelTypeEnum =
-  (typeof TopicChannelChannelTypeEnum)[keyof typeof TopicChannelChannelTypeEnum]
+export type TopicChannelTypeEnum =
+  (typeof TopicChannelTypeEnum)[keyof typeof TopicChannelTypeEnum]
 
 /**
  * Serializer for User

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -952,10 +952,10 @@ components:
       - pathway
       type: string
       description: |-
-        * `topic` - topic
-        * `department` - department
-        * `offeror` - offeror
-        * `pathway` - pathway
+        * `topic` - Topic
+        * `department` - Department
+        * `offeror` - Offeror
+        * `pathway` - Pathway
     DepartmentChannel:
       type: object
       description: Serializer for Channel model of type department
@@ -1006,9 +1006,10 @@ components:
             $ref: '#/components/schemas/Subfield'
           readOnly: true
         channel_type:
-          allOf:
-          - $ref: '#/components/schemas/DepartmentChannelChannelTypeEnum'
+          type: string
           default: department
+          allOf:
+          - $ref: '#/components/schemas/DepartmentChannelTypeEnum'
           readOnly: true
         department_detail:
           $ref: '#/components/schemas/ChannelDepartmentDetail'
@@ -1057,10 +1058,11 @@ components:
       - subfields
       - title
       - updated_on
-    DepartmentChannelChannelTypeEnum:
-      type: string
+    DepartmentChannelTypeEnum:
       enum:
       - department
+      type: string
+      description: '* `department` - Department'
     FeedImage:
       type: object
       description: Serializer for FeedImage
@@ -1169,7 +1171,9 @@ components:
         about:
           nullable: true
         channel_type:
-          $ref: ChannelTypeEnum
+          type: string
+          allOf:
+          - $ref: '#/components/schemas/ChannelTypeEnum'
         search_filter:
           type: string
           maxLength: 2048
@@ -1285,9 +1289,10 @@ components:
             $ref: '#/components/schemas/Subfield'
           readOnly: true
         channel_type:
-          allOf:
-          - $ref: '#/components/schemas/OfferorChannelChannelTypeEnum'
+          type: string
           default: offeror
+          allOf:
+          - $ref: '#/components/schemas/OfferorChannelTypeEnum'
           readOnly: true
         offeror_detail:
           $ref: '#/components/schemas/ChannelOfferorDetail'
@@ -1336,10 +1341,11 @@ components:
       - subfields
       - title
       - updated_on
-    OfferorChannelChannelTypeEnum:
-      type: string
+    OfferorChannelTypeEnum:
       enum:
       - offeror
+      type: string
+      description: '* `offeror` - Offeror'
     PaginatedAttestationList:
       type: object
       required:
@@ -1450,7 +1456,9 @@ components:
         about:
           nullable: true
         channel_type:
-          $ref: ChannelTypeEnum
+          type: string
+          allOf:
+          - $ref: '#/components/schemas/ChannelTypeEnum'
         search_filter:
           type: string
           maxLength: 2048
@@ -1587,9 +1595,10 @@ components:
             $ref: '#/components/schemas/Subfield'
           readOnly: true
         channel_type:
-          allOf:
-          - $ref: '#/components/schemas/PathwayChannelChannelTypeEnum'
+          type: string
           default: pathway
+          allOf:
+          - $ref: '#/components/schemas/PathwayChannelTypeEnum'
           readOnly: true
         created_on:
           type: string
@@ -1635,10 +1644,11 @@ components:
       - subfields
       - title
       - updated_on
-    PathwayChannelChannelTypeEnum:
-      type: string
+    PathwayChannelTypeEnum:
       enum:
       - pathway
+      type: string
+      description: '* `pathway` - Pathway'
     Profile:
       type: object
       description: Serializer for Profile
@@ -1918,9 +1928,10 @@ components:
             $ref: '#/components/schemas/Subfield'
           readOnly: true
         channel_type:
-          allOf:
-          - $ref: '#/components/schemas/TopicChannelChannelTypeEnum'
+          type: string
           default: topic
+          allOf:
+          - $ref: '#/components/schemas/TopicChannelTypeEnum'
           readOnly: true
         topic_detail:
           $ref: '#/components/schemas/ChannelTopicDetail'
@@ -1969,10 +1980,11 @@ components:
       - title
       - topic_detail
       - updated_on
-    TopicChannelChannelTypeEnum:
-      type: string
+    TopicChannelTypeEnum:
       enum:
       - topic
+      type: string
+      description: '* `topic` - Topic'
     User:
       type: object
       description: Serializer for User


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This resolves an error that was causing Redoc to fail to load. Specifically the `$ref` in the `channel_type` field wasn't correct (`ChannelType` instead of `#/components/schema/ChannelType)

### How can this be tested?

Run `docker compose up` and go to redoc: http://open.odl.local:8063/api/v0/schema/redoc/

The page should load without error.
