### PR TITLE
remove course filter from featured carousel

### DIFF
--- a/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
@@ -115,16 +115,15 @@ describe("Home Page Carousel", () => {
   test.each<{ tab: string; params: FeaturedRequest }>([
     {
       tab: "All",
-      params: { limit: 12, resource_type: ["course"] },
+      params: { limit: 12 },
     },
     {
       tab: "Free",
-      params: { limit: 12, resource_type: ["course"], free: true },
+      params: { limit: 12, free: true },
     },
     {
       tab: "With Certificate",
       params: {
-        resource_type: ["course"],
         limit: 12,
         certification: true,
         professional: false,
@@ -132,7 +131,7 @@ describe("Home Page Carousel", () => {
     },
     {
       tab: "Professional & Executive Learning",
-      params: { resource_type: ["course"], limit: 12, professional: true },
+      params: { limit: 12, professional: true },
     },
   ])("Featured Courses Carousel Tabs", async ({ tab, params }) => {
     const resources = learningResources.resources({ count: 12 })
@@ -140,7 +139,7 @@ describe("Home Page Carousel", () => {
 
     // The "All" tab is initially visible, so it needs a response.
     setMockResponse.get(
-      urls.learningResources.featured({ limit: 12, resource_type: ["course"] }),
+      urls.learningResources.featured({ limit: 12 }),
       learningResources.resources({ count: 0 }),
     )
     // This is for the clicked tab (which might be "All")

--- a/frontends/mit-open/src/pages/HomePage/carousels.ts
+++ b/frontends/mit-open/src/pages/HomePage/carousels.ts
@@ -2,7 +2,6 @@ import type { ResourceCarouselProps } from "@/page-components/ResourceCarousel/R
 import type { FeaturedApiFeaturedListRequest as FeaturedListParams } from "api"
 
 const FEATURED_COMMON_PARAMS: FeaturedListParams = {
-  resource_type: ["course"],
   limit: 12,
 }
 const FEATURED_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4686

### Description (What does it do?)
This PR removes the `resource_type: "course"` filter from the "Featured Courses" carousel on the home page, allowing any type of `LearningResource` to appear there.

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Log in and ensure your user has superuser privileges
 - Open the home page at http://localhost:8063/
 - Scroll down to the Media carousel and click the "add to learning list" icon on any of the media cards
 - In the popup, click the checkbox next to "MITx Featured Resources"
 - Refresh the page and you should now see the podcast episode in the Featured Courses carousel
