### PR TITLE
fix flaky test

### DIFF
--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -145,26 +145,30 @@ describe("FieldPage", () => {
       expect(carousels).toBe(null)
     })
   })
-  it("Displays the field search if search_filter is not undefined", async () => {
-    const { field } = setupApis({
-      search_filter:
-        "platform=ocw&platform=mitxonline&department=8&department=9",
-    })
-    renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
-    await screen.findByText(field.title)
-    const expectedProps = expect.objectContaining({
-      constantSearchParams: {
-        platform: ["ocw", "mitxonline"],
-        department: ["8", "9"],
-      },
-    })
-    const expectedContext = expect.anything()
 
-    expect(mockedFieldSearch).toHaveBeenLastCalledWith(
-      expectedProps,
-      expectedContext,
-    )
-  })
+  it.each(new Array(1000).fill(null))(
+    "Displays the field search if search_filter is not undefined",
+    async () => {
+      const { field } = setupApis({
+        search_filter:
+          "platform=ocw&platform=mitxonline&department=8&department=9",
+      })
+      renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
+      await screen.findByText(field.title)
+      const expectedProps = expect.objectContaining({
+        constantSearchParams: {
+          platform: ["ocw", "mitxonline"],
+          department: ["8", "9"],
+        },
+      })
+      const expectedContext = expect.anything()
+
+      expect(mockedFieldSearch).toHaveBeenLastCalledWith(
+        expectedProps,
+        expectedContext,
+      )
+    },
+  )
   it("Does not display the field search if search_filter is undefined", async () => {
     const { field } = setupApis()
     field.search_filter = undefined

--- a/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPage.test.tsx
@@ -152,29 +152,26 @@ describe("FieldPage", () => {
     expect(carousels).toBe(null)
   })
 
-  it.each(new Array(1000).fill(null))(
-    "Displays the field search if search_filter is not undefined",
-    async () => {
-      const { field } = setupApis({
-        search_filter:
-          "platform=ocw&platform=mitxonline&department=8&department=9",
-      })
-      renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
-      await screen.findByText(field.title)
-      const expectedProps = expect.objectContaining({
-        constantSearchParams: {
-          platform: ["ocw", "mitxonline"],
-          department: ["8", "9"],
-        },
-      })
-      const expectedContext = expect.anything()
+  it("Displays the field search if search_filter is not undefined", async () => {
+    const { field } = setupApis({
+      search_filter:
+        "platform=ocw&platform=mitxonline&department=8&department=9",
+    })
+    renderTestApp({ url: `/c/${field.channel_type}/${field.name}` })
+    await screen.findByText(field.title)
+    const expectedProps = expect.objectContaining({
+      constantSearchParams: {
+        platform: ["ocw", "mitxonline"],
+        department: ["8", "9"],
+      },
+    })
+    const expectedContext = expect.anything()
 
-      expect(mockedFieldSearch).toHaveBeenLastCalledWith(
-        expectedProps,
-        expectedContext,
-      )
-    },
-  )
+    expect(mockedFieldSearch).toHaveBeenLastCalledWith(
+      expectedProps,
+      expectedContext,
+    )
+  })
   it("Does not display the field search if search_filter is undefined", async () => {
     const { field } = setupApis()
     field.search_filter = undefined

--- a/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
+++ b/frontends/mit-open/src/pages/FieldPage/FieldPageSkeleton.tsx
@@ -311,6 +311,7 @@ const FieldSkeletonProps: React.FC<FieldSkeletonProps> = ({
             <FeaturedCoursesCarousel
               title="Featured Courses"
               config={FEATURED_RESOURCES_CAROUSEL}
+              isLoading={field.isLoading}
             />
           </Container>
         ) : null}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4707

### Description (What does it do?)
Fixes https://github.com/mitodl/hq/issues/4707. One additional change, see testing notes.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
1. Tests should pass. *Note that commit [9a86ebf](https://github.com/mitodl/mit-open/pull/1168/commits/9a86ebfcbd6441a9309db118110d3449b76b1137) includes running the originally flaky test 1000 times; they passed.*
2. Check that the "Featured Courses" carousel on unit pages still displays.
3. Check that the "Featured courses" carousel on unit pages only makes a single API call
    - Compare with https://mitopen-rc.odl.mit.edu/c/unit/ocw ... if you view the network tab, you'll see two API calls:
        - `featured/?limit=12`, which occurs while the channel is loading
        - then `featured/?limit=12&offered_by=ocw` after the channel has loaded

