### PR TITLE
Sortby parameter for news_events

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4055,6 +4055,7 @@ export const NewsEventsApiAxiosParamCreator = function (
      * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
+     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4062,6 +4063,7 @@ export const NewsEventsApiAxiosParamCreator = function (
       feed_type?: Array<NewsEventsListFeedTypeEnum>,
       limit?: number,
       offset?: number,
+      sortby?: NewsEventsListSortbyEnum,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v0/news_events/`
@@ -4090,6 +4092,10 @@ export const NewsEventsApiAxiosParamCreator = function (
 
       if (offset !== undefined) {
         localVarQueryParameter["offset"] = offset
+      }
+
+      if (sortby !== undefined) {
+        localVarQueryParameter["sortby"] = sortby
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -4167,6 +4173,7 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
      * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
+     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4174,6 +4181,7 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
       feed_type?: Array<NewsEventsListFeedTypeEnum>,
       limit?: number,
       offset?: number,
+      sortby?: NewsEventsListSortbyEnum,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -4185,6 +4193,7 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
         feed_type,
         limit,
         offset,
+        sortby,
         options,
       )
       const index = configuration?.serverIndex ?? 0
@@ -4252,6 +4261,7 @@ export const NewsEventsApiFactory = function (
           requestParameters.feed_type,
           requestParameters.limit,
           requestParameters.offset,
+          requestParameters.sortby,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -4299,6 +4309,13 @@ export interface NewsEventsApiNewsEventsListRequest {
    * @memberof NewsEventsApiNewsEventsList
    */
   readonly offset?: number
+
+  /**
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
+   * @type {'-created' | '-event_date' | '-id' | 'created' | 'event_date' | 'id'}
+   * @memberof NewsEventsApiNewsEventsList
+   */
+  readonly sortby?: NewsEventsListSortbyEnum
 }
 
 /**
@@ -4338,6 +4355,7 @@ export class NewsEventsApi extends BaseAPI {
         requestParameters.feed_type,
         requestParameters.limit,
         requestParameters.offset,
+        requestParameters.sortby,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -4369,6 +4387,19 @@ export const NewsEventsListFeedTypeEnum = {
 } as const
 export type NewsEventsListFeedTypeEnum =
   (typeof NewsEventsListFeedTypeEnum)[keyof typeof NewsEventsListFeedTypeEnum]
+/**
+ * @export
+ */
+export const NewsEventsListSortbyEnum = {
+  Created: "-created",
+  EventDate: "-event_date",
+  Id: "-id",
+  Created2: "created",
+  EventDate2: "event_date",
+  Id2: "id",
+} as const
+export type NewsEventsListSortbyEnum =
+  (typeof NewsEventsListSortbyEnum)[keyof typeof NewsEventsListSortbyEnum]
 
 /**
  * NewsEventsSourcesApi - axios parameter creator

--- a/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
@@ -45,11 +45,15 @@ const setupAPIs = () => {
   )
 
   setMockResponse.get(
-    urls.newsEvents.list({ feed_type: ["news"], limit: 6 }),
+    urls.newsEvents.list({ feed_type: ["news"], limit: 6, sortby: "-created" }),
     {},
   )
   setMockResponse.get(
-    urls.newsEvents.list({ feed_type: ["events"], limit: 5 }),
+    urls.newsEvents.list({
+      feed_type: ["events"],
+      limit: 5,
+      sortby: "event_date",
+    }),
     {},
   )
 
@@ -186,13 +190,21 @@ describe("Home Page News and Events", () => {
   test("Displays News section", async () => {
     const news = newsEvents.newsItems({ count: 6 })
     setMockResponse.get(
-      urls.newsEvents.list({ feed_type: ["news"], limit: 6 }),
+      urls.newsEvents.list({
+        feed_type: ["news"],
+        limit: 6,
+        sortby: "-created",
+      }),
       news,
     )
 
     const events = newsEvents.eventItems({ count: 5 })
     setMockResponse.get(
-      urls.newsEvents.list({ feed_type: ["events"], limit: 5 }),
+      urls.newsEvents.list({
+        feed_type: ["events"],
+        limit: 5,
+        sortby: "event_date",
+      }),
       events,
     )
 
@@ -229,13 +241,21 @@ describe("Home Page News and Events", () => {
   test("Displays Events section", async () => {
     const news = newsEvents.newsItems({ count: 6 })
     setMockResponse.get(
-      urls.newsEvents.list({ feed_type: ["news"], limit: 6 }),
+      urls.newsEvents.list({
+        feed_type: ["news"],
+        limit: 6,
+        sortby: "-created",
+      }),
       news,
     )
 
     const events = newsEvents.eventItems({ count: 5 })
     setMockResponse.get(
-      urls.newsEvents.list({ feed_type: ["events"], limit: 5 }),
+      urls.newsEvents.list({
+        feed_type: ["events"],
+        limit: 5,
+        sortby: "event_date",
+      }),
       events,
     )
 

--- a/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
@@ -240,11 +240,13 @@ const NewsEventsSection: React.FC = () => {
   const { data: news } = useNewsEventsList({
     feed_type: [NewsEventsListFeedTypeEnum.News],
     limit: 6,
+    sortby: "-created",
   })
 
   const { data: events } = useNewsEventsList({
     feed_type: [NewsEventsListFeedTypeEnum.Events],
     limit: 5,
+    sortby: "event_date",
   })
 
   const isAboveLg = useMuiBreakpointAtLeast("lg")

--- a/news_events/constants.py
+++ b/news_events/constants.py
@@ -10,3 +10,31 @@ class FeedType(ExtendedEnum):
 
     news = "News"
     events = "Events"
+
+
+NEWS_EVENTS_SORTBY_OPTIONS = {
+    "id": {
+        "title": "Object ID ascending",
+        "sort": "id",
+    },
+    "-id": {
+        "title": "Object ID descending",
+        "sort": "-id",
+    },
+    "event_date": {
+        "title": "Event date ascending",
+        "sort": "event_details__event_datetime",
+    },
+    "-event_date": {
+        "title": "Event date  descending",
+        "sort": "-event_details__event_datetime",
+    },
+    "created": {
+        "title": "Creation date ascending",
+        "sort": "created_on",
+    },
+    "-created": {
+        "title": "Creation date descending",
+        "sort": "-created_on",
+    },
+}

--- a/news_events/filters.py
+++ b/news_events/filters.py
@@ -1,8 +1,8 @@
 """API query filters for news & events"""
 
-from django_filters import FilterSet, MultipleChoiceFilter
+from django_filters import ChoiceFilter, FilterSet, MultipleChoiceFilter
 
-from news_events.constants import FeedType
+from news_events.constants import NEWS_EVENTS_SORTBY_OPTIONS, FeedType
 from news_events.models import FeedItem, FeedSource
 
 
@@ -14,6 +14,19 @@ class FeedItemFilter(FilterSet):
         field_name="source__feed_type",
         choices=(FeedType.as_list()),
     )
+
+    sortby = ChoiceFilter(
+        label="Sort By",
+        method="filter_sortby",
+        choices=(
+            [(key, value["title"]) for key, value in NEWS_EVENTS_SORTBY_OPTIONS.items()]
+        ),
+    )
+
+    def filter_sortby(self, queryset, _, value):
+        """Sort the queryset in the order specified by the value"""
+        sort_param = NEWS_EVENTS_SORTBY_OPTIONS[value]["sort"]
+        return queryset.order_by(sort_param)
 
     class Meta:
         model = FeedItem

--- a/news_events/filters_test.py
+++ b/news_events/filters_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from news_events.constants import FeedType
+from news_events.constants import NEWS_EVENTS_SORTBY_OPTIONS, FeedType
 from news_events.factories import FeedItemFactory, FeedSourceFactory
 
 SOURCE_API_URL = "/api/v0/news_events_sources/"
@@ -44,4 +44,38 @@ def test_item_filter_feed_type(client, multifilter):
     assert len(results) == 2
     assert sorted([result["id"] for result in results]) == sorted(
         [item.id for item in items]
+    )
+
+
+@pytest.mark.parametrize("sortby", ["created", "event_date"])
+@pytest.mark.parametrize("descending", [True, False])
+def test_learning_resource_sortby(client, sortby, descending):
+    """Test that the query is sorted in the correct order"""
+    source = FeedSourceFactory.create(feed_type=FeedType.events.name)
+    items = FeedItemFactory.create_batch(4, source=source, is_event=True)
+    sortby_param = sortby
+    if descending:
+        sortby_param = f"-{sortby}"
+
+    results = client.get(
+        f"{ITEM_API_URL}?feed_type=events&sortby={sortby_param}"
+    ).json()["results"]
+
+    def get_sort_field(item):
+        """Get the field to be sorted on"""
+        sort_fields = NEWS_EVENTS_SORTBY_OPTIONS[sortby]["sort"].split("__")
+        if len(sort_fields) < 2:
+            return getattr(item, sort_fields[0])
+        else:
+            return getattr(getattr(item, sort_fields[0]), sort_fields[1])
+
+    assert [result["id"] for result in results] == (
+        [
+            item.id
+            for item in sorted(
+                items,
+                key=lambda x: get_sort_field(x),
+                reverse=descending,
+            )
+        ]
     )

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -298,6 +298,26 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: sortby
+        schema:
+          type: string
+          enum:
+          - -created
+          - -event_date
+          - -id
+          - created
+          - event_date
+          - id
+        description: |-
+          Sort By
+
+          * `id` - Object ID ascending
+          * `-id` - Object ID descending
+          * `event_date` - Event date ascending
+          * `-event_date` - Event date  descending
+          * `created` - Creation date ascending
+          * `-created` - Creation date descending
       tags:
       - news_events
       responses:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4434

### Description (What does it do?)
Adds a `sortby` parameter to the news_events API endpoint and applies it to the news section (created date descending order) and events section (event date in ascending order) on the home page.

### Screenshots (if appropriate):
<img width="1431" alt="Screenshot 2024-05-31 at 11 27 53 AM" src="https://github.com/mitodl/mit-open/assets/187676/d8d6f83a-74b3-4916-9fba-60b94abd505b">



### How can this be tested?
Run `./manage.py backpopulate_news_events`
Go to the home page, "Stories" items should be in sorted by publishing (created) date descending, "Events" items should be sorted by event date ascending.
