### PR TITLE
facet order

### DIFF
--- a/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
@@ -51,23 +51,23 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   [ChannelTypeEnum.Topic]: [
     "free",
     "certification_type",
-    "department",
-    "offered_by",
     "learning_format",
+    "offered_by",
+    "department",
   ],
   [ChannelTypeEnum.Department]: [
     "free",
     "certification_type",
     "topic",
-    "offered_by",
     "learning_format",
+    "offered_by",
   ],
   [ChannelTypeEnum.Unit]: [
     "free",
     "topic",
     "certification_type",
-    "department",
     "learning_format",
+    "department",
   ],
   [ChannelTypeEnum.Pathway]: [],
 }


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4716

### Description (What does it do?)
This changes the facet order as described above

### How can this be tested?
Go to a unit, topic and department channel page. Verify that the facet orders are as described in the ticket