### PR TITLE
Absolute URL to backend for login routes

### DIFF
--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -22,6 +22,8 @@ import type {
 } from "../generated/v1"
 import type { BaseAPI } from "../generated/v1/base"
 
+const { axios_base_path: API_BASE_URL } = APP_SETTINGS
+
 // OpenAPI Generator declares parameters using interfaces, which makes passing
 // them to functions a little annoying.
 // See https://stackoverflow.com/questions/37006008/typescript-index-signature-is-missing-in-type for details.
@@ -52,119 +54,121 @@ type Params<API extends BaseAPI, K extends keyof API> = API[K] extends Callable
 
 const learningResources = {
   list: (params?: Params<LRApi, "learningResourcesList">) =>
-    `/api/v1/learning_resources/${query(params)}`,
+    `${API_BASE_URL}/api/v1/learning_resources/${query(params)}`,
   details: (params: Params<LRApi, "learningResourcesRetrieve">) =>
-    `/api/v1/learning_resources/${params.id}/`,
+    `${API_BASE_URL}/api/v1/learning_resources/${params.id}/`,
   featured: (params?: Params<FeaturedApi, "featuredList">) =>
-    `/api/v1/featured/${query(params)}`,
+    `${API_BASE_URL}/api/v1/featured/${query(params)}`,
 }
 
 const offerors = {
   list: (params?: Params<OfferorsApi, "offerorsList">) =>
-    `/api/v1/offerors/${query(params)}`,
+    `${API_BASE_URL}/api/v1/offerors/${query(params)}`,
 }
 
 const platforms = {
   list: (params?: Params<PlatformsApi, "platformsList">) =>
-    `/api/v1/platforms/${query(params)}`,
+    `${API_BASE_URL}/api/v1/platforms/${query(params)}`,
 }
 
 const topics = {
   list: (params?: Params<TopicsApi, "topicsList">) =>
-    `/api/v1/topics/${query(params)}`,
+    `${API_BASE_URL}/api/v1/topics/${query(params)}`,
 }
 
 const departments = {
   list: (params?: Params<DepartmentsApi, "departmentsList">) =>
-    `/api/v1/departments/${query(params)}`,
+    `${API_BASE_URL}/api/v1/departments/${query(params)}`,
 }
 
 const schools = {
   list: (params?: Params<SchoolsApi, "schoolsList">) =>
-    `/api/v1/schools/${query(params)}`,
+    `${API_BASE_URL}/api/v1/schools/${query(params)}`,
 }
 
 const learningPaths = {
   list: (params?: Params<LearningpathsApi, "learningpathsList">) =>
-    `/api/v1/learningpaths/${query(params)}`,
+    `${API_BASE_URL}/api/v1/learningpaths/${query(params)}`,
   resources: ({
     learning_resource_id: parentId,
     ...others
   }: Params<LearningpathsApi, "learningpathsItemsList">) =>
-    `/api/v1/learningpaths/${parentId}/items/${query(others)}`,
+    `${API_BASE_URL}/api/v1/learningpaths/${parentId}/items/${query(others)}`,
   resourceDetails: ({
     learning_resource_id: parentId,
     id,
   }: Params<LearningpathsApi, "learningpathsItemsPartialUpdate">) =>
-    `/api/v1/learningpaths/${parentId}/items/${id}/`,
+    `${API_BASE_URL}/api/v1/learningpaths/${parentId}/items/${id}/`,
   details: (params: Params<LearningpathsApi, "learningpathsRetrieve">) =>
-    `/api/v1/learningpaths/${params.id}/`,
+    `${API_BASE_URL}/api/v1/learningpaths/${params.id}/`,
 }
 
 const userLists = {
   list: (params?: Params<UserlistsApi, "userlistsList">) =>
-    `/api/v1/userlists/${query(params)}`,
+    `${API_BASE_URL}/api/v1/userlists/${query(params)}`,
   resources: ({
     userlist_id: parentId,
     ...others
   }: Params<UserlistsApi, "userlistsItemsList">) =>
-    `/api/v1/userlists/${parentId}/items/${query(others)}`,
+    `${API_BASE_URL}/api/v1/userlists/${parentId}/items/${query(others)}`,
   resourceDetails: ({
     userlist_id: parentId,
     id,
   }: Params<UserlistsApi, "userlistsItemsPartialUpdate">) =>
-    `/api/v1/userlists/${parentId}/items/${id}/`,
+    `${API_BASE_URL}/api/v1/userlists/${parentId}/items/${id}/`,
   details: (params: Params<UserlistsApi, "userlistsRetrieve">) =>
-    `/api/v1/userlists/${params.id}/`,
+    `${API_BASE_URL}/api/v1/userlists/${params.id}/`,
 }
 
 const articles = {
   list: (params?: Params<ArticlesApi, "articlesList">) =>
-    `/api/v1/articles/${query(params)}`,
-  details: (id: number) => `/api/v1/articles/${id}/`,
+    `${API_BASE_URL}/api/v1/articles/${query(params)}`,
+  details: (id: number) => `${API_BASE_URL}/api/v1/articles/${id}/`,
 }
 
 const userSubscription = {
   list: (
     params?: Params<SubscriptionApi, "learningResourcesUserSubscriptionList">,
-  ) => `/api/v1/learning_resources_user_subscription/${query(params)}`,
+  ) =>
+    `${API_BASE_URL}/api/v1/learning_resources_user_subscription/${query(params)}`,
   check: (
     params?: Params<
       SubscriptionApi,
       "learningResourcesUserSubscriptionCheckList"
     >,
-  ) => `/api/v1/learning_resources_user_subscription/check/${query(params)}`,
+  ) =>
+    `${API_BASE_URL}/api/v1/learning_resources_user_subscription/check/${query(params)}`,
   delete: (id: number) =>
