### PR TITLE
professional toggle

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/ProfessionalToggle.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/ProfessionalToggle.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+import {
+  Collapse,
+  ToggleButton,
+  ToggleButtonGroup,
+  styled,
+} from "ol-components"
+import { RiBookOpenLine, RiBriefcase3Line } from "@remixicon/react"
+
+const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
+  width: 100%;
+`
+const StyledButtonGroupContainer = styled.div`
+  margin-top: 10px;
+  margin-bottom: 10px;
+`
+const ExplanationContainer = styled.div`
+  margin: 10px;
+  font-size: 0.875em;
+  min-height: 35px;
+`
+
+const StyledRiBookOpenLine = styled(RiBookOpenLine)`
+  height: 20px;
+  margin-right: 3px;
+  margin-left: -2px;
+`
+
+const StyledRiBriefcase3Line = styled(RiBriefcase3Line)`
+  height: 20px;
+  margin-right: 3px;
+  margin-left: -2px;
+`
+
+const StyledToggleButton = styled(ToggleButton)(({ theme }) => ({
+  width: "100%",
+  height: "50px",
+  backgroundColor: theme.custom.colors.lightGray2,
+  color: theme.custom.colors.darkGray2,
+  "&.Mui-selected": {
+    backgroundColor: theme.custom.colors.white,
+    "&:hover": {
+      backgroundColor: theme.custom.colors.white,
+    },
+  },
+  "&:hover": {
+    backgroundColor: theme.custom.colors.white,
+  },
+}))
+
+const ViewAllButton = styled(StyledToggleButton)`
+  border-right: 2px solid;
+  border-color: ${({ theme }) => theme.custom.colors.silverGrayLight};
+  width: 25%;
+`
+const AcademicButton = styled(StyledToggleButton)`
+  border-right: 2px solid;
+  border-color: ${({ theme }) => theme.custom.colors.silverGrayLight};
+  width: 35%;
+`
+const ProfesionalButton = styled(StyledToggleButton)`
+  width: 40%;
+`
+
+const ProfessionalToggle: React.FC<{
+  professionalSetting: boolean | null | undefined | string
+  setParamValue: (_name: string, _rawValue: string | string[]) => void
+}> = ({ professionalSetting, setParamValue }) => {
+  const handleChange = (
+    event: React.MouseEvent<HTMLElement>,
+    newValue: string,
+  ) => {
+    setParamValue("professional", newValue)
+  }
+
+  if (professionalSetting === true || professionalSetting === false) {
+    professionalSetting = professionalSetting.toString()
+  } else {
+    professionalSetting = ""
+  }
+
+  return (
+    <StyledButtonGroupContainer>
+      <StyledToggleButtonGroup
+        value={professionalSetting}
+        exclusive
+        onChange={handleChange}
+      >
+        <ViewAllButton value="">All</ViewAllButton>
+        <AcademicButton value="false">
+          <StyledRiBookOpenLine /> Academic
+        </AcademicButton>
+        <ProfesionalButton value="true">
+          <StyledRiBriefcase3Line /> Professional
+        </ProfesionalButton>
+      </StyledToggleButtonGroup>
+      <Collapse in={professionalSetting === ""}>
+        <ExplanationContainer>
+          Content developed from MIT's academic and professional curriculum
+        </ExplanationContainer>
+      </Collapse>
+      <Collapse in={professionalSetting === "false"}>
+        <ExplanationContainer>
+          Content developed from MIT’s academic curriculum
+        </ExplanationContainer>
+      </Collapse>
+      <Collapse in={professionalSetting === "true"}>
+        <ExplanationContainer>
+          Content developed from MIT’s professional curriculum
+        </ExplanationContainer>
+      </Collapse>
+    </StyledButtonGroupContainer>
+  )
+}
+
+export default ProfessionalToggle

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -37,6 +37,8 @@ import LearningResourceCard from "@/page-components/LearningResourceCard/Learnin
 import _ from "lodash"
 
 import { ResourceTypeTabs } from "./ResourceTypeTabs"
+import ProfessionalToggle from "./ProfessionalToggle"
+
 import type { TabConfig } from "./ResourceTypeTabs"
 
 export const StyledDropdown = styled(SimpleSelect)`
@@ -187,9 +189,13 @@ export const FacetsTitleContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: baseline;
-  min-height: 40px;
-  padding-top: 8px;
+  min-height: 65px;
+  align-items: end;
+  padding-bottom: 10px;
+  padding-top: 20px;
+  ${({ theme }) => theme.breakpoints.up("sm")} {
+    min-height: 83px;
+  }
 `
 
 const PaginationContainer = styled.div`
