### PR TITLE
resource card fallback image and alt text fix

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -9,8 +9,10 @@ const _makeResource = factories.learningResources.resource
 
 const makeResource: typeof _makeResource = (overrides) => {
   const resource = _makeResource(overrides)
-  resource.image!.url =
-    "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
+  if (resource.image) {
+    resource.image.url =
+      "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
+  }
   return resource
 }
 
@@ -22,9 +24,12 @@ const meta: Meta<typeof LearningResourceCard> = {
   title: "ol-components/LearningResourceCard",
   argTypes: {
     resource: {
-      options: ["Loading", ...Object.values(ResourceTypeEnum)],
+      options: ["Loading", "Without Image", ...Object.values(ResourceTypeEnum)],
       mapping: {
         Loading: undefined,
+        "Without Image": makeResource({
+          image: null,
+        }),
         [ResourceTypeEnum.Course]: makeResource({
           resource_type: ResourceTypeEnum.Course,
         }),

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { render, screen } from "@testing-library/react"
 import { LearningResourceCard } from "./LearningResourceCard"
+import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
@@ -117,5 +118,26 @@ describe("Learning Resource Card", () => {
     const badge = screen.queryByText("Certificate")
 
     expect(badge).not.toBeInTheDocument()
+  })
+
+  test.each([
+    { image: null, expected: { src: DEFAULT_RESOURCE_IMG, alt: "" } },
+    {
+      image: { url: "https://example.com/image.jpg", alt: "An image" },
+      expected: { src: "https://example.com/image.jpg", alt: "An image" },
+    },
+    {
+      image: { url: "https://example.com/image.jpg", alt: null },
+      expected: { src: "https://example.com/image.jpg", alt: "" },
+    },
+  ])("Image is displayed if present", ({ expected, image }) => {
+    const resource = factories.learningResources.resource({ image })
+
+    render(<LearningResourceCard resource={resource} />)
+
+    const imageEls = screen.getAllByRole<HTMLImageElement>("img")
+    const matching = imageEls.filter((im) => im.src === expected.src)
+    expect(matching.length).toBe(1)
+    expect(matching[0]).toHaveAttribute("alt", expected.alt)
   })
 })

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -3,7 +3,12 @@ import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
 import { RiMenuAddLine, RiBookmarkLine, RiAwardFill } from "@remixicon/react"
 import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
-import { findBestRun, formatDate, getReadableResourceType } from "ol-utilities"
+import {
+  findBestRun,
+  formatDate,
+  getReadableResourceType,
+  DEFAULT_RESOURCE_IMG,
+} from "ol-utilities"
 import { Card } from "../Card/Card"
 import type { Size } from "../Card/Card"
 import { TruncateText } from "../TruncateText/TruncateText"
@@ -151,7 +156,10 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   }
   return (
     <Card className={className} size={size}>
-      <Card.Image src={resource.image?.url} alt={resource.image!.alt!} />
+      <Card.Image
+        src={resource.image?.url ?? DEFAULT_RESOURCE_IMG}
+        alt={resource.image?.alt ?? ""}
+      />
       <Card.Info>
         <Info resource={resource} />
       </Card.Info>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4530

### Description (What does it do?)
Fixes an issue where missing images were causing page to crash. Now the missing image alt text is "" and shows fallback image.

### Screenshots (if appropriate):
<img width="655" alt="Screenshot 2024-06-10 at 3 45 22 PM" src="https://github.com/mitodl/mit-open/assets/9010790/5bfab93b-dc5d-4a61-a35c-b3354e0ff05e">


### How can this be tested?
1. Tests should pass. 
2. `yarn storybook` and view http://localhost:6006/?path=/story/ol-components-learningresourcecard--course&args=resource:Without+Image ... the resource card should show a fallback image.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
