### PR TITLE
Update names in offerors.json

### DIFF
--- a/learning_resources/data/channel_templates/offerors.json
+++ b/learning_resources/data/channel_templates/offerors.json
@@ -7,7 +7,7 @@
     "banner_background": "/static/images/unit_banners/mitx.jpg"
   },
   "ocw": {
-    "name": "OCW",
+    "name": "OpenCourseWare",
     "logo": "/static/images/unit_logos/ocw.svg",
     "banner_background": "/static/images/unit_banners/ocw.jpg",
     "heading": "Free open online resources from over 2,500 MIT courses for self-paced learning and classroom teaching.",
@@ -28,14 +28,14 @@
     "sub_heading": "For technical professionals looking to enhance their skills, MIT xPRO offers courses tailored to address the challenges of  dynamic working environments. Developed by renowned experts and utilizing cutting-edge research in learning neuroscience, MIT xPRO programs prioritize real-world application. Professionals can build and apply skills directly on the job, fostering technical expertise and leadership acumen."
   },
   "mitpe": {
-    "name": "Professional Education",
+    "name": "MIT Professional Education",
     "logo": "/static/images/unit_logos/mitpe.svg",
     "banner_background": "/static/images/unit_banners/mitpe.jpg",
     "heading": "Immersing innovators and entrepreneurs, in selective, transformational learning-by-doing experiences",
     "sub_heading": "Whether online, on campus, or at your company site, MIT Professional Education offers several programs to fit your career goals and organization needs. With over 50 courses across more than 12 topic categories, and some now offered in Spanish, our programs are geared towards engineering and technology professionals across the globe."
   },
   "see": {
-    "name": "Sloan Executive Education",
+    "name": "MIT Sloan Executive Education",
     "logo": "/static/images/unit_logos/see.svg",
     "banner_background": "/static/images/unit_banners/see.jpg",
     "heading": "Providing business professionals with critical skills, tools, and frameworks to master their toughest challenges and drive organizational success.",


### PR DESCRIPTION
Names should match titles in Sub-Brand Content Authoring google doc.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Addresses a question in https://github.com/mitodl/mit-open/pull/1063#issuecomment-2166067759 

### Description (What does it do?)
<!--- Describe your changes in detail -->

Standardizes unit/offerors titles to match what is in https://docs.google.com/document/d/1-Kyull4biR4XhSsPK6ZLHhqEOLyUEdnQjP6Xlvqe2zI/edit#heading=h.1z6344o0szco


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

After this is changed, I expect the breadcrumbs on the OCW unit page will say "OpenCourseWare" instead of "OCW" 

