### PR TITLE
fix install and storybook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        yarn install
+        yarn install --immutable
         yarn workspace mit-open storybook & yarn workspace mit-open watch:docker
     environment:
       NODE_ENV: ${NODE_ENV:-development}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,11 @@ services:
       - frontend
     working_dir: /src
     image: node:20.13
-    command: >
-      /bin/sh -c 'yarn install && yarn storybook & yarn workspace mit-open watch:docker'
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        yarn install
+        yarn workspace mit-open storybook & yarn workspace mit-open watch:docker
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 8062

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,8 @@ services:
     command:
       - |
         yarn install --immutable
-        yarn workspace mit-open storybook & yarn workspace mit-open watch:docker
+        yarn workspace mit-open storybook &
+        yarn workspace mit-open watch:docker
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 8062


### PR DESCRIPTION
### What are the relevant tickets?
Followup to https://github.com/mitodl/mit-open/pull/936

### Description (What does it do?)
Fixes the storybook startup command.

### How can this be tested?
1. `rm -rf node_modules`
2. `docker compose up` with `COMPOSE_PROFILES=backend,frontend` in your env file.
3. Check http://localhost:8063/ (frontend) and http://localhost:6006 (storybook). They should be visible.