### PR TITLE
fix content file search

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -2249,43 +2249,6 @@ export interface LearningResourceSchool {
   departments: Array<LearningResourceBaseDepartment>
 }
 /**
- * SearchResponseSerializer with OpenAPI annotations for Learning Resources search
- * @export
- * @interface LearningResourceSearchResponse
- */
-export interface LearningResourceSearchResponse {
-  /**
-   *
-   * @type {number}
-   * @memberof LearningResourceSearchResponse
-   */
-  count: number
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceSearchResponse
-   */
-  next: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof LearningResourceSearchResponse
-   */
-  previous: string | null
-  /**
-   *
-   * @type {Array<LearningResource>}
-   * @memberof LearningResourceSearchResponse
-   */
-  results: Array<LearningResource>
-  /**
-   *
-   * @type {ContentFileSearchResponseMetadata}
-   * @memberof LearningResourceSearchResponse
-   */
-  metadata: ContentFileSearchResponseMetadata
-}
-/**
  * Serializer for LearningResourceTopic model
  * @export
  * @interface LearningResourceTopic
@@ -2315,6 +2278,43 @@ export interface LearningResourceTopic {
    * @memberof LearningResourceTopic
    */
   channel_url: string | null
+}
+/**
+ * SearchResponseSerializer with OpenAPI annotations for Learning Resources search
+ * @export
+ * @interface LearningResourcesSearchResponse
+ */
+export interface LearningResourcesSearchResponse {
+  /**
+   *
+   * @type {number}
+   * @memberof LearningResourcesSearchResponse
+   */
+  count: number
+  /**
+   *
+   * @type {string}
+   * @memberof LearningResourcesSearchResponse
+   */
+  next: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof LearningResourcesSearchResponse
+   */
+  previous: string | null
+  /**
+   *
+   * @type {Array<LearningResource>}
+   * @memberof LearningResourcesSearchResponse
+   */
+  results: Array<LearningResource>
+  /**
+   *
+   * @type {ContentFileSearchResponseMetadata}
+   * @memberof LearningResourcesSearchResponse
+   */
+  metadata: ContentFileSearchResponseMetadata
 }
 /**
  * * `undergraduate` - Undergraduate * `graduate` - Graduate * `high_school` - High School * `noncredit` - Non-Credit * `advanced` - Advanced * `intermediate` - Intermediate * `introductory` - Introductory
@@ -3248,7 +3248,7 @@ export interface PatchedUserListRequest {
 }
 
 /**
- *
+ * Serializer for PercolateQuery objects
  * @export
  * @interface PercolateQuery
  */
