### PR TITLE
Add "tertiary" button and align button terminology with Figma

### DIFF
--- a/frontends/mit-open/src/page-components/ArticleUpsertForm/ArticleUpsertForm.tsx
+++ b/frontends/mit-open/src/page-components/ArticleUpsertForm/ArticleUpsertForm.tsx
@@ -128,7 +128,7 @@ const ArticleUpsertForm = ({
         <Grid item xs={6}>
           {id ? (
             <Button
-              variant="outlined"
+              variant="secondary"
               disabled={!hasData || destroyArticle.isLoading}
               onClick={toggleConfirmationOpen.on}
             >
@@ -137,11 +137,11 @@ const ArticleUpsertForm = ({
           ) : null}
         </Grid>
         <FormControls item xs={6}>
-          <Button variant="outlined" onClick={onCancel}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
           <Button
-            variant="filled"
+            variant="primary"
             disabled={
               editorBusy || createArticle.isLoading || editArticle.isLoading
             }

--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -99,7 +99,7 @@ const StyledSearchIcon = styled(RiSearch2Line)(({ theme }) => ({
 const SearchButton: FunctionComponent = () => {
   return (
     <ActionButtonLink
-      edge="rounded"
+      edge="circular"
       variant="text"
       nativeAnchor={true}
       href={SEARCH}

--- a/frontends/mit-open/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-open/src/page-components/Header/UserMenu.tsx
@@ -159,7 +159,7 @@ const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
           <FlexContainer className="login-button-desktop">
             <ButtonLink
               data-testid="login-button-desktop"
-              edge="rounded"
+              edge="circular"
               size="small"
               nativeAnchor={true}
               href={loginUrl}
@@ -174,7 +174,7 @@ const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
           <FlexContainer className="login-button-mobile">
             <ActionButtonLink
               data-testid="login-button-mobile"
-              edge="rounded"
+              edge="circular"
               variant="text"
               nativeAnchor={true}
               href={loginUrl}

--- a/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceCard/LearningResourceCard.tsx
@@ -64,7 +64,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
           {user?.is_authenticated && user?.is_learning_path_editor && (
             <ActionButton
               variant="text"
-              edge="rounded"
+              edge="circular"
               color="secondary"
               aria-label="Add to Learning Path"
               onClick={showAddToLearningPathDialog}
@@ -75,7 +75,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
           {user?.is_authenticated && (
             <ActionButton
               variant="text"
-              edge="rounded"
+              edge="circular"
               color="secondary"
               aria-label="Add to User List"
               onClick={showAddToUserListDialog}

--- a/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
+++ b/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
@@ -59,7 +59,7 @@ const SearchSubscriptionToggle = ({
     return (
       <SimpleMenu
         trigger={
-          <Button variant="filled" endIcon={<ExpandMoreSharpIcon />}>
+          <Button variant="primary" endIcon={<ExpandMoreSharpIcon />}>
             Subscribed
           </Button>
         }
@@ -69,7 +69,7 @@ const SearchSubscriptionToggle = ({
   }
   return (
     <Button
-      variant="filled"
+      variant="primary"
       disabled={subscriptionCreate.isLoading}
       onClick={() =>
         subscriptionCreate.mutateAsync({

--- a/frontends/mit-open/src/pages/ArticleDetailsPage/ArticleDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ArticleDetailsPage/ArticleDetailsPage.tsx
@@ -45,7 +45,7 @@ const ArticlesDetailPage: React.FC = () => {
                   alignItems="center"
                   display="flex"
                 >
-                  <ButtonLink variant="outlined" href={articlesEditView(id)}>
+                  <ButtonLink variant="secondary" href={articlesEditView(id)}>
                     Edit
                   </ButtonLink>
                 </Grid>

--- a/frontends/mit-open/src/pages/ErrorPage/ErrorPageTemplate.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ErrorPageTemplate.tsx
@@ -27,7 +27,7 @@ const ErrorPageTemplate: React.FC<ErrorPageTemplateProps> = ({
         </MetaTags>
         <CardContent>{children}</CardContent>
         <CardActions>
-          <ButtonLink variant="outlined" href={HOME}>
+          <ButtonLink variant="secondary" href={HOME}>
             Home
           </ButtonLink>
         </CardActions>

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -112,7 +112,7 @@ const BrowseTopicsSection: React.FC = () => {
             )
           })}
         </Topics>
-        <SeeAllButton href="/topics/" edge="rounded" size="large">
+        <SeeAllButton href="/topics/" edge="circular" size="large">
           See all
         </SeeAllButton>
       </Container>

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
@@ -134,7 +134,7 @@ const LearningPathListingPage: React.FC = () => {
                 display="flex"
               >
                 {canEdit ? (
-                  <Button variant="filled" onClick={handleCreate}>
+                  <Button variant="primary" onClick={handleCreate}>
                     Create new list
                   </Button>
                 ) : null}

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -129,7 +129,7 @@ const UserListListingPage: React.FC = () => {
                 alignItems="center"
                 display="flex"
               >
-                <Button variant="filled" onClick={handleCreate}>
+                <Button variant="primary" onClick={handleCreate}>
                   Create new list
                 </Button>
               </Grid>

--- a/frontends/ol-components/src/components/BasicDialog/BasicDialog.tsx
+++ b/frontends/ol-components/src/components/BasicDialog/BasicDialog.tsx
@@ -90,11 +90,11 @@ const BasicDialog: React.FC<BasicDialogProps> = ({
       <DialogContent>{children}</DialogContent>
       {showFooter && (
         <DialogActions>
-          <Button variant="outlined" onClick={onClose}>
+          <Button variant="secondary" onClick={onClose}>
             {cancelText}
           </Button>
           <Button
-            variant="filled"
+            variant="primary"
             onClick={handleConfirm}
             disabled={confirming}
           >

--- a/frontends/ol-components/src/components/Button/Button.mdx
+++ b/frontends/ol-components/src/components/Button/Button.mdx
@@ -6,7 +6,7 @@ import * as ButtonStories from "./Button.stories";
 
 # Button
 
-Use prop `variant="filled" | "outlined" | "text"` to set the button variant:
+Use prop `variant="primary" | "secondary" | "tertiary" | "text"` to set the button variant:
 
 <Canvas of={ButtonStories.VariantStory} />
 
@@ -14,15 +14,11 @@ Use `size="small" | "medium" | "large"` to set the button size:
 
 <Canvas of={ButtonStories.SizeStory} />
 
-Use `color="red" | "dark"` to set the button color:
-
-<Canvas of={ButtonStories.ColorStory} />
-
 Use `disabled` to disable the button:
 
 <Canvas of={ButtonStories.DisabledStory} />
 
-Use `edge="rounded" | "sharp"` to set the button edge:
+Use `edge="circular" | "rounded"` to set the button edge:
 
 <Canvas of={ButtonStories.EdgeStory} />
 

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -112,13 +112,13 @@ export const EdgeStory: Story = {
   },
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} edge="rounded">
+      <Button {...args} edge="circular">
         rounded
       </Button>
       <Button {...args} edge="circular">
         circular
       </Button>
-      <Button {...args} variant="secondary" edge="rounded">
+      <Button {...args} variant="secondary" edge="circular">
         rounded
       </Button>
       <Button {...args} variant="secondary" edge="circular">

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -49,11 +49,14 @@ export const VariantStory: Story = {
   },
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} variant="filled">
-        Filled
+      <Button {...args} variant="primary">
+        Primary
       </Button>
-      <Button {...args} variant="outlined">
-        Outlined
+      <Button {...args} variant="secondary">
+        Secondary
+      </Button>
+      <Button {...args} variant="tertiary">
+        Tertiary
       </Button>
       <Button {...args} variant="text">
         Text
@@ -87,36 +90,17 @@ export const DisabledStory: Story = {
   },
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} disabled variant="filled">
-        Filled
+      <Button {...args} disabled variant="primary">
+        Primary
       </Button>
-      <Button {...args} disabled variant="outlined">
-        Outlined
+      <Button {...args} disabled variant="secondary">
+        Secondary
+      </Button>
+      <Button {...args} variant="tertiary">
+        Tertiary
       </Button>
       <Button {...args} disabled variant="text">
         Text
-      </Button>
-    </Stack>
-  ),
-}
-
-export const ColorStory: Story = {
-  argTypes: {
-    color: { table: { disable: true } },
-  },
-  render: (args) => (
-    <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} color="primary">
-        Primary
-      </Button>
-      <Button {...args} color="primary" variant="outlined">
-        Primary
-      </Button>
-      <Button {...args} color="secondary">
-        Secondary
-      </Button>
-      <Button {...args} color="secondary" variant="outlined">
-        Secondary
       </Button>
     </Stack>
   ),
@@ -128,17 +112,17 @@ export const EdgeStory: Story = {
   },
   render: (args) => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} edge="sharp">
-        Sharp
-      </Button>
       <Button {...args} edge="rounded">
-        Rounded
+        rounded
       </Button>
-      <Button {...args} variant="outlined" edge="sharp">
-        Sharp
+      <Button {...args} edge="circular">
+        circular
       </Button>
-      <Button {...args} variant="outlined" edge="rounded">
-        Rounded
+      <Button {...args} variant="secondary" edge="rounded">
+        rounded
+      </Button>
+      <Button {...args} variant="secondary" edge="circular">
+        circular
       </Button>
     </Stack>
   ),
@@ -172,10 +156,10 @@ export const IconOnlyStory: Story = {
       <ActionButton {...args}>
         <RiArrowRightLine />
       </ActionButton>
-      <ActionButton {...args} variant="outlined">
+      <ActionButton {...args} variant="secondary">
         <RiDeleteBinLine />
       </ActionButton>
-      <ActionButton {...args} variant="outlined" edge="rounded">
+      <ActionButton {...args} variant="secondary" edge="circular">
         <RiEditLine />
       </ActionButton>
     </Stack>
@@ -183,8 +167,8 @@ export const IconOnlyStory: Story = {
 }
 
 const SIZES = ["small", "medium", "large"] as const
-const EDGES = ["sharp", "rounded"] as const
-const VARIANTS = ["filled", "outlined", "text"] as const
+const EDGES = ["rounded", "circular"] as const
+const VARIANTS = ["primary", "secondary", "tertiary", "text"] as const
 const EXTRA_PROPS = [
   {},
   { startIcon: <RiArrowLeftLine /> },
@@ -195,10 +179,10 @@ export const LinkStory: Story = {
   decorators: [withRouter],
   render: () => (
     <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <ButtonLink href="" variant="filled">
+      <ButtonLink href="" variant="primary">
         Link
       </ButtonLink>
-      <ButtonLink href="" variant="outlined">
+      <ButtonLink href="" variant="secondary">
         Link
       </ButtonLink>
       <ButtonLink href="" variant="text">
@@ -239,7 +223,6 @@ export const ButtonsShowcase: Story = {
   ),
 }
 
-const COLORS = ["primary", "secondary"] as const
 const ICONS = [
   {
     component: <RiArrowLeftLine />,
@@ -262,33 +245,30 @@ export const ActionButtonsShowcase: Story = {
   render: () => (
     <>
       {VARIANTS.flatMap((variant) =>
-        EDGES.flatMap((edge) =>
-          COLORS.flatMap((color) => (
-            <Stack
-              direction="row"
-              gap={2}
-              key={`${variant}-${edge}-${color}`}
-              alignItems="center"
-              sx={{ my: 2 }}
-            >
-              {SIZES.map((size) => (
-                <React.Fragment key={size}>
-                  {ICONS.map((icon) => (
-                    <ActionButton
-                      key={icon.key}
-                      variant={variant}
-                      edge={edge}
-                      size={size}
-                      color={color}
-                    >
-                      {icon.component}
-                    </ActionButton>
-                  ))}
-                </React.Fragment>
-              ))}
-            </Stack>
-          )),
-        ),
+        EDGES.flatMap((edge) => (
+          <Stack
+            direction="row"
+            gap={2}
+            key={`${variant}-${edge}`}
+            alignItems="center"
+            sx={{ my: 2 }}
+          >
+            {SIZES.map((size) => (
+              <React.Fragment key={size}>
+                {ICONS.map((icon) => (
+                  <ActionButton
+                    key={icon.key}
+                    variant={variant}
+                    edge={edge}
+                    size={size}
+                  >
+                    {icon.component}
+                  </ActionButton>
+                ))}
+              </React.Fragment>
+            ))}
+          </Stack>
+        )),
       )}
     </>
   ),

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -103,6 +103,7 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     },
     variant === "tertiary" && {
       color: colors.darkGray2,
+      border: "none",
       backgroundColor: colors.lightGray2,
       ":hover:not(:disabled)": {
         backgroundColor: colors.white,

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -4,34 +4,32 @@ import { pxToRem } from "../ThemeProvider/typography"
 import tinycolor from "tinycolor2"
 import { Link } from "react-router-dom"
 
-type ButtonVariant = "outlined" | "filled" | "text"
+type ButtonVariant = "primary" | "secondary" | "tertiary" | "text"
 type ButtonSize = "small" | "medium" | "large"
-type ButtonEdge = "rounded" | "sharp"
-type ButtonColor = "primary" | "secondary"
+type ButtonEdge = "circular" | "rounded"
 
 type ButtonStyleProps = {
   variant?: ButtonVariant
   size?: ButtonSize
   edge?: ButtonEdge
-  color?: ButtonColor
   startIcon?: React.ReactNode
   endIcon?: React.ReactNode
 }
 
 const defaultProps: Required<Omit<ButtonStyleProps, "startIcon" | "endIcon">> =
   {
-    variant: "filled",
+    variant: "primary",
     size: "medium",
-    edge: "sharp",
-    color: "primary",
+    edge: "rounded",
   }
 
 const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
-  const { color, size, variant, edge, theme } = {
+  const { size, variant, edge, theme } = {
     ...defaultProps,
     ...props,
   }
-  const { palette, typography } = theme
+  const { typography } = theme
+  const { colors } = theme.custom
   return [
     {
       color: theme.palette.text.primary,
@@ -64,41 +62,61 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
       ...typography.buttonSmall,
     },
     // variant
-    variant === "filled" && {
-      backgroundColor: palette[color].main,
-      color: palette[color].contrastText,
+    variant === "primary" && {
+      backgroundColor: colors.mitRed,
+      color: colors.white,
       border: "none",
       ":hover:not(:disabled)": {
-        backgroundColor: palette[color].active,
+        backgroundColor: colors.red,
       },
       ":disabled": {
-        background: palette.action.disabled,
+        backgroundColor: colors.silverGray,
       },
     },
-    (variant === "outlined" || variant === "text") && {
+    (variant === "secondary" || variant === "text") && {
       backgroundColor: "transparent",
       borderColor: "currentcolor",
-      borderStyle: variant === "outlined" ? "solid" : "none",
+      borderStyle: variant === "secondary" ? "solid" : "none",
       borderWidth: {
         small: "1px",
         medium: "1.5px",
         large: "2px",
       }[size],
-      color: palette[color].main,
+    },
+    variant === "secondary" && {
+      color: colors.red,
       ":hover:not(:disabled)": {
-        backgroundColor: tinycolor(palette[color].main)
-          .setAlpha(0.06)
-          .toString(),
+        backgroundColor: tinycolor(colors.brightRed).setAlpha(0.06).toString(),
       },
       ":disabled": {
-        color: palette.action.disabled,
+        color: colors.silverGray,
+      },
+    },
+    variant === "text" && {
+      color: colors.darkGray2,
+      ":hover:not(:disabled)": {
+        backgroundColor: tinycolor(colors.darkGray1).setAlpha(0.06).toString(),
+      },
+      ":disabled": {
+        color: colors.silverGray,
+      },
+    },
+    variant === "tertiary" && {
+      color: colors.darkGray2,
+      backgroundColor: colors.lightGray2,
+      ":hover:not(:disabled)": {
+        backgroundColor: colors.white,
+      },
+      ":disabled": {
+        backgroundColor: colors.lightGray2,
+        color: colors.silverGrayLight,
       },
     },
     // edge
-    edge === "sharp" && {
+    edge === "rounded" && {
       borderRadius: "4px",
     },
-    edge === "rounded" && {
+    edge === "circular" && {
       // Pill-shaped buttons... Overlapping border radius get clipped to pill.
       borderRadius: "100vh",
     },
@@ -220,10 +238,9 @@ const ButtonLink: React.FC<ButtonLinkProps> = ({
 const ActionButtonDefaultProps: Required<
   Omit<ButtonStyleProps, "startIcon" | "endIcon">
 > = {
-  variant: "filled",
+  variant: "primary",
   size: "medium",
-  edge: "sharp",
-  color: "primary",
+  edge: "rounded",
 }
 
 type ActionButtonProps = Omit<ButtonStyleProps, "startIcon" | "endIcon"> &

--- a/frontends/ol-components/src/components/Carousel/Carousel.tsx
+++ b/frontends/ol-components/src/components/Carousel/Carousel.tsx
@@ -77,7 +77,7 @@ const Carousel: React.FC<CarouselProps> = ({
       <Stack direction="row" justifyContent="end" spacing={3} marginTop={3}>
         <ActionButton
           size="small"
-          edge="rounded"
+          edge="circular"
           onClick={pageDown}
           disabled={!canPageDown}
           aria-label="Previous"
@@ -86,7 +86,7 @@ const Carousel: React.FC<CarouselProps> = ({
         </ActionButton>
         <ActionButton
           size="small"
-          edge="rounded"
+          edge="circular"
           onClick={pageUp}
           disabled={!canPageUp}
           aria-label="Next"

--- a/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
+++ b/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
@@ -162,11 +162,11 @@ const FormDialog: React.FC<FormDialogProps> = ({
       </div>
       <DialogContent dividers={true}>{children}</DialogContent>
       <DialogActions>
-        <Button variant="outlined" onClick={onClose} {...cancelButtonProps}>
+        <Button variant="secondary" onClick={onClose} {...cancelButtonProps}>
           {cancelButtonContent}
         </Button>
         <Button
-          variant="filled"
+          variant="primary"
           type="submit"
           disabled={isSubmitting}
           {...submitButtonProps}

--- a/frontends/ol-components/src/components/ThemeProvider/Typography.stories.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/Typography.stories.tsx
@@ -1,8 +1,6 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import Typography from "@mui/material/Typography"
-import Button from "@mui/material/Button"
-import Stack from "@mui/material/Stack"
 
 const meta: Meta<typeof Typography> = {
   title: "smoot-design/Typography",
@@ -57,21 +55,6 @@ export const Paragraphs: Story = {
           <Typography variant="body4">Body level 4, {text}</Typography>
         </li>
       </ul>
-    )
-  },
-}
-
-export const Buttons: Story = {
-  render: () => {
-    return (
-      <Stack spacing={2} direction="row" alignItems="center">
-        <Button size="small" variant="outlined">
-          Small
-        </Button>
-        <Button size="large" variant="outlined">
-          Large
-        </Button>
-      </Stack>
     )
   },
 }

--- a/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
+++ b/frontends/ol-widgets/src/components/editing/ManageWidgetDialog.tsx
@@ -205,10 +205,10 @@ const DialogContentEditing: React.FC<WidgetEditingProps> = ({
                 })}
               </DialogContent>
               <DialogActions>
-                <Button variant="outlined" onClick={onCancel}>
+                <Button variant="secondary" onClick={onCancel}>
                   Cancel
                 </Button>
-                <Button type="submit" variant="filled">
+                <Button type="submit" variant="primary">
                   Submit
                 </Button>
               </DialogActions>
@@ -293,10 +293,10 @@ const DialogContentAdding: React.FC<WidgetAddingProps> = ({
               </Field>
             </DialogContent>
             <DialogActions>
-              <Button variant="outlined" onClick={onCancel}>
+              <Button variant="secondary" onClick={onCancel}>
                 Cancel
               </Button>
-              <Button type="submit" variant="filled">
+              <Button type="submit" variant="primary">
                 Next
               </Button>
             </DialogActions>

--- a/frontends/ol-widgets/src/components/editing/WidgetsListEditable.tsx
+++ b/frontends/ol-widgets/src/components/editing/WidgetsListEditable.tsx
@@ -229,10 +229,10 @@ const WidgetsListEditable: React.FC<WidgetsListEditableProps> = ({
         <h4 className="ol-widget-editing-header-row">
           Manage Widgets
           <div>
-            <Button size="small" variant="outlined" onClick={onCancel}>
+            <Button size="small" variant="secondary" onClick={onCancel}>
               Cancel
             </Button>
-            <Button size="small" variant="filled" onClick={handleDone}>
+            <Button size="small" variant="secondary" onClick={handleDone}>
               Done
             </Button>
           </div>


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4360 , which uses the tertiary button

### Description (What does it do?)
Our Figma page includes several button variants. This PR adds a new variant, `"tertiary"`.

Additionally, this PR aligns the button props with the terminology figma uses. For example:
```
Previous:
---------
    Figma                       code
        type="secondary"        color="primary"
        edge="circular"         variant="outlined"
                                edge="rounded"

Now:
---------
    Figma                       code
        variant="secondary"     variant="secondary"
        edge="circular"         edge="circular"

(Steve recently renamed "type" in Figma to "variant" for buttons.
We can't use "type" int he code since that's an HTML attribute.)
```


### Screenshots (if appropriate):
<img width="1077" alt="Screenshot 2024-05-31 at 3 49 46 PM" src="https://github.com/mitodl/mit-open/assets/9010790/b12106db-26e7-43c7-abc7-ad746a5af0a0">


### How can this be tested?
1. Look around the app. The buttons should all the the same as before. For example:
    - "See all" topics button on http://localhost:8063/
    - "Create new list" button at http://localhost:8063/userlists/
    - "Subscribe" button at http://localhost:8063/c/department/architecture/
2. Run `yarn storybook` and view the buttons at http://localhost:6006/?path=/docs/smoot-design-button--docs ... you should see the tertiary buttons.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
