### PR TITLE
Filled vs Unfilled Bookmarks

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -321,35 +321,19 @@ describe("LearningPath CRUD", () => {
       expect(invalidateResourceQueries).toHaveBeenCalledWith(
         queryClient,
         relationship.child,
-        { skipFeatured: true },
+        { skipFeatured: false },
       )
       expect(invalidateResourceQueries).toHaveBeenCalledWith(
         queryClient,
         relationship.parent,
       )
-
-      // Assert featured API called only once and that the result has been
-      // patched correctly. When the child is featured, we do NOT want to make
-      // a new API call to /featured, because the results of that API are randomly
-      // ordered.
-      expect(
-        makeRequest.mock.calls.filter((call) => call[0] === "get").length,
-      ).toEqual(1)
-      if (isChildFeatured) {
-        expect(featuredResult.current.data?.results).toEqual([
-          relationship.resource,
-          ...featured.results.slice(1),
-        ])
-      } else {
-        expect(featuredResult.current.data).toEqual(featured)
-      }
     },
   )
 
   test.each([{ isChildFeatured: false }, { isChildFeatured: true }])(
     "useLearningpathRelationshipDestroy calls correct API and patches child resource cache (isChildFeatured=$isChildFeatured)",
     async ({ isChildFeatured }) => {
-      const { relationship, pathUrls, resourceWithoutList } = makeData()
+      const { relationship, pathUrls } = makeData()
       const url = pathUrls.relationshipDetails
 
       const featured = factory.resources({ count: 3 })
@@ -377,28 +361,12 @@ describe("LearningPath CRUD", () => {
       expect(invalidateResourceQueries).toHaveBeenCalledWith(
         queryClient,
         relationship.child,
-        { skipFeatured: true },
+        { skipFeatured: false },
       )
       expect(invalidateResourceQueries).toHaveBeenCalledWith(
         queryClient,
         relationship.parent,
       )
-
-      // Assert featured API called only once and that the result has been
-      // patched correctly. When the child is featured, we do NOT want to make
-      // a new API call to /featured, because the results of that API are randomly
-      // ordered.
-      expect(
-        makeRequest.mock.calls.filter((call) => call[0] === "get").length,
-      ).toEqual(1)
-      if (isChildFeatured) {
-        expect(featuredResult.current.data?.results).toEqual([
-          resourceWithoutList,
-          ...featured.results.slice(1),
-        ])
-      } else {
-        expect(featuredResult.current.data).toEqual(featured)
-      }
     },
   )
 })

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -170,14 +170,15 @@ const useLearningpathRelationshipCreate = () => {
         learning_resource_id: params.parent,
         LearningPathRelationshipRequest: params,
       }),
-    onSuccess: (response, _vars) => {
-      queryClient.setQueriesData<PaginatedLearningResourceList>(
-        learningResources.featured({}).queryKey,
-        (old) => updateListParentsOnAdd(response.data, old),
-      )
-    },
     onSettled: (_response, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.child, { skipFeatured: true })
+      invalidateResourceQueries(
+        queryClient,
+        vars.child,
+        // do NOT skip invalidating the /featured/ lists,
+        // Changing a learning path might change the members of the featured
+        // lists.
+        { skipFeatured: false },
+      )
       invalidateResourceQueries(queryClient, vars.parent)
     },
   })
@@ -191,18 +192,15 @@ const useLearningpathRelationshipDestroy = () => {
         id: params.id,
         learning_resource_id: params.parent,
       }),
-    onSuccess: (_response, vars) => {
-      queryClient.setQueriesData<PaginatedLearningResourceList>(
-        learningResources.featured().queryKey,
-        (old) =>
-          updateListParentsOnDestroy(
-            { value: vars, type: "learning_path" },
-            old,
-          ),
-      )
-    },
     onSettled: (_response, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.child, { skipFeatured: true })
