### PR TITLE
setting 100px as default width for buttons

### DIFF
--- a/frontends/mit-open/src/page-components/Header/MenuButton.tsx
+++ b/frontends/mit-open/src/page-components/Header/MenuButton.tsx
@@ -1,4 +1,4 @@
-import { Button, styled } from "ol-components"
+import { styled } from "ol-components"
 import { RiMenuLine } from "@remixicon/react"
 import React from "react"
 
@@ -23,14 +23,25 @@ const MenuButtonInner = styled.div({
   alignItems: "flex-start",
 })
 
-const StyledMenuButton = styled(Button)({
+const StyledMenuButton = styled.button(({ theme }) => ({
   padding: "0",
   background: "transparent",
   "&:hover:not(:disabled)": {
     background: "transparent",
   },
   touchAction: "none",
-})
+  textAlign: "center",
+  display: "inline-flex",
+  justifyContent: "center",
+  alignItems: "center",
+  color: theme.palette.text.primary,
+  transition: `background ${theme.transitions.duration.short}ms`,
+  cursor: "pointer",
+  borderWidth: "1px",
+  borderColor: "currentcolor",
+  borderStyle: "none",
+  color: theme.custom.colors.white,
+}))
 
 interface MenuButtonProps {
   text?: string

--- a/frontends/mit-open/src/page-components/Header/MenuButton.tsx
+++ b/frontends/mit-open/src/page-components/Header/MenuButton.tsx
@@ -49,7 +49,7 @@ interface MenuButtonProps {
 }
 
 const MenuButton: React.FC<MenuButtonProps> = ({ text, onClick }) => (
-  <StyledMenuButton variant="text" onPointerDown={onClick}>
+  <StyledMenuButton onPointerDown={onClick}>
     <MenuButtonInner>
       <MenuIcon />
       {text ? <MenuButtonText>{text}</MenuButtonText> : ""}

--- a/frontends/mit-open/src/page-components/Header/MenuButton.tsx
+++ b/frontends/mit-open/src/page-components/Header/MenuButton.tsx
@@ -37,8 +37,6 @@ const StyledMenuButton = styled.button(({ theme }) => ({
   color: theme.palette.text.primary,
   transition: `background ${theme.transitions.duration.short}ms`,
   cursor: "pointer",
-  borderWidth: "1px",
-  borderColor: "currentcolor",
   borderStyle: "none",
 }))
 

--- a/frontends/mit-open/src/page-components/Header/MenuButton.tsx
+++ b/frontends/mit-open/src/page-components/Header/MenuButton.tsx
@@ -40,7 +40,6 @@ const StyledMenuButton = styled.button(({ theme }) => ({
   borderWidth: "1px",
   borderColor: "currentcolor",
   borderStyle: "none",
-  color: theme.custom.colors.white,
 }))
 
 interface MenuButtonProps {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -304,6 +304,7 @@ type ActionButtonProps = Omit<ButtonStyleProps, "startIcon" | "endIcon"> &
 
 const actionStyles = (size: ButtonSize) => {
   return {
+    minWidth: "auto",
     padding: 0,
     height: {
       small: "32px",

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -94,6 +94,7 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
       ":disabled": {
         cursor: "default",
       },
+      minWidth: "100px",
     },
     ...sizeStyles(size, hasBorder, theme),
     // responsive

--- a/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
+++ b/frontends/ol-components/src/components/TabButtons/TabButtonList.tsx
@@ -34,6 +34,7 @@ const TabButtonList: React.FC<TabListProps> = styled((props: TabListProps) => (
 
 const tabStyles = ({ theme }: { theme: Theme }) =>
   css({
+    minWidth: "auto",
     ":focus-visible": {
       outlineOffset: "-1px",
     },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/4717
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Sets a min width of 100px for buttons

### How can this be tested?
Checkout this branch and ensure all buttons such as the login button have a minimum width of 100px
