### PR TITLE
dashboard my lists style fixes

### DIFF
--- a/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
@@ -205,6 +205,7 @@ const LinkText = styled(Typography)(({ theme }) => ({
 
 const TabPanelStyled = styled(TabPanel)({
   padding: "0",
+  width: "100%",
 })
 
 const TitleText = styled(Typography)(({ theme }) => ({

--- a/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
+++ b/frontends/mit-open/src/pages/UserListListingPage/UserListListingPage.tsx
@@ -28,10 +28,13 @@ import { useNavigate } from "react-router"
 import * as urls from "@/common/urls"
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 
-const ListHeaderGrid = styled(Grid)`
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-`
+const PageContainer = styled(Container)({
+  marginTop: "1rem",
+})
+
+const ListHeaderGrid = styled(Grid)({
+  marginBottom: "1rem",
+})
 
 type EditUserListMenuProps = {
   userList: UserList
@@ -164,12 +167,12 @@ const UserListListingPage: React.FC = () => {
       <MetaTags>
         <title>User Lists</title>
       </MetaTags>
-      <Container maxWidth="sm">
+      <PageContainer maxWidth="sm">
         <UserListListingComponent
           title="User Lists"
           onActivate={handleActivate}
         />
-      </Container>
+      </PageContainer>
     </BannerPage>
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4627

### Description (What does it do?)
This PR adjusts the styles on the dashboard:

 - TabPanel width set to 100% so contents expand to the full width of it
 - Margin removed from the top of `UserListListingComponent` and put on the standalone page instead, so the title / add new list button line up with the dashboard menu

### Screenshots (if appropriate):
![image](https://github.com/mitodl/mit-open/assets/12089658/01f0e2cf-91f3-416b-ae7b-1a522dd71a25)
![image](https://github.com/mitodl/mit-open/assets/12089658/3ca0d313-3a2d-43c4-8a77-bcc48e31e313)

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Visit http://localhost:8063/dashboard
 - Ensure that the problems noted in the issue above are solved
 - Click around the rest of the dashboard and ensure there have been no side effects
