### PR TITLE
Use overwrite=True when calling pluggy function from upsert_offered_by

### DIFF
--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -264,10 +264,10 @@ def upsert_offered_by_data():
         for offeror in offered_by_json:
             offeror_fields = offeror["fields"]
             offered_by, _ = LearningResourceOfferor.objects.update_or_create(
-                name=offeror_fields["name"],
+                code=offeror_fields["code"],
                 defaults=offeror_fields,
             )
-            offeror_upserted_actions(offered_by)
+            offeror_upserted_actions(offered_by, overwrite=True)
             offerors.append(offeror_fields["name"])
         invalid_offerors = LearningResourceOfferor.objects.exclude(name__in=offerors)
         for offeror in invalid_offerors:


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/4763
- Closes https://github.com/mitodl/hq/issues/4761

### Description (What does it do?)
- Adds the `overwrite=True` kwarg to the `offeror_upserted_actions` call within the `upsert_offered_by_data` function.
- Updates the `upsert_offered_by_data` function to use `code` instead of `name` as the primary key to use for upserts.


### How can this be tested?
- Run the following if you haven't already done so:
  ```
  ./manage.py upsert_offered_by
  ./manage.py backpopulate_resource_channels
  ```
- Go to `http://open.odl.local:8062/c/unit/mitx/` and verify that the title in the browser tab is the same as what's specified for MITx in the file `learning_resources/fixtures/offered_by.json`
- Change the name for mitx in that json file to something else like "MITx Offeror"
- Rerun `./manage.py update_offered_by`
- Reload the url above, the browser tab title should now display the new name.

