### PR TITLE
Update the conditional for the marketing image chooser

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
@@ -211,7 +211,7 @@ const SlickCarousel = () => {
     do {
       const idx = Math.floor(Math.random() * 6) + 1
       imagePath = `/images/testimonial_images/testimonial-image-${idx}.png`
-    } while (lastMarketingImage !== imagePath)
+    } while (lastMarketingImage !== "" && lastMarketingImage !== imagePath)
 
     lastMarketingImage = imagePath
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4635

### Description (What does it do?)

The `generateMarketingImageSrc` uses a do..while to re-select a random marketing image if the image that we just displayed to the user is the one that gets selected again. This also needed to drop out of the loop if there wasn't a last marketing image, so now it does.

### How can this be tested?

Automated tests should pass. No real front-end change should be seen - the homepage should load and your testimonials images should be randomized and shouldn't repeat back-to-back (they will still repeat in the list as a whole). 
