### PR TITLE
Add a setting for CSRF_COOKIE_DOMAIN

### DIFF
--- a/app.json
+++ b/app.json
@@ -70,6 +70,10 @@
       "description": "CSAIL courses base URL",
       "required": false
     },
+    "CSRF_COOKIE_DOMAIN": {
+      "description": "The domain to set the CSRF cookie on",
+      "required": false
+    },
     "EDX_API_ACCESS_TOKEN_URL": {
       "description": "URL to retrieve a MITx access token",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -154,6 +154,7 @@ CORS_ALLOWED_ORIGIN_REGEXES = get_list_of_str("CORS_ALLOWED_ORIGIN_REGEXES", [])
 CORS_ALLOW_CREDENTIALS = True
 
 CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
+CSRF_COOKIE_DOMAIN = get_string("CSRF_COOKIE_DOMAIN", None)
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds a settting for `CSRF_COOKIE_DOMAIN` so that we can have django set the cookie on a shared domain for doing cross domain CSRF requests via cookie.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
It's difficult to reproduce the bug, but you can confirm the behavior works locally by setting `CSRF_COOKIE_DOMAIN=.odl.local`. You should then see this cookie get set on `.odl.local` when loading the app locally.