+      invalidateResourceQueries(
+        queryClient,
+        vars.child,
+        // do NOT skip invalidating the /featured/ lists,
+        // Changing a learning path might change the members of the featured
+        // lists.
+        { skipFeatured: false },
+      )
       invalidateResourceQueries(queryClient, vars.parent)
     },
   })
@@ -302,7 +300,15 @@ const useUserListRelationshipCreate = () => {
       )
     },
     onSettled: (_response, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.child, { skipFeatured: true })
+      invalidateResourceQueries(
+        queryClient,
+        vars.child,
+        // Do NOT invalidate the featured lists. Re-fetching the featured list
+        // data will cause the order to change, since the /featured API returns
+        // at random order.
+        // Instead, `onSuccess` hook will manually update the data.
+        { skipFeatured: true },
+      )
       invalidateUserListQueries(queryClient, vars.parent)
     },
   })
@@ -319,12 +325,19 @@ const useUserListRelationshipDestroy = () => {
     onSuccess: (_response, vars) => {
       queryClient.setQueriesData<PaginatedLearningResourceList>(
         learningResources.featured({}).queryKey,
-        (old) =>
-          updateListParentsOnDestroy({ value: vars, type: "userlist" }, old),
+        (old) => updateListParentsOnDestroy(vars, old),
       )
     },
     onSettled: (_response, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.child, { skipFeatured: true })
+      invalidateResourceQueries(
+        queryClient,
+        vars.child,
+        // Do NOT invalidate the featured lists. Re-fetching the featured list
+        // data will cause the order to change, since the /featured API returns
+        // at random order.
+        // Instead, `onSuccess` hook will manually update the data.
+        { skipFeatured: true },
+      )
       invalidateUserListQueries(queryClient, vars.parent)
     },
   })

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -27,6 +27,10 @@ import type {
   OfferorsApiOfferorsListRequest,
   PlatformsApiPlatformsListRequest,
   FeaturedApiFeaturedListRequest as FeaturedListParams,
+  UserListRelationship,
+  LearningPathRelationship,
+  MicroLearningPathRelationship,
+  MicroUserListRelationship,
 } from "../../generated/v1"
 import { createQueryKeys } from "@lukemorales/query-key-factory"
 
@@ -45,7 +49,7 @@ const learningResources = createQueryKeys("learningResources", {
         .learningResourcesList(params)
         .then((res) => res.data),
   }),
-  featured: (params: FeaturedListParams) => ({
+  featured: (params: FeaturedListParams = {}) => ({
     queryKey: [params],
     queryFn: () => featuredApi.featuredList(params).then((res) => res.data),
   }),
@@ -143,12 +147,12 @@ const learningResources = createQueryKeys("learningResources", {
   },
 })
 
-const learningPathHasResource =
+const listHasResource =
   (resourceId: number) =>
   (query: Query): boolean => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data = query.state.data as any
-    const resources: LearningResource[] = data.pages
+    const resources: LearningResource[] | UserList[] = data.pages
       ? data.pages.flatMap(
           (page: PaginatedLearningResourceList) => page.results,
         )
@@ -156,22 +160,20 @@ const learningPathHasResource =
     return resources.some((res) => res.id === resourceId)
   }
 
