### PR TITLE
Navigation UI fixes

### DIFF
--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -93,6 +93,8 @@ const LogoLink = styled(MITLogoLink)(({ theme }) => ({
 
 const LeftDivider = styled(Divider)({
   margin: "0 24px",
+  height: "24px",
+  alignSelf: "auto",
 })
 
 const RightDivider = styled(Divider)(({ theme }) => ({

--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -99,6 +99,8 @@ const LeftDivider = styled(Divider)({
 
 const RightDivider = styled(Divider)(({ theme }) => ({
   margin: "0 32px",
+  height: "24px",
+  alignSelf: "auto",
   [theme.breakpoints.down("sm")]: {
     margin: "0 16px",
   },

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 import React, { ReactElement } from "react"
 
 const DrawerContent = styled.div(({ theme }) => ({
-  paddingTop: "80px",
+  paddingTop: "60px",
   width: "366px",
   height: "100%",
   background: theme.custom.colors.white,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4779
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes the following adjustments:
<img width="721" alt="Screenshot 2024-07-08 at 10 14 43 AM" src="https://github.com/mitodl/mit-open/assets/196425/055012b0-5d4a-4a06-a49a-51c93ece8b09">

### How can this be tested?
1. Checkout this branch and verify the dividers in the header and side-nav margins match the ticket

