### PR TITLE
Fix a flaky test

### DIFF
--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -145,7 +145,10 @@ class LearningResourceOfferorFactory(DjangoModelFactory):
 
     code = FuzzyChoice([offeror.name for offeror in constants.OfferedBy])
     name = factory.LazyAttribute(lambda o: constants.OfferedBy[o.code].value)
-    professional = Faker("boolean")
+    professional = factory.LazyAttribute(
+        lambda o: o.code
+        not in (constants.OfferedBy.mitx.name, constants.OfferedBy.ocw.name)
+    )
 
     class Meta:
         model = models.LearningResourceOfferor
@@ -192,6 +195,15 @@ class LearningResourceFactory(DjangoModelFactory):
     content_tags = factory.PostGeneration(_post_gen_tags)
     published = True
     learning_format = factory.List(random.choices(LearningResourceFormat.names()))  # noqa: S311
+    professional = factory.LazyAttribute(
+        lambda o: o.resource_type
+        in (
+            constants.LearningResourceType.course.name,
+            constants.LearningResourceType.program.name,
+        )
+        and o.offered_by.professional
+    )
+    certification = factory.LazyAttribute(lambda o: o.professional)
 
     course = factory.Maybe(
         "create_course",

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -65,8 +65,6 @@ def offeror_featured_lists():
             resource = LearningResourceFactory.create(
                 offered_by=offeror,
                 is_course=True,
-                certification=bool(random.getrandbits(1)),
-                professional=offeror.professional,
             )
             if offered_by == OfferedBy.ocw.name:
                 LearningResourceRun.objects.filter(


### PR DESCRIPTION
### What are the relevant tickets?
N/A - https://github.com/mitodl/mit-open/actions/runs/9271481335/attempts/1


### Description (What does it do?)
Fixes a test that was occasionally failing due to no offerors being generated by the factory with `professional/certification=False`


### How can this be tested?
Test should consistently pass

