### PR TITLE
Rename test appropriately and increase the timeout

### DIFF
--- a/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/Dashboard.test.tsx
@@ -252,7 +252,7 @@ describe("DashboardPage", () => {
     })
   })
 
-  test("Renders the expected carousels on the home page", async () => {
+  test("Renders the expected carousels on the dashboard", async () => {
     const {
       profile,
       topPicks,
@@ -337,5 +337,5 @@ describe("DashboardPage", () => {
       )
       expect(courseTitle).toBeInTheDocument()
     })
-  })
+  }, 10000)
 })


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4624

### Description (What does it do?)
Recently the `DashboardPage` was added, along with a test that checks to make sure the various carousels inside display properly. The test ends up taking longer than 5 seconds sometimes and will time out. This PR fixes a typo in the test name and increases the timeout.

### How can this be tested?
You can run the tests locally with `yarn test`, but likely you will never get the timeout. Likely this is happening in Github Actions because the runners are very low power.