### PR TITLE
Drawer CSS fixes

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -10,7 +10,6 @@ import {
   formatDate,
   resourceThumbnailSrc,
   getReadableResourceType,
-  DEFAULT_RESOURCE_IMG,
 } from "ol-utilities"
 import type { EmbedlyConfig } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -27,10 +26,7 @@ const Container = styled.div<{ padTop?: boolean }>`
   padding: 18px 32px 160px;
   gap: 20px;
   ${({ padTop }) => (padTop ? "padding-top: 64px;" : "")}
-  width: 600px;
-  ${({ theme }) => theme.breakpoints.down("md")} {
-    width: 550px;
-  }
+  width: 516px;
   ${({ theme }) => theme.breakpoints.down("sm")} {
     width: auto;
   }
@@ -81,7 +77,6 @@ const Image = styled.img<{ aspect: number }>`
   aspect-ratio: ${({ aspect }) => aspect};
   border-radius: 8px;
   width: 100%;
-  object-fit: cover;
 `
 
 const SkeletonImage = styled(Skeleton)<{ aspect: number }>`
@@ -170,10 +165,6 @@ const ImageSection: React.FC<{
         aspect={config.width / config.height}
         alt={resource?.image.alt ?? ""}
       />
-    )
-  } else if (resource) {
-    return (
-      <Image src={DEFAULT_RESOURCE_IMG} aspect={config.width / config.height} />
     )
   } else {
     return (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -10,6 +10,7 @@ import {
   formatDate,
   resourceThumbnailSrc,
   getReadableResourceType,
+  DEFAULT_RESOURCE_IMG,
 } from "ol-utilities"
 import type { EmbedlyConfig } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
@@ -77,6 +78,7 @@ const Image = styled.img<{ aspect: number }>`
   aspect-ratio: ${({ aspect }) => aspect};
   border-radius: 8px;
   width: 100%;
+  object-fit: cover;
 `
 
 const SkeletonImage = styled(Skeleton)<{ aspect: number }>`
@@ -165,6 +167,10 @@ const ImageSection: React.FC<{
         aspect={config.width / config.height}
         alt={resource?.image.alt ?? ""}
       />
+    )
+  } else if (resource) {
+    return (
+      <Image src={DEFAULT_RESOURCE_IMG} aspect={config.width / config.height} />
     )
   } else {
     return (

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -86,7 +86,6 @@ const RoutedDrawer = <K extends string, R extends K = K>(
           <ActionButton
             style={closeSx}
             variant="text"
-            color="secondary"
             size="medium"
             onClick={setOpen.off}
             aria-label="Close"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4698

### Description (What does it do?)
This PR:
- makes the resource drawer a little narrow to match Figma. This also fixes an issue with scrollbars. 
- makes drawer close button match figma color

### Screenshots (if appropriate):
<img width="694" alt="Screenshot 2024-06-28 at 11 37 55 AM" src="https://github.com/mitodl/mit-open/assets/9010790/a4b1f0eb-d4f4-4c82-b62f-895ce30d6f41">
<img width="1081" alt="Screenshot 2024-06-28 at 11 38 12 AM" src="https://github.com/mitodl/mit-open/assets/9010790/60976d2b-8513-4e9e-9a1d-6da14d46e6db">


### How can this be tested?
1. You may want to first find a resource on `main` that erroneously has horizontal scrollbars. Click on any resource card to open the resource drawer. On `main,` a resource will have a horizontal scrollbar if it has a vertical scrollbar, so find one with long content or zoom in to make the text bigger.
2. Check the same resource on this branch. The drawer should be a bit narrower and there will not be a horizontal scrollbar. Also, the close icon in upper right should be darker.
