### PR TITLE
creating profile automatically for logged in user

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -18,6 +18,7 @@ from main.permissions import (
     AnonymousAccessReadonlyPermission,
     IsStaffPermission,
 )
+from profiles.api import ensure_profile
 from profiles.models import Profile, ProgramCertificate, ProgramLetter, UserWebsite
 from profiles.permissions import HasEditPermission, HasSiteEditPermission
 from profiles.serializers import (
@@ -70,7 +71,9 @@ class ProfileViewSet(
 
     def get_object(self):
         """Get the profile"""
+
         if self.kwargs["user__username"] == "me":
+            ensure_profile(self.request.user)
             return self.request.user.profile
         else:
             return super().get_object()

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -146,7 +146,7 @@ def test_get_profile(logged_in, user, user_client):
 
 
 def test_get_profile_automatically_creates_profile(user, user_client):
-    """Anonymous users should be able to view a person's profile"""
+    """Profiles should automatically get created for users without one"""
     user.profile.delete()
     url = reverse("profile:v0:profile_api-detail", kwargs={"user__username": "me"})
     resp = user_client.get(url)

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -145,6 +145,16 @@ def test_get_profile(logged_in, user, user_client):
     }
 
 
+def test_get_profile_automatically_creates_profile(user, user_client):
+    """Anonymous users should be able to view a person's profile"""
+    user.profile.delete()
+    url = reverse("profile:v0:profile_api-detail", kwargs={"user__username": "me"})
+    resp = user_client.get(url)
+    assert resp.status_code == 200
+    user.refresh_from_db()
+    assert user.profile is not None
+
+
 @pytest.mark.parametrize("email", ["", "test.email@example.com"])
 @pytest.mark.parametrize("email_optin", [None, True, False])
 @pytest.mark.parametrize("toc_optin", [None, True, False])


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/4677
<!--- N/A --->

### Description (What does it do?)
Automatically creates a profile for a user upon hitting the api profile endpoint

### How can this be tested?
1. checkout this branch.
2. create a new superuser or go to /admin/profiles/profile/ and delete the profile associated with your user
3. then navigate to any of the pages depending on profiles such as /onboarding and /dashboard/#profile and they should function normally.
4. go back into /admin/profiles/profile/ and see that you have a profile object for your user


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
