### PR TITLE
Working search filter on topics with commas

### DIFF
--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
@@ -29,7 +29,12 @@ const FieldPage: React.FC = () => {
   if (fieldQuery.data?.search_filter) {
     const urlParams = new URLSearchParams(fieldQuery.data.search_filter)
     for (const [key, value] of urlParams.entries()) {
-      searchParams[key as FacetKey] = value.split(",")
+      const paramEntry = searchParams[key as FacetKey]
+      if (paramEntry !== undefined) {
+        paramEntry.push(value)
+      } else {
+        searchParams[key as FacetKey] = [value]
+      }
     }
   }
 

--- a/learning_resources/filters_test.py
+++ b/learning_resources/filters_test.py
@@ -94,10 +94,7 @@ def mock_content_files():
     return content_files
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["department={}&department={}", "department={},{}"]
-)
-def test_learning_resource_filter_department(mock_courses, client, multifilter):
+def test_learning_resource_filter_department(mock_courses, client):
     """Test that the department_id filter works"""
     ocw_department = mock_courses.ocw_course.departments.first()
     mitx_department = mock_courses.mitx_course.departments.first()
@@ -108,9 +105,7 @@ def test_learning_resource_filter_department(mock_courses, client, multifilter):
     assert len(results) == 1
     assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
 
-    dept_filter = multifilter.format(
-        ocw_department.department_id, mitx_department.department_id
-    )
+    dept_filter = f"department={ocw_department.department_id}&department={mitx_department.department_id}"
     results = client.get(f"{RESOURCE_API_URL}?{dept_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -118,10 +113,7 @@ def test_learning_resource_filter_department(mock_courses, client, multifilter):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["offered_by={}&offered_by={}", "offered_by={},{}"]
-)
-def test_learning_resource_filter_offered_by(mock_courses, client, multifilter):
+def test_learning_resource_filter_offered_by(mock_courses, client):
     """Test that the offered_by filter works"""
 
     ocw_offeror = mock_courses.ocw_course.offered_by
@@ -133,7 +125,7 @@ def test_learning_resource_filter_offered_by(mock_courses, client, multifilter):
     assert len(results) == 1
     assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
 
-    offered_filter = multifilter.format(ocw_offeror.code, mitx_offeror.code)
+    offered_filter = f"offered_by={ocw_offeror.code}&offered_by={mitx_offeror.code}"
     results = client.get(f"{RESOURCE_API_URL}?{offered_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -141,8 +133,7 @@ def test_learning_resource_filter_offered_by(mock_courses, client, multifilter):
     )
 
 
-@pytest.mark.parametrize("multifilter", ["platform={}&platform={}", "platform={},{}"])
-def test_learning_resource_filter_platform(mock_courses, client, multifilter):
+def test_learning_resource_filter_platform(mock_courses, client):
     """Test that the platform filter works"""
 
     ocw_platform = mock_courses.ocw_course.platform
@@ -154,7 +145,7 @@ def test_learning_resource_filter_platform(mock_courses, client, multifilter):
     assert len(results) == 1
     assert results[0]["readable_id"] == mock_courses.ocw_course.readable_id
 
-    platform_filter = multifilter.format(ocw_platform.code, mitx_platform.code)
+    platform_filter = f"platform={ocw_platform.code}&platform={mitx_platform.code}"
     results = client.get(f"{RESOURCE_API_URL}?{platform_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -202,10 +193,7 @@ def test_learning_resource_filter_certification(offers_certification, client):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["offered_by={}&offered_by={}", "offered_by={},{}"]
-)
-def test_learning_resource_filter_certification_type(mock_courses, client, multifilter):
+def test_learning_resource_filter_certification_type(mock_courses, client):
     """Test that the certification_type filter works"""
 
     assert mock_courses.mitpe_course.offered_by.professional is True
