### PR TITLE
Fix celerybeat schedule

### DIFF
--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -199,6 +199,7 @@ def send_subscription_emails(self, subscription_type, period="daily"):
     """
     Send subscription emails by percolating matched documents
     """
+    log.info("Sending %s subscription emails for %s", period, subscription_type)
     delta = datetime.timedelta(days=1)
     if period == "weekly":
         delta = datetime.timedelta(days=7)

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -2,8 +2,6 @@
 Django settings for celery.
 """
 
-import json
-
 from celery.schedules import crontab
 
 from main.envs import get_bool, get_int, get_string
@@ -114,9 +112,7 @@ CELERY_BEAT_SCHEDULE = {
     "send-subscription-emails-every-1-days": {
         "task": "learning_resources_search.tasks.send_subscription_emails",
         "schedule": crontab(minute=30, hour=18),  # 2:30pm EST
-        "kwargs": json.dumps(
-            {"period": "daily", "subscription_type": "channel_subscription_type"}
-        ),
+        "kwargs": {"period": "daily", "subscription_type": "channel_subscription_type"},
     },
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4412

### Description (What does it do?)
FIxes one of the new scheduled celerybeat tasks


### How can this be tested?
- Temporarily change the last scheduled task in the `CELERY_BEAT_SCHEDULE` of main/settings_celery.py to a schedule of every 2 minutes (`"schedule": 120).
- Start containers.
- Within a couple of minutes, you should see `INFO/ForkPoolWorker-8] Sending daily subscription emails for channel_subscription_type` in the logs.  The task may fail at first if opensearch isn't done starting up.

