### PR TITLE
fix dashboard home certificate course carousel

### DIFF
--- a/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
@@ -85,10 +85,17 @@ describe("DashboardPage", () => {
     certificationCourses.results.map((course) => {
       course.certification = certification || false
     })
+    const freeCourses = factories.learningResources.courses({
+      count: 10,
+    })
+    freeCourses.results.map((course) => {
+      course.free = true
+    })
     const courses = [
       ...topPicks.results,
       ...topicsCourses,
       ...certificationCourses.results,
+      ...freeCourses.results,
     ]
     const resources = factories.learningResources.resources({ count: 20 })
 
@@ -138,6 +145,12 @@ describe("DashboardPage", () => {
     )
     setMockResponse.get(
       expect.stringContaining(
+        urls.search.resources({ free: true, limit: 12, sortby: "new" }),
+      ),
+      makeSearchResponse(freeCourses.results),
+    )
+    setMockResponse.get(
+      expect.stringContaining(
         urls.search.resources({ limit: 12, sortby: "new" }),
       ),
       makeSearchResponse([...courses, ...resources.results]),
@@ -163,6 +176,7 @@ describe("DashboardPage", () => {
       topPicks,
       topicsCourses,
       certificationCourses,
+      freeCourses,
       courses,
       resources,
     }
@@ -239,6 +253,7 @@ describe("DashboardPage", () => {
       topPicks,
       topicsCourses,
       certificationCourses,
+      freeCourses,
       courses,
       resources,
     } = setupAPIs()
@@ -269,18 +284,30 @@ describe("DashboardPage", () => {
         })
     })
 
-    const certificationText = `Courses ${profile.preference_search_filters.certification ? "with" : "without"} Certificates`
-    const certificationTitle = await screen.findByText(certificationText)
-    expect(certificationTitle).toBeInTheDocument()
-    const certificationCarousel = await screen.findByTestId(
-      "certification-carousel",
-    )
-    certificationCourses.results.forEach(async (course) => {
-      const courseTitle = await within(certificationCarousel).findByText(
-        course.title,
+    const certificationDesired = profile.preference_search_filters.certification
+    if (certificationDesired) {
+      const certificationText = "Courses with Certificates"
+      const certificationTitle = await screen.findByText(certificationText)
+      expect(certificationTitle).toBeInTheDocument()
+      const certificationCarousel = await screen.findByTestId(
+        "certification-carousel",
       )
-      expect(courseTitle).toBeInTheDocument()
-    })
+      certificationCourses.results.forEach(async (course) => {
+        const courseTitle = await within(certificationCarousel).findByText(
+          course.title,
+        )
+        expect(courseTitle).toBeInTheDocument()
+      })
+    } else {
+      const freeText = "Free courses"
+      const freeTitle = await screen.findByText(freeText)
+      expect(freeTitle).toBeInTheDocument()
+      const freeCarousel = await screen.findByTestId("free-carousel")
+      freeCourses.results.forEach(async (course) => {
+        const courseTitle = await within(freeCarousel).findByText(course.title)
+        expect(courseTitle).toBeInTheDocument()
+      })
+    }
 
     const newTitle = await screen.findByText("New")
     expect(newTitle).toBeInTheDocument()

--- a/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
@@ -145,7 +145,12 @@ describe("DashboardPage", () => {
     )
     setMockResponse.get(
       expect.stringContaining(
-        urls.search.resources({ free: true, limit: 12, sortby: "new" }),
+        urls.search.resources({
+          free: true,
+          limit: 12,
+          resource_type: ["course"],
+          sortby: "-views",
+        }),
       ),
       makeSearchResponse(freeCourses.results),
     )

--- a/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
@@ -36,9 +36,10 @@ import { useProfileMeQuery } from "api/hooks/profile"
 import {
   TopPicksCarouselConfig,
   TopicCarouselConfig,
-  CertificationCarouselConfig,
   NEW_LEARNING_RESOURCES_CAROUSEL,
   POPULAR_LEARNING_RESOURCES_CAROUSEL,
+  CERTIFICATE_COURSES_CAROUSEL,
+  FREE_COURSES_CAROUSEL,
 } from "./carousels"
 import ResourceCarousel from "@/page-components/ResourceCarousel/ResourceCarousel"
 
@@ -467,13 +468,23 @@ const DashboardPage: React.FC = () => {
                       />
                     </CarouselContainer>
                   ))}
-                  <CarouselContainer data-testid="certification-carousel">
-                    <ResourceCarousel
-                      title={`Courses ${certification ? "with" : "without"} Certificates`}
-                      isLoading={isLoadingProfile}
-                      config={CertificationCarouselConfig(certification)}
-                    />
-                  </CarouselContainer>
+                  {certification === true ? (
+                    <CarouselContainer data-testid="certification-carousel">
+                      <ResourceCarousel
+                        title={"Courses with Certificates"}
+                        isLoading={isLoadingProfile}
+                        config={CERTIFICATE_COURSES_CAROUSEL}
+                      />
+                    </CarouselContainer>
+                  ) : (
+                    <CarouselContainer data-testid="free-carousel">
+                      <ResourceCarousel
+                        title={"Free courses"}
+                        isLoading={isLoadingProfile}
+                        config={FREE_COURSES_CAROUSEL}
+                      />
+                    </CarouselContainer>
+                  )}
                   <CarouselContainer data-testid="new-learning-resources-carousel">
                     <ResourceCarousel
                       title="New"

--- a/frontends/mit-open/src/pages/DashboardPage/carousels.ts
+++ b/frontends/mit-open/src/pages/DashboardPage/carousels.ts
@@ -60,29 +60,37 @@ const TopicCarouselConfig: TopicCarouselConfigProps = (
   ]
 }
 
-type CertificationCarouselConfigProps = (
-  certification: boolean | undefined,
-) => ResourceCarouselProps["config"]
-
-const CertificationCarouselConfig: CertificationCarouselConfigProps = (
-  certification: boolean | undefined,
-) => {
-  return [
-    {
-      label: "All",
-      cardProps: { size: "small" },
-      data: {
-        type: "lr_search",
-        params: {
-          resource_type: ["course"],
-          limit: 12,
-          certification: certification,
-          sortby: "-views",
-        },
+const CERTIFICATE_COURSES_CAROUSEL: ResourceCarouselProps["config"] = [
+  {
+    label: "All",
+    cardProps: { size: "small" },
+    data: {
+      type: "lr_search",
+      params: {
+        resource_type: ["course"],
+        limit: 12,
+        certification: true,
+        sortby: "-views",
       },
     },
-  ]
-}
+  },
+]
+
+const FREE_COURSES_CAROUSEL: ResourceCarouselProps["config"] = [
+  {
+    label: "All",
+    cardProps: { size: "small" },
+    data: {
+      type: "lr_search",
+      params: {
+        resource_type: ["course"],
+        limit: 12,
+        free: true,
+        sortby: "-views",
+      },
+    },
+  },
+]
 
 const NEW_LEARNING_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
   {
@@ -109,7 +117,8 @@ const POPULAR_LEARNING_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
 export {
   TopPicksCarouselConfig,
   TopicCarouselConfig,
-  CertificationCarouselConfig,
+  CERTIFICATE_COURSES_CAROUSEL,
+  FREE_COURSES_CAROUSEL,
   NEW_LEARNING_RESOURCES_CAROUSEL,
   POPULAR_LEARNING_RESOURCES_CAROUSEL,
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4584

### Description (What does it do?)
This PR changes the behavior of the dashboard home so that if anything other than "yes" is selected during onboarding to the question "Are you seeking to receive a certificate?" then a carousel of free courses will be displayed instead.

### Screenshots (if appropriate):
![image](https://github.com/mitodl/mit-open/assets/12089658/ff6040d5-5cd1-438f-af21-9cb4e542d9a5)
![image](https://github.com/mitodl/mit-open/assets/12089658/0255d997-54c7-4e6d-8da1-ed09b45f9fd0)
![image](https://github.com/mitodl/mit-open/assets/12089658/d3c373c9-2cd2-4b6b-9f53-926e2516acdd)
![image](https://github.com/mitodl/mit-open/assets/12089658/cf9cc77b-639f-452b-bff0-537c81b7e965)

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Visit http://localhost:8063/onboarding and answer "yes" to "Are you seeking to receive a certificate?" and then complete the rest of the onboarding questions
 - Visit http://localhost:8063/dashboard and verify that you see a "Courses with Certificates" carousel containing courses that offer a certificate
 -  Visit http://localhost:8063/onboarding and answer "no" to "Are you seeking to receive a certificate?" and then complete the rest of the onboarding questions
 - Visit http://localhost:8063/dashboard and verify that you see a "Free courses" carousel containing courses that are free
 -  Visit http://localhost:8063/onboarding and answer "Not Sure Yet" to "Are you seeking to receive a certificate?" and then complete the rest of the onboarding questions
 - Visit http://localhost:8063/dashboard and verify that you see a "Free courses" carousel containing courses that are free
