### PR TITLE
sort the media carousel tabs by "new"

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/carousels.ts
+++ b/frontends/mit-open/src/pages/HomePage/carousels.ts
@@ -50,7 +50,11 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
     cardProps: { size: "small" },
     data: {
       type: "resources",
-      params: { resource_type: ["video", "podcast_episode"], limit: 12 },
+      params: {
+        resource_type: ["video", "podcast_episode"],
+        limit: 12,
+        sortby: "new",
+      },
     },
   },
   {
@@ -58,7 +62,7 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
     cardProps: { size: "small" },
     data: {
       type: "resources",
-      params: { resource_type: ["video"], limit: 12 },
+      params: { resource_type: ["video"], limit: 12, sortby: "new" },
     },
   },
   {
@@ -66,7 +70,7 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
     cardProps: { size: "small" },
     data: {
       type: "resources",
-      params: { resource_type: ["podcast_episode"], limit: 12 },
+      params: { resource_type: ["podcast_episode"], limit: 12, sortby: "new" },
     },
   },
 ]


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4683

### Description (What does it do?)
This PR adds `sortby: "new"` to the `MEDIA_CAROUSEL` configuration objects, sorting the results to put new items first.

### How can this be tested?
 - Spin up `mit-open` on the `main` branch
 - Make sure you have some media items, like videos or podcasts backpopulated in your database
 - Visit the home page at http://localhost:8063
 - Scroll down to the Media section and note the items that appear there in each tab
 - Switch to this PR branch
 - Refresh the page and check the carousel contents again, they should now be sorted by `new`
