### PR TITLE
Add search box to field pages

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -475,6 +475,7 @@ interface SearchDisplayProps {
   clearAllFacets: UseResourceSearchParamsResult["clearAllFacets"]
   toggleParamValue: UseResourceSearchParamsResult["toggleParamValue"]
   patchParams: UseResourceSearchParamsResult["patchParams"]
+  showProfessionalToggle?: boolean
 }
 
 const SearchDisplay: React.FC<SearchDisplayProps> = ({
@@ -489,6 +490,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   clearAllFacets,
   toggleParamValue,
   patchParams,
+  showProfessionalToggle,
 }) => {
   const allParams = useMemo(() => {
     return { ...constantSearchParams, ...requestParams }
@@ -512,10 +514,12 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   const filterContents = (
     <>
       <FacetStyles>
-        <ProfessionalToggle
-          professionalSetting={requestParams.professional}
-          setParamValue={setParamValue}
-        ></ProfessionalToggle>
+        {showProfessionalToggle && (
+          <ProfessionalToggle
+            professionalSetting={requestParams.professional}
+            setParamValue={setParamValue}
+          ></ProfessionalToggle>
+        )}
         <AvailableFacets
           facetManifest={facetManifest}
           activeFacets={requestParams}

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchInput.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchInput.tsx
@@ -26,7 +26,7 @@ const StyledInput = styled(Input)`
   border-radius: 0;
   border-top-left-radius: 8px;
   border-bottom-left-radius: 8px;
-  max-width: 81%;
+  width: 556px;
   border-right: none;
   height: 48px;
 
@@ -39,6 +39,7 @@ const StyledInput = styled(Input)`
     height: 37px;
     border-top-left-radius: 4px;
     border-bottom-left-radius: 4px;
+    width: 80%;
   }
 `
 
@@ -85,6 +86,8 @@ type SearchSubmitHandler = (event: SearchSubmissionEvent) => void
 
 interface SearchInputProps {
   className?: string
+  classNameInput?: string
+
   classNameClear?: string
   classNameSearch?: string
   value: string
@@ -118,13 +121,13 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
     )
 
   return (
-    <StyledFormGroup row>
+    <StyledFormGroup className={props.className} row>
       <StyledInput
         fullWidth={props.fullWidth}
         size={props.size}
         inputProps={muiInputProps}
         autoFocus={props.autoFocus}
-        className={props.className}
+        className={props.classNameInput}
         placeholder={props.placeholder}
         value={props.value}
         onChange={props.onChange}

--- a/frontends/mit-open/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
+++ b/frontends/mit-open/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
@@ -21,6 +21,10 @@ const QuoteContainer = styled.section(({ theme }) => ({
   color: theme.custom.colors.white,
   overflow: "auto",
   padding: "16px 0 24px 0",
+  marginBottom: "80px",
+  [theme.breakpoints.down("md")]: {
+    marginBottom: "40px",
+  },
 }))
 
 const QuoteBlock = styled.div(() => ({

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.tsx
@@ -10,6 +10,11 @@ import type {
 } from "@mitodl/course-search-utils"
 import { ChannelTypeEnum } from "api/v0"
 import TestimonialDisplay from "@/page-components/TestimonialDisplay/TestimonialDisplay"
+import { styled } from "ol-components"
+
+export const StyledTestimonialDisplay = styled(TestimonialDisplay)`
+  margin-bottom: 80px;
+`
 
 type RouteParams = {
   channelType: ChannelTypeEnum
@@ -34,7 +39,7 @@ const FieldPage: React.FC = () => {
       <FieldPageSkeleton name={name} channelType={channelType}>
         <p>{fieldQuery.data?.public_description}</p>
         {channelType === "unit" ? (
-          <TestimonialDisplay offerors={[name]} />
+          <StyledTestimonialDisplay offerors={[name]} />
         ) : null}
         {fieldQuery.data?.search_filter && (
           <FieldSearch

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -37,7 +37,7 @@ export const FieldTitleRow = styled.div`
 const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
   margin: "80px 0",
   [theme.breakpoints.down("sm")]: {
-    marginTop: "0px",
+    marginTop: "32px",
     marginBottom: "32px",
   },
 }))

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -179,7 +179,13 @@ describe("FieldSearch", () => {
   test.each([
     {
       fieldType: ChannelTypeEnum.Topic,
-      displayedFacets: ["Certificate", "Offered By", "Department", "Format"],
+      displayedFacets: [
+        "Professional",
+        "Certificate",
+        "Offered By",
+        "Department",
+        "Format",
+      ],
     },
     {
       fieldType: ChannelTypeEnum.Department,
@@ -231,6 +237,7 @@ describe("FieldSearch", () => {
       const facetsContainer = screen.getByTestId("facets-container")
 
       for (const facetName of [
+        "Professional",
         "Certificate",
         "Department",
         "Offered By",

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -48,8 +48,10 @@ const BackgroundImage = styled.img`
 `
 
 const SearchField = styled(SearchInput)`
-  background-color: ${({ theme }) => theme.custom.colors.white};
-  width: 100%;
+  ${({ theme }) => theme.breakpoints.up("md")} {
+    width: 680px;
+    min-width: 680px;
+  }
 `
 
 export const getFacetManifest = (
@@ -178,7 +180,7 @@ const SearchPage: React.FC = () => {
         <BackgroundImage src="/static/images/search_page_vector.png" />
         <Container>
           <GridContainer>
-            <GridColumn variant="sidebar-2-wide-main"></GridColumn>
+            <GridColumn variant="sidebar-2"></GridColumn>
             <Grid item xs={12} md={6} container alignItems="center">
               <SearchField
                 value={currentText}
@@ -207,6 +209,7 @@ const SearchPage: React.FC = () => {
         clearAllFacets={clearAllFacets}
         toggleParamValue={toggleParamValue}
         patchParams={patchParams}
+        showProfessionalToggle
       />
     </>
   )


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4552

### Description (What does it do?)
This PR 
1) Adds a search box to all channel pages
2) Hides the professional toggle for unit channels (but not other channels)
3) Switches the order of certificate and topics for unit channels (but not other channels)
4) Does some styling updates for the search and channel pages

### Screenshots (if appropriate):
<img width="1728" alt="Screenshot 2024-06-20 at 12 26 06 PM" src="https://github.com/mitodl/mit-open/assets/1934992/3d0fc83d-6166-407d-9982-7282d7516936">

<br>
<img width="377" alt="Screenshot 2024-06-20 at 12 26 24 PM" src="https://github.com/mitodl/mit-open/assets/1934992/c48b5f77-824a-401f-8604-92acff1d7b25">


<br>

<img width="377" alt="Screenshot 2024-06-20 at 12 26 32 PM" src="https://github.com/mitodl/mit-open/assets/1934992/88ed9ea5-ef98-4c3a-98d3-7eec135f5e13">

<br>
<img width="1727" alt="Screenshot 2024-06-20 at 12 51 08 PM" src="https://github.com/mitodl/mit-open/assets/1934992/bb74b48f-1117-4681-9e62-29d5ef8bcc77">

<br>
<img width="377" alt="Screenshot 2024-06-20 at 12 27 11 PM" src="https://github.com/mitodl/mit-open/assets/1934992/0c7cd36d-16ec-4f63-a3ae-87414ba6b1d0">
<br>
<img width="378" alt="Screenshot 2024-06-20 at 12 27 20 PM" src="https://github.com/mitodl/mit-open/assets/1934992/50c166c5-a926-4a89-a10a-4e4e1bb1c645">

### How can this be tested?
Go to http://localhost:8063/c/unit/xpro,  http://localhost:8063/c/department/biology and verify that the pages look good and like the designs
https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=3774-69019&m=dev

The designs for the mobile view on figma are not up to date, so i did my best. 

Go to http://localhost:8063/search and verify that there hasn't been a regression