### PR TITLE
Add backpopulate command for user profiles

### DIFF
--- a/profiles/management/commands/backpopulate_profiles.py
+++ b/profiles/management/commands/backpopulate_profiles.py
@@ -1,0 +1,24 @@
+"""Management command for backpopulating user profiles"""  # noqa: INP001
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+from profiles import api
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """Backpopulate user profiles"""
+
+    help = __doc__
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Run profile backpopulate"""
+
+        users_missing_profiles = User.objects.filter(profile__isnull=True)
+
+        self.stdout.write(f"Backpopulating {users_missing_profiles.count()} profiles")
+
+        for user in users_missing_profiles:
+            api.ensure_profile(user)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/4513

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a backpopulate script for user profiles

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- On the `main` branch, login with a user with no profile and go to `/onboarding`. You should see an error.
- Switch to this branch and run `./manage.py backpopulate_profiles`
- Retest `/onboarding`, it should now work for your user.