### PR TITLE
mitx - only ingest published courses

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -523,7 +523,13 @@ def load_programs(
     if programs and config.prune:
         for learning_resource in LearningResource.objects.filter(
             etl_source=etl_source, resource_type=LearningResourceType.program.name
-        ).exclude(id__in=[learning_resource.id for learning_resource in programs]):
+        ).exclude(
+            id__in=[
+                learning_resource.id
+                for learning_resource in programs
+                if learning_resource is not None
+            ]
+        ):
             learning_resource.published = False
             learning_resource.save()
             resource_unpublished_actions(learning_resource)

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -743,11 +743,14 @@ def test_load_courses(mocker, mock_blocklist, mock_duplicates, prune):
 
 def test_load_programs(mocker, mock_blocklist, mock_duplicates):
     """Test that load_programs calls the expected functions"""
-    program_data = [{"courses": [{"platform": "a"}, {}]}]
+    program_data = [{"courses": [{"platform": "a"}, {}], "id": 5}]
+
     mock_load_program = mocker.patch(
-        "learning_resources.etl.loaders.load_program", autospec=True
+        "learning_resources.etl.loaders.load_program",
+        autospec=True,
+        return_value=ProgramFactory.create().learning_resource,
     )
-    load_programs("mitx", program_data)
+    load_programs("mitx", program_data, config=ProgramLoaderConfig(prune=True))
     assert mock_load_program.call_count == len(program_data)
     mock_blocklist.assert_called_once()
     mock_duplicates.assert_called_once_with("mitx")

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -94,7 +94,7 @@ def extract_programs():
             _fetch_data(
                 settings.MITX_ONLINE_PROGRAMS_API_URL,
                 params={
-                    "courserun_is_enrollable": True,
+                    "page__live": True,
                     "live": True,
                 },
             )
@@ -112,7 +112,7 @@ def extract_courses():
             _fetch_data(
                 settings.MITX_ONLINE_COURSES_API_URL,
                 params={
-                    "courserun_is_enrollable": True,
+                    "page__live": True,
                     "live": True,
                 },
             )
@@ -262,7 +262,7 @@ def _fetch_courses_by_ids(course_ids):
                 settings.MITX_ONLINE_COURSES_API_URL,
                 params={
                     "id": ",".join([str(courseid) for courseid in course_ids]),
-                    "courserun_is_enrollable": True,
+                    "page__live": True,
                     "live": True,
                 },
             )

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -90,7 +90,15 @@ def parse_page_attribute(
 def extract_programs():
     """Loads the MITx Online catalog data"""  # noqa: D401
     if settings.MITX_ONLINE_PROGRAMS_API_URL:
-        return list(_fetch_data(settings.MITX_ONLINE_PROGRAMS_API_URL))
+        return list(
+            _fetch_data(
+                settings.MITX_ONLINE_PROGRAMS_API_URL,
+                params={
+                    "courserun_is_enrollable": True,
+                    "live": True,
+                },
+            )
+        )
     else:
         log.warning("Missing required setting MITX_ONLINE_PROGRAMS_API_URL")
 
@@ -100,7 +108,15 @@ def extract_programs():
 def extract_courses():
     """Loads the MITx Online catalog data"""  # noqa: D401
     if settings.MITX_ONLINE_COURSES_API_URL:
-        return list(_fetch_data(settings.MITX_ONLINE_COURSES_API_URL))
+        return list(
+            _fetch_data(
+                settings.MITX_ONLINE_COURSES_API_URL,
+                params={
+                    "courserun_is_enrollable": True,
+                    "live": True,
+                },
+            )
+        )
     else:
         log.warning("Missing required setting MITX_ONLINE_COURSES_API_URL")
 
@@ -244,7 +260,11 @@ def _fetch_courses_by_ids(course_ids):
         return list(
             _fetch_data(
                 settings.MITX_ONLINE_COURSES_API_URL,
-                params={"id": ",".join([str(courseid) for courseid in course_ids])},
+                params={
+                    "id": ",".join([str(courseid) for courseid in course_ids]),
+                    "courserun_is_enrollable": True,
+                    "live": True,
+                },
             )
         )
 

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -226,6 +226,8 @@ def _transform_course(course):
         },
         "published": bool(
             parse_page_attribute(course, "page_url")
+            and parse_page_attribute(course, "live")
+            and course.get("live", False)
         ),  # a course is only considered published if it has a page url
         "professional": False,
         "certification": has_certification,

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -194,6 +194,8 @@ def test_mitxonline_transform_programs(
                     ),
                     "published": bool(
                         course_data.get("page", {}).get("page_url", None)
+                        and course_data.get("page", {}).get("live", None)
+                        and course_data.get("live", None)
                     ),
                     "certification": True,
                     "certification_type": CertificationType.completion.name,
@@ -303,7 +305,11 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                 course_data.get("page", {}).get("description", None)
             ),
             "offered_by": OFFERED_BY,
-            "published": course_data.get("page", {}).get("page_url", None) is not None,
+            "published": bool(
+                course_data.get("page", {}).get("page_url", None)
+                and course_data.get("page", {}).get("live", None)
+                and course_data.get("live", None)
+            ),
             "professional": False,
             "certification": parse_certification(
                 "mitx",

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -53,7 +53,7 @@ mit_edx_etl = compose(
 mitxonline_programs_etl = compose(
     load_programs(
         ETLSource.mitxonline.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True), prune=True),
     ),
     mitxonline.transform_programs,
     mitxonline.extract_programs,

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -79,7 +79,7 @@ def test_mitxonline_programs_etl():
     mock_load_programs.assert_called_once_with(
         ETLSource.mitxonline.name,
         mock_transform.return_value,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True), prune=True),
     )
 
     assert result == mock_load_programs.return_value


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4579

### Description (What does it do?)
Makes it so that when we fetch from mitx we dont pull in courses that are unpublished

### How can this be tested?
1. checkout this branch
2. make sure the changes in this branch are picked up by celery (restart the celery container)
3. run ```./manage.py backpopulate_mitxonline_data```
4. it should show that it pulled in ~84 resources as opposed to main which pulls in ~99.
