### PR TITLE
Shanbady/navigation UI fixes

### DIFF
--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -27,6 +27,7 @@ import { useUserMe } from "api/hooks/user"
 const Bar = styled(AppBar)(({ theme }) => ({
   height: "60px",
   padding: "0 8px",
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
   backgroundColor: theme.custom.colors.white,
   color: theme.custom.colors.darkGray1,
   display: "flex",

--- a/frontends/mit-open/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-open/src/page-components/Header/UserMenu.tsx
@@ -159,7 +159,6 @@ const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
           <FlexContainer className="login-button-desktop">
             <ButtonLink
               data-testid="login-button-desktop"
-              edge="circular"
               size="small"
               reloadDocument={true}
               href={loginUrl}

--- a/frontends/mit-open/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-open/src/page-components/Header/UserMenu.tsx
@@ -27,7 +27,7 @@ const UserMenuContainer = styled.button({
 })
 
 const LoginButtonContainer = styled(FlexContainer)(({ theme }) => ({
-  paddingRight: "32px",
+  paddingRight: "16px",
   "&:hover": {
     textDecoration: "none",
   },

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -182,6 +182,7 @@ const NavDrawer = (props: NavDrawerProps) => {
       hideBackdrop={true}
       PaperProps={{
         sx: {
+          borderRight: "none",
           boxShadow: "0px 6px 24px 0px rgba(37, 38, 43, 0.10)",
           zIndex: (theme) => theme.zIndex.appBar - 1,
           overscrollBehavior: "contain",


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4476

### Description (What does it do?)
- Removes double border from side nav
- adds bottom border to header nav
- fixes spacing between signin and search button
- removes border radius from sign in button

### Screenshots (if appropriate):
<img width="1466" alt="Screenshot 2024-06-18 at 2 43 38 PM" src="https://github.com/mitodl/mit-open/assets/196425/68f96759-113f-4ff9-a9ab-27ba9d97eb34">

### How can this be tested?
checkout this branch and validate the changes listed above look as they should

