### PR TITLE
workflow changes to publish static assets to s3

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -19,6 +19,32 @@ jobs:
         with:
           ref: release
 
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "^20"
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Setup environment
+        run: sudo apt-get install libelf1
+
+      - name: Install frontend dependencies
+        run: yarn install --immutable
+
+      - name: Build frontend
+        run: NODE_ENV=production yarn build
+
+      - name: Upload frontend build to s3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ol-mitopen-app-storage-production
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
+          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --acl public-read --follow-symlinks
         env:
           AWS_S3_BUCKET: ol-mitopen-app-storage-production
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -40,10 +40,10 @@ jobs:
           args: --acl public-read --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ol-mitopen-app-storage-production
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
-          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
+          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
+          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,8 +42,8 @@ jobs:
           AWS_S3_BUCKET: ol-mitopen-app-storage-production
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
-          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
-          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
+          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -42,8 +42,8 @@ jobs:
           AWS_S3_BUCKET: ol-mitopen-app-storage-production
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
-          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
+          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --acl public-read --follow-symlinks
         env:
           AWS_S3_BUCKET: ol-mitopen-app-storage-rc
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RC }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -42,8 +42,8 @@ jobs:
           AWS_S3_BUCKET: ol-mitopen-app-storage-rc
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
-          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
+          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -40,10 +40,10 @@ jobs:
           args: --acl public-read --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ol-mitopen-app-storage-rc
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
-          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RC }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RC }}
+          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
+          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -42,8 +42,8 @@ jobs:
           AWS_S3_BUCKET: ol-mitopen-app-storage-rc
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RC }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RC }}
-          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
-          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+          SOURCE_DIR: "frontends/mit-open/build" # optional: defaults to entire repository
+          DEST_DIR: "frontend" # This dir will get cluttered but it is okay for now
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -19,6 +19,32 @@ jobs:
         with:
           ref: release-candidate
 
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+        with:
+          node-version: "^20"
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Setup environment
+        run: sudo apt-get install libelf1
+
+      - name: Install frontend dependencies
+        run: yarn install --immutable
+
+      - name: Build frontend
+        run: NODE_ENV=production yarn build
+
+      - name: Upload frontend build to s3
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ol-mitopen-app-storage-rc
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SOURCE_DIR: 'frontends/mit-open/build'      # optional: defaults to entire repository
+          DEST_DIR: 'frontend'  # This dir will get cluttered but it is okay for now
+
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
### What are the relevant tickets?
#629 

Goes with https://github.com/mitodl/ol-infrastructure/pull/2433

### Description (What does it do?)
Added workflow steps to build the frontend and publish it to s3 when a merge to `release-canidate` or `release` takes place.

Requires four new secrets in the repo: 
`AWS_ACCESS_KEY_ID_PROD`
`AWS_SECRET_ACCESS_KEY_PROD`
`AWS_ACCESS_KEY_ID_RC`
`AWS_SECRET_ACCESS_KEY_RC`

These new secrets are populated into this repo automatically by the link ol-inf PR. 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Run the new worflow and verify that files are published into s3. I've tested the gh -> s3 actions in my fork of the repo successfully. 
