### PR TITLE
Profile-based search filter preferences

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -1824,6 +1824,31 @@ export type PathwayChannelTypeEnum =
   (typeof PathwayChannelTypeEnum)[keyof typeof PathwayChannelTypeEnum]
 
 /**
+ * Serializer for profile search preference filters
+ * @export
+ * @interface PreferencesSearch
+ */
+export interface PreferencesSearch {
+  /**
+   *
+   * @type {boolean}
+   * @memberof PreferencesSearch
+   */
+  certification?: boolean
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof PreferencesSearch
+   */
+  topics?: Array<string>
+  /**
+   *
+   * @type {string}
+   * @memberof PreferencesSearch
+   */
+  learning_format?: string
+}
+/**
  * Serializer for Profile
  * @export
  * @interface Profile
@@ -1943,6 +1968,12 @@ export interface Profile {
    * @memberof Profile
    */
   learning_format?: PatchedProfileRequestLearningFormat
+  /**
+   *
+   * @type {PreferencesSearch}
+   * @memberof Profile
+   */
+  preference_search_filters: PreferencesSearch
 }
 /**
  * Serializer for Profile

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -1840,7 +1840,7 @@ export interface PreferencesSearch {
    * @type {Array<string>}
    * @memberof PreferencesSearch
    */
-  topics?: Array<string>
+  topic?: Array<string>
   /**
    *
    * @type {string}

--- a/frontends/api/src/test-utils/factories/profiles.ts
+++ b/frontends/api/src/test-utils/factories/profiles.ts
@@ -17,6 +17,7 @@ const profile: PartialFactory<Profile> = (overrides = {}): Profile => ({
   time_commitment: "",
   learning_format: "",
   certificate_desired: "",
+  preference_search_filters: {},
   ...overrides,
 })
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -2056,7 +2056,7 @@ components:
       properties:
         certification:
           type: boolean
-        topics:
+        topic:
           type: array
           items:
             type: string

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -2050,6 +2050,18 @@ components:
       - pathway
       type: string
       description: '* `pathway` - Pathway'
+    PreferencesSearch:
+      type: object
+      description: Serializer for profile search preference filters
+      properties:
+        certification:
+          type: boolean
+        topics:
+          type: array
+          items:
+            type: string
+        learning_format:
+          type: string
     Profile:
       type: object
       description: Serializer for Profile
@@ -2131,11 +2143,16 @@ components:
           oneOf:
           - $ref: '#/components/schemas/LearningFormatEnum'
           - $ref: '#/components/schemas/BlankEnum'
+        preference_search_filters:
+          allOf:
+          - $ref: '#/components/schemas/PreferencesSearch'
+          readOnly: true
       required:
       - image_file
       - image_medium_file
       - image_small_file
       - placename
+      - preference_search_filters
       - profile_image_medium
       - profile_image_small
       - username

--- a/profiles/factories.py
+++ b/profiles/factories.py
@@ -2,8 +2,10 @@
 
 from factory import Faker, Sequence, SubFactory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice
 from faker.providers import BaseProvider
 
+from learning_resources.constants import LearningResourceFormat
 from profiles.models import Profile, ProgramCertificate, ProgramLetter, UserWebsite
 
 
@@ -42,6 +44,11 @@ class ProfileFactory(DjangoModelFactory):
     email_optin = Faker("boolean")
 
     location = Faker("location")
+
+    learning_format = FuzzyChoice(LearningResourceFormat.names())
+    certificate_desired = FuzzyChoice(
+        [Profile.CertificateDesired.YES.value, Profile.CertificateDesired.NO.value]
+    )
 
     class Meta:
         model = Profile

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -75,7 +75,7 @@ class PreferencesSearchSerializer(serializers.Serializer):
     """Serializer for profile search preference filters"""
 
     certification = serializers.BooleanField(required=False)
-    topics = serializers.ListField(child=serializers.CharField(), required=False)
+    topic = serializers.ListField(child=serializers.CharField(), required=False)
     learning_format = serializers.CharField(required=False)
 
 
@@ -121,7 +121,7 @@ class ProfileSerializer(serializers.ModelSerializer):
                 obj.certificate_desired == Profile.CertificateDesired.YES.value
             )
         if obj.topic_interests and obj.topic_interests.count() > 0:
-            filters["topics"] = obj.topic_interests.values_list("name", flat=True)
+            filters["topic"] = obj.topic_interests.values_list("name", flat=True)
         if obj.learning_format:
             filters["learning_format"] = obj.learning_format
         return PreferencesSearchSerializer(instance=filters).data

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -89,7 +89,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     profile_image_small = serializers.SerializerMethodField(read_only=True)
     placename = serializers.SerializerMethodField(read_only=True)
     topic_interests = TopicInterestsField(default=list)
-    preference_search_filters = serializers.SerializerMethodField()
+    preference_search_filters = serializers.SerializerMethodField(read_only=True)
 
     def get_username(self, obj) -> str:
         """Custom getter for the username"""  # noqa: D401

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -263,7 +263,7 @@ def test_serialize_profile_preference_search_filters(
 
     search_filters = ProfileSerializer(profile).data["preference_search_filters"]
     assert search_filters.get("certification", None) == cert_filter
-    assert search_filters.get("topics", None) == (topics if topics else None)
+    assert search_filters.get("topic", None) == (topics if topics else None)
     assert search_filters.get("learning_format", None) == (
         lr_format if lr_format else None
     )

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -187,6 +187,7 @@ def test_location_validation(user, data, is_valid):
     assert serializer.is_valid(raise_exception=False) is is_valid
 
 
+@pytest.mark.django_db()
 @pytest.mark.parametrize(
     ("key", "value"),
     [
@@ -194,16 +195,21 @@ def test_location_validation(user, data, is_valid):
         ("bio", "bio_value"),
         ("headline", "headline_value"),
         ("location", {"value": "Hobbiton, The Shire, Middle-Earth"}),
+        ("learning_format", LearningResourceFormat.hybrid.name),
+        ("certificate_desired", Profile.CertificateDesired.YES.value),
     ],
 )
 def test_update_profile(mocker, user, key, value):
     """
     Test updating a profile via the ProfileSerializer
     """
+    topic_ids = [topic.id for topic in LearningResourceTopicFactory.create_batch(2)]
     profile = user.profile
 
     serializer = ProfileSerializer(
-        instance=user.profile, data={key: value}, partial=True
+        instance=user.profile,
+        data={key: value, "topic_interests": topic_ids},
+        partial=True,
     )
     serializer.is_valid(raise_exception=True)
     serializer.save()
@@ -217,6 +223,9 @@ def test_update_profile(mocker, user, key, value):
         "bio",
         "headline",
         "location",
+        "learning_format",
+        "certificate_desired",
+        "topic_interests",
     ):
         if prop == key:
             if isinstance(value, bool):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -7,6 +7,8 @@ import factory
 import pytest
 from rest_framework.exceptions import ValidationError
 
+from learning_resources.constants import LearningResourceFormat
+from learning_resources.factories import LearningResourceTopicFactory
 from learning_resources.serializers import LearningResourceTopicSerializer
 from profiles.factories import UserWebsiteFactory
 from profiles.models import FACEBOOK_DOMAIN, PERSONAL_SITE_TYPE, Profile
@@ -91,7 +93,7 @@ def test_serialize_create_user(db, mocker):
         "last_name": user.last_name,
         "is_learning_path_editor": False,
         "is_article_editor": False,
-        "profile": profile,
+        "profile": {**profile, "preference_search_filters": {}},
     }
 
 
@@ -223,6 +225,39 @@ def test_update_profile(mocker, user, key, value):
                 assert getattr(profile2, prop) == value
         else:
             assert getattr(profile2, prop) == getattr(profile, prop)
+
+
+@pytest.mark.django_db()
+@pytest.mark.parametrize(
+    ("cert_desired", "cert_filter"),
+    [
+        (Profile.CertificateDesired.YES.value, True),
+        (Profile.CertificateDesired.NO.value, False),
+        (Profile.CertificateDesired.NOT_SURE_YET.value, None),
+        ("", None),
+    ],
+)
+@pytest.mark.parametrize("topics", [["Biology", "Chemistry"], []])
+@pytest.mark.parametrize("lr_format", [LearningResourceFormat.hybrid.name, ""])
+def test_serialize_profile_preference_search_filters(
+    user, cert_desired, cert_filter, topics, lr_format
+):
+    """Tests that the ProfileSerializer includes search filters when an option is set via the context"""
+    profile = user.profile
+    profile.certificate_desired = cert_desired
+    profile.learning_format = lr_format
+    if topics:
+        profile.topic_interests.set(
+            [LearningResourceTopicFactory.create(name=topic) for topic in topics]
+        )
+    profile.save()
+
+    search_filters = ProfileSerializer(profile).data["preference_search_filters"]
+    assert search_filters.get("certification", None) == cert_filter
+    assert search_filters.get("topics", None) == (topics if topics else None)
+    assert search_filters.get("learning_format", None) == (
+        lr_format if lr_format else None
+    )
 
 
 def test_serialize_profile_websites(user):

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -136,6 +136,12 @@ def test_get_profile(logged_in, user, user_client):
         "certificate_desired": profile.certificate_desired,
         "time_commitment": profile.time_commitment,
         "learning_format": profile.learning_format,
+        "preference_search_filters": {
+            "learning_format": profile.learning_format,
+            "certification": (
+                profile.certificate_desired == Profile.CertificateDesired.YES.value
+            ),
+        },
     }
 
 
@@ -291,6 +297,9 @@ def test_patch_onboarding_fields(  # noqa: PLR0913
         kwargs={"user__username": logged_in_profile.user.username},
     )
 
+    setattr(logged_in_profile, field, before)
+    logged_in_profile.save()
+    logged_in_profile.refresh_from_db()
     assert getattr(logged_in_profile, field) == before
 
     resp = client.patch(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4386

### Description (What does it do?)
Adds a field to the profile serializer specifying which search filters to use, based on profile preferences


### How can this be tested?
In django admin, go to the `Profile` object for your user, assign values for topic interests, certification desired, and learning format fields.  Check the API response at `http://localhost:8063/api/v0/profiles/<username>` and verify that the `preference_search_filters` attribute has appropriate values.
