### PR TITLE
Fixes button styles to match design

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -106,8 +106,8 @@ const TopicBoxName = styled.p`
 
 const SeeAllButton = styled(Button)`
   margin: 0 auto;
-  width: 152px;
   box-sizing: content-box;
+  display: block;
 `
 
 const BrowseTopicsSection: React.FC = () => {
@@ -133,7 +133,9 @@ const BrowseTopicsSection: React.FC = () => {
             },
           )}
         </Topics>
-        <SeeAllButton edge="rounded">See all (coming soon)</SeeAllButton>
+        <SeeAllButton edge="rounded" size="large">
+          See all (coming soon)
+        </SeeAllButton>
       </Container>
     </Section>
   )

--- a/frontends/ol-components/src/components/ThemeProvider/typography.ts
+++ b/frontends/ol-components/src/components/ThemeProvider/typography.ts
@@ -141,6 +141,7 @@ const globalSettings: ThemeOptions["typography"] = {
     fontStyle: "normal",
     fontSize: pxToRem(14),
     lineHeight: pxToRem(14),
+    textTransform: "none",
   },
   buttonSmall: {
     fontFamily: "neue-haas-grotesk-text, sans-serif",


### PR DESCRIPTION
### What are the relevant tickets?

Relates to [Homepage: "Browse by Topics" #4185](https://github.com/mitodl/hq/issues/4185)

"See all" button styles are awry in Release Candidate https://github.com/mitodl/mit-open/pull/940:

Current:

<img width="319" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/42e14cb2-749c-4786-aef2-52e87f2dcd51">

With fix:

<img width="433" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/d7490728-a9fa-42d2-a84b-8b8b0f824088">
