### PR TITLE
Swap search and login button positions

### DIFF
--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -114,8 +114,8 @@ const LoggedOutView: FunctionComponent = () => {
   return (
     <FlexContainer>
       <DesktopOnly>
-        <UserMenu variant="desktop" />
         <SearchButton />
+        <UserMenu variant="desktop" />
       </DesktopOnly>
       <MobileOnly>
         <SearchButton />

--- a/frontends/mit-open/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-open/src/page-components/Header/UserMenu.tsx
@@ -27,7 +27,7 @@ const UserMenuContainer = styled.button({
 })
 
 const LoginButtonContainer = styled(FlexContainer)(({ theme }) => ({
-  paddingRight: "16px",
+  paddingLeft: "24px",
   "&:hover": {
     textDecoration: "none",
   },


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4718

### Description (What does it do?)

Switches search and login button position in header logged out view.

### Screenshots (if appropriate):

<img width="223" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/6ddf226a-6332-4334-8c4f-7dfe72a6611d">


### How can this be tested?

Load any page while logged out.
