### PR TITLE
fixing sort method for panel detail display

### DIFF
--- a/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.test.tsx
+++ b/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.test.tsx
@@ -40,4 +40,28 @@ describe("ChannelDetails", () => {
     screen.getByText(certifications.join(" | "))
     screen.getByText(contentTypes.join(" | "))
   })
+
+  it("Sorts displayed items correctly", async () => {
+    const field = factory.field({
+      title: "Test Title",
+      channel_type: "unit",
+    })
+    setMockResponse.get(
+      urls.fields.details(field.channel_type, field.name),
+      field,
+    )
+    render(
+      <BrowserRouter>
+        <ChannelDetails field={field} />
+      </BrowserRouter>,
+      { wrapper: ThemeProvider },
+    )
+
+    expect(screen.getByTestId("unit-details").firstChild).toHaveTextContent(
+      "Offerings",
+    )
+    expect(screen.getByTestId("unit-details").lastChild).toHaveTextContent(
+      "More Information",
+    )
+  })
 })

--- a/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
+++ b/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
@@ -63,7 +63,7 @@ const getFacetManifest = (channelType: ChannelTypeEnum) => {
     {
       name: "department",
       title: "Department",
-      order: 0,
+      order: -2,
     },
     {
       name: "offerings",
@@ -169,7 +169,7 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
     .sort((a, b) => {
       if (!("order" in a)) return 1
       if (!("order" in b)) return -1
-      return a.order - b.order
+      return a?.order - b?.order
     })
     .map((value) => {
       const detailValue = (

--- a/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
+++ b/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
@@ -166,13 +166,11 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
   )
 
   const body = facetManifest
-    .sort((a, b) =>
-      a?.order && b?.order && a?.order > b?.order
-        ? 1
-        : a?.order && b?.order && b?.order > a?.order
-          ? -1
-          : 0,
-    )
+    .sort((a, b) => {
+      if (!("order" in a)) return 1
+      if (!("order" in b)) return -1
+      return a.order - b.order
+    })
     .map((value) => {
       const detailValue = (
         channelDetails as unknown as { [key: string]: string }
@@ -198,7 +196,9 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
       }
       return null
     })
-  return <ChannelDetailsCard>{body}</ChannelDetailsCard>
+  return (
+    <ChannelDetailsCard data-testid="unit-details">{body}</ChannelDetailsCard>
+  )
 }
 
 export { ChannelDetails }

--- a/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
+++ b/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
@@ -169,7 +169,7 @@ const ChannelDetails: React.FC<ChannelDetailsProps> = (props) => {
     .sort((a, b) => {
       if (!("order" in a)) return 1
       if (!("order" in b)) return -1
-      return a?.order - b?.order
+      return (a?.order || 0) - (b?.order || 0)
     })
     .map((value) => {
       const detailValue = (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/4665
<!--- N/A --->

### Description (What does it do?)
This fixes the sorting of information displayed in the info panel on unit pages (https://mitopen-rc.odl.mit.edu/c/unit/mitx/)

In particular - Offerings should always be first and more information should be last.



### How can this be tested?
1. Checkout this branch
2. visit a unit page /c/unit/mitx/ etc.
3. see that offerings is always first and more information (if displayed) should always show up last

How this should behave is that everything should be sorted in natural order - we specify an 'order' of -1 for offerings which is followed by everything else which is 0 and then more information should always be last since it is >0. You can try playing with [the order parameter](https://github.com/mitodl/mit-open/blob/fdaa66a2bd46c0a49245ed424b3d07744864063e/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx#L106) and verify it behaves as we expect

