### PR TITLE
resource category tabs

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
-    "@mitodl/course-search-utils": "3.1.3",
+    "@mitodl/course-search-utils": "^3.1.4",
     "@mui/icons-material": "^5.15.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/react": "^7.57.0",

--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -153,14 +153,14 @@ const navData: NavData = {
           title: "Courses",
           icon: "/static/images/navdrawer/courses.svg",
           description: "Learn with MIT instructors",
-          href: querifiedSearchUrl({ tab: "courses" }),
+          href: querifiedSearchUrl({ resource_category: "course" }),
         },
         {
           title: "Programs",
           icon: "/static/images/navdrawer/programs.svg",
           description:
             "Learn in-depth from a series of courses and earn a certificate",
-          href: querifiedSearchUrl({ tab: "programs" }),
+          href: querifiedSearchUrl({ resource_category: "program" }),
         },
         {
           title: "Pathways",
@@ -173,7 +173,7 @@ const navData: NavData = {
           icon: "/static/images/navdrawer/learning_materials.svg",
           description:
             "Free teaching and learning materials including videos, podcasts, lecture notes, etc.",
-          href: querifiedSearchUrl({ tab: "learning-materials" }),
+          href: querifiedSearchUrl({ resource_category: "learning_material" }),
         },
       ],
     },

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -25,7 +25,7 @@ import {
 
 import {
   LearningResourcesSearchApiLearningResourcesSearchRetrieveRequest as LRSearchRequest,
-  ResourceTypeEnum,
+  ResourceCategoryEnum,
 } from "api"
 import { useLearningResourcesSearch } from "api/hooks/learningResources"
 import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
@@ -40,9 +40,9 @@ import type {
   FacetManifest,
 } from "@mitodl/course-search-utils"
 import _ from "lodash"
-import { ResourceTypeTabs } from "./ResourceTypeTabs"
+import { ResourceCategoryTabs } from "./ResourceCategoryTabs"
 import ProfessionalToggle from "./ProfessionalToggle"
-import type { TabConfig } from "./ResourceTypeTabs"
+import type { TabConfig } from "./ResourceCategoryTabs"
 
 import { ResourceListCard } from "../ResourceCard/ResourceCard"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
@@ -51,7 +51,7 @@ export const StyledSelect = styled(SimpleSelect)`
   min-width: 160px;
 `
 
-export const StyledResourceTabs = styled(ResourceTypeTabs.TabList)`
+export const StyledResourceTabs = styled(ResourceCategoryTabs.TabList)`
   margin-top: 0 px;
 `
 
@@ -416,27 +416,24 @@ export const TABS: TabConfig[] = [
     name: "all",
     label: "All",
     defaultTab: true,
-    resource_type: [],
+    resource_category: null,
   },
   {
     name: "courses",
     label: "Courses",
-    resource_type: [ResourceTypeEnum.Course],
+    resource_category: ResourceCategoryEnum.Course,
   },
   {
     name: "programs",
     label: "Programs",
-    resource_type: [ResourceTypeEnum.Program],
+    resource_category: ResourceCategoryEnum.Program,
   },
   {
     name: "learning-materials",
     label: "Learning Materials",
-    resource_type: Object.values(ResourceTypeEnum).filter(
-      (v) => v !== ResourceTypeEnum.Course && v !== ResourceTypeEnum.Program,
-    ),
+    resource_category: ResourceCategoryEnum.LearningMaterial,
   },
 ]
-export const ALL_RESOURCE_TABS = TABS.map((t) => t.resource_type)
 
 export const SORT_OPTIONS = [
   {
@@ -505,13 +502,17 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   const [searchParams] = useSearchParams()
   const scrollHook = useRef<HTMLDivElement>(null)
   const activeTab =
-    TABS.find((t) => t.name === searchParams.get("tab")) ??
+    TABS.find(
+      (t) => t.resource_category === searchParams.get("resource_category"),
+    ) ??
     TABS.find((t) => t.defaultTab) ??
     TABS[0]
   const allParams = useMemo(() => {
     return {
       ...constantSearchParams,
-      resource_type: activeTab.resource_type,
+      resource_category: activeTab.resource_category
+        ? [activeTab.resource_category]
+        : undefined,
       ...requestParams,
       aggregations: facetNames as LRSearchRequest["aggregations"],
       offset: (page - 1) * PAGE_SIZE,
@@ -519,7 +520,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   }, [
     requestParams,
     constantSearchParams,
-    activeTab?.resource_type,
+    activeTab?.resource_category,
     facetNames,
     page,
   ])
@@ -571,7 +572,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   return (
     <Container>
       <StyledGridContainer>
-        <ResourceTypeTabs.Context activeTabName={activeTab.name}>
+        <ResourceCategoryTabs.Context activeTabName={activeTab.name}>
           <DesktopFiltersColumn
             variant="sidebar-2"
             data-testid="facets-container"
@@ -602,7 +603,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               aggregations={data?.metadata.aggregations}
               onTabChange={() => setPage(1)}
             />
-            <ResourceTypeTabs.TabPanels tabs={TABS}>
+            <ResourceCategoryTabs.TabPanels tabs={TABS}>
               <MobileFilter>
                 <Button variant="text" onClick={toggleMobileDrawer(true)}>
                   <Typography variant="subtitle1">Filter</Typography>
@@ -701,9 +702,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   )}
                 />
               </PaginationContainer>
-            </ResourceTypeTabs.TabPanels>
+            </ResourceCategoryTabs.TabPanels>
           </StyledMainColumn>
-        </ResourceTypeTabs.Context>
+        </ResourceCategoryTabs.Context>
       </StyledGridContainer>
     </Container>
   )

--- a/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
@@ -154,7 +154,7 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
         }
       }),
     ),
-  ).concat(["resource_type"]) as UseResourceSearchParamsProps["facets"]
+  ).concat(["resource_category"]) as UseResourceSearchParamsProps["facets"]
 
   const {
     hasFacets,

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -120,7 +120,7 @@ describe("SearchPage", () => {
         "learning_format",
         "offered_by",
         "professional",
-        "resource_type",
+        "resource_category",
         "topic",
       ])
       expect(Object.fromEntries(apiSearchParams.entries())).toEqual(
@@ -187,9 +187,12 @@ describe("Search Page Tabs", () => {
   test.each([
     { url: "", expectedActive: /All/ },
     { url: "?all", expectedActive: /All/ },
-    { url: "?tab=courses", expectedActive: /Courses/ },
-    { url: "?tab=programs", expectedActive: /Programs/ },
-    { url: "?tab=learning-materials", expectedActive: /Learning Materials/ },
+    { url: "?resource_category=course", expectedActive: /Courses/ },
+    { url: "?resource_category=program", expectedActive: /Programs/ },
+    {
+      url: "?resource_category=learning_material",
+      expectedActive: /Learning Materials/,
+    },
   ])("Active tab determined by URL $url", async ({ url, expectedActive }) => {
     setMockApiResponses({
       search: {
@@ -240,14 +243,14 @@ describe("Search Page Tabs", () => {
     await user.click(tabCourses)
     expect(tabCourses).toHaveAttribute("aria-selected")
     const params1 = new URLSearchParams(location.current.search)
-    expect(params1.get("tab")).toBe("courses")
+    expect(params1.get("resource_category")).toBe("course")
     expect(params1.get("department")).toBe("8") // should preserve other params
 
     // Click "All"
     await user.click(tabAll)
     expect(tabAll).toHaveAttribute("aria-selected")
     const params2 = new URLSearchParams(location.current.search)
-    expect(params2.get("tab")).toBe(null)
+    expect(params2.get("resource_category")).toBe(null)
     expect(params2.get("department")).toBe("8") // should preserve other params
   })
 
@@ -257,11 +260,10 @@ describe("Search Page Tabs", () => {
         count: 700,
         metadata: {
           aggregations: {
-            resource_type: [
+            resource_category: [
               { key: "course", doc_count: 100 },
-              { key: "podcast", doc_count: 200 },
-              { key: "video", doc_count: 300 },
-              { key: "irrelevant", doc_count: 400 },
+              { key: "program", doc_count: 200 },
+              { key: "learning_material", doc_count: 300 },
             ],
           },
           suggestions: [],
@@ -284,8 +286,8 @@ describe("Search Page Tabs", () => {
       ).toEqual([
         "All(600)",
         "Courses(100)",
-        "Programs(0)",
-        "LearningMaterials(500)",
+        "Programs(200)",
+        "LearningMaterials(300)",
       ])
     })
   })
@@ -302,11 +304,11 @@ describe("Search Page Tabs", () => {
     })
 
     const { location } = renderWithProviders(<SearchPage />, {
-      url: "?page=3&tab=courses",
+      url: "?page=3&resource_category=course",
     })
     const tabPrograms = screen.getByRole("tab", { name: /Programs/ })
     await user.click(tabPrograms)
-    expect(location.current.search).toBe("?tab=programs")
+    expect(location.current.search).toBe("?resource_category=program")
   })
 })
 

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -116,7 +116,7 @@ export const getFacetManifest = (
 }
 
 const facetNames = [
-  "resource_type",
+  "resource_category",
   "certification_type",
   "learning_format",
   "department",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,11 +3405,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:3.1.3":
-  version: 3.1.3
-  resolution: "@mitodl/course-search-utils@npm:3.1.3"
+"@mitodl/course-search-utils@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "@mitodl/course-search-utils@npm:3.1.4"
   dependencies:
-    "@mitodl/open-api-axios": "npm:^2024.6.4"
+    "@mitodl/open-api-axios": "npm:^2024.7.2"
     axios: "npm:^1.6.7"
     fuse.js: "npm:^7.0.0"
     query-string: "npm:^6.13.1"
@@ -3426,17 +3426,17 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/bb0b0fafe2ec36b9b04729cde6e610b67b481b39489ce14a2d832fb2d5e48fa71f923d541869e29c3ca8e8944eab36e53ca0736e01893e7bd4d7c859454695ae
+  checksum: 10/65a051fda87f3f3439938da839a3bf98ff5fb3979731318ac68639391999d8aed9170ddb426986ff099a01e5c594ce9d9cbfdf8ffd5a82fb2d70c3bff73f5ad9
   languageName: node
   linkType: hard
 
-"@mitodl/open-api-axios@npm:^2024.6.4":
-  version: 2024.6.13
-  resolution: "@mitodl/open-api-axios@npm:2024.6.13"
+"@mitodl/open-api-axios@npm:^2024.7.2":
+  version: 2024.7.2
+  resolution: "@mitodl/open-api-axios@npm:2024.7.2"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/6505a551935929095bc324dc61e3577858938f761d19a16a7b5b3b385c539cf4ed56e15e9b57ccd09584fee9f076817114d3057e1148c54955f83b440e096133
+  checksum: 10/aaf77c821458ced4c86695aa3fb071a9186a87bec292247ff9b99b5f05b32e1369ea5d75f4e1cff3752c8d5f0cb5ba6c588b9be6e8b8f520cc425005bdcea058
   languageName: node
   linkType: hard
 
@@ -15984,7 +15984,7 @@ __metadata:
     "@emotion/react": "npm:^11.11.1"
     "@emotion/styled": "npm:^11.11.0"
     "@faker-js/faker": "npm:^8.0.0"
-    "@mitodl/course-search-utils": "npm:3.1.3"
+    "@mitodl/course-search-utils": "npm:^3.1.4"
     "@mui/icons-material": "npm:^5.15.15"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
     "@remixicon/react": "npm:^4.2.0"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4728

### Description (What does it do?)
This replaces the current logic for the resource tabs with data from the new resource_category field

This should be reviewed with https://github.com/mitodl/course-search-utils/pull/117/files which needs to be released first

### Screenshots (if appropriate):
NA

### How can this be tested?
Run ./manage.py recreate_index --all if you don't have resource_category in your search index

Go to http://localhost:8063/search and verify that the resource tabs work as expected
Go to http://localhost:8063/c/unit/ocw and verify that the resource tabs work as expected

### Additional Context
This can already be reviewed, however it depends on https://github.com/mitodl/course-search-utils/pull/117 which depends on releasing https://github.com/mitodl/mit-open/pull/1188  and updating axios

Also recreate_index is needs to run on prod before this can be merged so the resource_category field is updated in the search index

~~DO NOT MERGE UNTIL~~
1) ~~https://github.com/mitodl/mit-open/pull/1188 is released~~ done
2) ~~recreate_index is run on prod~~
3) ~~@mitodl/open-api-axios is updated~~ done
4) ~~https://github.com/mitodl/course-search-utils/pull/117 is updated to use the params from the updated @mitodl/open-api-axios~~ done
5) ~~course-search-utils is released with https://github.com/mitodl/course-search-utils/pull/117~~
6) ~~This pr is updated to point to the released version of  course-search-utils  instead of a branch~~
This is ready to merge once approved