### PR TITLE
make primary buttons shadowy, remove edge=none

### DIFF
--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof Button> = {
       control: { type: "select" },
     },
     edge: {
-      options: ["circular", "rounded", "none"],
+      options: ["circular", "rounded"],
       control: { type: "select" },
     },
     startIcon: {
@@ -247,29 +247,40 @@ export const LinkStory: Story = {
 }
 export const ButtonsShowcase: Story = {
   render: (args) => (
-    <Grid container rowGap={2} sx={{ maxWidth: "500px" }}>
+    <Grid container rowGap={2} sx={{ maxWidth: "600px" }}>
       {VARIANTS.flatMap((variant) =>
         EDGES.flatMap((edge) =>
           EXTRA_PROPS.map((extraProps, i) => {
-            return SIZES.map((size) => (
-              <Grid
-                item
-                xs={4}
-                display="flex"
-                alignItems="center"
-                key={`${variant}-${edge}-${size}-${i}`}
-              >
-                <Button
-                  {...args}
-                  variant={variant}
-                  edge={edge}
-                  size={size}
-                  {...extraProps}
-                >
-                  {args.children}
-                </Button>
-              </Grid>
-            ))
+            return (
+              <React.Fragment key={`${variant}-${edge}-${i}`}>
+                <Grid xs={3}>
+                  <pre>
+                    variant={variant}
+                    <br />
+                    edge={edge}
+                  </pre>
+                </Grid>
+                {SIZES.map((size) => (
+                  <Grid
+                    item
+                    xs={3}
+                    display="flex"
+                    alignItems="center"
+                    key={`${size}`}
+                  >
+                    <Button
+                      {...args}
+                      variant={variant}
+                      edge={edge}
+                      size={size}
+                      {...extraProps}
+                    >
+                      {args.children}
+                    </Button>
+                  </Grid>
+                ))}
+              </React.Fragment>
+            )
           }),
         ),
       )}
@@ -321,6 +332,11 @@ export const ActionButtonsShowcase: Story = {
             alignItems="center"
             sx={{ my: 2 }}
           >
+            <pre>
+              variant={variant}
+              <br />
+              edge={edge}
+            </pre>
             {SIZES.map((size) => (
               <React.Fragment key={size}>
                 {ICONS.map((icon) => (

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -77,7 +77,7 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     ...props,
   }
   const { colors } = theme.custom
-  const hasBorder = variant === "secondary" || variant === "text"
+  const hasBorder = variant === "secondary"
 
   return [
     {
@@ -110,17 +110,22 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
       backgroundColor: colors.mitRed,
       color: colors.white,
       border: "none",
+      /* Shadow/04dp */
+      boxShadow:
+        "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 3px 8px 0px rgba(37, 38, 43, 0.12)",
       ":hover:not(:disabled)": {
         backgroundColor: colors.red,
+        boxShadow: "none",
       },
       ":disabled": {
         backgroundColor: colors.silverGray,
+        boxShadow: "none",
       },
     },
     hasBorder && {
       backgroundColor: "transparent",
       borderColor: "currentcolor",
-      borderStyle: variant === "secondary" ? "solid" : "none",
+      borderStyle: "solid",
     },
     variant === "secondary" && {
       color: colors.red,
@@ -132,6 +137,8 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
       },
     },
     variant === "text" && {
+      backgroundColor: "transparent",
+      borderStyle: "none",
       color: colors.darkGray2,
       ":hover:not(:disabled)": {
         backgroundColor: tinycolor(colors.darkGray1).setAlpha(0.06).toString(),
@@ -176,14 +183,6 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
     edge === "circular" && {
       // Pill-shaped buttons... Overlapping border radius get clipped to pill.
       borderRadius: "100vh",
-    },
-    edge === "none" && {
-      border: "none",
-      ":hover:not(:disabled)": {
-        "&&": {
-          backgroundColor: "inherit",
-        },
-      },
     },
     // color
     color === "secondary" && {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4700

### Description (What does it do?)
Makes primary buttons (and only primary buttons) have a shadow to match figma.

### Screenshots (if appropriate):
App *There aren't too many primary buttons in the app so far.*
<img width="184" alt="Screenshot 2024-07-01 at 4 26 42 PM" src="https://github.com/mitodl/mit-open/assets/9010790/1b6c02b2-66a1-42b9-9c2b-65fe6328628b">

Storybook:
<img width="537" alt="Screenshot 2024-07-01 at 4 26 35 PM" src="https://github.com/mitodl/mit-open/assets/9010790/e7de3a92-7cd0-424e-a32f-2654239750d6">


### How can this be tested?
1. Run storybook (should be on 6006, if not, `yarn storybook`) and check:
    - http://localhost:6006/?path=/story/smoot-design-button--buttons-showcase

Buttons should be unchanged, except primary buttons should have a shadow AND only in their default state (no shadow on hover).
