### PR TITLE
Reduce functions occurring under atomic transactions; fix dedupe comparison in load_course function

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -303,16 +303,10 @@ def load_course(
             return None
 
         if deduplicated_course_id and readable_id != deduplicated_course_id:
-            log.error(
-                f"{readable_id} does not match deduplicated ID {deduplicated_course_id}"  # noqa: G004
-            )
             duplicate_resource = LearningResource.objects.filter(
                 platform=platform, readable_id=readable_id
             ).first()
             if duplicate_resource:
-                log.error(
-                    "Ubnpublishing duplicate resource with readable_id %s", readable_id
-                )
                 duplicate_resource.published = False
                 duplicate_resource.save()
                 resource_unpublished_actions(duplicate_resource)

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -505,6 +505,8 @@ def test_load_duplicate_course(
 
     if course_id_is_duplicate and duplicate_course_exists:
         mock_upsert_tasks.deindex_learning_resource.assert_called()
+    else:
+        mock_upsert_tasks.deindex_learning_resource.assert_not_called()
     if course.learning_resource.id:
         if course_exists:
             mock_upsert_tasks.upsert_learning_resource.assert_called_with(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4429
Closes https://github.com/mitodl/hq/issues/4428

### Description (What does it do?)
- Fixes a bug causing lots of unnecessary deindex calls during ETL pipeline runs
- Reduces the number of functions occurring under atomic transactions

### How can this be tested?
- Set DUPLICATE_COURSES_URL=https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/duplicate_courses.yml in your .env file
- With required variables set in your .env, run the following commands, and check that there are not DELETE opensearch calls immediately followed by POST calls for the same document id being made for nearly every resource:
  ```
  ./manage.py backpopulate_prolearn_data
  ./manage.py backpopulate_mit_edx_data
  ./manage.py backpopulate_mitxonline_data
  ```
- If you have any existing video resources, delete them all.
- Run `./manage.py backpopulate_youtube_data fetch`.  Intermittently check for videos at http://localhost:8063/admin/learning_resources/learningresource/?resource_type__exact=video, the count should increase consistently over time, not in infrequent large batches.

