### PR TITLE
Fix default image height in resource cards

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -30,18 +30,22 @@ const SkeletonImage = styled(Skeleton)<{ aspect: number }>`
   padding-bottom: ${({ aspect }) => 100 / aspect}%;
 `
 
+const getImageDimensions = (size: Size, isMedia: boolean) => {
+  const dimensions = {
+    small: { width: 190, height: isMedia ? 190 : 120 },
+    medium: { width: 298, height: isMedia ? 298 : 170 },
+  }
+  return dimensions[size]
+}
+
 const getEmbedlyUrl = (
   resource: LearningResource,
   size: Size,
   isMedia: boolean,
 ) => {
-  const dimensions = {
-    small: { width: 190, height: isMedia ? 190 : 120 },
-    medium: { width: 298, height: isMedia ? 298 : 170 },
-  }
   return embedlyCroppedImage(resource.image!.url!, {
     key: APP_SETTINGS.embedlyKey || process.env.EMBEDLY_KEY!,
-    ...dimensions[size],
+    ...getImageDimensions(size, isMedia),
   })
 }
 
@@ -99,7 +103,7 @@ const getStartDate = (resource: LearningResource, size: Size = "medium") => {
 
   if (!startDate) return null
 
-  return formatDate(startDate, `MMM${size === "medium" ? "M" : ""} DD, YYYY`)
+  return formatDate(startDate, `MM${size === "medium" ? "M" : ""} DD, YYYY`)
 }
 
 const StartDate: React.FC<{ resource: LearningResource; size?: Size }> = ({
@@ -188,7 +192,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             : DEFAULT_RESOURCE_IMG
         }
         alt={resource.image?.alt ?? ""}
-        height="auto"
+        height={getImageDimensions(size, isMedia).height}
       />
       <Card.Info>
         <Info resource={resource} />

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -103,7 +103,7 @@ const getStartDate = (resource: LearningResource, size: Size = "medium") => {
 
   if (!startDate) return null
 
-  return formatDate(startDate, `MM${size === "medium" ? "M" : ""} DD, YYYY`)
+  return formatDate(startDate, `MMM${size === "medium" ? "M" : ""} DD, YYYY`)
 }
 
 const StartDate: React.FC<{ resource: LearningResource; size?: Size }> = ({


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/4774

### Description (What does it do?)
<!--- Describe your changes in detail -->

Provides the image height explicitly - we cannot rely on the height of the image itself to preserve dimensions as the default image is fixed / does not go to Embedly for cropping.


### How can this be tested?

Navigate to the dashboard with no profile.

Ensure that the card image heights are equal. The issue was with the default image, so there must be a mixture with some default images for the check to be valid:


(Default image: <img width="60" alt="image" src="https://github.com/mitodl/mit-open/assets/939376/5bdfab89-1346-48a5-bf8d-da8bc66b58e5">).

