### PR TITLE
excluding users from serializer

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3272,12 +3272,6 @@ export interface PercolateQuery {
    * @memberof PercolateQuery
    */
   source_type: SourceTypeEnum
-  /**
-   *
-   * @type {Array<number>}
-   * @memberof PercolateQuery
-   */
-  users: Array<number>
 }
 
 /**

--- a/frontends/api/src/test-utils/factories/percolateQueries.ts
+++ b/frontends/api/src/test-utils/factories/percolateQueries.ts
@@ -8,7 +8,6 @@ const percolateQuery: Factory<PercolateQuery> = (overrides = {}) => {
     id: uniqueEnforcerId.enforce(() => faker.number.int()),
     original_query: {},
     query: {},
-    users: [],
     source_type: SourceTypeEnum.SearchSubscriptionType,
     ...overrides,
   }

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -531,7 +531,7 @@ class SearchResponseSerializer(serializers.Serializer):
 class PercolateQuerySerializer(serializers.ModelSerializer):
     class Meta:
         model = PercolateQuery
-        exclude = COMMON_IGNORED_FIELDS
+        exclude = (*COMMON_IGNORED_FIELDS, "users")
 
 
 class LearningResourceSearchResponseSerializer(SearchResponseSerializer):

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -9128,16 +9128,11 @@ components:
         query: {}
         source_type:
           $ref: '#/components/schemas/SourceTypeEnum'
-        users:
-          type: array
-          items:
-            type: integer
       required:
       - id
       - original_query
       - query
       - source_type
-      - users
     PercolateQuerySubscriptionRequestRequest:
       type: object
       description: |-


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1088 
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
makes it so that the subscribe endpoint does not regurgitate a list of all users in the system.

endpoint: /api/v1/learning_resources_user_subscription/subscribe/

without the changes:

<img width="1247" alt="Screenshot 2024-06-14 at 1 41 50 PM" src="https://github.com/mitodl/mit-open/assets/196425/20975309-54cb-494a-9b5b-6b7778eba8f9">

with these changes:
<img width="1224" alt="Screenshot 2024-06-14 at 1 58 53 PM" src="https://github.com/mitodl/mit-open/assets/196425/4698d55a-aef1-47ee-be64-86fde538a36c">


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
1. checkout this branch
2. login and visit /api/v1/learning_resources_user_subscription/subscribe/ and note that there is no "users" section in the api form
3. subscribe/unsubscribing on channel pages should still functioning normally

