### PR TITLE
Fix Featured API requests

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/FeaturedResourcesSection.tsx
@@ -29,7 +29,7 @@ const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
     label: "Free",
     pageSize: 4,
     data: {
-      type: "resources",
+      type: "lr_featured",
       params: { ...COMMON_PARAMS, free: true },
     },
   },
@@ -37,7 +37,7 @@ const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
     label: "Certificate",
     pageSize: 4,
     data: {
-      type: "resources",
+      type: "lr_featured",
       params: { ...COMMON_PARAMS, certification: true },
     },
   },
@@ -45,7 +45,7 @@ const FEATURED_RESOURCES_CAROUSEL: TabbedCarouselProps["config"] = [
     label: "Professional",
     pageSize: 4,
     data: {
-      type: "resources",
+      type: "lr_featured",
       params: { ...COMMON_PARAMS, professional: true },
     },
   },


### PR DESCRIPTION
### What are the relevant tickets?
Fixes API request in #959 

### Description (What does it do?)
The "Free", "With Certificate" and "Professional" tabs of the Featured Courses carousel were using wrong API.

### Screenshots (if appropriate):

<img width="1430" alt="Screenshot 2024-05-28 at 8 53 29 PM" src="https://github.com/mitodl/mit-open/assets/9010790/a5a2c3c7-eb1e-4c3e-ae7b-00539c647d72">

### How can this be tested?
1. Click the various tabs of the "Featured Courses" carousel on homepage.
2. Check the network tab that network requests look correct.
