### PR TITLE
Adding the PostHog settings to the "Build frontend" step

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,6 +35,11 @@ jobs:
         run: NODE_ENV=production yarn build
         env:
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_PROD }}
+          POSTHOG_ENABLED: false
+          POSTHOG_API_HOST: https://app.posthog.com
+          POSTHOG_TIMEOUT_MS: 1000
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen.odl.mit.edu
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -38,8 +38,8 @@ jobs:
           POSTHOG_ENABLED: false
           POSTHOG_API_HOST: https://app.posthog.com
           POSTHOG_TIMEOUT_MS: 1000
-          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
-          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID_PROD }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY_PROD }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen.odl.mit.edu
 

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,7 +35,7 @@ jobs:
         run: NODE_ENV=production yarn build
         env:
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_PROD }}
-          POSTHOG_ENABLED: false
+          POSTHOG_ENABLED: true
           POSTHOG_API_HOST: https://app.posthog.com
           POSTHOG_TIMEOUT_MS: 1000
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID_PROD }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -35,7 +35,7 @@ jobs:
         run: NODE_ENV=production yarn build
         env:
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_RC }}
-          POSTHOG_ENABLED: false
+          POSTHOG_ENABLED: true
           POSTHOG_API_HOST: https://app.posthog.com
           POSTHOG_TIMEOUT_MS: 1000
           POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID_RC }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -35,6 +35,11 @@ jobs:
         run: NODE_ENV=production yarn build
         env:
           EMBEDLY_KEY: ${{ secrets.EMBEDLY_KEY_RC }}
+          POSTHOG_ENABLED: false
+          POSTHOG_API_HOST: https://app.posthog.com
+          POSTHOG_TIMEOUT_MS: 1000
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen-rc.odl.mit.edu
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -38,8 +38,8 @@ jobs:
           POSTHOG_ENABLED: false
           POSTHOG_API_HOST: https://app.posthog.com
           POSTHOG_TIMEOUT_MS: 1000
-          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
-          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          POSTHOG_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID_RC }}
+          POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY_RC }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_AXIOS_BASE_PATH: https://api.mitopen-rc.odl.mit.edu
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4738


### Description (What does it do?)

The frontend build wasn't pulling in the PostHog settings, so never activated PostHog when deployed. This fixes that.

### How can this be tested?

Review changes and let me know if they make sense. Not real sure how to test a GitHub action (especially one that involves deploying stuff to S3). 
