### PR TITLE
Add channel links to unit cards

### DIFF
--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
@@ -106,6 +106,12 @@ describe("DepartmentListingPage", () => {
       makeSearchResponse(programCounts),
     )
 
+    units.forEach((unit) => {
+      setMockResponse.get(urls.fields.details("offeror", unit.code), {
+        channel_url: `/units/${unit.code}`,
+      })
+    })
+
     return {
       units,
       courseCounts,
@@ -132,10 +138,14 @@ describe("DepartmentListingPage", () => {
         const section = unit.professional
           ? professionalSection
           : academicSection
+        const channelLink = await within(section).findByRole("link", {
+          name: unit.name,
+        })
         const logoImage = await within(section).findByAltText(unit.name)
         const valuePropText = await within(section).findByText(
           unit.value_prop ? unit.value_prop : "",
         )
+        expect(channelLink).toHaveAttribute("href", `/units/${unit.code}`)
         expect(logoImage).toHaveAttribute(
           "src",
           `/static/images/units/${unit.code}.svg`,

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   CardContent,
   Container,
+  Link,
   Skeleton,
   Typography,
   styled,
@@ -19,6 +20,7 @@ import {
   OfferedByEnum,
 } from "api"
 import { MetaTags } from "ol-utilities"
+import { useChannelDetail } from "api/hooks/fields"
 
 const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
@@ -145,10 +147,20 @@ const GridContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const UnitCard = styled(Card)({
+const UnitCardContainer = styled(Card)({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
+})
+
+const UnitCardLink = styled(Link)({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  flexGrow: 1,
+  "&:hover": {
+    textDecoration: "none",
+  },
 })
 
 const UnitCardContent = styled(CardContent)({
@@ -276,33 +288,60 @@ const UnitCards: React.FC<UnitCardsProps> = (props) => {
           unitLogos[unit.code as OfferedByEnum] ||
           `/static/images/unit_logos/${unit.code}.svg`
         return unit.value_prop ? (
-          <UnitCard>
-            <UnitCardContent>
-              <LogoContainer>
-                <UnitLogo src={logo} alt={unit.name} />
-              </LogoContainer>
-              <ValuePropContainer>
-                <ValuePropText>{unit.value_prop}</ValuePropText>
-              </ValuePropContainer>
-              <CountsTextContainer>
-                <CountsText data-testid={`course-count-${unit.code}`}>
-                  {courseCount > 0 ? `Courses: ${courseCount}` : ""}
-                </CountsText>
-                <CountsText data-testid={`program-count-${unit.code}`}>
-                  {programCount > 0 ? `Programs: ${programCount}` : ""}
-                </CountsText>
-              </CountsTextContainer>
-            </UnitCardContent>
-          </UnitCard>
+          <UnitCard
+            key={unit.code}
+            unit={unit}
+            logo={logo}
+            courseCount={courseCount}
+            programCount={programCount}
+          />
         ) : null
       })}
     </>
   )
 }
 
+interface UnitCardProps {
+  unit: LearningResourceOfferorDetail
+  logo: string
+  courseCount: number
+  programCount: number
+}
+
+const UnitCard: React.FC<UnitCardProps> = (props) => {
+  const { unit, logo, courseCount, programCount } = props
+  const channelDetailQuery = useChannelDetail("offeror", unit.code)
+  const channelDetail = channelDetailQuery.data
+  const unitUrl = channelDetail?.channel_url
+  return channelDetailQuery.isLoading ? (
+    <UnitCardLoading />
+  ) : (
+    <UnitCardContainer>
+      <UnitCardLink href={unitUrl}>
+        <UnitCardContent>
+          <LogoContainer>
+            <UnitLogo src={logo} alt={unit.name} />
+          </LogoContainer>
+          <ValuePropContainer>
+            <ValuePropText>{unit.value_prop}</ValuePropText>
+          </ValuePropContainer>
+          <CountsTextContainer>
+            <CountsText data-testid={`course-count-${unit.code}`}>
+              {courseCount > 0 ? `Courses: ${courseCount}` : ""}
+            </CountsText>
+            <CountsText data-testid={`program-count-${unit.code}`}>
+              {programCount > 0 ? `Programs: ${programCount}` : ""}
+            </CountsText>
+          </CountsTextContainer>
+        </UnitCardContent>
+      </UnitCardLink>
+    </UnitCardContainer>
+  )
+}
+
 const UnitCardLoading = () => {
   return (
-    <UnitCard>
+    <UnitCardContainer>
       <UnitCardContent>
         <LogoContainer>
           <Skeleton variant="rectangular" width={500} height={50} />
@@ -311,7 +350,7 @@ const UnitCardLoading = () => {
           <Skeleton variant="text" width={500} height={200} />
         </ValuePropContainer>
       </UnitCardContent>
-    </UnitCard>
+    </UnitCardContainer>
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4485

### Description (What does it do?)
This PR adds a link to the appropriate channel on each of the cards on the "By Provider" page at `/units`

### Screenshots (if appropriate):
Nothing should have changed visually

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Make sure you have the latest `offered_by` data by running `docker compose exec web ./manage.py update_offered_by`
 - Visit http://localhost:8063/units
 - Ensure that the layout of the page has not changed compared to https://mitopen-rc.odl.mit.edu/units
 - Click the cards and ensure that you are sent to the appropriate channel page
