### PR TITLE
Some copy edits and minor about page styling updates

### DIFF
--- a/frontends/mit-open/src/pages/AboutPage/AboutPage.tsx
+++ b/frontends/mit-open/src/pages/AboutPage/AboutPage.tsx
@@ -5,9 +5,10 @@ import React from "react"
 
 const WHAT_IS_MIT_OPEN_FRAGMENT_IDENTIFIER = "what-is-mit-open"
 const NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER = "non-degree-learning"
-const WHAT_KINDS_OF_CONTENT_FRAGMENT_IDENTIFIER = "kinds-of-content"
+const ACADEMIC_AND_PROFESSIONAL_CONTENT = "kinds-of-content"
 
 const PageContainer = styled.div(({ theme }) => ({
+  color: theme.custom.colors.darkGray2,
   display: "flex",
   flexDirection: "column",
   alignItems: "flex-start",
@@ -33,11 +34,6 @@ const BannerContainerInner = styled.div({
   justifyContent: "center",
 })
 
-const Header = styled(Typography)(({ theme }) => ({
-  alignSelf: "stretch",
-  color: theme.custom.colors.black,
-}))
-
 const BodyContainer = styled.div({
   display: "flex",
   flexDirection: "column",
@@ -58,11 +54,6 @@ const MissionStatementContainer = styled.div(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     padding: "16px 16px",
   },
-}))
-
-const MissionStatementHeader = styled(Typography)(({ theme }) => ({
-  color: theme.custom.colors.mitRed,
-  ...theme.typography.h5,
 }))
 
 const SubHeaderContainer = styled.div(({ theme }) => ({
@@ -98,14 +89,14 @@ const SubHeaderImage = styled.img(({ theme }) => ({
 const BodySection = styled.div({
   display: "flex",
   flexDirection: "column",
-  alignItems: "center",
   alignSelf: "stretch",
   gap: "16px",
 })
 
-const BodyText = styled(Typography)(({ theme }) => ({
-  alignSelf: "stretch",
-  color: theme.custom.colors.black,
+const List = styled.ul(({ theme }) => ({
+  "li + li": {
+    marginTop: theme.typography.pxToRem(4),
+  },
 }))
 
 const AboutPage: React.FC = () => {
@@ -120,126 +111,133 @@ const AboutPage: React.FC = () => {
               ancestors={[{ href: urls.HOME, label: "Home" }]}
               current="About Us"
             />
-            <Header variant="h3">About Us</Header>
+            <Typography variant="h3" component="h1">
+              About Us
+            </Typography>
           </BannerContainerInner>
         </BannerContainer>
         <BodyContainer>
           <MissionStatementContainer>
-            <MissionStatementHeader>Mission</MissionStatementHeader>
-            <BodyText variant="body1">
-              MIT's mission to share learning with the world has been central to
-              the Institute since its founding in 1861. At the start of the 21st
-              century, MIT took that mission online, bringing learning resources
-              to a broader audience through digital platforms. Today, MIT is
-              advancing this mission further by providing non-degree learning
-              resources &ndash; online, in-person, and blended courses and
-              programs that offer the opportunity to learn from MIT faculty,
-              industry experts, and a global community of learners without
-              enrolling in a degree-seeking program. Through these resources,
-              millions of learners have gained the knowledge and tools needed to
-              advance their academic and professional goals.
-            </BodyText>
+            <Typography variant="body1">
+              Since its founding in 1861, MIT has been committed to sharing
+              knowledge with the world. At the beginning of the 21st century,
+              MIT expanded this mission by bringing learning resources online,
+              reaching a broader audience through digital platforms. Today, MIT
+              continues to advance this mission by offering non-degree learning
+              resources, including online, in-person, and blended courses and
+              programs. These opportunities allow learners to study with MIT
+              faculty, industry experts, and a global community without
+              enrolling in a degree program. Through these resources, millions
+              of learners have acquired the knowledge and skills needed to
+              further their academic and professional goals.
+            </Typography>
           </MissionStatementContainer>
           <SubHeaderContainer>
             <SubHeaderTextContainer>
               <Typography variant="subtitle1">
                 Our non-degree learning resources empower you to:
               </Typography>
-              <ul>
+              <List>
                 <li>
-                  Access content from world-renowned faculty and experts &ndash;
-                  much of it for free
+                  Learn for free from the same materials used by MIT students on
+                  campus
                 </li>
                 <li>
+                  Receive a certificate from MIT or learn for your own enjoyment
+                </li>
+                <li>
+                  Earn program credentials and apply for an accelerated master's
+                  degree program at MIT
+                </li>
+                <li>
+                  Download, share, and modify thousands of learning resources
+                </li>
+                <li>Access content from world-renowned faculty and experts</li>
+                <li>
                   Build job-relevant skills through application-focused
-                  offerings{" "}
+                  offerings
                 </li>
                 <li>
                   Experience peer-to-peer interactions and grow your network
                 </li>
-                <li>
-                  Receive a certificate from MIT, or just learn for your own
-                  enjoyment
-                </li>
-                <li>
-                  Learn from the same materials used by MIT students on campus
-                </li>
-                <li>
-                  Download, share and modify thousands of learning resources
-                </li>
                 <li>Continue your education at your own pace</li>
-              </ul>
+              </List>
             </SubHeaderTextContainer>
             <SubHeaderImage />
           </SubHeaderContainer>
           <BodySection>
-            <BodyText variant="h4" id={WHAT_IS_MIT_OPEN_FRAGMENT_IDENTIFIER}>
-              What is MIT Open?
-            </BodyText>
-            <BodyText variant="body1">
-              MIT Open is the best place to explore all of MIT's non-degree
-              learning programs. Learners can compare offerings across
-              departments and formats and complete a profile to receive
-              personalized recommendations that match their interests and goals.
-              <br />
-              <br />
-              MIT Open makes it easy to stay up-to-date on the latest non-degree
-              learning resources from MIT. Subscribe to topics, units, and
-              departments of interest to be notified when new courses, programs,
-              and more are added.
-              <br />
-              <br />
-              This portal includes courses and programs from MITx, MIT
-              Bootcamps, MIT OpenCourseWare, MIT Professional Education, MIT
-              Sloan Executive Education, MIT xPRO, and other departments across
-              MIT.
-            </BodyText>
-          </BodySection>
-          <BodySection>
-            <BodyText variant="h4" id={NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}>
-              What is non-degree learning at MIT?
-            </BodyText>
-            <BodyText variant="body1">
-              MIT's non-degree learning programs provide specific skills,
-              knowledge, or certifications without the time commitment and
-              breadth of study required for a full degree. These programs are
-              designed to be flexible and accessible, allowing professionals,
-              students, and lifelong learners to engage with MIT's educational
-              offerings from anywhere in the world. Many of these resources are
-              free or low-cost. Whether you're looking to upskill, explore a new
-              field, or gain a deeper understanding of a subject, MIT's
-              non-degree learning resources provide a pathway for personal and
-              professional growth.
-            </BodyText>
-          </BodySection>
-          <BodySection>
-            <BodyText
+            <Typography
               variant="h4"
-              id={WHAT_KINDS_OF_CONTENT_FRAGMENT_IDENTIFIER}
+              component="h2"
+              id={WHAT_IS_MIT_OPEN_FRAGMENT_IDENTIFIER}
             >
-              What kind of content is available from MIT Open?
-            </BodyText>
-            <BodyText variant="body1">
-              MIT Open organizes non-degree educational opportunities into two
-              categories: academic and professional.
-              <br />
-              <br />
+              What is {process.env.SITE_NAME}?
+            </Typography>
+            <Typography variant="body1">
+              {process.env.SITE_NAME} offers a single platform for accessing all
+              of MIT's non-degree learning resources. This includes courses,
+              programs, and various educational materials from different MIT
+              units such as MITx, MIT Bootcamps, MIT OpenCourseWare, MIT
+              Professional Education, MIT Sloan Executive Education, MIT xPRO,
+              and other departments across the Institute.
+            </Typography>
+            <Typography variant="body1">
+              Learners can search and browse by topic or department to explore
+              popular and upcoming courses. By creating a free account, they can
+              receive personalized recommendations tailored to their interests
+              and goals, create lists of learning resources, follow topics of
+              interest, and more
+            </Typography>
+          </BodySection>
+          <BodySection>
+            <Typography
+              variant="h4"
+              component="h2"
+              id={NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}
+            >
+              What is non-degree learning at MIT?
+            </Typography>
+            <Typography variant="body1">
+              MIT's non-degree learning programs offer targeted skills,
+              knowledge, and certifications without the extensive time
+              commitment of a full degree. These programs are designed to be
+              flexible and accessible, enabling professionals, students, and
+              lifelong learners to engage with MIT's educational offerings from
+              anywhere in the world. Many resources are available for free or at
+              a low cost. Whether you want to upskill, explore a new field, or
+              deepen your understanding of a subject, MIT's non-degree learning
+              resources provide a pathway for personal and professional growth.
+            </Typography>
+          </BodySection>
+          <BodySection>
+            <Typography
+              variant="h4"
+              component="h2"
+              id={ACADEMIC_AND_PROFESSIONAL_CONTENT}
+            >
+              Academic and Professional content
+            </Typography>
+            <Typography variant="body1">
+              MIT's non-degree offerings include content developed from MIT's
+              academic and professional curriculum.
+            </Typography>
+            <Typography variant="body1">
               MIT's Academic courses, programs, and materials mirror MIT
               curriculum and residential programs, making these available to a
               global audience. Approved by faculty committees, academic content
               furnishes a comprehensive foundation of knowledge, skills, and
               abilities for students pursuing their academic objectives.
-              Renowned for its rigor and challenge, MIT's academic offerings
+              Renowned for its rigor and challenge, MIT’s academic offerings
               deliver an experience on par with the campus environment.
-              <br />
-              <br />
+            </Typography>
+            <Typography variant="body1">
               MIT's Professional courses and programs are tailored for working
               professionals seeking essential practical skills across various
               industries. Led by MIT faculty and maintaining challenging
               standards, Professional courses and programs prioritize real-world
               applications, emphasize practical skills, and are directly
               relevant to today's workforce.
-            </BodyText>
+            </Typography>
           </BodySection>
         </BodyContainer>
       </PageContainer>
@@ -251,5 +249,5 @@ export {
   AboutPage,
   WHAT_IS_MIT_OPEN_FRAGMENT_IDENTIFIER,
   NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER,
-  WHAT_KINDS_OF_CONTENT_FRAGMENT_IDENTIFIER,
+  ACADEMIC_AND_PROFESSIONAL_CONTENT as WHAT_KINDS_OF_CONTENT_FRAGMENT_IDENTIFIER,
 }

--- a/frontends/mit-open/src/pages/AboutPage/AboutPage.tsx
+++ b/frontends/mit-open/src/pages/AboutPage/AboutPage.tsx
@@ -7,15 +7,13 @@ const WHAT_IS_MIT_OPEN_FRAGMENT_IDENTIFIER = "what-is-mit-open"
 const NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER = "non-degree-learning"
 const ACADEMIC_AND_PROFESSIONAL_CONTENT = "kinds-of-content"
 
-const PageContainer = styled.div(({ theme }) => ({
+const PageContainer = styled(Container)(({ theme }) => ({
   color: theme.custom.colors.darkGray2,
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  alignSelf: "stretch",
-  padding: "40px 84px 80px 84px",
-  [theme.breakpoints.down("md")]: {
-    padding: "40px 0 80px 0",
+  paddingTop: "40px",
+  paddingBottom: "80px",
+  [theme.breakpoints.down("sm")]: {
+    paddingTop: "28px",
+    paddingBottom: "32px",
   },
 }))
 
@@ -42,14 +40,13 @@ const BodyContainer = styled.div({
   gap: "40px",
 })
 
-const MissionStatementContainer = styled.div(({ theme }) => ({
+const HighlightContainer = styled.div(({ theme }) => ({
   display: "flex",
-  padding: "24px 32px",
   flexDirection: "column",
-  justifyContent: "center",
-  alignItems: "flex-start",
-  gap: "16px",
-  alignSelf: "stretch",
+  gap: "24px",
+  padding: "40px",
+  borderRadius: "8px",
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
   backgroundColor: theme.custom.colors.white,
   [theme.breakpoints.down("md")]: {
     padding: "16px 16px",
@@ -101,71 +98,68 @@ const List = styled.ul(({ theme }) => ({
 
 const AboutPage: React.FC = () => {
   return (
-    <Container>
-      <PageContainer>
-        <MetaTags title="About Us" />
-        <BannerContainer>
-          <BannerContainerInner>
-            <Breadcrumbs
-              variant="light"
-              ancestors={[{ href: urls.HOME, label: "Home" }]}
-              current="About Us"
-            />
-            <Typography variant="h3" component="h1">
-              About Us
+    <PageContainer>
+      <MetaTags title="About Us" />
+      <BannerContainer>
+        <BannerContainerInner>
+          <Breadcrumbs
+            variant="light"
+            ancestors={[{ href: urls.HOME, label: "Home" }]}
+            current="About Us"
+          />
+          <Typography variant="h3" component="h1">
+            About Us
+          </Typography>
+        </BannerContainerInner>
+      </BannerContainer>
+      <BodyContainer>
+        <Typography variant="body1">
+          Since its founding in 1861, MIT has been committed to sharing
+          knowledge with the world. At the beginning of the 21st century, MIT
+          expanded this mission by bringing learning resources online, reaching
+          a broader audience through digital platforms. Today, MIT continues to
+          advance this mission by offering non-degree learning resources,
+          including online, in-person, and blended courses and programs. These
+          opportunities allow learners to study with MIT faculty, industry
+          experts, and a global community without enrolling in a degree program.
+          Through these resources, millions of learners have acquired the
+          knowledge and skills needed to further their academic and professional
+          goals.
+        </Typography>
+        <SubHeaderContainer>
+          <SubHeaderTextContainer>
+            <Typography variant="subtitle1">
+              Our non-degree learning resources empower you to:
             </Typography>
-          </BannerContainerInner>
-        </BannerContainer>
-        <BodyContainer>
-          <MissionStatementContainer>
-            <Typography variant="body1">
-              Since its founding in 1861, MIT has been committed to sharing
-              knowledge with the world. At the beginning of the 21st century,
-              MIT expanded this mission by bringing learning resources online,
-              reaching a broader audience through digital platforms. Today, MIT
-              continues to advance this mission by offering non-degree learning
-              resources, including online, in-person, and blended courses and
-              programs. These opportunities allow learners to study with MIT
-              faculty, industry experts, and a global community without
-              enrolling in a degree program. Through these resources, millions
-              of learners have acquired the knowledge and skills needed to
-              further their academic and professional goals.
-            </Typography>
-          </MissionStatementContainer>
-          <SubHeaderContainer>
-            <SubHeaderTextContainer>
-              <Typography variant="subtitle1">
-                Our non-degree learning resources empower you to:
-              </Typography>
-              <List>
-                <li>
-                  Learn for free from the same materials used by MIT students on
-                  campus
-                </li>
-                <li>
-                  Receive a certificate from MIT or learn for your own enjoyment
-                </li>
-                <li>
-                  Earn program credentials and apply for an accelerated master's
-                  degree program at MIT
-                </li>
-                <li>
-                  Download, share, and modify thousands of learning resources
-                </li>
-                <li>Access content from world-renowned faculty and experts</li>
-                <li>
-                  Build job-relevant skills through application-focused
-                  offerings
-                </li>
-                <li>
-                  Experience peer-to-peer interactions and grow your network
-                </li>
-                <li>Continue your education at your own pace</li>
-              </List>
-            </SubHeaderTextContainer>
-            <SubHeaderImage />
-          </SubHeaderContainer>
-          <BodySection>
+            <List>
+              <li>
+                Learn for free from the same materials used by MIT students on
+                campus
+              </li>
+              <li>
+                Receive a certificate from MIT or learn for your own enjoyment
+              </li>
+              <li>
+                Earn program credentials and apply for an accelerated master's
+                degree program at MIT
+              </li>
+              <li>
+                Download, share, and modify thousands of learning resources
+              </li>
+              <li>Access content from world-renowned faculty and experts</li>
+              <li>
+                Build job-relevant skills through application-focused offerings
+              </li>
+              <li>
+                Experience peer-to-peer interactions and grow your network
+              </li>
+              <li>Continue your education at your own pace</li>
+            </List>
+          </SubHeaderTextContainer>
+          <SubHeaderImage />
+        </SubHeaderContainer>
+        <BodySection>
+          <HighlightContainer>
             <Typography
               variant="h4"
               component="h2"
@@ -188,60 +182,60 @@ const AboutPage: React.FC = () => {
               and goals, create lists of learning resources, follow topics of
               interest, and more
             </Typography>
-          </BodySection>
-          <BodySection>
-            <Typography
-              variant="h4"
-              component="h2"
-              id={NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}
-            >
-              What is non-degree learning at MIT?
-            </Typography>
-            <Typography variant="body1">
-              MIT's non-degree learning programs offer targeted skills,
-              knowledge, and certifications without the extensive time
-              commitment of a full degree. These programs are designed to be
-              flexible and accessible, enabling professionals, students, and
-              lifelong learners to engage with MIT's educational offerings from
-              anywhere in the world. Many resources are available for free or at
-              a low cost. Whether you want to upskill, explore a new field, or
-              deepen your understanding of a subject, MIT's non-degree learning
-              resources provide a pathway for personal and professional growth.
-            </Typography>
-          </BodySection>
-          <BodySection>
-            <Typography
-              variant="h4"
-              component="h2"
-              id={ACADEMIC_AND_PROFESSIONAL_CONTENT}
-            >
-              Academic and Professional content
-            </Typography>
-            <Typography variant="body1">
-              MIT's non-degree offerings include content developed from MIT's
-              academic and professional curriculum.
-            </Typography>
-            <Typography variant="body1">
-              MIT's Academic courses, programs, and materials mirror MIT
-              curriculum and residential programs, making these available to a
-              global audience. Approved by faculty committees, academic content
-              furnishes a comprehensive foundation of knowledge, skills, and
-              abilities for students pursuing their academic objectives.
-              Renowned for its rigor and challenge, MIT’s academic offerings
-              deliver an experience on par with the campus environment.
-            </Typography>
-            <Typography variant="body1">
-              MIT's Professional courses and programs are tailored for working
-              professionals seeking essential practical skills across various
-              industries. Led by MIT faculty and maintaining challenging
-              standards, Professional courses and programs prioritize real-world
-              applications, emphasize practical skills, and are directly
-              relevant to today's workforce.
-            </Typography>
-          </BodySection>
-        </BodyContainer>
-      </PageContainer>
-    </Container>
+          </HighlightContainer>
+        </BodySection>
+        <BodySection>
+          <Typography
+            variant="h4"
+            component="h2"
+            id={NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}
+          >
+            What is non-degree learning at MIT?
+          </Typography>
+          <Typography variant="body1">
+            MIT's non-degree learning programs offer targeted skills, knowledge,
+            and certifications without the extensive time commitment of a full
+            degree. These programs are designed to be flexible and accessible,
+            enabling professionals, students, and lifelong learners to engage
+            with MIT's educational offerings from anywhere in the world. Many
+            resources are available for free or at a low cost. Whether you want
+            to upskill, explore a new field, or deepen your understanding of a
+            subject, MIT's non-degree learning resources provide a pathway for
+            personal and professional growth.
+          </Typography>
+        </BodySection>
+        <BodySection>
+          <Typography
+            variant="h4"
+            component="h2"
+            id={ACADEMIC_AND_PROFESSIONAL_CONTENT}
+          >
+            Academic and Professional content
+          </Typography>
+          <Typography variant="body1">
+            MIT's non-degree offerings include content developed from MIT's
+            Academic and Professional curriculum.
+          </Typography>
+          <Typography variant="body1">
+            MIT's Academic courses, programs, and materials mirror MIT
+            curriculum and residential programs, making these available to a
+            global audience. Approved by faculty committees, academic content
+            furnishes a comprehensive foundation of knowledge, skills, and
+            abilities for students pursuing their academic objectives. Renowned
+            for its rigor and challenge, MIT's academic offerings deliver an
+            experience on par with the campus environment.
+          </Typography>
+          <Typography variant="body1">
+            MIT's Professional courses and programs are tailored for working
+            professionals seeking essential practical skills across various
+            industries. Led by MIT faculty and maintaining challenging
+            standards, Professional courses and programs prioritize real-world
+            applications, emphasize practical skills, and are directly relevant
+            to today's workforce.
+          </Typography>
+        </BodySection>
+      </BodyContainer>
+    </PageContainer>
   )
 }
 

--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -180,7 +180,7 @@ const HeroSearch: React.FC = () => {
           <BoldLink
             href={`${ABOUT}#${NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER}`}
           >
-            Non-Degree Education
+            Non-Degree Learning
           </BoldLink>
         </Typography>
         <ControlsContainer>


### PR DESCRIPTION
### What are the relevant tickets?
None.

### Description (What does it do?)
Two changes:
1. On homepage, Changes "Non-Degree Education" to "Non-Degree Learning" per recommendation from MIT copyeditor 
2. On about page:
    - minor copy edits
    - minor styling updates, mostly color.

**NOTE:** The "About" page figma was recently updated and this does NOT reflect the latest designs.

### Screenshots (if appropriate):
<img width="1732" alt="Screenshot 2024-06-21 at 2 01 22 PM" src="https://github.com/mitodl/mit-open/assets/9010790/b5e8343a-299b-4ed2-8692-c20ecd03430b">
<img width="1698" alt="Screenshot 2024-06-21 at 3 08 39 PM" src="https://github.com/mitodl/mit-open/assets/9010790/2e6d695e-a054-4a31-b6c3-2b974ac0555f">
<img width="1713" alt="Screenshot 2024-06-21 at 3 08 32 PM" src="https://github.com/mitodl/mit-open/assets/9010790/ac2d568a-b481-4c21-95a7-0c4d56897aa5">

### How can this be tested?
1. View the homepage. It should say "Non-Degree Learning".
2. View the About page. It should look similar to before, with minor copy edits, and should have darkGray2 text.