### PR TITLE
Error if using npm to install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict = true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "engines": {
     "node": "^20",
-    "yarn": "^4.1.1"
+    "yarn": "^4.1.1",
+    "npm": "please-use-yarn"
   },
   "workspaces": [
     "frontends"


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #978 

### Description (What does it do?)
This PR makes an error if you run `npm install` instead of `yarn install`.  



### How can this be tested?
1. Run `docker compose exec watch bash`.
2. Try running `docker compose exec watch npm install`. It should error with a reasonably helpful error message.
3. Try running `docker compose exec watch npm yarn install`. It should work.

