### PR TITLE
Shanbady/search page card mobile updates

### DIFF
--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -78,6 +78,7 @@ const Info = styled.div`
 
 const Title = styled.h3`
   flex-grow: 1;
+  color: ${theme.custom.colors.darkGray2};
   text-overflow: ellipsis;
   ${{ ...theme.typography.subtitle1 }}
   height: ${theme.typography.pxToRem(40)};

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -21,6 +21,12 @@ const IMAGE_SIZES = {
   desktop: { width: 236, height: 122 },
 }
 
+const CardLabel = styled.span`
+  ${theme.breakpoints.down("sm")} {
+    display: none;
+  }
+`
+
 const Certificate = styled.div`
   border-radius: 4px;
   background-color: ${theme.custom.colors.lightGray1};
@@ -38,7 +44,6 @@ const Certificate = styled.div`
 
   ${theme.breakpoints.down("md")} {
     ${{ ...theme.typography.body4 }}
-    background: none;
     color: ${theme.custom.colors.darkGray2};
     gap: 2px;
 
@@ -60,7 +65,6 @@ const Price = styled.div`
   color: ${theme.custom.colors.darkGray2};
   ${theme.breakpoints.down("md")} {
     ${{ ...theme.typography.subtitle3 }}
-    color: ${theme.custom.colors.mitRed};
   }
 `
 
@@ -279,7 +283,7 @@ const StartDate: React.FC<{ resource: LearningResource }> = ({ resource }) => {
 
   return (
     <div>
-      {label} <span>{startDate}</span>
+      <CardLabel>{label}</CardLabel> <span>{startDate}</span>
     </div>
   )
 }
@@ -289,7 +293,7 @@ const Format = ({ resource }: { resource: LearningResource }) => {
   if (!format) return null
   return (
     <div>
-      Format: <span>{format}</span>
+      <CardLabel>Format:</CardLabel> <span>{format}</span>
     </div>
   )
 }
@@ -390,7 +394,11 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Info>
         <Info resource={resource} />
       </ListCard.Info>
-      <ListCard.Title>{resource.title}</ListCard.Title>
+      <ListCard.Title
+        sx={(theme) => ({ color: theme.custom.colors.darkGray2 })}
+      >
+        {resource.title}
+      </ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
           <StyledActionButton

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -394,11 +394,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Info>
         <Info resource={resource} />
       </ListCard.Info>
-      <ListCard.Title
-        sx={(theme) => ({ color: theme.custom.colors.darkGray2 })}
-      >
-        {resource.title}
-      </ListCard.Title>
+      <ListCard.Title>{resource.title}</ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
           <StyledActionButton


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/4646


### Description (What does it do?)
Adjustments to the mobile styling of the learning resource cards on the search results page.


### Screenshots (if appropriate):

<img width="474" alt="Screenshot 2024-06-24 at 2 41 24 PM" src="https://github.com/mitodl/mit-open/assets/196425/be5bcb1c-da56-4126-8ee1-a3dfd920b877">


### How can this be tested?
1. Checkout this branch and validate that the changes in the [linked ticket](https://github.com/mitodl/hq/issues/4646) are there

