### PR TITLE
Search facet checkbox and label styles

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -214,16 +214,14 @@ export const FacetStyles = styled.div`
       .facet-count {
         font-size: 12px;
         padding-left: 3px;
-        color: ${({ theme }) => theme.custom.colors.silverGray};
+        color: ${({ theme }) => theme.custom.colors.silverGrayDark};
         float: right;
       }
     }
 
-    .facet-visible.checked,
-    .facet-visible:hover {
-      .facet-label label {
-        color: ${({ theme }) => theme.custom.colors.darkGray2};
-      }
+    .facet-visible.checked .facet-label label,
+    .facet-visible .facet-label label:hover {
+      color: ${({ theme }) => theme.custom.colors.darkGray2};
     }
 
     .facet-more-less {

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -155,13 +155,6 @@ export const FacetStyles = styled.div`
     }
   }
 
-  .facet-visible.checked,
-  .facet-visible:hover {
-    .facet-label label {
-      color: ${({ theme }) => theme.custom.colors.darkGray2};
-    }
-  }
-
   .facet-visible {
     margin-top: 4.5px;
     margin-bottom: 4.5px;
@@ -226,6 +219,13 @@ export const FacetStyles = styled.div`
       }
     }
 
+    .facet-visible.checked,
+    .facet-visible:hover {
+      .facet-label label {
+        color: ${({ theme }) => theme.custom.colors.darkGray2};
+      }
+    }
+
     .facet-more-less {
       cursor: pointer;
       color: ${({ theme }) => theme.palette.text.secondary};
@@ -282,6 +282,7 @@ export const FacetStyles = styled.div`
     padding-bottom: 12px;
     padding-top: 10px;
 
+    /* stylelint-disable no-descending-specificity */
     .facet-visible {
       .facet-label {
         label,
@@ -292,6 +293,7 @@ export const FacetStyles = styled.div`
 
       margin-bottom: 0;
     }
+    /* stylelint-enable no-descending-specificity */
   }
 `
 

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -147,10 +147,18 @@ export const FacetStyles = styled.div`
     display: flex;
     flex-direction: row;
     width: 100%;
+    align-items: baseline;
 
     label {
       ${truncateText(1)};
-      color: ${({ theme }) => theme.custom.colors.silverGray};
+      color: ${({ theme }) => theme.custom.colors.silverGrayDark};
+    }
+  }
+
+  .facet-visible.checked,
+  .facet-visible:hover {
+    .facet-label label {
+      color: ${({ theme }) => theme.custom.colors.darkGray2};
     }
   }
 
@@ -184,6 +192,7 @@ export const FacetStyles = styled.div`
       align-items: center;
       height: 25px;
       font-size: 0.875em;
+      gap: 4px;
 
       input,
       label {
@@ -191,22 +200,22 @@ export const FacetStyles = styled.div`
       }
 
       input[type="checkbox"] {
-        appearance: none;
-        display: flex;
-        place-content: center;
-        font-size: 2rem;
-        padding: 0.1rem;
-        border: 1px solid ${({ theme }) => theme.custom.colors.silverGrayLight};
-        border-radius: 4px;
-        margin-left: 4px;
-        margin-right: 10px;
-        accent-color: ${({ theme }) => theme.custom.colors.silverGrayLight};
-        height: 20px;
+        margin-left: 0;
+        margin-right: 2px;
+        height: 24px;
         width: 24px;
+        appearance: none;
+        background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 0H17C17.5523 0 18 0.44772 18 1V17C18 17.5523 17.5523 18 17 18H1C0.44772 18 0 17.5523 0 17V1C0 0.44772 0.44772 0 1 0ZM2 2V16H16V2H2Z' fill='%23B8C2CC'/%3E%3C/svg%3E%0A");
+        background-repeat: no-repeat;
+        background-position: 3px 3px;
+      }
+
+      input[type="checkbox"]:hover {
+        background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 0H17C17.5523 0 18 0.44772 18 1V17C18 17.5523 17.5523 18 17 18H1C0.44772 18 0 17.5523 0 17V1C0 0.44772 0.44772 0 1 0ZM2 2V16H16V2H2Z' fill='%23626A73'/%3E%3C/svg%3E%0A");
       }
 
       input[type="checkbox"]:checked {
-        appearance: auto;
+        background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 0H17C17.5523 0 18 0.44772 18 1V17C18 17.5523 17.5523 18 17 18H1C0.44772 18 0 17.5523 0 17V1C0 0.44772 0.44772 0 1 0ZM8.0026 13L15.0737 5.92893L13.6595 4.51472L8.0026 10.1716L5.17421 7.3431L3.75999 8.7574L8.0026 13Z' fill='%23A31F34'/%3E%3C/svg%3E%0A");
       }
 
       .facet-count {

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -287,7 +287,7 @@ export const FacetStyles = styled.div`
       .facet-label {
         label,
         .facet-count {
-          color: black;
+          color: ${({ theme }) => theme.custom.colors.darkGray2};
         }
       }
 

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -220,7 +220,8 @@ export const FacetStyles = styled.div`
     }
 
     .facet-visible.checked .facet-label label,
-    .facet-visible .facet-label label:hover {
+    .facet-visible .facet-label label:hover,
+    .facet-visible input:hover + .facet-label label {
       color: ${({ theme }) => theme.custom.colors.darkGray2};
     }
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/4654

### Description (What does it do?)
<!--- Describe your changes in detail -->

Styles the search facet check box and label to align with designs.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

<img width="321" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/a34d8741-7a63-4697-a2c6-f880df63f2b3">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Navigate to the search page. Default, hover and checked styling should match https://www.figma.com/proto/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?page-id=107%3A2479&node-id=3375-49853&viewport=-21276%2C125%2C0.84&t=x1opLeUv6Qp1anj1-1&scaling=min-zoom&starting-point-node-id=2197%3A31345

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

This change didn't call for a checkbox in ol-components as we can't provide a component into `@mitodl/course-search-utils` and are styling from outside it. We'll want to reuse the styles when we add one (add to list dialog is likely the next item). 

