### PR TITLE
Write the commit hash to the frontend build for doof

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -38,6 +38,9 @@ jobs:
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen.odl.mit.edu
 
+      - name: Write commit SHA to file
+        run: echo $GITHUB_SHA > frontends/mit-open/build/static/hash.txt
+
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -38,6 +38,9 @@ jobs:
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen-rc.odl.mit.edu
 
+      - name: Write commit SHA to file
+        run: echo $GITHUB_SHA > frontends/mit-open/build/static/hash.txt
+
       - name: Upload frontend build to s3
         uses: jakejarvis/s3-sync-action@master
         with:


### PR DESCRIPTION
### What are the relevant tickets?

Relates to [CI and deployment config for decoupled front end](https://github.com/mitodl/mit-open/issues/629)

### Description (What does it do?)

Doof is looking for the commit hash on the frontend domain to confirm releases, but it has moved to the api subdomain.

Writes the commit hash to the front end build so it is available at the existing URL `https://mitopen-rc.odl.mit.edu/static/hash.txt`.

Won't do any harm even if doof is updated to check at `api.mitopen-rc.odl.mit.edu` as we release front end and back end together.

### How can this be tested?

Run the RC release workflow and check that hash.txt is available at the URL above and contains the commit SHA.