### PR TITLE
Only publish enrollable mitxonline courses

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -114,6 +114,7 @@ def extract_courses():
                 params={
                     "page__live": True,
                     "live": True,
+                    "courserun_is_enrollable": True,
                 },
             )
         )
@@ -171,7 +172,7 @@ def _transform_run(course_run: dict, course: dict) -> dict:
         "enrollment_start": _parse_datetime(course_run.get("enrollment_start")),
         "enrollment_end": _parse_datetime(course_run.get("enrollment_end")),
         "url": parse_page_attribute(course, "page_url", is_url=True),
-        "published": bool(parse_page_attribute(course, "page_url")),
+        "published": bool(course_run["is_enrollable"] and course["page"]["live"]),
         "description": clean_data(parse_page_attribute(course_run, "description")),
         "image": _transform_image(course_run),
         "prices": sorted(
@@ -227,7 +228,8 @@ def _transform_course(course):
         "published": bool(
             parse_page_attribute(course, "page_url")
             and parse_page_attribute(course, "live")
-        ),  # a course is only considered published if it has a page url
+            and len([run for run in runs if run["published"]]) > 0
+        ),  # a course is only published if it has a live url and published runs
         "professional": False,
         "certification": has_certification,
         "certification_type": CertificationType.completion.name

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -195,6 +195,14 @@ def test_mitxonline_transform_programs(
                     "published": bool(
                         course_data.get("page", {}).get("page_url", None)
                         and course_data.get("page", {}).get("live", None)
+                        and len(
+                            [
+                                run
+                                for run in course_data["courseruns"]
+                                if run["is_enrollable"]
+                            ]
+                        )
+                        > 0
                     ),
                     "certification": True,
                     "certification_type": CertificationType.completion.name,
@@ -222,7 +230,8 @@ def test_mitxonline_transform_programs(
                             ),
                             "description": any_instance_of(str, type(None)),
                             "published": bool(
-                                parse_page_attribute(course_data, "page_url")
+                                course_run_data["is_enrollable"]
+                                and course_data["page"]["live"]
                             ),
                             "prices": sorted(
                                 {
@@ -362,7 +371,9 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
                     "end_date": any_instance_of(datetime, type(None)),
                     "enrollment_start": any_instance_of(datetime, type(None)),
                     "enrollment_end": any_instance_of(datetime, type(None)),
-                    "published": bool(course_data.get("page", {}).get("page_url")),
+                    "published": bool(
+                        course_run_data["is_enrollable"] and course_data["page"]["live"]
+                    ),
                     "prices": sorted(
                         {
                             "0.00",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4758

### Description (What does it do?)
Filters out and/or marks as unpublished mitxonline courses that are not enrollable.


### How can this be tested?
- Set the following in your backend.local.env file:
  ```
  MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/v2/courses/
  MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/v2/programs/
  ```
- Run `./manage.py backpopulate_mitxonline_data`
- Compare the following url's to ensure they are returning the same results:
  - http://api.open.odl.local:8063/api/v1/courses/?platform=mitxonline&department=8
  - https://mitxonline.mit.edu/catalog/courses/physics


