### PR TITLE
Add certification_type to search facets UI

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.1.0",
+    "@mitodl/course-search-utils": "^3.1.1",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -168,15 +168,15 @@ describe("FieldSearch", () => {
   test.each([
     {
       fieldType: ChannelTypeEnum.Topic,
-      displayedFacets: ["Resource Type", "Offered By", "Department", "Format"],
+      displayedFacets: ["Certificates", "Offered By", "Department", "Format"],
     },
     {
       fieldType: ChannelTypeEnum.Department,
-      displayedFacets: ["Resource Type", "Offered By", "Topic", "Format"],
+      displayedFacets: ["Certificates", "Offered By", "Topics", "Format"],
     },
     {
       fieldType: ChannelTypeEnum.Offeror,
-      displayedFacets: ["Resource Type", "Topic", "Platform", "Format"],
+      displayedFacets: ["Certificates", "Department", "Topics", "Format"],
     },
     {
       fieldType: ChannelTypeEnum.Pathway,
@@ -202,6 +202,7 @@ describe("FieldSearch", () => {
               offered_by: [{ key: "ocw", doc_count: 100 }],
               certification: [{ key: "true", doc_count: 100 }],
               learning_format: [{ key: "online", doc_count: 100 }],
+              certification_type: [{ key: "micromasters", doc_count: 100 }],
             },
             suggestions: [],
           },
@@ -217,10 +218,10 @@ describe("FieldSearch", () => {
       })
 
       for (const facetName of [
+        "Certificates",
         "Department",
         "Offered By",
-        "Platforn",
-        "Topic",
+        "Topics",
         "Format",
       ]) {
         if ((displayedFacets as string[]).includes(facetName as string)) {

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -212,7 +212,8 @@ describe("SearchPage", () => {
       })
       const apiSearchParams = getLastApiSearchParams()
       expect(apiSearchParams.getAll("aggregations").sort()).toEqual([
-        "certification",
+        "certification_type",
+        "department",
         "free",
         "learning_format",
         "offered_by",
@@ -244,7 +245,15 @@ describe("SearchPage", () => {
     const { location } = renderWithProviders(<SearchPage />, {
       url: "?topic=Physics&topic=Chemistry",
     })
+
     const clearAll = await screen.findByRole("button", { name: /clear all/i })
+
+    const showFacetButton = await screen.findByRole("button", {
+      name: /Topics/i,
+    })
+
+    await user.click(showFacetButton)
+
     const physics = await screen.findByRole("checkbox", { name: "Physics" })
     const chemistry = await screen.findByRole("checkbox", { name: "Chemistry" })
     // initial
@@ -295,6 +304,12 @@ test("Facet 'Offered By' uses API response for names", async () => {
     },
   })
   renderWithProviders(<SearchPage />)
+  const showFacetButton = await screen.findByRole("button", {
+    name: /Offered By/i,
+  })
+
+  await user.click(showFacetButton)
+
   const offeror0 = await screen.findByRole("checkbox", {
     name: offerors.results[0].name,
   })

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -9,6 +9,8 @@ import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
 import {
   useResourceSearchParams,
   UseResourceSearchParamsProps,
+  getCertificationTypeName,
+  getDepartmentName,
 } from "@mitodl/course-search-utils"
 import type { FacetManifest } from "@mitodl/course-search-utils"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
@@ -27,12 +29,13 @@ const SearchField = styled(SearchInput)`
   width: 100%;
 `
 
-const getFacetManifest = (
+export const getFacetManifest = (
   offerors: Record<string, LearningResourceOfferor>,
-): FacetManifest => {
+) => {
   return [
     {
       type: "group",
+      name: "free",
       facets: [
         {
           value: true,
@@ -42,24 +45,38 @@ const getFacetManifest = (
       ],
     },
     {
+      name: "certification_type",
+      title: "Certificates",
+      type: "static",
+      expandedOnLoad: true,
+      labelFunction: (key: string) => getCertificationTypeName(key) || key,
+    },
+    {
       name: "topic",
       title: "Topics",
       type: "filterable",
-      expandedOnLoad: true,
+      expandedOnLoad: false,
+    },
+    {
+      name: "department",
+      title: "Department",
+      type: "filterable",
+      expandedOnLoad: false,
+      labelFunction: (key: string) => getDepartmentName(key) || key,
     },
     {
       name: "offered_by",
       title: "Offered By",
       type: "static",
-      expandedOnLoad: true,
-      labelFunction: (key) => offerors[key]?.name ?? key,
+      expandedOnLoad: false,
+      labelFunction: (key: string) => offerors[key]?.name ?? key,
     },
     {
       name: "learning_format",
       title: "Format",
       type: "static",
-      expandedOnLoad: true,
-      labelFunction: (key) =>
+      expandedOnLoad: false,
+      labelFunction: (key: string) =>
         key
           .split("_")
           .map((word) => capitalize(word))
@@ -70,10 +87,11 @@ const getFacetManifest = (
 
 const facetNames = [
   "resource_type",
+  "certification_type",
   "learning_format",
+  "department",
   "topic",
   "offered_by",
-  "certification",
   "free",
   "professional",
 ] as UseResourceSearchParamsProps["facets"]
@@ -91,7 +109,6 @@ const useFacetManifest = () => {
 
 const SearchPage: React.FC = () => {
   const facetManifest = useFacetManifest()
-
   const [searchParams, setSearchParams] = useSearchParams()
 
   const setPage = useCallback(
@@ -160,7 +177,7 @@ const SearchPage: React.FC = () => {
         page={page}
         requestParams={params}
         setPage={setPage}
-        facetManifest={facetManifest}
+        facetManifest={facetManifest as FacetManifest}
         facetNames={facetNames}
         constantSearchParams={constantSearchParams}
         hasFacets={hasFacets}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4055,11 +4055,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "@mitodl/course-search-utils@npm:3.1.0"
+"@mitodl/course-search-utils@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@mitodl/course-search-utils@npm:3.1.1"
   dependencies:
-    "@mitodl/open-api-axios": "npm:^2024.5.6"
+    "@mitodl/open-api-axios": "npm:^2024.6.4"
     axios: "npm:^1.6.7"
     fuse.js: "npm:^7.0.0"
     query-string: "npm:^6.13.1"
@@ -4076,17 +4076,17 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/98c745b0bc2da1177fcf7acb414a63c162d9b4512e11e97aa4d3276e30a9b95d2d89bbf121135773ad08af0fc56a3c574530168a41e311d238fd2ee2ef850517
+  checksum: 10/2909f335ae042fbdb86009646d22fa9b788b9116b783ac3cbe9fc5ae757f04f8badb3eea9cacf56e829dfcfd9ff69a0a990f3407211fa7ebd8904819b558b4f6
   languageName: node
   linkType: hard
 
-"@mitodl/open-api-axios@npm:^2024.5.6":
-  version: 2024.5.24
-  resolution: "@mitodl/open-api-axios@npm:2024.5.24"
+"@mitodl/open-api-axios@npm:^2024.6.4":
+  version: 2024.6.5
+  resolution: "@mitodl/open-api-axios@npm:2024.6.5"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/b6db36425e1ed0ef3cfa980499d8695a2d00c91c462c82003998d207a392f989edcd16c58cbce64e004540abe50ce893d8ff2b04063ef87e59943391fb9347a9
+  checksum: 10/fdb0fe1970fb16b32193c5f896130e2ccf2418b0f4a21704cee051ff9d18497263383890d979581479d5b3e45bd2a05e2132d791c9f6c00d4d6bd36add2b240a
   languageName: node
   linkType: hard
 
@@ -18272,7 +18272,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.0"
-    "@mitodl/course-search-utils": "npm:^3.1.0"
+    "@mitodl/course-search-utils": "npm:^3.1.1"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
NOTE: This PR should be reviewed with https://github.com/mitodl/course-search-utils/pull/108

### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4487

### Description (What does it do?)
this pr adds certification_type as a facet to the search page
it also updates the other facets to match the ones in https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=107-2479&m=dev

This pr does not include styling updates - that will be included in a followup

### Screenshots (if appropriate):
<img width="397" alt="Screenshot 2024-06-05 at 4 28 04 PM" src="https://github.com/mitodl/mit-open/assets/1934992/d24bf6db-e3ef-4e3b-a348-18f7e63afcbd">
<img width="1714" alt="Screenshot 2024-06-05 at 4 27 52 PM" src="https://github.com/mitodl/mit-open/assets/1934992/7a50d9a8-4601-49cf-a120-a60c3772d32d">



### How can this be tested?
go to http://localhost:8063/search verify that you can filter by certificate type 

Go to a field page, for example http://localhost:8063/c/topic/biology/
Verify that you can filter by certificate type there as well
