### PR TITLE
Homepage Personalize: fix safari image stretching, cap image width

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/PersonalizeSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/PersonalizeSection.tsx
@@ -29,9 +29,16 @@ const PersonalizeContainer = styled(Container)(({ theme }) => ({
 
 const ImageContainer = styled.img(({ theme }) => ({
   display: "flex",
-  flex: 1,
   alignItems: "end",
   minWidth: "0px",
+  maxWidth: "646px",
+  [theme.breakpoints.up("sm")]: {
+    /**
+     * Flex 1, combined with the maxWidth, was causing the image to be stretched
+     * on Safari. We don't need flex 1 on the mobile layout, so omit it there.
+     */
+    flex: 1,
+  },
   [theme.breakpoints.down("sm")]: {
     maxWidth: "100%",
   },


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/4613

### Description (What does it do?)
Prevents image distortion in mobile safari.

Also caps image width at 646px to match figma.

### Screenshots (if appropriate):

**Chrome**

<img width="1698" alt="chrome0" src="https://github.com/mitodl/mit-open/assets/9010790/0f3a9f80-fcb8-4acd-a260-41c1faf66a68">
<img width="630" alt="chrome1" src="https://github.com/mitodl/mit-open/assets/9010790/57844e0c-2289-49e1-a855-8c4879074692">
<img width="498" alt="chrome2" src="https://github.com/mitodl/mit-open/assets/9010790/fcd2aa04-5120-4270-9741-df3feeb6860c">


<img width="1140" alt="safari_0" src="https://github.com/mitodl/mit-open/assets/9010790/1a4ceaff-257a-488e-9dc4-dc3140ee78bf">
<img width="642" alt="safari_1" src="https://github.com/mitodl/mit-open/assets/9010790/dfbf4b14-a8cd-4be0-8826-1e2216fc0828">
<img width="415" alt="safari_2" src="https://github.com/mitodl/mit-open/assets/9010790/6270b6b3-2758-4010-ab31-b0a95a19d9bb">

### How can this be tested?
1 Check image size in desktop vs mobile widths Chrome
2. Check image size in desktop vs mobile widths Safari
