### PR TITLE
better chunking for content files

### DIFF
--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -343,6 +343,52 @@ def index_run_content_files(run_id, index_types):
         )
 
 
+def index_content_files(content_file_ids, learning_resource_id, index_types):
+    """
+    Index a list of content files
+
+    Args:
+        content_file_ids(array of int): List of content file ids
+        learning_resource_id(int): Learning resource id of the content files
+        index_types (string): one of the values IndexestoUpdate. Whether the default
+            index, the reindexing index or both need to be updated
+    """
+
+    documents = (
+        serialize_content_file_for_bulk(content_file)
+        for content_file in ContentFile.objects.filter(pk__in=content_file_ids)
+    )
+
+    index_items(
+        documents,
+        COURSE_TYPE,
+        index_types=index_types,
+        routing=learning_resource_id,
+    )
+
+
+def deindex_content_files(content_file_ids, learning_resource_id):
+    """
+    Index a list of content files
+
+    Args:
+        content_file_ids(array of int): List of content file ids
+        learning_resource_id(int): Learning resource id of the content files
+    """
+
+    documents = (
+        serialize_content_file_for_bulk_deletion(content_file)
+        for content_file in ContentFile.objects.filter(pk__in=content_file_ids)
+    )
+
+    deindex_items(
+        documents,
+        COURSE_TYPE,
+        index_types=IndexestoUpdate.all_indexes.value,
+        routing=learning_resource_id,
+    )
+
+
 def deindex_run_content_files(run_id, unpublished_only):
     """
     Deindex and delete a list of content files by run from the index


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4669

### Description (What does it do?)
The celery tasks for updating learning resources update OPENSEARCH_INDEXING_CHUNK_SIZE learning resources at a time. The celery task updating content files were indexed by courses so they updated all the content files for a OPENSEARCH_INDEXING_CHUNK_SIZE list of courses which was sometimes hundreds of thousands of content files. This pr breaks up content file updates into celery jobs with up to OPENSEARCHOPENSEARCH_DOCUMENT_INDEXING_CHUNK_SIZE content files 


### How can this be tested?
docker-compose run web ./manage.py recreate_index --courses should complete and not throw errors
docker-compose run web ./manage.py update_index --content_files should complete and not throw errors