### PR TITLE
sort by -views instead

### DIFF
--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -213,7 +213,7 @@ const navData: NavData = {
         {
           title: "Popular",
           icon: "/static/images/navdrawer/popular.svg",
-          href: querifiedSearchUrl({ sortby: "popular" }),
+          href: querifiedSearchUrl({ sortby: "-views" }),
         },
         {
           title: "Free",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4690

### Description (What does it do?)
This PR changes the link attached to the "Popular" option in the nav menu to use `-views` as the `sortby` argument instead of `popular`.

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Open the nav menu and click "Popular"
 - When the search page loads, verify that you see `sortby=-views` in the query string and that the "Popular" option is selected in the "Sort by" dropdown
