### PR TITLE
Featured Courses Carousel

### DIFF
--- a/frontends/api/src/clients.ts
+++ b/frontends/api/src/clients.ts
@@ -10,6 +10,7 @@ import {
   PlatformsApi,
   LearningResourcesUserSubscriptionApi,
   SchoolsApi,
+  FeaturedApi,
 } from "./generated/v1/api"
 
 import {
@@ -33,6 +34,8 @@ const learningResourcesSearchApi = new LearningResourcesSearchApi(
   BASE_PATH,
   axiosInstance,
 )
+
+const featuredApi = new FeaturedApi(undefined, BASE_PATH, axiosInstance)
 
 const learningpathsApi = new LearningpathsApi(
   undefined,
@@ -88,4 +91,5 @@ export {
   searchSubscriptionApi,
   schoolsApi,
   newsEventsApi,
+  featuredApi,
 }

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -27,6 +27,7 @@ import type {
   UserListRelationshipRequest,
   MicroUserListRelationship,
   PlatformsApiPlatformsListRequest,
+  FeaturedApiFeaturedListRequest as FeaturedListParams,
 } from "../../generated/v1"
 import learningResources, {
   invalidateResourceQueries,
@@ -46,6 +47,10 @@ const useLearningResourcesList = (
 
 const useLearningResourcesDetail = (id: number) => {
   return useQuery(learningResources.detail(id))
+}
+
+const useFeaturedLearningResourcesList = (params: FeaturedListParams = {}) => {
+  return useQuery(learningResources.featured(params))
 }
 
 const useLearningResourceTopics = (
@@ -420,6 +425,7 @@ const useSchoolsList = () => {
 
 export {
   useLearningResourcesList,
+  useFeaturedLearningResourcesList,
   useLearningResourcesDetail,
   useLearningResourceTopics,
   useLearningPathsList,

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -8,6 +8,7 @@ import {
   offerorsApi,
   platformsApi,
   schoolsApi,
+  featuredApi,
 } from "../../clients"
 import axiosInstance from "../../axios"
 import type {
@@ -25,6 +26,7 @@ import type {
   UserList,
   OfferorsApiOfferorsListRequest,
   PlatformsApiPlatformsListRequest,
+  FeaturedApiFeaturedListRequest as FeaturedListParams,
 } from "../../generated/v1"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 
@@ -42,6 +44,10 @@ const learningResources = createQueryKeys("learningResources", {
       learningResourcesApi
         .learningResourcesList(params)
         .then((res) => res.data),
+  }),
+  featured: (params: FeaturedListParams) => ({
+    queryKey: [params],
+    queryFn: () => featuredApi.featuredList(params).then((res) => res.data),
   }),
   topics: (params: TopicsListRequest) => ({
     queryKey: [params],
@@ -186,6 +192,7 @@ const invalidateResourceQueries = (
     learningResources.list._def,
     learningResources.learningpaths._ctx.list._def,
     learningResources.userlists._ctx.list._def,
+    learningResources.featured._def,
   ]
   lists.forEach((queryKey) => {
     queryClient.invalidateQueries({

--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -8,6 +8,7 @@
 import type { NewsEventsApiNewsEventsListRequest } from "../generated/v0"
 import type {
   LearningResourcesApi as LRApi,
+  FeaturedApi,
   TopicsApi,
   LearningpathsApi,
   ArticlesApi,
@@ -54,6 +55,8 @@ const learningResources = {
     `/api/v1/learning_resources/${query(params)}`,
   details: (params: Params<LRApi, "learningResourcesRetrieve">) =>
     `/api/v1/learning_resources/${params.id}/`,
+  featured: (params?: Params<FeaturedApi, "featuredList">) =>
+    `/api/v1/featured/${query(params)}`,
 }
 
 const offerors = {

--- a/frontends/mit-open/src/page-components/TabbedCarousel/TabbedCarousel.tsx
+++ b/frontends/mit-open/src/page-components/TabbedCarousel/TabbedCarousel.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import {
+  useFeaturedLearningResourcesList,
   useLearningResourcesList,
   useLearningResourcesSearch,
 } from "api/hooks/learningResources"
@@ -11,7 +12,12 @@ import {
   Carousel,
   styled,
 } from "ol-components"
-import type { TabConfig, ResourceDataSource, SearchDataSource } from "./types"
+import type {
+  TabConfig,
+  ResourceDataSource,
+  SearchDataSource,
+  FeaturedDataSource,
+} from "./types"
 import { LearningResource } from "api"
 import LearningResourceCard from "../LearningResourceCard/LearningResourceCard"
 
@@ -42,6 +48,16 @@ const SearchData: React.FC<DataPanelProps<SearchDataSource>> = ({
   return children({ resources: data?.results ?? [], isLoading })
 }
 
+const FeaturedData: React.FC<DataPanelProps<FeaturedDataSource>> = ({
+  dataConfig,
+  children,
+}) => {
+  const { data, isLoading } = useFeaturedLearningResourcesList(
+    dataConfig.params,
+  )
+  return children({ resources: data?.results ?? [], isLoading })
+}
+
 /**
  * A wrapper to load data based `TabConfig.data`.
  *
@@ -55,6 +71,8 @@ const DataPanel: React.FC<DataPanelProps> = ({ dataConfig, children }) => {
       return <ResourcesData dataConfig={dataConfig}>{children}</ResourcesData>
     case "lr_search":
       return <SearchData dataConfig={dataConfig}>{children}</SearchData>
+    case "lr_featured":
+      return <FeaturedData dataConfig={dataConfig}>{children}</FeaturedData>
     default:
       // @ts-expect-error This will always be an error if the switch statement
       // is exhaustive since dataConfig will have type `never`

--- a/frontends/mit-open/src/page-components/TabbedCarousel/types.ts
+++ b/frontends/mit-open/src/page-components/TabbedCarousel/types.ts
@@ -1,6 +1,7 @@
 import type {
   LearningResourcesApiLearningResourcesListRequest as LRListRequest,
   LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest as SearchRequest,
+  FeaturedApiFeaturedListRequest as FeaturedListParams,
 } from "api"
 
 interface ResourceDataSource {
@@ -13,10 +14,20 @@ interface SearchDataSource {
   params: SearchRequest
 }
 
+interface FeaturedDataSource {
+  type: "lr_featured"
+  params: FeaturedListParams
+}
+
 type TabConfig = {
   label: React.ReactNode
   pageSize: number
-  data: ResourceDataSource | SearchDataSource
+  data: ResourceDataSource | SearchDataSource | FeaturedDataSource
 }
 
-export type { TabConfig, ResourceDataSource, SearchDataSource }
+export type {
+  TabConfig,
+  ResourceDataSource,
+  SearchDataSource,
+  FeaturedDataSource,
+}

--- a/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { Container, styled, Typography } from "ol-components"
+import TabbedCarousel from "@/page-components/TabbedCarousel/TabbedCarousel"
+import type { TabbedCarouselProps } from "@/page-components/TabbedCarousel/TabbedCarousel"
+import type { FeaturedApiFeaturedListRequest as FeaturedListParams } from "api"
+
+const Section = styled.section`
+  padding: 80px 0;
+  overflow: auto;
+  ${({ theme }) => theme.breakpoints.down("md")} {
+    padding: 40px 0;
+  }
+`
+
+const SORT_AND_PAGE: FeaturedListParams = {
+  resource_type: ["course"],
+  limit: 12,
+  sortby: "upcoming",
+}
+const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
+  {
+    label: "Free",
+    pageSize: 4,
+    data: {
+      type: "resources",
+      params: { ...SORT_AND_PAGE, free: true },
+    },
+  },
+  {
+    label: "Certificate",
+    pageSize: 4,
+    data: {
+      type: "resources",
+      params: { ...SORT_AND_PAGE, certification: true },
+    },
+  },
+  {
+    label: "Professional",
+    pageSize: 4,
+    data: {
+      type: "resources",
+      params: { ...SORT_AND_PAGE, professional: true },
+    },
+  },
+]
+
+const FeaturedResourcesSection: React.FC = () => {
+  return (
+    <Section>
+      <Container>
+        <Typography variant="h2">Featured Courses</Typography>
+        <TabbedCarousel config={FEATURED_RESOURCES_CAROUSEL} />
+      </Container>
+    </Section>
+  )
+}
+
+export default FeaturedResourcesSection

--- a/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
@@ -35,6 +35,10 @@ const setup = () => {
     expect.stringContaining(urls.learningResources.list()),
     resources,
   )
+  setMockResponse.get(
+    expect.stringContaining(urls.learningResources.featured()),
+    resources,
+  )
 
   setMockResponse.get(
     urls.newsEvents.list({ feed_type: ["news"], limit: 6 }),
@@ -100,9 +104,10 @@ describe("Home Page Carousel", () => {
       results: [],
     })
     setup()
-    const [upcoming, media] = screen.getAllByRole("tablist")
-    within(upcoming).getByRole("tab", { name: "All" })
-    within(upcoming).getByRole("tab", { name: "Professional" })
+    const [featured, media] = screen.getAllByRole("tablist")
+    within(featured).getByRole("tab", { name: "Free" })
+    within(featured).getByRole("tab", { name: "Certificate" })
+    within(featured).getByRole("tab", { name: "Professional" })
     within(media).getByRole("tab", { name: "All" })
     within(media).getByRole("tab", { name: "Videos" })
     within(media).getByRole("tab", { name: "Podcasts" })

--- a/frontends/mit-open/src/pages/HomePage/HomePage.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Container, styled } from "ol-components"
 import HeroSearch from "./HeroSearch"
-import UpcomingCoursesSection from "./UpcomingCoursesSection"
+import FeaturedResourcesSection from "./FeaturedResourcesSection"
 import MediaSection from "./MediaSection"
 import BrowseTopicsSection from "./BrowseTopicsSection"
 import NewsEventsSection from "./NewsEventsSection"
@@ -31,7 +31,7 @@ const HomePage: React.FC = () => {
           <HeroSearch />
         </Container>
       </FullWidthBackground>
-      <UpcomingCoursesSection />
+      <FeaturedResourcesSection />
       <MediaSection />
       <BrowseTopicsSection />
       <NewsEventsSection />

--- a/frontends/mit-open/src/pages/HomePage/UpcomingCoursesSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/UpcomingCoursesSection.tsx
@@ -36,6 +36,11 @@ const UPCOMING_COURSES_CAROUSEL: TabbedCarouselProps["config"] = [
   },
 ]
 
+/**
+ * Display upcoming courses.
+ *
+ * This is currently unused but we are keeping around for the moment.
+ */
 const UpcomingCoursesSection: React.FC = () => {
   return (
     <Section>


### PR DESCRIPTION
### What are the relevant tickets?
- closes https://github.com/mitodl/hq/issues/4361

### Description (What does it do?)
- This PR replaces the "Upcoming Courses" carousel with a "Featured Courses" carousel.

### Screenshots (if appropriate):
<img width="1058" alt="Screenshot 2024-05-24 at 5 08 05 PM" src="https://github.com/mitodl/mit-open/assets/9010790/45bc4a27-97b3-468e-a1d7-7b84574c56fb">



### How can this be tested?
1. View  http://localhost:8063/api/v1/featured/ ... if you have no featured resources, run `./manage.py populate_featured_lists`
2. View the homepage. You should see the featured courses carousel.
    - The carousel should show a balanced mix of content from various providers
3. The courses shown there should match the data at http://localhost:8063/api/v1/featured/

