### PR TITLE
extract images for news articles

### DIFF
--- a/news_events/etl/medium_mit_news.py
+++ b/news_events/etl/medium_mit_news.py
@@ -1,6 +1,7 @@
 """ETL functions for MIT News data."""
 
 import feedparser
+from bs4 import BeautifulSoup
 
 from news_events.constants import FeedType
 from news_events.etl.utils import stringify_time_struct
@@ -42,15 +43,31 @@ def transform_items(items_data: list[dict]) -> list[dict]:
     Returns:
         list of dict: list of transformed items
     """
-    return [
-        {
+    entries = []
+    for item in items_data:
+        content = (item.get("content") or [{}])[0].get("value", "")
+        soup = BeautifulSoup(content, "lxml")
+        figures = soup.find_all("figure")
+        image_data = None
+        if (
+            len(figures) > 0
+            and figures[0].next_element
+            and figures[0].next_element.name == "img"
+        ):
+            image_attrs = figures[0].next_element.attrs
+            image_data = {
+                "url": image_attrs.get("src"),
+                "alt": image_attrs.get("alt"),
+                "description": image_attrs.get("alt", ""),
+            }
+
+        entry = {
             "guid": item.get("id"),
             "title": item.get("title", ""),
             "url": item.get("link", None),
             "summary": item.get("summary", ""),
-            "content": (item.get("content") or [{}])[0].get("value", ""),
-            # This RSS does not include images for news items
-            "image": None,
+            "content": content,
+            "image": image_data,
             "detail": {
                 "authors": [
                     author["name"] for author in item.get("authors", []) if author
@@ -59,8 +76,8 @@ def transform_items(items_data: list[dict]) -> list[dict]:
                 "publish_date": stringify_time_struct(item.get("published_parsed")),
             },
         }
-        for item in items_data
-    ]
+        entries.append(entry)
+    return entries
 
 
 def transform_image(image_data: dict) -> dict:
@@ -91,6 +108,7 @@ def transform(sources_data: list[tuple[dict, str]]) -> list[dict]:
         list of dict: list of transformed sources data
 
     """
+
     return [
         {
             "title": source_data["feed"].get("title", ""),

--- a/news_events/etl/medium_mit_news_test.py
+++ b/news_events/etl/medium_mit_news_test.py
@@ -54,6 +54,9 @@ def test_transform(mocker, medium_mit_rss_data):
         assert item["title"] == feed_items[idx]["title"]
         assert item["url"] == feed_items[idx]["link"]
         assert item["guid"] == feed_items[idx]["id"]
+        if item["image"]:
+            assert item["image"]["url"] in feed_items[idx]["content"][0]["value"]
+            assert item["image"]["alt"] in feed_items[idx]["content"][0]["value"]
         assert item["detail"]["publish_date"] == stringify_time_struct(
             feed_items[idx]["published_parsed"]
         )


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes #4354 --->

### Description (What does it do?)
This PR parses an article's image from the "content" html. It assumes that the the first <figure><img></figure> encountered is the appropriate image for the article (otherwise defaults to None)


### How can this be tested?
1 - checkout this branch - make sure you delete existing news articles via admin /admin/news_events
2 - populate articles by manually running the etl 
  ```
  from news_events.tasks import get_medium_mit_news
  get_medium_mit_news()
  ```
3 - go back to news article admin /admin/news_events and validate that the image associated with each article is unique (and appears to be the appropriate photo)

