### PR TITLE
Search facet styles and animation

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded",
+    "@mitodl/course-search-utils": "3.1.3",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "^3.1.2",
+    "@mitodl/course-search-utils": "git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -217,6 +217,7 @@ export const FacetStyles = styled.div`
         background-image: url("data:image/svg+xml,%3Csvg width='18' height='18' viewBox='0 0 18 18' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 0H17C17.5523 0 18 0.44772 18 1V17C18 17.5523 17.5523 18 17 18H1C0.44772 18 0 17.5523 0 17V1C0 0.44772 0.44772 0 1 0ZM2 2V16H16V2H2Z' fill='%23B8C2CC'/%3E%3C/svg%3E%0A");
         background-repeat: no-repeat;
         background-position: 3px 3px;
+        flex-shrink: 0;
       }
 
       input[type="checkbox"]:hover {

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -129,16 +129,22 @@ export const FacetStyles = styled.div`
   .filter-section-button {
     ${({ theme }) => css({ ...theme.typography.subtitle2 })}
     color: ${({ theme }) => theme.custom.colors.darkGray2};
-    padding-left: 0;
+    padding: 0;
     background-color: transparent;
     display: flex;
     width: 100%;
     border: none;
     cursor: pointer;
     justify-content: space-between;
+    align-items: center;
+    margin-bottom: 14px;
 
     i {
       color: ${({ theme }) => theme.custom.colors.silverGrayLight};
+    }
+
+    &:hover i {
+      color: ${({ theme }) => theme.custom.colors.darkGray2};
     }
   }
 
@@ -157,8 +163,8 @@ export const FacetStyles = styled.div`
   }
 
   .facet-visible {
-    margin-top: 4.5px;
-    margin-bottom: 4.5px;
+    margin-top: 6px;
+    margin-bottom: 6px;
   }
 
   .facet-visible:last-child {
@@ -179,6 +185,14 @@ export const FacetStyles = styled.div`
     padding-right: 24px;
     margin-top: 0;
     margin-bottom: 0;
+    max-height: 55px;
+    transition: max-height 0.4s ease-out;
+    overflow: hidden;
+
+    &.facets-expanded {
+      max-height: 600px;
+      transition: max-height 0.4s ease-in;
+    }
 
     .facet-visible {
       display: flex;
@@ -187,6 +201,7 @@ export const FacetStyles = styled.div`
       height: 25px;
       font-size: 0.875em;
       gap: 4px;
+      margin-left: -2px;
 
       input,
       label {
@@ -268,7 +283,7 @@ export const FacetStyles = styled.div`
   input.facet-filter {
     background-color: initial;
     padding: 10px;
-    margin-top: 10px;
+    margin-top: 0;
     margin-bottom: 10px;
     width: 100%;
   }

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -74,6 +74,7 @@ export const getFacetManifest = (
       title: "Certificate",
       type: "static",
       expandedOnLoad: true,
+      preserveItems: true,
       labelFunction: (key: string) => getCertificationTypeName(key) || key,
     },
     {
@@ -81,12 +82,14 @@ export const getFacetManifest = (
       title: "Topic",
       type: "filterable",
       expandedOnLoad: true,
+      preserveItems: true,
     },
     {
       name: "learning_format",
       title: "Format",
       type: "static",
       expandedOnLoad: true,
+      preserveItems: true,
       labelFunction: (key: string) =>
         key
           .split("_")
@@ -98,6 +101,7 @@ export const getFacetManifest = (
       title: "Offered By",
       type: "static",
       expandedOnLoad: false,
+      preserveItems: true,
       labelFunction: (key: string) => offerors[key]?.name ?? key,
     },
     {
@@ -105,6 +109,7 @@ export const getFacetManifest = (
       title: "Department",
       type: "filterable",
       expandedOnLoad: false,
+      preserveItems: true,
       labelFunction: (key: string) => getDepartmentName(key) || key,
     },
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4063,9 +4063,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded":
-  version: 3.1.2
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=3a1fd10701341abccd901829096cb0e40beef9d9"
+"@mitodl/course-search-utils@npm:3.1.3":
+  version: 3.1.3
+  resolution: "@mitodl/course-search-utils@npm:3.1.3"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.6.4"
     axios: "npm:^1.6.7"
@@ -4084,7 +4084,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/208b68e423b2b143e6fe6ba7fbcb7f59cae87b82a81987ecdba341057b00e76f4062787af51bff5287a192e753015c2210e483558366bcc9772c31a2d5017565
+  checksum: 10/bb0b0fafe2ec36b9b04729cde6e610b67b481b39489ce14a2d832fb2d5e48fa71f923d541869e29c3ca8e8944eab36e53ca0736e01893e7bd4d7c859454695ae
   languageName: node
   linkType: hard
 
@@ -18419,7 +18419,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.0"
-    "@mitodl/course-search-utils": "git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded"
+    "@mitodl/course-search-utils": "npm:3.1.3"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4063,9 +4063,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.1.2":
+"@mitodl/course-search-utils@git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded":
   version: 3.1.2
-  resolution: "@mitodl/course-search-utils@npm:3.1.2"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=3a1fd10701341abccd901829096cb0e40beef9d9"
   dependencies:
     "@mitodl/open-api-axios": "npm:^2024.6.4"
     axios: "npm:^1.6.7"
@@ -4084,7 +4084,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/30a6c96dcffebbf1f5f7e281af3a51183019e07eb2268fbbb3ec5a6a6eff8a4c8f57c8b959d487d7fb4af2827730fae1c63fd0139d72393e555b0216a2f41b5b
+  checksum: 10/208b68e423b2b143e6fe6ba7fbcb7f59cae87b82a81987ecdba341057b00e76f4062787af51bff5287a192e753015c2210e483558366bcc9772c31a2d5017565
   languageName: node
   linkType: hard
 
@@ -18419,7 +18419,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.0"
-    "@mitodl/course-search-utils": "npm:^3.1.2"
+    "@mitodl/course-search-utils": "git+https://github.com/mitodl/course-search-utils.git#jk/4668-facet-expanded"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4668

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Style updates to the search facet.
- Animate heights when collapse/expanding accordion.

### Screenshots (if appropriate):

<img width="325" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/60b94722-cef8-481b-aa54-75eb0845b5ba">


https://github.com/mitodl/mit-open/assets/939376/13f1885f-d151-46c0-a978-42fbcd581678



### How can this be tested?

Navigate to the search page (/search) or a unit page (e.g. /c/unit/ocw/) and check that the styles are correct according to [the designs](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=1074-24976&t=wT2cCr1LlUUS9ZOQ-0).

The height animation has been added working towards this: https://www.figma.com/proto/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?page-id=944%3A1257&node-id=7524-164457&viewport=98%2C-365%2C0.45&t=8wAncZUPXYAlIOwb-1&scaling=min-zoom&content-scaling=fixed, but not the spin animation on the chevron or the stretchy shadow effect (the animation was marked as low priority, so going for quicker wins).

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

This needed a change to @mitodl/course-search-utils, PR here: https://github.com/mitodl/course-search-utils/pull/114, to add a classname to the facet container when expanded and to provide a prop so we can tell it not to remove the accordion contents so we can control and animate the height in the calling code.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
