### PR TITLE
homepage hero bug fixes

### DIFF
--- a/frontends/mit-open/src/GlobalStyles.tsx
+++ b/frontends/mit-open/src/GlobalStyles.tsx
@@ -29,11 +29,6 @@ const pageCss = css`
 
   a {
     text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-
     color: inherit;
   }
 

--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -6,7 +6,6 @@ import {
   SearchInputProps,
   styled,
   ChipLink,
-  useMuiBreakpointAtLeast,
 } from "ol-components"
 import type { ChipLinkProps } from "ol-components"
 
@@ -112,6 +111,7 @@ const ControlsContainer = styled.div(({ theme }) => ({
     "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 2px 4px 0px rgba(37, 38, 43, 0.10)",
   [theme.breakpoints.down("sm")]: {
     padding: "12px",
+    gap: "16px",
   },
 }))
 const LinksContainer = styled.div(({ theme }) => ({
@@ -167,7 +167,6 @@ const HeroSearch: React.FC = () => {
     },
     [navigate],
   )
-  const isMobile = !useMuiBreakpointAtLeast("sm")
   return (
     <HeroWrapper>
       <TitleAndControls>
@@ -183,7 +182,7 @@ const HeroSearch: React.FC = () => {
         <ControlsContainer>
           <SearchInput
             placeholder="Search for courses, programs, learning, and teaching materials"
-            size={isMobile ? "medium" : "hero"}
+            size="hero"
             fullWidth
             value={searchText}
             onChange={onSearchChange}

--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -43,17 +43,29 @@ const SEARCH_CHIPS: SearchChip[] = [
 const HeroWrapper = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
+  alignItems: "center",
+  gap: "51px",
   color: theme.custom.colors.darkGray1,
 }))
 
+const TitleAndControls = styled.div({
+  flex: "1 1 auto",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  justifyContent: "center",
+  marginTop: "32px",
+  marginBottom: "32px",
+})
+
 const ImageContainer = styled.div(({ theme }) => ({
+  flex: "0 1.33 auto",
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
   justifyContent: "center",
-  marginLeft: "48px",
-  maxWidth: "400px",
-  flex: 1,
+  marginTop: "22px",
+  transform: "translateX(24px)",
   [theme.breakpoints.down("md")]: {
     display: "none",
   },
@@ -129,20 +141,6 @@ const BrowseContainer = styled.div(({ theme }) => ({
 
   [theme.breakpoints.down("sm")]: {
     flex: 1,
-  },
-}))
-
-const TitleAndControls = styled.div(({ theme }) => ({
-  flex: 1,
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  justifyContent: "center",
-  marginTop: "120px",
-  marginBottom: "120px",
-  [theme.breakpoints.down("md")]: {
-    marginTop: "32px",
-    marginBottom: "32px",
   },
 }))
 

--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -44,7 +44,7 @@ const HeroWrapper = styled.div(({ theme }) => ({
   flexDirection: "row",
   alignItems: "center",
   gap: "51px",
-  color: theme.custom.colors.darkGray1,
+  color: theme.custom.colors.darkGray2,
 }))
 
 const TitleAndControls = styled.div({

--- a/frontends/mit-open/src/pages/HomePage/HomePage.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.tsx
@@ -8,7 +8,7 @@ import ResourceCarousel from "@/page-components/ResourceCarousel/ResourceCarouse
 import * as carousels from "./carousels"
 
 const FullWidthBackground = styled.div({
-  background: "linear-gradient(0deg, #FFF 0%, #E7EBEE 100%);",
+  background: "linear-gradient(0deg, #FFF 0%, #E9ECEF 100%);",
 })
 
 const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({

--- a/frontends/mit-open/src/pages/HomePage/HomePage.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.tsx
@@ -12,7 +12,8 @@ const FullWidthBackground = styled.div({
 })
 
 const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
-  margin: "80px 0",
+  marginTop: "16px",
+  marginBotto: "80px",
   [theme.breakpoints.down("sm")]: {
     marginTop: "0px",
     marginBottom: "32px",

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -12,6 +12,7 @@ const defaultProps = {
 const buttonPadding = {
   medium: 4,
   hero: 6,
+  heroMobile: 4,
 }
 
 /**
@@ -50,7 +51,9 @@ const Input = styled(InputBase)(({
       },
     },
     size === "medium" && {
-      ...theme.typography.body2,
+      "& .MuiInputBase-input": {
+        ...theme.typography.body2,
+      },
       paddingLeft: "12px",
       paddingRight: "12px",
       borderRadius: "4px",
@@ -72,11 +75,12 @@ const Input = styled(InputBase)(({
         height: "40px",
       },
     size === "hero" && {
-      ...theme.typography.body1,
+      "& .MuiInputBase-input": {
+        ...theme.typography.body1,
+      },
       paddingLeft: "16px",
       paddingRight: "16px",
       borderRadius: "8px",
-
       "&.MuiInputBase-adornedStart": {
         paddingLeft: `${16 - buttonPadding.hero}px`,
         "&.Mui-focused": {
@@ -89,10 +93,30 @@ const Input = styled(InputBase)(({
           paddingRight: `${15 - buttonPadding.hero}px`,
         },
       },
+      [theme.breakpoints.down("sm")]: {
+        "& .MuiInputBase-input": {
+          ...theme.typography.body4,
+        },
+        "&.MuiInputBase-adornedStart": {
+          paddingLeft: `${12 - buttonPadding.heroMobile}px`,
+          "&.Mui-focused": {
+            paddingLeft: `${11 - buttonPadding.heroMobile}px`,
+          },
+        },
+        "&.MuiInputBase-adornedEnd": {
+          paddingRight: `${12 - buttonPadding.heroMobile}px`,
+          "&.Mui-focused": {
+            paddingRight: `${11 - buttonPadding.heroMobile}px`,
+          },
+        },
+      },
     },
     size === "hero" &&
       !multiline && {
         height: "56px",
+        [theme.breakpoints.down("sm")]: {
+          height: "37px",
+        },
       },
   ]
 })
@@ -130,6 +154,13 @@ const AdornmentButtonStyled = styled("button")(({ theme }) => ({
     height: pxToRem(24 + 2 * buttonPadding.hero),
     ".MuiSvgIcon-root": {
       fontSize: pxToRem(24),
+    },
+    [theme.breakpoints.down("sm")]: {
+      width: pxToRem(16 + 2 * buttonPadding.heroMobile),
+      height: pxToRem(16 + 2 * buttonPadding.heroMobile),
+      ".MuiSvgIcon-root": {
+        fontSize: pxToRem(16),
+      },
     },
   },
 

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -31,7 +31,7 @@ const Input = styled(InputBase)(({
       borderWidth: "1px",
       borderStyle: "solid",
       "&:hover:not(.Mui-disabled)": {
-        borderWidth: "2px",
+        borderColor: theme.custom.colors.black,
       },
       "&.Mui-focused": {
         borderWidth: "2px",
@@ -53,13 +53,15 @@ const Input = styled(InputBase)(({
       borderRadius: "4px",
       "&.MuiInputBase-adornedStart": {
         paddingLeft: `${12 - buttonPadding.medium}px`,
+        "&.Mui-focused": {
+          paddingLeft: `${11 - buttonPadding.medium}px`,
+        },
       },
       "&.MuiInputBase-adornedEnd": {
         paddingRight: `${12 - buttonPadding.medium}px`,
-      },
-      "&:hover:not(.Mui-disabled), &.Mui-focused": {
-        paddingLeft: "11px",
-        paddingRight: "11px",
+        "&.Mui-focused": {
+          paddingRight: `${11 - buttonPadding.medium}px`,
+        },
       },
     },
     size === "medium" &&
@@ -74,13 +76,15 @@ const Input = styled(InputBase)(({
 
       "&.MuiInputBase-adornedStart": {
         paddingLeft: `${16 - buttonPadding.hero}px`,
+        "&.Mui-focused": {
+          paddingLeft: `${15 - buttonPadding.hero}px`,
+        },
       },
       "&.MuiInputBase-adornedEnd": {
         paddingRight: `${16 - buttonPadding.hero}px`,
-      },
-      "&:hover:not(.Mui-disabled), &.Mui-focused": {
-        paddingLeft: "15px",
-        paddingRight: "15px",
+        "&.Mui-focused": {
+          paddingRight: `${15 - buttonPadding.hero}px`,
+        },
       },
     },
     size === "hero" &&

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -32,11 +32,11 @@ const Input = styled(InputBase)(({
       borderWidth: "1px",
       borderStyle: "solid",
       "&:hover:not(.Mui-disabled)": {
-        borderColor: theme.custom.colors.black,
+        borderColor: theme.custom.colors.darkGray2,
       },
       "&.Mui-focused": {
         borderWidth: "2px",
-        color: theme.custom.colors.black,
+        color: theme.custom.colors.darkGray2,
         borderColor: "currentcolor",
       },
       "&.Mui-error": {

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -45,6 +45,9 @@ const Input = styled(InputBase)(({
         opacity: "0.3",
         color: theme.custom.colors.black,
       },
+      "& input:placeholder-shown": {
+        textOverflow: "ellipsis",
+      },
     },
     size === "medium" && {
       ...theme.typography.body2,

--- a/frontends/ol-components/src/components/ThemeProvider/chips.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/chips.tsx
@@ -76,6 +76,9 @@ const chipComponent: NonNullable<ThemeOptions["components"]>["MuiChip"] = {
       style: {
         borderColor: colors.silverGrayLight,
         color: colors.darkGray1,
+        "&.Mui-focusVisible": {
+          backgroundColor: "transparent",
+        },
         "&.MuiChip-clickable:hover, &.MuiChip-deletable:hover": {
           color: colors.darkGray1,
           borderColor: colors.silverGrayDark,
@@ -90,6 +93,9 @@ const chipComponent: NonNullable<ThemeOptions["components"]>["MuiChip"] = {
         border: "1px solid",
         borderColor: colors.silverGrayLight,
         color: colors.darkGray1,
+        "&.Mui-focusVisible": {
+          backgroundColor: "white",
+        },
         "&.MuiChip-clickable:hover, &.MuiChip-deletable:hover": {
           color: colors.darkGray1,
           borderColor: colors.silverGrayDark,
@@ -103,6 +109,9 @@ const chipComponent: NonNullable<ThemeOptions["components"]>["MuiChip"] = {
         backgroundColor: colors.lightGray2,
         border: "none",
         color: colors.darkGray2,
+        "&.Mui-focusVisible": {
+          backgroundColor: colors.lightGray2,
+        },
         "&.MuiChip-clickable:hover, &.MuiChip-deletable:hover": {
           color: colors.darkGray1,
           backgroundColor: colors.silverGrayLight,
@@ -115,6 +124,9 @@ const chipComponent: NonNullable<ThemeOptions["components"]>["MuiChip"] = {
         backgroundColor: colors.silverGrayDark,
         border: "none",
         color: colors.white,
+        "&.Mui-focusVisible": {
+          backgroundColor: colors.silverGrayDark,
+        },
         "&.MuiChip-clickable:hover, &.MuiChip-deletable:hover": {
           backgroundColor: colors.darkGray1,
         },
@@ -126,6 +138,9 @@ const chipComponent: NonNullable<ThemeOptions["components"]>["MuiChip"] = {
         backgroundColor: colors.mitRed,
         border: "none",
         color: colors.white,
+        "&.Mui-focusVisible": {
+          backgroundColor: colors.mitRed,
+        },
         "&.MuiChip-clickable:hover, &.MuiChip-deletable:hover": {
           backgroundColor: colors.red,
         },


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/4463

### Description (What does it do?)
This PR addresses several issues in the homepage hero section:
- Fixes hover shift on the search icon. *This bug affected search page, too, and all inputs with icon adornments.*
- Fixes hover effect—darken the border, not thicken.
- Makes hero image match figma on full screen.
     - Figma does not indicate the behavior for screens between mobile and desktop. The image and searchbox scale.
- Shifts hero image so it slightly overflows the content container, as in figma. 
- Adjusts the font size and padding of the mobile view search input.
     - `size="hero"` for input should now match the new figma "mobile (hero)" input.

### Screenshots (if appropriate):

*Note: The text colors in this movie are slightly wrong. They are corrected in the screenshots. The movie primarily shoes sizing behavior.*
https://github.com/mitodl/mit-open/assets/9010790/6714b2bf-087d-4324-8df3-5a275611ade3

<img width="1481" alt="Screenshot 2024-06-07 at 5 31 13 PM" src="https://github.com/mitodl/mit-open/assets/9010790/b029c5ae-7eb6-4759-b25e-4bfef547e1bf">

<img width="766" alt="Screenshot 2024-06-07 at 5 31 38 PM" src="https://github.com/mitodl/mit-open/assets/9010790/cfda96d7-3341-4d17-91a0-21b98168d878">

<img width="623" alt="Screenshot 2024-06-07 at 5 31 43 PM" src="https://github.com/mitodl/mit-open/assets/9010790/5e12aee4-c9ba-472b-b246-8bc13748786b">

<img width="1397" alt="Screenshot 2024-06-07 at 4 46 50 PM" src="https://github.com/mitodl/mit-open/assets/9010790/310375a9-c115-46a1-bf6d-bde01124c0fb">


### How can this be tested?
Load the homepage and try it at different sizes.
