### PR TITLE
Use course_description_html field for OCW courses

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -240,7 +240,7 @@ def transform_run(course_data: dict) -> dict:
         "run_id": course_data["run_id"],
         "published": True,
         "instructors": parse_instructors(course_data.get("instructors", [])),
-        "description": clean_data(course_data.get("course_description")),
+        "description": clean_data(course_data.get("course_description_html")),
         "year": year,
         "semester": semester,
         "availability": AvailabilityType.current.value,
@@ -331,7 +331,7 @@ def transform_course(course_data: dict) -> dict:
                 .get("image-alt")
             ),
         },
-        "description": clean_data(course_data["course_description"]),
+        "description": clean_data(course_data["course_description_html"]),
         "url": course_data.get("url"),
         "last_modified": course_data.get("last_modified"),
         "published": True,

--- a/learning_resources/etl/ocw_test.py
+++ b/learning_resources/etl/ocw_test.py
@@ -16,6 +16,7 @@ from learning_resources.etl.ocw import (
     transform_contentfile,
     transform_course,
 )
+from learning_resources.etl.utils import clean_data
 from learning_resources.factories import ContentFileFactory
 from learning_resources.models import ContentFile
 from learning_resources.utils import (
@@ -216,6 +217,9 @@ def test_transform_course(  # noqa: PLR0913
         assert transformed_json["runs"][0]["level"] == ["undergraduate", "high_school"]
         assert transformed_json["runs"][0]["semester"] == (term if term else None)
         assert transformed_json["runs"][0]["year"] == (year if year else None)
+        assert transformed_json["description"] == clean_data(
+            course_json["course_description_html"]
+        )
         assert (
             transformed_json["image"]["url"]
             == "http://test.edu/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg"

--- a/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/data.json
+++ b/test_json/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/data.json
@@ -1,7 +1,8 @@
 {
   "course_title": "Unified Engineering I, II, III, \u0026 IV",
   "course_description": "The basic objective of Unified Engineering is to give a solid understanding of the fundamental disciplines of aerospace engineering, as well as their interrelationships and applications. These disciplines are Materials and Structures (M); Computers and Programming (C); Fluid Mechanics (F); Thermodynamics (T); Propulsion (P); and Signals and Systems (S). In choosing to teach these subjects in a unified manner, the instructors seek to explain the common intellectual threads in these disciplines, as well as their combined application to solve engineering Systems Problems (SP). Throughout the year, the instructors emphasize the connections among the disciplines.\n",
-  "site_uid": null,
+  "course_description_html": "The basic objective of Unified Engineering is to give a solid understanding of the fundamental disciplines of aerospace engineering, as well as their interrelationships and applications. These disciplines are Materials and Structures (M); Computers and Programming (C); Fluid Mechanics (F); Thermodynamics (T); Propulsion (P); and Signals and Systems (S). In choosing to teach these subjects in a unified manner, the instructors seek to explain the common intellectual threads in these disciplines, as well as their combined application to solve engineering Systems Problems (SP). Throughout the year, the instructors emphasize the connections among the disciplines.",
+  "site_uid": "b51a7887-101f-4e96-a07c-9e53c20bfeb6",
   "legacy_uid": "97db384e-f340-09a6-4df7-cb86cf701979",
   "instructors": [
     {
@@ -98,9 +99,11 @@
   "level": ["Undergraduate", "High School"],
   "image_src": "/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg",
   "course_image_metadata": {
+    "content_type": "resource",
     "description": "An abstracted aircraft wing with illustrated systems. (Image by MIT OCW.)",
     "draft": false,
-    "file": "https://open-learning-course-data-production.s3.amazonaws.com/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg",
+    "file": "/courses/16-01-unified-engineering-i-ii-iii-iv-fall-2005-spring-2006/8f56bbb35d0e456dc8b70911bec7cd0d_16-01f05.jpg",
+    "file_size": 79218,
     "file_type": "image/jpeg",
     "image_metadata": {
       "caption": "An abstracted aircraft wing, illustrating the connections between the disciplines of Unified Engineering. (Image by MIT OpenCourseWare.)",
@@ -108,8 +111,17 @@
       "image-alt": "Illustration of an aircraft wing showing connections between the disciplines of the course."
     },
     "iscjklanguage": false,
+    "learning_resource_types": [],
+    "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+    "ocw_type": "OCWImage",
     "resourcetype": "Image",
     "title": "16-01f05.jpg",
-    "uid": "8f56bbb3-5d0e-456d-c8b7-0911bec7cd0d"
+    "uid": "8f56bbb3-5d0e-456d-c8b7-0911bec7cd0d",
+    "video_files": {
+      "video_thumbnail_file": null
+    },
+    "video_metadata": {
+      "youtube_id": null
+    }
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4592

### Description (What does it do?)
Alters the OCW pipeline to extract descriptions from the `course_description_html` field.



### How can this be tested?
- Set `AWS_` and `OCW_` values to the same as RC in your .env file.
- Run the following:
  > ./manage.py backpopulate_ocw_data --skip-contentfiles --course-name res-21g-3003-marguerite-de-roberval-a-web-based-approach-to-teaching-a-renaissance-heroine-fall-2023 --overwrite
- When done, check that the description for the course contains a few `<p>` tags but no links or other HTML elements.
