### PR TITLE
Fix detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -104,50 +104,6 @@
       ]
     }
   ],
-  "results": {
-    "authentication/utils.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "authentication/utils.py",
-        "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
-        "is_verified": false,
-        "line_number": 21
-      }
-    ],
-    "flow-typed/npm/jsdom_vx.x.x.js": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "flow-typed/npm/jsdom_vx.x.x.js",
-        "hashed_secret": "b780c0c4bc48f194a80759c5f91e958f0f3578e8",
-        "is_verified": false,
-        "line_number": 2548
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "flow-typed/npm/jsdom_vx.x.x.js",
-        "hashed_secret": "8659a16d191e467d6160bc08277af0893d1cebc9",
-        "is_verified": false,
-        "line_number": 2551
-      }
-    ],
-    "frontends/mit-open/src/reducers/auth.js": [
-      {
-        "type": "Secret Keyword",
-        "filename": "frontends/mit-open/src/reducers/auth.js",
-        "hashed_secret": "e3c328a97de7239b3f60eecda765a69535205744",
-        "is_verified": false,
-        "line_number": 18
-      }
-    ],
-    "mail/templates/password_reset/body.html": [
-      {
-        "type": "Secret Keyword",
-        "filename": "mail/templates/password_reset/body.html",
-        "hashed_secret": "93f64017194ac1d984f80fc133f60bb9ec09215a",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ]
-  },
-  "generated_at": "2024-05-21T18:36:14Z"
+  "results": {},
+  "generated_at": "2024-05-28T18:05:16Z"
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the `detect-secrets` baseline file by running `detect-secrets scan --baseline .secrets.baseline`. There are apparently some files that are putting this checker into a weird state where it will detect these changes, fail, but not actually update the baseline file.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Go to the `main` branch and verify when you run `pre-commit run detect-secrets -a` that you see it fail with error output but no change to `.secrets.baseline`
- Checkout this branch and verify that  `pre-commit run detect-secrets -a` succeeds with no error output and no file changes.
