### PR TITLE
Append `/static` to the front of the testimonial marketing card image

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
@@ -220,7 +220,7 @@ const SlickCarousel = () => {
             >
               <TestimonialCardImage>
                 <img
-                  src={`/images/testimonial_images/testimonial-image-${MARKETING_IMAGE_IDX[idx % 6]}.png`}
+                  src={`/static/images/testimonial_images/testimonial-image-${MARKETING_IMAGE_IDX[idx % 6]}.png`}
                 />
               </TestimonialCardImage>
               <TestimonialCardQuote>


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

The marketing images aren't showing on production - it turns out the image URLs need to be prepended with `/static` to work in the deployed environment. (This is not the case for local deployments [at the moment](https://github.com/mitodl/hq/issues/4602) so this wasn't caught in testing.) This just does that.

### How can this be tested?

View the homepage and verify the image URLs start with `/static` and that the images appear. (They should still appear - your local deployment should be able to serve the images up with or without the `/static`.) 
