### PR TITLE
Configure JS bundles to use a separate API domain for backend

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -32,7 +32,11 @@ jobs:
         run: yarn install --immutable
 
       - name: Build frontend
-        run: EMBEDLY_KEY=${{ secrets.EMBEDLY_KEY_PROD }} NODE_ENV=production yarn build
+        run: NODE_ENV=production yarn build
+        env:
+          EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_PROD }}
+          MITOPEN_AXIOS_WITH_CREDENTIALS: true
+          MITOPEN_AXIOS_BASE_PATH: https://api.mitopen.odl.mit.edu
 
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -32,7 +32,11 @@ jobs:
         run: yarn install --immutable
 
       - name: Build frontend
-        run: EMBEDLY_KEY=${{ secrets.EMBEDLY_KEY_RC }} NODE_ENV=production yarn build
+        run: NODE_ENV=production yarn build
+        env:
+          EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_RC }}
+          MITOPEN_AXIOS_WITH_CREDENTIALS: true
+          MITOPEN_AXIOS_BASE_PATH: https://api.mitopen-rc.odl.mit.edu
 
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The static assets are being configured to get served via S3. In order to separate out the paths between front and back end this sets the API URL compiled into the assets to have an `api.` domain prefix, simplifying the Fastly routing logic.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Verify that the compiled assets for the RC release point to the API subdomain.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


### Checklist:
- Verify that the specified domains match what is desired for RC and production environments
- Update Heroku and Route 53 configurations to serve the Django application from the `api.` subdomain
- Update Fastly configuration to exclude the Django application (at least for now)