### PR TITLE
Add featured courses carousel to unit channel page

### DIFF
--- a/frontends/mit-open/src/common/utils.test.ts
+++ b/frontends/mit-open/src/common/utils.test.ts
@@ -1,0 +1,39 @@
+import { getSearchParamMap } from "./utils"
+
+describe("getSearchParamMap", () => {
+  it("should return an empty object when there are no parameters", () => {
+    const urlParams = new URLSearchParams()
+    const result = getSearchParamMap(urlParams)
+    expect(result).toEqual({})
+  })
+
+  it("should handle one parameter", () => {
+    const urlParams = new URLSearchParams()
+    urlParams.append("q", "test search")
+    const result = getSearchParamMap(urlParams)
+    expect(result).toEqual({ q: ["test search"] })
+  })
+
+  it("should handle multiple parameters", () => {
+    const urlParams = new URLSearchParams()
+    urlParams.append("q", "test search")
+    urlParams.append("offeror", "mitx")
+    const result = getSearchParamMap(urlParams)
+    expect(result).toEqual({ q: ["test search"], offeror: ["mitx"] })
+  })
+
+  it("should handle parameters with multiple values", () => {
+    const urlParams = new URLSearchParams()
+    urlParams.append("topic", "Leadership")
+    urlParams.append("topic", "Business")
+    const result = getSearchParamMap(urlParams)
+    expect(result).toEqual({ topic: ["Leadership", "Business"] })
+  })
+
+  it("should handle parameters with comma-separated values", () => {
+    const urlParams = new URLSearchParams()
+    urlParams.append("topic", "Leadership,Business,Management")
+    const result = getSearchParamMap(urlParams)
+    expect(result).toEqual({ topic: ["Leadership", "Business", "Management"] })
+  })
+})

--- a/frontends/mit-open/src/common/utils.ts
+++ b/frontends/mit-open/src/common/utils.ts
@@ -1,0 +1,13 @@
+const getSearchParamMap = (urlParams: URLSearchParams) => {
+  const params: Record<string, string[] | string> = {}
+  for (const [key] of urlParams.entries()) {
+    const paramValues = urlParams.getAll(key)
+    const finalparams = paramValues.map((p) => {
+      return p.indexOf(",") !== -1 ? p.split(",") : p
+    })
+    params[key] = finalparams.flat()
+  }
+  return params
+}
+
+export { getSearchParamMap }

--- a/frontends/mit-open/src/common/utils.ts
+++ b/frontends/mit-open/src/common/utils.ts
@@ -2,10 +2,8 @@ const getSearchParamMap = (urlParams: URLSearchParams) => {
   const params: Record<string, string[] | string> = {}
   for (const [key] of urlParams.entries()) {
     const paramValues = urlParams.getAll(key)
-    const finalparams = paramValues.map((p) => {
-      return p.indexOf(",") !== -1 ? p.split(",") : p
-    })
-    params[key] = finalparams.flat()
+    const finalparams = paramValues.flatMap((p) => p.split(","))
+    params[key] = finalparams
   }
   return params
 }

