### PR TITLE
Mb/mitxonline price zero

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -158,9 +158,9 @@ def _transform_run(course_run: dict, course: dict) -> dict:
         "published": bool(parse_page_attribute(course, "page_url")),
         "description": clean_data(parse_page_attribute(course_run, "description")),
         "image": _transform_image(course_run),
-        "prices": sorted(
+        "prices": list(
             {
-                0.00,
+                "0.00",
                 *[
                     price
                     for price in [

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -158,13 +158,19 @@ def _transform_run(course_run: dict, course: dict) -> dict:
         "published": bool(parse_page_attribute(course, "page_url")),
         "description": clean_data(parse_page_attribute(course_run, "description")),
         "image": _transform_image(course_run),
-        "prices": [
-            price
-            for price in [
-                product.get("price") for product in course_run.get("products", [])
-            ]
-            if price is not None
-        ],
+        "prices": sorted(
+            {
+                0.00,
+                *[
+                    price
+                    for price in [
+                        product.get("price")
+                        for product in course_run.get("products", [])
+                    ]
+                    if price is not None
+                ],
+            }
+        ),
         "instructors": [
             {"full_name": instructor["name"]}
             for instructor in parse_page_attribute(course, "instructors", is_list=True)

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -223,14 +223,13 @@ def test_mitxonline_transform_programs(
                             "published": bool(
                                 parse_page_attribute(course_data, "page_url")
                             ),
-                            "prices": [
-                                price
-                                for price in [
-                                    product.get("price")
-                                    for product in course_run_data.get("products", [])
-                                ]
-                                if price is not None
-                            ],
+                            "prices": {
+                                0.00,
+                                *[
+                                    seat.get("price")
+                                    for seat in course_run_data.get("seats")
+                                ],
+                            },
                             "instructors": [
                                 {"full_name": instructor["name"]}
                                 for instructor in parse_page_attribute(

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -223,13 +223,21 @@ def test_mitxonline_transform_programs(
                             "published": bool(
                                 parse_page_attribute(course_data, "page_url")
                             ),
-                            "prices": {
-                                0.00,
-                                *[
-                                    seat.get("price")
-                                    for seat in course_run_data.get("seats")
-                                ],
-                            },
+                            "prices": list(
+                                {
+                                    "0.00",
+                                    *[
+                                        price
+                                        for price in [
+                                            product.get("price")
+                                            for product in course_run_data.get(
+                                                "products", []
+                                            )
+                                        ]
+                                        if price is not None
+                                    ],
+                                }
+                            ),
                             "instructors": [
                                 {"full_name": instructor["name"]}
                                 for instructor in parse_page_attribute(
@@ -351,14 +359,19 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                     "enrollment_start": any_instance_of(datetime, type(None)),
                     "enrollment_end": any_instance_of(datetime, type(None)),
                     "published": bool(course_data.get("page", {}).get("page_url")),
-                    "prices": [
-                        price
-                        for price in [
-                            product.get("price")
-                            for product in course_run_data.get("products", [])
-                        ]
-                        if price is not None
-                    ],
+                    "prices": list(
+                        {
+                            "0.00",
+                            *[
+                                price
+                                for price in [
+                                    product.get("price")
+                                    for product in course_run_data.get("products", [])
+                                ]
+                                if price is not None
+                            ],
+                        }
+                    ),
                     "instructors": [
                         {"full_name": instructor["name"]}
                         for instructor in parse_page_attribute(

--- a/learning_resources/etl/openedx.py
+++ b/learning_resources/etl/openedx.py
@@ -227,7 +227,9 @@ def _transform_course_run(config, course_run, course_last_modified, marketing_ur
         "availability": course_run.get("availability"),
         "url": marketing_url
         or "{}{}/course/".format(config.alt_url, course_run.get("key")),
-        "prices": [seat.get("price") for seat in course_run.get("seats")],
+        "prices": sorted(
+            {0.00, *[seat.get("price") for seat in course_run.get("seats")]}
+        ),
         "instructors": [
             {
                 "first_name": person.get("given_name"),

--- a/learning_resources/etl/openedx.py
+++ b/learning_resources/etl/openedx.py
@@ -227,8 +227,8 @@ def _transform_course_run(config, course_run, course_last_modified, marketing_ur
         "availability": course_run.get("availability"),
         "url": marketing_url
         or "{}{}/course/".format(config.alt_url, course_run.get("key")),
-        "prices": sorted(
-            {0.00, *[seat.get("price") for seat in course_run.get("seats")]}
+        "prices": list(
+            {"0.00", *[seat.get("price") for seat in course_run.get("seats", [])]}
         ),
         "instructors": [
             {

--- a/learning_resources/etl/openedx_test.py
+++ b/learning_resources/etl/openedx_test.py
@@ -180,7 +180,7 @@ def test_transform_course(  # noqa: PLR0913
                         "languages": ["en-us"],
                         "last_modified": any_instance_of(datetime),
                         "level": ["intermediate"],
-                        "prices": ["150.00", "0.00"],
+                        "prices": ["0.00", "150.00"],
                         "semester": "spring",
                         "description": "short_description",
                         "start_date": expected_dt,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4606

### Description (What does it do?)
Always makes sure there is a $0 in run prices from MITx Online, openedx courses.


### How can this be tested?
Run the following, with required .env settings from heroku RC:
```
./manage.py backpopulate_mitxonline_data
./manage.py backpopulate_mit_edx_data
```

Check that the imported runs have a `prices` list containing at least one 0.

