### PR TITLE
show podcast_episode in media carousel all

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/carousels.ts
+++ b/frontends/mit-open/src/pages/HomePage/carousels.ts
@@ -50,7 +50,7 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
     cardProps: { size: "small" },
     data: {
       type: "resources",
-      params: { resource_type: ["video", "podcast"], limit: 12 },
+      params: { resource_type: ["video", "podcast_episode"], limit: 12 },
     },
   },
   {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4648

### Description (What does it do?)
Updates the media carousel to show Podcast episodes in "All" tab.

### How can this be tested?
1. Visit the homepage. View Media Carousel. It should show podcast episodes in the "All" tab.
    - Click one of them... you should see duration in the drawer. Also can inspect network tab.