@@ -287,7 +293,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     },
     { keepPreviousData: true },
   )
-
   return (
     <Container>
       <GridContainer>
@@ -312,6 +317,10 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               ) : null}
             </FacetsTitleContainer>
             <FacetStyles>
+              <ProfessionalToggle
+                professionalSetting={requestParams.professional}
+                setParamValue={setParamValue}
+              ></ProfessionalToggle>
               <AvailableFacets
                 facetManifest={facetManifest}
                 activeFacets={requestParams}

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -345,6 +345,29 @@ test("Set sort", async () => {
   expect(popularitySelect).toHaveAttribute("aria-selected", "true")
 })
 
+test("The professional toggle updates the professional setting", async () => {
+  setMockApiResponses({ search: { count: 137 } })
+  const { location } = renderWithProviders(<SearchPage />)
+  const professionalToggle = await screen.getAllByText("Professional")[0]
+  await user.click(professionalToggle)
+  await waitFor(() => {
+    const params = new URLSearchParams(location.current.search)
+    expect(params.get("professional")).toBe("true")
+  })
+  const academicToggle = await screen.getAllByText("Academic")[0]
+  await user.click(academicToggle)
+  await waitFor(() => {
+    const params = new URLSearchParams(location.current.search)
+    expect(params.get("professional")).toBe("false")
+  })
+  const viewAllToggle = await screen.getAllByText("All")[0]
+  await user.click(viewAllToggle)
+  await waitFor(() => {
+    const params = new URLSearchParams(location.current.search)
+    expect(params.get("professional")).toBe(null)
+  })
+})
+
 test("Clearing text updates URL", async () => {
   setMockApiResponses({})
   const { location } = renderWithProviders(<SearchPage />, { url: "?q=meow" })

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from "react"
 import { styled, Container, SearchInput, Grid } from "ol-components"
 import { MetaTags, capitalize } from "ol-utilities"
 import SearchDisplay from "@/page-components/SearchDisplay/SearchDisplay"
-
 import type { LearningResourceOfferor } from "api"
 import { useOfferorsList } from "api/hooks/learningResources"
 
@@ -39,16 +38,6 @@ const getFacetManifest = (
           value: true,
           name: "free",
           label: "Free",
-        },
-        {
-          value: true,
-          name: "certification",
-          label: "With Certificate",
-        },
-        {
-          value: true,
-          name: "professional",
-          label: "Professional",
         },
       ],
     },

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -109,6 +109,8 @@ export { default as Radio } from "@mui/material/Radio"
 export type { RadioProps } from "@mui/material/Radio"
 export { default as RadioGroup } from "@mui/material/RadioGroup"
 export type { RadioGroupProps } from "@mui/material/RadioGroup"
+export { default as ToggleButton } from "@mui/material/ToggleButton"
+export { default as ToggleButtonGroup } from "@mui/material/ToggleButtonGroup"
 
 // Mui Custom Form Inputs
 export { default as FormControl } from "@mui/material/FormControl"
@@ -123,6 +125,8 @@ export { default as Pagination } from "@mui/material/Pagination"
 export type { PaginationProps } from "@mui/material/Pagination"
 export { default as Typography } from "@mui/material/Typography"
 export type { TypographyProps } from "@mui/material/Typography"
+
+export { default as Collapse } from "@mui/material/Collapse"
 
 export { default as Menu } from "@mui/material/Menu"
 export type { MenuProps } from "@mui/material/Menu"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4433

### Description (What does it do?)
This pr adds a toggle for updating academic/professional in the search and channel pages

### Screenshots (if appropriate):
<img width="392" alt="Screenshot 2024-06-04 at 12 04 47 PM" src="https://github.com/mitodl/mit-open/assets/1934992/375225f9-896d-4cde-bdda-5ec5667b7d71">
<img width="1705" alt="Screenshot 2024-06-04 at 12 04 31 PM" src="https://github.com/mitodl/mit-open/assets/1934992/59962d58-0d23-4c1f-9284-c8c7074d20be">
<img width="1702" alt="Screenshot 2024-06-04 at 12 04 11 PM" src="https://github.com/mitodl/mit-open/assets/1934992/38453d10-0f44-47b0-8013-e9dc1e574035">


### How can this be tested?
Go to http://localhost:8063/search
and
http://localhost:8063/c/offeror/xpro

Verify that the professional toggle works as expected and looks like the design.

The final design with the correct colors is here:
https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=107-2479&m=dev


