### PR TITLE
Fix and reenable onboarding page tests

### DIFF
--- a/frontends/mit-open/src/pages/OnboardingPage/OnboardingPage.test.tsx
+++ b/frontends/mit-open/src/pages/OnboardingPage/OnboardingPage.test.tsx
@@ -91,7 +91,7 @@ const queryNextButton = () => screen.queryByRole("button", { name: "Next" })
 const queryBackButton = () => screen.queryByRole("button", { name: "Back" })
 const queryFinishButton = () => screen.queryByRole("button", { name: "Finish" })
 
-describe.skip("OnboardingPage", () => {
+describe("OnboardingPage", () => {
   describe("Topic Interests step", () => {
     const STEP = 0
     const TITLE = STEP_TITLES[STEP]
@@ -110,7 +110,7 @@ describe.skip("OnboardingPage", () => {
       const finishButton = queryFinishButton()
 
       expect(backButton).toBeNil()
-      expect(nextButton).toBeDisabled()
+      expect(nextButton).not.toBeNil()
       expect(finishButton).toBeNil()
     })
   })
@@ -132,8 +132,8 @@ describe.skip("OnboardingPage", () => {
       const nextButton = await findNextButton()
       const finishButton = queryFinishButton()
 
-      expect(backButton).toBeEnabled()
-      expect(nextButton).toBeDisabled()
+      expect(backButton).not.toBeNil()
+      expect(nextButton).not.toBeNil()
       expect(finishButton).toBeNil()
     })
 
@@ -167,8 +167,8 @@ describe.skip("OnboardingPage", () => {
       const nextButton = await findNextButton()
       const finishButton = queryFinishButton()
 
-      expect(backButton).toBeEnabled()
-      expect(nextButton).toBeDisabled()
+      expect(backButton).not.toBeNil()
+      expect(nextButton).not.toBeNil()
       expect(finishButton).toBeNil()
     })
 
@@ -202,8 +202,8 @@ describe.skip("OnboardingPage", () => {
       const nextButton = await findNextButton()
       const finishButton = queryFinishButton()
 
-      expect(backButton).toBeEnabled()
-      expect(nextButton).toBeDisabled()
+      expect(backButton).not.toBeNil()
+      expect(nextButton).not.toBeNil()
       expect(finishButton).toBeNil()
     })
 
@@ -237,8 +237,8 @@ describe.skip("OnboardingPage", () => {
       const nextButton = await findNextButton()
       const finishButton = queryFinishButton()
 
-      expect(backButton).toBeEnabled()
-      expect(nextButton).toBeDisabled()
+      expect(backButton).not.toBeNil()
+      expect(nextButton).not.toBeNil()
       expect(finishButton).toBeNil()
     })
 
@@ -272,9 +272,9 @@ describe.skip("OnboardingPage", () => {
       const nextButton = queryNextButton()
       const finishButton = await findFinishButton()
 
-      expect(backButton).toBeEnabled()
+      expect(backButton).not.toBeNil()
       expect(nextButton).toBeNil()
-      expect(finishButton).toBeDisabled()
+      expect(finishButton).not.toBeNil()
     })
 
     test("Back button should go to previous step", async () => {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/4703

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes the onboarding tests. The failures were originally around the buttons being disabled/enabled assertions failing and now we don't disable them so these assertions were just updated to confirm the correct buttons are shown.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tests should pass and there should be no more warning of skipped tests.