### PR TITLE
resource type for learning materials

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -514,7 +514,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
         ? [activeTab.resource_category]
         : undefined,
       ...requestParams,
-      aggregations: facetNames as LRSearchRequest["aggregations"],
+      aggregations: (facetNames || []).concat([
+        "resource_category",
+      ]) as LRSearchRequest["aggregations"],
       offset: (page - 1) * PAGE_SIZE,
     }
   }, [

--- a/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/ChannelSearch.tsx
@@ -50,6 +50,7 @@ const StyledSearchInput = styled(SearchInput)`
 const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   [ChannelTypeEnum.Topic]: [
     "free",
+    "resource_type",
     "certification_type",
     "learning_format",
     "offered_by",
@@ -57,6 +58,7 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   ],
   [ChannelTypeEnum.Department]: [
     "free",
+    "resource_type",
     "certification_type",
     "topic",
     "learning_format",
@@ -64,6 +66,7 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   ],
   [ChannelTypeEnum.Unit]: [
     "free",
+    "resource_type",
     "topic",
     "certification_type",
     "learning_format",
@@ -86,9 +89,10 @@ const getFacetManifestForChannelType = (
   channelType: ChannelTypeEnum,
   offerors: Record<string, LearningResourceOfferor>,
   constantSearchParams: Facets,
+  resourceCategory: string | null,
 ): FacetManifest => {
   const facets = FACETS_BY_CHANNEL_TYPE[channelType] || []
-  return getFacetManifest(offerors)
+  return getFacetManifest(offerors, resourceCategory)
     .filter(
       (facetSetting) =>
         !Object.keys(constantSearchParams).includes(facetSetting.name) &&
@@ -114,6 +118,7 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
   }, [offerorsQuery.data?.results])
 
   const [searchParams, setSearchParams] = useSearchParams()
+  const resourceCategory = searchParams.get("resource_category")
 
   const facetManifest = useMemo(
     () =>
@@ -121,8 +126,9 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
         channelType,
         offerors,
         constantSearchParams,
+        resourceCategory,
       ),
-    [offerors, channelType, constantSearchParams],
+    [offerors, channelType, constantSearchParams, resourceCategory],
   )
 
   const setPage = useCallback(
@@ -154,7 +160,7 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
         }
       }),
     ),
-  ).concat(["resource_category"]) as UseResourceSearchParamsProps["facets"]
+  ) as UseResourceSearchParamsProps["facets"]
 
   const {
     hasFacets,

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -121,6 +121,7 @@ describe("SearchPage", () => {
         "offered_by",
         "professional",
         "resource_category",
+        "resource_type",
         "topic",
       ])
       expect(Object.fromEntries(apiSearchParams.entries())).toEqual(
@@ -166,6 +167,37 @@ describe("SearchPage", () => {
     await screen.findByRole("button", { name: /clear all/i }) // Clear All shows again
     expect(physics).toBeChecked()
     expect(location.current.search).toBe("?topic=Physics")
+  })
+
+  test("Shows Learning Resource facet only if learning materials tab is selected", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            resource_category: [
+              { key: "course", doc_count: 100 },
+              { key: "learning_material", doc_count: 200 },
+            ],
+            resource_type: [
+              { key: "course", doc_count: 100 },
+              { key: "podcast", doc_count: 100 },
+              { key: "video", doc_count: 100 },
+            ],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    renderWithProviders(<SearchPage />)
+
+    const facetsContainer = screen.getByTestId("facets-container")
+    expect(within(facetsContainer).queryByText("Resource Type")).toBeNull()
+    const tabLearningMaterial = screen.getByRole("tab", {
+      name: /Learning Material/,
+    })
+    await user.click(tabLearningMaterial)
+    await within(facetsContainer).findByText("Resource Type")
   })
 
   test("Submitting text updates URL", async () => {

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -54,10 +54,13 @@ const SearchField = styled(SearchInput)`
   }
 `
 
+const LEARNING_MATERIAL = "learning_material"
+
 export const getFacetManifest = (
   offerors: Record<string, LearningResourceOfferor>,
+  resourceCategory: string | null,
 ) => {
-  return [
+  const mainfest = [
     {
       type: "group",
       name: "free",
@@ -68,6 +71,18 @@ export const getFacetManifest = (
           label: "Free",
         },
       ],
+    },
+    {
+      name: "resource_type",
+      title: "Resource Type",
+      type: "static",
+      expandedOnLoad: true,
+      preserveItems: true,
+      labelFunction: (key: string) =>
+        key
+          .split("_")
+          .map((word) => capitalize(word))
+          .join(" "),
     },
     {
       name: "certification_type",
@@ -113,10 +128,17 @@ export const getFacetManifest = (
       labelFunction: (key: string) => getDepartmentName(key) || key,
     },
   ]
+
+  //Only display the resource_type facet if the resource_category is learning_material
+  if (resourceCategory !== LEARNING_MATERIAL) {
+    mainfest.splice(1, 1)
+  }
+
+  return mainfest
 }
 
 const facetNames = [
-  "resource_category",
+  "resource_type",
   "certification_type",
   "learning_format",
   "department",
@@ -128,18 +150,21 @@ const facetNames = [
 
 const constantSearchParams = {}
 
-const useFacetManifest = () => {
+const useFacetManifest = (resourceCategory: string | null) => {
   const offerorsQuery = useOfferorsList()
   const offerors = useMemo(() => {
     return _.keyBy(offerorsQuery.data?.results ?? [], (o) => o.code)
   }, [offerorsQuery.data?.results])
-  const facetManifest = useMemo(() => getFacetManifest(offerors), [offerors])
+  const facetManifest = useMemo(
+    () => getFacetManifest(offerors, resourceCategory),
+    [offerors, resourceCategory],
+  )
   return facetManifest
 }
 
 const SearchPage: React.FC = () => {
-  const facetManifest = useFacetManifest()
   const [searchParams, setSearchParams] = useSearchParams()
+  const facetManifest = useFacetManifest(searchParams.get("resource_category"))
 
   const setPage = useCallback(
     (newPage: number) => {


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4736

### Description (What does it do?)
The "Resource Type" facet is displayed, but only if the selected tab is "Learning Material"

### Screenshots (if appropriate):
<img width="1658" alt="Screenshot 2024-07-03 at 10 50 12 AM" src="https://github.com/mitodl/mit-open/assets/1934992/29e129f7-ffc6-4416-8f97-4b9fea8b9c7f">


### How can this be tested?
Go to http://localhost:8062/search. There should not be a Resource Type facet displayed. 
Click on the "Learning Materials" tab. There should not be a Resource Type facet displayed and you should be able to select a type of learning material

Go to http://localhost:8062/c/topic/mathematics
Again there should be a Resource Type facet only if Learning Material is selected
