### PR TITLE
search prefs learning format as list

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -1831,10 +1831,10 @@ export interface PreferencesSearch {
   topic?: Array<string>
   /**
    *
-   * @type {string}
+   * @type {Array<string>}
    * @memberof PreferencesSearch
    */
-  learning_format?: string
+  learning_format?: Array<string>
 }
 /**
  * Serializer for Profile

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -2052,7 +2052,9 @@ components:
           items:
             type: string
         learning_format:
-          type: string
+          type: array
+          items:
+            type: string
     Profile:
       type: object
       description: Serializer for Profile

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -76,7 +76,9 @@ class PreferencesSearchSerializer(serializers.Serializer):
 
     certification = serializers.BooleanField(required=False)
     topic = serializers.ListField(child=serializers.CharField(), required=False)
-    learning_format = serializers.CharField(required=False)
+    learning_format = serializers.ListField(
+        child=serializers.CharField(), required=False
+    )
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -123,7 +125,7 @@ class ProfileSerializer(serializers.ModelSerializer):
         if obj.topic_interests and obj.topic_interests.count() > 0:
             filters["topic"] = obj.topic_interests.values_list("name", flat=True)
         if obj.learning_format:
-            filters["learning_format"] = obj.learning_format
+            filters["learning_format"] = [obj.learning_format]
         return PreferencesSearchSerializer(instance=filters).data
 
     def validate_location(self, location):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -265,7 +265,7 @@ def test_serialize_profile_preference_search_filters(
     assert search_filters.get("certification", None) == cert_filter
     assert search_filters.get("topic", None) == (topics if topics else None)
     assert search_filters.get("learning_format", None) == (
-        lr_format if lr_format else None
+        [lr_format] if lr_format else None
     )
 
 

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -137,7 +137,7 @@ def test_get_profile(logged_in, user, user_client):
         "time_commitment": profile.time_commitment,
         "learning_format": profile.learning_format,
         "preference_search_filters": {
-            "learning_format": profile.learning_format,
+            "learning_format": [profile.learning_format],
             "certification": (
                 profile.certificate_desired == Profile.CertificateDesired.YES.value
             ),


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4386

### Description (What does it do?)
Changes the `learning_format` field inside `profile.preference_search_filters` to be a list.


### How can this be tested?
In django admin, go to the `Profile` object for your user, assign values for topic interests, certification desired, and learning format fields.  Check the API response at `http://localhost:8063/api/v0/profiles/<username>` and verify that the `preference_search_filters` attribute has appropriate values, and `learning_format` is a list (if that profile field is not null).
