### PR TITLE
Fix several ETL bugs

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -150,9 +150,9 @@ def _transform_run(course_run: dict, course: dict) -> dict:
             {"full_name": instructor["name"]}
             for instructor in parse_page_attribute(course, "instructors", is_list=True)
         ],
-        "availability": AvailabilityType.current.name
+        "availability": AvailabilityType.current.value
         if parse_page_attribute(course, "page_url")
-        else AvailabilityType.archived.name,
+        else AvailabilityType.archived.value,
     }
 
 
@@ -166,6 +166,7 @@ def _transform_course(course):
     Returns:
         dict: normalized course data
     """  # noqa: D401
+    runs = [_transform_run(course_run, course) for course_run in course["courseruns"]]
     return {
         "readable_id": course["readable_id"],
         "platform": PlatformType.mitxonline.name,
@@ -175,9 +176,7 @@ def _transform_course(course):
         "offered_by": copy.deepcopy(OFFERED_BY),
         "topics": transform_topics(course.get("topics", [])),
         "departments": extract_valid_department_from_id(course["readable_id"]),
-        "runs": [
-            _transform_run(course_run, course) for course_run in course["courseruns"]
-        ],
+        "runs": runs,
         "course": {
             "course_numbers": generate_course_numbers_json(
                 course["readable_id"], is_ocw=False
@@ -187,7 +186,7 @@ def _transform_course(course):
             parse_page_attribute(course, "page_url")
         ),  # a course is only considered published if it has a page url
         "professional": False,
-        "certification": parse_certification(OFFERED_BY, course.get("courseruns", [])),
+        "certification": parse_certification(OFFERED_BY["code"], runs),
         "image": _transform_image(course),
         "url": parse_page_attribute(course, "page_url", is_url=True),
         "description": parse_page_attribute(course, "description"),
@@ -251,9 +250,9 @@ def transform_programs(programs):
                     "image": _transform_image(program),
                     "description": parse_page_attribute(program, "description"),
                     "prices": parse_program_prices(program),
-                    "availability": AvailabilityType.current.name
+                    "availability": AvailabilityType.current.value
                     if parse_page_attribute(program, "page_url")
-                    else AvailabilityType.archived.name,
+                    else AvailabilityType.archived.value,
                 }
             ],
             "courses": [

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -150,6 +150,9 @@ def _transform_run(course_run: dict, course: dict) -> dict:
             {"full_name": instructor["name"]}
             for instructor in parse_page_attribute(course, "instructors", is_list=True)
         ],
+        "availability": AvailabilityType.current.name
+        if parse_page_attribute(course, "page_url")
+        else AvailabilityType.archived.name,
     }
 
 

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -214,6 +214,9 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                                     course_run_data, "instructors", is_list=True
                                 )
                             ],
+                            "availability": AvailabilityType.current.name
+                            if parse_page_attribute(course_data, "page_url")
+                            else AvailabilityType.archived.name,
                         }
                         for course_run_data in course_data["courseruns"]
                     ],
@@ -307,6 +310,9 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                             course_run_data, "instructors", is_list=True
                         )
                     ],
+                    "availability": AvailabilityType.current.name
+                    if parse_page_attribute(course_data, "page_url")
+                    else AvailabilityType.archived.name,
                 }
                 for course_run_data in course_data["courseruns"]
             ],

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -20,6 +20,7 @@ from learning_resources.etl.mitxonline import (
     OFFERED_BY,
     _parse_datetime,
     _transform_image,
+    _transform_run,
     extract_courses,
     extract_programs,
     parse_page_attribute,
@@ -149,9 +150,9 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                     "title": program_data["title"],
                     "description": program_data.get("description", None),
                     "url": parse_page_attribute(program_data, "page_url", is_url=True),
-                    "availability": AvailabilityType.current.name
+                    "availability": AvailabilityType.current.value
                     if parse_page_attribute(program_data, "page_url")
-                    else AvailabilityType.archived.name,
+                    else AvailabilityType.archived.value,
                 }
             ],
             "courses": [
@@ -171,9 +172,7 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                     "published": bool(
                         course_data.get("page", {}).get("page_url", None)
                     ),
-                    "certification": parse_certification(
-                        OFFERED_BY, course_data["courseruns"]
-                    ),
+                    "certification": True,
                     "url": parse_page_attribute(course_data, "page_url", is_url=True),
                     "topics": [
                         {"name": topic_name}
@@ -214,9 +213,9 @@ def test_mitxonline_transform_programs(mock_mitxonline_programs_data):
                                     course_run_data, "instructors", is_list=True
                                 )
                             ],
-                            "availability": AvailabilityType.current.name
+                            "availability": AvailabilityType.current.value
                             if parse_page_attribute(course_data, "page_url")
-                            else AvailabilityType.archived.name,
+                            else AvailabilityType.archived.value,
                         }
                         for course_run_data in course_data["courseruns"]
                     ],
@@ -257,7 +256,13 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
             "offered_by": OFFERED_BY,
             "published": course_data.get("page", {}).get("page_url", None) is not None,
             "professional": False,
-            "certification": parse_certification(OFFERED_BY, course_data["courseruns"]),
+            "certification": parse_certification(
+                "mitx",
+                [
+                    _transform_run(course_run, course_data)
+                    for course_run in course_data["courseruns"]
+                ],
+            ),
             "topics": [
                 {"name": topic_name}
                 for topic_name in chain.from_iterable(
@@ -310,9 +315,9 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                             course_run_data, "instructors", is_list=True
                         )
                     ],
-                    "availability": AvailabilityType.current.name
+                    "availability": AvailabilityType.current.value
                     if parse_page_attribute(course_data, "page_url")
-                    else AvailabilityType.archived.name,
+                    else AvailabilityType.archived.value,
                 }
                 for course_run_data in course_data["courseruns"]
             ],

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -72,26 +72,32 @@ oll_etl = compose(
 
 
 prolearn_programs_etl = compose(
-    load_programs(ETLSource.prolearn.name),
+    load_programs(
+        ETLSource.prolearn.name,
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+    ),
     prolearn.transform_programs,
     prolearn.extract_programs,
 )
 
 
 prolearn_courses_etl = compose(
-    load_courses(ETLSource.prolearn.name),
+    load_courses(ETLSource.prolearn.name, config=CourseLoaderConfig(prune=True)),
     prolearn.transform_courses,
     prolearn.extract_courses,
 )
 
 
 xpro_programs_etl = compose(
-    load_programs(ETLSource.xpro.name),
+    load_programs(
+        ETLSource.xpro.name,
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+    ),
     xpro.transform_programs,
     xpro.extract_programs,
 )
 xpro_courses_etl = compose(
-    load_courses(ETLSource.xpro.name),
+    load_courses(ETLSource.xpro.name, config=CourseLoaderConfig(prune=True)),
     xpro.transform_courses,
     xpro.extract_courses,
 )

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -144,7 +144,9 @@ def test_xpro_programs_etl():
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
     mock_load_programs.assert_called_once_with(
-        ETLSource.xpro.name, mock_transform.return_value
+        ETLSource.xpro.name,
+        mock_transform.return_value,
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
     )
 
     assert result == mock_load_programs.return_value
@@ -165,6 +167,7 @@ def test_xpro_courses_etl():
     mock_load_courses.assert_called_once_with(
         ETLSource.xpro.name,
         mock_transform.return_value,
+        config=CourseLoaderConfig(prune=True),
     )
 
     assert result == mock_load_courses.return_value
@@ -310,7 +313,9 @@ def test_prolearn_programs_etl():
     mock_extract.assert_called_once_with()
     mock_transform.assert_called_once_with(mock_extract.return_value)
     mock_load_programs.assert_called_once_with(
-        ETLSource.prolearn.name, mock_transform.return_value
+        ETLSource.prolearn.name,
+        mock_transform.return_value,
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
     )
 
     assert result == mock_load_programs.return_value
@@ -331,6 +336,7 @@ def test_prolearn_courses_etl():
     mock_load_courses.assert_called_once_with(
         ETLSource.prolearn.name,
         mock_transform.return_value,
+        config=CourseLoaderConfig(prune=True),
     )
 
     assert result == mock_load_courses.return_value


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4300
Closes https://github.com/mitodl/hq/issues/4299

### Description (What does it do?)
Sets `prune=true` on xpro and prolearn courses so old courses that are no longer returned by the API are set to unpublished.
Populates the "availability" attribute on mitxonline course runs 

### How can this be tested?
Prolearn/xpro fix:
```
from learning_resources.factories import LearningResourceFactory
from learning_resources.models import LearningResource
from learning_resources.etl.pipelines import *

# Create a fake prolearn course (or xpro course)
pl = LearningResourceFactory.create(resource_type="course", etl_source="prolearn", published=True)
print(pl.published)

# Run the ETL pipeline
prolearn_courses_etl()

# Refresh the fake course and check that it is now unpublished
pl.refresh_from_db()
print(pl.published)
```

MITx Online fix:
- Run `./manage.py backpopulate_mitxonline_data`
- Check this URL and make sure that most/all mitxonline courses are returned:
http://localhost:8063/api/v1/courses/?platform=mitxonline&certification=true
