### PR TITLE
Update Select and Dropdown components

### DIFF
--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -10,6 +10,7 @@ import {
   BasicDialog,
   styled,
   RadioChoiceField,
+  MenuItem,
 } from "ol-components"
 import * as Yup from "yup"
 import { PrivacyLevelEnum, type LearningPathResource, UserList } from "api"
@@ -222,6 +223,9 @@ const UpsertLearningPathDialog = NiceModal.create(
               }
             />
           )}
+          renderOption={(props, opt) => {
+            return <MenuItem {...props}>{opt.name}</MenuItem>
+          }}
         />
         <BooleanRadioChoiceField
           className="form-row"

--- a/frontends/mit-open/src/page-components/Profile/EducationLevelChoice.tsx
+++ b/frontends/mit-open/src/page-components/Profile/EducationLevelChoice.tsx
@@ -1,15 +1,22 @@
 import React from "react"
 
-import {
-  Select,
-  MenuItem,
-  FormControl,
-  FormLabel,
-  SelectChangeEvent,
-} from "ol-components"
+import { FormControl, FormLabel, SimpleSelect } from "ol-components"
+import type { SimpleSelectFieldProps, SimpleSelectOption } from "ol-components"
 import { CurrentEducationEnum, CurrentEducationEnumDescriptions } from "api/v0"
 
 import { ProfileFieldUpdateProps } from "./types"
+
+const OPTIONS: SimpleSelectOption[] = [
+  {
+    label: <em>Please select</em>,
+    disabled: true,
+    value: "",
+  },
+  ...Object.values(CurrentEducationEnum).map((value) => ({
+    value,
+    label: CurrentEducationEnumDescriptions[value],
+  })),
+]
 
 const EducationLevelSelect: React.FC<
   ProfileFieldUpdateProps<"current_education">
@@ -18,7 +25,7 @@ const EducationLevelSelect: React.FC<
     CurrentEducationEnum | ""
   >(value || "")
 
-  const handleChange = (event: SelectChangeEvent<typeof educationLevel>) => {
+  const handleChange: SimpleSelectFieldProps["onChange"] = (event) => {
     setEducationLevel(event.target.value as CurrentEducationEnum)
   }
 
@@ -29,18 +36,11 @@ const EducationLevelSelect: React.FC<
   return (
     <FormControl component="fieldset" fullWidth>
       <FormLabel component="label">{label}</FormLabel>
-      <Select displayEmpty onChange={handleChange} value={educationLevel}>
-        <MenuItem disabled value="">
-          <em>Please select</em>
-        </MenuItem>
-        {Object.values(CurrentEducationEnum).map((value, index) => {
-          return (
-            <MenuItem value={value} key={index}>
-              {CurrentEducationEnumDescriptions[value]}
-            </MenuItem>
-          )
-        })}
-      </Select>
+      <SimpleSelect
+        value={educationLevel}
+        onChange={handleChange}
+        options={OPTIONS}
+      />
     </FormControl>
   )
 }

--- a/frontends/mit-open/src/page-components/Profile/LearningFormatChoice.tsx
+++ b/frontends/mit-open/src/page-components/Profile/LearningFormatChoice.tsx
@@ -1,12 +1,11 @@
 import React from "react"
 import {
-  RadioChoiceBoxField,
-  Select,
-  SelectChangeEvent,
-  MenuItem,
   FormControl,
   FormLabel,
+  SimpleSelect,
+  RadioChoiceBoxField,
 } from "ol-components"
+import type { SimpleSelectFieldProps, SimpleSelectOption } from "ol-components"
 import { LearningFormatEnum, LearningFormatEnumDescriptions } from "api/v0"
 
 import { ProfileFieldUpdateProps, ProfileFieldStateHook } from "./types"
@@ -19,6 +18,15 @@ const CHOICES = [
   value,
   label: LearningFormatEnumDescriptions[value],
 }))
+
+const SELECT_OPTIONS: SimpleSelectOption[] = [
+  {
+    label: <em>Please select</em>,
+    disabled: true,
+    value: "",
+  },
+  ...CHOICES,
+]
 
 type Props = ProfileFieldUpdateProps<"learning_format">
 type State = LearningFormatEnum | ""
