### PR TITLE
adding command to remove old tables

### DIFF
--- a/channels/migrations/0009_rename_field_to_channel.py
+++ b/channels/migrations/0009_rename_field_to_channel.py
@@ -17,6 +17,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL("DROP TABLE IF EXISTS channels_channel CASCADE"),
         migrations.RenameModel(
             old_name="FieldChannel",
             new_name="Channel",

--- a/channels/migrations/0009_rename_field_to_channel.py
+++ b/channels/migrations/0009_rename_field_to_channel.py
@@ -17,7 +17,57 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunSQL("DROP TABLE IF EXISTS channels_channel CASCADE"),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channel CASCADE", migrations.RunSQL.noop
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelgrouprole CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelinvitation CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelmembershipconfig CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelmembershipconfig_channels CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelsubscription CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_channelinvitation CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_comment CASCADE", migrations.RunSQL.noop
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_linkmeta CASCADE", migrations.RunSQL.noop
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_post CASCADE", migrations.RunSQL.noop
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_redditaccesstoken CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_redditrefreshtoken CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_spamcheckresult CASCADE",
+            migrations.RunSQL.noop,
+        ),
+        migrations.RunSQL(
+            "DROP TABLE IF EXISTS channels_subscription CASCADE", migrations.RunSQL.noop
+        ),
         migrations.RenameModel(
             old_name="FieldChannel",
             new_name="Channel",


### PR DESCRIPTION
### What are the relevant tickets?
Removes old tables that were left behind by legacy apps

### Description (What does it do?)
This pr modifies a migration that is failing on deploy by prepending it with sql to remove conflicting tables


### How can this be tested?
1. checkout main
2. roll the channels app migration to 0008 via ```python manage.py migrate channels 0008```
3. get into the db shell ```python manage.py dbshell``` and artificially create a channels table with a conflicting relation via 

CREATE TABLE channels_channel (
    widget_list_id     integer,
    name    varchar(40)
);
alter table channels_channel
  add constraint fk_widgets_w
  foreign key (widget_list_id) 
  references widgets_widgetlist (id);


4. attempt to re-run migrations and see that it fails with an error we see on rc deploy.
5. checkout this branch
6. re-run migrations and it should succeed


### Additional Context
@rhysyngsun is looking for other tables we need to add to this migration
