### PR TITLE
mitxonline etl v2 api

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -41,7 +41,8 @@ def _fetch_data(url, params=None):
             url, params=params, timeout=settings.REQUESTS_TIMEOUT
         ).json()
         results = response["results"]
-        yield results
+        for result in results:
+            yield from result
         url = response.get("next")
 
 
@@ -91,7 +92,7 @@ def extract_programs():
     programs = []
     if settings.MITX_ONLINE_PROGRAMS_API_URL:
         [
-            programs.extend(response)
+            programs.append(response)
             for response in _fetch_data(settings.MITX_ONLINE_PROGRAMS_API_URL)
         ]
     else:
@@ -102,16 +103,12 @@ def extract_programs():
 
 def extract_courses():
     """Loads the MITx Online catalog data"""  # noqa: D401
-    courses = []
     if settings.MITX_ONLINE_COURSES_API_URL:
-        [
-            courses.extend(response)
-            for response in _fetch_data(settings.MITX_ONLINE_COURSES_API_URL)
-        ]
+        return list(_fetch_data(settings.MITX_ONLINE_COURSES_API_URL))
     else:
         log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
 
-    return courses
+    return []
 
 
 def parse_program_prices(program_data: dict) -> list[float]:

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -238,11 +238,11 @@ def transform_courses(courses):
     ]
 
 
-def _fetch_courses_data(course_ids):
+def _fetch_courses_by_ids(course_ids):
     courses = []
     if settings.MITX_ONLINE_COURSES_API_URL:
         [
-            courses.extend(_transform_course(response))
+            courses.extend(response)
             for response in _fetch_data(
                 settings.MITX_ONLINE_COURSES_API_URL,
                 params={"id": ",".join([str(courseid) for courseid in course_ids])},
@@ -305,8 +305,8 @@ def transform_programs(programs):
                 }
             ],
             "courses": [
-                course
-                for course in _fetch_courses_data(program["courses"])
+                _transform_course(course)
+                for course in _fetch_courses_by_ids(program["courses"])
                 if not re.search(EXCLUDE_REGEX, course["title"], re.IGNORECASE)
             ],
         }

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -89,16 +89,12 @@ def parse_page_attribute(
 
 def extract_programs():
     """Loads the MITx Online catalog data"""  # noqa: D401
-    programs = []
     if settings.MITX_ONLINE_PROGRAMS_API_URL:
-        [
-            programs.append(response)
-            for response in _fetch_data(settings.MITX_ONLINE_PROGRAMS_API_URL)
-        ]
+        return list(_fetch_data(settings.MITX_ONLINE_PROGRAMS_API_URL))
     else:
         log.warning("Missing required setting MITX_ONLINE_PROGRAMS_API_URL")
 
-    return programs
+    return []
 
 
 def extract_courses():

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -41,8 +41,8 @@ def _fetch_data(url, params=None):
             url, params=params, timeout=settings.REQUESTS_TIMEOUT
         ).json()
         results = response["results"]
-        for result in results:
-            yield from result
+
+        yield from results
         url = response.get("next")
 
 

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -242,12 +242,13 @@ def _fetch_courses_data(course_ids):
     courses = []
     if settings.MITX_ONLINE_COURSES_API_URL:
         [
-            courses.extend(response)
+            courses.extend(_transform_course(response))
             for response in _fetch_data(
-                settings.MITX_ONLINE_COURSES_API_URL, params={"id[]": course_ids}
+                settings.MITX_ONLINE_COURSES_API_URL,
+                params={"id": ",".join([str(courseid) for courseid in course_ids])},
             )
         ]
-        return transform_courses(courses)
+        return courses
     log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
     return []
 

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -33,7 +33,7 @@ EXCLUDE_REGEX = r"PROCTORED EXAM"
 OFFERED_BY = {"code": OfferedBy.mitx.name}
 
 
-def _fetch_data(url, params):
+def _fetch_data(url, params=None):
     if not params:
         params = {}
     while url:

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -37,7 +37,9 @@ def _fetch_data(url, params):
     if not params:
         params = {}
     while url:
-        response = requests.get(url, params=params, timeout=200).json()
+        response = requests.get(
+            url, params=params, timeout=settings.REQUESTS_TIMEOUT
+        ).json()
         results = response["results"]
         yield results
         url = response.get("next")

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -95,7 +95,7 @@ def extract_programs():
             for response in _fetch_data(settings.MITX_ONLINE_PROGRAMS_API_URL)
         ]
     else:
