### PR TITLE
Adding call to update program topics during ETL loads

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -468,6 +468,7 @@ def load_program(
         load_image(learning_resource, image_data)
         load_offered_by(learning_resource, offered_by_data)
         load_departments(learning_resource, departments_data)
+        add_parent_topics_to_learning_resource(learning_resource)
 
         program, _ = Program.objects.get_or_create(learning_resource=learning_resource)
 

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -93,6 +93,8 @@ def load_topics(resource, topics_data):
 
         resource.topics.set(topics)
         resource.save()
+        add_parent_topics_to_learning_resource(resource)
+
     return resource.topics.all()
 
 
@@ -360,7 +362,6 @@ def load_course(
         load_image(learning_resource, image_data)
         load_departments(learning_resource, department_data)
         load_content_tags(learning_resource, content_tags_data)
-        add_parent_topics_to_learning_resource(learning_resource)
 
         update_index(learning_resource, created)
     return learning_resource
@@ -468,7 +469,6 @@ def load_program(
         load_image(learning_resource, image_data)
         load_offered_by(learning_resource, offered_by_data)
         load_departments(learning_resource, departments_data)
-        add_parent_topics_to_learning_resource(learning_resource)
 
         program, _ = Program.objects.get_or_create(learning_resource=learning_resource)
 


### PR DESCRIPTION

### What are the relevant tickets?

Fixes a bug noticed in mitodl/hq#4186

### Description (What does it do?)

When backpopulating courses, the `load_course` function calls a function to ensure that the parent topics for a given learning resource are also attached to the learning resource. This is something that should happen regardless of the ETL source - if the learning resource involves topics, we need to attach the parent topics to it - so this PR moves that call into the general `load_topics` function, which is called by every `load_` function for resources that have topics in them.

### How can this be tested?

You will need to make sure you have the OCW topics in place. See https://github.com/mitodl/mit-open/pull/844 for details.

Test backpopulating data. The resources should have both the topics associated with them and the parent topics. 

My suggestion is to test with xPRO data, as that has courses and programs that have topic data, and with podcasts; prior to this you'd have gotten parent topics loaded from the xPRO courses but not the programs, and not from the podcasts. With the new code, you should get parent topics for all of these.