-const userListHasResource =
-  (resourceId: number) =>
-  (query: Query): boolean => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const data = query.state.data as any
-    const resources: UserList[] = data.pages
-      ? data.pages.flatMap(
-          (page: PaginatedLearningResourceList) => page.results,
-        )
-      : data.results
-    return resources.some((res) => res.id === resourceId)
-  }
-
+/**
+ * Invalidate Resource queries that a specific resource appears in.
+ *
+ * By default, this will invalidate featured list queries. This can result in
+ * odd behavior because the featured list item order is randomized: when the
+ * featured list cache is invalidated, the newly fetched data may be in a
+ * different order. To maintain the order, use skipFeatured to skip invalidation
+ * of featured lists and instead manually update the cached data via
+ * `updateListParentsOnAdd`.
+ */
 const invalidateResourceQueries = (
   queryClient: QueryClient,
   resourceId: LearningResource["id"],
+  { skipFeatured = false } = {},
 ) => {
   /**
    * Invalidate details queries.
@@ -191,17 +193,13 @@ const invalidateResourceQueries = (
   const lists = [
     learningResources.list._def,
     learningResources.learningpaths._ctx.list._def,
-    learningResources.userlists._ctx.list._def,
-    learningResources.featured._def,
+    learningResources.search._def,
+    ...(skipFeatured ? [] : [learningResources.featured._def]),
   ]
   lists.forEach((queryKey) => {
     queryClient.invalidateQueries({
       queryKey,
-      predicate: learningPathHasResource(resourceId),
-    })
-    queryClient.invalidateQueries({
-      queryKey,
-      predicate: userListHasResource(resourceId),
+      predicate: listHasResource(resourceId),
     })
   })
 }
@@ -213,7 +211,86 @@ const invalidateUserListQueries = (
   queryClient.invalidateQueries(
     learningResources.userlists._ctx.detail(userListId).queryKey,
   )
+  const lists = [learningResources.userlists._ctx.list._def]
+  lists.forEach((queryKey) => {
+    queryClient.invalidateQueries({
+      queryKey,
+      predicate: listHasResource(userListId),
+    })
+  })
+}
+
+/**
+ * Given
+ *  - a list of learning resources L
+ *  - a new relationship between learningpath/userlist and a resource R
+ * Update the list L so that it includes the updated resource R. (If the list
+ * did not contain R to begin with, no change is made)
+ */
+const updateListParentsOnAdd = (
+  relationship: LearningPathRelationship | UserListRelationship,
+  oldList?: PaginatedLearningResourceList,
+) => {
+  if (!oldList) return oldList
+  const matchIndex = oldList.results.findIndex(
+    (res) => res.id === relationship.child,
+  )
+  if (matchIndex === -1) return oldList
+  const updatesResults = [...oldList.results]
+  updatesResults[matchIndex] = relationship.resource
+  return {
+    ...oldList,
+    results: updatesResults,
+  }
+}
+
+type WrappedRelationship =
+  | {
+      value?: MicroLearningPathRelationship
+      type: "learning_path"
+    }
+  | {
+      value?: MicroUserListRelationship
+      type: "userlist"
+    }
+/**
+ * Given
+ *  - a list of learning resources L
+ *  - a destroyed relationship between learningpath/userlist and a resource R
+ * Update the list L so that it includes the updated resource R. (If the list
+ * did not contain R to begin with, no change is made)
+ */
+const updateListParentsOnDestroy = (
+  relationship: WrappedRelationship,
+  list?: PaginatedLearningResourceList,
+) => {
+  if (!list) return list
+  const { value } = relationship
+  if (!value) return list
+  const matchIndex = list.results.findIndex((res) => res.id === value.child)
+  if (matchIndex === -1) return list
+  const updatedResults = [...list.results]
+  const newResource = { ...updatedResults[matchIndex] }
+  if (relationship.type === "learning_path") {
+    newResource.learning_path_parents =
+      newResource.learning_path_parents?.filter((m) => m.id !== value.id) ??
+      null
+  }
+  if (relationship.type === "userlist") {
+    newResource.user_list_parents =
+      newResource.user_list_parents?.filter((m) => m.id !== value.id) ?? null
+  }
+  updatedResults[matchIndex] = newResource
+  return {
+    ...list,
+    results: updatedResults,
+  }
 }
 
 export default learningResources
-export { invalidateResourceQueries, invalidateUserListQueries }
+export {
+  invalidateResourceQueries,
+  invalidateUserListQueries,
+  updateListParentsOnAdd,
+  updateListParentsOnDestroy,
+}

--- a/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
@@ -12,8 +12,9 @@ import {
 import { useResourceDrawerHref } from "../LearningResourceDrawer/LearningResourceDrawer"
 import { useUserMe } from "api/hooks/user"
 import { SignupPopover } from "../SignupPopover/SignupPopover"
+import { LearningResource } from "api"
 
-const useResourceCard = () => {
+const useResourceCard = (resource?: LearningResource | null) => {
   const getDrawerHref = useResourceDrawerHref()
   const { data: user } = useUserMe()
 
@@ -48,12 +49,17 @@ const useResourceCard = () => {
       }
     }, [user])
 
+  const inUserList = !!resource?.user_list_parents?.length
+  const inLearningPath = !!resource?.learning_path_parents?.length
+
   return {
     getDrawerHref,
     anchorEl,
     handleClosePopover,
     handleAddToLearningPathClick,
     handleAddToUserListClick,
+    inUserList,
+    inLearningPath,
   }
 }
 
@@ -76,7 +82,9 @@ const ResourceCard: React.FC<ResourceCardProps> = ({ resource, ...others }) => {
     handleClosePopover,
     handleAddToLearningPathClick,
     handleAddToUserListClick,
-  } = useResourceCard()
+    inUserList,
+    inLearningPath,
+  } = useResourceCard(resource)
   return (
     <>
       <LearningResourceCard
@@ -84,6 +92,8 @@ const ResourceCard: React.FC<ResourceCardProps> = ({ resource, ...others }) => {
         href={resource ? getDrawerHref(resource.id) : undefined}
         onAddToLearningPathClick={handleAddToLearningPathClick}
         onAddToUserListClick={handleAddToUserListClick}
+        inUserList={inUserList}
+        inLearningPath={inLearningPath}
         {...others}
       />
       <SignupPopover anchorEl={anchorEl} onClose={handleClosePopover} />
@@ -113,7 +123,10 @@ const ResourceListCard: React.FC<ResourceListCardProps> = ({
     handleClosePopover,
     handleAddToLearningPathClick,
     handleAddToUserListClick,
-  } = useResourceCard()
+    inUserList,
+    inLearningPath,
+  } = useResourceCard(resource)
+  console.log(inUserList)
   return (
     <>
       <LearningResourceListCard
@@ -121,6 +134,8 @@ const ResourceListCard: React.FC<ResourceListCardProps> = ({
         href={resource ? getDrawerHref(resource.id) : undefined}
         onAddToLearningPathClick={handleAddToLearningPathClick}
         onAddToUserListClick={handleAddToUserListClick}
+        inUserList={inUserList}
+        inLearningPath={inLearningPath}
         {...others}
       />
       <SignupPopover anchorEl={anchorEl} onClose={handleClosePopover} />

--- a/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
+++ b/frontends/mit-open/src/page-components/ResourceCard/ResourceCard.tsx
@@ -126,7 +126,6 @@ const ResourceListCard: React.FC<ResourceListCardProps> = ({
     inUserList,
     inLearningPath,
   } = useResourceCard(resource)
-  console.log(inUserList)
   return (
     <>
       <LearningResourceListCard

--- a/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
+++ b/frontends/mit-open/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from "react"
 import {
   Button,
   SimpleMenu,
-  ActionButton,
   Grid,
   LoadingSpinner,
   BannerPage,
@@ -11,7 +10,7 @@ import {
   Typography,
   PlainList,
   LearningResourceListCard,
-  theme,
+  ListCardActionButton,
 } from "ol-components"
 import type { SimpleMenuItem } from "ol-components"
 import EditIcon from "@mui/icons-material/Edit"
@@ -31,13 +30,6 @@ import { useUserMe } from "api/hooks/user"
 const ListHeaderGrid = styled(Grid)`
   margin-top: 1rem;
   margin-bottom: 1rem;
-`
-
-const StyledActionButton = styled(ActionButton)`
-  ${theme.breakpoints.down("md")} {
-    width: 16px;
-    height: 16px;
-  }
 `
 
 const EditListMenu: React.FC<{ resource: LearningPathResource }> = ({
@@ -63,15 +55,15 @@ const EditListMenu: React.FC<{ resource: LearningPathResource }> = ({
   return (
     <SimpleMenu
       trigger={
-        <StyledActionButton
+        <ListCardActionButton
           variant="secondary"
-          edge="none"
+          edge="circular"
           color="secondary"
           size="small"
           aria-label={`Edit list ${resource.title}`}
         >
           <MoreVertIcon fontSize="inherit" />
-        </StyledActionButton>
+        </ListCardActionButton>
       }
       items={items}
     />

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -10,6 +10,7 @@ import { theme } from "../ThemeProvider/ThemeProvider"
 import { Link } from "react-router-dom"
 import { Wrapper, containerStyles } from "./Card"
 import { TruncateText } from "../TruncateText/TruncateText"
+import { ActionButton, ActionButtonProps } from "../Button/Button"
 
 const LinkContainer = styled(Link)`
   ${containerStyles}
@@ -114,6 +115,9 @@ const Bottom = styled.div`
   }
 `
 
+/**
+ * Slot intended to contain ListCardAction buttons.
+ */
 const Actions = styled.div<{ hasImage?: boolean }>`
   display: flex;
   gap: 8px;
@@ -121,12 +125,27 @@ const Actions = styled.div<{ hasImage?: boolean }>`
   bottom: 24px;
   right: ${({ hasImage }) => (hasImage ? "284px" : "24px")};
   ${theme.breakpoints.down("md")} {
-    bottom: 12px;
-    right: ${({ hasImage }) => (hasImage ? "124px" : "12px")};
+    bottom: 8px;
+    gap: 4px;
+    right: ${({ hasImage }) => (hasImage ? "120px" : "8px")};
   }
 
   background-color: ${theme.custom.colors.white};
 `
+
+const ListCardActionButton = styled(ActionButton)<{ isMobile?: boolean }>(
+  ({ theme }) => ({
+    [theme.breakpoints.down("md")]: {
+      borderStyle: "none",
+      width: "24px",
+      height: "24px",
+      svg: {
+        width: "16px",
+        height: "16px",
+      },
+    },
+  }),
+)
 
 type CardProps = {
   children: ReactNode[] | ReactNode
@@ -140,6 +159,7 @@ type Card = FC<CardProps> & {
   Title: FC<{ children: ReactNode }>
   Footer: FC<{ children: ReactNode }>
   Actions: FC<{ children: ReactNode }>
+  Action: FC<ActionButtonProps>
 }
 
 const ListCard: Card = ({ children, className, href }) => {
@@ -192,5 +212,7 @@ ListCard.Info = Info
 ListCard.Title = Title
 ListCard.Footer = Footer
 ListCard.Actions = Actions
+ListCard.Action = ListCardActionButton
 
 export { ListCard }
+export { ListCardActionButton }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
-import { RiMenuAddLine, RiBookmarkLine, RiAwardFill } from "@remixicon/react"
+import {
+  RiMenuAddLine,
+  RiBookmarkLine,
+  RiBookmarkFill,
+  RiAwardFill,
+} from "@remixicon/react"
 import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
 import {
   findBestRun,
@@ -13,7 +18,7 @@ import {
 import { Card } from "../Card/Card"
 import type { Size } from "../Card/Card"
 import { TruncateText } from "../TruncateText/TruncateText"
-import { ActionButton } from "../Button/Button"
+import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { imgConfigs } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
 
@@ -119,6 +124,25 @@ interface LearningResourceCardProps {
   href?: string
   onAddToLearningPathClick?: ResourceIdCallback | null
   onAddToUserListClick?: ResourceIdCallback | null
+  inUserList?: boolean
+  inLearningPath?: boolean
+}
+
+const FILLED_PROPS = { variant: "primary" } as const
+const UNFILLED_PROPS = { color: "secondary", variant: "secondary" } as const
+const CardActionButton: React.FC<
+  Pick<ActionButtonProps, "aria-label" | "onClick" | "children"> & {
+    filled?: boolean
+  }
+> = ({ filled, ...props }) => {
+  return (
+    <ActionButton
+      edge="circular"
+      size={"small"}
+      {...(filled ? FILLED_PROPS : UNFILLED_PROPS)}
+      {...props}
+    />
+  )
 }
 
 const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
@@ -129,6 +153,8 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   href,
   onAddToLearningPathClick,
   onAddToUserListClick,
+  inLearningPath,
+  inUserList,
 }) => {
   if (isLoading) {
     const { width, height } = imgConfigs["column"]
@@ -166,28 +192,22 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       </Card.Title>
       <Card.Actions>
         {onAddToLearningPathClick && (
-          <ActionButton
-            variant="secondary"
-            edge="circular"
-            color="secondary"
-            size="small"
+          <CardActionButton
+            filled={inLearningPath}
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
             <RiMenuAddLine />
-          </ActionButton>
+          </CardActionButton>
         )}
         {onAddToUserListClick && (
-          <ActionButton
-            variant="secondary"
-            edge="circular"
-            color="secondary"
-            size="small"
+          <CardActionButton
+            filled={inUserList}
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
-            <RiBookmarkLine />
-          </ActionButton>
+            {inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+          </CardActionButton>
         )}
       </Card.Actions>
       <Card.Footer>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -17,7 +17,7 @@ import {
   pluralize,
 } from "ol-utilities"
 import { ListCard } from "../Card/ListCard"
-import { ActionButton, ActionButtonProps } from "../Button/Button"
+import { ActionButtonProps } from "../Button/Button"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { useMuiBreakpointAtLeast } from "../../hooks/useBreakpoint"
 
@@ -356,19 +356,6 @@ interface LearningResourceListCardProps {
   inLearningPath?: boolean
 }
 
-const StyledActionButton = styled(ActionButton)<{ isMobile?: boolean }>(
-  ({ theme }) => ({
-    [theme.breakpoints.down("md")]: {
-      borderStyle: "none",
-      width: "24px",
-      height: "24px",
-      svg: {
-        width: "16px",
-        height: "16px",
-      },
-    },
-  }),
-)
 const FILLED_PROPS = { variant: "primary" } as const
 const UNFILLED_PROPS = { color: "secondary", variant: "secondary" } as const
 const CardActionButton: React.FC<
@@ -378,10 +365,9 @@ const CardActionButton: React.FC<
   }
 > = ({ filled, isMobile, ...props }) => {
   return (
-    <StyledActionButton
+    <ListCard.Action
       edge="circular"
       size={"small"}
-      isMobile={isMobile}
       {...(filled ? FILLED_PROPS : UNFILLED_PROPS)}
       {...props}
     />
@@ -431,7 +417,6 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
         {onAddToLearningPathClick && (
           <CardActionButton
             filled={inLearningPath}
-            isMobile={isMobile}
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
@@ -441,7 +426,6 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            isMobile={isMobile}
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
-import { RiMenuAddLine, RiBookmarkLine, RiAwardFill } from "@remixicon/react"
+import {
+  RiMenuAddLine,
+  RiBookmarkLine,
+  RiAwardFill,
+  RiBookmarkFill,
+} from "@remixicon/react"
 import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
 import {
   findBestRun,
@@ -12,7 +17,7 @@ import {
   pluralize,
 } from "ol-utilities"
 import { ListCard } from "../Card/ListCard"
-import { ActionButton } from "../Button/Button"
+import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { useMuiBreakpointAtLeast } from "../../hooks/useBreakpoint"
 
@@ -78,15 +83,6 @@ const BorderSeparator = styled.div`
     padding-left: 8px;
     border-left: 1px solid ${theme.custom.colors.lightGray2};
   }
-`
-
-const StyledActionButton = styled(ActionButton)<{ edge: string }>`
-  ${({ edge }) =>
-    edge === "none"
-      ? `
-  width: 16px;
-  height: 16px;`
-      : ""}
 `
 
 type ResourceIdCallback = (
@@ -356,6 +352,40 @@ interface LearningResourceListCardProps {
   onAddToLearningPathClick?: ResourceIdCallback | null
   onAddToUserListClick?: ResourceIdCallback | null
   editMenu?: React.ReactNode | null
+  inUserList?: boolean
+  inLearningPath?: boolean
+}
+
+const StyledActionButton = styled(ActionButton)<{ isMobile?: boolean }>(
+  ({ theme }) => ({
+    [theme.breakpoints.down("md")]: {
+      borderStyle: "none",
+      width: "24px",
+      height: "24px",
+      svg: {
+        width: "16px",
+        height: "16px",
+      },
+    },
+  }),
+)
+const FILLED_PROPS = { variant: "primary" } as const
+const UNFILLED_PROPS = { color: "secondary", variant: "secondary" } as const
+const CardActionButton: React.FC<
+  Pick<ActionButtonProps, "aria-label" | "onClick" | "children"> & {
+    filled?: boolean
+    isMobile?: boolean
+  }
+> = ({ filled, isMobile, ...props }) => {
+  return (
+    <StyledActionButton
+      edge="circular"
+      size={"small"}
+      isMobile={isMobile}
+      {...(filled ? FILLED_PROPS : UNFILLED_PROPS)}
+      {...props}
+    />
+  )
 }
 
 const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
@@ -366,6 +396,8 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
   onAddToLearningPathClick,
   onAddToUserListClick,
   editMenu,
+  inLearningPath,
+  inUserList,
 }) => {
   const isMobile = !useMuiBreakpointAtLeast("md")
 
@@ -397,28 +429,24 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
       <ListCard.Title>{resource.title}</ListCard.Title>
       <ListCard.Actions>
         {onAddToLearningPathClick && (
-          <StyledActionButton
-            variant="secondary"
-            edge={isMobile ? "none" : "circular"}
-            color="secondary"
-            size="small"
+          <CardActionButton
+            filled={inLearningPath}
+            isMobile={isMobile}
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
             <RiMenuAddLine />
-          </StyledActionButton>
+          </CardActionButton>
         )}
         {onAddToUserListClick && (
-          <StyledActionButton
-            variant="secondary"
-            edge={isMobile ? "none" : "circular"}
-            color="secondary"
-            size="small"
+          <CardActionButton
+            filled={inUserList}
+            isMobile={isMobile}
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
-            <RiBookmarkLine />
-          </StyledActionButton>
+            {inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+          </CardActionButton>
         )}
         {editMenu}
       </ListCard.Actions>

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -28,6 +28,7 @@ export {
   ActionButtonLink,
   ButtonLink,
 } from "./components/Button/Button"
+export { ListCardActionButton } from "./components/Card/ListCard"
 
 export type {
   ButtonProps,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4712

### Description (What does it do?)
Makes userlist bookmark and learningpath icon filled vs unfilled based on membership in at least 1 list.

### Screenshots (if appropriate):

**Cards**
<img width="874" alt="Screenshot 2024-06-26 at 6 32 13 PM" src="https://github.com/mitodl/mit-open/assets/9010790/72ea0e01-0209-4bd7-b171-3ed2978f6721">

**List Cards**
<img width="1041" alt="Screenshot 2024-06-26 at 6 32 46 PM" src="https://github.com/mitodl/mit-open/assets/9010790/2cc00d60-8f86-42f4-9b78-53dbac63bbec">

**List Cards, Mobile**
<img width="734" alt="Screenshot 2024-06-26 at 6 32 57 PM" src="https://github.com/mitodl/mit-open/assets/9010790/b976cd8e-88fb-4237-9086-801533ad5ad6">


### How can this be tested?

1. As a logged in user, click the bookmark button on a card to change its membership in "userlists".
    - try this throughout the app, particularly for horizontal "ListCard" (search page) and vertical cards
2. When the resource belongs to at least one list, the bookmark should be filled.
3. When the resource belongs to zero lists, the bookmark should be unfilled.
4. The stafflist button should behave similarly.
5. Try adding/removing featured courses (homepage "Featured Courses" carousel) to a **userlist**.
    - in contrast to RC, the carousel resources should maintain their order.