### PR TITLE
Point the webpack dev server proxy to the new API subdomain

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "watch": "API_BASE_URL=http://localhost:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
     "watch:docker": "API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:rc": "API_BASE_URL=https://mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:rc": "API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
### What are the relevant tickets?

Relates to [CI and deployment config for decoupled front end](https://github.com/mitodl/mit-open/issues/629)

### Description (What does it do?)

Small PR to point the Webpack Dev Server proxy for API routes to the RC backend living at its new subdomain when running locally via the package.json script.