@@ -11567,7 +11567,7 @@ export const LearningResourcesSearchApiFp = function (
       (
         axios?: AxiosInstance,
         basePath?: string,
-      ) => AxiosPromise<LearningResourceSearchResponse>
+      ) => AxiosPromise<LearningResourcesSearchResponse>
     > {
       const localVarAxiosArgs =
         await localVarAxiosParamCreator.learningResourcesSearchRetrieve(
@@ -11629,7 +11629,7 @@ export const LearningResourcesSearchApiFactory = function (
     learningResourcesSearchRetrieve(
       requestParameters: LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest = {},
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<LearningResourceSearchResponse> {
+    ): AxiosPromise<LearningResourcesSearchResponse> {
       return localVarFp
         .learningResourcesSearchRetrieve(
           requestParameters.aggregations,

--- a/frontends/mit-open/src/page-components/SearchDisplay/ResourceTypeTabs.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/ResourceTypeTabs.tsx
@@ -6,7 +6,7 @@ import {
   TabPanel,
   styled,
 } from "ol-components"
-import { ResourceTypeEnum, LearningResourceSearchResponse } from "api"
+import { ResourceTypeEnum, LearningResourcesSearchResponse } from "api"
 
 const TabsList = styled(TabButtonList)({
   ".MuiTabScrollButton-root.Mui-disabled": {
@@ -25,7 +25,7 @@ type TabConfig = {
   resource_type: ResourceTypeEnum[]
 }
 
-type Aggregations = LearningResourceSearchResponse["metadata"]["aggregations"]
+type Aggregations = LearningResourcesSearchResponse["metadata"]["aggregations"]
 const resourceTypeCounts = (aggregations?: Aggregations) => {
   if (!aggregations) return null
   const buckets = aggregations?.resource_type ?? []

--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { renderWithProviders, screen, waitFor, within } from "@/test-utils"
-import type { LearningResourceSearchResponse } from "api"
+import type { LearningResourcesSearchResponse } from "api"
 import DepartmentListingPage from "./DepartmentListingPage"
 import { factories, setMockResponse, urls } from "api/test-utils"
 import invariant from "tiny-invariant"
@@ -8,7 +8,7 @@ import { faker } from "@faker-js/faker/locale/en"
 
 const makeSearchResponse = (
   aggregations: Record<string, number>,
-): LearningResourceSearchResponse => {
+): LearningResourcesSearchResponse => {
   return {
     metadata: {
       suggestions: [],

--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -15,7 +15,7 @@ import {
 import { MetaTags, pluralize } from "ol-utilities"
 import type {
   LearningResourceSchool,
-  LearningResourceSearchResponse,
+  LearningResourcesSearchResponse,
 } from "api"
 import {
   useLearningResourcesSearch,
@@ -186,7 +186,7 @@ const SchoolList = styled(PlainList)(({ theme }) => ({
 }))
 
 const aggregateByDepartment = (
-  data: LearningResourceSearchResponse,
+  data: LearningResourcesSearchResponse,
 ): Record<string, number> => {
   const buckets = data.metadata.aggregations["department"] ?? []
   return Object.fromEntries(

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -1,7 +1,7 @@
 import { assertInstanceOf } from "ol-utilities"
 import { urls, factories, makeRequest } from "api/test-utils"
 import type { FieldChannel } from "api/v0"
-import type { LearningResourceSearchResponse } from "api"
+import type { LearningResourcesSearchResponse } from "api"
 import {
   renderTestApp,
   screen,
@@ -22,7 +22,7 @@ const mockedFieldSearch = jest.mocked(FieldSearch)
 
 const setupApis = (
   fieldPatch?: Partial<FieldChannel>,
-  search?: Partial<LearningResourceSearchResponse>,
+  search?: Partial<LearningResourcesSearchResponse>,
   { isSubscribed = false, isAuthenticated = false } = {},
 ) => {
   const field = factories.fields.field(fieldPatch)

--- a/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldSearch.test.tsx
@@ -1,6 +1,6 @@
 import { screen, within, waitFor, renderTestApp } from "@/test-utils"
 import { setMockResponse, urls, factories, makeRequest } from "api/test-utils"
-import type { LearningResourceSearchResponse } from "api"
+import type { LearningResourcesSearchResponse } from "api"
 import invariant from "tiny-invariant"
 import { makeWidgetListResponse } from "ol-widgets/src/factories"
 import type { FieldChannel } from "api/v0"
@@ -10,7 +10,7 @@ const setMockApiResponses = ({
   search,
   fieldPatch,
 }: {
-  search?: Partial<LearningResourceSearchResponse>
+  search?: Partial<LearningResourcesSearchResponse>
   fieldPatch?: Partial<FieldChannel>
 }) => {
   const field = factories.fields.field(fieldPatch)

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -9,7 +9,7 @@ import {
 import SearchPage from "./SearchPage"
 import { setMockResponse, urls, factories, makeRequest } from "api/test-utils"
 import type {
-  LearningResourceSearchResponse,
+  LearningResourcesSearchResponse,
   PaginatedLearningResourceOfferorDetailList,
 } from "api"
 import invariant from "tiny-invariant"
@@ -19,7 +19,7 @@ const setMockApiResponses = ({
   search,
   offerors,
 }: {
-  search?: Partial<LearningResourceSearchResponse>
+  search?: Partial<LearningResourcesSearchResponse>
   offerors?: PaginatedLearningResourceOfferorDetailList
 }) => {
   setMockResponse.get(urls.userMe.get(), {

--- a/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.test.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { renderWithProviders, screen, waitFor, within } from "@/test-utils"
-import type { LearningResourceSearchResponse } from "api"
+import type { LearningResourcesSearchResponse } from "api"
 import TopicsListingPage from "./TopicsListingPage"
 import { factories, setMockResponse, urls } from "api/test-utils"
 import invariant from "tiny-invariant"
 
 const makeSearchResponse = (
   aggregations: Record<string, number>,
-): LearningResourceSearchResponse => {
+): LearningResourcesSearchResponse => {
   return {
     metadata: {
       suggestions: [],

--- a/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.tsx
+++ b/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.tsx
@@ -18,7 +18,7 @@ import {
   useLearningResourceTopics,
   useLearningResourcesSearch,
 } from "api/hooks/learningResources"
-import { LearningResourceSearchResponse, LearningResourceTopic } from "api"
+import { LearningResourcesSearchResponse, LearningResourceTopic } from "api"
 import RootTopicIcon from "@/components/RootTopicIcon/RootTopicIcon"
 import { HOME } from "@/common/urls"
 
@@ -181,7 +181,7 @@ const TopicBoxLoading = () => {
 const Page = styled.div({})
 
 const aggregateByTopic = (
-  data: LearningResourceSearchResponse,
+  data: LearningResourcesSearchResponse,
 ): Record<string, number> => {
   const buckets = data.metadata.aggregations["topic"] ?? []
   return Object.fromEntries(

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { renderWithProviders, screen, waitFor, within } from "@/test-utils"
-import type { LearningResourceSearchResponse } from "api"
+import type { LearningResourcesSearchResponse } from "api"
 import UnitsListingPage from "./UnitsListingPage"
 import { factories, setMockResponse, urls } from "api/test-utils"
 
 const makeSearchResponse = (
   aggregations: Record<string, number>,
-): LearningResourceSearchResponse => {
+): LearningResourcesSearchResponse => {
   return {
     metadata: {
       suggestions: [],

--- a/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-open/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -15,7 +15,7 @@ import { RiBookOpenLine, RiSuitcaseLine } from "@remixicon/react"
 import React from "react"
 import {
   LearningResourceOfferorDetail,
-  LearningResourceSearchResponse,
+  LearningResourcesSearchResponse,
   OfferedByEnum,
 } from "api"
 import { MetaTags } from "ol-utilities"
@@ -26,7 +26,7 @@ const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
 
 const aggregateByUnits = (
-  data: LearningResourceSearchResponse,
+  data: LearningResourcesSearchResponse,
 ): Record<string, number> => {
   const buckets = data.metadata.aggregations["offered_by"] ?? []
   return Object.fromEntries(

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -39,7 +39,7 @@ from learning_resources_search.serializers import (
     ContentFileSearchRequestSerializer,
     ContentFileSerializer,
     LearningResourcesSearchRequestSerializer,
-    SearchResponseSerializer,
+    LearningResourcesSearchResponseSerializer,
     extract_values,
     serialize_percolate_query,
 )
@@ -827,7 +827,9 @@ def test_learning_resources_search_response_serializer(
     settings.OPENSEARCH_MAX_SUGGEST_HITS = 10
     request = get_request_object(learning_resources_search_view.url)
     assert JSONRenderer().render(
-        SearchResponseSerializer(raw_data, context={"request": request}).data
+        LearningResourcesSearchResponseSerializer(
+            raw_data, context={"request": request}
+        ).data
     ) == JSONRenderer().render(response)
 
 
@@ -884,7 +886,9 @@ def test_learning_resources_search_response_serializer_user_parents(  # noqa: PL
             ]
 
     assert JSONRenderer().render(
-        SearchResponseSerializer(raw_data, context={"request": request}).data
+        LearningResourcesSearchResponseSerializer(
+            raw_data, context={"request": request}
+        ).data
     ) == JSONRenderer().render(response)
 
 

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -25,11 +25,10 @@ from learning_resources_search.models import PercolateQuery
 from learning_resources_search.serializers import (
     ContentFileSearchRequestSerializer,
     ContentFileSearchResponseSerializer,
-    LearningResourceSearchResponseSerializer,
     LearningResourcesSearchRequestSerializer,
+    LearningResourcesSearchResponseSerializer,
     PercolateQuerySerializer,
     PercolateQuerySubscriptionRequestSerializer,
-    SearchResponseSerializer,
 )
 
 log = logging.getLogger(__name__)
@@ -53,7 +52,7 @@ class ESView(APIView):
 @extend_schema_view(
     get=extend_schema(
         parameters=[LearningResourcesSearchRequestSerializer()],
-        responses=LearningResourceSearchResponseSerializer(),
+        responses=LearningResourcesSearchResponseSerializer(),
     ),
 )
 @action(methods=["GET"], detail=False, name="Search Learning Resources")
@@ -73,7 +72,9 @@ class LearningResourcesSearchView(ESView):
                 request_data.data | {"endpoint": LEARNING_RESOURCE}
             )
             return Response(
-                SearchResponseSerializer(response, context={"request": request}).data
+                LearningResourcesSearchResponseSerializer(
+                    response, context={"request": request}
+                ).data
             )
         else:
             errors = {}
@@ -237,7 +238,9 @@ class ContentFileSearchView(ESView):
                 request_data.data | {"endpoint": CONTENT_FILE_TYPE}
             )
             return Response(
-                SearchResponseSerializer(response, context={"request": request}).data
+                ContentFileSearchResponseSerializer(
+                    response, context={"request": request}
+                ).data
             )
         else:
             errors = {}

--- a/learning_resources_search/views_test.py
+++ b/learning_resources_search/views_test.py
@@ -16,8 +16,9 @@ from rest_framework.test import APIRequestFactory
 from learning_resources_search.constants import CONTENT_FILE_TYPE, LEARNING_RESOURCE
 from learning_resources_search.serializers import (
     ContentFileSearchRequestSerializer,
+    ContentFileSearchResponseSerializer,
     LearningResourcesSearchRequestSerializer,
-    SearchResponseSerializer,
+    LearningResourcesSearchResponseSerializer,
 )
 
 FAKE_SEARCH_RESPONSE = {
@@ -80,7 +81,7 @@ def test_learn_resources_search(mocker, client, learning_resources_search_view):
         | {"endpoint": LEARNING_RESOURCE}
     )
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
-        SearchResponseSerializer(FAKE_SEARCH_RESPONSE).data
+        LearningResourcesSearchResponseSerializer(FAKE_SEARCH_RESPONSE).data
     )
 
 
@@ -225,7 +226,7 @@ def test_content_file_search(mocker, client, content_file_search_view):
         | {"endpoint": CONTENT_FILE_TYPE}
     )
     assert JSONRenderer().render(resp.json()) == JSONRenderer().render(
-        SearchResponseSerializer(
+        ContentFileSearchResponseSerializer(
             FAKE_SEARCH_RESPONSE, context={"request": request}
         ).data
     )

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2477,7 +2477,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LearningResourceSearchResponse'
+                $ref: '#/components/schemas/LearningResourcesSearchResponse'
           description: ''
   /api/v1/learning_resources_user_subscription/:
     get:
@@ -8442,7 +8442,29 @@ components:
       - id
       - name
       - url
-    LearningResourceSearchResponse:
+    LearningResourceTopic:
+      type: object
+      description: Serializer for LearningResourceTopic model
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          maxLength: 128
+        parent:
+          type: integer
+          nullable: true
+        channel_url:
+          type: string
+          description: Get the channel url for the topic if it exists
+          readOnly: true
+          nullable: true
+      required:
+      - channel_url
+      - id
+      - name
+    LearningResourcesSearchResponse:
       type: object
       description: |-
         SearchResponseSerializer with OpenAPI annotations for Learning Resources
@@ -8495,28 +8517,6 @@ components:
       - next
       - previous
       - results
-    LearningResourceTopic:
-      type: object
-      description: Serializer for LearningResourceTopic model
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        name:
-          type: string
-          maxLength: 128
-        parent:
-          type: integer
-          nullable: true
-        channel_url:
-          type: string
-          description: Get the channel url for the topic if it exists
-          readOnly: true
-          nullable: true
-      required:
-      - channel_url
-      - id
-      - name
     LevelEnum:
       enum:
       - undergraduate
@@ -9159,6 +9159,7 @@ components:
           $ref: '#/components/schemas/PrivacyLevelEnum'
     PercolateQuery:
       type: object
+      description: Serializer for PercolateQuery objects
       properties:
         id:
           type: integer


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4697 

### Description (What does it do?)
This PR fixes the current error on api/v1/content_files_search by makes user_list_parents and learning_path_parents 
something that is added to /learning_resources_search results only and not /content_file_search

Also renames the LearningResourceSearchResponse to LearningResourcesSearchResponse since the view is called /learning_resources_search and the other serializer is called LearningResourcesSearchRequest

### Screenshots (if appropriate):
NA

### How can this be tested?
Go to http://localhost:8063/api/v1/content_file_search/. Verify that it does not throw an error both when you are logged in and when you are not logged in 

Go to http://localhost:8063/api/v1/learning_resources_search/.  If you don't have them already create some user lists and learning paths and add some resources into the lists. Verify that user_list_parents and learning_path_parents are set when  /learning_resources_search/ returns resources that are part of a user list. Log out.  Verify that user_list_parents and learning_path_parents are set to [] for all resources.