### PR TITLE
Adds a separate pane for the filter CTAs, adds an apply button on mobile

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -393,27 +393,12 @@ const StyledDrawer = styled(Drawer)`
 `
 
 const MobileFacetSearchButtons = styled.div`
-  width: 100%;
+  display: flex;
   gap: 12px;
-`
 
-const MobileApplyFiltersButton = styled(Button)`
-  background-color: ${({ theme }) => theme.custom.colors.mitRed};
-  color: ${({ theme }) => theme.custom.colors.white};
-  padding: 12px;
-  border-radius: 4px;
-  width: 144px;
-  margin-right: 12px;
-  box-shadow:
-    0 2px 4px 0 #25262b1a,
-    0 3px 8px 0 #25262b1f;
-`
-
-const MobileClearAllButton = styled(Button)`
-  background-color: white;
-  padding: 12px;
-  border-radius: 4px;
-  width: 144px;
+  & > button {
+    flex: 1;
+  }
 `
 
 const MobileDrawerCloseButton = styled(Button)`
@@ -673,20 +658,20 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   </MobileFacetsTitleContainer>
                   {hasFacets ? (
                     <MobileFacetSearchButtons>
-                      <MobileApplyFiltersButton
-                        variant="text"
+                      <Button
+                        variant="primary"
                         size="small"
                         onClick={toggleMobileDrawer(false)}
                       >
                         Apply Filters
-                      </MobileApplyFiltersButton>
-                      <MobileClearAllButton
-                        variant="text"
+                      </Button>
+                      <Button
+                        variant="text-secondary"
                         size="small"
                         onClick={clearAllFacets}
                       >
                         Clear All
-                      </MobileClearAllButton>
+                      </Button>
                     </MobileFacetSearchButtons>
                   ) : null}
                   {filterContents}

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -666,7 +666,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                         Apply Filters
                       </Button>
                       <Button
-                        variant="text-secondary"
+                        variant="noBorder"
                         size="small"
                         onClick={clearAllFacets}
                       >

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -392,10 +392,28 @@ const StyledDrawer = styled(Drawer)`
   }
 `
 
+const MobileFacetSearchButtons = styled.div`
+  width: 100%;
+  gap: 12px;
+`
+
+const MobileApplyFiltersButton = styled(Button)`
+  background-color: ${({ theme }) => theme.custom.colors.mitRed};
+  color: ${({ theme }) => theme.custom.colors.white};
+  padding: 12px;
+  border-radius: 4px;
+  width: 144px;
+  margin-right: 12px;
+  box-shadow:
+    0px 2px 4px 0px rgba(37, 38, 43, 0.1),
+    0px 3px 8px 0px rgba(37, 38, 43, 0.12);
+`
+
 const MobileClearAllButton = styled(Button)`
   background-color: white;
   padding: 12px;
   border-radius: 4px;
+  width: 144px;
 `
 
 const MobileDrawerCloseButton = styled(Button)`
@@ -643,15 +661,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                       <div>
                         <Typography variant="subtitle3">Filter</Typography>
                       </div>
-                      {hasFacets ? (
-                        <MobileClearAllButton
-                          variant="text"
-                          size="small"
-                          onClick={clearAllFacets}
-                        >
-                          Clear all
-                        </MobileClearAllButton>
-                      ) : null}
                     </div>
                     <MobileDrawerCloseButton
                       size="large"
@@ -662,6 +671,20 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                       <RiCloseLine fontSize="inherit" />
                     </MobileDrawerCloseButton>
                   </MobileFacetsTitleContainer>
