### PR TITLE
Fixing image width and position on the homepage carousel; prefer cover image over avatar if it exists

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
@@ -56,7 +56,9 @@ const TestimonialCardImage = styled.div({
   height: "326px",
   img: {
     height: "326px",
+    width: "300px",
     objectFit: "cover",
+    objectPosition: "center",
     borderTopLeftRadius: "8px",
     borderBottomLeftRadius: "8px",
     [theme.breakpoints.down("md")]: {
@@ -208,7 +210,7 @@ const SlickCarousel = () => {
               className="testimonial-card"
             >
               <TestimonialCardImage>
-                <img src={resource.avatar} />
+                <img src={resource.cover ? resource.cover : resource.avatar} />
               </TestimonialCardImage>
               <TestimonialCardQuote>
                 <div className="testimonial-quote-opener">&ldquo;</div>


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4522

### Description (What does it do?)

Fixes a handful of minor but pretty visible issues on the homepage testimonial carousel:
- The image container didn't have a width set - it needed to be 300px per Figma, so if you added an image that was >300px it'd mess everything up.
- If the image was being resized to fit, the image wasn't centered in the container.
- If the testimonial had a cover image, we should display that, not the avatar.

### Screenshots (if appropriate):

This one is slightly too wide on RC:
![Screenshot 2024-06-12 at 2 17 52 PM](https://github.com/mitodl/mit-open/assets/945611/7a76aeeb-380e-4a73-937e-5d1b31ced331)

This one is tiny and gets expanded to fit the height, and ends up _really_ too wide on RC:
![Screenshot 2024-06-12 at 2 17 46 PM](https://github.com/mitodl/mit-open/assets/945611/8bb6f72e-b374-4d91-98de-15bfe11831ee)

This one should have been this cover image:
![Screenshot 2024-06-12 at 2 17 41 PM](https://github.com/mitodl/mit-open/assets/945611/d91cfd96-40de-4513-8977-1526078fc6c0)

These are all copied from RC, so you should see similar cards there, all broken in some way. 

Note that the cover image one (the last) is still a bit weird looking but that is because the cover image wasn't created for Open, AFAIK. Ideally someone will upload an image that's meant to be in that spot.

### How can this be tested?

Set up a set of testimonials in your local instance. You can pull the images from RC - Django Admin should have links; just find the attestations that have names that match what's in the screenshots above.

In the branch, the images should all appear to be the same size (300px). In cases where the image is being resized to fit (the one for Kabwe and the one for Latham do this), the image should be centered in the box.
