### PR TITLE
Carousel: Align loading and loaded card sizes

### DIFF
--- a/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -1,63 +1,149 @@
 import React from "react"
 import ResourceCarousel from "./ResourceCarousel"
 import type { ResourceCarouselProps } from "./ResourceCarousel"
-import { renderWithProviders, screen, user, waitFor } from "@/test-utils"
+import {
+  expectLastProps,
+  renderWithProviders,
+  screen,
+  user,
+  waitFor,
+} from "@/test-utils"
 import { factories, setMockResponse, makeRequest, urls } from "api/test-utils"
-import { act } from "@testing-library/react"
+import { LearningResourceCard } from "ol-components"
+import { ControlledPromise } from "ol-test-utilities"
+
+jest.mock("ol-components", () => {
+  const actual = jest.requireActual("ol-components")
+  return {
+    ...actual,
+    LearningResourceCard: jest.fn(actual.LearningResourceCard),
+  }
+})
+
+const spyLearningResourceCard = jest.mocked(LearningResourceCard)
 
 describe("ResourceCarousel", () => {
-  const setupApis = () => {
+  const setupApis = ({
+    count = 3,
+    autoResolve = true,
+  }: { count?: number; autoResolve?: boolean } = {}) => {
     const resources = {
-      search: factories.learningResources.resources({ count: 10 }),
-      list: factories.learningResources.resources({ count: 10 }),
+      search: factories.learningResources.resources({ count }),
+      list: factories.learningResources.resources({ count }),
     }
+    setMockResponse.get(urls.userMe.get(), {})
+
+    const searchResponse = new ControlledPromise()
+    const listResponse = new ControlledPromise()
     setMockResponse.get(
       expect.stringContaining(urls.search.resources()),
-      resources.search,
+      searchResponse,
     )
     setMockResponse.get(
       expect.stringContaining(urls.learningResources.list()),
-      resources.list,
+      listResponse,
     )
-    return resources
+    const resolve = () => {
+      searchResponse.resolve(resources.search)
+      listResponse.resolve(resources.list)
+    }
+    if (autoResolve) {
+      resolve()
+    }
+    return { resources, resolve }
   }
 
-  it("returns results from the correct endpoint", async () => {
-    const config: ResourceCarouselProps["config"] = [
-      {
-        label: "Resources",
-        data: {
-          type: "resources",
-          params: { resource_type: ["video", "podcast"] },
+  it.each([
+    { cardProps: undefined },
+    { cardProps: { size: "small" } },
+    { cardProps: { size: "medium" } },
+    { cardProps: undefined },
+    { cardProps: { size: "small" } },
+    { cardProps: { size: "medium" } },
+  ] as const)(
+    "Shows loading state then renders results from the correct endpoint with expected props",
+    async ({ cardProps }) => {
+      const config: ResourceCarouselProps["config"] = [
+        {
+          label: "Resources",
+          data: {
+            type: "resources",
+            params: { resource_type: ["video", "podcast"] },
+          },
+          cardProps,
         },
-      },
-      {
-        label: "Search",
-        data: {
-          type: "lr_search",
-          params: { professional: true },
+        {
+          label: "Search",
+          data: {
+            type: "lr_search",
+            params: { professional: true },
+          },
+          cardProps,
         },
-      },
-    ]
+      ]
 
-    setMockResponse.get(urls.userMe.get(), {})
-    const { list, search } = setupApis()
-    renderWithProviders(
-      <ResourceCarousel title="My Carousel" config={config} />,
-    )
-    const tabs = screen.getAllByRole("tab")
-    expect(tabs).toHaveLength(2)
-    expect(tabs[0]).toHaveTextContent("Resources")
-    expect(tabs[1]).toHaveTextContent("Search")
+      const { resources, resolve } = setupApis({ autoResolve: false })
 
-    await screen.findByText(list.results[0].title)
-    await user.click(tabs[0])
-    await user.click(tabs[1])
-    await act(() => {
-      return new Promise((resolve) => setTimeout(resolve, 1000))
-    })
-    await screen.findByText(search.results[0].title)
-  }, 10000)
+      renderWithProviders(
+        <ResourceCarousel title="My Carousel" config={config} />,
+      )
+
+      expectLastProps(spyLearningResourceCard, {
+        isLoading: true,
+        ...cardProps,
+      })
+      resolve()
+
+      const tabs = screen.getAllByRole("tab")
+
+      expect(tabs).toHaveLength(2)
+      expect(tabs[0]).toHaveTextContent("Resources")
+      expect(tabs[1]).toHaveTextContent("Search")
+
+      await screen.findByText(resources.list.results[0].title)
+      await screen.findByText(resources.list.results[1].title)
+      await screen.findByText(resources.list.results[2].title)
+      expectLastProps(spyLearningResourceCard, { ...cardProps })
+
+      await user.click(tabs[1])
+      await screen.findByText(resources.search.results[0].title)
+      await screen.findByText(resources.search.results[1].title)
+      await screen.findByText(resources.search.results[2].title)
+      expectLastProps(spyLearningResourceCard, { ...cardProps })
+    },
+  )
+
+  it.each([
+    { labels: ["First Tab", "Second Tab"], expectTabs: true },
+    { labels: ["Irrelevant title"], expectTabs: false },
+  ])(
+    "Only renders tabs if multiple config items",
+    async ({ labels, expectTabs }) => {
+      const config: ResourceCarouselProps["config"] = labels.map((label) => {
+        return {
+          label,
+          data: { type: "resources", params: {} },
+        }
+      })
+
+      const { resources } = setupApis()
+      renderWithProviders(
+        <ResourceCarousel title="My Carousel" config={config} />,
+      )
+
+      if (expectTabs) {
+        const tabs = await screen.findAllByRole("tab")
+        expect(tabs.map((tab) => tab.textContent)).toEqual(labels)
+      } else {
+        const tabs = screen.queryAllByRole("tab")
+        expect(tabs).toHaveLength(0)
+      }
+
+      await screen.findByText(resources.list.results[1].title)
+      await screen.findByText(resources.list.results[0].title)
+      await screen.findByText(resources.list.results[2].title)
+    },
+  )
 
   it("calls API with expected parameters", async () => {
     const config: ResourceCarouselProps["config"] = [

--- a/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -274,6 +274,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                       isLoading
                       key={index}
                       resource={null}
+                      {...tabConfig.cardProps}
                     />
                   ))
                 : resources.map((resource) => (


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4531

### Description (What does it do?)
This PR makes sure that the `cardProps` specified in carousel config are passed to the loading state, too.

### Screenshots (if appropriate):
<img width="500" alt="Screenshot 2024-06-10 at 3 16 48 PM" src="https://github.com/mitodl/mit-open/assets/9010790/82a126a6-4478-43c6-b0d1-d835ba6e6343">
<img width="500" alt="Screenshot 2024-06-10 at 3 16 52 PM" src="https://github.com/mitodl/mit-open/assets/9010790/031a96e0-628a-43d4-990c-f859dee318db">


### How can this be tested?
Load the homepage. Media cards should be same size in loading and loaded states.

