### PR TITLE
stop publishing github pages every pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,36 +319,3 @@ jobs:
         with:
           name: playwright-report
           path: e2e_testing/playwright-report
-
-  publish-pages:
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-
-    permissions:
-      pages: write
-      id-token: write
-      actions: read
-
-    needs:
-      - build-storybook
-      # - e2e-tests
-
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4
-        with:
-          path: pages-site
-
-      # - name: Move E2E test report
-      #   run: mv playwright-report pages-site/
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
-        with:
-          path: pages-site
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
### What are the relevant tickets?
Toward https://github.com/mitodl/hq/issues/4760

### Description (What does it do?)
This PR removes our existing gh-pages publishing step. You can see at https://mitodl.github.io/mit-open/ that it's not working, but it runs on every PR. I'd like to stop running it while I debug this.

### How can this be tested?
Tests should pass