-    `/api/v1/learning_resources_user_subscription/${id}/unsubscribe/`,
+    `${API_BASE_URL}/api/v1/learning_resources_user_subscription/${id}/unsubscribe/`,
   post: () => "/api/v1/learning_resources_user_subscription/subscribe/",
 }
 
 const fields = {
   details: (channelType: string, name: string) =>
-    `/api/v0/channels/type/${channelType}/${name}/`,
-  patch: (id: number) => `/api/v0/channels/${id}/`,
+    `${API_BASE_URL}/api/v0/channels/type/${channelType}/${name}/`,
+  patch: (id: number) => `${API_BASE_URL}/api/v0/channels/${id}/`,
 }
 
 const widgetLists = {
-  details: (id: number) => `/api/v0/widget_lists/${id}/`,
+  details: (id: number) => `${API_BASE_URL}/api/v0/widget_lists/${id}/`,
 }
 
 const programLetters = {
-  details: (id: string) => `/api/v1/program_letters/${id}/`,
+  details: (id: string) => `${API_BASE_URL}/api/v1/program_letters/${id}/`,
 }
 
 const search = {
   resources: (params?: LearningResourcesSearchRequest) =>
-    `/api/v1/learning_resources_search/${queryify(params)}`,
+    `${API_BASE_URL}/api/v1/learning_resources_search/${queryify(params)}`,
 }
 
 const userMe = {
-  get: () => "/api/v0/users/me/",
+  get: () => `${API_BASE_URL}/api/v0/users/me/`,
 }
 
 const newsEvents = {
   list: (params?: NewsEventsApiNewsEventsListRequest) =>
-    `/api/v0/news_events/${query(params)}`,
+    `${API_BASE_URL}/api/v0/news_events/${query(params)}`,
 }
 
 export {

--- a/frontends/mit-open/jest.config.ts
+++ b/frontends/mit-open/jest.config.ts
@@ -16,6 +16,7 @@ const config: Config.InitialOptions = {
   globals: {
     APP_SETTINGS: {
       embedlyKey: "embedly_key",
+      axios_base_path: "https://api.mitopen-test.odl.mit.edu",
     },
   },
 }

--- a/frontends/mit-open/src/common/urls.test.ts
+++ b/frontends/mit-open/src/common/urls.test.ts
@@ -1,19 +1,21 @@
 import { login } from "./urls"
 
+const { axios_base_path: API_BASE_URL } = APP_SETTINGS
+
 test("login encodes the next parameter appropriately", () => {
-  expect(login()).toBe("/login/ol-oidc/?next=/")
-  expect(login({})).toBe("/login/ol-oidc/?next=/")
+  expect(login()).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/`)
+  expect(login({})).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/`)
 
   expect(
     login({
       pathname: "/foo/bar",
     }),
-  ).toBe("/login/ol-oidc/?next=/foo/bar")
+  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/foo/bar`)
 
   expect(
     login({
       pathname: "/foo/bar",
       search: "?cat=meow",
     }),
-  ).toBe("/login/ol-oidc/?next=/foo/bar%3Fcat%3Dmeow")
+  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/foo/bar%3Fcat%3Dmeow`)
 })

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -36,8 +36,8 @@ export const makeFieldEditPath = (channelType: string, name: string) =>
 export const makeFieldManageWidgetsPath = (channelType: string, name: string) =>
   generatePath(FIELD_EDIT_WIDGETS, { channelType, name })
 
-export const LOGIN = "/login/ol-oidc/"
-export const LOGOUT = "/logout/"
+export const LOGIN = `${APP_SETTINGS.axios_base_path}/login/ol-oidc/`
+export const LOGOUT = `${APP_SETTINGS.axios_base_path}/logout/`
 
 /**
  * Returns the URL to the login page, with a `next` parameter to redirect back

--- a/frontends/mit-open/src/page-components/Header/Header.test.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.test.tsx
@@ -87,8 +87,8 @@ describe("UserMenu", () => {
     const mobileLoginButton = await screen.findByTestId("login-button-mobile")
     invariant(desktopLoginButton instanceof HTMLAnchorElement)
     invariant(mobileLoginButton instanceof HTMLAnchorElement)
-    expect(desktopLoginButton.href).toBe(`${window.origin}${expectedUrl}`)
-    expect(mobileLoginButton.href).toBe(`${window.origin}${expectedUrl}`)
+    expect(desktopLoginButton.href).toBe(expectedUrl)
+    expect(mobileLoginButton.href).toBe(expectedUrl)
 
     // Check for real navigation; Login page needs a page reload
     await expectWindowNavigation(() => user.click(desktopLoginButton))
@@ -111,7 +111,7 @@ describe("UserMenu", () => {
     })
 
     invariant(authLink instanceof HTMLAnchorElement)
-    expect(authLink.href).toBe(`${window.origin}${expected.url}`)
+    expect(authLink.href).toBe(expected.url)
 
     // Check for real navigation; Login page needs a page reload
     await expectWindowNavigation(() => user.click(authLink))


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/mit-open/issues/629

### Description (What does it do?)
<!--- Describe your changes in detail -->

Sets the login and logout URLs to the backend now living on the `api.` subdomain.

For RC:
`https://api.mitopen-rc.odl.mit.edu/login/`
`https://api.mitopen-rc.odl.mit.edu/login/ol-oidc/`

Requires that `MITOPEN_AXIOS_BASE_PATH` be set on the GitHub Actions environment to
RC: `https://api.mitopen-rc.odl.mit.edu`
Prod: `https://api.mitopen.odl.mit.edu`

