### PR TITLE
Absolute login return URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
 
       - name: Webpack build
         run: yarn run build
+        env:
+          MITOPEN_AXIOS_BASE_PATH: https://api.mitopen-test.odl.mit.edu
 
       - name: Lints
         run: yarn run lint-check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - 5432:5432
     environment:
       - POSTGRES_PASSWORD=postgres
+    volumes:
+      - pgdata:/var/lib/postgresql
 
   redis:
     profiles:
@@ -143,3 +145,4 @@ volumes:
   opensearch-data1:
   django_media:
   yarn-cache:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,7 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 8062
+      MITOPEN_AXIOS_BASE_PATH: http://od.odl.local:8063
     env_file: .env
     ports:
       - "8062:8062"

--- a/frontends/api/src/clients.ts
+++ b/frontends/api/src/clients.ts
@@ -24,7 +24,7 @@ import {
 
 import axiosInstance from "./axios"
 
-const BASE_PATH = APP_SETTINGS.axios_base_path?.replace(/\/+$/, "") ?? ""
+const BASE_PATH = process.env.MITOPEN_AXIOS_BASE_PATH?.replace(/\/+$/, "") ?? ""
 const learningResourcesApi = new LearningResourcesApi(
   undefined,
   BASE_PATH,

--- a/frontends/api/src/hooks/testimonials/index.test.ts
+++ b/frontends/api/src/hooks/testimonials/index.test.ts
@@ -27,6 +27,7 @@ describe("useTestimonialList", () => {
     async (params) => {
       const data = factory.testimonials({ count: 3 })
       const url = urls.testimonials.list(params)
+
       const { wrapper } = setupReactQueryTest()
       setMockResponse.get(url, data)
       const useTestHook = () => useTestimonialList(params)

--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -26,7 +26,7 @@ import type {
 import type { BaseAPI } from "../generated/v1/base"
 import type { BaseAPI as BaseAPIv0 } from "../generated/v0/base"
 
-const { axios_base_path: API_BASE_URL } = APP_SETTINGS
+const API_BASE_URL = process.env.MITOPEN_AXIOS_BASE_PATH
 
 // OpenAPI Generator declares parameters using interfaces, which makes passing
 // them to functions a little annoying.
@@ -168,7 +168,7 @@ const programLetters = {
 const testimonials = {
   list: (params?: Paramsv0<TestimonialsApi, "testimonialsList">) =>
     `${API_BASE_URL}/api/v0/testimonials/${query(params)}`,
-  details: (id: number) => `/api/v0/testimonials/${id}/`,
+  details: (id: number) => `${API_BASE_URL}/api/v0/testimonials/${id}/`,
 }
 
 const search = {

--- a/frontends/mit-open/jest.config.ts
+++ b/frontends/mit-open/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config.InitialOptions = {
       embedlyKey: "embedly_key",
       axios_base_path: "https://api.mitopen-test.odl.mit.edu",
     },
+    MITOPEN_AXIOS_BASE_PATH: "https://api.mitopen-test.odl.mit.edu",
   },
 }
 

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -8,9 +8,9 @@
     "url": "https://github.com/mitodl/mit-open.git"
   },
   "scripts": {
-    "watch": "API_BASE_URL=http://localhost:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:docker": "API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:rc": "API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:docker": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:rc": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -8,9 +8,9 @@
     "url": "https://github.com/mitodl/mit-open.git"
   },
   "scripts": {
-    "watch": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8062 API_BASE_URL=http://od.odl.local:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
     "watch:docker": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:rc": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:rc": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8062 API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",

--- a/frontends/mit-open/src/common/urls.test.ts
+++ b/frontends/mit-open/src/common/urls.test.ts
@@ -3,19 +3,23 @@ import { login } from "./urls"
 const { axios_base_path: API_BASE_URL } = APP_SETTINGS
 
 test("login encodes the next parameter appropriately", () => {
-  expect(login()).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/`)
-  expect(login({})).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/`)
+  expect(login()).toBe(`${API_BASE_URL}/login/ol-oidc/?next=http://localhost/`)
+  expect(login({})).toBe(
+    `${API_BASE_URL}/login/ol-oidc/?next=http://localhost/`,
+  )
 
   expect(
     login({
       pathname: "/foo/bar",
     }),
-  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/foo/bar`)
+  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=http://localhost/foo/bar`)
 
   expect(
     login({
       pathname: "/foo/bar",
       search: "?cat=meow",
     }),
-  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=/foo/bar%3Fcat%3Dmeow`)
+  ).toBe(
+    `${API_BASE_URL}/login/ol-oidc/?next=http://localhost/foo/bar%3Fcat%3Dmeow`,
+  )
 })

--- a/frontends/mit-open/src/common/urls.test.ts
+++ b/frontends/mit-open/src/common/urls.test.ts
@@ -1,18 +1,22 @@
 import { login } from "./urls"
 
-const { axios_base_path: API_BASE_URL } = APP_SETTINGS
+const { MITOPEN_AXIOS_BASE_PATH } = process.env
 
 test("login encodes the next parameter appropriately", () => {
-  expect(login()).toBe(`${API_BASE_URL}/login/ol-oidc/?next=http://localhost/`)
+  expect(login()).toBe(
+    `${MITOPEN_AXIOS_BASE_PATH}/login/ol-oidc/?next=http://localhost/`,
+  )
   expect(login({})).toBe(
-    `${API_BASE_URL}/login/ol-oidc/?next=http://localhost/`,
+    `${MITOPEN_AXIOS_BASE_PATH}/login/ol-oidc/?next=http://localhost/`,
   )
 
   expect(
     login({
       pathname: "/foo/bar",
     }),
-  ).toBe(`${API_BASE_URL}/login/ol-oidc/?next=http://localhost/foo/bar`)
+  ).toBe(
+    `${MITOPEN_AXIOS_BASE_PATH}/login/ol-oidc/?next=http://localhost/foo/bar`,
+  )
 
   expect(
     login({
@@ -20,6 +24,6 @@ test("login encodes the next parameter appropriately", () => {
       search: "?cat=meow",
     }),
   ).toBe(
-    `${API_BASE_URL}/login/ol-oidc/?next=http://localhost/foo/bar%3Fcat%3Dmeow`,
+    `${MITOPEN_AXIOS_BASE_PATH}/login/ol-oidc/?next=http://localhost/foo/bar%3Fcat%3Dmeow`,
   )
 })

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -38,8 +38,8 @@ export const makeFieldEditPath = (channelType: string, name: string) =>
 export const makeFieldManageWidgetsPath = (channelType: string, name: string) =>
   generatePath(FIELD_EDIT_WIDGETS, { channelType, name })
 
-export const LOGIN = `${APP_SETTINGS.axios_base_path}/login/ol-oidc/`
-export const LOGOUT = `${APP_SETTINGS.axios_base_path}/logout/`
+export const LOGIN = `${process.env.MITOPEN_AXIOS_BASE_PATH}/login/ol-oidc/`
+export const LOGOUT = `${process.env.MITOPEN_AXIOS_BASE_PATH}/logout/`
 
 /**
  * Returns the URL to the login page, with a `next` parameter to redirect back
@@ -60,7 +60,7 @@ export const login = ({
    * There's no need to encode the path parameter (it might contain slashes,
    * but those are allowed in search parameters) so let's keep it readable.
    */
-  const next = `${pathname}${encodeURIComponent(search)}`
+  const next = `${window.location.origin}${pathname}${encodeURIComponent(search)}`
   return `${LOGIN}?next=${next}`
 }
 

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -14,8 +14,14 @@ const HtmlWebpackPlugin = require("html-webpack-plugin")
 const CopyPlugin = require("copy-webpack-plugin")
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin")
 
-const { NODE_ENV, ENVIRONMENT, PORT, API_BASE_URL, WEBPACK_ANALYZE } =
-  process.env
+const {
+  NODE_ENV,
+  ENVIRONMENT,
+  PORT,
+  MITOPEN_AXIOS_BASE_PATH,
+  API_BASE_URL,
+  WEBPACK_ANALYZE,
+} = process.env
 
 const MITOPEN_FEATURES_PREFIX = "FEATURE_"
 
@@ -216,11 +222,11 @@ module.exports = (env, argv) => {
             "/static/admin",
             "/static/hijack",
           ],
-          target: API_BASE_URL,
+          target: API_BASE_URL || MITOPEN_AXIOS_BASE_PATH,
           changeOrigin: true,
           secure: false,
           headers: {
-            Origin: API_BASE_URL,
+            Origin: API_BASE_URL || MITOPEN_AXIOS_BASE_PATH,
           },
         },
       ],

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -139,6 +139,7 @@ module.exports = (env, argv) => {
       }),
       new webpack.EnvironmentPlugin({
         ENVIRONMENT: "production",
+        MITOPEN_AXIOS_BASE_PATH: undefined,
       }),
     ]
       .concat(

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "watch": "yarn workspace mit-open run watch",
     "watch:rc": "yarn workspace mit-open run watch:rc",
     "style-lint": "yarn workspace frontends run style-lint",
-    "test": "yarn workspace frontends global:test",
-    "test-watch": "yarn workspace frontends test-watch",
+    "test": "MITOPEN_AXIOS_BASE_PATH=https://api.mitopen-test.odl.mit.edu yarn workspace frontends global:test",
+    "test-watch": "MITOPEN_AXIOS_BASE_PATH=https://api.mitopen-test.odl.mit.edu yarn workspace frontends test-watch",
     "storybook": "yarn workspace frontends storybook",
     "lint-check": "yarn workspace frontends run lint-check",
     "typecheck": "yarn workspace frontends run typecheck"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Fixes issue with user being returned to the api.mitopen-rc.odl.mit.edu subdomain after successful login instead of the frontend domain, mitopen-rc.odl.mit.edu.

- We are also seeing an issue with the logout path being `undefined/logout/`. This is set here https://github.com/mitodl/mit-open/blob/ddfb02e400905514d6917c1d9d1e24ae2ec76025/frontends/mit-open/src/common/urls.ts#L42C14-L42C20 . `APP_SETTINGS.axios_base_path` provided by `MITOPEN_AXIOS_BASE_PATH` from the environment during build in the Webpack config. This is hardcoded in the Actions workflow, so the current mechanism may be unreliable. The included change uses the Webpack Environment plugin as an alternative to provide the value on `process.env.MITOPEN_AXIOS_BASE_PATH`


### Description (What does it do?)
<!--- Describe your changes in detail -->

- Sets the full current URL on the next param on the `/login/ol-oidc/`.
- Uses the Webpack Environment plugin to supply the API base path on process.env during build.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Clear cookies.
- Login via header link.
- Confirm you are on the frontend domain after successful login.
- Log out via the header user menu.
- Confirm you arrive at the Keycloak logged out screen.
- Return to the frontend and confirm you are logged out.
