### PR TITLE
adding post logout redirect to logout url

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -32,7 +32,7 @@ class CustomLogoutView(views.LogoutView):
             user, provider=OlOpenIdConnectAuth.name
         ).first()
         id_token = user_social_auth_record.extra_data.get("id_token")
-        return f"{settings.KEYCLOAK_BASE_URL}/realms/{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/logout?id_token_hint={id_token}"  # noqa: E501
+        return f"{settings.KEYCLOAK_BASE_URL}/realms/{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/logout?id_token_hint={id_token}&post_logout_redirect_uri={settings.LOGOUT_REDIRECT_URL}"  # noqa: E501
 
     def get(
         self,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #https://github.com/mitodl/hq/issues/4745


### Description (What does it do?)
This PR simply adds a 'post_logout_redirect_uri" parameter to the logout url.


### How can this be tested?
I dont have a real way of testing this locally howver the settings change that let this happen on the keycloak side are already in place on rc.

What i would try is:
1. login on https://mitopen-rc.odl.mit.edu/
2. logout - you should land on a kaycloak page that tells you that you are logged out.
3. in the url add post_logout_redirect_uri=https://mitopen-rc.odl.mit.edu/ and refresh. it should land you on the homepage.

