### PR TITLE
Update OCW unit name in offerors.json

### DIFF
--- a/learning_resources/data/channel_templates/offerors.json
+++ b/learning_resources/data/channel_templates/offerors.json
@@ -7,7 +7,7 @@
     "banner_background": "/static/images/unit_banners/mitx.jpg"
   },
   "ocw": {
-    "name": "OpenCourseWare",
+    "name": "MIT OpenCourseWare",
     "logo": "/static/images/unit_logos/ocw.svg",
     "banner_background": "/static/images/unit_banners/ocw.jpg",
     "heading": "Free open online resources from over 2,500 MIT courses for self-paced learning and classroom teaching.",


### PR DESCRIPTION
The unit name is "MIT OpenCourseWare"

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

none

### Description (What does it do?)
<!--- Describe your changes in detail -->

"OpenCourseWare" => "MIT OpenCourseWare" 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

After this is changed, I expect the breadcrumbs on the OCW unit page will say "MIT OpenCourseWare" instead of "OCW"