### PR TITLE
Signup Popover

### DIFF
--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -148,7 +148,8 @@ const userSubscription = {
     `${API_BASE_URL}/api/v1/learning_resources_user_subscription/check/${query(params)}`,
   delete: (id: number) =>
     `${API_BASE_URL}/api/v1/learning_resources_user_subscription/${id}/unsubscribe/`,
-  post: () => "/api/v1/learning_resources_user_subscription/subscribe/",
+  post: () =>
+    `${API_BASE_URL}/api/v1/learning_resources_user_subscription/subscribe/`,
 }
 
 const fields = {

--- a/frontends/mit-open/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useCallback } from "react"
 import {
   RoutedDrawer,
   LearningResourceExpanded,
@@ -96,10 +96,13 @@ const useOpenLearningResourceDrawer = () => {
 const useResourceDrawerHref = () => {
   const [search] = useSearchParams()
 
-  return (id: number) => {
-    search.set(RESOURCE_DRAWER_QUERY_PARAM, id.toString())
-    return `?${search.toString()}`
-  }
+  return useCallback(
+    (id: number) => {
+      search.set(RESOURCE_DRAWER_QUERY_PARAM, id.toString())
+      return `?${search.toString()}`
+    },
+    [search],
+  )
 }
 
 export default LearningResourceDrawer

--- a/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -1,0 +1,138 @@
+import React from "react"
+import * as NiceModal from "@ebay/nice-modal-react"
+import { renderWithProviders, user, screen } from "../../test-utils"
+import type { User } from "../../test-utils"
+import { ResourceCard, ResourceListCard } from "./ResourceCard"
+import {
+  AddToLearningPathDialog,
+  AddToUserListDialog,
+} from "../Dialogs/AddToListDialog"
+import type { ResourceCardProps } from "./ResourceCard"
+import { urls, factories, setMockResponse } from "api/test-utils"
+import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
+import invariant from "tiny-invariant"
+
+jest.mock("@ebay/nice-modal-react", () => {
+  const actual = jest.requireActual("@ebay/nice-modal-react")
+  return {
+    __esModule: true,
+    ...actual,
+    show: jest.fn(),
+  }
+})
+
+describe.each([
+  {
+    CardComponent: ResourceCard,
+  },
+  {
+    CardComponent: ResourceListCard,
+  },
+])("$CardComponent", ({ CardComponent }) => {
+  const makeResource = factories.learningResources.resource
+  type SetupOptions = {
+    user?: Partial<User>
+    props?: Partial<ResourceCardProps>
+  }
+  const setup = ({ user, props = {} }: SetupOptions = {}) => {
+    const { resource = makeResource() } = props
+    if (user?.is_authenticated) {
+      setMockResponse.get(urls.userMe.get(), user)
+    } else {
+      setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+    }
+    const { view, location } = renderWithProviders(
+      <CardComponent {...props} resource={resource} />,
+    )
+    return { resource, view, location }
+  }
+
+  const labels = {
+    addToLearningPaths: "Add to Learning Path",
+    addToUserList: "Add to User List",
+  }
+
+  test("Applies className to the resource card", () => {
+    const { view } = setup({ user: {}, props: { className: "test-class" } })
+    expect(view.container.firstChild).toHaveClass("test-class")
+  })
+
+  test.each([
+    {
+      user: { is_authenticated: true, is_learning_path_editor: false },
+      expectAddToLearningPathButton: false,
+    },
+    {
+      user: { is_authenticated: true, is_learning_path_editor: true },
+      expectAddToLearningPathButton: true,
+    },
+    {
+      user: { is_authenticated: false },
+      expectAddToLearningPathButton: false,
+    },
+  ])(
+    "Always shows 'Add to User List' button, but only shows 'Add to Learning Path' button if user is a learning path editor",
+    async ({ user, expectAddToLearningPathButton }) => {
+      setup({ user })
+      await screen.findByRole("button", {
+        name: labels.addToUserList,
+      })
+      const addToLearningPathButton = screen.queryByRole("button", {
+        name: labels.addToLearningPaths,
+      })
+      expect(!!addToLearningPathButton).toBe(expectAddToLearningPathButton)
+    },
+  )
+
+  test("Clicking add to list button opens AddToListDialog when authenticated", async () => {
+    const showModal = jest.mocked(NiceModal.show)
+
+    const { resource } = setup({
+      user: { is_learning_path_editor: true, is_authenticated: true },
+    })
+    const addToUserListButton = await screen.findByRole("button", {
+      name: labels.addToUserList,
+    })
+    const addToLearningPathButton = await screen.findByRole("button", {
+      name: labels.addToLearningPaths,
+    })
+
+    expect(showModal).not.toHaveBeenCalled()
+    await user.click(addToLearningPathButton)
+    invariant(resource)
+    expect(showModal).toHaveBeenLastCalledWith(AddToLearningPathDialog, {
+      resourceId: resource.id,
+    })
+    await user.click(addToUserListButton)
+    expect(showModal).toHaveBeenLastCalledWith(AddToUserListDialog, {
+      resourceId: resource.id,
+    })
+  })
+
+  test("Clicking 'Add to User List' opens signup popover if not authenticated", async () => {
+    setup({
+      user: { is_authenticated: false },
+    })
+    const addToUserListButton = await screen.findByRole("button", {
+      name: labels.addToUserList,
+    })
+    await user.click(addToUserListButton)
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toBeVisible()
+    expect(dialog).toHaveTextContent("Sign Up")
+  })
+
+  test("Clicking card opens resource drawer", async () => {
+    const { resource, location } = setup({
+      user: { is_learning_path_editor: true },
+    })
+    invariant(resource)
+    const cardTitle = screen.getByRole("heading", { name: resource.title })
+    await user.click(cardTitle)
+    expect(
+      new URLSearchParams(location.current.search).get(
+        RESOURCE_DRAWER_QUERY_PARAM,
+      ),
+    ).toBe(String(resource.id))
+  })
+})

--- a/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
@@ -62,6 +62,13 @@ type ResourceCardProps = Omit<
   "href" | "onAddToLearningPathClick" | "onAddToUserListClick"
 >
 
+/**
+ * Just like `ol-components/LearningResourceCard`, but with builtin actions:
+ *  - click opens the Resource Drawer
+ *  - onAddToListClick opens the Add to List modal
+ *    - for unauthenticated users, a popover prompts signup instead.
+ *  - onAddToLearningPathClick opens the Add to Learning Path modal
+ */
 const ResourceCard: React.FC<ResourceCardProps> = ({ resource, ...others }) => {
   const {
     getDrawerHref,
@@ -89,6 +96,13 @@ type ResourceListCardProps = Omit<
   "href" | "onAddToLearningPathClick" | "onAddToUserListClick"
 >
 
+/**
+ * Just like `ol-components/LearningResourceListCard`, but with builtin actions:
+ *  - click opens the Resource Drawer
+ *  - onAddToListClick opens the Add to List modal
+ *    - for unauthenticated users, a popover prompts signup instead.
+ *  - onAddToLearningPathClick opens the Add to Learning Path modal
+ */
 const ResourceListCard: React.FC<ResourceListCardProps> = ({
   resource,
   ...others

--- a/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useMemo, useState } from "react"
+import { LearningResourceCard, LearningResourceListCard } from "ol-components"
+import * as NiceModal from "@ebay/nice-modal-react"
+import type {
+  LearningResourceCardProps,
+  LearningResourceListCardProps,
+} from "ol-components"
+import {
+  AddToLearningPathDialog,
+  AddToUserListDialog,
+} from "../Dialogs/AddToListDialog"
+import { useResourceDrawerHref } from "../LearningResourceDrawer/LearningResourceDrawer"
+import { useUserMe } from "api/hooks/user"
+import { SignupPopover } from "../SignupPopover/SignupPopover"
+
+const useResourceCard = () => {
+  const getDrawerHref = useResourceDrawerHref()
+  const { data: user } = useUserMe()
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+
+  const handleClosePopover = useCallback(() => {
+    setAnchorEl(null)
+  }, [])
+  const handleAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"] =
+    useMemo(() => {
+      if (user?.is_authenticated && user?.is_learning_path_editor) {
+        return (event, resourceId: number) => {
+          NiceModal.show(AddToLearningPathDialog, { resourceId })
+        }
+      }
+      return null
+    }, [user])
+
+  const handleAddToUserListClick: LearningResourceCardProps["onAddToUserListClick"] =
+    useMemo(() => {
+      if (!user) {
+        // user info is still loading
+        return null
+      }
+      if (user.is_authenticated) {
+        return (event, resourceId: number) => {
+          NiceModal.show(AddToUserListDialog, { resourceId })
+        }
+      }
+      return (event) => {
+        setAnchorEl(event.currentTarget)
+      }
+    }, [user])
+
+  return {
+    getDrawerHref,
+    anchorEl,
+    handleClosePopover,
+    handleAddToLearningPathClick,
+    handleAddToUserListClick,
+  }
+}
+
+type ResourceCardProps = Omit<
+  LearningResourceCardProps,
+  "href" | "onAddToLearningPathClick" | "onAddToUserListClick"
+>
+
+const ResourceCard: React.FC<ResourceCardProps> = ({ resource, ...others }) => {
+  const {
+    getDrawerHref,
+    anchorEl,
+    handleClosePopover,
+    handleAddToLearningPathClick,
+    handleAddToUserListClick,
+  } = useResourceCard()
+  return (
+    <>
+      <LearningResourceCard
+        resource={resource}
+        href={resource ? getDrawerHref(resource.id) : undefined}
+        onAddToLearningPathClick={handleAddToLearningPathClick}
+        onAddToUserListClick={handleAddToUserListClick}
+        {...others}
+      />
+      <SignupPopover anchorEl={anchorEl} onClose={handleClosePopover} />
+    </>
+  )
+}
+
+type ResourceListCardProps = Omit<
+  LearningResourceListCardProps,
+  "href" | "onAddToLearningPathClick" | "onAddToUserListClick"
+>
+
+const ResourceListCard: React.FC<ResourceListCardProps> = ({
+  resource,
+  ...others
+}) => {
+  const {
+    getDrawerHref,
+    anchorEl,
+    handleClosePopover,
+    handleAddToLearningPathClick,
+    handleAddToUserListClick,
+  } = useResourceCard()
+  return (
+    <>
+      <LearningResourceListCard
+        resource={resource}
+        href={resource ? getDrawerHref(resource.id) : undefined}
+        onAddToLearningPathClick={handleAddToLearningPathClick}
+        onAddToUserListClick={handleAddToUserListClick}
+        {...others}
+      />
+      <SignupPopover anchorEl={anchorEl} onClose={handleClosePopover} />
+    </>
+  )
+}
+
+export { ResourceCard, ResourceListCard }
+export type { ResourceCardProps, ResourceListCardProps }

--- a/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -11,6 +11,7 @@ import {
 import { factories, setMockResponse, makeRequest, urls } from "api/test-utils"
 import { LearningResourceCard } from "ol-components"
 import { ControlledPromise } from "ol-test-utilities"
+import invariant from "tiny-invariant"
 
 jest.mock("ol-components", () => {
   const actual = jest.requireActual("ol-components")
@@ -161,9 +162,17 @@ describe("ResourceCarousel", () => {
       <ResourceCarousel title="My Carousel" config={config} />,
     )
     await waitFor(() => {
-      expect(makeRequest.mock.calls.length > 0).toBe(true)
+      expect(makeRequest).toHaveBeenCalledWith(
+        "get",
+        expect.stringContaining(urls.learningResources.list()),
+        undefined,
+      )
     })
-    const [_method, url] = makeRequest.mock.calls[0]
+    const [_method, url] =
+      makeRequest.mock.calls.find(([_method, url]) => {
+        return url.includes(urls.learningResources.list())
+      }) ?? []
+    invariant(url)
     const urlParams = new URLSearchParams(url.split("?")[1])
     expect(urlParams.getAll("resource_type")).toEqual(["course", "program"])
     expect(urlParams.get("professional")).toEqual("true")

--- a/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import * as NiceModal from "@ebay/nice-modal-react"
 import {
   useFeaturedLearningResourcesList,
   useLearningResourcesList,
@@ -12,7 +11,6 @@ import {
   TabContext,
   TabButtonList,
   styled,
-  LearningResourceCard,
   Typography,
 } from "ol-components"
 import type {
@@ -22,12 +20,7 @@ import type {
   FeaturedDataSource,
 } from "./types"
 import { LearningResource } from "api"
-import { useUserMe } from "api/hooks/user"
-import {
-  AddToLearningPathDialog,
-  AddToUserListDialog,
-} from "../Dialogs/AddToListDialog"
-import { useResourceDrawerHref } from "../LearningResourceDrawer/LearningResourceDrawer"
+import { ResourceCard } from "../ResourceCard/ResourceCard"
 
 const StyledCarousel = styled(Carousel)({
   /**
@@ -261,23 +254,8 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
   className,
   isLoading,
 }) => {
-  const { data: user } = useUserMe()
   const [tab, setTab] = React.useState("0")
   const [ref, setRef] = React.useState<HTMLDivElement | null>(null)
-  const getDrawerHref = useResourceDrawerHref()
-
-  const showAddToLearningPathDialog =
-    user?.is_authenticated && user?.is_learning_path_editor
-      ? (resourceId: number) => {
-          NiceModal.show(AddToLearningPathDialog, { resourceId })
-        }
-      : null
-
-  const showAddToUserListDialog = user?.is_authenticated
-    ? (resourceId: number) => {
-        NiceModal.show(AddToUserListDialog, { resourceId })
-      }
-    : null
 
   return (
     <MobileOverflow className={className}>
@@ -305,7 +283,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
             <StyledCarousel arrowsContainer={ref}>
               {isLoading || childrenLoading
                 ? Array.from({ length: 6 }).map((_, index) => (
-                    <LearningResourceCard
+                    <ResourceCard
                       isLoading
                       key={index}
                       resource={null}
@@ -313,13 +291,10 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                     />
                   ))
                 : resources.map((resource) => (
-                    <LearningResourceCard
+                    <ResourceCard
                       key={resource.id}
                       resource={resource}
                       {...tabConfig.cardProps}
-                      href={getDrawerHref(resource.id)}
-                      onAddToLearningPathClick={showAddToLearningPathDialog}
-                      onAddToUserListClick={showAddToUserListDialog}
                     />
                   ))}
             </StyledCarousel>

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -12,10 +12,8 @@ import {
   SimpleSelect,
   truncateText,
   css,
-  LearningResourceListCard,
   Drawer,
 } from "ol-components"
-import * as NiceModal from "@ebay/nice-modal-react"
 
 import {
   RiCloseLine,
@@ -44,12 +42,8 @@ import _ from "lodash"
 import { ResourceTypeTabs } from "./ResourceTypeTabs"
 import ProfessionalToggle from "./ProfessionalToggle"
 import type { TabConfig } from "./ResourceTypeTabs"
-import { useUserMe } from "api/hooks/user"
-import {
-  AddToLearningPathDialog,
-  AddToUserListDialog,
-} from "../Dialogs/AddToListDialog"
-import { useResourceDrawerHref } from "@/page-components/LearningResourceDrawer/LearningResourceDrawer"
+
+import { ResourceListCard } from "../ResourceCard/ResourceCard"
 
 export const StyledDropdown = styled(SimpleSelect)`
   margin-left: 8px;
@@ -509,22 +503,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     { keepPreviousData: true },
   )
 
-  const { data: user } = useUserMe()
-
-  const getDrawerHref = useResourceDrawerHref()
-
-  const showAddToLearningPathDialog =
-    user?.is_authenticated && user?.is_learning_path_editor
-      ? (resourceId: number) => {
-          NiceModal.show(AddToLearningPathDialog, { resourceId })
-        }
-      : null
-
-  const showAddToUserListDialog = user?.is_authenticated
-    ? (resourceId: number) => {
-        NiceModal.show(AddToUserListDialog, { resourceId })
-      }
-    : null
   const [mobileDrawerOpen, setMobileDrawerOpen] = React.useState(false)
 
   const toggleMobileDrawer = (newOpen: boolean) => () => {
@@ -647,7 +625,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                       .fill(null)
                       .map((a, index) => (
                         <li key={index}>
-                          <LearningResourceListCard isLoading={isLoading} />
+                          <ResourceListCard isLoading={isLoading} />
                         </li>
                       ))}
                   </PlainList>
@@ -655,12 +633,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   <PlainList itemSpacing={1.5}>
                     {data.results.map((resource) => (
                       <li key={resource.id}>
-                        <LearningResourceListCard
-                          resource={resource}
-                          href={getDrawerHref(resource.id)}
-                          onAddToLearningPathClick={showAddToLearningPathDialog}
-                          onAddToUserListClick={showAddToUserListDialog}
-                        />
+                        <ResourceListCard resource={resource} />
                       </li>
                     ))}
                   </PlainList>

--- a/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
+++ b/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
@@ -1,0 +1,123 @@
+import React from "react"
+import { renderWithProviders, screen, user, within } from "@/test-utils"
+import { SearchSubscriptionToggle } from "./SearchSubscriptionToggle"
+import { urls, setMockResponse, factories, makeRequest } from "api/test-utils"
+import { SourceTypeEnum } from "api"
+import type { LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckListRequest as CheckSubscriptionRequest } from "api"
+
+type SetupApisOptions = {
+  isAuthenticated?: boolean
+  isSubscribed?: boolean
+  subscriptionRequest?: CheckSubscriptionRequest
+}
+const setupApis = ({
+  isAuthenticated = false,
+  isSubscribed = false,
+  subscriptionRequest = {},
+}: SetupApisOptions = {}) => {
+  setMockResponse.get(urls.userMe.get(), {
+    is_authenticated: isAuthenticated,
+  })
+
+  const subscribeResponse = isSubscribed
+    ? factories.percolateQueries.percolateQueryList({ count: 1 }).results
+    : factories.percolateQueries.percolateQueryList({ count: 0 }).results
+  setMockResponse.get(
+    `${urls.userSubscription.check(subscriptionRequest)}`,
+    subscribeResponse,
+  )
+
+  const subscribeUrl = urls.userSubscription.post()
+  setMockResponse.post(subscribeUrl, subscribeResponse)
+
+  const unsubscribeUrl = urls.userSubscription.delete(subscribeResponse[0]?.id)
+  setMockResponse.delete(unsubscribeUrl, subscribeResponse[0])
+  return {
+    subscribeUrl,
+    unsubscribeUrl,
+  }
+}
+
+test("Shows subscription popover if user is NOT authenticated", async () => {
+  // Don't set up all the APIs... We don't want to call the others for unauthenticated users.
+  setMockResponse.get(urls.userMe.get(), {}, { code: 403 })
+  renderWithProviders(
+    <SearchSubscriptionToggle
+      searchParams={new URLSearchParams()}
+      sourceType="channel_subscription_type"
+    />,
+  )
+  const subscribeButton = await screen.findByRole("button", {
+    name: "Follow",
+  })
+  await user.click(subscribeButton)
+  const popover = await screen.findByRole("dialog")
+  within(popover).getByRole("link", { name: "Sign Up" })
+})
+
+test.each(Object.values(SourceTypeEnum))(
+  "Allows subscribing if authenticated and NOT subscribed (source_type=%s)",
+  async (sourceType) => {
+    const { subscribeUrl } = setupApis({
+      isAuthenticated: true,
+      isSubscribed: false,
+      subscriptionRequest: {
+        source_type: sourceType,
+        offered_by: ["ocw"],
+      },
+    })
+    renderWithProviders(
+      <SearchSubscriptionToggle
+        searchParams={new URLSearchParams([["offered_by", "ocw"]])}
+        sourceType={sourceType}
+      />,
+    )
+    const subscribeButton = await screen.findByRole("button", {
+      name: "Follow",
+    })
+    await user.click(subscribeButton)
+    expect(makeRequest).toHaveBeenCalledWith("post", subscribeUrl, {
+      source_type: sourceType,
+      offered_by: ["ocw"],
+    })
+  },
+)
+
+test.each(Object.values(SourceTypeEnum))(
+  "Allows unsubscribing if authenticated and subscribed (source_type=%s)",
+  async (sourceType) => {
+    const { unsubscribeUrl } = setupApis({
+      isAuthenticated: true,
+      isSubscribed: true,
+      subscriptionRequest: {
+        source_type: sourceType,
+        offered_by: ["ocw"],
+      },
+    })
+
+    renderWithProviders(
+      <SearchSubscriptionToggle
+        searchParams={new URLSearchParams([["offered_by", "ocw"]])}
+        sourceType={sourceType}
+      />,
+    )
+
+    const subscribedButton = await screen.findByRole("button", {
+      name: "Following",
+    })
+
+    await user.click(subscribedButton)
+
+    const menu = screen.getByRole("menu")
+    const unsubscribeButton = within(menu).getByRole("menuitem", {
+      name: "Unfollow",
+    })
+    await user.click(unsubscribeButton)
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      "delete",
+      unsubscribeUrl,
+      undefined,
+    )
+  },
+)

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.test.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.test.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+import { SignupPopover } from "./SignupPopover"
+import { renderWithProviders, screen, within } from "@/test-utils"
+import invariant from "tiny-invariant"
+import * as urls from "@/common/urls"
+
+test("SignupPopover shows link to sign up", async () => {
+  renderWithProviders(
+    <SignupPopover anchorEl={document.body} onClose={jest.fn} />,
+  )
+  const dialog = screen.getByRole("dialog")
+  const link = within(dialog).getByRole("link")
+  invariant(link instanceof HTMLAnchorElement)
+  expect(link.href).toMatch(urls.login())
+})

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.test.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.test.tsx
@@ -7,9 +7,17 @@ import * as urls from "@/common/urls"
 test("SignupPopover shows link to sign up", async () => {
   renderWithProviders(
     <SignupPopover anchorEl={document.body} onClose={jest.fn} />,
+    {
+      url: "/some-path?dog=woof",
+    },
   )
   const dialog = screen.getByRole("dialog")
   const link = within(dialog).getByRole("link")
   invariant(link instanceof HTMLAnchorElement)
-  expect(link.href).toMatch(urls.login())
+  expect(link.href).toMatch(
+    urls.login({
+      pathname: "/some-path",
+      search: "?dog=woof",
+    }),
+  )
 })

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { Popover, Typography, styled, ButtonLink } from "ol-components"
+import type { PopoverProps } from "ol-components"
+import * as urls from "@/common/urls"
+
+const StyledPopover = styled(Popover)({
+  width: "300px",
+  maxWidth: "100vw",
+})
+const HeaderText = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.darkGray2,
+  marginBottom: "8px",
+}))
+const BodyText = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+  marginBottom: "16px",
+}))
+
+const Footer = styled.div({
+  display: "flex",
+  justifyContent: "end",
+})
+
+type SignupPopoverProps = Pick<PopoverProps, "anchorEl" | "onClose">
+const SignupPopover: React.FC<SignupPopoverProps> = (props) => {
+  return (
+    <StyledPopover {...props} open={!!props.anchorEl}>
+      <HeaderText variant="subtitle2">Join MIT Open for free</HeaderText>
+      <BodyText variant="body2">
+        As a member, get personalized recommendations, curate learning lists,
+        and follow your areas of interests.
+      </BodyText>
+      <Footer>
+        <ButtonLink href={urls.login()}>Sign Up</ButtonLink>
+      </Footer>
+    </StyledPopover>
+  )
+}
+
+export { SignupPopover }
+export type { SignupPopoverProps }

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Popover, Typography, styled, ButtonLink } from "ol-components"
 import type { PopoverProps } from "ol-components"
 import * as urls from "@/common/urls"
+import { useLocation } from "react-router"
 
 const StyledPopover = styled(Popover)({
   width: "300px",
@@ -26,15 +27,25 @@ type SignupPopoverProps = Pick<
   "anchorEl" | "onClose" | "placement"
 >
 const SignupPopover: React.FC<SignupPopoverProps> = (props) => {
+  const loc = useLocation()
   return (
     <StyledPopover {...props} open={!!props.anchorEl}>
-      <HeaderText variant="subtitle2">Join MIT Open for free</HeaderText>
+      <HeaderText variant="subtitle2">
+        Join {process.env.SITE_NAME} for free.
+      </HeaderText>
       <BodyText variant="body2">
         As a member, get personalized recommendations, curate learning lists,
         and follow your areas of interests.
       </BodyText>
       <Footer>
-        <ButtonLink href={urls.login()}>Sign Up</ButtonLink>
+        <ButtonLink
+          href={urls.login({
+            pathname: loc.pathname,
+            search: loc.search,
+          })}
+        >
+          Sign Up
+        </ButtonLink>
       </Footer>
     </StyledPopover>
   )

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
@@ -21,7 +21,10 @@ const Footer = styled.div({
   justifyContent: "end",
 })
 
-type SignupPopoverProps = Pick<PopoverProps, "anchorEl" | "onClose">
+type SignupPopoverProps = Pick<
+  PopoverProps,
+  "anchorEl" | "onClose" | "placement"
+>
 const SignupPopover: React.FC<SignupPopoverProps> = (props) => {
   return (
     <StyledPopover {...props} open={!!props.anchorEl}>

--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -12,6 +12,7 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@mui/base": "5.0.0-beta.40",
     "@mui/icons-material": "^5.15.15",
     "@mui/lab": "^5.0.0-alpha.170",
     "@mui/material": "^5.15.15",

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -108,13 +108,25 @@ describe("Learning Resource Card", () => {
     const addToLearningPathButton = screen.getByLabelText(
       "Add to Learning Path",
     )
+
     await addToLearningPathButton.click()
 
     const addToUserListButton = screen.getByLabelText("Add to User List")
+
     await addToUserListButton.click()
 
-    expect(onAddToLearningPathClick).toHaveBeenCalledWith(resource.id)
-    expect(onAddToUserListClick).toHaveBeenCalledWith(resource.id)
+    expect(onAddToLearningPathClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.any(HTMLElement),
+      }),
+      resource.id,
+    )
+    expect(onAddToUserListClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.any(HTMLElement),
+      }),
+      resource.id,
+    )
   })
 
   test("Displays certificate badge", () => {

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -36,7 +36,10 @@ const getEmbedlyUrl = (resource: LearningResource, size: Size) => {
   })
 }
 
-type ResourceIdCallback = (resourceId: number) => void
+type ResourceIdCallback = (
+  event: React.MouseEvent<HTMLButtonElement>,
+  resourceId: number,
+) => void
 
 const Info = ({ resource }: { resource: LearningResource }) => {
   return (
@@ -169,7 +172,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             color="secondary"
             size="small"
             aria-label="Add to Learning Path"
-            onClick={() => onAddToLearningPathClick(resource.id)}
+            onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
             <RiMenuAddLine />
           </ActionButton>
@@ -181,7 +184,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             color="secondary"
             size="small"
             aria-label="Add to User List"
-            onClick={() => onAddToUserListClick(resource.id)}
+            onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             <RiBookmarkLine />
           </ActionButton>
@@ -195,3 +198,4 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
 }
 
 export { LearningResourceCard }
+export type { LearningResourceCardProps }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -113,8 +113,18 @@ describe("Learning Resource List Card", () => {
     const addToUserListButton = screen.getByLabelText("Add to User List")
     await addToUserListButton.click()
 
-    expect(onAddToLearningPathClick).toHaveBeenCalledWith(resource.id)
-    expect(onAddToUserListClick).toHaveBeenCalledWith(resource.id)
+    expect(onAddToLearningPathClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.any(HTMLElement),
+      }),
+      resource.id,
+    )
+    expect(onAddToUserListClick).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: expect.any(HTMLElement),
+      }),
+      resource.id,
+    )
   })
 
   test("Displays certificate badge", () => {

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -85,7 +85,10 @@ const StyledActionButton = styled(ActionButton)<{ edge: string }>`
       : ""}
 `
 
-type ResourceIdCallback = (resourceId: number) => void
+type ResourceIdCallback = (
+  event: React.MouseEvent<HTMLButtonElement>,
+  resourceId: number,
+) => void
 
 const getEmbedlyUrl = (url: string, isMobile: boolean) => {
   return embedlyCroppedImage(url, {
@@ -396,7 +399,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
             color="secondary"
             size="small"
             aria-label="Add to Learning Path"
-            onClick={() => onAddToLearningPathClick(resource.id)}
+            onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
             <RiMenuAddLine />
           </StyledActionButton>
@@ -408,7 +411,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
             color="secondary"
             size="small"
             aria-label="Add to User List"
-            onClick={() => onAddToUserListClick(resource.id)}
+            onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             <RiBookmarkLine />
           </StyledActionButton>
@@ -427,3 +430,4 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
 }
 
 export { LearningResourceListCard }
+export type { LearningResourceListCardProps }

--- a/frontends/ol-components/src/components/Popover/Popover.stories.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.stories.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import React from "react"
+import type { Meta, StoryObj } from "@storybook/react"
+import { Popover } from "./Popover"
+import type { PopoverProps } from "./Popover"
+import { Button } from "../Button/Button"
+import Typography from "@mui/material/Typography"
+import styled from "@emotion/styled"
+
+const ScrollWrapper = styled.div({
+  width: "250px",
+  height: "250px",
+  overflow: "auto",
+  border: "1pt solid blue",
+})
+const Wrapper = styled.div({
+  width: "500px",
+  height: "500px",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  border: "1pt solid red",
+})
+
+const StoryPopover = (args: PopoverProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null)
+  return (
+    <Wrapper>
+      <Popover
+        {...args}
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={() => setAnchorEl(null)}
+      />
+
+      <Button onClick={(event) => setAnchorEl(event.currentTarget)}>
+        Open Popover
+      </Button>
+    </Wrapper>
+  )
+}
+
+const meta: Meta<typeof Popover> = {
+  render: (args) => {
+    return <StoryPopover {...args} />
+  },
+  title: "smoot-design/Popover",
+  argTypes: {
+    placement: {
+      control: { type: "select" },
+      options: [undefined, "top", "right", "bottom", "left"],
+    },
+    modal: {
+      control: { type: "select" },
+      options: [undefined, false, true],
+    },
+    children: {
+      table: { disable: true },
+    },
+  },
+  args: {
+    children: (
+      <>
+        <Typography variant="h3">Popover Content!</Typography>
+        <Button variant="secondary" onClick={console.log}>
+          First
+        </Button>
+        <Button onClick={console.log}>Second</Button>
+      </>
+    ),
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof Popover>
+
+export const Basic: Story = {}
+
+export const Scrolling: Story = {
+  render: (args) => {
+    return (
+      <ScrollWrapper>
+        <StoryPopover {...args} />
+      </ScrollWrapper>
+    )
+  },
+}
+
+export const Focus: Story = {
+  render: (args) => {
+    return (
+      <>
+        <StoryPopover {...args} />
+        <Button variant="secondary">Focus Me</Button>
+      </>
+    )
+  },
+}

--- a/frontends/ol-components/src/components/Popover/Popover.test.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react"
+import user from "@testing-library/user-event"
+import { Popover } from "./Popover"
+import type { PopoverProps } from "./Popover"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
+
+const PopoverTest = (props: Omit<PopoverProps, "anchorEl">) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null)
+  return (
+    <div>
+      <button ref={setAnchorEl}>Anchor</button>
+      {anchorEl && (
+        <Popover data-testid="popover" {...props} anchorEl={anchorEl}>
+          <h2>Popover content</h2>
+          <button>Button 1</button>
+          <button>Button 2</button>
+        </Popover>
+      )}
+
+      <button>Other Button</button>
+    </div>
+  )
+}
+
+test.each([{ modal: true }, {}, {}])(
+  "Traps focus if modal = $modal",
+  async ({ modal }) => {
+    render(<PopoverTest open onClose={jest.fn()} modal={modal} />, {
+      wrapper: ThemeProvider,
+    })
+
+    const popover = screen.getByTestId("popover")
+    expect(popover.contains(document.activeElement)).toBe(true)
+
+    await user.tab()
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Button 1" }),
+    )
+
+    await user.tab()
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Button 2" }),
+    )
+
+    await user.tab()
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Button 1" }),
+    )
+  },
+)
+
+test("Popover does not trap focus if modal=false", async () => {
+  render(<PopoverTest open onClose={jest.fn()} modal={false} />, {
+    wrapper: ThemeProvider,
+  })
+
+  expect(document.activeElement).toBe(document.body)
+  await user.tab()
+  expect(document.activeElement).toBe(
+    screen.getByRole("button", { name: "Anchor" }),
+  )
+
+  await user.tab()
+  expect(document.activeElement).toBe(
+    screen.getByRole("button", { name: "Button 1" }),
+  )
+  await user.tab()
+  expect(document.activeElement).toBe(
+    screen.getByRole("button", { name: "Button 2" }),
+  )
+  await user.tab()
+  expect(document.activeElement).toBe(
+    screen.getByRole("button", { name: "Other Button" }),
+  )
+})
+
+test.each([
+  { role: "dialog", modal: true },
+  { role: "dialog" },
+  { role: "tooltip", modal: false },
+])("popover role is $role if $modal", ({ modal, role }) => {
+  render(<PopoverTest open onClose={jest.fn()} modal={modal} />, {
+    wrapper: ThemeProvider,
+  })
+  const popover = screen.getByTestId("popover")
+  const el = screen.getByRole(role)
+  expect(popover).toBe(el)
+})
+
+test("Calls onClose when escape is pressed", async () => {
+  const onClose = jest.fn()
+  render(<PopoverTest open onClose={onClose} />, {
+    wrapper: ThemeProvider,
+  })
+
+  await user.type(document.body, "{esc}")
+  expect(onClose).toHaveBeenCalled()
+})
+
+test("Calls onClose when clicking outside popover", async () => {
+  const onClose = jest.fn()
+  render(<PopoverTest open onClose={onClose} />, {
+    wrapper: ThemeProvider,
+  })
+
+  const popover = screen.getByTestId("popover")
+  expect(popover).toBeVisible()
+
+  await user.click(document.body)
+  expect(onClose).toHaveBeenCalled()
+})
+
+test("Popover is open/closed based on 'open'", async () => {
+  const onClose = jest.fn()
+  const { rerender } = render(<PopoverTest open onClose={onClose} />, {
+    wrapper: ThemeProvider,
+  })
+
+  const popover = screen.getByTestId("popover")
+  expect(popover).toBeVisible()
+
+  rerender(<PopoverTest open={false} onClose={onClose} />)
+
+  await waitForElementToBeRemoved(popover)
+})

--- a/frontends/ol-components/src/components/Popover/Popover.test.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.test.tsx
@@ -67,15 +67,16 @@ test("Popover does not trap focus if modal=false", async () => {
 
   await user.tab()
   expect(document.activeElement).toBe(
+    screen.getByRole("button", { name: "Other Button" }),
+  )
+
+  await user.tab()
+  expect(document.activeElement).toBe(
     screen.getByRole("button", { name: "Button 1" }),
   )
   await user.tab()
   expect(document.activeElement).toBe(
     screen.getByRole("button", { name: "Button 2" }),
-  )
-  await user.tab()
-  expect(document.activeElement).toBe(
-    screen.getByRole("button", { name: "Other Button" }),
   )
 })
 

--- a/frontends/ol-components/src/components/Popover/Popover.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.tsx
@@ -97,16 +97,6 @@ const getModifiers = (
       offset: [0, 10],
     },
   },
-  {
-    name: "preventOverflow",
-    enabled: true,
-    options: {
-      altAxis: true,
-      altBoundary: true,
-      tether: true,
-      padding: 8,
-    },
-  },
 ]
 
 const Arrow = styled("div")({
@@ -169,7 +159,6 @@ const Popover: React.FC<PopoverProps> = ({
     <StyledPopper
       open={open}
       modifiers={modifiers}
-      disablePortal
       transition
       {...props}
       {...(modal ? { role: "dialog" } : {})}

--- a/frontends/ol-components/src/components/Popover/Popover.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.tsx
@@ -1,0 +1,198 @@
+import * as React from "react"
+import styled from "@emotion/styled"
+import MuiPopper from "@mui/material/Popper"
+import type { PopperProps } from "@mui/material/Popper"
+import Fade from "@mui/material/Fade"
+import { FocusTrap } from "@mui/base/FocusTrap"
+import ClickAwayListener from "@mui/material/ClickAwayListener"
+
+const StyledPopper = styled(MuiPopper)(({ theme }) => ({
+  zIndex: 1,
+  "& > div": {
+    position: "relative",
+  },
+  '&[data-popper-placement*="bottom"]': {
+    "& > div": {
+      marginTop: 2,
+    },
+    "& .MuiPopper-arrow": {
+      top: 0,
+      marginTop: "-0.9em",
+      width: "3em",
+      height: "1em",
+      "&::before": {
+        borderWidth: "0 1em 1em 1em",
+        borderColor: `transparent transparent ${theme.palette.background.paper} transparent`,
+      },
+    },
+  },
+  '&[data-popper-placement*="top"]': {
+    "& > div": {
+      marginBottom: 2,
+    },
+    "& .MuiPopper-arrow": {
+      bottom: 0,
+      marginBottom: "-0.9em",
+      width: "3em",
+      height: "1em",
+      "&::before": {
+        borderWidth: "1em 1em 0 1em",
+        borderColor: `${theme.palette.background.paper} transparent transparent transparent`,
+      },
+    },
+  },
+  '&[data-popper-placement*="right"]': {
+    "& > div": {
+      marginLeft: 2,
+    },
+    "& .MuiPopper-arrow": {
+      left: 0,
+      marginLeft: "-0.9em",
+      height: "3em",
+      width: "1em",
+      "&::before": {
+        borderWidth: "1em 1em 1em 0",
+        borderColor: `transparent ${theme.palette.background.paper} transparent transparent`,
+      },
+    },
+  },
+  '&[data-popper-placement*="left"]': {
+    "& > div": {
+      marginRight: 2,
+    },
+    "& .MuiPopper-arrow": {
+      right: 0,
+      marginRight: "-0.9em",
+      height: "3em",
+      width: "1em",
+      "&::before": {
+        borderWidth: "1em 0 1em 1em",
+        borderColor: `transparent transparent transparent ${theme.palette.background.paper}`,
+      },
+    },
+  },
+}))
+
+const getModifiers = (
+  arrowEl: HTMLElement | null,
+): PopperProps["modifiers"] => [
+  {
+    name: "flip",
+    enabled: true,
+  },
+  {
+    name: "preventOverflow",
+    enabled: true,
+  },
+  {
+    name: "arrow",
+    enabled: !!arrowEl,
+    options: {
+      element: arrowEl,
+    },
+  },
+  {
+    name: "offset",
+    options: {
+      offset: [0, 10],
+    },
+  },
+  {
+    name: "preventOverflow",
+    enabled: true,
+    options: {
+      altAxis: true,
+      altBoundary: true,
+      tether: true,
+      padding: 8,
+    },
+  },
+]
+
+const Arrow = styled("div")({
+  position: "absolute",
+  fontSize: 7,
+  width: "3em",
+  height: "3em",
+  "&::before": {
+    content: '""',
+    margin: "auto",
+    display: "block",
+    width: 0,
+    height: 0,
+    borderStyle: "solid",
+  },
+})
+
+const Content = styled.div(({ theme }) => ({
+  padding: "16px",
+  backgroundColor: theme.custom.colors.white,
+  boxShadow:
+    "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 6px 24px 0px rgba(37, 38, 43, 0.24)",
+}))
+
+type PopoverProps = Pick<PopperProps, "anchorEl" | "placement" | "open"> & {
+  children?: React.ReactNode
+  /**
+   * Called when
+   *  - clicking outside the popover
+   *  - pressing "Escape"
+   */
+  onClose: () => void
+  /**
+   * If true (default: `true`), traps focus.
+   *
+   * Note: "Escape" closes the popover.
+   */
+  modal?: boolean
+}
+const Popover: React.FC<PopoverProps> = ({
+  children,
+  onClose,
+  modal = true,
+  open,
+  ...props
+}) => {
+  const [arrowRef, setArrowRef] = React.useState<HTMLDivElement | null>(null)
+  const modifiers = getModifiers(arrowRef)
+  const content = (
+    <div tabIndex={-1}>
+      <ClickAwayListener onClickAway={onClose}>
+        <Content>
+          <Arrow ref={setArrowRef} className="MuiPopper-arrow" />
+          {children}
+        </Content>
+      </ClickAwayListener>
+    </div>
+  )
+  return (
+    <StyledPopper
+      open={open}
+      modifiers={modifiers}
+      disablePortal
+      transition
+      {...props}
+      {...(modal ? { role: "dialog" } : {})}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          onClose()
+        }
+      }}
+    >
+      {({ TransitionProps }) => (
+        <Fade {...TransitionProps} timeout={300}>
+          {modal ? (
+            <div>
+              <FocusTrap open={open}>{content}</FocusTrap>
+            </div>
+          ) : (
+            content
+          )}
+        </Fade>
+      )}
+    </StyledPopper>
+  )
+}
+
+export { Popover }
+export type { PopoverProps }

--- a/frontends/ol-components/src/components/Popover/Popover.tsx
+++ b/frontends/ol-components/src/components/Popover/Popover.tsx
@@ -6,6 +6,10 @@ import Fade from "@mui/material/Fade"
 import { FocusTrap } from "@mui/base/FocusTrap"
 import ClickAwayListener from "@mui/material/ClickAwayListener"
 
+/**
+ * Based on MUI demo:
+ * https://github.com/mui/material-ui/blob/d3ef60158ba066779102fba775dda6765e2cc0f5/docs/data/material/components/popper/ScrollPlayground.js#L175
+ */
 const StyledPopper = styled(MuiPopper)(({ theme }) => ({
   zIndex: 1,
   "& > div": {
@@ -95,6 +99,13 @@ const getModifiers = (
     name: "offset",
     options: {
       offset: [0, 10],
+    },
+  },
+  {
+    name: "preventOverflow",
+    enabled: true,
+    options: {
+      padding: 8,
     },
   },
 ]

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -179,6 +179,7 @@ export * from "./components/TruncateText/TruncateText"
 export * from "./components/ThemeProvider/ThemeProvider"
 export * from "./components/RadioChoiceField/RadioChoiceField"
 export * from "./components/ChoiceBox/ChoiceBox"
+export * from "./components/Popover/Popover"
 
 export * from "./constants/imgConfigs"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19079,6 +19079,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.0"
+    "@mui/base": "npm:5.0.0-beta.40"
     "@mui/icons-material": "npm:^5.15.15"
     "@mui/lab": "npm:^5.0.0-alpha.170"
     "@mui/material": "npm:^5.15.15"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4591

### Description (What does it do?)
Adds a signup popover to
- channel page "Subscribe" button
- Resource card "action" buttons [TODO]

### Screenshots (if appropriate):
<img width="1720" alt="Screenshot 2024-06-18 at 5 05 03 PM" src="https://github.com/mitodl/mit-open/assets/9010790/bec8b41a-228c-4c3c-b3ab-b6444d5c674d">
<img width="664" alt="Screenshot 2024-06-18 at 5 05 15 PM" src="https://github.com/mitodl/mit-open/assets/9010790/468b2209-03f3-481d-a8c9-823dd3c0db28">


<img width="1724" alt="Screenshot 2024-06-18 at 4 52 37 PM" src="https://github.com/mitodl/mit-open/assets/9010790/e08056c1-faab-4f78-aa65-b699cea4ff0d">
<img width="502" alt="Screenshot 2024-06-18 at 4 31 21 PM" src="https://github.com/mitodl/mit-open/assets/9010790/6390d783-780c-4ab7-ad33-e23d1175bafa">

<img width="1627" alt="Screenshot 2024-06-18 at 4 52 52 PM" src="https://github.com/mitodl/mit-open/assets/9010790/541e0175-f218-4e02-9989-7c21e79f9a0f">
<img width="578" alt="Screenshot 2024-06-18 at 4 53 51 PM" src="https://github.com/mitodl/mit-open/assets/9010790/a114fa6a-7e20-4c6c-97fd-fa2978c23437">


### How can this be tested?
1. Check Cards on homepage, search page, and channel pages:
    - Click the "Add to list" buttons as an authenticated user (staff or otherwise). There should be no changes:
        - Bookmark = "Add to user list"
        - Itemized list = "Add to learning path"
     - As an unauthenticated user, you should only see the bookmark button, and it should open a popover prompting signup.
2. Check "Subscribe" button on channel pages, e.g., http://localhost:8063/c/unit/ocw
     - authenticated users: Subscribe / unsubscribe functions as before
     - unauthenticated users get the popover for signup.
3. http://localhost:6006/?path=/story/smoot-design-popover--basic and the adjacent two popover stories are worht looking at i guess.
