### PR TITLE
switch default sort to use popular instead of created on

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["is_learning_material", "-created_on"]
+DEFAULT_SORT = ["is_learning_material", "-views"]
 
 
 def gen_content_file_id(content_file_id):

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1762,7 +1762,7 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, ["is_learning_material", {"created_on": {"order": "desc"}}]),
+        (None, None, ["is_learning_material", {"views": {"order": "desc"}}]),
         (None, "text", None),
     ],
 )


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Ferdi asked for the default sort to sort by popularity instead of new

So the sort is now by is_learning_material (false first) then popularity

### How can this be tested?
Go to http://localhost:8063/search verify that the sort order is the same as http://localhost:8063/search?sortby=-views with everything that isn't a course or program excluded 

If you search by text, the search should continue to be by relevance