### PR TITLE
update sloan executive education offerings

### DIFF
--- a/learning_resources/fixtures/offered_by.json
+++ b/learning_resources/fixtures/offered_by.json
@@ -107,7 +107,7 @@
         "Managers and executives",
         "Current and future business leaders"
       ],
-      "formats": ["Online", "In-Person", "Blended"],
+      "formats": ["Online", "In-Person", "Hybrid"],
       "fee": ["Paid", "Free Webinars and Blogs"],
       "certifications": ["Executive Certificates", "Professional Certificates"],
       "content_types": ["Professional"],

--- a/learning_resources/fixtures/offered_by.json
+++ b/learning_resources/fixtures/offered_by.json
@@ -100,12 +100,7 @@
       "name": "Sloan Executive Education",
       "code": "see",
       "professional": true,
-      "offerings": [
-        "Courses",
-        "Programs",
-        "Enterprise or Organizational accounts",
-        "Custom Engagements"
-      ],
+      "offerings": ["Courses", "Programs"],
       "audience": [
         "Global Business Professionals (all levels)",
         "Entrepreneurs and intrapreneurs",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4719

### Description (What does it do?)
This PR removes the "Enterprise or Organizational accounts" and "Custom Engagements" offerings from the Sloan Executive Education unit.

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Run `docker compose exec web ./manage.py update_offered_by`
 - Visit http://localhost:8063/c/unit/see/ and verify that you only see Courses and Programs under offerings