--- a/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
+++ b/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-
+import { getSearchParamMap } from "@/common/utils"
 import {
   useSearchSubscriptionCreate,
   useSearchSubscriptionDelete,
@@ -19,17 +19,7 @@ const SearchSubscriptionToggle = ({
   sourceType: SourceTypeEnum
 }) => {
   const subscribeParams: Record<string, string[] | string> = useMemo(() => {
-    const params: Record<string, string[] | string> = {
-      source_type: sourceType,
-    }
-    for (const [key] of searchParams.entries()) {
-      const paramValues = searchParams.getAll(key)
-      const finalparams = paramValues.map((p) => {
-        return p.indexOf(",") !== -1 ? p.split(",") : p
-      })
-      params[key] = finalparams.flat()
-    }
-    return params
+    return { source_type: sourceType, ...getSearchParamMap(searchParams) }
   }, [searchParams, sourceType])
 
   const { data: user } = useUserMe()

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldAppearanceForm.test.tsx
@@ -5,8 +5,8 @@ import {
   user,
   waitFor,
 } from "../../test-utils"
+import { factories, urls, setMockResponse } from "api/test-utils"
 import { fields as factory } from "api/test-utils/factories"
-import { urls, setMockResponse } from "api/test-utils"
 import { makeFieldViewPath, makeFieldEditPath } from "@/common/urls"
 import { makeWidgetListResponse } from "ol-widgets/src/factories"
 import type { FieldChannel } from "api/v0"
@@ -15,6 +15,10 @@ const setupApis = (fieldOverrides: Partial<FieldChannel>) => {
   const field = factory.field({ is_moderator: true, ...fieldOverrides })
   setMockResponse.get(urls.userMe.get(), {})
   field.search_filter = undefined
+  setMockResponse.get(
+    urls.learningResources.featured({ limit: 12 }),
+    factories.learningResources.resources({ count: 0 }),
+  )
 
   setMockResponse.get(
     urls.fields.details(field.channel_type, field.name),
@@ -64,6 +68,7 @@ describe("EditFieldAppearanceForm", () => {
       featured_list: null, // so we don't have to mock userList responses
       lists: [],
     })
+
     const newTitle = "New Title"
     const newDesc = "New Description"
     const newChannelType = "topic"

--- a/frontends/mit-open/src/pages/FieldPage/EditFieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/EditFieldPage.test.tsx
@@ -11,6 +11,10 @@ describe("EditFieldPage", () => {
       field,
     )
     setMockResponse.get(
+      apiUrls.learningResources.featured({ limit: 12 }),
+      factories.learningResources.resources({ count: 0 }),
+    )
+    setMockResponse.get(
       apiUrls.userSubscription.check({
         source_type: "channel_subscription_type",
       }),
@@ -33,6 +37,10 @@ describe("EditFieldPage", () => {
   it("Displays message and no tabs for non-moderators", async () => {
     const field = factory.field({ is_moderator: false })
     setMockResponse.get(apiUrls.userMe.get(), {})
+    setMockResponse.get(
+      apiUrls.learningResources.featured({ limit: 12 }),
+      factories.learningResources.resources({ count: 0 }),
+    )
     setMockResponse.get(
       apiUrls.userSubscription.check({
         source_type: "channel_subscription_type",

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -35,6 +35,15 @@ const setupApis = (
     urls.fields.details(field.channel_type, field.name),
     field,
   )
+  setMockResponse.get(
+    urls.learningResources.featured({ limit: 12, platform: ["ocw"] }),
+    factories.learningResources.resources({ count: 0 }),
+  )
+  setMockResponse.get(
+    urls.learningResources.featured({ limit: 12 }),
+    factories.learningResources.resources({ count: 0 }),
+  )
+
   const urlParams = new URLSearchParams(fieldPatch?.search_filter)
   const subscribeParams: Record<string, string[] | string> = {}
   for (const [key, value] of urlParams.entries()) {

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -115,10 +115,10 @@ describe("FieldPage", () => {
     expect(images[0].src).toContain(field.configuration.banner_background)
     expect(images[1].src).toContain(field.configuration.logo)
   })
-  it("Displays a featured carousel if the channel type is 'offeror'", async () => {
+  it("Displays a featured carousel if the channel type is 'unit'", async () => {
     const { field } = setupApis({
-      search_filter: "offeror=ocw",
-      channel_type: "offeror",
+      search_filter: "unit=ocw",
+      channel_type: "unit",
     })
 
     renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -128,6 +128,19 @@ describe("FieldPage", () => {
       expect(carousel).toBeInTheDocument()
     })
   })
+  it("Does not display a featured carousel if the channel type is not 'unit'", async () => {
+    const { field } = setupApis({
+      search_filter: "topic=physics",
+      channel_type: "topic",
+    })
+
+    renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
+    await screen.findAllByText(field.title)
+    const carousels = screen.queryByText("Featured Courses")
+    act(() => {
+      expect(carousels).toBe(null)
+    })
+  })
   it("Displays the field search if search_filter is not undefined", async () => {
     const { field } = setupApis({ search_filter: "platform=ocw" })
     renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -8,6 +8,7 @@ import {
   setMockResponse,
   within,
   user,
+  act,
   waitFor,
 } from "../../test-utils"
 import FieldSearch from "./FieldSearch"
@@ -114,7 +115,19 @@ describe("FieldPage", () => {
     expect(images[0].src).toContain(field.configuration.banner_background)
     expect(images[1].src).toContain(field.configuration.logo)
   })
+  it("Displays a featured carousel if the channel type is 'offeror'", async () => {
+    const { field } = setupApis({
+      search_filter: "offeror=ocw",
+      channel_type: "offeror",
+    })
 
+    renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
+    await screen.findAllByText(field.title)
+    const carousel = await screen.findByText("Featured Courses")
+    act(() => {
+      expect(carousel).toBeInTheDocument()
+    })
+  })
   it("Displays the field search if search_filter is not undefined", async () => {
     const { field } = setupApis({ search_filter: "platform=ocw" })
     renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -71,14 +71,11 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
   const field = useChannelDetail(String(channelType), String(name))
   const urlParams = new URLSearchParams(field.data?.search_filter)
   const displayConfiguration = field.data?.configuration
-  const memoizedUrlParams = useMemo(() => {
-    const urlParams = new URLSearchParams(field.data?.search_filter)
-    return urlParams
-  }, [field.data?.search_filter])
 
   const urlParamMap: Record<string, string[] | string> = useMemo(() => {
-    return getSearchParamMap(memoizedUrlParams)
-  }, [memoizedUrlParams])
+    const urlParams = new URLSearchParams(field.data?.search_filter)
+    return getSearchParamMap(urlParams)
+  }, [field])
 
   const FEATURED_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
     {

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -82,7 +82,7 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
 
   const FEATURED_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
     {
-      cardProps: { size: "small" },
+      cardProps: { size: "medium" },
       data: {
         type: "lr_featured",
         params: { limit: 12, ...urlParamMap },

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -264,12 +264,14 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
         </Container>
       }
     >
-      <Container>
-        <FeaturedCoursesCarousel
-          title="Featured Courses"
-          config={FEATURED_RESOURCES_CAROUSEL}
-        />
-      </Container>
+      {channelType === "unit" ? (
+        <Container>
+          <FeaturedCoursesCarousel
+            title="Featured Courses"
+            config={FEATURED_RESOURCES_CAROUSEL}
+          />
+        </Container>
+      ) : null}
       {children}
     </BannerPage>
   )

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { Link } from "react-router-dom"
 import * as routes from "../../common/urls"
 import { BannerPage, styled, Container, Typography, Box } from "ol-components"
@@ -7,8 +7,11 @@ import { ChannelDetails } from "@/page-components/ChannelDetails/ChannelDetails"
 import { useChannelDetail } from "api/hooks/fields"
 import FieldMenu from "@/components/FieldMenu/FieldMenu"
 import FieldAvatar from "@/components/FieldAvatar/FieldAvatar"
-
+import ResourceCarousel, {
+  ResourceCarouselProps,
+} from "@/page-components/ResourceCarousel/ResourceCarousel"
 import { SourceTypeEnum } from "api"
+import { getSearchParamMap } from "@/common/utils"
 
 export const FieldTitleRow = styled.div`
   display: flex;
@@ -22,6 +25,13 @@ export const FieldTitleRow = styled.div`
   }
 `
 
+const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
+  margin: "80px 0",
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "0px",
+    marginBottom: "32px",
+  },
+}))
 export const FieldControls = styled.div`
   position: relative;
   min-height: 38px;
@@ -61,6 +71,25 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
   const field = useChannelDetail(String(channelType), String(name))
   const urlParams = new URLSearchParams(field.data?.search_filter)
   const displayConfiguration = field.data?.configuration
+  const memoizedUrlParams = useMemo(() => {
+    const urlParams = new URLSearchParams(field.data?.search_filter)
+    return urlParams
+  }, [field.data?.search_filter])
+
+  const urlParamMap: Record<string, string[] | string> = useMemo(() => {
+    return getSearchParamMap(memoizedUrlParams)
+  }, [memoizedUrlParams])
+
+  const FEATURED_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
+    {
+      cardProps: { size: "small" },
+      data: {
+        type: "lr_featured",
+        params: { limit: 12, ...urlParamMap },
+      },
+      label: undefined,
+    },
+  ]
 
   return (
     <BannerPage
@@ -238,6 +267,12 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
         </Container>
       }
     >
+      <Container>
+        <FeaturedCoursesCarousel
+          title="Featured Courses"
+          config={FEATURED_RESOURCES_CAROUSEL}
+        />
+      </Container>
       {children}
     </BannerPage>
   )

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -26,6 +26,14 @@ const setMockApiResponses = ({
       factories.percolateQueries,
     )
   }
+  setMockResponse.get(
+    urls.learningResources.featured({ limit: 12, offered_by: ["ocw"] }),
+    factories.learningResources.resources({ count: 0 }),
+  )
+  setMockResponse.get(
+    urls.learningResources.featured({ limit: 12 }),
+    factories.learningResources.resources({ count: 0 }),
+  )
 
   setMockResponse.get(
     urls.userSubscription.check({ source_type: "channel_subscription_type" }),


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/4501


### Description (What does it do?)
This PR adds a featured carousel to offerer pages:


### Screenshots (if appropriate):
<img width="730" alt="Screenshot 2024-06-11 at 9 55 52 AM" src="https://github.com/mitodl/mit-open/assets/196425/262af22b-9a90-4501-b4b6-d5a6e3caa42b">

### How can this be tested?
1. Checkout this branch
2. navigate to an offeror page (/c/offeror/mitpe, /c/offeror/mitx, /c/offeror/see etc)
3. There should be a carousel below the banner that displays courses relevant to the offeror/unit


### Additional Context
 other channel pages (/c/topics/physics etc) should not display a carousel. There is an empty space but that is to be cleaned up in a separate ticket.
