### PR TITLE
Featured Courses: add All tab

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
@@ -12,18 +12,25 @@ const Section = styled.section`
   }
 `
 
-const SORT_AND_PAGE: FeaturedListParams = {
+const COMMON_PARAMS: FeaturedListParams = {
   resource_type: ["course"],
   limit: 12,
-  sortby: "upcoming",
 }
 const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
+  {
+    label: "All",
+    pageSize: 4,
+    data: {
+      type: "lr_featured",
+      params: { ...COMMON_PARAMS },
+    },
+  },
   {
     label: "Free",
     pageSize: 4,
     data: {
       type: "resources",
-      params: { ...SORT_AND_PAGE, free: true },
+      params: { ...COMMON_PARAMS, free: true },
     },
   },
   {
@@ -31,7 +38,7 @@ const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
     pageSize: 4,
     data: {
       type: "resources",
-      params: { ...SORT_AND_PAGE, certification: true },
+      params: { ...COMMON_PARAMS, certification: true },
     },
   },
   {
@@ -39,7 +46,7 @@ const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
     pageSize: 4,
     data: {
       type: "resources",
-      params: { ...SORT_AND_PAGE, professional: true },
+      params: { ...COMMON_PARAMS, professional: true },
     },
   },
 ]

--- a/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
@@ -105,6 +105,7 @@ describe("Home Page Carousel", () => {
     })
     setup()
     const [featured, media] = screen.getAllByRole("tablist")
+    within(featured).getByRole("tab", { name: "All" })
     within(featured).getByRole("tab", { name: "Free" })
     within(featured).getByRole("tab", { name: "Certificate" })
     within(featured).getByRole("tab", { name: "Professional" })


### PR DESCRIPTION
### What are the relevant tickets?
- This is a follow to https://github.com/mitodl/mit-open/pull/959 ... I forgot to commit the "All" tab. 

### Description (What does it do?)
This PR adds the "All" tab to the "Featured Courses" carousel.

### Screenshots (if appropriate):
<img width="1058" alt="Screenshot 2024-05-24 at 5 08 05 PM" src="https://github.com/mitodl/mit-open/assets/9010790/45bc4a27-97b3-468e-a1d7-7b84574c56fb">

### How can this be tested?
1. View  http://localhost:8063/api/v1/featured/ ... if you have no featured resources, run `./manage.py populate_featured_lists`
2. View the homepage. You should see the featured courses carousel.
    - The carousel should show a balanced mix of content from various providers
3. The courses shown there should match the data at http://localhost:8063/api/v1/featured/

