### PR TITLE
fixing width of unit page logo for small devices

### DIFF
--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -67,8 +67,6 @@ const AvatarContainer = styled.div<AvatarStyleProps>`
   }
 `
 const AvatarImg = styled.img<AvatarStyleProps>`
-  align-items: center;
-  justify-content: center;
   min-height: 0;
   min-width: 0;
   ${({ imageVariant }) =>

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -61,6 +61,10 @@ const AvatarContainer = styled.div<AvatarStyleProps>`
   align-items: center;
   height: ${({ imageSize }) => IMG_SIZES[imageSize]};
   width: auto;
+  ${({ theme }) => theme.breakpoints.down("sm")} {
+    height: auto;
+    width: 100%;
+  }
 `
 const AvatarImg = styled.img<AvatarStyleProps>`
   display: flex;
@@ -73,6 +77,10 @@ const AvatarImg = styled.img<AvatarStyleProps>`
     imageVariant === "inverted" ? "filter: saturate(0%) invert(100%);" : ""}
   height: ${({ imageSize }) => IMG_SIZES[imageSize]};
   width: auto;
+  ${({ theme }) => theme.breakpoints.down("sm")} {
+    height: auto;
+    width: 100%;
+  }
 `
 const AvatarInitials = styled(AvatarImg.withComponent("div"))(
   ({ theme, imageSize = "medium" }) => ({

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -67,8 +67,6 @@ const AvatarContainer = styled.div<AvatarStyleProps>`
   }
 `
 const AvatarImg = styled.img<AvatarStyleProps>`
-  display: flex;
-  flex-direction: row;
   align-items: center;
   justify-content: center;
   min-height: 0;
@@ -78,8 +76,7 @@ const AvatarImg = styled.img<AvatarStyleProps>`
   height: ${({ imageSize }) => IMG_SIZES[imageSize]};
   width: auto;
   ${({ theme }) => theme.breakpoints.down("sm")} {
-    height: auto;
-    width: 100%;
+    height: min(calc(100vh), ${({ imageSize }) => IMG_SIZES[imageSize]});
   }
 `
 const AvatarInitials = styled(AvatarImg.withComponent("div"))(

--- a/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
+++ b/frontends/mit-open/src/components/FieldAvatar/FieldAvatar.tsx
@@ -73,9 +73,6 @@ const AvatarImg = styled.img<AvatarStyleProps>`
     imageVariant === "inverted" ? "filter: saturate(0%) invert(100%);" : ""}
   height: ${({ imageSize }) => IMG_SIZES[imageSize]};
   width: auto;
-  ${({ theme }) => theme.breakpoints.down("sm")} {
-    height: min(calc(100vh), ${({ imageSize }) => IMG_SIZES[imageSize]});
-  }
 `
 const AvatarInitials = styled(AvatarImg.withComponent("div"))(
   ({ theme, imageSize = "medium" }) => ({

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -164,6 +164,9 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
                           py: 0,
                           pb: "8px",
                         },
+                        [theme.breakpoints.down("sm")]: {
+                          width: "100%",
+                        },
                       })}
                     >
                       {displayConfiguration?.logo ? (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/4670
<!--- N/A --->

### Description (What does it do?)
Sets the unit page logo width to 100% on small devices.

### Screenshots (if appropriate):
Before:
<img width="180" alt="Screenshot 2024-06-24 at 10 49 08 AM" src="https://github.com/mitodl/mit-open/assets/196425/54cc12f8-b0c0-402c-95b8-032c4ee7c870">

After:
<img width="180" alt="Screenshot 2024-06-24 at 10 48 46 AM" src="https://github.com/mitodl/mit-open/assets/196425/701b0d2d-460e-450d-bfff-aa7060966690">

### How can this be tested?
1. checkout this branch.
2. visit a unit page in mobile/small view and see that logo does not get clipped. This affects /c/unit/see/ in particular


