### PR TITLE
change non-degree education to learning

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -180,7 +180,7 @@ const HeroSearch: React.FC = () => {
           <BoldLink
             href={`${ABOUT}#${NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}`}
           >
-            Non-Degree Education
+            Non-Degree Learning
           </BoldLink>
         </Typography>
         <ControlsContainer>


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Changes "Non-Degree Education" to "Non-Degree Learning" per recommendation from MIT copyeditor 

### Screenshots (if appropriate):
<img width="1732" alt="Screenshot 2024-06-21 at 2 01 22 PM" src="https://github.com/mitodl/mit-open/assets/9010790/b5e8343a-299b-4ed2-8692-c20ecd03430b">

### How can this be tested?
Read