### PR TITLE
Filtering by free=true should exclude all professional courses

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -537,6 +537,12 @@ export interface CourseResource {
    */
   learning_format: Array<CourseResourceLearningFormatInner>
   /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof CourseResource
+   */
+  free: boolean
+  /**
    *
    * @type {CourseResourceResourceTypeEnum}
    * @memberof CourseResource
@@ -954,6 +960,12 @@ export interface LearningPathResource {
    * @memberof LearningPathResource
    */
   learning_format: Array<CourseResourceLearningFormatInner>
+  /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof LearningPathResource
+   */
+  free: boolean
   /**
    *
    * @type {LearningPathResourceResourceTypeEnum}
@@ -3240,6 +3252,12 @@ export interface PodcastEpisodeResource {
    */
   learning_format: Array<CourseResourceLearningFormatInner>
   /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof PodcastEpisodeResource
+   */
+  free: boolean
+  /**
    *
    * @type {PodcastEpisodeResourceResourceTypeEnum}
    * @memberof PodcastEpisodeResource
@@ -3508,6 +3526,12 @@ export interface PodcastResource {
    * @memberof PodcastResource
    */
   learning_format: Array<CourseResourceLearningFormatInner>
+  /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof PodcastResource
+   */
+  free: boolean
   /**
    *
    * @type {PodcastResourceResourceTypeEnum}
@@ -4004,6 +4028,12 @@ export interface ProgramResource {
    * @memberof ProgramResource
    */
   learning_format: Array<CourseResourceLearningFormatInner>
+  /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof ProgramResource
+   */
+  free: boolean
   /**
    *
    * @type {ProgramResourceResourceTypeEnum}
@@ -4560,6 +4590,12 @@ export interface VideoPlaylistResource {
    */
   learning_format: Array<CourseResourceLearningFormatInner>
   /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof VideoPlaylistResource
+   */
+  free: boolean
+  /**
    *
    * @type {VideoPlaylistResourceResourceTypeEnum}
    * @memberof VideoPlaylistResource
@@ -4822,6 +4858,12 @@ export interface VideoResource {
    * @memberof VideoResource
    */
   learning_format: Array<CourseResourceLearningFormatInner>
+  /**
+   * Return true if the resource is free/has a free option
+   * @type {boolean}
+   * @memberof VideoResource
+   */
+  free: boolean
   /**
    *
    * @type {VideoResourceResourceTypeEnum}

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -114,7 +114,7 @@ class LearningResourceFilter(FilterSet):
             | Q(runs__prices__isnull=True)
             | Q(runs__prices=[])
             | Q(runs__prices__contains=[Decimal(0.00)])
-        )
+        ) & Q(professional=False)
         if value:
             # Free resources
             return queryset.filter(free_filter)

--- a/learning_resources/filters_test.py
+++ b/learning_resources/filters_test.py
@@ -200,7 +200,9 @@ def test_learning_resource_filter_certification(offers_certification, client):
 def test_learning_resource_filter_free(client):
     """Test that the free filter works"""
 
-    free_course = LearningResourceFactory.create(is_course=True, runs=[])
+    free_course = LearningResourceFactory.create(
+        is_course=True, runs=[], professional=False
+    )
     LearningResourceRunFactory.create(learning_resource=free_course, prices=[0.00])
 
     paid_course = LearningResourceFactory.create(is_course=True, runs=[])
@@ -208,13 +210,20 @@ def test_learning_resource_filter_free(client):
         learning_resource=paid_course, prices=[50.00, 100.00]
     )
 
-    free2pay_course = LearningResourceFactory(is_course=True, runs=[])
+    free2pay_course = LearningResourceFactory(
+        is_course=True, runs=[], professional=False
+    )
     LearningResourceRunFactory.create(
         learning_resource=free2pay_course, prices=[0.00, 100.00]
     )
 
+    priceless_pro_course = LearningResourceFactory(
+        is_course=True, runs=[], professional=True
+    )
+    LearningResourceRunFactory.create(learning_resource=priceless_pro_course, prices=[])
+
     always_free_podcast_episode = LearningResourceFactory.create(
-        is_podcast_episode=True
+        is_podcast_episode=True, professional=False
     )
 
     results = client.get(f"{RESOURCE_API_URL}?free=true").json()["results"]
@@ -222,8 +231,9 @@ def test_learning_resource_filter_free(client):
     for resource in [free_course, free2pay_course, always_free_podcast_episode]:
         assert resource.id in [result["id"] for result in results]
     results = client.get(f"{RESOURCE_API_URL}?free=false").json()["results"]
-    assert len(results) == 1
-    assert results[0]["id"] == paid_course.id
+    assert len(results) == 2
+    for resource in [paid_course, priceless_pro_course]:
+        assert resource.id in [result["id"] for result in results]
 
 
 @pytest.mark.parametrize(

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -191,7 +191,6 @@ def test_learning_resource_serializer(  # noqa: PLR0913
 
     assert result == {
         "id": resource.id,
-        "certification": resource.certification,
         "title": resource.title,
         "description": resource.description,
         "full_description": resource.full_description,
@@ -206,6 +205,12 @@ def test_learning_resource_serializer(  # noqa: PLR0913
         ).data,
         "prices": resource.prices,
         "professional": resource.professional,
+        "certification": resource.certification,
+        "free": (
+            not resource.professional
+            and detail_key
+            not in (LearningResourceType.course.name, LearningResourceType.program.name)
+        ),
         "published": resource.published,
         "readable_id": resource.readable_id,
         "course_feature": sorted([tag.name for tag in resource.content_tags.all()]),

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -66,7 +66,7 @@ def offeror_featured_lists():
                 offered_by=offeror,
                 is_course=True,
                 certification=bool(random.getrandbits(1)),
-                professional=bool(random.getrandbits(1)),
+                professional=offeror.professional,
             )
             if offered_by == OfferedBy.ocw.name:
                 LearningResourceRun.objects.filter(

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1428,7 +1428,6 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                 "course.course_numbers.sort_coursenum",
                 "course.course_numbers.primary",
                 "resource_relations",
-                "free",
             ]
         },
     }
@@ -1631,7 +1630,6 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                 "course.course_numbers.sort_coursenum",
                 "course.course_numbers.primary",
                 "resource_relations",
-                "free",
             ]
         },
     }

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -360,5 +360,4 @@ SOURCE_EXCLUDED_FIELDS = [
     "course.course_numbers.sort_coursenum",
     "course.course_numbers.primary",
     "resource_relations",
-    "free",
 ]

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -2,7 +2,6 @@
 
 import logging
 from collections import defaultdict
-from decimal import Decimal
 from typing import TypedDict
 
 from django.conf import settings
@@ -63,16 +62,6 @@ def serialize_learning_resource_for_update(
     serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
     # Note: this is an ES-specific field that is filtered out on retrieval
     #       see SOURCE_EXCLUDED_FIELDS in learning_resources_search/constants.py
-    if learning_resource_obj.resource_type in [
-        LearningResourceType.course.name,
-        LearningResourceType.program.name,
-    ]:
-        prices = learning_resource_obj.prices
-        serialized_data["free"] = not learning_resource_obj.professional and (
-            Decimal(0.00) in prices or not prices or prices == []
-        )
-    else:
-        serialized_data["free"] = True
     if learning_resource_obj.resource_type == LearningResourceType.course.name:
         serialized_data["course"]["course_numbers"] = [
             SearchCourseNumberSerializer(instance=num).data

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -68,7 +68,9 @@ def serialize_learning_resource_for_update(
         LearningResourceType.program.name,
     ]:
         prices = learning_resource_obj.prices
-        serialized_data["free"] = Decimal(0.00) in prices or not prices or prices == []
+        serialized_data["free"] = not learning_resource_obj.professional and (
+            Decimal(0.00) in prices or not prices or prices == []
+        )
     else:
         serialized_data["free"] = True
     if learning_resource_obj.resource_type == LearningResourceType.course.name:

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -1,5 +1,6 @@
 """Tests for opensearch serializers"""
 
+from decimal import Decimal
 from types import SimpleNamespace
 
 import factory
@@ -14,6 +15,7 @@ from rest_framework.test import APIRequestFactory
 from learning_resources import factories
 from learning_resources.constants import DEPARTMENTS, LearningResourceType
 from learning_resources.etl.constants import CourseNumberType
+from learning_resources.factories import LearningResourceRunFactory
 from learning_resources.models import LearningResource
 from learning_resources.serializers import LearningResourceSerializer
 from learning_resources_search import serializers
@@ -66,15 +68,23 @@ def test_serialize_bulk_learning_resources(mocker):
     "resource_type",
     set(LearningResourceType.names()) - {LearningResourceType.course.name},
 )
-def test_serialize_learning_resource_for_bulk(resource_type):
+@pytest.mark.parametrize("is_professional", [True, False])
+@pytest.mark.parametrize("no_price", [True, False])
+def test_serialize_learning_resource_for_bulk(resource_type, is_professional, no_price):
     """
     Test that serialize_program_for_bulk yields a valid LearningResourceSerializer for resource types other than "course"
     The "course" resource type is tested by `test_serialize_course_numbers_for_bulk` below.
     """
-    resource = factories.LearningResourceFactory.create(resource_type=resource_type)
+    resource = factories.LearningResourceFactory.create(
+        resource_type=resource_type, professional=is_professional, runs=[]
+    )
+    LearningResourceRunFactory.create(
+        learning_resource=resource, prices=[Decimal(0.00 if no_price else 1.00)]
+    )
     free_dict = {
         "free": resource_type
         not in [LearningResourceType.program.name, LearningResourceType.course.name]
+        or (no_price and not is_professional)
     }
     assert serializers.serialize_learning_resource_for_bulk(resource) == {
         "_id": resource.id,

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -6927,6 +6927,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/CourseResourceResourceTypeEnum'
@@ -6977,6 +6981,7 @@ components:
       - course
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -7270,6 +7275,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/LearningPathResourceResourceTypeEnum'
@@ -7318,6 +7327,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -9051,6 +9061,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/PodcastEpisodeResourceResourceTypeEnum'
@@ -9100,6 +9114,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -9275,6 +9290,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/PodcastResourceResourceTypeEnum'
@@ -9324,6 +9343,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -9641,6 +9661,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/ProgramResourceResourceTypeEnum'
@@ -9690,6 +9714,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -10066,6 +10091,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/VideoPlaylistResourceResourceTypeEnum'
@@ -10115,6 +10144,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format
@@ -10280,6 +10310,10 @@ components:
             - code
             - name
           readOnly: true
+        free:
+          type: boolean
+          description: Return true if the resource is free/has a free option
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/VideoResourceResourceTypeEnum'
@@ -10329,6 +10363,7 @@ components:
       - certification
       - course_feature
       - departments
+      - free
       - id
       - image
       - learning_format


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4324
Closes https://github.com/mitodl/hq/issues/4307


### Description (What does it do?)
- Adjusts the filter code so professional resources are never considered free, even if they have no prices or a $0 price.
- Adds an explicit `free` field to the `LearningResourceSerializer` (previously it was only added as a hidden search index field)

### How can this be tested?
- Run `./manage.py backpopulate_prolearn_data`
- Wait a minute or two for the search index to update, then the following url should return 0 results:  http://localhost:8063/api/v1/learning_resources_search/?offered_by=see,mitpe,bootcamps&free=true
- And this url should return all the resources from sloan, professional education, and bootcamps: http://localhost:8063/api/v1/learning_resources_search/?offered_by=see,mitpe,bootcamps&free=false
