### PR TITLE
Square aspect ratio for media resource images

### DIFF
--- a/frontends/mit-open/src/page-components/ResourceCarousel/types.ts
+++ b/frontends/mit-open/src/page-components/ResourceCarousel/types.ts
@@ -3,10 +3,7 @@ import type {
   LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest as SearchRequest,
   FeaturedApiFeaturedListRequest as FeaturedListParams,
 } from "api"
-
-type CardProps = {
-  size?: "small" | "medium"
-}
+import type { LearningResourceCardProps } from "ol-components"
 
 interface ResourceDataSource {
   type: "resources"
@@ -27,7 +24,7 @@ type DataSource = ResourceDataSource | SearchDataSource | FeaturedDataSource
 
 type TabConfig<D extends DataSource = DataSource> = {
   label: React.ReactNode
-  cardProps?: CardProps
+  cardProps?: Pick<LearningResourceCardProps, "size" | "isMedia">
   data: D
 }
 

--- a/frontends/mit-open/src/pages/HomePage/HomePage.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.tsx
@@ -28,8 +28,10 @@ const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
 }))
 const MediaCarousel = styled(ResourceCarousel)(({ theme }) => ({
   margin: "80px 0",
+  minHeight: "388px",
   [theme.breakpoints.down("md")]: {
     margin: "40px 0",
+    minHeight: "418px",
   },
 }))
 

--- a/frontends/mit-open/src/pages/HomePage/carousels.ts
+++ b/frontends/mit-open/src/pages/HomePage/carousels.ts
@@ -46,7 +46,7 @@ const FEATURED_RESOURCES_CAROUSEL: ResourceCarouselProps["config"] = [
 const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
   {
     label: "All",
-    cardProps: { size: "small" },
+    cardProps: { size: "small", isMedia: true },
     data: {
       type: "resources",
       params: {
@@ -58,7 +58,7 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
   },
   {
     label: "Videos",
-    cardProps: { size: "small" },
+    cardProps: { size: "small", isMedia: true },
     data: {
       type: "resources",
       params: { resource_type: ["video"], limit: 12, sortby: "new" },
@@ -66,7 +66,7 @@ const MEDIA_CAROUSEL: ResourceCarouselProps["config"] = [
   },
   {
     label: "Podcasts",
-    cardProps: { size: "small" },
+    cardProps: { size: "small", isMedia: true },
     data: {
       type: "resources",
       params: { resource_type: ["podcast_episode"], limit: 12, sortby: "new" },

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -66,10 +66,11 @@ const Body = styled.div`
   margin: 16px;
 `
 
-const Image = styled.img<{ size?: Size }>`
+const Image = styled.img<{ height?: number | string; size?: Size }>`
   display: block;
   width: 100%;
-  height: ${({ size }) => (size === "small" ? 120 : 170)}px;
+  height: ${({ height, size }) =>
+    height ?? (size === "small" ? "120px" : "170px")};
   background-color: ${theme.custom.colors.lightGray1};
   object-fit: cover;
 `
@@ -147,6 +148,7 @@ type CardProps = {
 
 type ImageProps = ImgHTMLAttributes<HTMLImageElement> & {
   size?: Size
+  height?: number | string
   style?: CSSProperties
 }
 type TitleProps = {
@@ -214,6 +216,7 @@ const Card: Card = ({ children, className, size, href }) => {
         {image && (
           <Image
             size={size}
+            height={image.height}
             {...(image as ImgHTMLAttributes<HTMLImageElement>)}
           />
         )}

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -25,10 +25,14 @@ const SkeletonImage = styled(Skeleton)<{ aspect: number }>`
   padding-bottom: ${({ aspect }) => 100 / aspect}%;
 `
 
-const getEmbedlyUrl = (resource: LearningResource, size: Size) => {
+const getEmbedlyUrl = (
+  resource: LearningResource,
+  size: Size,
+  isMedia: boolean,
+) => {
   const dimensions = {
-    small: { width: 190, height: 120 },
-    medium: { width: 298, height: 170 },
+    small: { width: 190, height: isMedia ? 190 : 120 },
+    medium: { width: 298, height: isMedia ? 298 : 170 },
   }
   return embedlyCroppedImage(resource.image!.url!, {
     key: APP_SETTINGS.embedlyKey || process.env.EMBEDLY_KEY!,
@@ -116,6 +120,7 @@ interface LearningResourceCardProps {
   resource?: LearningResource | null
   className?: string
   size?: Size
+  isMedia?: boolean
   href?: string
   onAddToLearningPathClick?: ResourceIdCallback | null
   onAddToUserListClick?: ResourceIdCallback | null
@@ -126,16 +131,18 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   resource,
   className,
   size = "medium",
+  isMedia = false,
   href,
   onAddToLearningPathClick,
   onAddToUserListClick,
 }) => {
   if (isLoading) {
     const { width, height } = imgConfigs["column"]
+    const aspect = isMedia ? 1 : width / height
     return (
       <Card className={className} size={size}>
         <Card.Content>
-          <SkeletonImage variant="rectangular" aspect={width / height} />
+          <SkeletonImage variant="rectangular" aspect={aspect} />
           <Skeleton height={25} width="65%" sx={{ margin: "23px 16px 0" }} />
           <Skeleton height={25} width="80%" sx={{ margin: "0 16px 35px" }} />
           <Skeleton height={25} width="30%" sx={{ margin: "0 16px 16px" }} />
@@ -151,10 +158,11 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Image
         src={
           resource.image?.url
-            ? getEmbedlyUrl(resource, size)
+            ? getEmbedlyUrl(resource, size, isMedia)
             : DEFAULT_RESOURCE_IMG
         }
         alt={resource.image?.alt ?? ""}
+        height="auto"
       />
       <Card.Info>
         <Info resource={resource} />


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4523

### Description (What does it do?)
<!--- Describe your changes in detail -->

Displays media resource (podcast episodes, videos) images tn the homepage Media section carousel with square aspect ratios.

### Screenshots (if appropriate):

<img width="1410" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/00cad993-3fc4-40e0-8304-6ee8ada2749e">

### How can this be tested?

Navigate to homepage. Check resource cards in the Media section have images with aspect ratio 1 and that their loading state reflects loaded proportions. Check that other resource cards are not affected.

### Additional Context

- Adds an `isMedia` prop to the `LearningResourceCard`. 
- Sets this on the Media section cards by carousel configuration

Opted to do this by configuration because although we can detect that a resource is media by its resource type (`podcast`, `podcast_episode`, `video`), if we do that at the card level we end up with these:

<img width="400" alt="Screenshot 2024-06-27 at 17 45 41" src="https://github.com/mitodl/mit-open/assets/939376/59f18a48-eb85-48d5-a64c-f40ad86923c9">



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
