### PR TITLE
Webpack build config loads .env files for running outside of Docker

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "watch": "NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:docker": "API_DEV_PROXY_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:docker": "API_DEV_PROXY_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=docker webpack serve",
     "watch:rc": "API_DEV_PROXY_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -2,6 +2,7 @@
 const path = require("path")
 
 if (process.env.ENVIRONMENT === "local") {
+  console.info("Loading environment from .env files")
   require("dotenv").config({
     path: [
       path.resolve(__dirname, "../../env/frontend.local.env"),
@@ -267,7 +268,7 @@ module.exports = (env, argv) => {
       devMiddleware: {
         writeToDisk: true,
       },
-      host: ENVIRONMENT === "docker" ? "0.0.0.0" : "::",
+      host: "0.0.0.0",
       proxy: [
         {
           context: [

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require("path")
 require("dotenv").config({
-  path: path.resolve(__dirname, "../../.env"),
+  path: [
+    path.resolve(__dirname, "../../env/frontend.local.env"),
+    path.resolve(__dirname, "../../env/frontend.env"),
+    path.resolve(__dirname, "../../env/shared.local.env"),
+    path.resolve(__dirname, "../../env/shared.env"),
+    path.resolve(__dirname, "../../.env"),
+  ],
 })
 
 const webpack = require("webpack")

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require("path")
 
-if (process.env.ENVIRONMENT !== "docker") {
+if (process.env.ENVIRONMENT === "local") {
   require("dotenv").config({
     path: [
       path.resolve(__dirname, "../../env/frontend.local.env"),

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -1,14 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require("path")
-require("dotenv").config({
-  path: [
-    path.resolve(__dirname, "../../env/frontend.local.env"),
-    path.resolve(__dirname, "../../env/frontend.env"),
-    path.resolve(__dirname, "../../env/shared.local.env"),
-    path.resolve(__dirname, "../../env/shared.env"),
-    path.resolve(__dirname, "../../.env"),
-  ],
-})
+
+if (process.env.ENVIRONMENT !== "docker") {
+  require("dotenv").config({
+    path: [
+      path.resolve(__dirname, "../../env/frontend.local.env"),
+      path.resolve(__dirname, "../../env/frontend.env"),
+      path.resolve(__dirname, "../../env/shared.local.env"),
+      path.resolve(__dirname, "../../env/shared.env"),
+      path.resolve(__dirname, "../../.env"),
+    ],
+  })
+}
 
 const webpack = require("webpack")
 const BundleTracker = require("webpack-bundle-tracker")


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->

Uses the `dotenv` package to read the .env files when running outside of Docker. Inside Docker, they are supplied on the  Docker Compose run config.

This is to accommodate the recent and excellent cleanup of env var handling: https://github.com/mitodl/mit-open/pull/1179

Checks that the `ENVIRONMENT` is `"local"` before reading in the .env files.

Also sets the Webpack dev server to use host 0.0.0.0.

### How can this be tested?

This also sets the `ENVIRONMENT` to `docker` for `yarn run watch:docker`. It was set to this at some point previously, though if we see issues, that would be the most likely cause.