@@ -66,11 +74,8 @@ const LearningFormatChoiceBoxField: React.FC<Props> = ({
 const LearningFormatSelect: React.FC<Props> = ({ label, value, onUpdate }) => {
   const [learningFormat, setLearningFormat] = React.useState<State>(value || "")
 
-  const handleChange = (event: SelectChangeEvent<typeof learningFormat>) => {
-    setLearningFormat(() => {
-      const target = event.target as HTMLInputElement
-      return target.value as LearningFormatEnum
-    })
+  const handleChange: SimpleSelectFieldProps["onChange"] = (event) => {
+    setLearningFormat(event.target.value as LearningFormatEnum)
   }
   React.useEffect(() => {
     onUpdate("learning_format", learningFormat)
@@ -79,16 +84,11 @@ const LearningFormatSelect: React.FC<Props> = ({ label, value, onUpdate }) => {
   return (
     <FormControl component="fieldset" fullWidth>
       <FormLabel component="label">{label}</FormLabel>
-      <Select displayEmpty onChange={handleChange} value={learningFormat}>
-        <MenuItem disabled value="">
-          <em>Please select</em>
-        </MenuItem>
-        {CHOICES.map((choice) => (
-          <MenuItem value={choice.value} key={choice.value}>
-            {choice.label}
-          </MenuItem>
-        ))}
-      </Select>
+      <SimpleSelect
+        options={SELECT_OPTIONS}
+        onChange={handleChange}
+        value={learningFormat}
+      />
     </FormControl>
   )
 }

--- a/frontends/mit-open/src/page-components/Profile/TimeCommitmentChoice.tsx
+++ b/frontends/mit-open/src/page-components/Profile/TimeCommitmentChoice.tsx
@@ -2,11 +2,10 @@ import React from "react"
 import {
   FormControl,
   FormLabel,
-  Select,
-  SelectChangeEvent,
-  MenuItem,
+  SimpleSelect,
   RadioChoiceBoxField,
 } from "ol-components"
+import type { SimpleSelectFieldProps, SimpleSelectOption } from "ol-components"
 import { TimeCommitmentEnum, TimeCommitmentEnumDescriptions } from "api/v0"
 
 import { ProfileFieldUpdateProps } from "./types"
@@ -21,6 +20,15 @@ const CHOICES = [
   value,
   label: TimeCommitmentEnumDescriptions[value],
 }))
+
+const SELECT_OPTIONS: SimpleSelectOption[] = [
+  {
+    label: <em>Please select</em>,
+    disabled: true,
+    value: "",
+  },
+  ...CHOICES,
+]
 
 type Props = ProfileFieldUpdateProps<"time_commitment">
 type State = TimeCommitmentEnum | ""
@@ -57,11 +65,8 @@ const TimeCommitmentRadioChoiceBoxField: React.FC<Props> = ({
 const TimeCommitmentSelect: React.FC<Props> = ({ label, value, onUpdate }) => {
   const [timeCommitment, setTimeCommitment] = React.useState<State>(value || "")
 
-  const handleChange = (event: SelectChangeEvent<typeof timeCommitment>) => {
-    setTimeCommitment(() => {
-      const target = event.target as HTMLInputElement
-      return target.value as TimeCommitmentEnum
-    })
+  const handleChange: SimpleSelectFieldProps["onChange"] = (event) => {
+    setTimeCommitment(event.target.value as TimeCommitmentEnum)
   }
   React.useEffect(() => {
     onUpdate("time_commitment", timeCommitment)
@@ -70,16 +75,11 @@ const TimeCommitmentSelect: React.FC<Props> = ({ label, value, onUpdate }) => {
   return (
     <FormControl component="fieldset" fullWidth>
       <FormLabel component="label">{label}</FormLabel>
-      <Select displayEmpty onChange={handleChange} value={timeCommitment}>
-        <MenuItem disabled value="">
-          <em>Please select</em>
-        </MenuItem>
-        {CHOICES.map((choice) => (
-          <MenuItem value={choice.value} key={choice.value}>
-            {choice.label}
-          </MenuItem>
-        ))}
-      </Select>
+      <SimpleSelect
+        options={SELECT_OPTIONS}
+        onChange={handleChange}
+        value={timeCommitment}
+      />
     </FormControl>
   )
 }

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -439,19 +439,19 @@ export const ALL_RESOURCE_TABS = TABS.map((t) => t.resource_type)
 export const SORT_OPTIONS = [
   {
     label: "Best Match",
-    key: "",
+    value: "",
   },
   {
     label: "New",
-    key: "new",
+    value: "new",
   },
   {
     label: "Popular",
-    key: "-views",
+    value: "-views",
   },
   {
     label: "Upcoming",
-    key: "upcoming",
+    value: "upcoming",
   },
 ]
 
@@ -559,7 +559,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       options={SORT_OPTIONS}
       className="sort-dropdown"
       renderValue={(value) => {
-        const opt = SORT_OPTIONS.find((option) => option.key === value)
+        const opt = SORT_OPTIONS.find((option) => option.value === value)
         return `Sort by: ${opt?.label}`
       }}
     />

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -46,24 +46,8 @@ import type { TabConfig } from "./ResourceTypeTabs"
 import { ResourceListCard } from "../ResourceCard/ResourceCard"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
 
-export const StyledDropdown = styled(SimpleSelect)`
-  margin-left: 8px;
-  margin-right: 0;
-  margin-top: 0;
+export const StyledSelect = styled(SimpleSelect)`
   min-width: 160px;
-  height: 32px;
-  background: ${({ theme }) => theme.custom.colors.white};
-
-  svg {
-    width: 0.75em;
-    height: 0.75em;
-  }
-
-  div {
-    min-height: 0 px;
-    padding-right: 1px !important;
-    font-size: 12px !important;
-  }
 `
 
 export const StyledResourceTabs = styled(ResourceTypeTabs.TabList)`
@@ -73,11 +57,6 @@ export const StyledResourceTabs = styled(ResourceTypeTabs.TabList)`
 export const DesktopSortContainer = styled.div`
   float: right;
 
-  div {
-    height: 32px;
-    bottom: 1px;
-  }
-
   ${({ theme }) => theme.breakpoints.down("md")} {
     display: none;
   }
@@ -86,11 +65,6 @@ export const MobileSortContainer = styled.div`
   float: right;
   ${({ theme }) => theme.breakpoints.up("md")} {
     display: none;
-  }
-
-  div {
-    height: 32px;
-    bottom: -2px;
   }
 `
 
@@ -578,7 +552,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   )
 
   const sortDropdown = (
-    <StyledDropdown
+    <StyledSelect
+      size="small"
       initialValue={requestParams.sortby || ""}
       isMultiple={false}
       onChange={(e) => setParamValue("sortby", e.target.value)}

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -554,12 +554,10 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   const sortDropdown = (
     <StyledSelect
       size="small"
-      initialValue={requestParams.sortby || ""}
-      isMultiple={false}
+      value={requestParams.sortby || ""}
       onChange={(e) => setParamValue("sortby", e.target.value)}
       options={SORT_OPTIONS}
       className="sort-dropdown"
-      sx={{ fontSize: "small" }}
       renderValue={(value) => {
         const opt = SORT_OPTIONS.find((option) => option.key === value)
         return `Sort by: ${opt?.label}`

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -9,9 +9,8 @@ import type {
 } from "@mitodl/course-search-utils"
 import { BOOLEAN_FACET_NAMES } from "@mitodl/course-search-utils"
 import { Skeleton, styled } from "ol-components"
+import type { SimpleSelectOption } from "ol-components"
 import { StyledSelect } from "@/page-components/SearchDisplay/SearchDisplay"
-
-export type KeyWithLabel = { key: string; label: string }
 
 const StyledSkeleton = styled(Skeleton)`
   display: inline-flex;
@@ -51,19 +50,19 @@ const filteredResultsWithLabels = (
   results: Aggregation,
   labelFunction: ((value: string) => string) | null | undefined,
   constantsForFacet: string[] | null,
-): KeyWithLabel[] => {
-  const newResults = [] as KeyWithLabel[]
+): SimpleSelectOption[] => {
+  const newResults = [] as SimpleSelectOption[]
   if (constantsForFacet) {
     constantsForFacet.map((key: string) => {
       newResults.push({
-        key: key,
+        value: key,
         label: labelFunction ? labelFunction(key) : key,
       })
     })
   } else {
     results.map((singleFacet: Bucket) => {
       newResults.push({
-        key: singleFacet.key,
+        value: singleFacet.key,
         label: labelFunction ? labelFunction(singleFacet.key) : singleFacet.key,
       })
     })
@@ -113,15 +112,15 @@ const AvailableFacetsDropdowns: React.FC<
         }
 
         if (!isMultiple) {
-          facetItems.unshift({ key: "", label: "no selection" })
+          facetItems.unshift({ value: "", label: "no selection" })
         }
 
         return (
           facetItems.length && (
             <StyledSelect
               key={facetSetting.name}
-              initialValue={displayValue}
-              isMultiple={isMultiple}
+              value={displayValue}
+              multiple={isMultiple}
               onChange={(e) => onFacetChange(facetSetting.name, e.target.value)}
               renderValue={() => {
                 return facetSetting.title

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearchFacetDisplay.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@mitodl/course-search-utils"
 import { BOOLEAN_FACET_NAMES } from "@mitodl/course-search-utils"
 import { Skeleton, styled } from "ol-components"
-import { StyledDropdown } from "@/page-components/SearchDisplay/SearchDisplay"
+import { StyledSelect } from "@/page-components/SearchDisplay/SearchDisplay"
 
 export type KeyWithLabel = { key: string; label: string }
 
@@ -118,7 +118,7 @@ const AvailableFacetsDropdowns: React.FC<
 
         return (
           facetItems.length && (
-            <StyledDropdown
+            <StyledSelect
               key={facetSetting.name}
               initialValue={displayValue}
               isMultiple={isMultiple}

--- a/frontends/ol-components/src/components/FormHelpers/FormHelpers.tsx
+++ b/frontends/ol-components/src/components/FormHelpers/FormHelpers.tsx
@@ -50,7 +50,13 @@ const ControlLabel: React.FC<ControlLabelProps> = ({
   id,
 }) => {
   return (
-    <Typography id={id} component="label" htmlFor={htmlFor} variant="subtitle2">
+    <Typography
+      id={id}
+      component="label"
+      htmlFor={htmlFor}
+      variant="subtitle2"
+      sx={{ marginBottom: "4px" }}
+    >
       {label}
       {required ? <Required aria-hidden="true">*</Required> : null}
     </Typography>

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled"
 import { pxToRem } from "../ThemeProvider/typography"
 import InputBase from "@mui/material/InputBase"
 import type { InputBaseProps } from "@mui/material/InputBase"
+import type { Theme } from "@mui/material/styles"
 
 const defaultProps = {
   size: "medium",
@@ -16,6 +17,35 @@ const buttonPadding = {
 }
 
 /**
+ * Base styles for Input and Select components. Includes border, color, hover effects.
+ */
+const baseInputStyles = (theme: Theme) => ({
+  backgroundColor: "white",
+  color: theme.custom.colors.silverGrayDark,
+  borderColor: theme.custom.colors.silverGrayLight,
+  borderWidth: "1px",
+  borderStyle: "solid",
+  "&:hover:not(.Mui-disabled)": {
+    borderColor: theme.custom.colors.darkGray2,
+  },
+  "&.Mui-focused": {
+    borderWidth: "2px",
+    color: theme.custom.colors.darkGray2,
+    borderColor: "currentcolor",
+  },
+  "&.Mui-error": {
+    borderColor: theme.custom.colors.red,
+  },
+  "& input::placeholder": {
+    opacity: "0.3",
+    color: theme.custom.colors.black,
+  },
+  "& input:placeholder-shown": {
+    textOverflow: "ellipsis",
+  },
+})
+
+/**
  * A styled input that supports start and end adornments. In most cases, the
  * higher-level TextField component should be used instead of this component.
  */
@@ -25,31 +55,7 @@ const Input = styled(InputBase)(({
   multiline,
 }) => {
   return [
-    {
-      backgroundColor: "white",
-      color: theme.custom.colors.silverGrayDark,
-      borderColor: theme.custom.colors.silverGrayLight,
-      borderWidth: "1px",
-      borderStyle: "solid",
-      "&:hover:not(.Mui-disabled)": {
-        borderColor: theme.custom.colors.darkGray2,
-      },
-      "&.Mui-focused": {
-        borderWidth: "2px",
-        color: theme.custom.colors.darkGray2,
-        borderColor: "currentcolor",
-      },
-      "&.Mui-error": {
-        borderColor: theme.custom.colors.red,
-      },
-      "& input::placeholder": {
-        opacity: "0.3",
-        color: theme.custom.colors.black,
-      },
-      "& input:placeholder-shown": {
-        textOverflow: "ellipsis",
-      },
-    },
+    baseInputStyles(theme),
     size === "medium" && {
       "& .MuiInputBase-input": {
         ...theme.typography.body2,
@@ -207,5 +213,5 @@ const AdornmentButton: React.FC<AdornmentButtonProps> = (props) => {
 
 type InputProps = Omit<InputBaseProps, "color">
 
-export { AdornmentButton, Input }
+export { AdornmentButton, Input, baseInputStyles }
 export type { InputProps, AdornmentButtonProps }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import { ButtonLink } from "../Button/Button"
-import MenuItem from "@mui/material/MenuItem"
 import Chip from "@mui/material/Chip"
 import type { LearningResource, LearningResourceTopic } from "api"
 import { ResourceTypeEnum, PlatformEnum } from "api"
@@ -13,9 +12,9 @@ import {
   getReadableResourceType,
 } from "ol-utilities"
 import type { EmbedlyConfig } from "ol-utilities"
-import type { SelectChangeEvent } from "@mui/material/Select"
 import { theme } from "../ThemeProvider/ThemeProvider"
-import { SelectField } from "../SelectField/SelectField"
+import { SimpleSelect } from "../SimpleSelect/SimpleSelect"
+import type { SimpleSelectProps } from "../SimpleSelect/SimpleSelect"
 import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import { ChipLink } from "../Chips/ChipLink"
@@ -319,7 +318,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     }
   }, [resource])
 
-  const onDateChange = (event: SelectChangeEvent) => {
+  const onDateChange: SimpleSelectProps["onChange"] = (event) => {
     const run = resource?.runs?.find(
       (run) => run.id === Number(event.target.value),
     )
@@ -333,6 +332,11 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     if (!resource) {
       return <Skeleton height={40} style={{ marginTop: 0, width: "60%" }} />
     }
+    const dateOptions: SimpleSelectProps["options"] =
+      resource.runs?.map((run) => ({
+        value: run.id.toString(),
+        label: formatDate(run.start_date!, "MMMM DD, YYYY"),
+      })) ?? []
 
     if (
       [ResourceTypeEnum.Course, ResourceTypeEnum.Program].includes(
@@ -343,18 +347,11 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       return (
         <Date>
           <DateLabel>Start Date:</DateLabel>
-          <SelectField
-            label={null}
-            value={selectedRun?.id as unknown as string}
-            defaultValue=""
+          <SimpleSelect
+            value={selectedRun?.id.toString() ?? ""}
             onChange={onDateChange}
-          >
-            {resource.runs?.map((run) => (
-              <MenuItem key={run.id} value={run.id}>
-                {formatDate(run.start_date!, "MMMM DD, YYYY")}
-              </MenuItem>
-            ))}
-          </SelectField>
+            options={dateOptions}
+          />
         </Date>
       )
     }

--- a/frontends/ol-components/src/components/MenuItem/MenuItem.tsx
+++ b/frontends/ol-components/src/components/MenuItem/MenuItem.tsx
@@ -1,0 +1,60 @@
+import MuiMenuItem from "@mui/material/MenuItem"
+import type { MenuItemProps as MuiMenuItemProps } from "@mui/material/MenuItem"
+import styled from "@emotion/styled"
+
+type MenuItemProps = MuiMenuItemProps & {
+  size?: "small" | "medium" | "large"
+}
+
+const DEFAULT_SIZE = "medium"
+
+const MenuItem = styled(MuiMenuItem)<MenuItemProps>(
+  ({ theme, size = DEFAULT_SIZE }) => [
+    {
+      padding: "8px 12px",
+      color: theme.custom.colors.darkGray2,
+      backgroundColor: theme.custom.colors.white,
+      "&:hover": {
+        backgroundColor: theme.custom.colors.lightGray1,
+      },
+      "&.Mui-disabled": {
+        opacity: 1,
+        color: theme.custom.colors.silverGrayDark,
+        backgroundColor: theme.custom.colors.white,
+      },
+      '&.Mui-selected:not(.Mui-disabled), .MuiAutocomplete-listbox &.MuiAutocomplete-option[aria-selected="true"].Mui-focused, .MuiAutocomplete-listbox &.MuiAutocomplete-option[aria-selected="true"]':
+        {
+          backgroundColor: theme.custom.colors.red,
+          color: theme.custom.colors.white,
+          "&:hover": {
+            backgroundColor: theme.custom.colors.mitRed,
+          },
+        },
+      ".MuiAutocomplete-listbox &.MuiAutocomplete-option.Mui-focusVisible": {
+        /**
+         * For autocomplete fields in particular, the input field maintains
+         * focus while the menu is open, so browser does not provide its default
+         * focus styling. MUI does provide its own styling for focusVisible in
+         * this case, but we tend to use the outline generally.
+         */
+        outline: [
+          "2px auto rgb(0, 95, 204)", // fallback
+          "2px auto Highlight", // firefox
+          "2px auto -webkit-focus-ring-color", // webkit,
+        ],
+      },
+    },
+    size === "small" && {
+      ...theme.typography.body3,
+    },
+    size === "medium" && {
+      ...theme.typography.body2,
+    },
+    size === "large" && {
+      ...theme.typography.body1,
+    },
+  ],
+)
+
+export { MenuItem }
+export type { MenuItemProps }

--- a/frontends/ol-components/src/components/SelectField/SelectField.mdx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.mdx
@@ -6,9 +6,11 @@ import * as SelectField from "./SelectField.stories";
 
 # SelectField
 
+**NOTE: Prefer using `SimpleSelectField`, wherein options are specified by an array of objects rather than using `MenuItem` Children.**
+
 `SelectField` includes an input, label, help text, and error message. Internally, it uses `<Select />`. The child menu items should be `<MenuItem>...</MenuItem>` components; "placeholder" text can be added via a disabled `MenuItem`.
 
-SelectFields come in two sizes, `size="medium" | "hero"`:
+SelectFields come in two sizes, `size="small" | "medium" | "large"`:
 
 <Canvas of={SelectField.Sizes} />
 

--- a/frontends/ol-components/src/components/SelectField/SelectField.stories.tsx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.stories.tsx
@@ -3,14 +3,13 @@ import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { SelectField } from "./SelectField"
 import type { SelectFieldProps } from "./SelectField"
-import MenuItem from "@mui/material/MenuItem"
+import { MenuItem } from "../MenuItem/MenuItem"
 
 import Stack from "@mui/material/Stack"
 import Grid from "@mui/material/Grid"
 import { fn } from "@storybook/test"
-import { useArgs } from "@storybook/preview-api"
 
-const SIZES = ["medium", "hero"] satisfies SelectFieldProps["size"][]
+const SIZES = ["small", "medium", "large"] satisfies SelectFieldProps["size"][]
 const meta: Meta<typeof SelectField> = {
   title: "smoot-design/SelectField",
   argTypes: {
@@ -20,12 +19,7 @@ const meta: Meta<typeof SelectField> = {
         type: "select",
       },
     },
-    value: {
-      control: { type: "select" },
-      options: ["", "value1", "value2", "value3"],
-    },
     onChange: { table: { disable: true } },
-    children: { table: { disable: true } },
   },
   args: {
     onChange: fn(),
@@ -33,84 +27,86 @@ const meta: Meta<typeof SelectField> = {
     label: "Label",
     helpText: "Help text the quick brown fox jumps over the lazy dog",
     errorText: "Error text the quick brown fox jumps over the lazy dog",
-    value: "value1",
     name: "select-example",
-    children: [
-      <MenuItem key="placeholder" value="" disabled>
-        Please select one...
-      </MenuItem>,
-      <MenuItem key="value1" value="value1">
-        Option 1
-      </MenuItem>,
-      <MenuItem key="value2" value="value2">
-        Option 2
-      </MenuItem>,
-      <MenuItem key="value3" value="value3">
-        Option 3
-      </MenuItem>,
-    ],
   },
 }
 
 export default meta
 
+const ITEMS = [
+  { label: "Please select one...", props: { value: "", disabled: true } },
+  { label: "Option 1", props: { value: "value1" } },
+  { label: "Option 2", props: { value: "value2" } },
+  { label: "Option 3", props: { value: "value3" } },
+]
+
 type Story = StoryObj<typeof SelectField>
 
 export const Sizes: Story = {
-  render: () => {
-    const [args, setArgs] = useArgs<SelectFieldProps>()
+  render: (args) => {
+    const [value, setValue] = React.useState("")
     const onChange: SelectFieldProps["onChange"] = (event, node) => {
-      setArgs({ value: event.target.value })
+      setValue(event.target.value as string)
       args.onChange?.(event, node)
     }
+    const props = { ...args, value, onChange }
     return (
-      <Stack direction="row" gap={2}>
-        <SelectField {...args} onChange={onChange} size="medium" />
-        <SelectField {...args} onChange={onChange} size="hero" />
+      <Stack direction="column" gap={2}>
+        {SIZES.map((size) => (
+          <SelectField key={size} {...props} size={size}>
+            {ITEMS.map((item) => (
+              <MenuItem key={item.props.value} {...item.props} size={size}>
+                {item.label}
+              </MenuItem>
+            ))}
+          </SelectField>
+        ))}
       </Stack>
     )
   },
 }
 
+const STATES = [
+  { label: "Placeholder", extraProps: { value: "" } },
+  { label: "Default", extraProps: {} },
+  { label: "Required", extraProps: { required: true } },
+  { label: "Error", extraProps: { error: true } },
+  { label: "Disabled", extraProps: { disabled: true } },
+]
 export const States: Story = {
-  render: () => {
-    const [args, setArgs] = useArgs<SelectFieldProps>()
+  render: (args) => {
+    const [value, setValue] = React.useState("")
     const onChange: SelectFieldProps["onChange"] = (event, node) => {
-      setArgs({ value: event.target.value })
+      setValue(event.target.value as string)
       args.onChange?.(event, node)
+    }
+    const props = {
+      ...args,
+      value,
+      onChange,
     }
     return (
       <Grid container spacing={2} alignItems="top" maxWidth="400px">
-        <Grid item xs={4}>
-          Placeholder
-        </Grid>
-        <Grid item xs={8}>
-          <SelectField {...args} value="" />
-        </Grid>
-        <Grid item xs={4}>
-          Default
-        </Grid>
-        <Grid item xs={8}>
-          <SelectField {...args} onChange={onChange} />
-        </Grid>
-        <Grid item xs={4}>
-          Required
-        </Grid>
-        <Grid item xs={8}>
-          <SelectField required {...args} onChange={onChange} />
-        </Grid>
-        <Grid item xs={4}>
-          Error
-        </Grid>
-        <Grid item xs={8}>
-          <SelectField {...args} error onChange={onChange} />
-        </Grid>
-        <Grid item xs={4}>
-          Disabled
-        </Grid>
-        <Grid item xs={8}>
-          <SelectField {...args} onChange={onChange} disabled />
-        </Grid>
+        {STATES.map(({ label, extraProps }) => (
+          <>
+            <Grid item xs={4}>
+              {label}
+            </Grid>
+            <Grid item xs={8}>
+              <SelectField {...props} {...extraProps}>
+                {ITEMS.map((item) => (
+                  <MenuItem
+                    key={item.props.value}
+                    {...item.props}
+                    size={args.size}
+                  >
+                    {item.label}
+                  </MenuItem>
+                ))}
+              </SelectField>
+            </Grid>
+          </>
+        ))}
       </Grid>
     )
   },

--- a/frontends/ol-components/src/components/SelectField/SelectField.stories.tsx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.stories.tsx
@@ -11,7 +11,7 @@ import { fn } from "@storybook/test"
 
 const SIZES = ["small", "medium", "large"] satisfies SelectFieldProps["size"][]
 const meta: Meta<typeof SelectField> = {
-  title: "smoot-design/SelectField",
+  title: "smoot-design/Dropdowns/SelectField (low-level)",
   argTypes: {
     size: {
       options: SIZES,

--- a/frontends/ol-components/src/components/SelectField/SelectField.tsx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.tsx
@@ -96,6 +96,14 @@ const SelectIcon = styled(RiArrowDownSLine)({
   width: "1em",
 })
 
+/**
+ * WARNING: You likely do not need this component. Try one of
+ *
+ *  - `SimpleSelect`,
+ *  - `SimpleSelectField`
+ *
+ * instead.
+ */
 function Select<Value = unknown>({ size, ...props }: SelectProps<Value>) {
   return (
     <MuiSelect
@@ -117,10 +125,6 @@ type SelectFieldProps<Value = unknown> = Omit<
 > &
   SelectProps<Value>
 
-/**
- * A form field for text input via dropdown. Supports labels, help text, error
- *  text, and start/end adornments.
- */
 function SelectField<Value = unknown>({
   label,
   required,

--- a/frontends/ol-components/src/components/SelectField/SelectField.tsx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.tsx
@@ -10,6 +10,7 @@ import { FormFieldWrapper } from "../FormHelpers/FormHelpers"
 import type { FormFieldWrapperProps } from "../FormHelpers/FormHelpers"
 import styled from "@emotion/styled"
 import { baseInputStyles } from "../Input/Input"
+import { RiArrowDownSLine } from "@remixicon/react"
 
 type SelectProps<Value = unknown> = Omit<
   MuiSelectProps<Value>,
@@ -33,6 +34,13 @@ const SelectInput = styled(InputBase as React.FC<SelectInputProps>)(
           backgroundColor: "transparent",
         },
       },
+      ".MuiSelect-icon": {
+        // MUI sizes icons via fontSize, remixicon doesn't.
+        // This usually isn't an issue. In this case, we need to size the icon
+        // MUI's way so that its transformations apply correctly.
+        height: "1em",
+        width: "1em",
+      },
     },
     size === "small" && {
       ...theme.typography.body3,
@@ -40,6 +48,13 @@ const SelectInput = styled(InputBase as React.FC<SelectInputProps>)(
       ".MuiInputBase-input": {
         height: "100%",
         padding: "8px 12px",
+      },
+      "&&& .MuiInputBase-input": {
+        paddingRight: "28px", // 12px + 16px icon
+      },
+      ".MuiSelect-icon": {
+        fontSize: 16,
+        right: "12px",
       },
     },
     size === "medium" && {
@@ -49,6 +64,13 @@ const SelectInput = styled(InputBase as React.FC<SelectInputProps>)(
         height: "100%",
         padding: "8px 12px",
       },
+      "&&& .MuiInputBase-input": {
+        paddingRight: "32px", // 12px + 20px icon
+      },
+      ".MuiSelect-icon": {
+        fontSize: 20,
+        right: "12px",
+      },
     },
     size === "large" && {
       ...theme.typography.body1,
@@ -57,9 +79,22 @@ const SelectInput = styled(InputBase as React.FC<SelectInputProps>)(
         height: "100%",
         padding: "8px 16px",
       },
+      "&&& .MuiInputBase-input": {
+        paddingRight: "40px", // 16px + 24px icon
+      },
+      ".MuiSelect-icon": {
+        fontSize: 24,
+        right: "16px",
+      },
     },
   ],
 )
+
+const SelectIcon = styled(RiArrowDownSLine)({
+  fontSize: "24px",
+  height: "1em",
+  width: "1em",
+})
 
 function Select<Value = unknown>({ size, ...props }: SelectProps<Value>) {
   return (
@@ -70,6 +105,7 @@ function Select<Value = unknown>({ size, ...props }: SelectProps<Value>) {
       // to be the same. But our Select has an extra "small" size.
       // Passing the size here generates the expected classes on root select.
       size={size}
+      IconComponent={SelectIcon}
       input={<SelectInput size={size} />}
     />
   )

--- a/frontends/ol-components/src/components/SelectField/SelectField.tsx
+++ b/frontends/ol-components/src/components/SelectField/SelectField.tsx
@@ -4,18 +4,73 @@ import type {
   SelectProps as MuiSelectProps,
   SelectChangeEvent,
 } from "@mui/material/Select"
-import { Input } from "../Input/Input"
+import InputBase from "@mui/material/InputBase"
+import type { InputBaseProps } from "@mui/material/InputBase"
 import { FormFieldWrapper } from "../FormHelpers/FormHelpers"
 import type { FormFieldWrapperProps } from "../FormHelpers/FormHelpers"
+import styled from "@emotion/styled"
+import { baseInputStyles } from "../Input/Input"
 
-type SelectProps<Value = unknown> = Omit<MuiSelectProps<Value>, "input">
+type SelectProps<Value = unknown> = Omit<
+  MuiSelectProps<Value>,
+  "input" | "size"
+> & { size?: "small" | "medium" | "large"; inputProps?: SelectInputProps }
+type SelectInputProps = Omit<InputBaseProps, "size"> & {
+  size?: "small" | "medium" | "large"
+}
 
-function Select<Value = unknown>(props: SelectProps<Value>) {
+const DEFAULT_SIZE = "medium"
+
+const SelectInput = styled(InputBase as React.FC<SelectInputProps>)(
+  ({ theme, size = DEFAULT_SIZE }) => [
+    baseInputStyles(theme),
+    {
+      ".MuiInputBase-input": {
+        boxSizing: "border-box",
+        display: "inline-flex",
+        alignItems: "center",
+        "&:focus": {
+          backgroundColor: "transparent",
+        },
+      },
+    },
+    size === "small" && {
+      ...theme.typography.body3,
+      height: "32px",
+      ".MuiInputBase-input": {
+        height: "100%",
+        padding: "8px 12px",
+      },
+    },
+    size === "medium" && {
+      ...theme.typography.body2,
+      height: "40px",
+      ".MuiInputBase-input": {
+        height: "100%",
+        padding: "8px 12px",
+      },
+    },
+    size === "large" && {
+      ...theme.typography.body1,
+      height: "48px",
+      ".MuiInputBase-input": {
+        height: "100%",
+        padding: "8px 16px",
+      },
+    },
+  ],
+)
+
+function Select<Value = unknown>({ size, ...props }: SelectProps<Value>) {
   return (
     <MuiSelect
       variant="standard"
       {...props}
-      input={<Input size={props.size} />}
+      // @ts-expect-error MUI Typescript really wants Input and Select sizes
+      // to be the same. But our Select has an extra "small" size.
+      // Passing the size here generates the expected classes on root select.
+      size={size}
+      input={<SelectInput size={size} />}
     />
   )
 }

--- a/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.stories.tsx
+++ b/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.stories.tsx
@@ -6,7 +6,7 @@ import DeleteIcon from "@mui/icons-material/Delete"
 import { withRouter } from "storybook-addon-react-router-v6"
 
 const meta: Meta<typeof SimpleMenu> = {
-  title: "ol-components/SimpleMenu",
+  title: "smoot-design/Dropdowns/SimpleMenu",
   component: SimpleMenu,
   argTypes: {
     onVisibilityChange: {

--- a/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.test.tsx
+++ b/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.test.tsx
@@ -4,6 +4,7 @@ import user from "@testing-library/user-event"
 import { SimpleMenu } from "./SimpleMenu"
 import type { SimpleMenuItem } from "./SimpleMenu"
 import type { LinkProps } from "react-router-dom"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
 // Mock react-router-dom's Link so we don't need to set up a Router
 jest.mock("react-router-dom", () => {
@@ -30,7 +31,9 @@ describe("SimpleMenu", () => {
       { key: "two", label: "Item 2", onClick: jest.fn() },
     ]
 
-    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />)
+    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />, {
+      wrapper: ThemeProvider,
+    })
 
     expect(screen.queryByRole("menu")).toBe(null)
     await user.click(screen.getByRole("button", { name: "Open Menu" }))
@@ -43,7 +46,9 @@ describe("SimpleMenu", () => {
       { key: "two", label: "Item 2", onClick: jest.fn() },
     ]
 
-    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />)
+    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />, {
+      wrapper: ThemeProvider,
+    })
     await user.click(screen.getByRole("button", { name: "Open Menu" }))
     const menu = screen.getByRole("menu")
 
@@ -66,6 +71,7 @@ describe("SimpleMenu", () => {
         trigger={<button onClick={triggerHandler}>Open Menu</button>}
         items={items}
       />,
+      { wrapper: ThemeProvider },
     )
 
     await user.click(screen.getByRole("button", { name: "Open Menu" }))
@@ -87,6 +93,7 @@ describe("SimpleMenu", () => {
         trigger={<button>Open Menu</button>}
         items={items}
       />,
+      { wrapper: ThemeProvider },
     )
 
     expect(visibilityHandler).not.toHaveBeenCalled()
@@ -109,7 +116,9 @@ describe("SimpleMenu", () => {
       { key: "two", label: "Item 2", href: "./woof" },
     ]
 
-    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />)
+    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />, {
+      wrapper: ThemeProvider,
+    })
     await user.click(screen.getByRole("button", { name: "Open Menu" }))
     const item2 = screen.getByRole("menuitem", { name: "Item 2" })
     expect(item2.dataset.reactComponent).toBe("react-router-dom-link")
@@ -127,7 +136,9 @@ describe("SimpleMenu", () => {
       { key: "two", label: "Item 2", href: "./woof", LinkComponent },
     ]
 
-    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />)
+    render(<SimpleMenu trigger={<button>Open Menu</button>} items={items} />, {
+      wrapper: ThemeProvider,
+    })
     await user.click(screen.getByRole("button", { name: "Open Menu" }))
     const item2 = screen.getByRole("menuitem", { name: "Item 2" })
     expect(item2.dataset.reactComponent).toBe("custom-link")

--- a/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.tsx
+++ b/frontends/ol-components/src/components/SimpleMenu/SimpleMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from "react"
 import Menu, { MenuProps } from "@mui/material/Menu"
-import MenuItem from "@mui/material/MenuItem"
+import { MenuItem } from "../MenuItem/MenuItem"
 import ListItemIcon from "@mui/material/ListItemIcon"
 import { Link as RouterLink } from "react-router-dom"
 import type { LinkProps as RouterLinkProps } from "react-router-dom"

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react"
 import { SimpleSelect, SimpleSelectProps } from "./SimpleSelect"
+import type { SimpleSelectOption } from "./SimpleSelect"
 import type { SelectChangeEvent } from "@mui/material/Select"
 
 function StateWrapper(props: SimpleSelectProps) {
@@ -28,32 +29,37 @@ const meta: Meta<typeof SimpleSelect> = {
 export default meta
 
 type Story = StoryObj<typeof SimpleSelect>
-const options = [
+const options: SimpleSelectOption[] = [
   {
-    key: "bagel",
+    value: "",
+    label: "Please select",
+    disabled: true,
+  },
+  {
+    value: "bagel",
     label: "Bagel",
   },
   {
-    key: "bacon",
+    value: "bacon",
     label: "Bacon",
   },
   {
-    key: "french_toast",
+    value: "french_toast",
     label: "French Toast",
   },
   {
-    key: "eggs",
+    value: "eggs",
     label: "Eggs",
   },
   {
-    key: "belgian_waffles",
+    value: "belgian_waffles",
     label: "Belgian Waffles",
   },
 ]
 
 export const SingleSelect: Story = {
   args: {
-    value: "bagel",
+    value: "",
     multiple: false,
     options: options,
   },

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
@@ -4,22 +4,20 @@ import { SimpleSelect, SimpleSelectProps } from "./SimpleSelect"
 import type { SelectChangeEvent } from "@mui/material/Select"
 
 function StateWrapper(props: SimpleSelectProps) {
-  const [value, setValue] = useState(props.initialValue)
+  const [value, setValue] = useState(props.value)
 
   const handleChange = (event: SelectChangeEvent<string | string[]>) => {
     setValue(event.target.value)
   }
 
-  return (
-    <SimpleSelect {...props} initialValue={value} onChange={handleChange} />
-  )
+  return <SimpleSelect {...props} value={value} onChange={handleChange} />
 }
 
 const meta: Meta<typeof SimpleSelect> = {
   title: "ol-components/SimpleSelect",
   component: StateWrapper,
   argTypes: {
-    isMultiple: {
+    multiple: {
       table: {
         disable: true,
       },
@@ -55,16 +53,16 @@ const options = [
 
 export const SingleSelect: Story = {
   args: {
-    initialValue: "bagel",
-    isMultiple: false,
+    value: "bagel",
+    multiple: false,
     options: options,
   },
 }
 
 export const MultipleSelect: Story = {
   args: {
-    initialValue: ["bagel", "bacon"],
-    isMultiple: true,
+    value: ["bagel", "bacon"],
+    multiple: true,
     options: options,
   },
 }

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.stories.tsx
@@ -15,7 +15,7 @@ function StateWrapper(props: SimpleSelectProps) {
 }
 
 const meta: Meta<typeof SimpleSelect> = {
-  title: "ol-components/SimpleSelect",
+  title: "smoot-design/Dropdowns/SimpleSelect",
   component: StateWrapper,
   argTypes: {
     multiple: {

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.test.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import user from "@testing-library/user-event"
+import { SimpleSelect, SimpleSelectField } from "./SimpleSelect"
+import type { SimpleSelectProps } from "./SimpleSelect"
+import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
+
+const OPTIONS = [
+  {
+    label: "Option 1",
+    value: "option1",
+  },
+  {
+    label: "Option 2",
+    value: "option2",
+  },
+  {
+    label: "Option 3",
+    value: "option3",
+    disabled: true,
+  },
+]
+
+const setupInput = (props: Partial<SimpleSelectProps> = {}) => {
+  const onChange = jest.fn()
+  const view = render(
+    <SimpleSelect
+      options={OPTIONS}
+      value={props.value ?? "option1"}
+      onChange={onChange}
+      name="select-example"
+    />,
+    { wrapper: ThemeProvider },
+  )
+
+  return { onChange, view }
+}
+
+const setupField = (props: Partial<SimpleSelectProps> = {}) => {
+  const onChange = jest.fn()
+  const view = render(
+    <SimpleSelectField
+      options={OPTIONS}
+      value={props.value ?? "option1"}
+      onChange={onChange}
+      name="select-example"
+      label="Select Example"
+    />,
+    { wrapper: ThemeProvider },
+  )
+
+  return { onChange, view }
+}
+
+test.each([
+  { setup: setupInput, label: "SimpleSelect" },
+  { setup: setupField, label: "SimpleSelectField" },
+])("$label Renders options and calls onChange", async ({ setup }) => {
+  const { onChange } = setup()
+  const select = screen.getByRole("combobox")
+  await user.click(select)
+  const options = screen.getAllByRole("option")
+  expect(options).toHaveLength(3)
+  expect(options[0]).toHaveTextContent("Option 1")
+  expect(options[1]).toHaveTextContent("Option 2")
+  expect(options[2]).toHaveTextContent("Option 3")
+
+  expect(options[0]).not.toHaveClass("Mui-disabled")
+  expect(options[1]).not.toHaveClass("Mui-disabled")
+  expect(options[2]).toHaveClass("Mui-disabled")
+
+  expect(screen.getByRole("option", { selected: true })).toBe(options[0])
+
+  await user.click(options[1])
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: { value: "option2", name: "select-example" },
+    }),
+    expect.anything(),
+  )
+})

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -5,7 +5,13 @@ import { MenuItem } from "../MenuItem/MenuItem"
 
 type SimpleSelectProps = Pick<
   SelectProps<string | string[]>,
-  "value" | "size" | "multiple" | "onChange" | "renderValue" | "className"
+  | "value"
+  | "size"
+  | "multiple"
+  | "onChange"
+  | "renderValue"
+  | "className"
+  | "name"
 > & {
   /**
    * The options for the dropdown
@@ -25,6 +31,9 @@ interface SimpleSelectOption {
   disabled?: boolean
 }
 
+/**
+ * An input for selection via dropdown.
+ */
 const SimpleSelect: React.FC<SimpleSelectProps> = ({ options, ...others }) => {
   return (
     <Select {...others} displayEmpty>
@@ -56,6 +65,10 @@ type SimpleSelectFieldProps = Pick<
   options: SimpleSelectOption[]
 }
 
+/**
+ * A form field for text input via select dropdowns. Supports labels, help text,
+ * error text, and start/end adornments.
+ */
 const SimpleSelectField: React.FC<SimpleSelectFieldProps> = ({
   options,
   ...others

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -2,40 +2,15 @@ import React from "react"
 import { Select } from "../SelectField/SelectField"
 import type { SelectProps } from "../SelectField/SelectField"
 import { MenuItem } from "../MenuItem/MenuItem"
-import type { SelectChangeEvent } from "@mui/material/Select"
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
-import { Theme, SxProps } from "@mui/material/styles"
 
-interface SimpleSelectProps {
-  /**
-   * Value of initial selection for the dropdown
-   */
-  initialValue: string | string[]
-  /**
-   * Whether the dropdown allows multiple selections
-   */
-  isMultiple: boolean
-  /**
-  The function that runs when there is a selection from the dropdown
-   */
-  onChange: (event: SelectChangeEvent<string[] | string>) => void
+type SimpleSelectProps = Pick<
+  SelectProps<string | string[]>,
+  "value" | "size" | "multiple" | "onChange" | "renderValue" | "className"
+> & {
   /**
    * The options for the dropdown
    */
   options: SimpleSelectOptionProps[]
-  /**
-   * Function that controls the display for the dropdown
-   */
-  renderValue?: (selected: string | string[] | void) => string
-  /**
-   * class name for the dropdown and base for key for dropdown options
-   */
-  className?: string
-  /**
-   * styles for the dropdown and options
-   */
-  sx?: SxProps<Theme>
-  size?: SelectProps["size"]
 }
 
 interface SimpleSelectOptionProps {
@@ -49,34 +24,14 @@ interface SimpleSelectOptionProps {
   label: string
 }
 
-const SimpleSelect: React.FC<SimpleSelectProps> = ({
-  className,
-  initialValue,
-  isMultiple,
-  onChange,
-  options,
-  renderValue,
-  size,
-  sx,
-}) => {
+const SimpleSelect: React.FC<SimpleSelectProps> = ({ options, ...others }) => {
   return (
-    <Select
-      size={size}
-      multiple={isMultiple}
-      displayEmpty
-      value={initialValue}
-      onChange={onChange}
-      className={className}
-      renderValue={renderValue}
-      IconComponent={() => <ExpandMoreIcon />}
-      sx={sx}
-    >
+    <Select {...others} displayEmpty>
       {options.map((option) => (
         <MenuItem
-          size={size}
+          size={others.size}
           value={option.key.toString()}
           key={option.key.toString()}
-          sx={sx}
         >
           {option.label}
         </MenuItem>

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Select } from "../SelectField/SelectField"
-import type { SelectProps } from "../SelectField/SelectField"
+import { Select, SelectField } from "../SelectField/SelectField"
+import type { SelectProps, SelectFieldProps } from "../SelectField/SelectField"
 import { MenuItem } from "../MenuItem/MenuItem"
 
 type SimpleSelectProps = Pick<
@@ -10,35 +10,66 @@ type SimpleSelectProps = Pick<
   /**
    * The options for the dropdown
    */
-  options: SimpleSelectOptionProps[]
+  options: SimpleSelectOption[]
 }
 
-interface SimpleSelectOptionProps {
+interface SimpleSelectOption {
   /**
    * value for the dropdown option
    */
-  key: string
+  value: string
   /**
    * label for the dropdown option
    */
-  label: string
+  label: React.ReactNode
+  disabled?: boolean
 }
 
 const SimpleSelect: React.FC<SimpleSelectProps> = ({ options, ...others }) => {
   return (
     <Select {...others} displayEmpty>
-      {options.map((option) => (
-        <MenuItem
-          size={others.size}
-          value={option.key.toString()}
-          key={option.key.toString()}
-        >
-          {option.label}
+      {options.map(({ label, value, ...itemProps }) => (
+        <MenuItem key={value} size={others.size} {...itemProps} value={value}>
+          {label}
         </MenuItem>
       ))}
     </Select>
   )
 }
 
-export { SimpleSelect }
-export type { SimpleSelectProps, SimpleSelectOptionProps }
+type SimpleSelectFieldProps = Pick<
+  SelectFieldProps<string | string[]>,
+  | "fullWidth"
+  | "label"
+  | "helpText"
+  | "errorText"
+  | "required"
+  | "size"
+  | "value"
+  | "onChange"
+  | "name"
+  | "className"
+> & {
+  /**
+   * The options for the dropdown
+   */
+  options: SimpleSelectOption[]
+}
+
+const SimpleSelectField: React.FC<SimpleSelectFieldProps> = ({
+  options,
+  ...others
+}) => {
+  return (
+    <SelectField {...others}>
+      {options.map(({ value, label, ...itemProps }) => (
+        <MenuItem size={others.size} value={value} key={value} {...itemProps}>
+          {label}
+        </MenuItem>
+      ))}
+    </SelectField>
+  )
+}
+
+export { SimpleSelect, SimpleSelectField }
+export type { SimpleSelectProps, SimpleSelectFieldProps, SimpleSelectOption }

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -75,6 +75,7 @@ const SimpleSelectField: React.FC<SimpleSelectFieldProps> = ({
 }) => {
   return (
     <SelectField {...others}>
+      <MenuItem style={{ display: "none" }}></MenuItem>
       {options.map(({ value, label, ...itemProps }) => (
         <MenuItem size={others.size} value={value} key={value} {...itemProps}>
           {label}

--- a/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
+++ b/frontends/ol-components/src/components/SimpleSelect/SimpleSelect.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Select } from "../SelectField/SelectField"
-import MenuItem from "@mui/material/MenuItem"
+import type { SelectProps } from "../SelectField/SelectField"
+import { MenuItem } from "../MenuItem/MenuItem"
 import type { SelectChangeEvent } from "@mui/material/Select"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { Theme, SxProps } from "@mui/material/styles"
@@ -34,6 +35,7 @@ interface SimpleSelectProps {
    * styles for the dropdown and options
    */
   sx?: SxProps<Theme>
+  size?: SelectProps["size"]
 }
 
 interface SimpleSelectOptionProps {
@@ -54,10 +56,12 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
   onChange,
   options,
   renderValue,
+  size,
   sx,
 }) => {
   return (
     <Select
+      size={size}
       multiple={isMultiple}
       displayEmpty
       value={initialValue}
@@ -69,6 +73,7 @@ const SimpleSelect: React.FC<SimpleSelectProps> = ({
     >
       {options.map((option) => (
         <MenuItem
+          size={size}
           value={option.key.toString()}
           key={option.key.toString()}
           sx={sx}

--- a/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -73,6 +73,11 @@ const themeOptions: ThemeOptions = {
         },
       },
     },
+    MuiMenu: {
+      styleOverrides: {
+        paper: { borderRadius: "4px" },
+      },
+    },
     MuiChip: chips.chipComponent,
   },
 }

--- a/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -74,9 +74,10 @@ const themeOptions: ThemeOptions = {
       },
     },
     MuiMenu: {
-      styleOverrides: {
-        paper: { borderRadius: "4px" },
-      },
+      styleOverrides: { paper: { borderRadius: "4px" } },
+    },
+    MuiAutocomplete: {
+      styleOverrides: { paper: { borderRadius: "4px" } },
     },
     MuiChip: chips.chipComponent,
   },

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -145,7 +145,7 @@ export { default as Collapse } from "@mui/material/Collapse"
 
 export { default as Menu } from "@mui/material/Menu"
 export type { MenuProps } from "@mui/material/Menu"
-export { default as MenuItem } from "@mui/material/MenuItem"
+export * from "./components/MenuItem/MenuItem"
 
 export { default as Stepper } from "@mui/material/Stepper"
 export { default as Step } from "@mui/material/Step"

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -186,14 +186,18 @@ export * from "./constants/imgConfigs"
 export { Input, AdornmentButton } from "./components/Input/Input"
 export type { InputProps, AdornmentButtonProps } from "./components/Input/Input"
 export { TextField } from "./components/TextField/TextField"
-export { SimpleSelect } from "./components/SimpleSelect/SimpleSelect"
+export {
+  SimpleSelect,
+  SimpleSelectField,
+} from "./components/SimpleSelect/SimpleSelect"
 export type {
   SimpleSelectProps,
-  SimpleSelectOptionProps,
+  SimpleSelectFieldProps,
+  SimpleSelectOption,
 } from "./components/SimpleSelect/SimpleSelect"
 
 export type { TextFieldProps } from "./components/TextField/TextField"
-export { Select, SelectField } from "./components/SelectField/SelectField"
+export { SelectField } from "./components/SelectField/SelectField"
 export type {
   SelectChangeEvent,
   SelectProps,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4673

### Description (What does it do?)
This PR aligns our Select and Dropdown components with Figma designs.

### Screenshots (if appropriate):
<img width="952" alt="Screenshot 2024-06-24 at 11 14 55 AM" src="https://github.com/mitodl/mit-open/assets/9010790/2c60ec9e-0546-4149-bb40-133c02cd9fa7">
<img width="1511" alt="Screenshot 2024-06-24 at 8 07 34 PM" src="https://github.com/mitodl/mit-open/assets/9010790/a1ffa2b8-022f-4a86-9df1-03112635705b">
<img width="840" alt="Screenshot 2024-06-24 at 8 04 32 PM" src="https://github.com/mitodl/mit-open/assets/9010790/704dd6b2-c44b-4699-b867-95d039e815b9">
<img width="780" alt="Screenshot 2024-06-24 at 8 04 08 PM" src="https://github.com/mitodl/mit-open/assets/9010790/fab62761-f2ac-486b-ae9f-728c8ffb95c2">


### How can this be tested?
Try Select and Dropdown components throughout the app. For exmaple
- Dropdown: *button that opens a menu*
    - The usermenu dropdown in top-right corner (when logged in)
- Select: *Input field with choices from a menu*
    - The "Sort" select field on search page (and channel pages)
    - The select-based form fields on `/dashboard#profile` (education, format, time) 
    - The "Topics" autocomplete field on `/learningpaths/` (creation / editing menu)

Things to try:
1. The entire select field should be clickable.  (In contrast to RC, where the edges are not clickable.)
2. The select field chevron should flip when the dropdown is open 
3. The "Selected" and "hover" state colors should match Figma
    - simultaneous selected + hover might not be in Figma, but I verified with @steven-hatch 
4. Try keyboard navigation of select menu
5. Try the autocomplete select (in Learningpaths editing dialogue)—it's implementation was slightly different. 
6. View the associated storybook stories under the "Dropdowns" folder, http://localhost:6006/?path=/story/smoot-design-dropdowns-simpleselect--single-select

