### PR TITLE
Scroll results into view when paginating

### DIFF
--- a/frontends/jest-shared-setup.ts
+++ b/frontends/jest-shared-setup.ts
@@ -23,6 +23,8 @@ Object.defineProperty(window, "matchMedia", {
   })),
 })
 
+Element.prototype.scrollIntoView = jest.fn()
+
 /*
  * This used to live in ol-ckeditor but we also need it now for NukaCarousel,
  * so it's now here so it's available across the board.

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -503,7 +503,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   setSearchParams,
 }) => {
   const [searchParams] = useSearchParams()
-  const scrollHook = useRef<HTMLInputElement>(null)
+  const scrollHook = useRef<HTMLDivElement>(null)
   const activeTab =
     TABS.find((t) => t.name === searchParams.get("tab")) ??
     TABS.find((t) => t.defaultTab) ??

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React, { useMemo, useRef } from "react"
 import {
   styled,
   Pagination,
@@ -503,6 +503,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   setSearchParams,
 }) => {
   const [searchParams] = useSearchParams()
+  const scrollHook = useRef<HTMLInputElement>(null)
   const activeTab =
     TABS.find((t) => t.name === searchParams.get("tab")) ??
     TABS.find((t) => t.defaultTab) ??
@@ -569,6 +570,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
   return (
     <Container>
+      <div ref={scrollHook} />
       <StyledGridContainer>
         <ResourceTypeTabs.Context activeTabName={activeTab.name}>
           <DesktopFiltersColumn
@@ -680,7 +682,15 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 <Pagination
                   count={getLastPage(data?.count ?? 0)}
                   page={page}
-                  onChange={(_, newPage) => setPage(newPage)}
+                  onChange={(_, newPage) => {
+                    setPage(newPage)
+                    setTimeout(() => {
+                      scrollHook.current?.scrollIntoView({
+                        block: "end",
+                        behavior: "smooth",
+                      })
+                    }, 0)
+                  }}
                   renderItem={(item) => (
                     <PaginationItem
                       slots={{

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -570,7 +570,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
   return (
     <Container>
-      <div ref={scrollHook} />
       <StyledGridContainer>
         <ResourceTypeTabs.Context activeTabName={activeTab.name}>
           <DesktopFiltersColumn
@@ -652,8 +651,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 </StyledDrawer>
                 <MobileSortContainer>{sortDropdown}</MobileSortContainer>
               </MobileFilter>
-
               <StyledResultsContainer>
+                <div ref={scrollHook} />
                 {isLoading ? (
                   <PlainList itemSpacing={1.5}>
                     {Array(PAGE_SIZE)

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -686,7 +686,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                     setPage(newPage)
                     setTimeout(() => {
                       scrollHook.current?.scrollIntoView({
-                        block: "end",
+                        block: "center",
                         behavior: "smooth",
                       })
                     }, 0)


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/4741

### Description (What does it do?)

Scrolls the top of the search results to the center of the page on pagination.

### Screenshots (if appropriate):


https://github.com/mitodl/mit-open/assets/939376/816e3a70-5be4-46d4-8566-dda64becd94d


### How can this be tested?

Navigate to the search page or a unit page and paginate through search results.
- http://od.odl.local:8063/search/
- http://od.odl.local:8063/c/unit/ocw/
