### PR TITLE
show courses and programs first in default sort

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -40,7 +40,7 @@ import {
 } from "./base"
 
 /**
- * * `resource_type` - resource_type * `certification` - certification * `certification_type` - certification_type * `offered_by` - offered_by * `platform` - platform * `topic` - topic * `department` - department * `level` - level * `course_feature` - course_feature * `professional` - professional * `free` - free * `learning_format` - learning_format
+ * * `resource_type` - resource_type * `certification` - certification * `certification_type` - certification_type * `offered_by` - offered_by * `platform` - platform * `topic` - topic * `department` - department * `level` - level * `course_feature` - course_feature * `professional` - professional * `free` - free * `learning_format` - learning_format * `is_learning_material` - is_learning_material
  * @export
  * @enum {string}
  */
@@ -58,6 +58,7 @@ export const AggregationsEnumDescriptions = {
   professional: "professional",
   free: "free",
   learning_format: "learning_format",
+  is_learning_material: "is_learning_material",
 } as const
 
 export const AggregationsEnum = {
@@ -109,6 +110,10 @@ export const AggregationsEnum = {
    * learning_format
    */
   LearningFormat: "learning_format",
+  /**
+   * is_learning_material
+   */
+  IsLearningMaterial: "is_learning_material",
 } as const
 
 export type AggregationsEnum =
@@ -3352,6 +3357,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    * @memberof PercolateQuerySubscriptionRequestRequest
    */
   certification?: boolean | null
+  /**
+   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
+   * @type {boolean}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  is_learning_material?: boolean | null
   /**
    * The type of certificate               * `micromasters` - Micromasters Credential * `professional` - Professional Certificate * `completion` - Certificate of Completion * `none` - No Certificate
    * @type {Array<CertificationTypeEnum>}
@@ -11350,6 +11361,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -11372,6 +11384,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
@@ -11427,6 +11440,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (id) {
         localVarQueryParameter["id"] = id
+      }
+
+      if (is_learning_material !== undefined) {
+        localVarQueryParameter["is_learning_material"] = is_learning_material
       }
 
       if (learning_format) {
@@ -11510,6 +11527,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -11532,6 +11550,7 @@ export const LearningResourcesSearchApiFp = function (
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
@@ -11559,6 +11578,7 @@ export const LearningResourcesSearchApiFp = function (
           department,
           free,
           id,
+          is_learning_material,
           learning_format,
           level,
           limit,
@@ -11619,6 +11639,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
+          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -11645,7 +11666,7 @@ export const LearningResourcesSearchApiFactory = function (
 export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly aggregations?: Array<LearningResourcesSearchRetrieveAggregationsEnum>
@@ -11691,6 +11712,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly id?: Array<number>
+
+  /**
+   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
+   * @type {boolean}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -11798,6 +11826,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
+        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -11831,6 +11860,7 @@ export const LearningResourcesSearchRetrieveAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
+  IsLearningMaterial: "is_learning_material",
 } as const
 export type LearningResourcesSearchRetrieveAggregationsEnum =
   (typeof LearningResourcesSearchRetrieveAggregationsEnum)[keyof typeof LearningResourcesSearchRetrieveAggregationsEnum]
@@ -12005,6 +12035,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12028,6 +12059,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
@@ -12084,6 +12116,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (id) {
         localVarQueryParameter["id"] = id
+      }
+
+      if (is_learning_material !== undefined) {
+        localVarQueryParameter["is_learning_material"] = is_learning_material
       }
 
       if (learning_format) {
@@ -12158,6 +12194,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12180,6 +12217,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
@@ -12235,6 +12273,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (id) {
         localVarQueryParameter["id"] = id
+      }
+
+      if (is_learning_material !== undefined) {
+        localVarQueryParameter["is_learning_material"] = is_learning_material
       }
 
       if (learning_format) {
@@ -12305,6 +12347,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12329,6 +12372,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
@@ -12386,6 +12430,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (id) {
         localVarQueryParameter["id"] = id
+      }
+
+      if (is_learning_material !== undefined) {
+        localVarQueryParameter["is_learning_material"] = is_learning_material
       }
 
       if (learning_format) {
@@ -12531,6 +12579,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12554,6 +12603,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
@@ -12582,6 +12632,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
+          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12619,6 +12670,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12641,6 +12693,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
@@ -12668,6 +12721,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
+          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12704,6 +12758,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
+     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12728,6 +12783,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
+      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
@@ -12754,6 +12810,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
+          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12847,6 +12904,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
+          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12883,6 +12941,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
+          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12918,6 +12977,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
+          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12964,7 +13024,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckListRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>
@@ -13010,6 +13070,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly id?: Array<number>
+
+  /**
+   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13104,7 +13171,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionListRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionListAggregationsEnum>
@@ -13150,6 +13217,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly id?: Array<number>
+
+  /**
+   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13237,7 +13311,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreateRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>
@@ -13283,6 +13357,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly id?: Array<number>
+
+  /**
+   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13418,6 +13499,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
+        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13456,6 +13538,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
+        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13493,6 +13576,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
+        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13548,6 +13632,7 @@ export const LearningResourcesUserSubscriptionCheckListAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
+  IsLearningMaterial: "is_learning_material",
 } as const
 export type LearningResourcesUserSubscriptionCheckListAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionCheckListAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionCheckListAggregationsEnum]
@@ -13728,6 +13813,7 @@ export const LearningResourcesUserSubscriptionListAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
+  IsLearningMaterial: "is_learning_material",
 } as const
 export type LearningResourcesUserSubscriptionListAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionListAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionListAggregationsEnum]
@@ -13900,6 +13986,7 @@ export const LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum =
     Professional: "professional",
     Free: "free",
     LearningFormat: "learning_format",
+    IsLearningMaterial: "is_learning_material",
   } as const
 export type LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum]

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = "-created_on"
+DEFAULT_SORT = ["is_learning_material", "-created_on"]
 
 
 def gen_content_file_id(content_file_id):
@@ -551,7 +551,7 @@ def construct_search(search_params):
         sort = generate_sort_clause(search_params)
         search = search.sort(sort)
     elif not search_params.get("q"):
-        search = search.sort(DEFAULT_SORT)
+        search = search.sort(*DEFAULT_SORT)
 
     if search_params.get("endpoint") == CONTENT_FILE_TYPE:
         query_type_query = {"exists": {"field": "content_type"}}
@@ -598,7 +598,6 @@ def execute_learn_search(search_params):
     """
 
     search = construct_search(search_params)
-
     return search.execute().to_dict()
 
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1428,6 +1428,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                 "course.course_numbers.sort_coursenum",
                 "course.course_numbers.primary",
                 "resource_relations",
+                "is_learning_material",
             ]
         },
     }
@@ -1630,6 +1631,7 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                 "course.course_numbers.sort_coursenum",
                 "course.course_numbers.primary",
                 "resource_relations",
+                "is_learning_material",
             ]
         },
     }
@@ -1760,7 +1762,7 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, [{"created_on": {"order": "desc"}}]),
+        (None, None, ["is_learning_material", {"created_on": {"order": "desc"}}]),
         (None, "text", None),
     ],
 )

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -74,6 +74,7 @@ LEARNING_RESOURCE_SEARCH_FILTERS = {
     "platform": FilterConfig("platform.code"),
     "offered_by": FilterConfig("offered_by.code"),
     "learning_format": FilterConfig("learning_format.code"),
+    "is_learning_material": FilterConfig("is_learning_material"),
 }
 
 SEARCH_NESTED_FILTERS = {
@@ -368,4 +369,5 @@ SOURCE_EXCLUDED_FIELDS = [
     "course.course_numbers.sort_coursenum",
     "course.course_numbers.primary",
     "resource_relations",
+    "is_learning_material",
 ]

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -38,6 +38,8 @@ from learning_resources.serializers import (
 from learning_resources_search.api import gen_content_file_id
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
+    COURSE_TYPE,
+    PROGRAM_TYPE,
 )
 from learning_resources_search.models import PercolateQuery
 from learning_resources_search.utils import remove_child_queries
@@ -79,6 +81,8 @@ def serialize_learning_resource_for_update(
     return {
         "resource_relations": {"name": "resource"},
         "created_on": learning_resource_obj.created_on,
+        "is_learning_material": learning_resource_obj.resource_type
+        not in [COURSE_TYPE, PROGRAM_TYPE],
         **serialized_data,
     }
 
@@ -175,6 +179,7 @@ LEARNING_RESOURCE_AGGREGATIONS = [
     "professional",
     "free",
     "learning_format",
+    "is_learning_material",
 ]
 
 CONTENT_FILE_AGGREGATIONS = ["topic", "content_feature_type", "platform", "offered_by"]
@@ -260,6 +265,13 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         allow_null=True,
         default=None,
         help_text="True if the learning resource offers a certificate",
+    )
+    is_learning_material = ArrayWrappedBoolean(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="True if the learning resource is a podcast, podcast episode, video, "
+        "video playlist, or learning path",
     )
     certification_choices = CertificationType.as_tuple()
     certification_type = StringArrayField(

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -142,6 +142,7 @@ response_test_raw_data_1 = {
                     "url": "http://xpro.mit.edu/courses/course-v1:xPRO+MCPO+R1/",
                     "resource_type": "course",
                     "platform": "globalalumni",
+                    "is_learning_material": False,
                 },
             }
         ],
@@ -278,6 +279,7 @@ response_test_response_1 = {
             "url": "http://xpro.mit.edu/courses/course-v1:xPRO+MCPO+R1/",
             "resource_type": "course",
             "platform": "globalalumni",
+            "is_learning_material": False,
         }
     ],
     "metadata": {
@@ -344,6 +346,7 @@ response_test_raw_data_2 = {
                     "last_modified": None,
                     "runs": [],
                     "course_feature": [],
+                    "is_learning_material": True,
                     "user_list_parents": [],
                 },
             }
@@ -507,6 +510,7 @@ response_test_response_2 = {
             "last_modified": None,
             "runs": [],
             "course_feature": [],
+            "is_learning_material": True,
             "user_list_parents": [],
         }
     ],
@@ -589,6 +593,7 @@ def test_serialize_learning_resource_for_bulk(resource_type, is_professional, no
         "_id": resource.id,
         "resource_relations": {"name": "resource"},
         "created_on": resource.created_on,
+        "is_learning_material": resource.resource_type not in ["course", "program"],
         **free_dict,
         **LearningResourceSerializer(resource).data,
     }
@@ -635,6 +640,7 @@ def test_serialize_course_numbers_for_bulk(
         "resource_relations": {"name": "resource"},
         "created_on": resource.created_on,
         "free": False,
+        "is_learning_material": False,
         **LearningResourceSerializer(resource).data,
     }
     expected_data["course"]["course_numbers"][0] = {
@@ -713,6 +719,7 @@ def test_learning_resources_search_request_serializer():
         "certification": "false",
         "certification_type": CertificationType.none.name,
         "free": True,
+        "is_learning_material": True,
         "offered_by": "xpro,ocw",
         "platform": "xpro,edx,ocw",
         "topic": "Math",
@@ -730,6 +737,7 @@ def test_learning_resources_search_request_serializer():
         "sortby": "-start_date",
         "professional": [True],
         "certification": [False],
+        "is_learning_material": [True],
         "certification_type": [CertificationType.none.name],
         "free": [True],
         "offered_by": ["xpro", "ocw"],

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2093,6 +2093,7 @@ paths:
             - professional
             - free
             - learning_format
+            - is_learning_material
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2107,6 +2108,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
+              * `is_learning_material` - is_learning_material
         description: Show resource counts by category
       - in: query
         name: certification
@@ -2254,6 +2256,13 @@ paths:
           items:
             type: integer
         description: The id value for the learning resource
+      - in: query
+        name: is_learning_material
+        schema:
+          type: boolean
+          nullable: true
+        description: True if the learning resource is a podcast, podcast episode,
+          video, video playlist, or learning path
       - in: query
         name: learning_format
         schema:
@@ -2494,6 +2503,7 @@ paths:
             - professional
             - free
             - learning_format
+            - is_learning_material
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2508,6 +2518,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
+              * `is_learning_material` - is_learning_material
         description: Show resource counts by category
       - in: query
         name: certification
@@ -2655,6 +2666,13 @@ paths:
           items:
             type: integer
         description: The id value for the learning resource
+      - in: query
+        name: is_learning_material
+        schema:
+          type: boolean
+          nullable: true
+        description: True if the learning resource is a podcast, podcast episode,
+          video, video playlist, or learning path
       - in: query
         name: learning_format
         schema:
@@ -2920,6 +2938,7 @@ paths:
             - professional
             - free
             - learning_format
+            - is_learning_material
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2934,6 +2953,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
+              * `is_learning_material` - is_learning_material
         description: Show resource counts by category
       - in: query
         name: certification
@@ -3081,6 +3101,13 @@ paths:
           items:
             type: integer
         description: The id value for the learning resource
+      - in: query
+        name: is_learning_material
+        schema:
+          type: boolean
+          nullable: true
+        description: True if the learning resource is a podcast, podcast episode,
+          video, video playlist, or learning path
       - in: query
         name: learning_format
         schema:
@@ -3337,6 +3364,7 @@ paths:
             - professional
             - free
             - learning_format
+            - is_learning_material
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -3351,6 +3379,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
+              * `is_learning_material` - is_learning_material
         description: Show resource counts by category
       - in: query
         name: certification
@@ -3498,6 +3527,13 @@ paths:
           items:
             type: integer
         description: The id value for the learning resource
+      - in: query
+        name: is_learning_material
+        schema:
+          type: boolean
+          nullable: true
+        description: True if the learning resource is a podcast, podcast episode,
+          video, video playlist, or learning path
       - in: query
         name: learning_format
         schema:
@@ -6873,6 +6909,7 @@ components:
       - professional
       - free
       - learning_format
+      - is_learning_material
       type: string
       description: |-
         * `resource_type` - resource_type
@@ -6887,6 +6924,7 @@ components:
         * `professional` - professional
         * `free` - free
         * `learning_format` - learning_format
+        * `is_learning_material` - is_learning_material
       x-enum-descriptions:
       - resource_type
       - certification
@@ -6900,6 +6938,7 @@ components:
       - professional
       - free
       - learning_format
+      - is_learning_material
     Article:
       type: object
       description: Serializer for LearningResourceInstructor model
@@ -9218,6 +9257,11 @@ components:
           type: boolean
           nullable: true
           description: True if the learning resource offers a certificate
+        is_learning_material:
+          type: boolean
+          nullable: true
+          description: True if the learning resource is a podcast, podcast episode,
+            video, video playlist, or learning path
         certification_type:
           type: array
           items:


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4578
makes backend changes needed for https://github.com/mitodl/hq/issues/4620

### Description (What does it do?)
This pr adds a new "is_learning_material"  boolean to the learning resources search index and api. This is true for Podcast, Podcast Episode, Video, Video Playlist. 

It also updates the default sort when there is no text filter to  [is_learning_material, -created_on] instead of just -created_on so that courses and programs are shown before "learning materials"

### How can this be tested?

recreate your search index by running manage.py recreate_index --all ` this will take a while if you have a lot of content files

go to http://localhost:8063/search
go to http://localhost:8063/search?sortby=new in a different tab

Verify that the default sort ("best match") shows the same resources as sort by new but with everything except for courses and programs excluded.

Try searching for text term. The default sort should sort by relevance

Verify that http://localhost:8063/api/v1/learning_resources_search/?is_learning_material=true, http://localhost:8063/api/v1/learning_resources_search/?is_learning_material=false and http://localhost:8063/api/v1/learning_resources_search/?aggregations=is_learning_material gives the expected results and http://localhost:8063/api/v1/schema/redoc/#tag/learning_resources_search/operation/learning_resources_search_retrieve looks good