+                  {hasFacets ? (
+                    <MobileFacetSearchButtons>
+                      <MobileApplyFiltersButton variant="text" size="small">
+                        Apply Filters
+                      </MobileApplyFiltersButton>
+                      <MobileClearAllButton
+                        variant="text"
+                        size="small"
+                        onClick={clearAllFacets}
+                      >
+                        Clear All
+                      </MobileClearAllButton>
+                    </MobileFacetSearchButtons>
+                  ) : null}
                   {filterContents}
                 </StyledDrawer>
                 <MobileSortContainer>{sortDropdown}</MobileSortContainer>

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -405,8 +405,8 @@ const MobileApplyFiltersButton = styled(Button)`
   width: 144px;
   margin-right: 12px;
   box-shadow:
-    0px 2px 4px 0px rgba(37, 38, 43, 0.1),
-    0px 3px 8px 0px rgba(37, 38, 43, 0.12);
+    0 2px 4px 0 #25262b1a,
+    0 3px 8px 0 #25262b1f;
 `
 
 const MobileClearAllButton = styled(Button)`
@@ -673,7 +673,11 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   </MobileFacetsTitleContainer>
                   {hasFacets ? (
                     <MobileFacetSearchButtons>
-                      <MobileApplyFiltersButton variant="text" size="small">
+                      <MobileApplyFiltersButton
+                        variant="text"
+                        size="small"
+                        onClick={toggleMobileDrawer(false)}
+                      >
                         Apply Filters
                       </MobileApplyFiltersButton>
                       <MobileClearAllButton

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -89,7 +89,7 @@ export const VariantStory: Story = {
       <Button {...args} variant="text">
         Text
       </Button>
-      <Button {...args} variant="text-secondary">
+      <Button {...args} variant="noBorder">
         Text Secondary
       </Button>
       <Button {...args} variant="inverted">

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -27,7 +27,14 @@ const meta: Meta<typeof Button> = {
   component: Button,
   argTypes: {
     variant: {
-      options: ["primary", "secondary", "tertiary", "text"],
+      options: [
+        "primary",
+        "secondary",
+        "tertiary",
+        "text",
+        "inverted",
+        "text-secondary",
+      ],
       control: { type: "select" },
     },
     size: {
@@ -81,6 +88,12 @@ export const VariantStory: Story = {
       </Button>
       <Button {...args} variant="text">
         Text
+      </Button>
+      <Button {...args} variant="text-secondary">
+        Text Secondary
+      </Button>
+      <Button {...args} variant="inverted">
+        Inverted
       </Button>
     </Stack>
   ),

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -10,7 +10,7 @@ type ButtonVariant =
   | "secondary"
   | "tertiary"
   | "text"
-  | "text-secondary"
+  | "noBorder"
   | "inverted"
 type ButtonSize = "small" | "medium" | "large"
 type ButtonEdge = "circular" | "rounded" | "none"
@@ -139,7 +139,7 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
         color: colors.silverGray,
       },
     },
-    variant === "text-secondary" && {
+    variant === "noBorder" && {
       backgroundColor: colors.white,
       color: colors.darkGray2,
       border: "none",

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -5,7 +5,13 @@ import tinycolor from "tinycolor2"
 import { Link } from "react-router-dom"
 import type { Theme } from "@mui/material/styles"
 
-type ButtonVariant = "primary" | "secondary" | "tertiary" | "text" | "inverted"
+type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "text"
+  | "text-secondary"
+  | "inverted"
 type ButtonSize = "small" | "medium" | "large"
 type ButtonEdge = "circular" | "rounded" | "none"
 
@@ -126,6 +132,17 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     },
     variant === "text" && {
       color: colors.darkGray2,
+      ":hover:not(:disabled)": {
+        backgroundColor: tinycolor(colors.darkGray1).setAlpha(0.06).toString(),
+      },
+      ":disabled": {
+        color: colors.silverGray,
+      },
+    },
+    variant === "text-secondary" && {
+      backgroundColor: colors.white,
+      color: colors.darkGray2,
+      border: "none",
       ":hover:not(:disabled)": {
         backgroundColor: tinycolor(colors.darkGray1).setAlpha(0.06).toString(),
       },


### PR DESCRIPTION

### What are the relevant tickets?

Closes mitodl/hq#4599

### Description (What does it do?)

In the filter drawer on mobile, there should be a CTA section that includes an Apply Filters and a Clear All button if the learner has selected any of the options in the drawer, and it should appear below the title and close box. This adds those. (Currently, there is a Clear All button but it is set in the title area, so that one just moves down a bit.) 

### Screenshots (if appropriate):

![image](https://github.com/mitodl/mit-open/assets/945611/0cfd0144-41f2-431a-97dd-805e8bc4fa71)

### How can this be tested?

Open the drawer while in tablet or mobile mode (width < 900px). You should see the buttons once you select something in the pane. They should be hidden if you don't have anything selected.