### PR TITLE
Fix populate_featured_lists mgmt command

### DIFF
--- a/learning_resources/management/commands/populate_featured_lists.py
+++ b/learning_resources/management/commands/populate_featured_lists.py
@@ -48,7 +48,7 @@ class Command(BaseCommand):
 
             # Get the channel for the offeror
             unit_channel = FieldChannel.objects.filter(
-                unit_detail__offeror=offeror
+                unit_detail__unit=offeror
             ).first()
             if not unit_channel:
                 self.stderr.write(
@@ -89,6 +89,6 @@ class Command(BaseCommand):
 
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            "Population of offeror channel featured lists finished, "
+            "Population of unit channel featured lists finished, "
             f"took {total_seconds} seconds"
         )


### PR DESCRIPTION
### What are the relevant tickets?
N/A, related to 

### Description (What does it do?)
Fixes a bug in the `populate_featured_lists` mgmt command introduced by https://github.com/mitodl/mit-open/pull/1031

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Run `./manage.py backpopulate_resource_channels --all` followed by `./manage.py populate_featured_lists`, they should both complete successfully.