-        log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
+        log.warning("Missing required setting MITX_ONLINE_PROGRAMS_API_URL")
     return programs
 
 

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -112,7 +112,7 @@ def test_mitxonline_transform_programs(
     """Test that mitxonline program data is correctly transformed into our normalized structure"""
 
     mocker.patch(
-        "learning_resources.etl.mitxonline._fetch_courses_data",
+        "learning_resources.etl.mitxonline._fetch_courses_by_ids",
         return_value=transform_courses(
             sorted(mock_mitxonline_courses_data["results"], key=lambda x: x["id"])
         ),
@@ -444,7 +444,7 @@ def test_program_run_start_date_value(  # noqa: PLR0913
     expected_dt,
 ):
     mocker.patch(
-        "learning_resources.etl.mitxonline._fetch_courses_data",
+        "learning_resources.etl.mitxonline._fetch_courses_by_ids",
         return_value=mock_mitxonline_courses_data["results"],
     )
 

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -113,8 +113,15 @@ def test_mitxonline_transform_programs(
 
     mocker.patch(
         "learning_resources.etl.mitxonline._fetch_data",
-        return_value=[mock_mitxonline_courses_data["results"]],
+        return_value=[
+            [
+                result
+                for result in mock_mitxonline_courses_data["results"]
+                if "PROCTORED EXAM" not in result["title"]
+            ]
+        ],
     )
+
     result = transform_programs(mock_mitxonline_programs_data["results"])
 
     expected = [
@@ -271,7 +278,10 @@ def test_mitxonline_transform_programs(
         result[i]["courses"] = sorted(
             result[i]["courses"], key=lambda x: x["readable_id"]
         )
-
+        for j in range(len(result[i]["courses"])):
+            course = result[i]["courses"][j]
+            for key in course:
+                assert result[i]["courses"][j][key] == expected[i]["courses"][j][key]
     assert result == expected
 
 

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -112,10 +112,8 @@ def test_mitxonline_transform_programs(
     """Test that mitxonline program data is correctly transformed into our normalized structure"""
 
     mocker.patch(
-        "learning_resources.etl.mitxonline._fetch_courses_by_ids",
-        return_value=transform_courses(
-            sorted(mock_mitxonline_courses_data["results"], key=lambda x: x["id"])
-        ),
+        "learning_resources.etl.mitxonline._fetch_data",
+        return_value=[mock_mitxonline_courses_data["results"]],
     )
     result = transform_programs(mock_mitxonline_programs_data["results"])
 
@@ -444,8 +442,8 @@ def test_program_run_start_date_value(  # noqa: PLR0913
     expected_dt,
 ):
     mocker.patch(
-        "learning_resources.etl.mitxonline._fetch_courses_by_ids",
-        return_value=mock_mitxonline_courses_data["results"],
+        "learning_resources.etl.mitxonline._fetch_data",
+        return_value=[mock_mitxonline_courses_data["results"]],
     )
 
     """Test that the start date value is correctly determined for program runs"""

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -272,7 +272,7 @@ def test_mitxonline_transform_programs(
         result[i]["courses"] = sorted(
             result[i]["courses"], key=lambda x: x["readable_id"]
         )
-        for j in range(len(result[i]["courses"])):
+        for j in range(len(expected[i]["courses"])):
             course = result[i]["courses"][j]
             for key in course:
                 assert result[i]["courses"][j][key] == expected[i]["courses"][j][key]

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -113,13 +113,7 @@ def test_mitxonline_transform_programs(
 
     mocker.patch(
         "learning_resources.etl.mitxonline._fetch_data",
-        return_value=[
-            [
-                result
-                for result in mock_mitxonline_courses_data["results"]
-                if "PROCTORED EXAM" not in result["title"]
-            ]
-        ],
+        return_value=mock_mitxonline_courses_data["results"],
     )
 
     result = transform_programs(mock_mitxonline_programs_data["results"])
@@ -450,7 +444,7 @@ def test_program_run_start_date_value(  # noqa: PLR0913
 ):
     mocker.patch(
         "learning_resources.etl.mitxonline._fetch_data",
-        return_value=[mock_mitxonline_courses_data["results"]],
+        return_value=mock_mitxonline_courses_data["results"],
     )
 
     """Test that the start date value is correctly determined for program runs"""

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -107,10 +107,11 @@ def test_mitxonline_extract_courses_disabled(settings):
 
 
 def test_mitxonline_transform_programs(
-    mock_mitxonline_programs_data, mock_mitxonline_courses_data, mocker
+    mock_mitxonline_programs_data, mock_mitxonline_courses_data, mocker, settings
 ):
     """Test that mitxonline program data is correctly transformed into our normalized structure"""
-
+    settings.MITX_ONLINE_PROGRAMS_API_URL = "http://localhost/test/programs/api"
+    settings.MITX_ONLINE_COURSES_API_URL = "http://localhost/test/courses/api"
     mocker.patch(
         "learning_resources.etl.mitxonline._fetch_data",
         return_value=mock_mitxonline_courses_data["results"],

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -271,10 +271,7 @@ def test_mitxonline_transform_programs(
         result[i]["courses"] = sorted(
             result[i]["courses"], key=lambda x: x["readable_id"]
         )
-        for j in range(len(expected[i]["courses"])):
-            course = result[i]["courses"][j]
-            for key in course:
-                assert result[i]["courses"][j][key] == expected[i]["courses"][j][key]
+
     assert result == expected
 
 

--- a/test_json/mitxonline_courses.json
+++ b/test_json/mitxonline_courses.json
@@ -1,860 +1,669 @@
-[
-  {
-    "id": 3,
-    "title": "Data Analysis for Social Scientists",
-    "readable_id": "course-v1:MITxT+14.310x",
-    "courseruns": [
-      {
-        "title": "Data Analysis for Social Scientists",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.310x+3T2022",
-        "run_tag": "3T2022",
-        "id": 36,
-        "products": [
-          {
-            "id": 22,
-            "price": "1000.00",
-            "description": "course-v1:MITxT+14.100x+3T2022",
-            "is_active": true,
-            "product_flexible_price": {
-              "amount": null,
-              "automatic": false,
-              "discount_type": null,
-              "redemption_type": null,
-              "max_redemptions": null,
-              "discount_code": "",
-              "payment_type": null,
-              "activation_date": null,
-              "expiration_date": null
-            }
-          }
-        ],
-        "page": {
-          "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-          "page_url": "/courses/course-v1:MITxT+14.310x/",
-          "financial_assistance_form_url": ""
+{
+  "count": 97,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 13,
+      "title": "14.100x - PROCTORED EXAM",
+      "readable_id": "course-v1:MITxT+14.100PEx",
+      "next_run_id": null,
+      "departments": [],
+      "page": {
+        "feature_image_src": "/media/original_images/14.100x_xGKvQiK.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
+        "page_url": "/courses/course-v1:MITxT+14.100PEx/",
+        "description": "do not publish",
+        "live": false,
+        "length": "do not publish",
+        "effort": null
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Microeconomics - PROCTORED EXAM",
+          "start_date": "2022-08-17T15:00:00Z",
+          "end_date": "2022-09-08T15:00:00Z",
+          "enrollment_start": "2022-08-17T13:30:00Z",
+          "enrollment_end": "2022-08-26T15:00:00Z",
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100PEx+2T2022",
+          "courseware_id": "course-v1:MITxT+14.100PEx+2T2022",
+          "certificate_available_date": "2022-01-21T15:00:00Z",
+          "upgrade_deadline": "2022-08-29T15:00:00Z",
+          "is_upgradable": false,
+          "is_enrollable": false,
+          "is_self_paced": false,
+          "run_tag": "2T2022",
+          "id": 48,
+          "live": true,
+          "course_number": "14.100PEx",
+          "products": [],
+          "approved_flexible_price_exists": false
+        },
+        {
+          "title": "Microeconomics - PROCTORED EXAM",
+          "start_date": "2022-01-03T15:00:00Z",
+          "end_date": "2022-01-24T15:00:00Z",
+          "enrollment_start": "2022-01-03T15:00:00Z",
+          "enrollment_end": "2022-01-10T23:59:00Z",
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100PEx+1T2022/course/",
+          "courseware_id": "course-v1:MITxT+14.100PEx+1T2022",
+          "certificate_available_date": "2022-01-21T15:00:00Z",
+          "upgrade_deadline": "2022-01-24T15:00:00Z",
+          "is_upgradable": false,
+          "is_enrollable": false,
+          "is_self_paced": false,
+          "run_tag": "1T2022",
+          "id": 16,
+          "live": true,
+          "course_number": "14.100PEx",
+          "products": [],
+          "approved_flexible_price_exists": false
         }
-      }
-    ],
-    "next_run_id": 36,
-    "topics": []
-  },
-  {
-    "id": 2,
-    "title": "Designing and Running Randomized Evaluations",
-    "readable_id": "course-v1:MITxT+JPAL102x",
-    "page": {
-      "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
-      "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-      "financial_assistance_form_url": ""
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Designing and Running Randomized Evaluations",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
-        "enrollment_start": "2022-03-08T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+JPAL102x+3T2022",
-        "run_tag": "3T2022",
-        "id": 22,
-        "products": [
-          {
-            "id": 22,
-            "price": "2000.00",
-            "description": "course-v2:MITxT+15.100x+3T2023",
-            "is_active": true,
-            "product_flexible_price": {
-              "amount": null,
-              "automatic": false,
-              "discount_type": null,
-              "redemption_type": null,
-              "max_redemptions": null,
-              "discount_code": "",
-              "payment_type": null,
-              "activation_date": null,
-              "expiration_date": null
+    {
+      "id": 47,
+      "title": "Analysis of Transport Phenomena: Asymptotics",
+      "readable_id": "course-v1:MITxT+10.50.CH04x",
+      "next_run_id": 152,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/4-drkpurple.jpg?v=b6024e4bdf229b618e36f2e942f2ae6f173dd9d3",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH04x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "2 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Asymptotics",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": null,
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH04x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH04x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 152,
+          "live": true,
+          "course_number": "10.50.CH04x",
+          "products": [
+            {
+              "id": 133,
+              "price": "29.00",
+              "description": "course-v1:MITxT+10.50.CH04x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
             }
-          }
-        ]
-      }
-    ],
-    "next_run_id": 22,
-    "topics": []
-  },
-  {
-    "id": 5,
-    "title": "Foundations of Development Policy",
-    "readable_id": "course-v1:MITxT+14.740x",
-    "courseruns": [
-      {
-        "title": "Foundations of Development Policy",
-        "start_date": "2023-01-31T15:00:00Z",
-        "end_date": "2023-04-19T15:00:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2023-03-07T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2023/course/",
-        "courseware_id": "course-v1:MITxT+14.740x+1T2023",
-        "run_tag": "1T2023",
-        "id": 37,
-        "products": []
-      }
-    ],
-    "next_run_id": 37,
-    "topics": []
-  },
-  {
-    "id": 16,
-    "title": "Good Economics for Hard Times",
-    "readable_id": "course-v1:MITxT+14.009x",
-    "courseruns": [
-      {
-        "title": "Good Economics for Hard Times",
-        "start_date": "2023-05-30T15:00:00Z",
-        "end_date": "2023-08-16T15:00:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2023-07-04T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2023/course/",
-        "courseware_id": "course-v1:MITxT+14.009x+2T2023",
-        "run_tag": "2T2023",
-        "id": 38,
-        "products": []
-      }
-    ],
-    "next_run_id": 38,
-    "topics": []
-  },
-  {
-    "id": 1,
-    "title": "Microeconomics",
-    "readable_id": "course-v1:MITxT+14.100x",
-    "page": {
-      "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-      "page_url": "/courses/course-v1:MITxT+14.100x/",
-      "financial_assistance_form_url": ""
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Microeconomics",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T23:30:00Z",
-        "enrollment_start": "2022-07-06T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.100x+3T2022",
-        "run_tag": "3T2022",
-        "id": 35,
-        "products": []
-      }
-    ],
-    "next_run_id": 35,
-    "topics": []
-  },
-  {
-    "id": 6,
-    "title": "Political Economy and Economic Development",
-    "readable_id": "course-v1:MITxT+14.750x",
-    "page": {
-      "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
-      "page_url": "/courses/course-v1:MITxT+14.750x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Political Economy and Economic Development",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
-        "enrollment_start": "2021-11-02T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.750x+3T2022",
-        "run_tag": "3T2022",
-        "id": 10,
-        "products": [
-          {
-            "id": 22,
-            "description": "course-v4:MITxT+16.100x+3T2023",
-            "is_active": true,
-            "product_flexible_price": {
-              "amount": null,
-              "automatic": false,
-              "discount_type": null,
-              "redemption_type": null,
-              "max_redemptions": null,
-              "discount_code": "",
-              "payment_type": null,
-              "activation_date": null,
-              "expiration_date": null
+    {
+      "id": 50,
+      "title": "Analysis of Transport Phenomena: Convection",
+      "readable_id": "course-v1:MITxT+10.50.CH07x",
+      "next_run_id": 155,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/7-drkBlue_5uVzT1f.jpg?v=0f9790b2ce8c75e91f5fbf01c5373d36fb75a81e",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH07x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "6 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Convection",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+10.50.CH07x+1T2023/home",
+          "courseware_id": "course-v1:MITxT+10.50.CH07x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 155,
+          "live": true,
+          "course_number": "10.50.CH07x",
+          "products": [
+            {
+              "id": 136,
+              "price": "79.00",
+              "description": "course-v1:MITxT+10.50.CH07x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
             }
-          }
-        ]
-      }
-    ],
-    "next_run_id": 10,
-    "topics": []
-  },
-  {
-    "id": 4,
-    "title": "The Challenges of Global Poverty",
-    "readable_id": "course-v1:MITxT+14.73x",
-    "page": {
-      "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
-      "page_url": "/courses/course-v1:MITxT+14.73x/",
-      "financial_assistance_form_url": ""
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "The Challenges of Global Poverty",
-        "start_date": "2022-09-06T15:00:00Z",
-        "end_date": "2022-11-22T15:00:00Z",
-        "enrollment_start": "2022-03-08T23:59:00Z",
-        "enrollment_end": "2022-10-11T23:59:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+14.73x+3T2022",
-        "run_tag": "3T2022",
-        "id": 21,
-        "products": []
-      }
-    ],
-    "next_run_id": 21,
-    "topics": []
-  },
-  {
-    "id": 22,
-    "title": "Bringing Workers Voice into Technology and Employment Strategies",
-    "readable_id": "course-v1:MITxT+15.699x",
-    "page": {
-      "feature_image_src": "/media/original_images/negative-space-female-factory-worker-engine-hard-hat-yellow-chevanon-photo.jpg?v=fcf6e582d2d28a8c7c4b34b82759e145a2306269",
-      "page_url": "/courses/course-v1:MITxT+15.699x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 52,
+      "title": "Analysis of Transport Phenomena: Electrochemical Transport",
+      "readable_id": "course-v1:MITxT+10.50.CH09x",
+      "next_run_id": 157,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/9-red.jpg?v=71fc9e04b14d210d7f5062dee34dc4e32db6967a",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH09x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "2 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Electrochemical Transport",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH09x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH09x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 157,
+          "live": true,
+          "course_number": "10.50.CH09x",
+          "products": [
+            {
+              "id": 138,
+              "price": "29.00",
+              "description": "course-v1:MITxT+10.50.CH09x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Bringing Workers Voice into Technology and Employment Strategies",
-        "start_date": "2022-09-07T16:00:00Z",
-        "end_date": "2022-10-19T16:00:00Z",
-        "enrollment_start": "2022-06-09T00:00:00Z",
-        "enrollment_end": "2022-09-19T16:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+15.699x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+15.699x+3T2022",
-        "run_tag": "3T2022",
-        "id": 31,
-        "products": []
-      }
-    ],
-    "next_run_id": 31,
-    "topics": []
-  },
-  {
-    "id": 9,
-    "title": "Cellular Solids 1: Structures, Properties and Engineering Applications",
-    "readable_id": "course-v1:MITxT+3.054x",
-    "page": {
-      "feature_image_src": "/media/original_images/3054AboutPageImage_Final_resized.png?v=8486faa001525f1d3350f87de992acbcb3cc70ba",
-      "page_url": "/courses/course-v1:MITxT+3.054x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 49,
+      "title": "Analysis of Transport Phenomena: Fluid Mechanics",
+      "readable_id": "course-v1:MITxT+10.50.CH06x",
+      "next_run_id": 154,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/6-ltBlue.jpg?v=af26cc60badb0a7b289813f9ccbf4c8f77ad8490",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH06x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "9 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Fluid Mechanics",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH06x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH06x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 154,
+          "live": true,
+          "course_number": "10.50.CH06x",
+          "products": [
+            {
+              "id": 135,
+              "price": "129.00",
+              "description": "course-v1:MITxT+10.50.CH06x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Cellular Solids: Structure, Properties and Applications",
-        "start_date": "2022-05-04T05:30:00Z",
-        "end_date": "2023-05-03T00:00:00Z",
-        "enrollment_start": "2022-04-25T00:00:00Z",
-        "enrollment_end": "2023-05-03T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+3.054x+3T2021/course/",
-        "courseware_id": "course-v1:MITxT+3.054x+3T2021",
-        "run_tag": "3T2021",
-        "id": 14,
-        "products": []
-      }
-    ],
-    "next_run_id": 14,
-    "topics": []
-  },
-  {
-    "id": 19,
-    "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
-    "readable_id": "course-v1:MITxT+11.S952x",
-    "page": {
-      "feature_image_src": "/media/original_images/11.S952x_Course_Image.png?v=faba2ccb0ebef1badccda77298e5829b9eb9dd04",
-      "page_url": "/courses/course-v1:MITxT+11.S952x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 45,
+      "title": "Analysis of Transport Phenomena: Mathematical Formulation",
+      "readable_id": "course-v1:MITxT+10.50.CH02x",
+      "next_run_id": 150,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/drkGreen_375.png?v=67357416dbff6268f5463acc4ea8847b8a08428a",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH02x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "4 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Mathematical Formulation",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH02x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH02x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 150,
+          "live": true,
+          "course_number": "10.50.CH02x",
+          "products": [
+            {
+              "id": 131,
+              "price": "59.00",
+              "description": "course-v1:MITxT+10.50.CH02x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "COVID-19 in Slums & Informal Settlements: Guidelines & Responses",
-        "start_date": "2022-08-29T16:00:00Z",
-        "end_date": "2023-04-14T16:00:00Z",
-        "enrollment_start": "2022-08-01T00:00:00Z",
-        "enrollment_end": "2023-03-15T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+11.S952x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+11.S952x+2T2022",
-        "run_tag": "2T2022",
-        "id": 28,
-        "products": []
-      }
-    ],
-    "next_run_id": 28,
-    "topics": []
-  },
-  {
-    "id": 10,
-    "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.310PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-      "page_url": "/courses/course-v1:MITxT+14.310PEx/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 44,
+      "title": "Analysis of Transport Phenomena: Models",
+      "readable_id": "course-v1:MITxT+10.50.CH01x",
+      "next_run_id": 149,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/1-ltGreen.jpg?v=f40e3581924ca77414ae3977c8cdb1a94765e46e",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH01x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "2 Weeks",
+        "effort": "10-12 hrs/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Models",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH01x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH01x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 149,
+          "live": true,
+          "course_number": "10.50.CH01x",
+          "products": [
+            {
+              "id": 130,
+              "price": "29.00",
+              "description": "course-v1:MITxT+10.50.CH01x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Data Analysis for Social Scientists - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T15:00:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.310PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.310PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 50,
-        "products": []
-      }
-    ],
-    "next_run_id": 50,
-    "topics": []
-  },
-  {
-    "id": 11,
-    "title": "Designing and Running Randomized Evaluations - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+JPAL102PEx",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 30,
-    "title": "Electrical, Optical & Magnetic Materials and Devices",
-    "readable_id": "course-v1:MITxT+3.15x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.15x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 51,
+      "title": "Analysis of Transport Phenomena: Nonequilibrium Thermodynamics",
+      "readable_id": "course-v1:MITxT+10.50.CH08x",
+      "next_run_id": 156,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/8-orange.jpg?v=0be48100571b661b7c8a5b8de061f25232d91301",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH08x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "2 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Nonequilibrium Thermodynamics",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH08x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH08x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 156,
+          "live": true,
+          "course_number": "10.50.CH08x",
+          "products": [
+            {
+              "id": 137,
+              "price": "29.00",
+              "description": "course-v1:MITxT+10.50.CH08x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Electrical, Optical & Magnetic Materials and Devices",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.15x+2T2022",
-        "courseware_id": "course-v1:MITxT+3.15x+2T2022",
-        "run_tag": "2T2022",
-        "id": 43,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 29,
-    "title": "Electronic, Optical, and Magnetic Properties of Materials",
-    "readable_id": "course-v1:MITxT+3.024x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.024x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 46,
+      "title": "Analysis of Transport Phenomena: Scaling",
+      "readable_id": "course-v1:MITxT+10.50.CH03x",
+      "next_run_id": 151,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/3-purple.jpg?v=82c25a37e88b44529a7f4439348f07f099308d1a",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH03x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "3 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Scaling",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH03x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH03x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 151,
+          "live": true,
+          "course_number": "10.50.CH03x",
+          "products": [
+            {
+              "id": 132,
+              "price": "39.00",
+              "description": "course-v1:MITxT+10.50.CH03x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Electronic, Optical, and Magnetic Properties of Materials Course Navigation",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.024x+2T2022",
-        "courseware_id": "course-v1:MITxT+3.024x+2T2022",
-        "run_tag": "2T2022",
-        "id": 42,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 18,
-    "title": "Evaluating Social Programs",
-    "readable_id": "course-v1:MITxT+JPAL_RCT101x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+JPAL_RCT101x/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 48,
+      "title": "Analysis of Transport Phenomena: Series Expansions",
+      "readable_id": "course-v1:MITxT+10.50.CH05x",
+      "next_run_id": 153,
+      "departments": [
+        {
+          "name": "Chemical Engineering"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/5-brown_2.2.jpg?v=ff1b83927266cef6dcfe8c0c30c0adf18205847b",
+        "page_url": "/courses/course-v1:MITxT+10.50.CH05x/",
+        "description": "Graduate-level introduction to mathematical modeling of heat and mass transfer (diffusion and convection), fluid dynamics, chemical reactions, and phase transformations.",
+        "live": true,
+        "length": "6 weeks",
+        "effort": "10-12 hours/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "Analysis of Transport Phenomena: Series Expansions",
+          "start_date": "2023-03-01T14:00:00Z",
+          "end_date": "2025-02-26T14:00:00Z",
+          "enrollment_start": "2023-01-03T14:00:00Z",
+          "enrollment_end": null,
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+10.50.CH05x+1T2023",
+          "courseware_id": "course-v1:MITxT+10.50.CH05x+1T2023",
+          "certificate_available_date": "2025-02-26T14:00:00Z",
+          "upgrade_deadline": "2025-02-16T14:00:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 153,
+          "live": true,
+          "course_number": "10.50.CH05x",
+          "products": [
+            {
+              "id": 134,
+              "price": "79.00",
+              "description": "course-v1:MITxT+10.50.CH05x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Evaluating Social Programs (RCT101x)",
-        "start_date": "2022-04-13T15:00:00Z",
-        "end_date": "2030-05-08T04:00:00Z",
-        "enrollment_start": "2022-04-13T05:00:00Z",
-        "enrollment_end": "2030-04-05T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL_RCT101x+1T2022/course/",
-        "courseware_id": "course-v1:MITxT+JPAL_RCT101x+1T2022",
-        "run_tag": "1T2022",
-        "id": 27,
-        "products": []
-      }
-    ],
-    "next_run_id": 27,
-    "topics": []
-  },
-  {
-    "id": 12,
-    "title": "Foundations of Development Policy - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.740PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
-      "page_url": "/courses/course-v1:MITxT+14.740PEx/",
-      "financial_assistance_form_url": ""
+    {
+      "id": 54,
+      "title": "AP® Microeconomics",
+      "readable_id": "course-v1:MITxT+14.01x",
+      "next_run_id": 184,
+      "departments": [
+        {
+          "name": "Economics"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/14.01x_Course_Image_MITxO.png?v=f6aacc1df41d983b5cda78201a7fc86751229a62",
+        "page_url": "/courses/course-v1:MITxT+14.01x/",
+        "description": "An overview of introductory microeconomics. Learn the key principles of economics and how to apply them to the real world - and the AP® exam!",
+        "live": true,
+        "length": "12 Weeks",
+        "effort": "4 Hours / Week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "AP® Microeconomics",
+          "start_date": "2023-03-07T15:00:00Z",
+          "end_date": "2023-08-25T15:00:00Z",
+          "enrollment_start": "2023-02-07T15:00:00Z",
+          "enrollment_end": "2023-08-25T00:00:00Z",
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.01x+1T2023/course",
+          "courseware_id": "course-v1:MITxT+14.01x+1T2023",
+          "certificate_available_date": "2023-08-25T15:00:00Z",
+          "upgrade_deadline": "2023-08-15T15:00:00Z",
+          "is_upgradable": false,
+          "is_enrollable": false,
+          "is_self_paced": true,
+          "run_tag": "1T2023",
+          "id": 159,
+          "live": true,
+          "course_number": "14.01x",
+          "products": [
+            {
+              "id": 140,
+              "price": "49.00",
+              "description": "course-v1:MITxT+14.01x+1T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        },
+        {
+          "title": "AP® Microeconomics",
+          "start_date": "2023-08-29T15:00:00Z",
+          "end_date": "2024-08-23T15:00:00Z",
+          "enrollment_start": "2023-07-11T15:00:00Z",
+          "enrollment_end": "2024-08-23T00:00:00Z",
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.01x+2T2023/course",
+          "courseware_id": "course-v1:MITxT+14.01x+2T2023",
+          "certificate_available_date": "2024-08-23T15:00:00Z",
+          "upgrade_deadline": "2024-08-13T23:59:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "2T2023",
+          "id": 184,
+          "live": true,
+          "course_number": "14.01x",
+          "products": [
+            {
+              "id": 163,
+              "price": "49.00",
+              "description": "course-v1:MITxT+14.01x+2T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
     },
-    "courseruns": [
-      {
-        "title": "Foundations of Development Policy - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.740PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.740PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 49,
-        "products": []
-      }
-    ],
-    "next_run_id": 49,
-    "topics": []
-  },
-  {
-    "id": 34,
-    "title": "Good Economics for Hard Times - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.009PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-      "page_url": "/courses/course-v1:MITxT+14.009PEx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Good Economics for Hard Times - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.009PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.009PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 47,
-        "products": []
-      }
-    ],
-    "next_run_id": 47,
-    "topics": []
-  },
-  {
-    "id": 27,
-    "title": "How Language Works",
-    "readable_id": "course-v1:MITxT+24.900x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+24.900x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "How Language Works",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+24.900x+3T2022",
-        "courseware_id": "course-v1:MITxT+24.900x+3T2022",
-        "run_tag": "3T2022",
-        "id": 40,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 23,
-    "title": "Mechanics: Kinematics and Dynamics",
-    "readable_id": "course-v1:MITxT+8.01.1x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.1x_Image_2022_MITxO.png?v=593cb814d4e22283198eceb20855662bf41704d8",
-      "page_url": "/courses/course-v1:MITxT+8.01.1x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Kinematics and Dynamics",
-        "start_date": "2022-09-22T16:00:00Z",
-        "end_date": "2023-04-13T16:00:00Z",
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+8.01.1x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+8.01.1x+3T2022",
-        "run_tag": "3T2022",
-        "id": 32,
-        "products": []
-      }
-    ],
-    "next_run_id": 32,
-    "topics": []
-  },
-  {
-    "id": 31,
-    "title": "Mechanics: Momentum and Energy",
-    "readable_id": "course-v1:MITxT+8.01.2x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.2x_courseImage_435p-244p.png?v=50a30ec2256f4ebb8ae26b8904f1fab41fd36650",
-      "page_url": "/courses/course-v1:MITxT+8.01.2x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Momentum and Energy",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.2x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.2x+3T2022",
-        "run_tag": "3T2022",
-        "id": 44,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 32,
-    "title": "Mechanics: Rotational Dynamics",
-    "readable_id": "course-v1:MITxT+8.01.3x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+8.01.3x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Rotational Dynamics",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.3x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.3x+3T2022",
-        "run_tag": "3T2022",
-        "id": 45,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 33,
-    "title": "Mechanics: Simple Harmonic Motion",
-    "readable_id": "course-v1:MITxT+8.01.4x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.4x_courseimage01_435p-244p.jpg?v=0a2fac7fe3be47df2d6b0651b7e57e2871f901ad",
-      "page_url": "/courses/course-v1:MITxT+8.01.4x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Mechanics: Simple Harmonic Motion",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.01.4x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.01.4x+3T2022",
-        "run_tag": "3T2022",
-        "id": 46,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 13,
-    "title": "Microeconomics - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.100PEx",
-    "page": {
-      "feature_image_src": "/media/original_images/14.100x_xGKvQiK.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-      "page_url": "/courses/course-v1:MITxT+14.100PEx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Microeconomics - PROCTORED EXAM",
-        "start_date": "2022-08-17T15:00:00Z",
-        "end_date": "2022-09-07T15:00:00Z",
-        "enrollment_start": "2022-08-17T13:30:00Z",
-        "enrollment_end": "2022-08-26T15:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.100PEx+2T2022",
-        "courseware_id": "course-v1:MITxT+14.100PEx+2T2022",
-        "run_tag": "2T2022",
-        "id": 48,
-        "products": []
-      }
-    ],
-    "next_run_id": 48,
-    "topics": []
-  },
-  {
-    "id": 21,
-    "title": "Minds and Machines",
-    "readable_id": "course-v1:MITxT+24.09x",
-    "page": {
-      "feature_image_src": "/media/original_images/2409x_FL15_Thumbnail.jpeg?v=cc95c149b6f5f3597bd83079320b347cd03da6ef",
-      "page_url": "/courses/course-v1:MITxT+24.09x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Minds and Machines",
-        "start_date": "2022-06-08T17:00:00Z",
-        "end_date": "2022-08-31T17:00:00Z",
-        "enrollment_start": "2022-05-30T16:00:00Z",
-        "enrollment_end": "2022-08-31T16:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.09x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.09x+2T2022",
-        "run_tag": "2T2022",
-        "id": 30,
-        "products": []
-      }
-    ],
-    "next_run_id": 30,
-    "topics": []
-  },
-  {
-    "id": 24,
-    "title": "Moral Problems and the Good Life",
-    "readable_id": "course-v1:MITxT+24.02x",
-    "page": {
-      "feature_image_src": "/media/original_images/24.02x_course_image_01.jpg?v=a6b6b81b428417cddb6966a998a9dcb4ca7867eb",
-      "page_url": "/courses/course-v1:MITxT+24.02x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Moral Problems and the Good Life",
-        "start_date": "2022-11-17T16:00:00Z",
-        "end_date": "2023-02-02T16:00:00Z",
-        "enrollment_start": "2022-06-17T00:00:00Z",
-        "enrollment_end": "2023-01-26T00:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.02x+3T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.02x+3T2022",
-        "run_tag": "3T2022",
-        "id": 33,
-        "products": []
-      }
-    ],
-    "next_run_id": 33,
-    "topics": []
-  },
-  {
-    "id": 20,
-    "title": "Paradox and Infinity",
-    "readable_id": "course-v1:MITxT+24.118x",
-    "page": {
-      "feature_image_src": "/media/original_images/24.118x_CourseImage_20170926_sm.png?v=5f596811c909028fcbc4361d295c0122e0d791b5",
-      "page_url": "/courses/course-v1:MITxT+24.118x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Paradox and Infinity",
-        "start_date": "2022-06-29T16:00:00Z",
-        "end_date": "2022-08-31T16:00:00Z",
-        "enrollment_start": "2022-06-20T16:00:00Z",
-        "enrollment_end": "2022-08-31T16:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+24.118x+2T2022/course/",
-        "courseware_id": "course-v1:MITxT+24.118x+2T2022",
-        "run_tag": "2T2022",
-        "id": 29,
-        "products": []
-      }
-    ],
-    "next_run_id": 29,
-    "topics": []
-  },
-  {
-    "id": 14,
-    "title": "Political Economy and Economic Development - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.750PEx",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 25,
-    "title": "Problems of Philosophy",
-    "readable_id": "course-v1:MITxT+24.10x",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 8,
-    "title": "Qualitative Research Methods: Analyzing Data",
-    "readable_id": "course-v1:MITxT+21A.819.2x",
-    "page": {
-      "feature_image_src": "/media/original_images/21A.819.2x_courseImage_1134p-675p.jpg?v=b7305a970e6cdaff78231fbf31853c9dc70d9cac",
-      "page_url": "/courses/course-v1:MITxT+21A.819.2x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Qualitative Research Methods: Analyzing Data",
-        "start_date": "2021-11-17T15:30:00Z",
-        "end_date": "2022-10-27T17:00:00Z",
-        "enrollment_start": "2021-11-17T15:00:00Z",
-        "enrollment_end": "2022-10-20T17:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.2x+3T2021/course/",
-        "courseware_id": "course-v1:MITxT+21A.819.2x+3T2021",
-        "run_tag": "3T2021",
-        "id": 13,
-        "products": []
-      }
-    ],
-    "next_run_id": 13,
-    "topics": []
-  },
-  {
-    "id": 7,
-    "title": "Qualitative Research Methods: Conversational Interviewing",
-    "readable_id": "course-v1:MITxT+21A.819.1x",
-    "page": {
-      "feature_image_src": "/media/original_images/21A.819x_CourseImage_1134p-675p.jpg?v=430c765ca446c319a4c920aa1846bf918599328a",
-      "page_url": "/courses/course-v1:MITxT+21A.819.1x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Qualitative Research Methods: Conversational Interviewing",
-        "start_date": "2021-11-17T15:30:00Z",
-        "end_date": "2022-10-27T17:00:00Z",
-        "enrollment_start": "2021-11-17T15:00:00Z",
-        "enrollment_end": "2022-10-20T17:00:00Z",
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+21A.819.1x+3T2021/course/",
-        "courseware_id": "course-v1:MITxT+21A.819.1x+3T2021",
-        "run_tag": "3T2021",
-        "id": 12,
-        "products": []
-      }
-    ],
-    "next_run_id": 12,
-    "topics": []
-  },
-  {
-    "id": 26,
-    "title": "Quantum Mechanics: A First Course",
-    "readable_id": "course-v1:MITxT+8.04x",
-    "page": {
-      "feature_image_src": "/media/original_images/8.04x_replacement_20200917_DiIr66w.png?v=aa4947564bf5b8228085ee3139c62c873d21a66d",
-      "page_url": "/courses/course-v1:MITxT+8.04x/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Quantum Mechanics: A First Course",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+8.04x+3T2022",
-        "courseware_id": "course-v1:MITxT+8.04x+3T2022",
-        "run_tag": "3T2022",
-        "id": 39,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 28,
-    "title": "Structure of Materials",
-    "readable_id": "course-v1:MITxT+3.012Sx",
-    "page": {
-      "feature_image_src": "/media/original_images/8.01.3x_courseImage_MITyoyo_435p-244p.jpg?v=ad82db903797ca19d9726a4db938fa16274321b8",
-      "page_url": "/courses/course-v1:MITxT+3.012Sx/",
-      "financial_assistance_form_url": ""
-    },
-    "courseruns": [
-      {
-        "title": "Structure of Materials",
-        "start_date": null,
-        "end_date": null,
-        "enrollment_start": null,
-        "enrollment_end": null,
-        "expiration_date": null,
-        "courseware_url": "https://courses.mitxonline.mit.edu/learn/course/course-v1:MITxT+3.012Sx+2T2022",
-        "courseware_id": "course-v1:MITxT+3.012Sx+2T2022",
-        "run_tag": "2T2022",
-        "id": 41,
-        "products": []
-      }
-    ],
-    "next_run_id": null,
-    "topics": []
-  },
-  {
-    "id": 15,
-    "title": "The Challenges of Global Poverty - PROCTORED EXAM",
-    "readable_id": "course-v1:MITxT+14.73PEx",
-    "courseruns": [],
-    "next_run_id": null,
-    "topics": []
-  }
-]
+    {
+      "id": 96,
+      "title": "Bootstrapping for Entrepreneurs",
+      "readable_id": "course-v1:MITxT+15.356.2x",
+      "next_run_id": 240,
+      "departments": [
+        {
+          "name": "Management"
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/15-356-2x_Image.jpg?v=3a1d8836abb252670315f0cf70875d8a2feda19a",
+        "page_url": "/courses/course-v1:MITxT+15.356.2x/",
+        "description": "Not every entrepreneur has the resources to grow a venture. In fact, most don’t. But growth in resource scarcity is possible – and even can be advantageous. The goal of this course is to show you how.",
+        "live": true,
+        "length": "4 weeks",
+        "effort": "2-3 hrs/week"
+      },
+      "programs": null,
+      "topics": [],
+      "courseruns": [
+        {
+          "title": "User Innovation in Resource Scarcity",
+          "start_date": "2024-01-16T16:00:00Z",
+          "end_date": "2025-01-14T16:00:00Z",
+          "enrollment_start": "2023-12-14T16:00:00Z",
+          "enrollment_end": "2024-12-19T16:00:00Z",
+          "expiration_date": null,
+          "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+15.356.2x+2T2023/course",
+          "courseware_id": "course-v1:MITxT+15.356.2x+2T2023",
+          "certificate_available_date": "2025-01-14T16:00:00Z",
+          "upgrade_deadline": "2024-12-19T23:59:00Z",
+          "is_upgradable": true,
+          "is_enrollable": true,
+          "is_self_paced": true,
+          "run_tag": "2T2023",
+          "id": 240,
+          "live": true,
+          "course_number": "15.356.2x",
+          "products": [
+            {
+              "id": 211,
+              "price": "49.00",
+              "description": "course-v1:MITxT+15.356.2x+2T2023",
+              "is_active": true,
+              "product_flexible_price": null
+            }
+          ],
+          "approved_flexible_price_exists": false
+        }
+      ]
+    }
+  ]
+}

--- a/test_json/mitxonline_programs.json
+++ b/test_json/mitxonline_programs.json
@@ -1,240 +1,1095 @@
-[
-  {
-    "title": "Data, Economics and Development Policy",
-    "readable_id": "program-v1:MITx+DEDP",
-    "id": 1,
-    "courses": [
-      {
-        "id": 1,
-        "title": "Microeconomics",
-        "readable_id": "course-v1:MITxT+14.100x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-          "page_url": "/courses/course-v1:MITxT+14.100x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
-          {
-            "title": "Microeconomics",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T23:30:00Z",
-            "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.100x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+14.100x+3T2022",
-            "run_tag": "3T2022",
-            "id": 35,
-            "products": [
-              {
-                "id": 22,
-                "description": "course-v1:MITxT+14.100x+3T2022",
-                "is_active": true,
-                "product_flexible_price": {
-                  "amount": null,
-                  "automatic": false,
-                  "discount_type": null,
-                  "redemption_type": null,
-                  "max_redemptions": null,
-                  "discount_code": "",
-                  "payment_type": null,
-                  "activation_date": null,
-                  "expiration_date": null
+{
+  "count": 9,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "title": "18.03x Differential Equations",
+      "readable_id": "program-v1:MITxT+18.03x",
+      "id": 5,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 5,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 36,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 5,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 37,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 5,
+                    "course": 62,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 38
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 5,
+                    "course": 95,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 39
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 5,
+                    "course": 74,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 40
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 5,
+                    "course": 79,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 41
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 5,
+                    "course": 94,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 42
                 }
-              }
-            ]
-          }
-        ],
-        "next_run_id": 35,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.100x.jpg?v=8fe621cc0d80ebe4e57fd1b240e9f95d8c2b31db",
-        "page_url": "/courses/course-v1:MITxT+14.100x/",
-        "financial_assistance_form_url": ""
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mit-dome.png",
+        "page_url": "/programs/program-v1:MITxT+18.03x/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"38wzq\">Scientists and engineers understand the world through differential equations. You can too.</p>",
+        "live": false,
+        "length": "14 weeks",
+        "effort": "7 hrs/wk",
+        "price": "$175"
       },
-      {
-        "id": 2,
-        "title": "Designing and Running Randomized Evaluations",
-        "readable_id": "course-v1:MITxT+JPAL102x",
-        "page": {
-          "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
-          "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
-          {
-            "title": "Designing and Running Randomized Evaluations",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
-            "enrollment_start": "2022-03-08T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+JPAL102x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+JPAL102x+3T2022",
-            "run_tag": "3T2022",
-            "id": 22,
-            "products": []
-          }
-        ],
-        "next_run_id": 22,
-        "topics": [],
-        "feature_image_src": "/media/original_images/JPAL102x.jpg?v=bf1f606cd8105828ceb9529ba5592d507d3b8d58",
-        "page_url": "/courses/course-v1:MITxT+JPAL102x/",
-        "financial_assistance_form_url": ""
+      "program_type": "Series",
+      "departments": ["Mathematics"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "Analysis of Transport Phenomena",
+      "readable_id": "program-v1:MITxT+10.50x",
+      "id": 9,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [44, 45, 46, 47, 48, 49, 50, 51, 52],
+        "electives": []
       },
-      {
-        "id": 3,
-        "title": "Data Analysis for Social Scientists",
-        "readable_id": "course-v1:MITxT+14.310x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-          "page_url": "/courses/course-v1:MITxT+14.310x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
-          {
-            "title": "Data Analysis for Social Scientists",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
-            "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.310x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+14.310x+3T2022",
-            "run_tag": "3T2022",
-            "id": 36,
-            "products": []
-          }
-        ],
-        "next_run_id": 36,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.310x.max-800x600.jpg?v=9db950769510bfdc810f3a84699f139c26d0ffb4",
-        "page_url": "/courses/course-v1:MITxT+14.310x/",
-        "financial_assistance_form_url": ""
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 9,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 59,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 9,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 60,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 44,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 61
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 45,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 62
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 46,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 63
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 47,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 64
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 48,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 65
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 49,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 66
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 50,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 67
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 51,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 68
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 9,
+                    "course": 52,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 69
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mit-dome.png",
+        "page_url": "/programs/program-v1:MITxT+10.50x/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"us5gu\">Graduate-level introduction to mathematical modeling</p>",
+        "live": true,
+        "length": "Modules vary in length from 2-9 weeks",
+        "effort": "10-12 hours per week",
+        "price": "varies from $29-$129"
       },
-      {
-        "id": 4,
-        "title": "The Challenges of Global Poverty",
-        "readable_id": "course-v1:MITxT+14.73x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
-          "page_url": "/courses/course-v1:MITxT+14.73x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
-          {
-            "title": "The Challenges of Global Poverty",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
-            "enrollment_start": "2022-03-08T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.73x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+14.73x+3T2022",
-            "run_tag": "3T2022",
-            "id": 21,
-            "products": []
-          }
-        ],
-        "next_run_id": 21,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.73x.jpg?v=b7ce961774d5d79edb9b0e22135f5b5b8ca006dc",
-        "page_url": "/courses/course-v1:MITxT+14.73x/",
-        "financial_assistance_form_url": ""
+      "program_type": "Series",
+      "departments": ["Chemical Engineering"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "Data, Economics, and Design of Policy",
+      "readable_id": "program-v1:MITx+DEDP+2T2023",
+      "id": 3,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+        "electives": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96]
       },
-      {
-        "id": 5,
-        "title": "Foundations of Development Policy",
-        "readable_id": "course-v1:MITxT+14.740x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
-          "page_url": "/courses/course-v1:MITxT+14.740x/",
-          "financial_assistance_form_url": ""
-        },
-        "courseruns": [
-          {
-            "title": "Foundations of Development Policy",
-            "start_date": "2023-01-31T15:00:00Z",
-            "end_date": "2023-04-19T15:00:00Z",
-            "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2023-03-07T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.740x+1T2023/course/",
-            "courseware_id": "course-v1:MITxT+14.740x+1T2023",
-            "run_tag": "1T2023",
-            "id": 37,
-            "products": []
-          }
-        ],
-        "next_run_id": 37,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.740x.jpg?v=ce04d2d27a6d4b2f20d60f48e3c437726d02dc08",
-        "page_url": "/courses/course-v1:MITxT+14.740x/",
-        "financial_assistance_form_url": ""
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 3,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 21,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 3,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 22,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 1,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 23
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 2,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 24
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 3,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 25
+                }
+              ]
+            },
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "min_number_of",
+                "operator_value": "2",
+                "program": 3,
+                "course": null,
+                "title": "Elective Courses",
+                "elective_flag": true
+              },
+              "id": 26,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 5,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 27
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 6,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 28
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 1,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 29
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 3,
+                    "course": 16,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 30
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mit-dome.png",
+        "page_url": "/programs/program-v1:MITx+DEDP+2T2023/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"n8d75\">Data, Economics and Development Public Policy description</p>",
+        "live": true,
+        "length": "1",
+        "effort": null,
+        "price": "0"
       },
-      {
-        "id": 6,
-        "title": "Political Economy and Economic Development",
-        "readable_id": "course-v1:MITxT+14.750x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
-          "page_url": "/courses/course-v1:MITxT+14.750x/",
-          "financial_assistance_form_url": ""
+      "program_type": "MicroMasters®",
+      "departments": ["Economics"],
+      "live": false,
+      "topics": [
+        {
+          "name": "Economics"
         },
-        "courseruns": [
-          {
-            "title": "Political Economy and Economic Development",
-            "start_date": "2022-09-06T15:00:00Z",
-            "end_date": "2022-11-22T15:00:00Z",
-            "enrollment_start": "2021-11-02T23:59:00Z",
-            "enrollment_end": "2022-10-11T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.750x+3T2022/course/",
-            "courseware_id": "course-v1:MITxT+14.750x+3T2022",
-            "run_tag": "3T2022",
-            "id": 10,
-            "products": []
-          }
-        ],
-        "next_run_id": 10,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.750x.jpg?v=444c4611e9d1bccef38b160d01d2015d4a601d72",
-        "page_url": "/courses/course-v1:MITxT+14.750x/",
-        "financial_assistance_form_url": ""
+        {
+          "name": "Policy and Administration"
+        },
+        {
+          "name": "Social Sciences"
+        }
+      ]
+    },
+    {
+      "title": "Data, Economics, and Design of Policy: International Development",
+      "readable_id": "program-v1:MITx+DEDP",
+      "id": 1,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [1, 2, 3],
+        "electives": [5, 6, 4]
       },
-      {
-        "id": 16,
-        "title": "Good Economics for Hard Times",
-        "readable_id": "course-v1:MITxT+14.009x",
-        "page": {
-          "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-          "page_url": "/courses/course-v1:MITxT+14.009x/",
-          "financial_assistance_form_url": ""
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 1,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 1,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 1,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 2,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 1,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 4
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 2,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 5
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 3,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 6
+                }
+              ]
+            },
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "min_number_of",
+                "operator_value": "2",
+                "program": 1,
+                "course": null,
+                "title": "Elective Courses",
+                "elective_flag": true
+              },
+              "id": 3,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 5,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 7
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 6,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 8
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 1,
+                    "course": 4,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 20
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/InternationalDevelopment-track_image_1134.jpg?v=32d70d0ad6a7b87b4cfbc4717e20177d601afb42",
+        "page_url": "/programs/program-v1:MITx+DEDP/",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "description": "<p data-block-key=\"s6wzo\">Grapple with some of the world’s most pressing problems from a rigorous, data-driven perspective developed by Nobel prize winners Esther Duflo and Abhijit Banerjee. Complete three core courses and two out of three electives plus proctored exams to earn your credential. You may then apply to the Master’s degree offered by MIT’s #1 world-ranked Economics Department.</p>",
+        "live": true,
+        "length": "3 terms (12 months)",
+        "effort": "12-14 hours per week",
+        "price": "$250 - $1000"
+      },
+      "program_type": "MicroMasters®",
+      "departments": ["Economics"],
+      "live": true,
+      "topics": [
+        {
+          "name": "Economics"
         },
-        "courseruns": [
-          {
-            "title": "Good Economics for Hard Times",
-            "start_date": "2023-05-30T15:00:00Z",
-            "end_date": "2023-08-16T15:00:00Z",
-            "enrollment_start": "2022-07-06T23:59:00Z",
-            "enrollment_end": "2023-07-04T23:59:00Z",
-            "expiration_date": null,
-            "courseware_url": "https://courses.mitxonline.mit.edu/courses/course-v1:MITxT+14.009x+2T2023/course/",
-            "courseware_id": "course-v1:MITxT+14.009x+2T2023",
-            "run_tag": "2T2023",
-            "id": 38,
-            "products": []
-          }
-        ],
-        "next_run_id": 38,
-        "topics": [],
-        "feature_image_src": "/media/original_images/14.009x_-_course_image_-_SMALL.jpg?v=52e6adb90be9d738874676756fe22cd1ad9e1965",
-        "page_url": "/courses/course-v1:MITxT+14.009x/",
-        "financial_assistance_form_url": ""
-      }
-    ],
-    "start_date": "2021-10-05T15:00:00Z",
-    "end_date": "2023-08-16T15:00:00Z",
-    "enrollment_start": "2021-10-05T15:00:00Z",
-    "topics": []
-  }
-]
+        {
+          "name": "Policy and Administration"
+        },
+        {
+          "name": "Social Sciences"
+        }
+      ]
+    },
+    {
+      "title": "Data, Economics, and Design of Policy: Public Policy",
+      "readable_id": "program-v1:MITx+DEDP-Public-Policy",
+      "id": 2,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [1, 2, 3],
+        "electives": [16, 68]
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 2,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 12,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 2,
+                "course": null,
+                "title": "Core: Complete all",
+                "elective_flag": false
+              },
+              "id": 13,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 2,
+                    "course": 1,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 14
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 2,
+                    "course": 2,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 15
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 2,
+                    "course": 3,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 16
+                }
+              ]
+            },
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "min_number_of",
+                "operator_value": "2",
+                "program": 2,
+                "course": null,
+                "title": "Public Policy Electives",
+                "elective_flag": true
+              },
+              "id": 17,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 2,
+                    "course": 16,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 18
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 2,
+                    "course": 68,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 19
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/PublicPolicy-track_image_1134.jpg?v=38dd4da1307b5f85d96d20dffece2c0c25902295",
+        "page_url": "/programs/program-v1:MITx+DEDP-Public-Policy/",
+        "financial_assistance_form_url": "/programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/",
+        "description": "<p data-block-key=\"kkj7y\">Learn to evaluate the effectiveness of policies that tackle issues facing the US and other high-income economies. This program covers local issues such as minimum wage and employment, food stamps and consumer welfare, and economics of risk and safety regulation, as well as global issues such as trade, climate change, and immigration that are at the forefront of public policy debates.</p>",
+        "live": true,
+        "length": "3 terms (12 months)",
+        "effort": "12-14 hours per week",
+        "price": "$250 - $1000"
+      },
+      "program_type": "MicroMasters®",
+      "departments": ["Economics"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "Differential Calculus",
+      "readable_id": "program-v1:MITxT+18.01x",
+      "id": 6,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [61, 69, 80],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 6,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 43,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 6,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 44,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 61,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 45
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 69,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 46
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 80,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 47
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mit-dome.png",
+        "page_url": "/programs/program-v1:MITxT+18.01x/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"z30uy\">Discover the derivative---what it is, how to compute it, and when to apply it in solving real world problems. Part 1 of 3.</p>",
+        "live": true,
+        "length": "11 weeks",
+        "effort": "6-10 hrs/wk",
+        "price": "$175"
+      },
+      "program_type": "Series",
+      "departments": ["Mathematics"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "Introductory Electricity and Magnetics",
+      "readable_id": "program-v1:MITxT+8.02x",
+      "id": 7,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 7,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 48,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 7,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 49,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 7,
+                    "course": 59,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 50
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 7,
+                    "course": 57,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 51
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 7,
+                    "course": 56,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 52
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mit-dome.png",
+        "page_url": "/programs/program-v1:MITxT+8.02x/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"fwblk\">Learn how charges interact with each other and create electric fields and electric potential landscapes. This introductory Electromagnetism physics course requires the use of calculus. </p>",
+        "live": false,
+        "length": "5 weeks",
+        "effort": "8-14 hrs/wk",
+        "price": "$149"
+      },
+      "program_type": "Series",
+      "departments": ["Materials Science and Engineering"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "xMinor in Materials for Electronic, Optical, and Magnetic Devices",
+      "readable_id": "program-v1:MITxT+3.DMSE",
+      "id": 4,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 4,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 31,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 4,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 32,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 4,
+                    "course": 28,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 33
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 4,
+                    "course": 29,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 34
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 4,
+                    "course": 30,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 35
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/program_image_fullsize.jpeg?v=889d845ede39b9b93be80ed3f9e394f9894b3b70",
+        "page_url": "/programs/program-v1:MITxT+3.DMSE/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"epxow\">Discover the science and engineering behind the materials and devices that power our modern world.</p>",
+        "live": false,
+        "length": "Approximately 16 weeks (150 hours) per course",
+        "effort": "8-12 hours per week",
+        "price": "$150 per course"
+      },
+      "program_type": "Series",
+      "departments": ["Materials Science and Engineering"],
+      "live": true,
+      "topics": []
+    },
+    {
+      "title": "xSeries in Introduction to Mechanics",
+      "readable_id": "program-v1:MITxT+8.01x",
+      "id": 8,
+      "courses": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+      "requirements": {
+        "required": [13, 47, 50, 52, 49, 45, 44, 51, 46, 48, 54, 96],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 8,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 53,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 8,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 54,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 8,
+                    "course": 23,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 55
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 8,
+                    "course": 31,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 56
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 8,
+                    "course": 32,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 57
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 8,
+                    "course": 33,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 58
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/media/original_images/8.01.1x_Image_2022_MITxO.png?v=593cb814d4e22283198eceb20855662bf41704d8",
+        "page_url": "/programs/program-v1:MITxT+8.01x/",
+        "financial_assistance_form_url": "",
+        "description": "<p data-block-key=\"t73r0\">Learn physics just like an MIT freshman with this calculus-based online series that explores kinematics, momentum, rotational dynamics, and simple harmonic motion.</p>",
+        "live": true,
+        "length": "5 weeks",
+        "effort": "10-12 hrs/week",
+        "price": "$149"
+      },
+      "program_type": "Series",
+      "departments": [],
+      "live": true,
+      "topics": []
+    }
+  ]
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/4484
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Switches mitx online to use v2 urls which include pagination


### How can this be tested?
1. Checkout this branch
2. make sure you have set the new v2 urls in .env:
  ```
  MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/v2/courses/ 
  MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/v2/programs/
  ```
3. run  ```python manage.py backpopulate_mitxonline_data``` and verify it runs without issues and loads around 99 courses


### Additional Context
Sibling PR in infrastructure: https://github.com/mitodl/ol-infrastructure/pull/2476



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
