### PR TITLE
OLL contentfiles

### DIFF
--- a/fixtures/aws.py
+++ b/fixtures/aws.py
@@ -83,6 +83,15 @@ def mitxonline_aws_settings(aws_settings):
     return aws_settings
 
 
+@pytest.fixture(autouse=True)
+def oll_aws_settings(aws_settings):
+    """Default OLL test settings"""  # noqa: D401
+    aws_settings.OLL_LEARNING_COURSE_BUCKET_NAME = (  # impossible bucket name
+        "test-oll-bucket"
+    )
+    return aws_settings
+
+
 @pytest.fixture()
 def mock_xpro_learning_bucket(
     xpro_aws_settings,
@@ -127,4 +136,19 @@ def mock_mitx_learning_bucket(
         aws_secret_access_key=mitx_aws_settings.AWS_SECRET_ACCESS_KEY,
     )
     bucket = s3.create_bucket(Bucket=mitx_aws_settings.EDX_LEARNING_COURSE_BUCKET_NAME)
+    return SimpleNamespace(s3=s3, bucket=bucket)
+
+
+@pytest.fixture()
+def mock_oll_learning_bucket(
+    oll_aws_settings,
+    mock_s3_fixture,  # noqa: ARG001
+):  # pylint: disable=unused-argument
+    """Mock OLL learning bucket"""
+    s3 = boto3.resource(
+        "s3",
+        aws_access_key_id=oll_aws_settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=oll_aws_settings.AWS_SECRET_ACCESS_KEY,
+    )
+    bucket = s3.create_bucket(Bucket=oll_aws_settings.OLL_LEARNING_COURSE_BUCKET_NAME)
     return SimpleNamespace(s3=s3, bucket=bucket)

--- a/learning_resources/etl/edx_shared.py
+++ b/learning_resources/etl/edx_shared.py
@@ -26,7 +26,7 @@ def get_most_recent_course_archives(
     Args:
         etl_source(str): The edx ETL source
         s3_prefix(str): The prefix for S3 object keys
-        override_base_prefix(bool): If true, override the default prefix of "20"
+        override_base_prefix(bool): Override the default prefix of "20"
 
     Returns:
         list of str: edx archive S3 keys
@@ -80,10 +80,7 @@ def get_most_recent_course_archives(
 
 
 def sync_edx_course_files(
-    etl_source: str,
-    ids: list[int],
-    keys: list[str],
-    s3_prefix: str | None = None,
+    etl_source: str, ids: list[int], keys: list[str], s3_prefix: str | None = None
 ):
     """
     Sync all edx course run files for a list of course ids to database
@@ -117,7 +114,10 @@ def sync_edx_course_files(
         elif etl_source == ETLSource.oll.name:
             # Additional processing of run ids and tarfile names,
             # because oll data is structured differently
-            run_id = rf"{run_id.strip("_OLL").replace('-', '.').replace('_', '.')}"  # noqa: B005
+            run_id = rf"{run_id.strip("_OLL").replace(
+                '-', '.'
+            ).replace('_', '.').replace('+', '.')}"  # noqa: B005
+            runs = runs.filter(run_id__iregex=run_id)
         else:
             runs = runs.filter(run_id=run_id)
         log.info("There are %d runs for %s", runs.count(), run_id)

--- a/learning_resources/etl/edx_shared.py
+++ b/learning_resources/etl/edx_shared.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 def get_most_recent_course_archives(
-    etl_source: str, s3_prefix: str | None = None
+    etl_source: str, *, s3_prefix: str | None = None, override_base_prefix=False
 ) -> list[str]:
     """
     Retrieve a list of S3 keys for the most recent edx course archives
@@ -26,6 +26,7 @@ def get_most_recent_course_archives(
     Args:
         etl_source(str): The edx ETL source
         s3_prefix(str): The prefix for S3 object keys
+        override_base_prefix(bool): If true, override the default prefix of "20"
 
     Returns:
         list of str: edx archive S3 keys
@@ -37,19 +38,35 @@ def get_most_recent_course_archives(
     if s3_prefix is None:
         s3_prefix = "courses"
     try:
-        course_tar_regex = rf".*/{s3_prefix}/.*\.tar\.gz$"
-        most_recent_export_date = next(
+        log.info("Getting recent archives from %s with prefix %s", bucket, s3_prefix)
+        course_tar_regex = (
+            rf"{s3_prefix}/.*\.tar\.gz$"
+            if override_base_prefix
+            else rf".*/{s3_prefix}/.*\.tar\.gz$"
+        )
+        most_recent_export_file = next(
             reversed(  # noqa: C413
                 sorted(
                     [
                         obj
-                        for obj in bucket.objects.filter(Prefix="20")
+                        for obj in bucket.objects.filter(
+                            # Use s3_prefix for OLL, "20" for all others
+                            Prefix=s3_prefix if override_base_prefix else "20"
+                        )
                         if re.search(course_tar_regex, obj.key)
                     ],
                     key=lambda obj: obj.last_modified,
                 )
             )
-        ).key.split("/")[0]
+        )
+        if override_base_prefix:
+            # More hoops to get desired result from OLL compared to other sources
+            most_recent_export_date = "/".join(
+                [s3_prefix, most_recent_export_file.key.lstrip(s3_prefix).split("/")[0]]
+            )
+        else:
+            most_recent_export_date = most_recent_export_file.key.split("/")[0]
+        log.info("Most recent export date is %s", most_recent_export_date)
         return [
             obj.key
             for obj in bucket.objects.filter(Prefix=most_recent_export_date)
@@ -63,7 +80,10 @@ def get_most_recent_course_archives(
 
 
 def sync_edx_course_files(
-    etl_source: str, ids: list[int], keys: list[str], s3_prefix: str | None = None
+    etl_source: str,
+    ids: list[int],
+    keys: list[str],
+    s3_prefix: str | None = None,
 ):
     """
     Sync all edx course run files for a list of course ids to database
@@ -79,7 +99,8 @@ def sync_edx_course_files(
         s3_prefix = "courses"
     for key in keys:
         matches = re.search(rf"{s3_prefix}/(.+)\.tar\.gz$", key)
-        run_id = matches.group(1)
+        run_id = matches.group(1).split("/")[-1]
+        log.info("Run is is %s", run_id)
         runs = LearningResourceRun.objects.filter(
             learning_resource__etl_source=etl_source,
             learning_resource_id__in=ids,
@@ -87,20 +108,26 @@ def sync_edx_course_files(
         )
         if etl_source == ETLSource.mit_edx.name:
             # Additional processing of run ids and tarfile names,
-            # because edx data is a mess of id/file formats
+            # because edx data is structured differently
             run_id = run_id.strip(  # noqa: B005
                 "-course-prod-analytics.xml"
             )  # suffix on edx tar file basename
             potential_run_ids = rf"{run_id.replace('-', '.').replace('+', '.')}"
             runs = runs.filter(run_id__iregex=potential_run_ids)
+        elif etl_source == ETLSource.oll.name:
+            # Additional processing of run ids and tarfile names,
+            # because oll data is structured differently
+            run_id = rf"{run_id.strip("_OLL").replace('-', '.').replace('_', '.')}"  # noqa: B005
         else:
             runs = runs.filter(run_id=run_id)
+        log.info("There are %d runs for %s", runs.count(), run_id)
         run = runs.first()
 
         if not run:
             continue
         with TemporaryDirectory() as export_tempdir:
             course_tarpath = Path(export_tempdir, key.split("/")[-1])
+            log.info("course tarpath is %s", course_tarpath)
             bucket.download_file(key, course_tarpath)
             checksum = calc_checksum(course_tarpath)
             if run.checksum == checksum:

--- a/learning_resources/etl/edx_shared.py
+++ b/learning_resources/etl/edx_shared.py
@@ -127,7 +127,7 @@ def sync_edx_course_files(
             continue
         with TemporaryDirectory() as export_tempdir:
             course_tarpath = Path(export_tempdir, key.split("/")[-1])
-            log.info("course tarpath is %s", course_tarpath)
+            log.info("course tarpath for run %s is %s", run.run_id, course_tarpath)
             bucket.download_file(key, course_tarpath)
             checksum = calc_checksum(course_tarpath)
             if run.checksum == checksum:

--- a/learning_resources/etl/edx_shared.py
+++ b/learning_resources/etl/edx_shared.py
@@ -16,6 +16,8 @@ from learning_resources.models import LearningResourceRun
 
 log = logging.getLogger(__name__)
 
+EDX_S3_BASE_PREFIX = "20"
+
 
 def get_most_recent_course_archives(
     etl_source: str, *, s3_prefix: str | None = None, override_base_prefix=False
@@ -51,7 +53,9 @@ def get_most_recent_course_archives(
                         obj
                         for obj in bucket.objects.filter(
                             # Use s3_prefix for OLL, "20" for all others
-                            Prefix=s3_prefix if override_base_prefix else "20"
+                            Prefix=s3_prefix
+                            if override_base_prefix
+                            else EDX_S3_BASE_PREFIX
                         )
                         if re.search(course_tar_regex, obj.key)
                     ],

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -474,6 +474,7 @@ def get_learning_course_bucket_name(etl_source: str) -> str:
         ETLSource.mit_edx.name: settings.EDX_LEARNING_COURSE_BUCKET_NAME,
         ETLSource.xpro.name: settings.XPRO_LEARNING_COURSE_BUCKET_NAME,
         ETLSource.mitxonline.name: settings.MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME,
+        ETLSource.oll.name: settings.OLL_LEARNING_COURSE_BUCKET_NAME,
     }
     return bucket_names.get(etl_source)
 

--- a/learning_resources/management/commands/backpopulate_oll_files.py
+++ b/learning_resources/management/commands/backpopulate_oll_files.py
@@ -24,6 +24,12 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Run Populate OLL course run files"""
+        if not (
+            settings.OLL_LEARNING_COURSE_BUCKET_NAME
+            and settings.OLL_LEARNING_COURSE_BUCKET_PREFIX
+        ):
+            self.stderr.write("OLL contentfile settings not configured, skipping")
+            return
         chunk_size = options["chunk_size"]
         task = import_all_oll_files.delay(chunk_size=chunk_size)
         self.stdout.write(f"Started task {task} to get OLL course run file data")

--- a/learning_resources/management/commands/backpopulate_oll_files.py
+++ b/learning_resources/management/commands/backpopulate_oll_files.py
@@ -24,10 +24,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Run Populate OLL course run files"""
-        if not (
-            settings.OLL_LEARNING_COURSE_BUCKET_NAME
-            and settings.OLL_LEARNING_COURSE_BUCKET_PREFIX
-        ):
+        if not settings.OLL_LEARNING_COURSE_BUCKET_NAME:
             self.stderr.write("OLL contentfile settings not configured, skipping")
             return
         chunk_size = options["chunk_size"]

--- a/learning_resources/management/commands/backpopulate_oll_files.py
+++ b/learning_resources/management/commands/backpopulate_oll_files.py
@@ -1,0 +1,36 @@
+"""Management command for populating OLL course run file data"""
+
+from django.core.management import BaseCommand
+
+from learning_resources.tasks import import_all_oll_files
+from main import settings
+from main.utils import now_in_utc
+
+
+class Command(BaseCommand):
+    """Populate OLL course run files"""
+
+    help = "Populate OLL course run files"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-c",
+            "--chunk-size",
+            dest="chunk_size",
+            default=settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE,
+            type=int,
+            help="Chunk size for batch import task",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Run Populate OLL course run files"""
+        chunk_size = options["chunk_size"]
+        task = import_all_oll_files.delay(chunk_size=chunk_size)
+        self.stdout.write(f"Started task {task} to get OLL course run file data")
+        self.stdout.write("Waiting on task...")
+        start = now_in_utc()
+        task.get()
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            f"Population of OLL file data finished, took {total_seconds} seconds"
+        )

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -140,6 +140,18 @@ def import_all_mit_edx_files(self, chunk_size=None):
 
 
 @app.task(bind=True)
+def import_all_oll_files(self, chunk_size=None):
+    """Ingest MIT edX files from an S3 bucket"""
+    raise self.replace(
+        get_content_tasks(
+            ETLSource.oll.name,
+            chunk_size,
+            s3_prefix=settings.EDX_LEARNING_COURSE_BUCKET_PREFIX,
+        )
+    )
+
+
+@app.task(bind=True)
 def import_all_mitxonline_files(self, chunk_size=None):
     """Ingest MITx Online files from an S3 bucket"""
     raise self.replace(

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -101,7 +101,11 @@ def get_content_files(
 
 
 def get_content_tasks(
-    etl_source: str, chunk_size: int | None = None, s3_prefix: str | None = None
+    etl_source: str,
+    *,
+    chunk_size: int | None = None,
+    s3_prefix: str | None = None,
+    override_base_prefix: bool = False,
 ) -> celery.group:
     """
     Return a list of grouped celery tasks for indexing edx content
@@ -110,7 +114,10 @@ def get_content_tasks(
         chunk_size = settings.LEARNING_COURSE_ITERATOR_CHUNK_SIZE
 
     blocklisted_ids = load_course_blocklist()
-    archive_keys = get_most_recent_course_archives(etl_source, s3_prefix=s3_prefix)
+    archive_keys = get_most_recent_course_archives(
+        etl_source, s3_prefix=s3_prefix, override_base_prefix=override_base_prefix
+    )
+    log.info("Found %d %s course archives", len(archive_keys), archive_keys)
     return celery.group(
         [
             get_content_files.si(ids, etl_source, archive_keys, s3_prefix=s3_prefix)
@@ -133,7 +140,7 @@ def import_all_mit_edx_files(self, chunk_size=None):
     raise self.replace(
         get_content_tasks(
             ETLSource.mit_edx.name,
-            chunk_size,
+            chunk_size=chunk_size,
             s3_prefix=settings.EDX_LEARNING_COURSE_BUCKET_PREFIX,
         )
     )
@@ -145,8 +152,9 @@ def import_all_oll_files(self, chunk_size=None):
     raise self.replace(
         get_content_tasks(
             ETLSource.oll.name,
-            chunk_size,
-            s3_prefix=settings.EDX_LEARNING_COURSE_BUCKET_PREFIX,
+            chunk_size=chunk_size,
+            s3_prefix=settings.OLL_LEARNING_COURSE_BUCKET_PREFIX,
+            override_base_prefix=True,
         )
     )
 
@@ -157,7 +165,7 @@ def import_all_mitxonline_files(self, chunk_size=None):
     raise self.replace(
         get_content_tasks(
             ETLSource.mitxonline.name,
-            chunk_size,
+            chunk_size=chunk_size,
         )
     )
 
@@ -169,7 +177,7 @@ def import_all_xpro_files(self, chunk_size=None):
     raise self.replace(
         get_content_tasks(
             ETLSource.xpro.name,
-            chunk_size,
+            chunk_size=chunk_size,
         )
     )
 

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -117,7 +117,6 @@ def get_content_tasks(
     archive_keys = get_most_recent_course_archives(
         etl_source, s3_prefix=s3_prefix, override_base_prefix=override_base_prefix
     )
-    log.info("Found %d %s course archives", len(archive_keys), archive_keys)
     return celery.group(
         [
             get_content_files.si(ids, etl_source, archive_keys, s3_prefix=s3_prefix)

--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -110,7 +110,7 @@ def test_import_all_mit_edx_files(settings, mocker, mocked_celery, mock_blocklis
         tasks.import_all_mit_edx_files.delay(4)
     get_content_tasks_mock.assert_called_once_with(
         ETLSource.mit_edx.name,
-        4,
+        chunk_size=4,
         s3_prefix="simeon-mitx-course-tarballs",
     )
 
@@ -127,7 +127,7 @@ def test_import_all_mitxonline_files(settings, mocker, mocked_celery, mock_block
         tasks.import_all_mitxonline_files.delay(3)
     get_content_tasks_mock.assert_called_once_with(
         PlatformType.mitxonline.name,
-        3,
+        chunk_size=3,
     )
 
 
@@ -140,7 +140,24 @@ def test_import_all_xpro_files(settings, mocker, mocked_celery, mock_blocklist):
     )
     with pytest.raises(mocked_celery.replace_exception_class):
         tasks.import_all_xpro_files.delay(3)
-    get_content_tasks_mock.assert_called_once_with(PlatformType.xpro.name, 3)
+    get_content_tasks_mock.assert_called_once_with(PlatformType.xpro.name, chunk_size=3)
+
+
+@mock_s3
+def test_import_all_oll_files(settings, mocker, mocked_celery, mock_blocklist):
+    """import_all_oll_files should start chunked tasks with correct bucket, platform"""
+    setup_s3(settings)
+    get_content_tasks_mock = mocker.patch(
+        "learning_resources.tasks.get_content_tasks", autospec=True
+    )
+    with pytest.raises(mocked_celery.replace_exception_class):
+        tasks.import_all_oll_files.delay(4)
+    get_content_tasks_mock.assert_called_once_with(
+        ETLSource.oll.name,
+        chunk_size=4,
+        s3_prefix="open-learning-library/courses",
+        override_base_prefix=True,
+    )
 
 
 @mock_s3

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -73,6 +73,12 @@ CELERY_BEAT_SCHEDULE = {
             minute=0, hour=16, day_of_week=2
         ),  # 12:00 PM EST on Tuesdays
     },
+    "update-oll-files-every-1-weeks": {
+        "task": "learning_resources.tasks.import_all_oll_files",
+        "schedule": crontab(
+            minute=0, hour=16, day_of_week=3
+        ),  # 12:00 PM EST on Wednesdays
+    },
     "update-youtube-videos": {
         "task": "learning_resources.tasks.get_youtube_data",
         "schedule": get_int(

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -63,11 +63,9 @@ OLL_API_CLIENT_ID = get_string("OLL_API_CLIENT_ID", None)
 OLL_API_CLIENT_SECRET = get_string("OLL_API_CLIENT_SECRET", None)
 OLL_BASE_URL = get_string("OLL_BASE_URL", None)
 OLL_ALT_URL = get_string("OLL_ALT_URL", None)
-OLL_LEARNING_COURSE_BUCKET_NAME = get_string(
-    "OLL_LEARNING_COURSE_BUCKET_NAME", "open-learning-library/courses"
-)
+OLL_LEARNING_COURSE_BUCKET_NAME = get_string("OLL_LEARNING_COURSE_BUCKET_NAME", None)
 OLL_LEARNING_COURSE_BUCKET_PREFIX = get_string(
-    "OLL_LEARNING_COURSE_BUCKET_PREFIX", None
+    "OLL_LEARNING_COURSE_BUCKET_PREFIX", "open-learning-library/courses"
 )
 # More MIT URLs
 SEE_BASE_URL = get_string("SEE_BASE_URL", None)

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -63,7 +63,12 @@ OLL_API_CLIENT_ID = get_string("OLL_API_CLIENT_ID", None)
 OLL_API_CLIENT_SECRET = get_string("OLL_API_CLIENT_SECRET", None)
 OLL_BASE_URL = get_string("OLL_BASE_URL", None)
 OLL_ALT_URL = get_string("OLL_ALT_URL", None)
-
+OLL_LEARNING_COURSE_BUCKET_NAME = get_string(
+    "OLL_LEARNING_COURSE_BUCKET_NAME", "open-learning-library/courses"
+)
+OLL_LEARNING_COURSE_BUCKET_PREFIX = get_string(
+    "OLL_LEARNING_COURSE_BUCKET_PREFIX", None
+)
 # More MIT URLs
 SEE_BASE_URL = get_string("SEE_BASE_URL", None)
 MITPE_BASE_URL = get_string("MITPE_BASE_URL", None)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4435

### Description (What does it do?)
- Adds a task to import Open Learning Library contentfiles and schedules it to run once/week
- Modifies relevant functions to deal with some peculiarities of OLL file/directory structure on S3



### How can this be tested?
- Set `OLL_LEARNING_COURSE_BUCKET_NAME=ol-data-lake-landing-zone-production`in your .env file along with current `AWS`  and `OLL_` settings from heroku.
- Run `./manage.py backpopulate_oll_data` to get some OLL courses imported first.
- Run `./manage.py backpopulate_oll_files` to get the OLL contentfiles.
- When done (may take awhile), there should be about ~32500 contentfiles for OLL:
```
from learning_resources.models import ContentFile
ContentFile.objects.filter(run__learning_resource__etl_source="oll").count()
```
