### PR TITLE
resource category

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -40,7 +40,7 @@ import {
 } from "./base"
 
 /**
- * * `resource_type` - resource_type * `certification` - certification * `certification_type` - certification_type * `offered_by` - offered_by * `platform` - platform * `topic` - topic * `department` - department * `level` - level * `course_feature` - course_feature * `professional` - professional * `free` - free * `learning_format` - learning_format * `is_learning_material` - is_learning_material
+ * * `resource_type` - resource_type * `certification` - certification * `certification_type` - certification_type * `offered_by` - offered_by * `platform` - platform * `topic` - topic * `department` - department * `level` - level * `course_feature` - course_feature * `professional` - professional * `free` - free * `learning_format` - learning_format * `resource_category` - resource_category
  * @export
  * @enum {string}
  */
@@ -58,7 +58,7 @@ export const AggregationsEnumDescriptions = {
   professional: "professional",
   free: "free",
   learning_format: "learning_format",
-  is_learning_material: "is_learning_material",
+  resource_category: "resource_category",
 } as const
 
 export const AggregationsEnum = {
@@ -111,9 +111,9 @@ export const AggregationsEnum = {
    */
   LearningFormat: "learning_format",
   /**
-   * is_learning_material
+   * resource_category
    */
-  IsLearningMaterial: "is_learning_material",
+  ResourceCategory: "resource_category",
 } as const
 
 export type AggregationsEnum =
@@ -655,6 +655,12 @@ export interface CourseResource {
    * @memberof CourseResource
    */
   free: boolean
+  /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof CourseResource
+   */
+  resource_category: string
   /**
    *
    * @type {CourseResourceResourceTypeEnum}
@@ -1285,6 +1291,12 @@ export interface LearningPathResource {
    * @memberof LearningPathResource
    */
   free: boolean
+  /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof LearningPathResource
+   */
+  resource_category: string
   /**
    *
    * @type {LearningPathResourceResourceTypeEnum}
@@ -3358,12 +3370,6 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   certification?: boolean | null
   /**
-   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
-   * @type {boolean}
-   * @memberof PercolateQuerySubscriptionRequestRequest
-   */
-  is_learning_material?: boolean | null
-  /**
    * The type of certificate               * `micromasters` - Micromasters Credential * `professional` - Professional Certificate * `completion` - Certificate of Completion * `none` - No Certificate
    * @type {Array<CertificationTypeEnum>}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -3399,6 +3405,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    * @memberof PercolateQuerySubscriptionRequestRequest
    */
   learning_format?: Array<LearningFormatEnum>
+  /**
+   * The category of learning resource               * `course` - Course * `program` - Program * `learning_material` - Learning Material
+   * @type {Array<ResourceCategoryEnum>}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  resource_category?: Array<ResourceCategoryEnum>
   /**
    *
    * @type {SourceTypeEnum}
@@ -3769,6 +3781,12 @@ export interface PodcastEpisodeResource {
    */
   free: boolean
   /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof PodcastEpisodeResource
+   */
+  resource_category: string
+  /**
    *
    * @type {PodcastEpisodeResourceResourceTypeEnum}
    * @memberof PodcastEpisodeResource
@@ -4053,6 +4071,12 @@ export interface PodcastResource {
    * @memberof PodcastResource
    */
   free: boolean
+  /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof PodcastResource
+   */
+  resource_category: string
   /**
    *
    * @type {PodcastResourceResourceTypeEnum}
@@ -4577,6 +4601,12 @@ export interface ProgramResource {
    */
   free: boolean
   /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof ProgramResource
+   */
+  resource_category: string
+  /**
    *
    * @type {ProgramResourceResourceTypeEnum}
    * @memberof ProgramResource
@@ -4768,6 +4798,36 @@ export const RelationTypeEnum = {
 
 export type RelationTypeEnum =
   (typeof RelationTypeEnum)[keyof typeof RelationTypeEnum]
+
+/**
+ * * `course` - Course * `program` - Program * `learning_material` - Learning Material
+ * @export
+ * @enum {string}
+ */
+
+export const ResourceCategoryEnumDescriptions = {
+  course: "Course",
+  program: "Program",
+  learning_material: "Learning Material",
+} as const
+
+export const ResourceCategoryEnum = {
+  /**
+   * Course
+   */
+  Course: "course",
+  /**
+   * Program
+   */
+  Program: "program",
+  /**
+   * Learning Material
+   */
+  LearningMaterial: "learning_material",
+} as const
+
+export type ResourceCategoryEnum =
+  (typeof ResourceCategoryEnum)[keyof typeof ResourceCategoryEnum]
 
 /**
  * * `course` - course * `program` - program * `learning_path` - learning_path * `podcast` - podcast * `podcast_episode` - podcast_episode * `video` - video * `video_playlist` - video_playlist
@@ -5269,6 +5329,12 @@ export interface VideoPlaylistResource {
    */
   free: boolean
   /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof VideoPlaylistResource
+   */
+  resource_category: string
+  /**
    *
    * @type {VideoPlaylistResourceResourceTypeEnum}
    * @memberof VideoPlaylistResource
@@ -5547,6 +5613,12 @@ export interface VideoResource {
    * @memberof VideoResource
    */
   free: boolean
+  /**
+   * Return the resource category of the resource
+   * @type {string}
+   * @memberof VideoResource
+   */
+  resource_category: string
   /**
    *
    * @type {VideoResourceResourceTypeEnum}
@@ -7819,6 +7891,7 @@ export const CoursesApiAxiosParamCreator = function (
      * @param {Array<CoursesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<CoursesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<CoursesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {CoursesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -7839,6 +7912,7 @@ export const CoursesApiAxiosParamCreator = function (
       platform?: Array<CoursesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<CoursesListResourceCategoryEnum>,
       resource_type?: Array<CoursesListResourceTypeEnum>,
       sortby?: CoursesListSortbyEnum,
       topic?: Array<string>,
@@ -7914,6 +7988,10 @@ export const CoursesApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -8100,6 +8178,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
      * @param {Array<CoursesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<CoursesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<CoursesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {CoursesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -8120,6 +8199,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
       platform?: Array<CoursesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<CoursesListResourceCategoryEnum>,
       resource_type?: Array<CoursesListResourceTypeEnum>,
       sortby?: CoursesListSortbyEnum,
       topic?: Array<string>,
@@ -8144,6 +8224,7 @@ export const CoursesApiFp = function (configuration?: Configuration) {
         platform,
         professional,
         readable_id,
+        resource_category,
         resource_type,
         sortby,
         topic,
@@ -8272,6 +8353,7 @@ export const CoursesApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -8479,6 +8561,13 @@ export interface CoursesApiCoursesListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof CoursesApiCoursesList
+   */
+  readonly resource_category?: Array<CoursesListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof CoursesApiCoursesList
@@ -8596,6 +8685,7 @@ export class CoursesApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -8767,6 +8857,16 @@ export const CoursesListPlatformEnum = {
 } as const
 export type CoursesListPlatformEnum =
   (typeof CoursesListPlatformEnum)[keyof typeof CoursesListPlatformEnum]
+/**
+ * @export
+ */
+export const CoursesListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type CoursesListResourceCategoryEnum =
+  (typeof CoursesListResourceCategoryEnum)[keyof typeof CoursesListResourceCategoryEnum]
 /**
  * @export
  */
@@ -9141,6 +9241,7 @@ export const FeaturedApiAxiosParamCreator = function (
      * @param {Array<FeaturedListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<FeaturedListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<FeaturedListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {FeaturedListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -9161,6 +9262,7 @@ export const FeaturedApiAxiosParamCreator = function (
       platform?: Array<FeaturedListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<FeaturedListResourceCategoryEnum>,
       resource_type?: Array<FeaturedListResourceTypeEnum>,
       sortby?: FeaturedListSortbyEnum,
       topic?: Array<string>,
@@ -9236,6 +9338,10 @@ export const FeaturedApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -9336,6 +9442,7 @@ export const FeaturedApiFp = function (configuration?: Configuration) {
      * @param {Array<FeaturedListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<FeaturedListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<FeaturedListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {FeaturedListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -9356,6 +9463,7 @@ export const FeaturedApiFp = function (configuration?: Configuration) {
       platform?: Array<FeaturedListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<FeaturedListResourceCategoryEnum>,
       resource_type?: Array<FeaturedListResourceTypeEnum>,
       sortby?: FeaturedListSortbyEnum,
       topic?: Array<string>,
@@ -9380,6 +9488,7 @@ export const FeaturedApiFp = function (configuration?: Configuration) {
         platform,
         professional,
         readable_id,
+        resource_category,
         resource_type,
         sortby,
         topic,
@@ -9465,6 +9574,7 @@ export const FeaturedApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -9588,6 +9698,13 @@ export interface FeaturedApiFeaturedListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof FeaturedApiFeaturedList
+   */
+  readonly resource_category?: Array<FeaturedListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof FeaturedApiFeaturedList
@@ -9657,6 +9774,7 @@ export class FeaturedApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -9790,6 +9908,16 @@ export const FeaturedListPlatformEnum = {
 } as const
 export type FeaturedListPlatformEnum =
   (typeof FeaturedListPlatformEnum)[keyof typeof FeaturedListPlatformEnum]
+/**
+ * @export
+ */
+export const FeaturedListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type FeaturedListResourceCategoryEnum =
+  (typeof FeaturedListResourceCategoryEnum)[keyof typeof FeaturedListResourceCategoryEnum]
 /**
  * @export
  */
@@ -10129,6 +10257,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {LearningResourcesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -10149,6 +10278,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       platform?: Array<LearningResourcesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<LearningResourcesListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesListResourceTypeEnum>,
       sortby?: LearningResourcesListSortbyEnum,
       topic?: Array<string>,
@@ -10224,6 +10354,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -10494,6 +10628,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningResourcesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<LearningResourcesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {LearningResourcesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -10514,6 +10649,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       platform?: Array<LearningResourcesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<LearningResourcesListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesListResourceTypeEnum>,
       sortby?: LearningResourcesListSortbyEnum,
       topic?: Array<string>,
@@ -10539,6 +10675,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           platform,
           professional,
           readable_id,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -10712,6 +10849,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -10975,6 +11113,13 @@ export interface LearningResourcesApiLearningResourcesListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof LearningResourcesApiLearningResourcesList
+   */
+  readonly resource_category?: Array<LearningResourcesListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof LearningResourcesApiLearningResourcesList
@@ -11136,6 +11281,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -11310,6 +11456,16 @@ export type LearningResourcesListPlatformEnum =
 /**
  * @export
  */
+export const LearningResourcesListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type LearningResourcesListResourceCategoryEnum =
+  (typeof LearningResourcesListResourceCategoryEnum)[keyof typeof LearningResourcesListResourceCategoryEnum]
+/**
+ * @export
+ */
 export const LearningResourcesListResourceTypeEnum = {
   Course: "course",
   LearningPath: "learning_path",
@@ -11361,7 +11517,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -11370,6 +11525,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrievePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesSearchRetrieveResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -11384,7 +11540,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
@@ -11393,6 +11548,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       platform?: Array<LearningResourcesSearchRetrievePlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesSearchRetrieveResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesSearchRetrieveResourceTypeEnum>,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
@@ -11442,10 +11598,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["id"] = id
       }
 
-      if (is_learning_material !== undefined) {
-        localVarQueryParameter["is_learning_material"] = is_learning_material
-      }
-
       if (learning_format) {
         localVarQueryParameter["learning_format"] = learning_format
       }
@@ -11476,6 +11628,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (q !== undefined) {
         localVarQueryParameter["q"] = q
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -11527,7 +11683,6 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -11536,6 +11691,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrievePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesSearchRetrieveResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -11550,7 +11706,6 @@ export const LearningResourcesSearchApiFp = function (
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
@@ -11559,6 +11714,7 @@ export const LearningResourcesSearchApiFp = function (
       platform?: Array<LearningResourcesSearchRetrievePlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesSearchRetrieveResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesSearchRetrieveResourceTypeEnum>,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
@@ -11578,7 +11734,6 @@ export const LearningResourcesSearchApiFp = function (
           department,
           free,
           id,
-          is_learning_material,
           learning_format,
           level,
           limit,
@@ -11587,6 +11742,7 @@ export const LearningResourcesSearchApiFp = function (
           platform,
           professional,
           q,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -11639,7 +11795,6 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
-          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -11648,6 +11803,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.q,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -11666,7 +11822,7 @@ export const LearningResourcesSearchApiFactory = function (
 export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'resource_category'>}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly aggregations?: Array<LearningResourcesSearchRetrieveAggregationsEnum>
@@ -11712,13 +11868,6 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly id?: Array<number>
-
-  /**
-   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
-   * @type {boolean}
-   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
-   */
-  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -11777,6 +11926,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   readonly q?: string
 
   /**
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly resource_category?: Array<LearningResourcesSearchRetrieveResourceCategoryEnum>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist'>}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
@@ -11826,7 +11982,6 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
-        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -11835,6 +11990,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.q,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -11860,7 +12016,7 @@ export const LearningResourcesSearchRetrieveAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
-  IsLearningMaterial: "is_learning_material",
+  ResourceCategory: "resource_category",
 } as const
 export type LearningResourcesSearchRetrieveAggregationsEnum =
   (typeof LearningResourcesSearchRetrieveAggregationsEnum)[keyof typeof LearningResourcesSearchRetrieveAggregationsEnum]
@@ -11984,6 +12140,16 @@ export type LearningResourcesSearchRetrievePlatformEnum =
 /**
  * @export
  */
+export const LearningResourcesSearchRetrieveResourceCategoryEnum = {
+  Course: "course",
+  Program: "program",
+  LearningMaterial: "learning_material",
+} as const
+export type LearningResourcesSearchRetrieveResourceCategoryEnum =
+  (typeof LearningResourcesSearchRetrieveResourceCategoryEnum)[keyof typeof LearningResourcesSearchRetrieveResourceCategoryEnum]
+/**
+ * @export
+ */
 export const LearningResourcesSearchRetrieveResourceTypeEnum = {
   Course: "course",
   Program: "program",
@@ -12035,7 +12201,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12044,6 +12209,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -12059,7 +12225,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
@@ -12068,6 +12233,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       platform?: Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
@@ -12118,10 +12284,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["id"] = id
       }
 
-      if (is_learning_material !== undefined) {
-        localVarQueryParameter["is_learning_material"] = is_learning_material
-      }
-
       if (learning_format) {
         localVarQueryParameter["learning_format"] = learning_format
       }
@@ -12152,6 +12314,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (q !== undefined) {
         localVarQueryParameter["q"] = q
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -12194,7 +12360,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12203,6 +12368,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -12217,7 +12383,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
@@ -12226,6 +12391,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       platform?: Array<LearningResourcesUserSubscriptionListPlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
@@ -12275,10 +12441,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["id"] = id
       }
 
-      if (is_learning_material !== undefined) {
-        localVarQueryParameter["is_learning_material"] = is_learning_material
-      }
-
       if (learning_format) {
         localVarQueryParameter["learning_format"] = learning_format
       }
@@ -12309,6 +12471,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (q !== undefined) {
         localVarQueryParameter["q"] = q
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -12347,7 +12513,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12356,6 +12521,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -12372,7 +12538,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
@@ -12381,6 +12546,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       platform?: Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
@@ -12432,10 +12598,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["id"] = id
       }
 
-      if (is_learning_material !== undefined) {
-        localVarQueryParameter["is_learning_material"] = is_learning_material
-      }
-
       if (learning_format) {
         localVarQueryParameter["learning_format"] = learning_format
       }
@@ -12466,6 +12628,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (q !== undefined) {
         localVarQueryParameter["q"] = q
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -12579,7 +12745,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12588,6 +12753,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -12603,7 +12769,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
@@ -12612,6 +12777,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       platform?: Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
@@ -12632,7 +12798,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
-          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12641,6 +12806,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           platform,
           professional,
           q,
+          resource_category,
           resource_type,
           sortby,
           source_type,
@@ -12670,7 +12836,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12679,6 +12844,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -12693,7 +12859,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
@@ -12702,6 +12867,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       platform?: Array<LearningResourcesUserSubscriptionListPlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
@@ -12721,7 +12887,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
-          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12730,6 +12895,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           platform,
           professional,
           q,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -12758,7 +12924,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Sloan School of Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Studies and Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Health Sciences and Technology * &#x60;IDS&#x60; - Institute for Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
-     * @param {boolean | null} [is_learning_material] True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
@@ -12767,6 +12932,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean | null} [professional]
      * @param {string} [q] The search text
+     * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -12783,7 +12949,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
       free?: boolean | null,
       id?: Array<number>,
-      is_learning_material?: boolean | null,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
@@ -12792,6 +12957,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       platform?: Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>,
       professional?: boolean | null,
       q?: string,
+      resource_category?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>,
       resource_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
@@ -12810,7 +12976,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           department,
           free,
           id,
-          is_learning_material,
           learning_format,
           level,
           limit,
@@ -12819,6 +12984,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           platform,
           professional,
           q,
+          resource_category,
           resource_type,
           sortby,
           source_type,
@@ -12904,7 +13070,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
-          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12913,6 +13078,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.q,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.source_type,
@@ -12941,7 +13107,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
-          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12950,6 +13115,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.q,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -12977,7 +13143,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.department,
           requestParameters.free,
           requestParameters.id,
-          requestParameters.is_learning_material,
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
@@ -12986,6 +13151,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.q,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.source_type,
@@ -13024,7 +13190,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckListRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'resource_category'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>
@@ -13070,13 +13236,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly id?: Array<number>
-
-  /**
-   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
-   */
-  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13135,6 +13294,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly q?: string
 
   /**
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly resource_category?: Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
@@ -13171,7 +13337,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionListRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'resource_category'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionListAggregationsEnum>
@@ -13217,13 +13383,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly id?: Array<number>
-
-  /**
-   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
-   */
-  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13282,6 +13441,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly q?: string
 
   /**
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly resource_category?: Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
@@ -13311,7 +13477,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
 export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreateRequest {
   /**
    * Show resource counts by category
-   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'is_learning_material'>}
+   * @type {Array<'resource_type' | 'certification' | 'certification_type' | 'offered_by' | 'platform' | 'topic' | 'department' | 'level' | 'course_feature' | 'professional' | 'free' | 'learning_format' | 'resource_category'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly aggregations?: Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>
@@ -13357,13 +13523,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly id?: Array<number>
-
-  /**
-   * True if the learning resource is a podcast, podcast episode, video, video playlist, or learning path
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
-   */
-  readonly is_learning_material?: boolean | null
 
   /**
    * The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13420,6 +13579,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly q?: string
+
+  /**
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly resource_category?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>
 
   /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
@@ -13499,7 +13665,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
-        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13508,6 +13673,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.q,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.source_type,
@@ -13538,7 +13704,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
-        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13547,6 +13712,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.q,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -13576,7 +13742,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.department,
         requestParameters.free,
         requestParameters.id,
-        requestParameters.is_learning_material,
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
@@ -13585,6 +13750,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.q,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.source_type,
@@ -13632,7 +13798,7 @@ export const LearningResourcesUserSubscriptionCheckListAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
-  IsLearningMaterial: "is_learning_material",
+  ResourceCategory: "resource_category",
 } as const
 export type LearningResourcesUserSubscriptionCheckListAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionCheckListAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionCheckListAggregationsEnum]
@@ -13756,6 +13922,16 @@ export type LearningResourcesUserSubscriptionCheckListPlatformEnum =
 /**
  * @export
  */
+export const LearningResourcesUserSubscriptionCheckListResourceCategoryEnum = {
+  Course: "course",
+  Program: "program",
+  LearningMaterial: "learning_material",
+} as const
+export type LearningResourcesUserSubscriptionCheckListResourceCategoryEnum =
+  (typeof LearningResourcesUserSubscriptionCheckListResourceCategoryEnum)[keyof typeof LearningResourcesUserSubscriptionCheckListResourceCategoryEnum]
+/**
+ * @export
+ */
 export const LearningResourcesUserSubscriptionCheckListResourceTypeEnum = {
   Course: "course",
   Program: "program",
@@ -13813,7 +13989,7 @@ export const LearningResourcesUserSubscriptionListAggregationsEnum = {
   Professional: "professional",
   Free: "free",
   LearningFormat: "learning_format",
-  IsLearningMaterial: "is_learning_material",
+  ResourceCategory: "resource_category",
 } as const
 export type LearningResourcesUserSubscriptionListAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionListAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionListAggregationsEnum]
@@ -13937,6 +14113,16 @@ export type LearningResourcesUserSubscriptionListPlatformEnum =
 /**
  * @export
  */
+export const LearningResourcesUserSubscriptionListResourceCategoryEnum = {
+  Course: "course",
+  Program: "program",
+  LearningMaterial: "learning_material",
+} as const
+export type LearningResourcesUserSubscriptionListResourceCategoryEnum =
+  (typeof LearningResourcesUserSubscriptionListResourceCategoryEnum)[keyof typeof LearningResourcesUserSubscriptionListResourceCategoryEnum]
+/**
+ * @export
+ */
 export const LearningResourcesUserSubscriptionListResourceTypeEnum = {
   Course: "course",
   Program: "program",
@@ -13986,7 +14172,7 @@ export const LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum =
     Professional: "professional",
     Free: "free",
     LearningFormat: "learning_format",
-    IsLearningMaterial: "is_learning_material",
+    ResourceCategory: "resource_category",
   } as const
 export type LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum =
   (typeof LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum)[keyof typeof LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum]
@@ -14109,6 +14295,17 @@ export const LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum = {
 } as const
 export type LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum =
   (typeof LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum)[keyof typeof LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum]
+/**
+ * @export
+ */
+export const LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum =
+  {
+    Course: "course",
+    Program: "program",
+    LearningMaterial: "learning_material",
+  } as const
+export type LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum =
+  (typeof LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum)[keyof typeof LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum]
 /**
  * @export
  */
@@ -14594,6 +14791,7 @@ export const LearningpathsApiAxiosParamCreator = function (
      * @param {Array<LearningpathsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<LearningpathsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningpathsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {LearningpathsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -14614,6 +14812,7 @@ export const LearningpathsApiAxiosParamCreator = function (
       platform?: Array<LearningpathsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<LearningpathsListResourceCategoryEnum>,
       resource_type?: Array<LearningpathsListResourceTypeEnum>,
       sortby?: LearningpathsListSortbyEnum,
       topic?: Array<string>,
@@ -14689,6 +14888,10 @@ export const LearningpathsApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -15093,6 +15296,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningpathsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<LearningpathsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningpathsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {LearningpathsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -15113,6 +15317,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
       platform?: Array<LearningpathsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<LearningpathsListResourceCategoryEnum>,
       resource_type?: Array<LearningpathsListResourceTypeEnum>,
       sortby?: LearningpathsListSortbyEnum,
       topic?: Array<string>,
@@ -15138,6 +15343,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
           platform,
           professional,
           readable_id,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -15392,6 +15598,7 @@ export const LearningpathsApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -15688,6 +15895,13 @@ export interface LearningpathsApiLearningpathsListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof LearningpathsApiLearningpathsList
+   */
+  readonly resource_category?: Array<LearningpathsListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof LearningpathsApiLearningpathsList
@@ -15923,6 +16137,7 @@ export class LearningpathsApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -16077,6 +16292,16 @@ export const LearningpathsListPlatformEnum = {
 } as const
 export type LearningpathsListPlatformEnum =
   (typeof LearningpathsListPlatformEnum)[keyof typeof LearningpathsListPlatformEnum]
+/**
+ * @export
+ */
+export const LearningpathsListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type LearningpathsListResourceCategoryEnum =
+  (typeof LearningpathsListResourceCategoryEnum)[keyof typeof LearningpathsListResourceCategoryEnum]
 /**
  * @export
  */
@@ -16749,6 +16974,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
      * @param {Array<PodcastEpisodesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<PodcastEpisodesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<PodcastEpisodesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {PodcastEpisodesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -16769,6 +16995,7 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
       platform?: Array<PodcastEpisodesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<PodcastEpisodesListResourceCategoryEnum>,
       resource_type?: Array<PodcastEpisodesListResourceTypeEnum>,
       sortby?: PodcastEpisodesListSortbyEnum,
       topic?: Array<string>,
@@ -16844,6 +17071,10 @@ export const PodcastEpisodesApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -16945,6 +17176,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
      * @param {Array<PodcastEpisodesListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<PodcastEpisodesListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<PodcastEpisodesListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {PodcastEpisodesListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -16965,6 +17197,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
       platform?: Array<PodcastEpisodesListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<PodcastEpisodesListResourceCategoryEnum>,
       resource_type?: Array<PodcastEpisodesListResourceTypeEnum>,
       sortby?: PodcastEpisodesListSortbyEnum,
       topic?: Array<string>,
@@ -16990,6 +17223,7 @@ export const PodcastEpisodesApiFp = function (configuration?: Configuration) {
           platform,
           professional,
           readable_id,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -17078,6 +17312,7 @@ export const PodcastEpisodesApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -17201,6 +17436,13 @@ export interface PodcastEpisodesApiPodcastEpisodesListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof PodcastEpisodesApiPodcastEpisodesList
+   */
+  readonly resource_category?: Array<PodcastEpisodesListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof PodcastEpisodesApiPodcastEpisodesList
@@ -17270,6 +17512,7 @@ export class PodcastEpisodesApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -17403,6 +17646,16 @@ export const PodcastEpisodesListPlatformEnum = {
 } as const
 export type PodcastEpisodesListPlatformEnum =
   (typeof PodcastEpisodesListPlatformEnum)[keyof typeof PodcastEpisodesListPlatformEnum]
+/**
+ * @export
+ */
+export const PodcastEpisodesListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type PodcastEpisodesListResourceCategoryEnum =
+  (typeof PodcastEpisodesListResourceCategoryEnum)[keyof typeof PodcastEpisodesListResourceCategoryEnum]
 /**
  * @export
  */
@@ -17588,6 +17841,7 @@ export const PodcastsApiAxiosParamCreator = function (
      * @param {Array<PodcastsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<PodcastsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<PodcastsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {PodcastsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -17608,6 +17862,7 @@ export const PodcastsApiAxiosParamCreator = function (
       platform?: Array<PodcastsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<PodcastsListResourceCategoryEnum>,
       resource_type?: Array<PodcastsListResourceTypeEnum>,
       sortby?: PodcastsListSortbyEnum,
       topic?: Array<string>,
@@ -17683,6 +17938,10 @@ export const PodcastsApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -17859,6 +18118,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
      * @param {Array<PodcastsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<PodcastsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<PodcastsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {PodcastsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -17879,6 +18139,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
       platform?: Array<PodcastsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<PodcastsListResourceCategoryEnum>,
       resource_type?: Array<PodcastsListResourceTypeEnum>,
       sortby?: PodcastsListSortbyEnum,
       topic?: Array<string>,
@@ -17903,6 +18164,7 @@ export const PodcastsApiFp = function (configuration?: Configuration) {
         platform,
         professional,
         readable_id,
+        resource_category,
         resource_type,
         sortby,
         topic,
@@ -18028,6 +18290,7 @@ export const PodcastsApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -18207,6 +18470,13 @@ export interface PodcastsApiPodcastsListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof PodcastsApiPodcastsList
+   */
+  readonly resource_category?: Array<PodcastsListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof PodcastsApiPodcastsList
@@ -18320,6 +18590,7 @@ export class PodcastsApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -18453,6 +18724,16 @@ export const PodcastsListPlatformEnum = {
 } as const
 export type PodcastsListPlatformEnum =
   (typeof PodcastsListPlatformEnum)[keyof typeof PodcastsListPlatformEnum]
+/**
+ * @export
+ */
+export const PodcastsListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type PodcastsListResourceCategoryEnum =
+  (typeof PodcastsListResourceCategoryEnum)[keyof typeof PodcastsListResourceCategoryEnum]
 /**
  * @export
  */
@@ -18672,6 +18953,7 @@ export const ProgramsApiAxiosParamCreator = function (
      * @param {Array<ProgramsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<ProgramsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<ProgramsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {ProgramsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -18692,6 +18974,7 @@ export const ProgramsApiAxiosParamCreator = function (
       platform?: Array<ProgramsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<ProgramsListResourceCategoryEnum>,
       resource_type?: Array<ProgramsListResourceTypeEnum>,
       sortby?: ProgramsListSortbyEnum,
       topic?: Array<string>,
@@ -18767,6 +19050,10 @@ export const ProgramsApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -18867,6 +19154,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
      * @param {Array<ProgramsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<ProgramsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<ProgramsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {ProgramsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -18887,6 +19175,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
       platform?: Array<ProgramsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<ProgramsListResourceCategoryEnum>,
       resource_type?: Array<ProgramsListResourceTypeEnum>,
       sortby?: ProgramsListSortbyEnum,
       topic?: Array<string>,
@@ -18911,6 +19200,7 @@ export const ProgramsApiFp = function (configuration?: Configuration) {
         platform,
         professional,
         readable_id,
+        resource_category,
         resource_type,
         sortby,
         topic,
@@ -18996,6 +19286,7 @@ export const ProgramsApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -19119,6 +19410,13 @@ export interface ProgramsApiProgramsListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof ProgramsApiProgramsList
+   */
+  readonly resource_category?: Array<ProgramsListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof ProgramsApiProgramsList
@@ -19188,6 +19486,7 @@ export class ProgramsApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -19321,6 +19620,16 @@ export const ProgramsListPlatformEnum = {
 } as const
 export type ProgramsListPlatformEnum =
   (typeof ProgramsListPlatformEnum)[keyof typeof ProgramsListPlatformEnum]
+/**
+ * @export
+ */
+export const ProgramsListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type ProgramsListResourceCategoryEnum =
+  (typeof ProgramsListResourceCategoryEnum)[keyof typeof ProgramsListResourceCategoryEnum]
 /**
  * @export
  */
@@ -21653,6 +21962,7 @@ export const VideoPlaylistsApiAxiosParamCreator = function (
      * @param {Array<VideoPlaylistsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<VideoPlaylistsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<VideoPlaylistsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {VideoPlaylistsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -21673,6 +21983,7 @@ export const VideoPlaylistsApiAxiosParamCreator = function (
       platform?: Array<VideoPlaylistsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<VideoPlaylistsListResourceCategoryEnum>,
       resource_type?: Array<VideoPlaylistsListResourceTypeEnum>,
       sortby?: VideoPlaylistsListSortbyEnum,
       topic?: Array<string>,
@@ -21748,6 +22059,10 @@ export const VideoPlaylistsApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -21928,6 +22243,7 @@ export const VideoPlaylistsApiFp = function (configuration?: Configuration) {
      * @param {Array<VideoPlaylistsListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<VideoPlaylistsListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<VideoPlaylistsListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {VideoPlaylistsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -21948,6 +22264,7 @@ export const VideoPlaylistsApiFp = function (configuration?: Configuration) {
       platform?: Array<VideoPlaylistsListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<VideoPlaylistsListResourceCategoryEnum>,
       resource_type?: Array<VideoPlaylistsListResourceTypeEnum>,
       sortby?: VideoPlaylistsListSortbyEnum,
       topic?: Array<string>,
@@ -21973,6 +22290,7 @@ export const VideoPlaylistsApiFp = function (configuration?: Configuration) {
           platform,
           professional,
           readable_id,
+          resource_category,
           resource_type,
           sortby,
           topic,
@@ -22099,6 +22417,7 @@ export const VideoPlaylistsApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -22278,6 +22597,13 @@ export interface VideoPlaylistsApiVideoPlaylistsListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof VideoPlaylistsApiVideoPlaylistsList
+   */
+  readonly resource_category?: Array<VideoPlaylistsListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof VideoPlaylistsApiVideoPlaylistsList
@@ -22391,6 +22717,7 @@ export class VideoPlaylistsApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -22527,6 +22854,16 @@ export type VideoPlaylistsListPlatformEnum =
 /**
  * @export
  */
+export const VideoPlaylistsListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type VideoPlaylistsListResourceCategoryEnum =
+  (typeof VideoPlaylistsListResourceCategoryEnum)[keyof typeof VideoPlaylistsListResourceCategoryEnum]
+/**
+ * @export
+ */
 export const VideoPlaylistsListResourceTypeEnum = {
   Course: "course",
   LearningPath: "learning_path",
@@ -22584,6 +22921,7 @@ export const VideosApiAxiosParamCreator = function (
      * @param {Array<VideosListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<VideosListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<VideosListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {VideosListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -22604,6 +22942,7 @@ export const VideosApiAxiosParamCreator = function (
       platform?: Array<VideosListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<VideosListResourceCategoryEnum>,
       resource_type?: Array<VideosListResourceTypeEnum>,
       sortby?: VideosListSortbyEnum,
       topic?: Array<string>,
@@ -22679,6 +23018,10 @@ export const VideosApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id.join(
           COLLECTION_FORMATS.csv,
         )
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -22779,6 +23122,7 @@ export const VideosApiFp = function (configuration?: Configuration) {
      * @param {Array<VideosListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - OCW * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - Professional Education * &#x60;see&#x60; - Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
      * @param {boolean} [professional]
      * @param {Array<string>} [readable_id] Multiple values may be separated by commas.
+     * @param {Array<VideosListResourceCategoryEnum>} [resource_category] The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<VideosListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
      * @param {VideosListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] Multiple values may be separated by commas.
@@ -22799,6 +23143,7 @@ export const VideosApiFp = function (configuration?: Configuration) {
       platform?: Array<VideosListPlatformEnum>,
       professional?: boolean,
       readable_id?: Array<string>,
+      resource_category?: Array<VideosListResourceCategoryEnum>,
       resource_type?: Array<VideosListResourceTypeEnum>,
       sortby?: VideosListSortbyEnum,
       topic?: Array<string>,
@@ -22823,6 +23168,7 @@ export const VideosApiFp = function (configuration?: Configuration) {
         platform,
         professional,
         readable_id,
+        resource_category,
         resource_type,
         sortby,
         topic,
@@ -22907,6 +23253,7 @@ export const VideosApiFactory = function (
           requestParameters.platform,
           requestParameters.professional,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
@@ -23030,6 +23377,13 @@ export interface VideosApiVideosListRequest {
   readonly readable_id?: Array<string>
 
   /**
+   * The resource category of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * @memberof VideosApiVideosList
+   */
+  readonly resource_category?: Array<VideosListResourceCategoryEnum>
+
+  /**
    * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist
    * @type {Array<'course' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
    * @memberof VideosApiVideosList
@@ -23099,6 +23453,7 @@ export class VideosApi extends BaseAPI {
         requestParameters.platform,
         requestParameters.professional,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
@@ -23232,6 +23587,16 @@ export const VideosListPlatformEnum = {
 } as const
 export type VideosListPlatformEnum =
   (typeof VideosListPlatformEnum)[keyof typeof VideosListPlatformEnum]
+/**
+ * @export
+ */
+export const VideosListResourceCategoryEnum = {
+  Course: "course",
+  LearningMaterial: "learning_material",
+  Program: "program",
+} as const
+export type VideosListResourceCategoryEnum =
+  (typeof VideosListResourceCategoryEnum)[keyof typeof VideosListResourceCategoryEnum]
 /**
  * @export
  */

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -34,6 +34,14 @@ class LearningResourceType(ExtendedEnum):
     video_playlist = "Video Playlist"
 
 
+LEARNING_MATERIAL_RESOURCE_CATEGORY = "learning_material"
+RESOURCE_CATEGORY_VALUES = [
+    LearningResourceType.course.name,
+    LearningResourceType.program.name,
+    LEARNING_MATERIAL_RESOURCE_CATEGORY,
+]
+
+
 class OfferedBy(ExtendedEnum):
     """
     Enum for our Offered By labels. They are our MIT "brands" for LearningResources

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -14,6 +14,7 @@ from django_filters import (
 from learning_resources.constants import (
     DEPARTMENTS,
     LEARNING_RESOURCE_SORTBY_OPTIONS,
+    RESOURCE_CATEGORY_VALUES,
     CertificationType,
     LearningResourceFormat,
     LearningResourceType,
@@ -115,6 +116,17 @@ class LearningResourceFilter(FilterSet):
         lookup_expr="iexact",
     )
 
+    resource_category = MultipleChoiceFilter(
+        label="The resource category of the learning resources",
+        method="filter_resource_category",
+        choices=(
+            [
+                (value, value.replace("_", " ").title())
+                for value in RESOURCE_CATEGORY_VALUES
+            ]
+        ),
+    )
+
     def filter_free(self, queryset, _, value):
         """Free cost filter for learning resources"""
         free_filter = (
@@ -129,6 +141,24 @@ class LearningResourceFilter(FilterSet):
         else:
             # Resources that are not offered for free
             return queryset.exclude(free_filter)
+
+    def filter_resource_category(self, queryset, _, value):
+        """Filter by resource category"""
+        query_or_filters = Q()
+        for val in value:
+            if val in [
+                LearningResourceType.course.name,
+                LearningResourceType.program.name,
+            ]:
+                query_or_filters |= Q(resource_type=val)
+            else:
+                query_or_filters |= ~Q(
+                    resource_type__in=[
+                        LearningResourceType.course.name,
+                        LearningResourceType.program.name,
+                    ]
+                )
+        return queryset.filter(query_or_filters)
 
     def filter_readable_id(self, queryset, _, value):
         """Readable id filter for leaarning resources"""

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -15,6 +15,7 @@ from rest_framework.exceptions import ValidationError
 from channels.models import Channel
 from learning_resources import constants, models
 from learning_resources.constants import (
+    LEARNING_MATERIAL_RESOURCE_CATEGORY,
     CertificationType,
     LearningResourceFormat,
     LearningResourceType,
@@ -454,6 +455,17 @@ class LearningResourceBaseSerializer(serializers.ModelSerializer, WriteableTopic
         child=LearningResourceFormatSerializer(), read_only=True
     )
     free = serializers.SerializerMethodField()
+    resource_category = serializers.SerializerMethodField()
+
+    def get_resource_category(self, instance) -> str:
+        """Return the resource category of the resource"""
+        if instance.resource_type in [
+            LearningResourceType.course.name,
+            LearningResourceType.program.name,
+        ]:
+            return instance.resource_type
+        else:
+            return LEARNING_MATERIAL_RESOURCE_CATEGORY
 
     def get_free(self, instance) -> bool:
         """Return true if the resource is free/has a free option"""
@@ -549,6 +561,7 @@ class LearningResourceBaseSerializer(serializers.ModelSerializer, WriteableTopic
         model = models.LearningResource
         read_only_fields = [
             "free",
+            "resource_category",
             "certification",
             "certification_type",
             "professional",

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -13,6 +13,7 @@ from channels.factories import (
 from channels.models import Channel
 from learning_resources import factories, serializers, utils
 from learning_resources.constants import (
+    LEARNING_MATERIAL_RESOURCE_CATEGORY,
     CertificationType,
     LearningResourceFormat,
     LearningResourceRelationTypes,
@@ -190,6 +191,14 @@ def test_learning_resource_serializer(  # noqa: PLR0913
     ).data
     expected = specific_serializer_cls(instance=resource, context=context).data
 
+    if resource.resource_type in [
+        LearningResourceType.course.name,
+        LearningResourceType.program.name,
+    ]:
+        resource_category = resource.resource_type
+    else:
+        resource_category = LEARNING_MATERIAL_RESOURCE_CATEGORY
+
     assert result == expected
 
     assert result == {
@@ -223,6 +232,7 @@ def test_learning_resource_serializer(  # noqa: PLR0913
                 )
             )
         ),
+        "resource_category": resource_category,
         "published": resource.published,
         "readable_id": resource.readable_id,
         "course_feature": sorted([tag.name for tag in resource.content_tags.all()]),

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -74,7 +74,7 @@ LEARNING_RESOURCE_SEARCH_FILTERS = {
     "platform": FilterConfig("platform.code"),
     "offered_by": FilterConfig("offered_by.code"),
     "learning_format": FilterConfig("learning_format.code"),
-    "is_learning_material": FilterConfig("is_learning_material"),
+    "resource_category": FilterConfig("resource_category"),
 }
 
 SEARCH_NESTED_FILTERS = {
@@ -111,6 +111,7 @@ LEARNING_RESOURCE_MAP = {
         },
     },
     "free": {"type": "boolean"},
+    "is_learning_material": {"type": "boolean"},
     "learning_format": {
         "type": "nested",
         "properties": {
@@ -158,6 +159,7 @@ LEARNING_RESOURCE_MAP = {
     },
     "professional": {"type": "boolean"},
     "resource_type": {"type": "keyword"},
+    "resource_category": {"type": "keyword"},
     "topics": {
         "type": "nested",
         "properties": {

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -718,14 +718,14 @@ def test_learning_resources_search_request_serializer():
         "certification": "false",
         "certification_type": [CertificationType.none.name],
         "free": True,
-        "is_learning_material": True,
+        "resource_category": ["course", "program"],
         "topic": ["Math", "Atoms,Molecules,and Ions"],
         "offered_by": ["xpro", "ocw"],
         "platform": ["xpro", "edx", "ocw"],
         "department": ["18", "5"],
         "level": ["high_school", "undergraduate"],
         "course_feature": ["Lecture Videos"],
-        "aggregations": ["resource_type", "platform", "level"],
+        "aggregations": ["resource_type", "platform", "level", "resource_category"],
     }
 
     cleaned = {
@@ -736,7 +736,7 @@ def test_learning_resources_search_request_serializer():
         "sortby": "-start_date",
         "professional": [True],
         "certification": [False],
-        "is_learning_material": [True],
+        "resource_category": ["course", "program"],
         "certification_type": [CertificationType.none.name],
         "free": [True],
         "offered_by": ["xpro", "ocw"],
@@ -745,7 +745,7 @@ def test_learning_resources_search_request_serializer():
         "department": ["18", "5"],
         "level": ["high_school", "undergraduate"],
         "course_feature": ["Lecture Videos"],
-        "aggregations": ["resource_type", "platform", "level"],
+        "aggregations": ["resource_type", "platform", "level", "resource_category"],
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -787,6 +787,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -1369,6 +1387,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -1744,6 +1780,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -2093,7 +2147,7 @@ paths:
             - professional
             - free
             - learning_format
-            - is_learning_material
+            - resource_category
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2108,7 +2162,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
-              * `is_learning_material` - is_learning_material
+              * `resource_category` - resource_category
         description: Show resource counts by category
       - in: query
         name: certification
@@ -2257,13 +2311,6 @@ paths:
             type: integer
         description: The id value for the learning resource
       - in: query
-        name: is_learning_material
-        schema:
-          type: boolean
-          nullable: true
-        description: True if the learning resource is a podcast, podcast episode,
-          video, video playlist, or learning path
-      - in: query
         name: learning_format
         schema:
           type: array
@@ -2399,6 +2446,22 @@ paths:
           type: string
           minLength: 1
         description: The search text
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            enum:
+            - course
+            - program
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
         name: resource_type
         schema:
@@ -2503,7 +2566,7 @@ paths:
             - professional
             - free
             - learning_format
-            - is_learning_material
+            - resource_category
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2518,7 +2581,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
-              * `is_learning_material` - is_learning_material
+              * `resource_category` - resource_category
         description: Show resource counts by category
       - in: query
         name: certification
@@ -2667,13 +2730,6 @@ paths:
             type: integer
         description: The id value for the learning resource
       - in: query
-        name: is_learning_material
-        schema:
-          type: boolean
-          nullable: true
-        description: True if the learning resource is a podcast, podcast episode,
-          video, video playlist, or learning path
-      - in: query
         name: learning_format
         schema:
           type: array
@@ -2809,6 +2865,22 @@ paths:
           type: string
           minLength: 1
         description: The search text
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            enum:
+            - course
+            - program
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
         name: resource_type
         schema:
@@ -2938,7 +3010,7 @@ paths:
             - professional
             - free
             - learning_format
-            - is_learning_material
+            - resource_category
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -2953,7 +3025,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
-              * `is_learning_material` - is_learning_material
+              * `resource_category` - resource_category
         description: Show resource counts by category
       - in: query
         name: certification
@@ -3102,13 +3174,6 @@ paths:
             type: integer
         description: The id value for the learning resource
       - in: query
-        name: is_learning_material
-        schema:
-          type: boolean
-          nullable: true
-        description: True if the learning resource is a podcast, podcast episode,
-          video, video playlist, or learning path
-      - in: query
         name: learning_format
         schema:
           type: array
@@ -3244,6 +3309,22 @@ paths:
           type: string
           minLength: 1
         description: The search text
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            enum:
+            - course
+            - program
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
         name: resource_type
         schema:
@@ -3364,7 +3445,7 @@ paths:
             - professional
             - free
             - learning_format
-            - is_learning_material
+            - resource_category
             type: string
             description: |-
               * `resource_type` - resource_type
@@ -3379,7 +3460,7 @@ paths:
               * `professional` - professional
               * `free` - free
               * `learning_format` - learning_format
-              * `is_learning_material` - is_learning_material
+              * `resource_category` - resource_category
         description: Show resource counts by category
       - in: query
         name: certification
@@ -3528,13 +3609,6 @@ paths:
             type: integer
         description: The id value for the learning resource
       - in: query
-        name: is_learning_material
-        schema:
-          type: boolean
-          nullable: true
-        description: True if the learning resource is a podcast, podcast episode,
-          video, video playlist, or learning path
-      - in: query
         name: learning_format
         schema:
           type: array
@@ -3670,6 +3744,22 @@ paths:
           type: string
           minLength: 1
         description: The search text
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            enum:
+            - course
+            - program
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
         name: resource_type
         schema:
@@ -4048,6 +4138,24 @@ paths:
             type: string
         description: Multiple values may be separated by commas.
         explode: false
+        style: form
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
         style: form
       - in: query
         name: resource_type
@@ -4750,6 +4858,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -5123,6 +5249,24 @@ paths:
             type: string
         description: Multiple values may be separated by commas.
         explode: false
+        style: form
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
         style: form
       - in: query
         name: resource_type
@@ -5585,6 +5729,24 @@ paths:
             type: string
         description: Multiple values may be separated by commas.
         explode: false
+        style: form
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
         style: form
       - in: query
         name: resource_type
@@ -6352,6 +6514,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -6793,6 +6973,24 @@ paths:
         explode: false
         style: form
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - course
+            - learning_material
+            - program
+        description: |-
+          The resource category of the learning resources
+
+          * `course` - Course
+          * `program` - Program
+          * `learning_material` - Learning Material
+        explode: true
+        style: form
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -6909,7 +7107,7 @@ components:
       - professional
       - free
       - learning_format
-      - is_learning_material
+      - resource_category
       type: string
       description: |-
         * `resource_type` - resource_type
@@ -6924,7 +7122,7 @@ components:
         * `professional` - professional
         * `free` - free
         * `learning_format` - learning_format
-        * `is_learning_material` - is_learning_material
+        * `resource_category` - resource_category
       x-enum-descriptions:
       - resource_type
       - certification
@@ -6938,7 +7136,7 @@ components:
       - professional
       - free
       - learning_format
-      - is_learning_material
+      - resource_category
     Article:
       type: object
       description: Serializer for LearningResourceInstructor model
@@ -7313,6 +7511,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/CourseResourceResourceTypeEnum'
@@ -7374,6 +7576,7 @@ components:
       - prices
       - professional
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -7719,6 +7922,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/LearningPathResourceResourceTypeEnum'
@@ -7778,6 +7985,7 @@ components:
       - platform
       - prices
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -9258,11 +9466,6 @@ components:
           type: boolean
           nullable: true
           description: True if the learning resource offers a certificate
-        is_learning_material:
-          type: boolean
-          nullable: true
-          description: True if the learning resource is a podcast, podcast episode,
-            video, video playlist, or learning path
         certification_type:
           type: array
           items:
@@ -9315,6 +9518,12 @@ components:
           description: "The format(s) in which the learning resource is offered  \
             \           \n\n* `online` - Online\n* `hybrid` - Hybrid\n* `in_person`\
             \ - In person"
+        resource_category:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResourceCategoryEnum'
+          description: "The category of learning resource             \n\n* `course`\
+            \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
         source_type:
           allOf:
           - $ref: '#/components/schemas/SourceTypeEnum'
@@ -9585,6 +9794,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/PodcastEpisodeResourceResourceTypeEnum'
@@ -9646,6 +9859,7 @@ components:
       - prices
       - professional
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -9830,6 +10044,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/PodcastResourceResourceTypeEnum'
@@ -9891,6 +10109,7 @@ components:
       - prices
       - professional
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -10220,6 +10439,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/ProgramResourceResourceTypeEnum'
@@ -10281,6 +10504,7 @@ components:
       - professional
       - program
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -10355,6 +10579,20 @@ components:
       - Learning Path Items
       - Podcast Episodes
       - Playlist Videos
+    ResourceCategoryEnum:
+      enum:
+      - course
+      - program
+      - learning_material
+      type: string
+      description: |-
+        * `course` - Course
+        * `program` - Program
+        * `learning_material` - Learning Material
+      x-enum-descriptions:
+      - Course
+      - Program
+      - Learning Material
     ResourceTypeEnum:
       enum:
       - course
@@ -10700,6 +10938,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/VideoPlaylistResourceResourceTypeEnum'
@@ -10760,6 +11002,7 @@ components:
       - prices
       - professional
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title
@@ -10935,6 +11178,10 @@ components:
           type: boolean
           description: Return true if the resource is free/has a free option
           readOnly: true
+        resource_category:
+          type: string
+          description: Return the resource category of the resource
+          readOnly: true
         resource_type:
           allOf:
           - $ref: '#/components/schemas/VideoResourceResourceTypeEnum'
@@ -10995,6 +11242,7 @@ components:
       - prices
       - professional
       - readable_id
+      - resource_category
       - resource_type
       - runs
       - title


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4727

### Description (What does it do?)
This pr adds resource_category as a serializer field and a filter for the /learning_resource and /learning_resources_search apis. It removes is_learning_material stays from the 


### How can this be tested?
Run docker-compose run web ./manage.py recreate_index --all

Go to http://localhost:8063/api/v1/learning_resources/
Verify that the resource_category filter works, for example http://localhost:8063/api/v1/learning_resources/?resource_category=learning+material

Got to http://localhost:8063/api/v1/learning_resources_search
Verify that the resource_category filter works, for example http://localhost:8063/api/v1/learning_resources_search/?resource_category=learning+material
Verify that aggregations work with resource_category http://localhost:8063/api/v1/learning_resources_search/?aggregations=resource_category

Go to http://localhost:8063/api/v1/schema/redoc and verify that the documentation looks good
