### PR TITLE
Revert "Error if using npm to install"

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict = true

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "private": true,
   "engines": {
     "node": "^20",
-    "yarn": "^4.1.1",
-    "npm": "please-use-yarn"
+    "yarn": "^4.1.1"
   },
   "workspaces": [
     "frontends"


### PR DESCRIPTION
### What does this do
Reverts mitodl/mit-open#986

#986 broke heroku becauses it tries to be helpful and install the specified npm version. The specified version, `please-use-yarn` does not exist.

### How to test this
Merge and try deploying to heroku.