### PR TITLE
units page fixes

### DIFF
--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -91,6 +91,10 @@ const PageHeaderText = styled(Typography)(({ theme }) => ({
   ...theme.typography.subtitle1,
 }))
 
+const CardStyled = styled(Card)({
+  height: "100%",
+})
+
 const UnitContainer = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
@@ -308,7 +312,7 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
   return channelDetailQuery.isLoading ? (
     <UnitCardLoading />
   ) : (
-    <Card href={unitUrl}>
+    <CardStyled href={unitUrl}>
       <Card.Content>
         <UnitCardContainer>
           <UnitCardContent>
@@ -329,7 +333,7 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
           </UnitCardContent>
         </UnitCardContainer>
       </Card.Content>
-    </Card>
+    </CardStyled>
   )
 }
 

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -308,7 +308,7 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
   return channelDetailQuery.isLoading ? (
     <UnitCardLoading />
   ) : (
-    <Card link={true} href={unitUrl}>
+    <Card href={unitUrl}>
       <Card.Content>
         <UnitCardContainer>
           <UnitCardContent>

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -4,10 +4,8 @@ import {
 } from "api/hooks/learningResources"
 import {
   Banner,
-  MuiCard,
-  CardContent,
+  Card,
   Container,
-  Link,
   Skeleton,
   Typography,
   styled,
@@ -149,23 +147,15 @@ const GridContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const UnitCardContainer = styled(MuiCard)({
+const UnitCardContainer = styled.div({
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
+  padding: "16px",
+  height: "100%",
 })
 
-const UnitCardLink = styled(Link)({
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
-  flexGrow: 1,
-  "&:hover": {
-    textDecoration: "none",
-  },
-})
-
-const UnitCardContent = styled(CardContent)({
+const UnitCardContent = styled.div({
   display: "flex",
   flexDirection: "column",
   flexGrow: 1,
@@ -318,41 +308,47 @@ const UnitCard: React.FC<UnitCardProps> = (props) => {
   return channelDetailQuery.isLoading ? (
     <UnitCardLoading />
   ) : (
-    <UnitCardContainer>
-      <UnitCardLink href={unitUrl}>
-        <UnitCardContent>
-          <LogoContainer>
-            <UnitLogo src={logo} alt={unit.name} />
-          </LogoContainer>
-          <ValuePropContainer>
-            <ValuePropText>{unit.value_prop}</ValuePropText>
-          </ValuePropContainer>
-          <CountsTextContainer>
-            <CountsText data-testid={`course-count-${unit.code}`}>
-              {courseCount > 0 ? `Courses: ${courseCount}` : ""}
-            </CountsText>
-            <CountsText data-testid={`program-count-${unit.code}`}>
-              {programCount > 0 ? `Programs: ${programCount}` : ""}
-            </CountsText>
-          </CountsTextContainer>
-        </UnitCardContent>
-      </UnitCardLink>
-    </UnitCardContainer>
+    <Card link={true} href={unitUrl}>
+      <Card.Content>
+        <UnitCardContainer>
+          <UnitCardContent>
+            <LogoContainer>
+              <UnitLogo src={logo} alt={unit.name} />
+            </LogoContainer>
+            <ValuePropContainer>
+              <ValuePropText>{unit.value_prop}</ValuePropText>
+            </ValuePropContainer>
+            <CountsTextContainer>
+              <CountsText data-testid={`course-count-${unit.code}`}>
+                {courseCount > 0 ? `Courses: ${courseCount}` : ""}
+              </CountsText>
+              <CountsText data-testid={`program-count-${unit.code}`}>
+                {programCount > 0 ? `Programs: ${programCount}` : ""}
+              </CountsText>
+            </CountsTextContainer>
+          </UnitCardContent>
+        </UnitCardContainer>
+      </Card.Content>
+    </Card>
   )
 }
 
 const UnitCardLoading = () => {
   return (
-    <UnitCardContainer>
-      <UnitCardContent>
-        <LogoContainer>
-          <Skeleton variant="rectangular" width={500} height={50} />
-        </LogoContainer>
-        <ValuePropContainer>
-          <Skeleton variant="text" width={500} height={200} />
-        </ValuePropContainer>
-      </UnitCardContent>
-    </UnitCardContainer>
+    <Card>
+      <Card.Content>
+        <UnitCardContainer>
+          <UnitCardContent>
+            <LogoContainer>
+              <Skeleton variant="rectangular" width={500} height={50} />
+            </LogoContainer>
+            <ValuePropContainer>
+              <Skeleton variant="text" width={500} height={200} />
+            </ValuePropContainer>
+          </UnitCardContent>
+        </UnitCardContainer>
+      </Card.Content>
+    </Card>
   )
 }
 

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -55,7 +55,7 @@ const sortUnits = (
 }
 
 const Page = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.white,
+  backgroundColor: theme.custom.colors.lightGray1,
 }))
 
 const PageContent = styled.div(({ theme }) => ({


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4561

### Description (What does it do?)
This PR fixes some design issues with the units page noted in the above issue:

 - Background color corrected from `white` to `lightGray1`
 - Use our `Card` component so the cards have the hover styles / link behavior that other cards have

### Screenshots (if appropriate):
![image](https://github.com/mitodl/mit-open/assets/12089658/7bed22ee-78a3-45d7-89a4-d71efefdb19b)
![image](https://github.com/mitodl/mit-open/assets/12089658/580e48be-60d8-4b4e-8ccb-25d6666b275f)


### How can this be tested?
 - Spin up `mit-open` on this branch
 - Visit http://localhost:8063/units/ and verify that all the changes described in the issue are sufficiently addressed

### Additional Context
The fixes to breadcrumbs were addressed in https://github.com/mitodl/mit-open/pull/1089