### PR TITLE
Sort run prices on save; make learning resource prices equal "next run" prices

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -603,11 +603,11 @@ export interface CourseResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof CourseResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -1233,11 +1233,11 @@ export interface LearningPathResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof LearningPathResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -3710,11 +3710,11 @@ export interface PodcastEpisodeResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof PodcastEpisodeResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -3995,11 +3995,11 @@ export interface PodcastResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof PodcastResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -4518,11 +4518,11 @@ export interface ProgramResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof ProgramResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -5210,11 +5210,11 @@ export interface VideoPlaylistResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof VideoPlaylistResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}
@@ -5489,11 +5489,11 @@ export interface VideoResource {
    */
   certification_type: CourseResourceCertificationType
   /**
-   * Returns the prices for the learning resource
-   * @type {Array<number>}
+   *
+   * @type {Array<string>}
    * @memberof VideoResource
    */
-  prices: Array<number>
+  prices: Array<string>
   /**
    *
    * @type {Array<LearningResourceRun>}

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -233,7 +233,7 @@ const _learningResourceShared = (): Partial<
     image: learningResourceImage(),
     offered_by: maybe(learningResourceOfferor) ?? null,
     platform: maybe(learningResourcePlatform) ?? null,
-    prices: [0.0],
+    prices: ["0.00"],
     readable_id: faker.lorem.slug(),
     course_feature: repeat(faker.lorem.word),
     runs: [],

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -99,7 +99,7 @@ const getPrice = (resource: LearningResource) => {
     return null
   }
   const price = resource.prices?.[0]
-  if (resource.platform?.code === PlatformEnum.Ocw || price === 0) {
+  if (resource.free) {
     return "Free"
   }
   return price ? `$${price}` : null

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -221,7 +221,7 @@ def load_run(
     instructors_data = run_data.pop("instructors", [])
 
     # Make sure any prices are unique and sorted in ascending order
-    run_data["prices"] = sorted(set(run_data.get("prices", [])))
+    run_data["prices"] = sorted(set(run_data.get("prices", [])), key=lambda x: float(x))
 
     with transaction.atomic():
         (

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -490,10 +490,12 @@ class LearningResourceRunFactory(DjangoModelFactory):
     end_date = factory.LazyAttribute(
         lambda obj: obj.start_date + timedelta(days=90) if obj.start_date else None
     )
-    prices = [
-        decimal.Decimal(random.uniform(100, 200))  # noqa: S311
-        for _ in range(random.randint(1, 3))  # noqa: S311
-    ]
+    prices = sorted(
+        [
+            decimal.Decimal(random.uniform(100, 200))  # noqa: S311
+            for _ in range(random.randint(1, 3))  # noqa: S311
+        ]
+    )
 
     @factory.post_generation
     def instructors(self, create, extracted, **kwargs):  # noqa: ARG002

--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -476,7 +476,7 @@ class LearningResourceRunFactory(DjangoModelFactory):
             constants.AvailabilityType.archived.value,
         )
     )
-    enrollment_start = factory.Faker("date_time", tzinfo=UTC)
+    enrollment_start = factory.Faker("future_datetime", tzinfo=UTC)
     enrollment_end = factory.LazyAttribute(
         lambda obj: (
             (obj.enrollment_start + timedelta(days=45))

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -256,7 +256,7 @@ class LearningResource(TimestampedModel):
             LearningResourceType.program.name,
         ]:
             next_run = self.next_run
-            return next_run.prices if next_run else [Decimal(0.00)]
+            return next_run.prices if next_run else []
         else:
             return [Decimal(0.00)]
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -2,12 +2,12 @@
 
 from decimal import Decimal
 
-from django.contrib.admin.utils import flatten
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import JSONField
+from django.db.models import JSONField, Q
 from django.db.models.functions import Lower
+from django.utils import timezone
 
 from learning_resources import constants
 from learning_resources.constants import (
@@ -240,17 +240,23 @@ class LearningResource(TimestampedModel):
         return None
 
     @property
+    def next_run(self):
+        """Returns the next run for the learning resource"""
+        return (
+            self.runs.filter(Q(published=True) & Q(start_date__gt=timezone.now()))
+            .order_by("start_date")
+            .first()
+        )
+
+    @property
     def prices(self) -> list[Decimal]:
         """Returns the prices for the learning resource"""
         if self.resource_type in [
             LearningResourceType.course.name,
             LearningResourceType.program.name,
         ]:
-            return list(
-                set(
-                    flatten([(run.prices or [Decimal(0.0)]) for run in self.runs.all()])
-                )
-            )
+            next_run = self.next_run
+            return next_run.prices if next_run else [Decimal(0.00)]
         else:
             return [Decimal(0.00)]
 

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -47,3 +47,4 @@ def test_course_creation():
     assert resource.topics.count() > 0
     assert resource.offered_by is not None
     assert resource.runs.count() == course.runs.count()
+    assert resource.prices == resource.next_run.prices

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -443,7 +443,10 @@ class LearningResourceBaseSerializer(serializers.ModelSerializer, WriteableTopic
     )
     certification = serializers.ReadOnlyField(read_only=True)
     certification_type = CertificateTypeField(read_only=True)
-    prices = serializers.ReadOnlyField()
+    prices = serializers.ListField(
+        child=serializers.DecimalField(max_digits=10, decimal_places=2),
+        read_only=True,
+    )
     runs = LearningResourceRunSerializer(read_only=True, many=True, allow_null=True)
     image = serializers.SerializerMethodField()
     learning_path_parents = serializers.SerializerMethodField()

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -206,7 +206,7 @@ def test_learning_resource_serializer(  # noqa: PLR0913
         "platform": serializers.LearningResourcePlatformSerializer(
             instance=resource.platform
         ).data,
-        "prices": resource.prices,
+        "prices": sorted(resource.prices),
         "professional": resource.professional,
         "certification": resource.certification,
         "certification_type": {
@@ -214,9 +214,14 @@ def test_learning_resource_serializer(  # noqa: PLR0913
             "name": CertificationType[resource.certification_type].value,
         },
         "free": (
-            not resource.professional
-            and detail_key
+            detail_key
             not in (LearningResourceType.course.name, LearningResourceType.program.name)
+            or (
+                not resource.professional
+                and (
+                    not resource.prices or all(price == 0 for price in resource.prices)
+                )
+            )
         ),
         "published": resource.published,
         "readable_id": resource.readable_id,

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -206,7 +206,7 @@ def test_learning_resource_serializer(  # noqa: PLR0913
         "platform": serializers.LearningResourcePlatformSerializer(
             instance=resource.platform
         ).data,
-        "prices": sorted(resource.prices),
+        "prices": sorted([f"{price:.2f}" for price in resource.prices]),
         "professional": resource.professional,
         "certification": resource.certification,
         "certification_type": {

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -7223,9 +7223,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -7629,9 +7629,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -9489,9 +9489,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -9734,9 +9734,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -10124,9 +10124,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -10604,9 +10604,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array
@@ -10839,9 +10839,9 @@ components:
         prices:
           type: array
           items:
-            type: number
-            format: double
-          description: Returns the prices for the learning resource
+            type: string
+            format: decimal
+            pattern: ^-?\d{0,8}(?:\.\d{0,2})?$
           readOnly: true
         runs:
           type: array


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4585

### Description (What does it do?)
- Modifies the calculation of `LearningResource.prices` to return the prices of the resource's next run (if any).
- Adds a line to the `etl.loaders.load_run` function to sort the list of prices before saving.


### How can this be tested?
#### LearningResourceRun.prices sort
- On the main branch, if you haven't already, run `backpopulate_mit_edx_data` (you will need the `EDX_API_` settings from heroku).  Check that the following returns some unsorted run prices:
  ```python
  from learning_resources.models import LearningResourceRun
  for run in LearningResourceRun.objects.filter(published=True, prices__isnull=False):
      if run.prices != sorted(run.prices):
          print(run.id, run.learning_resource.etl_source, run.learning_resource.resource_type, run.prices)
  ```
- Switch to this branch, run `backpopulate_mit_edx_data` again.  This time, if you run the above code, no runs should be returned

#### LearningResource.prices
Go to `http://localhost:8063/api/v1/courses` and check that the resource `prices` field is the same as for the next run of that resource.

### Additional Context
This PR won't update existing runs with unsorted price, but the ETL pipelines that will do so run every day.


