### PR TITLE
Randomize featured api order by offeror, keep sorting by position

### DIFF
--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -836,11 +836,9 @@ class FeaturedViewSet(
             QuerySet of LearningResource objects that are in
             featured learning paths from certain offerors
         """
-        featured_list_ids = (
-            FieldChannel.objects.filter(channel_type=ChannelType.offeror.name)
-            .values_list("featured_list", flat=True)
-            .order_by("?")
-        )
+        featured_list_ids = FieldChannel.objects.filter(
+            channel_type=ChannelType.offeror.name
+        ).values_list("featured_list", flat=True)
 
         return (
             self._get_base_queryset()

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -836,15 +836,17 @@ class FeaturedViewSet(
             QuerySet of LearningResource objects that are in
             featured learning paths from certain offerors
         """
-        featured_list_ids = FieldChannel.objects.filter(
-            channel_type=ChannelType.offeror.name
-        ).values_list("featured_list", flat=True)
+        featured_list_ids = (
+            FieldChannel.objects.filter(channel_type=ChannelType.offeror.name)
+            .values_list("featured_list", flat=True)
+            .order_by("?")
+        )
 
         return (
             self._get_base_queryset()
             .filter(parents__parent_id__in=featured_list_ids)
             .filter(published=True)
             .annotate(position=F("parents__position"))
-            .order_by("position")
+            .order_by("position", "?")
             .distinct()
         )

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -916,19 +916,28 @@ def test_popular_sort(client, resource_type):
 def test_featured_view(client, offeror_featured_lists):
     """The featured api endpoint should return resources in expected order"""
     url = reverse("lr:v1:featured_api-list")
-    resp = client.get(f"{url}?limit=12")
-    assert resp.data.get("count") == 18
-    assert len(resp.data.get("results")) == 12
-    # Should get 1st resource from every featured list, then 2nd, etc.
-    for idx, resource in enumerate(resp.data.get("results")):
-        position = int(idx / 6)  # 6 offerors: 0,0,0,0,0,0,1,1,1,1,1,1
-        offeror = LearningResourceOfferor.objects.get(
-            code=resource["offered_by"]["code"]
-        )
-        featured_list = FieldChannel.objects.get(
-            offeror_detail__offeror=offeror
-        ).featured_list
-        assert featured_list.children.all()[position].child.id == resource["id"]
+    resp_1 = client.get(f"{url}?limit=12")
+    assert resp_1.data.get("count") == 18
+    assert len(resp_1.data.get("results")) == 12
+
+    # Second request should return same resources in different order
+    resp_2 = client.get(f"{url}?limit=12")
+    resp_1_ids = [resource["id"] for resource in resp_1.data.get("results")]
+    resp_2_ids = [resource["id"] for resource in resp_2.data.get("results")]
+    assert resp_1_ids != resp_2_ids
+    assert sorted(resp_1_ids) == sorted(resp_2_ids)
+
+    for resp in [resp_1, resp_2]:
+        # Should get 1st resource from every featured list, then 2nd, etc.
+        for idx, resource in enumerate(resp.data.get("results")):
+            position = int(idx / 6)  # 6 offerors: 0,0,0,0,0,0,1,1,1,1,1,1
+            offeror = LearningResourceOfferor.objects.get(
+                code=resource["offered_by"]["code"]
+            )
+            featured_list = FieldChannel.objects.get(
+                offeror_detail__offeror=offeror
+            ).featured_list
+            assert featured_list.children.all()[position].child.id == resource["id"]
 
 
 @pytest.mark.parametrize("parameter", ["certification", "free", "professional"])


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4183

### Description (What does it do?)
Keeps sorting featured resources by their positions in their respective offeror featured lists, but randomizes the order of offerors within each position.

### How can this be tested?
- Run the following (you can probably skip the backpopulate ones if you've run them before):
```
./manage.py update_offered_by
./manage.py backpopulate_prolearn_data
./manage.py backpopulate_xpro_data
./manage.py backpopulate_mitxonline_data
./manage.py backpopulate_ocw_data. --skip-contentfiles
./manage.py populate_featured_lists
```

Go to  http://localhost:8063/, note the content of the featured list carousel, and then refresh repeatedly.  The first 6 resources should always be the same, but their order should differ.  Ditto for the next set of 6, etc.

