### PR TITLE
Homepage Stories & Events layout fixes

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
@@ -73,7 +73,6 @@ const EventsContainer = styled.section`
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
-  align-self: stretch;
 `
 
 const StoryCard = styled(Card)<{ mobile: boolean }>`
@@ -145,8 +144,6 @@ const EventMonth = styled.p`
 `
 
 const EventTitle = styled.p`
-  height: ${theme.typography.pxToRem(59)};
-  align-self: stretch;
   color: ${theme.custom.colors.darkGray2};
   ${{ ...theme.typography.subtitle1 }}
   margin: 0;
@@ -176,7 +173,9 @@ const Story: React.FC<{ item: NewsFeedItem; mobile: boolean }> = ({
   return (
     <StoryCard mobile={mobile} href={item.url}>
       <Card.Image src={item.image?.url} alt={item.image?.alt} />
-      <Card.Title>{item.title}</Card.Title>
+      <Card.Title lines={2} style={{ marginBottom: -13 }}>
+        {item.title}
+      </Card.Title>
       <Card.Footer>
         Published: {formatDate(item.news_details?.publish_date)}
       </Card.Footer>
@@ -258,7 +257,7 @@ const NewsEventsSection: React.FC = () => {
           <Content>
             <StoriesContainer>
               <Typography variant="h4">Stories</Typography>
-              <Grid container columnSpacing="24px" rowSpacing="29px">
+              <Grid container columnSpacing="24px" rowSpacing="28px">
                 {stories.map((item) => (
                   <Grid item key={item.id} xs={12} sm={12} md={6} lg={4} xl={4}>
                     <Story item={item as NewsFeedItem} mobile={false} />

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -73,7 +73,7 @@ const isOcw = (resource: LearningResource) =>
   resource.resource_type === ResourceTypeEnum.Course &&
   resource.platform?.code === PlatformEnum.Ocw
 
-const getStartDate = (resource: LearningResource) => {
+const getStartDate = (resource: LearningResource, size?: Size) => {
   let startDate = resource.next_start_date
 
   if (!startDate) {
@@ -87,7 +87,7 @@ const getStartDate = (resource: LearningResource) => {
 
   if (!startDate) return null
 
-  return formatDate(startDate, "MMMM DD, YYYY")
+  return formatDate(startDate, `MMM${size === "medium" ? "M" : ""} DD, YYYY`)
 }
 
 const StartDate: React.FC<{ resource: LearningResource; size?: Size }> = ({
@@ -98,11 +98,8 @@ const StartDate: React.FC<{ resource: LearningResource; size?: Size }> = ({
 
   if (!startDate) return null
 
-  const label = isOcw(resource)
-    ? size === "medium"
-      ? "As taught in:"
-      : ""
-    : "Starts:"
+  const label =
+    size === "medium" ? (isOcw(resource) ? "As taught in:" : "Starts:") : ""
 
   return (
     <>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -73,7 +73,7 @@ const isOcw = (resource: LearningResource) =>
   resource.resource_type === ResourceTypeEnum.Course &&
   resource.platform?.code === PlatformEnum.Ocw
 
-const getStartDate = (resource: LearningResource, size?: Size) => {
+const getStartDate = (resource: LearningResource, size: Size = "medium") => {
   let startDate = resource.next_start_date
 
   if (!startDate) {


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4477

### Description (What does it do?)

1. Card default and hover state design updates were done in previous PR (https://github.com/mitodl/mit-open/pull/1054).

2. Fixes the bottom horizontal alignment on the News and Events Homepage section cards.

3+4. vertically centers the title in the event cards.

### Screenshots (if appropriate):

<img width="1455" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/1ee9862c-4534-4d8f-92d5-155cc567d04d">





### How can this be tested?

Load the Homepage and check that the above items are addresses and the layout matches [the designs](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=3852-51239&m=dev).

### Additional Context

- Also addresses issue where the footer text and action buttons collide in the small variant cards. Not solved necessarily, but "Start:" label removed and month abbreviated to 3 letters (small mode only).

Previously:
<img width="167" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/d5103813-d195-43b1-a7cb-9f357a37ccfe">

- Adds the facility to pass styles to override the Card slots.

