### PR TITLE
Adds ScrollRestoration to the spot in the routes

### DIFF
--- a/frontends/mit-open/src/routes.tsx
+++ b/frontends/mit-open/src/routes.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { RouteObject, Outlet } from "react-router"
+import { ScrollRestoration } from "react-router-dom"
 import HomePage from "@/pages/HomePage/HomePage"
 import RestrictedRoute from "@/components/RestrictedRoute/RestrictedRoute"
 import LearningPathListingPage from "@/pages/LearningPathListingPage/LearningPathListingPage"
@@ -47,6 +48,11 @@ const routes: RouteObject[] = [
         <PageWrapper>
           <Header />
           <PageWrapperInner>
+            <ScrollRestoration
+              getKey={(location) => {
+                return location.pathname
+              }}
+            />
             <Outlet />
           </PageWrapperInner>
           <Footer />

--- a/frontends/mit-open/src/test-utils/setupJest.ts
+++ b/frontends/mit-open/src/test-utils/setupJest.ts
@@ -25,3 +25,5 @@ jest.mock("@/page-components/LearningResourceCard/LearningResourceCard", () => {
     default: jest.fn(actual.default),
   }
 })
+
+window.scrollTo = jest.fn()


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4379

### Description (What does it do?)

Adds the `ScrollRestoration` component to the routes as per the docs/the original issue so that the browser scrolls to the top when (and only when) the user navigates to a page that results in the URL path changing (so, not when the query string changes).

This also adds a mock to the Jest setup for mit-open for `window.scrollTo` as Jest doesn't include that in its DOM.

### How can this be tested?

Navigate to the homepage, then scroll down to the Browse by Topics section. Click See All. You should see the Topics page, but you should also be at the top of the page. Switching off this branch and repeating the test should put you on the Topics page but down the page some as you'd already scrolled.

From a Channel page (you can just click one of the Topics or do a search, etc.), scroll down so that the header is not visible in your browser window but you can still see the Filters section. Activate a filter. The filter should take effect and the URL should change to include the filter in its query string but the browser should not scroll. 

Scrolling down on these and returning to the homepage using the Home link in the footer should bring you to the top of the homepage.
