### PR TITLE
local dev: Read `MITOPEN_AXIOS_BASE_PATH` from env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: 8062
-      MITOPEN_AXIOS_BASE_PATH: http://od.odl.local:8063
+      MITOPEN_AXIOS_BASE_PATH: ${MITOPEN_BASE_URL}
     env_file: .env
     ports:
       - "8062:8062"

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -8,9 +8,9 @@
     "url": "https://github.com/mitodl/mit-open.git"
   },
   "scripts": {
-    "watch": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8062 API_BASE_URL=http://od.odl.local:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:docker": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8063 API_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:rc": "MITOPEN_AXIOS_BASE_PATH=http://od.odl.local:8062 API_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch": "NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:docker": "API_DEV_PROXY_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:rc": "API_DEV_PROXY_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",
@@ -38,6 +38,7 @@
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.10.0",
     "dotenv": "^16.4.5",
+    "envalid": "^8.0.0",
     "html-webpack-plugin": "^5.6.0",
     "mini-css-extract-plugin": "^2.6.1",
     "ol-test-utilities": "0.0.0",

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -50,16 +50,6 @@ const {
   }),
 })
 
-console.log("env vars:")
-console.log({
-  NODE_ENV,
-  ENVIRONMENT,
-  PORT,
-  MITOPEN_AXIOS_BASE_PATH,
-  API_DEV_PROXY_BASE_URL,
-  WEBPACK_ANALYZE,
-})
-
 const MITOPEN_FEATURES_PREFIX = "FEATURE_"
 
 const getFeatureFlags = () => {
@@ -103,7 +93,7 @@ module.exports = (env, argv) => {
   const config = {
     mode,
     context: __dirname,
-    devtool: "source-map",
+    devtool: isProduction ? "source-map" : "eval-source-map",
     entry: {
       root: "./src/App",
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11532,6 +11532,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"envalid@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "envalid@npm:8.0.0"
+  dependencies:
+    tslib: "npm:2.6.2"
+  checksum: 10/cf2159a070c7335ecc9cd01523654fb7c8fdc63b92bef47d18027c406dfcf2b4a72663e70ddd91fa91967fa71c7716fe643dcd4a652f9ab0f93722feddb9e1b2
+  languageName: node
+  linkType: hard
+
 "envinfo@npm:^7.7.3":
   version: 7.13.0
   resolution: "envinfo@npm:7.13.0"
@@ -18370,6 +18379,7 @@ __metadata:
     css-loader: "npm:^6.10.0"
     dotenv: "npm:^16.4.5"
     enforce-unique: "npm:^1.3.0"
+    envalid: "npm:^8.0.0"
     formik: "npm:^2.4.5"
     html-webpack-plugin: "npm:^5.6.0"
     lodash: "npm:^4.17.21"
@@ -24773,17 +24783,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:2.6.2, tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1, tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^1.13.0, tslib@npm:^1.8.1":
   version: 1.14.1
   resolution: "tslib@npm:1.14.1"
   checksum: 10/7dbf34e6f55c6492637adb81b555af5e3b4f9cc6b998fb440dac82d3b42bdc91560a35a5fb75e20e24a076c651438234da6743d139e4feabf0783f3cdfe1dddb
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.4.0, tslib@npm:^2.6.1, tslib@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "tslib@npm:2.6.2"
-  checksum: 10/bd26c22d36736513980091a1e356378e8b662ded04204453d353a7f34a4c21ed0afc59b5f90719d4ba756e581a162ecbf93118dc9c6be5acf70aa309188166ca
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Followup to https://github.com/mitodl/mit-open/pull/829

### Description (What does it do?) 
https://github.com/mitodl/mit-open/pull/829 hardcoded the value of MITOPEN_AXIOS_BASE_PATH. It seems better to read this from an environment variable. For example, many people use `locahlhost:8063` not `od.odl.localhost:8063`.

This PR reads MITOPEN_AXIOS_BASE_PATH from the environment, and introduces [`envalid`](https://www.npmjs.com/package/envalid) for validating some JS-required environment variables.

Additionally, I changed the source maps we use for local dev. Several people have noticed bad stack traces, and I am hoping this helps. 

### How can this be tested?
1. With `COMPOSE_PROFILES=backend,frontend` in your `.env` file, run `docker compose up`. The frontend should work fine with `MITOPEN_BASE_URL=http://localhost:8063` or `MITOPEN_BASE_URL=http://od.odllocalhost:8063` (if your etc/hosts) is set up that way.
2. If you have node on your host:
     1. `COMPOSE_PROFILES=backend`
     2. on host, `yarn install` and `yarn watch`
     3. The frontend should be available at http://localhost:8062
