### PR TITLE
Make resource.prices = most recent published run prices if there is no next run

### DIFF
--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -2,7 +2,6 @@
 
 from decimal import Decimal
 
-from django.contrib.admin.utils import flatten
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -256,18 +255,11 @@ class LearningResource(TimestampedModel):
             LearningResourceType.course.name,
             LearningResourceType.program.name,
         ]:
-            next_run = self.next_run
-            return (
-                next_run.prices
-                if next_run and next_run.prices
-                else sorted(
-                    set(
-                        flatten(
-                            [run.prices for run in self.runs.filter(published=True)]
-                        )
-                    )
-                )
+            next_run = (
+                self.next_run
+                or self.runs.filter(published=True).order_by("-start_date").first()
             )
+            return next_run.prices if next_run and next_run.prices else []
         else:
             return [Decimal(0.00)]
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -2,6 +2,7 @@
 
 from decimal import Decimal
 
+from django.contrib.admin.utils import flatten
 from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
@@ -256,7 +257,17 @@ class LearningResource(TimestampedModel):
             LearningResourceType.program.name,
         ]:
             next_run = self.next_run
-            return next_run.prices if next_run else []
+            return (
+                next_run.prices
+                if next_run and next_run.prices
+                else sorted(
+                    set(
+                        flatten(
+                            [run.prices for run in self.runs.filter(published=True)]
+                        )
+                    )
+                )
+            )
         else:
             return [Decimal(0.00)]
 

--- a/learning_resources/models_test.py
+++ b/learning_resources/models_test.py
@@ -1,10 +1,16 @@
 """Tests for learning_resources.models"""
 
+from datetime import timedelta
+from decimal import Decimal
+
 import pytest
+from django.contrib.admin.utils import flatten
+from django.db.models import F
 
 from learning_resources.constants import LearningResourceType
 from learning_resources.factories import (
     CourseFactory,
+    LearningResourceRunFactory,
     ProgramFactory,
 )
 
@@ -48,3 +54,31 @@ def test_course_creation():
     assert resource.offered_by is not None
     assert resource.runs.count() == course.runs.count()
     assert resource.prices == resource.next_run.prices
+
+
+def test_course_prices_current_no_next():
+    """Test that course.prices == published run prices if no next run"""
+    course = CourseFactory.create()
+    resource = course.learning_resource
+    resource.runs.update(start_date=F("start_date") - timedelta(days=3650))
+    unpub_run = LearningResourceRunFactory.create(
+        learning_resource=resource, published=False, prices=[Decimal("987654.32")]
+    )
+    resource.refresh_from_db()
+    assert resource.next_run is None
+    # Prices should be from any published run if no next run
+    assert resource.prices == sorted(
+        set(flatten([run.prices for run in resource.runs.filter(published=True)]))
+    )
+    assert len(resource.prices) > 0
+    assert unpub_run.prices[0] not in resource.prices
+
+
+def test_course_prices_unpublished_runs():
+    """Test that course.prices == [] if no published run"""
+    course = CourseFactory.create()
+    resource = course.learning_resource
+    resource.runs.update(published=False)
+    resource.refresh_from_db()
+    assert resource.next_run is None
+    assert resource.prices == []


### PR DESCRIPTION
### What are the relevant tickets?
Followup to https://github.com/mitodl/hq/issues/4585 and https://github.com/mitodl/mit-open/pull/1085

### Description (What does it do?)
If there is no next run, make `resource.prices` equal to the prices of the run with the most recent start date.


### How can this be tested?


### Additional Context
- Set required .env variables and run `./manage.py backpopulate_mitxonline_data`
- Go to http://localhost:8063/search/?offered_by=mitx&platform=mitxonline&q=%22Product+and+Service+Creation+in+the+Internet+Age%22
- You should see the course "Product and Service Creation in the Internet Age" listed there with a certificate price of $49



![Screenshot 2024-06-18 at 1 06 09 PM](https://github.com/mitodl/mit-open/assets/187676/73623334-678e-4913-9f51-83a55a085cc7)
