### PR TITLE
de-flake a test

### DIFF
--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -85,7 +85,7 @@ const learningResourceBaseSchool: Factory<LearningResourceBaseSchool> = (
 ) => {
   return {
     id: uniqueEnforcerId.enforce(() => faker.number.int()),
-    name: faker.lorem.word(),
+    name: faker.lorem.words(3),
     url: faker.internet.url(),
     ...overrides,
   }
@@ -118,7 +118,7 @@ const learnigResourceSchool: Factory<LearningResourceSchool> = (
 ) => {
   return {
     id: uniqueEnforcerId.enforce(() => faker.number.int()),
-    name: faker.lorem.word(),
+    name: faker.lorem.words(3),
     url: faker.internet.url(),
     departments: repeat(learningResourceBaseDepartment),
     ...overrides,

--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
@@ -91,40 +91,37 @@ describe("DepartmentListingPage", () => {
     screen.getByRole("heading", { name: "Browse by Academic Department" })
   })
 
-  it.each(new Array(1000).fill(null))(
-    "Lists schools and departments",
-    async () => {
-      const { schools, departments } = setupApis()
-      renderWithProviders(<DepartmentListingPage />)
+  it("Lists schools and departments", async () => {
+    const { schools, departments } = setupApis()
+    renderWithProviders(<DepartmentListingPage />)
 
-      const school0 = (
-        await screen.findByRole("heading", {
-          name: schools[0].name,
-        })
-      ).closest("li")
-      const school1 = (
-        await screen.findByRole("heading", {
-          name: schools[1].name,
-        })
-      ).closest("li")
-      invariant(school0)
-      invariant(school1)
+    const school0 = (
+      await screen.findByRole("heading", {
+        name: schools[0].name,
+      })
+    ).closest("li")
+    const school1 = (
+      await screen.findByRole("heading", {
+        name: schools[1].name,
+      })
+    ).closest("li")
+    invariant(school0)
+    invariant(school1)
 
-      const school0depts = within(school0).getAllByRole("link")
-      const school1depts = within(school1).getAllByRole("link")
+    const school0depts = within(school0).getAllByRole("link")
+    const school1depts = within(school1).getAllByRole("link")
 
-      expect(school0depts).toHaveLength(2)
-      expect(school1depts).toHaveLength(3)
+    expect(school0depts).toHaveLength(2)
+    expect(school1depts).toHaveLength(3)
 
-      const [d1, d2, d3, d4, d5] = departments
-      expect(school0depts[0]).toHaveTextContent(d1.name)
-      expect(school0depts[1]).toHaveTextContent(d2.name)
+    const [d1, d2, d3, d4, d5] = departments
+    expect(school0depts[0]).toHaveTextContent(d1.name)
+    expect(school0depts[1]).toHaveTextContent(d2.name)
 
-      expect(school1depts[0]).toHaveTextContent(d3.name)
-      expect(school1depts[1]).toHaveTextContent(d4.name)
-      expect(school1depts[2]).toHaveTextContent(d5.name)
-    },
-  )
+    expect(school1depts[0]).toHaveTextContent(d3.name)
+    expect(school1depts[1]).toHaveTextContent(d4.name)
+    expect(school1depts[2]).toHaveTextContent(d5.name)
+  })
 
   test("Department links show course and program counts", async () => {
     const { departments } = setupApis()

--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
@@ -91,37 +91,40 @@ describe("DepartmentListingPage", () => {
     screen.getByRole("heading", { name: "Browse by Academic Department" })
   })
 
-  it("Lists schools and departments", async () => {
-    const { schools, departments } = setupApis()
-    renderWithProviders(<DepartmentListingPage />)
+  it.each(new Array(1000).fill(null))(
+    "Lists schools and departments",
+    async () => {
+      const { schools, departments } = setupApis()
+      renderWithProviders(<DepartmentListingPage />)
 
-    const school0 = (
-      await screen.findByRole("heading", {
-        name: schools[0].name,
-      })
-    ).closest("li")
-    const school1 = (
-      await screen.findByRole("heading", {
-        name: schools[1].name,
-      })
-    ).closest("li")
-    invariant(school0)
-    invariant(school1)
+      const school0 = (
+        await screen.findByRole("heading", {
+          name: schools[0].name,
+        })
+      ).closest("li")
+      const school1 = (
+        await screen.findByRole("heading", {
+          name: schools[1].name,
+        })
+      ).closest("li")
+      invariant(school0)
+      invariant(school1)
 
-    const school0depts = within(school0).getAllByRole("link")
-    const school1depts = within(school1).getAllByRole("link")
+      const school0depts = within(school0).getAllByRole("link")
+      const school1depts = within(school1).getAllByRole("link")
 
-    expect(school0depts).toHaveLength(2)
-    expect(school1depts).toHaveLength(3)
+      expect(school0depts).toHaveLength(2)
+      expect(school1depts).toHaveLength(3)
 
-    const [d1, d2, d3, d4, d5] = departments
-    expect(school0depts[0]).toHaveTextContent(d1.name)
-    expect(school0depts[1]).toHaveTextContent(d2.name)
+      const [d1, d2, d3, d4, d5] = departments
+      expect(school0depts[0]).toHaveTextContent(d1.name)
+      expect(school0depts[1]).toHaveTextContent(d2.name)
 
-    expect(school1depts[0]).toHaveTextContent(d3.name)
-    expect(school1depts[1]).toHaveTextContent(d4.name)
-    expect(school1depts[2]).toHaveTextContent(d5.name)
-  })
+      expect(school1depts[0]).toHaveTextContent(d3.name)
+      expect(school1depts[1]).toHaveTextContent(d4.name)
+      expect(school1depts[2]).toHaveTextContent(d5.name)
+    },
+  )
 
   test("Department links show course and program counts", async () => {
     const { departments } = setupApis()


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4222

### Description (What does it do?)
This PR should resolve
- https://github.com/mitodl/hq/issues/4222

That issue reported a test within `DepartmentListingPage.test.tsx` failing 2/3 times due to finding 'too many elements with heading "role" and name ...'. Locally, I was getting about 2 failures out of 1000 runs, so something seems to have changed since that issue was reported.

Anyway, this PR increases school names from 1 word to 3 words, so name collisions should be extremely rare now. (We could also make them unique, but Faker has [deprecated](https://github.com/faker-js/faker/issues/1785) that method so I'd rather not add more usages).

### Screenshots (if appropriate):


### How can this be tested?
CI should pass. Note CI checks on commit [1675010](https://github.com/mitodl/mit-open/pull/1166/commits/1675010e24ba1d0b87a1fc61776c669174169fe5) passed, which use 1000 runs of that test.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