@@ -278,10 +266,7 @@ def test_learning_resource_filter_free(client):
         assert resource.id in [result["id"] for result in results]
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["resource_type={}&resource_type={}", "resource_type={},{}"]
-)
-def test_learning_resource_filter_resource_type(client, multifilter):
+def test_learning_resource_filter_resource_type(client):
     """Test that the resource type filter works"""
     ProgramFactory.create()
     podcast = PodcastFactory.create().learning_resource
@@ -293,9 +278,7 @@ def test_learning_resource_filter_resource_type(client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == podcast.id
 
-    resource_filter = multifilter.format(
-        LearningResourceType.podcast.name, LearningResourceType.learning_path.name
-    )
+    resource_filter = f"resource_type={LearningResourceType.podcast.name}&resource_type={LearningResourceType.learning_path.name}"
     results = client.get(f"{RESOURCE_API_URL}?{resource_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -413,8 +396,7 @@ def test_learning_resource_sortby_new(client):
     )
 
 
-@pytest.mark.parametrize("multifilter", ["topic={}&topic={}", "topic={},{}"])
-def test_learning_resource_filter_topics(mock_courses, client, multifilter):
+def test_learning_resource_filter_topics(mock_courses, client):
     """Test that the topic filter works"""
     assert (
         list(
@@ -430,10 +412,7 @@ def test_learning_resource_filter_topics(mock_courses, client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == mock_courses.mitx_course.id
 
-    topic_filter = multifilter.format(
-        mock_courses.mitx_course.topics.first().name.lower(),
-        mock_courses.ocw_course.topics.first().name.upper(),
-    )
+    topic_filter = f"topic={mock_courses.mitx_course.topics.first().name.lower()}&topic={mock_courses.ocw_course.topics.first().name.upper()}"
     results = client.get(f"{RESOURCE_API_URL}?{topic_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -441,10 +420,7 @@ def test_learning_resource_filter_topics(mock_courses, client, multifilter):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["course_feature={}&course_feature={}", "course_feature={},{}"]
-)
-def test_learning_resource_filter_course_features(client, multifilter):
+def test_learning_resource_filter_course_features(client):
     """Test that the resource_content_tag filter works"""
 
     resource_with_exams = LearningResourceFactory.create(
@@ -463,7 +439,9 @@ def test_learning_resource_filter_course_features(client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == resource_with_exams.id
 
-    feature_filter = multifilter.format("EXAMS", "lEcture nOtes")
+    feature_filter = "course_feature={}&course_feature={}".format(
+        "EXAMS", "lEcture nOtes"
+    )
     results = client.get(f"{RESOURCE_API_URL}?{feature_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -471,15 +449,7 @@ def test_learning_resource_filter_course_features(client, multifilter):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter",
-    [
-        "level=high_school&level=graduate",
-        "level=high_school,graduate",
-        "level=high_school,graduate&level=graduate",
-    ],
-)
-def test_learning_resource_filter_level(client, multifilter):
+def test_learning_resource_filter_level(client):
     """Test that the level filter works"""
 
     hs_run = LearningResourceRunFactory.create(
@@ -502,14 +472,13 @@ def test_learning_resource_filter_level(client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == grad_run.learning_resource.id
 
-    results = client.get(f"{RESOURCE_API_URL}?{multifilter}").json()["results"]
+    results = client.get(f"{RESOURCE_API_URL}?level=high_school&level=graduate").json()[
+        "results"
+    ]
     assert len(results) == 2
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["learning_format={}&learning_format={}", "learning_format={},{}"]
-)
-def test_learning_resource_filter_formats(mock_courses, client, multifilter):
+def test_learning_resource_filter_formats(mock_courses, client):
     """Test that the learning_format filter works"""
     LearningResource.objects.filter(id=mock_courses.ocw_course.id).update(
         learning_format=[LearningResourceFormat.online.name]
@@ -533,9 +502,7 @@ def test_learning_resource_filter_formats(mock_courses, client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == mock_courses.mitpe_course.id
 
-    multiformats_filter = multifilter.format(
-        LearningResourceFormat.in_person.name, LearningResourceFormat.hybrid.name
-    )
+    multiformats_filter = f"learning_format={LearningResourceFormat.in_person.name}&learning_format={LearningResourceFormat.hybrid.name}"
     results = client.get(f"{RESOURCE_API_URL}?{multiformats_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["readable_id"] for result in results]) == sorted(
@@ -543,8 +510,7 @@ def test_learning_resource_filter_formats(mock_courses, client, multifilter):
     )
 
 
-@pytest.mark.parametrize("multifilter", ["run_id={}&run_id={}", "run_id={},{}"])
-def test_content_file_filter_run_id(mock_content_files, client, multifilter):
+def test_content_file_filter_run_id(mock_content_files, client):
     """Test that the run_id filter works for contentfiles"""
 
     results = client.get(
@@ -553,8 +519,8 @@ def test_content_file_filter_run_id(mock_content_files, client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == mock_content_files[1].id
 
-    feature_filter = multifilter.format(
-        mock_content_files[0].run.id, mock_content_files[1].run.id
+    feature_filter = (
+        f"run_id={mock_content_files[0].run.id}&run_id={mock_content_files[1].run.id}"
     )
     results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
     assert len(results) == 2
@@ -563,10 +529,7 @@ def test_content_file_filter_run_id(mock_content_files, client, multifilter):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["resource_id={}&resource_id={}", "resource_id={},{}"]
-)
-def test_content_file_filter_resource_id(mock_content_files, client, multifilter):
+def test_content_file_filter_resource_id(mock_content_files, client):
     """Test that the resource_id filter works for contentfiles"""
 
     results = client.get(
@@ -577,10 +540,7 @@ def test_content_file_filter_resource_id(mock_content_files, client, multifilter
         int(results[0]["resource_id"]) == mock_content_files[1].run.learning_resource.id
     )
 
-    feature_filter = multifilter.format(
-        mock_content_files[0].run.learning_resource.id,
-        mock_content_files[1].run.learning_resource.id,
-    )
+    feature_filter = f"resource_id={mock_content_files[0].run.learning_resource.id}&resource_id={mock_content_files[1].run.learning_resource.id}"
     results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([int(result["resource_id"]) for result in results]) == sorted(
@@ -591,8 +551,7 @@ def test_content_file_filter_resource_id(mock_content_files, client, multifilter
     )
 
 
-@pytest.mark.parametrize("multifilter", ["platform={}&platform={}", "platform={},{}"])
-def test_content_file_filter_platform(mock_content_files, client, multifilter):
+def test_content_file_filter_platform(mock_content_files, client):
     """Test that the platform filter works"""
 
     results = client.get(
@@ -601,10 +560,7 @@ def test_content_file_filter_platform(mock_content_files, client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == mock_content_files[1].id
 
-    platform_filter = multifilter.format(
-        mock_content_files[1].run.learning_resource.platform.code,
-        mock_content_files[0].run.learning_resource.platform.code,
-    )
+    platform_filter = f"platform={mock_content_files[1].run.learning_resource.platform.code}&platform={mock_content_files[0].run.learning_resource.platform.code}"
     results = client.get(f"{CONTENT_API_URL}?{platform_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["id"] for result in results]) == sorted(
@@ -612,10 +568,7 @@ def test_content_file_filter_platform(mock_content_files, client, multifilter):
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter", ["offered_by={}&offered_by={}", "offered_by={},{}"]
-)
-def test_content_file_filter_offered_by(mock_content_files, client, multifilter):
+def test_content_file_filter_offered_by(mock_content_files, client):
     """Test that the offered_by filter works for contentfiles"""
 
     results = client.get(
@@ -624,10 +577,7 @@ def test_content_file_filter_offered_by(mock_content_files, client, multifilter)
     assert len(results) == 1
     assert results[0]["id"] == mock_content_files[1].id
 
-    offered_filter = multifilter.format(
-        mock_content_files[1].run.learning_resource.offered_by.code,
-        mock_content_files[0].run.learning_resource.offered_by.code,
-    )
+    offered_filter = f"offered_by={mock_content_files[1].run.learning_resource.offered_by.code}&offered_by={mock_content_files[0].run.learning_resource.offered_by.code}"
     results = client.get(f"{CONTENT_API_URL}?{offered_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["id"] for result in results]) == sorted(
@@ -635,11 +585,7 @@ def test_content_file_filter_offered_by(mock_content_files, client, multifilter)
     )
 
 
-@pytest.mark.parametrize(
-    "multifilter",
-    ["content_feature_type={}&content_feature_type={}", "content_feature_type={},{}"],
-)
-def test_learning_resource_filter_content_feature_type(client, multifilter):
+def test_learning_resource_filter_content_feature_type(client):
     """Test that the resource_content_tag filter works"""
 
     cf_with_exams = ContentFileFactory.create(
@@ -660,7 +606,9 @@ def test_learning_resource_filter_content_feature_type(client, multifilter):
     assert len(results) == 1
     assert results[0]["id"] == cf_with_exams.id
 
-    feature_filter = multifilter.format("EXAMS", "lEcture nOtes")
+    feature_filter = "content_feature_type={}&content_feature_type={}".format(
+        "EXAMS", "lEcture nOtes"
+    )
     results = client.get(f"{CONTENT_API_URL}?{feature_filter}").json()["results"]
     assert len(results) == 2
     assert sorted([result["id"] for result in results]) == sorted(

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -117,20 +117,6 @@ def extract_values(obj, key):
     return extract(obj, array, key)
 
 
-class StringArrayField(serializers.ListField):
-    """
-    Character separated ListField.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def to_internal_value(self, data):
-        normalized = ",".join(data).split(",")
-
-        return super().to_internal_value(normalized)
-
-
 class ArrayWrappedBoolean(serializers.BooleanField):
     """
     Wrapper that wraps booleans in arrays so they have the same format as
@@ -194,7 +180,7 @@ class SearchRequestSerializer(serializers.Serializer):
         required=False, help_text="Number of results to return per page"
     )
     offered_by_choices = [(e.name.lower(), e.value) for e in OfferedBy]
-    offered_by = StringArrayField(
+    offered_by = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(choices=offered_by_choices),
         help_text=(
@@ -203,7 +189,7 @@ class SearchRequestSerializer(serializers.Serializer):
         ),
     )
     platform_choices = [(e.name.lower(), e.value) for e in PlatformType]
-    platform = StringArrayField(
+    platform = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(choices=platform_choices),
         help_text=(
@@ -211,7 +197,7 @@ class SearchRequestSerializer(serializers.Serializer):
             \n\n{build_choice_description_list(platform_choices)}"
         ),
     )
-    topic = StringArrayField(
+    topic = serializers.ListField(
         required=False,
         child=serializers.CharField(),
         help_text="The topic name. To see a list of options go to api/v1/topics/",
@@ -226,7 +212,7 @@ class SearchRequestSerializer(serializers.Serializer):
 
 
 class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
-    id = StringArrayField(
+    id = serializers.ListField(
         required=False,
         child=serializers.IntegerField(),
         help_text="The id value for the learning resource",
@@ -240,7 +226,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         help_text="If the parameter starts with '-' the sort is in descending order",
     )
     resource_choices = [(e.name, e.value.lower()) for e in LearningResourceType]
-    resource_type = StringArrayField(
+    resource_type = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(
             choices=resource_choices,
@@ -274,7 +260,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         "video playlist, or learning path",
     )
     certification_choices = CertificationType.as_tuple()
-    certification_type = StringArrayField(
+    certification_type = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(
             choices=certification_choices,
@@ -285,7 +271,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         ),
     )
     department_choices = list(DEPARTMENTS.items())
-    department = StringArrayField(
+    department = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(choices=department_choices),
         help_text=(
@@ -294,23 +280,23 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         ),
     )
 
-    level = StringArrayField(
+    level = serializers.ListField(
         required=False, child=serializers.ChoiceField(choices=LevelType.as_list())
     )
 
-    course_feature = StringArrayField(
+    course_feature = serializers.ListField(
         required=False,
         child=serializers.CharField(),
         help_text="The course feature. "
         "Possible options are at api/v1/course_features/",
     )
-    aggregations = StringArrayField(
+    aggregations = serializers.ListField(
         required=False,
         help_text="Show resource counts by category",
         child=serializers.ChoiceField(choices=LEARNING_RESOURCE_AGGREGATIONS),
     )
     learning_format_choices = LearningResourceFormat.as_list()
-    learning_format = StringArrayField(
+    learning_format = serializers.ListField(
         required=False,
         child=serializers.ChoiceField(choices=learning_format_choices),
         help_text=(
@@ -321,7 +307,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
 
 
 class ContentFileSearchRequestSerializer(SearchRequestSerializer):
-    id = StringArrayField(
+    id = serializers.ListField(
         required=False,
         child=serializers.IntegerField(),
         help_text="The id value for the content file",
@@ -331,23 +317,23 @@ class ContentFileSearchRequestSerializer(SearchRequestSerializer):
         choices=CONTENT_FILE_SORTBY_OPTIONS,
         help_text="if the parameter starts with '-' the sort is in descending order",
     )
-    content_feature_type = StringArrayField(
+    content_feature_type = serializers.ListField(
         required=False,
         child=serializers.CharField(),
         help_text="The feature type of the content file. "
         "Possible options are at api/v1/course_features/",
     )
-    aggregations = StringArrayField(
+    aggregations = serializers.ListField(
         required=False,
         help_text="Show resource counts by category",
         child=serializers.ChoiceField(choices=CONTENT_FILE_AGGREGATIONS),
     )
-    run_id = StringArrayField(
+    run_id = serializers.ListField(
         required=False,
         child=serializers.IntegerField(),
         help_text="The id value of the run that the content file belongs to",
     )
-    resource_id = StringArrayField(
+    resource_id = serializers.ListField(
         required=False,
         child=serializers.IntegerField(),
         help_text="The id value of the parent learning resource for the content file",

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 import factory
 import pytest
 from django.db.models import signals
-from django.http import QueryDict
 from django.urls import reverse
 from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
@@ -713,20 +712,20 @@ def test_learning_resources_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
-        "id": "1",
+        "id": ["1"],
         "sortby": "-start_date",
         "professional": "true",
         "certification": "false",
-        "certification_type": CertificationType.none.name,
+        "certification_type": [CertificationType.none.name],
         "free": True,
         "is_learning_material": True,
-        "offered_by": "xpro,ocw",
-        "platform": "xpro,edx,ocw",
-        "topic": "Math",
-        "department": "18,5",
-        "level": "high_school,undergraduate",
-        "course_feature": "Lecture Videos",
-        "aggregations": "resource_type,platform,level",
+        "topic": ["Math", "Atoms,Molecules,and Ions"],
+        "offered_by": ["xpro", "ocw"],
+        "platform": ["xpro", "edx", "ocw"],
+        "department": ["18", "5"],
+        "level": ["high_school", "undergraduate"],
+        "course_feature": ["Lecture Videos"],
+        "aggregations": ["resource_type", "platform", "level"],
     }
 
     cleaned = {
@@ -742,18 +741,15 @@ def test_learning_resources_search_request_serializer():
         "free": [True],
         "offered_by": ["xpro", "ocw"],
         "platform": ["xpro", "edx", "ocw"],
-        "topic": ["Math"],
+        "topic": ["Math", "Atoms,Molecules,and Ions"],
         "department": ["18", "5"],
         "level": ["high_school", "undergraduate"],
         "course_feature": ["Lecture Videos"],
         "aggregations": ["resource_type", "platform", "level"],
     }
 
-    request_data = QueryDict("", mutable=True)
-    request_data.update(data)
-
-    serialized = LearningResourcesSearchRequestSerializer(data=request_data)
-    assert serialized.is_valid() is True
+    serialized = LearningResourcesSearchRequestSerializer(data=data)
+    assert serialized.is_valid()
     assert serialized.data == cleaned
 
 
@@ -762,15 +758,15 @@ def test_content_file_search_request_serializer():
         "q": "text",
         "offset": 1,
         "limit": 1,
-        "id": "1",
+        "id": ["1"],
         "sortby": "-id",
-        "topic": "Math",
-        "aggregations": "topic",
-        "content_feature_type": "Assignment",
-        "run_id": "1,2",
-        "resource_id": "1,2,3",
-        "offered_by": "xpro,ocw",
-        "platform": "xpro,edx,ocw",
+        "topic": ["Math"],
+        "aggregations": ["topic"],
+        "content_feature_type": ["Assignment"],
+        "run_id": ["1", "2"],
+        "resource_id": ["1", "2", "3"],
+        "offered_by": ["xpro", "ocw"],
+        "platform": ["xpro", "edx", "ocw"],
     }
 
     cleaned = {
@@ -788,10 +784,7 @@ def test_content_file_search_request_serializer():
         "platform": ["xpro", "edx", "ocw"],
     }
 
-    request_data = QueryDict("", mutable=True)
-    request_data.update(data)
-
-    serialized = ContentFileSearchRequestSerializer(data=request_data)
+    serialized = ContentFileSearchRequestSerializer(data=data)
     assert serialized.is_valid() is True
     assert serialized.data == cleaned
 
@@ -799,10 +792,10 @@ def test_content_file_search_request_serializer():
 @pytest.mark.parametrize(
     ("parameter", "value"),
     [
-        ("resource_type", "course,program,spaceship"),
-        ("platform", "xpro,spaceship"),
-        ("offered_by", "spaceship"),
-        ("aggregations", "spaceship"),
+        ("resource_type", ["course", "program", "spaceship"]),
+        ("platform", ["xpro", "spaceship"]),
+        ("offered_by", ["spaceship"]),
+        ("aggregations", ["spaceship"]),
     ],
 )
 def test_learning_resources_search_request_serializer_invalid(parameter, value):
@@ -810,10 +803,7 @@ def test_learning_resources_search_request_serializer_invalid(parameter, value):
         parameter: value,
     }
 
-    request_data = QueryDict("", mutable=True)
-    request_data.update(data)
-
-    serialized = LearningResourcesSearchRequestSerializer(data=request_data)
+    serialized = LearningResourcesSearchRequestSerializer(data=data)
     assert serialized.is_valid() is False
     assert list(serialized.errors[parameter].values()) == [
         ['"spaceship" is not a valid choice.']


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4013

### Description (What does it do?)
- Converts `LearningResourcesSearchRequestSerializer` fields from a `StringArray` to a standard `ListField`
- Makes changes to db rest api's to handle query parameter values containing commas.
- Removes ability to have comma-delimited query parameter values (like `?topic=Biology,Chemistry`; must be `?topic=Biology&topic=Chemistry`)

### How can this be tested?

#### Backend
The following should work and return results (if you have imported OCW courses):
http://localhost:8063/search/?topic=Atomic,%20Molecular,%20Optical%20Physics
http://localhost:8063/search/?topic=Atomic%2C+Molecular%2C+Optical+Physics&topic=Epidemiology
http://localhost:8063/api/v1/courses/?topic=Atomic,%20Molecular,%20Optical%20Physics
http://localhost:8063/api/v1/courses/?topic=Atomic%2C+Molecular%2C+Optical+Physics&topic=Epidemiology

#### Frontend
The following page should work and return search results (assuming you've run the mgmt command `backpopulate_resource_channels --all`:  http://localhost:8063/c/topic/atomic-molecular-optical-physics/


Update a channel with a search filter containing multiple values for certain facets:
```python
from channels.models import FieldChannel
FieldChannel.objects.filter(unit_detail__unit__code="ocw").update(
  search_filter="offered_by=ocw&topic=Biology&topic=Physics&department=7&department=8"
)
```
Go to http://localhost:8063/c/unit/ocw and make sure the search request returns results using the same topic and department parameters as above.