### PR TITLE
Style tab components to match figma

### DIFF
--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -201,7 +201,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
 type ButtonLinkProps = ButtonStyleProps &
   React.ComponentProps<"a"> & {
-    href: string
+    href?: string
     /**
      * If true, the component will render a native anchor element rather than
      * a react router Link.
@@ -216,25 +216,22 @@ type ButtonLinkProps = ButtonStyleProps &
     nativeAnchor?: boolean
   }
 
-const ButtonLink: React.FC<ButtonLinkProps> = ({
-  children,
-  href,
-  nativeAnchor,
-  ...props
-}) => {
-  if (nativeAnchor) {
+const ButtonLink = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  ({ children, href = "", nativeAnchor, ...props }, ref) => {
+    if (nativeAnchor) {
+      return (
+        <AnchorStyled href={href} {...props} ref={ref}>
+          <ButtonInner {...props}>{children}</ButtonInner>
+        </AnchorStyled>
+      )
+    }
     return (
-      <AnchorStyled href={href} {...props}>
+      <LinkStyled to={href} {...props} ref={ref}>
         <ButtonInner {...props}>{children}</ButtonInner>
-      </AnchorStyled>
+      </LinkStyled>
     )
-  }
-  return (
-    <LinkStyled to={href} {...props}>
-      <ButtonInner {...props}>{children}</ButtonInner>
-    </LinkStyled>
-  )
-}
+  },
+)
 
 const ActionButtonDefaultProps: Required<
   Omit<ButtonStyleProps, "startIcon" | "endIcon">

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.mdx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.mdx
@@ -1,0 +1,18 @@
+import { Canvas, Meta } from "@storybook/blocks";
+
+import * as TabButtonList from "./TabButtonList.stories";
+
+<Meta of={TabButtonList} />
+
+# Tabs
+
+Use `TabButtonList` and `TabButton` to render a list of tabs styled as our tertiary buttons:
+
+<Canvas of={TabButtonList.ButtonTabs} />
+
+By default, the tabs will be scrollable if there are too many to fit in the container:
+<Canvas of={TabButtonList.ManyButtonTabs} />
+
+Use `TabButtonLink` for tabs that should affect the URL:
+
+<Canvas of={TabButtonList.LinkTabs} />

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.stories.tsx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.stories.tsx
@@ -33,18 +33,11 @@ const meta: Meta<StoryProps> = {
     },
   },
   args: {
-    count: 8,
+    count: 4,
     variant: "scrollable",
     allowScrollButtonsMobile: true,
     scrollButtons: "auto",
   },
-}
-
-export default meta
-
-type Story = StoryObj<StoryProps>
-
-export const ButtonTabs: Story = {
   render: ({ count, ...others }) => {
     const [value, setValue] = React.useState("tab1")
     return (
@@ -66,8 +59,12 @@ export const ButtonTabs: Story = {
                 ))}
             </TabButtonList>
 
-            <Stack direction="row" justifyContent="end" spacing={3}>
-              <Button>Extra Content</Button>
+            <Stack
+              direction="row"
+              justifyContent="end"
+              sx={{ paddingLeft: "16px" }}
+            >
+              <Button>Other UI</Button>
             </Stack>
           </Stack>
           {Array(count)
@@ -84,6 +81,17 @@ export const ButtonTabs: Story = {
   },
 }
 
+export default meta
+
+type Story = StoryObj<StoryProps>
+
+export const ButtonTabs: Story = {}
+export const ManyButtonTabs: Story = {
+  args: {
+    count: 12,
+  },
+}
+
 export const LinkTabs: Story = {
   decorators: [withRouter],
   parameters: {
@@ -95,7 +103,6 @@ export const LinkTabs: Story = {
   },
   render: () => {
     const location = useLocation()
-    console.log(location)
     return (
       <div>
         Current Location:

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.stories.tsx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.stories.tsx
@@ -1,0 +1,113 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import { TabButtonList, TabButton, TabButtonLink } from "./TabButtonList"
+import TabContext from "@mui/lab/TabContext"
+import { Button } from "../Button/Button"
+import Stack from "@mui/material/Stack"
+import TabPanel from "@mui/lab/TabPanel"
+import Typography from "@mui/material/Typography"
+import { faker } from "@faker-js/faker/locale/en"
+import Container from "@mui/material/Container"
+import { TabListProps } from "@mui/lab/TabList"
+import {
+  reactRouterParameters,
+  withRouter,
+} from "storybook-addon-react-router-v6"
+import { useLocation } from "react-router"
+
+type StoryProps = TabListProps & {
+  count: number
+}
+
+const meta: Meta<StoryProps> = {
+  title: "smoot-design/Tabs",
+  argTypes: {
+    variant: {
+      options: ["scrollable", "fullWidth", "standard"],
+      control: { type: "radio" },
+    },
+    scrollButtons: {
+      options: ["auto", true, false],
+      control: { type: "radio" },
+    },
+  },
+  args: {
+    count: 8,
+    variant: "scrollable",
+    allowScrollButtonsMobile: true,
+    scrollButtons: "auto",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<StoryProps>
+
+export const ButtonTabs: Story = {
+  render: ({ count, ...others }) => {
+    const [value, setValue] = React.useState("tab1")
+    return (
+      <Container maxWidth="sm">
+        <TabContext value={value}>
+          <Stack direction="row">
+            <TabButtonList
+              {...others}
+              onChange={(_event, val) => setValue(val)}
+            >
+              {Array(count)
+                .fill(null)
+                .map((_, i) => (
+                  <TabButton
+                    key={`tab-${i}`}
+                    value={`tab${i + 1}`}
+                    label={`Tab ${i + 1}`}
+                  />
+                ))}
+            </TabButtonList>
+
+            <Stack direction="row" justifyContent="end" spacing={3}>
+              <Button>Extra Content</Button>
+            </Stack>
+          </Stack>
+          {Array(count)
+            .fill(null)
+            .map((_, i) => (
+              <TabPanel key={`tab-${i}`} value={`tab${i + 1}`}>
+                <Typography variant="h4">Header {i + 1}</Typography>
+                {faker.lorem.paragraphs(2)}
+              </TabPanel>
+            ))}
+        </TabContext>
+      </Container>
+    )
+  },
+}
+
+export const LinkTabs: Story = {
+  decorators: [withRouter],
+  parameters: {
+    reactRouter: reactRouterParameters({
+      location: {
+        hash: "#link2",
+      },
+    }),
+  },
+  render: () => {
+    const location = useLocation()
+    console.log(location)
+    return (
+      <div>
+        Current Location:
+        <pre>{JSON.stringify(location, null, 2)}</pre>
+        <TabContext value={location.hash}>
+          <TabButtonList>
+            <TabButtonLink value="#link1" href="#link1" label="Tab 1" />
+            <TabButtonLink value="#link2" href="#link2" label="Tab 2" />
+            <TabButtonLink value="#link3" href="#link3" label="Tab 3" />
+          </TabButtonList>
+        </TabContext>
+      </div>
+    )
+  },
+}

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import MuiTab from "@mui/material/Tab"
+import type { TabProps } from "@mui/material/Tab"
+import MuiTabList from "@mui/lab/TabList"
+import type { TabListProps } from "@mui/lab/TabList"
+import styled from "@emotion/styled"
+import { Button, ButtonLink } from "../Button/Button"
+import type { ButtonLinkProps, ButtonProps } from "../Button/Button"
+import { css } from "@emotion/react"
+import type { Theme } from "@mui/material/styles"
+
+const TabButtonList: React.FC<TabListProps> = styled(MuiTabList)([
+  {
+    minHeight: "unset",
+    ".MuiTabs-indicator": {
+      display: "none",
+    },
+    ".MuiTabs-flexContainer": {
+      gap: "8px",
+      alignItems: "center",
+    },
+    ".MuiTabs-scroller": {
+      display: "flex",
+    },
+  },
+])
+
+const tabStyles = ({ theme }: { theme: Theme }) =>
+  css({
+    ":focus-visible": {
+      outlineOffset: "-1px",
+    },
+    '&[aria-selected="true"]': {
+      backgroundColor: theme.custom.colors.white,
+      borderColor: theme.custom.colors.darkGray2,
+    },
+  })
+const TabButtonStyled = styled(Button)(tabStyles)
+const TabLinkStyled = styled(ButtonLink)(tabStyles)
+
+const tabButtonProps = {
+  variant: "tertiary",
+  size: "small",
+} as const
+const TabButtonInner = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  // Omits the `className` prop from the underlying Button so that MUI does not
+  // style it. We style it ourselves.
+  (props, ref) => {
+    const { className, ...others } = props
+    return <TabButtonStyled {...tabButtonProps} {...others} ref={ref} />
+  },
+)
+
+const TabLinkInner = React.forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  (props, ref) => {
+    const { className, ...others } = props
+    return <TabLinkStyled {...tabButtonProps} {...others} ref={ref} />
+  },
+)
+
+const TabButton = (props: TabProps<"button">) => (
+  <MuiTab {...props} component={TabButtonInner} />
+)
+const TabButtonLink = (props: TabProps<"a">) => (
+  <MuiTab {...props} component={TabLinkInner} />
+)
+
+export { TabButtonList, TabButton, TabButtonLink }

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
@@ -9,7 +9,14 @@ import type { ButtonLinkProps, ButtonProps } from "../Button/Button"
 import { css } from "@emotion/react"
 import type { Theme } from "@mui/material/styles"
 
-const TabButtonList: React.FC<TabListProps> = styled(MuiTabList)([
+const defaultTabListProps = {
+  variant: "scrollable",
+  allowScrollButtonsMobile: true,
+  scrollButtons: "auto",
+} as const
+const TabButtonList: React.FC<TabListProps> = styled((props: TabListProps) => (
+  <MuiTabList {...defaultTabListProps} {...props} />
+))([
   {
     minHeight: "unset",
     ".MuiTabs-indicator": {

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -90,13 +90,18 @@ export type { SkeletonProps } from "@mui/material/Skeleton"
 export { default as Stack } from "@mui/material/Stack"
 export type { StackProps } from "@mui/material/Stack"
 
+export { default as Tab } from "@mui/material/Tab"
 export type { TabProps } from "@mui/material/Tab"
+
+export { default as TabList } from "@mui/lab/TabList"
+export type { TabListProps } from "@mui/lab/TabList"
+
 export {
   TabButton,
   TabButtonLink,
   TabButtonList,
 } from "./components/TabButtons/TabButtonList"
-export type { TabListProps } from "@mui/lab/TabList"
+
 export { default as TabContext } from "@mui/lab/TabContext"
 export type { TabContextProps } from "@mui/lab/TabContext"
 export { default as TabPanel } from "@mui/lab/TabPanel"

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -90,9 +90,12 @@ export type { SkeletonProps } from "@mui/material/Skeleton"
 export { default as Stack } from "@mui/material/Stack"
 export type { StackProps } from "@mui/material/Stack"
 
-export { default as Tab } from "@mui/material/Tab"
 export type { TabProps } from "@mui/material/Tab"
-export { default as TabList } from "@mui/lab/TabList"
+export {
+  TabButton,
+  TabButtonLink,
+  TabButtonList,
+} from "./components/TabButtons/TabButtonList"
 export type { TabListProps } from "@mui/lab/TabList"
 export { default as TabContext } from "@mui/lab/TabContext"
 export type { TabContextProps } from "@mui/lab/TabContext"


### PR DESCRIPTION
### What are the relevant tickets?
Adds a component for use in
- https://github.com/mitodl/hq/issues/4456
- https://github.com/mitodl/hq/issues/4360

### Description (What does it do?)
Adds a version of TabList that uses our tertiary button.

### Screenshots (if appropriate):
<img width="609" alt="Screenshot 2024-06-05 at 11 20 12 AM" src="https://github.com/mitodl/mit-open/assets/9010790/fa0e192d-3e02-4ef3-a071-de155f1f4db8">


### How can this be tested?
1. View http://localhost:6006/?path=/docs/smoot-design-tabs--docs and the associated stories. Try thing slike:
    - changing tabs
    - navigating with keyboard
    - shrinking screen.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
