### PR TITLE
removing check for live attribute

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -227,7 +227,6 @@ def _transform_course(course):
         "published": bool(
             parse_page_attribute(course, "page_url")
             and parse_page_attribute(course, "live")
-            and course.get("live", False)
         ),  # a course is only considered published if it has a page url
         "professional": False,
         "certification": has_certification,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/mit-open/issues/1127

### Description (What does it do?)
Fixes the "published" attribute for courses that are pulled in when running ``` python manage.py backpopulate_mitxonline_data```


### How can this be tested?
1. checkout this branch
2. restart celery ```docker compose restart celery```
3. run ``` python manage.py backpopulate_mitxonline_data```
4. check to see that mitxonline courses that are live show up as published.  http://od.odl.local:8063/admin/learning_resources/learningresource/?q=course-v1%3AMITxT%2B15.356.1x 
5. try deleting the course and re-running the backpopulate command and see that it works the same
