### PR TITLE
Fix flaky test by specifying a sort of program courses in serializer

### DIFF
--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -290,6 +290,7 @@ class ProgramSerializer(serializers.ModelSerializer):
                 LearningResource.objects.filter(id__in=ids)
                 .select_related(*LearningResource.related_selects)
                 .prefetch_related(*LearningResource.prefetches)
+                .order_by("next_start_date", "id")
             ),
             many=True,
         ).data

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -68,7 +68,9 @@ def test_serialize_program_to_json():
             "courses": [
                 # this is currently messy because program.courses is a list of LearningResourceRelationships
                 serializers.CourseResourceSerializer(instance=course_rel.child).data
-                for course_rel in program.courses.filter(child__published=True)
+                for course_rel in program.courses.filter(
+                    child__published=True
+                ).order_by("child__next_start_date", "child__id")
             ]
         },
     )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/947 (hopefully for good this time)

### Description (What does it do?)
Specifies ordering for program courses in the serializer (`next_start_date` and `id`).

### How can this be tested?
The test should pass every time.
