### PR TITLE
Change LOGIN_REDIRECT_URL and LOGOUT_REDIRECT_URL to use the base URL

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -174,11 +174,11 @@ if DEBUG:
 
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
-LOGIN_REDIRECT_URL = get_string("MITOPEN_LOGIN_REDIRECT_URL", "/")
+LOGIN_REDIRECT_URL = SITE_BASE_URL
 LOGIN_URL = "/login"
 LOGIN_ERROR_URL = "/login"
 LOGOUT_URL = "/logout"
-LOGOUT_REDIRECT_URL = get_string("MITOPEN_LOGOUT_REDIRECT_URL", "/")
+LOGOUT_REDIRECT_URL = SITE_BASE_URL
 
 MITOPEN_TOS_URL = get_string(
     "MITOPEN_TOS_URL", urljoin(SITE_BASE_URL, "/terms-and-conditions/")


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4509

### Description (What does it do?)

Changes the `LOGIN_REDIRECT_URL` and `LOGOUT_REDIRECT_URL` settings to just use the base URL setting. This should have the effect of always redirecting to the homepage.

### How can this be tested?

Test login and logout; you should be bounced back to the base URL location.
