### PR TITLE
fix learning path count, increase item page size

### DIFF
--- a/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/DashboardPage.tsx
@@ -310,7 +310,7 @@ interface UserListDetailsTabProps {
 
 const UserListDetailsTab: React.FC<UserListDetailsTabProps> = (props) => {
   const { userListId } = props
-  const pathQuery = useUserListsDetail(userListId)
+  const listQuery = useUserListsDetail(userListId)
   const itemsQuery = useInfiniteUserListItems({ userlist_id: userListId })
   const items = useMemo(() => {
     const pages = itemsQuery.data?.pages
@@ -319,12 +319,11 @@ const UserListDetailsTab: React.FC<UserListDetailsTabProps> = (props) => {
   return (
     <ListDetailsComponent
       listType={ListType.UserList}
-      title={pathQuery?.data?.title}
-      description={pathQuery.data?.description}
+      list={listQuery.data}
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() => manageListDialogs.upsertUserList(pathQuery.data)}
+      handleEdit={() => manageListDialogs.upsertUserList(listQuery.data)}
     />
   )
 }

--- a/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
@@ -18,17 +18,29 @@ type RouteParams = {
 const LearningPathDetailsPage: React.FC = () => {
   const id = Number(useParams<RouteParams>().id)
   const pathQuery = useLearningPathsDetail(id)
-  const itemsQuery = useInfiniteLearningPathItems({ learning_resource_id: id })
+  const itemsQuery = useInfiniteLearningPathItems({
+    learning_resource_id: id,
+    limit: 100,
+  })
   const items = useMemo(() => {
     const pages = itemsQuery.data?.pages
     return pages?.flatMap((p) => p.results ?? []) ?? []
   }, [itemsQuery.data])
+  const list = useMemo(() => {
+    if (!pathQuery.data) {
+      return undefined
+    }
+    return {
+      title: pathQuery.data.title,
+      description: pathQuery.data.description,
+      item_count: pathQuery.data.learning_path.item_count,
+    }
+  }, [pathQuery.data])
 
   return (
     <ListDetailsPage
       listType={ListType.LearningPath}
-      title={pathQuery?.data?.title}
-      description={pathQuery.data?.description}
+      list={list}
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}

--- a/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.tsx
@@ -9,10 +9,14 @@ import ItemsListing from "./ItemsListing"
 import type { LearningResourceListItem } from "./ItemsListing"
 
 type OnEdit = () => void
+type ListData = {
+  title: string
+  description?: string | null
+  item_count: number
+}
 type ListDetailsPageProps = {
   listType: string
-  title: string | undefined
-  description: string | null | undefined
+  list?: ListData
   items: LearningResourceListItem[]
   isLoading: boolean
   isFetching: boolean
@@ -20,31 +24,22 @@ type ListDetailsPageProps = {
 }
 
 const ListDetailsComponent: React.FC<ListDetailsPageProps> = (props) => {
-  const {
-    listType,
-    title,
-    description,
-    items,
-    isLoading,
-    isFetching,
-    handleEdit,
-  } = props
+  const { listType, list, items, isLoading, isFetching, handleEdit } = props
   const { data: user } = useUserMe()
   const [isSorting, toggleIsSorting] = useToggle(false)
 
   const canEdit = user?.is_learning_path_editor
   const showSort = canEdit && !!items.length
-  const count = items.length
-
+  const count = list?.item_count
   return (
     <GridContainer>
       <GridColumn variant="single-full">
         <Grid container>
           <Grid item xs={12}>
             <Typography variant="h3" component="h1">
-              {title}
+              {list?.title}
             </Typography>
-            {description && <p>{description}</p>}
+            {list?.description && <p>{list.description}</p>}
           </Grid>
           <Grid
             item
@@ -101,8 +96,7 @@ const ListDetailsComponent: React.FC<ListDetailsPageProps> = (props) => {
 
 const ListDetailsPage: React.FC<ListDetailsPageProps> = ({
   listType,
-  title,
-  description,
+  list,
   items,
   isLoading,
   isFetching,
@@ -113,12 +107,11 @@ const ListDetailsPage: React.FC<ListDetailsPageProps> = ({
       src="/static/images/course_search_banner.png"
       className="learningpaths-page"
     >
-      <MetaTags title={title} />
+      <MetaTags title={list?.title} />
       <Container maxWidth="sm">
         <ListDetailsComponent
           listType={listType}
-          title={title}
-          description={description}
+          list={list}
           items={items}
           isLoading={isLoading}
           isFetching={isFetching}

--- a/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
@@ -17,7 +17,7 @@ type RouteParams = {
 
 const UserListDetailsPage: React.FC = () => {
   const id = Number(useParams<RouteParams>().id)
-  const pathQuery = useUserListsDetail(id)
+  const listQuery = useUserListsDetail(id)
   const itemsQuery = useInfiniteUserListItems({ userlist_id: id })
   const items = useMemo(() => {
     const pages = itemsQuery.data?.pages
@@ -27,12 +27,11 @@ const UserListDetailsPage: React.FC = () => {
   return (
     <ListDetailsPage
       listType={ListType.UserList}
-      title={pathQuery?.data?.title}
-      description={pathQuery.data?.description}
+      list={listQuery.data}
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
-      handleEdit={() => manageListDialogs.upsertUserList(pathQuery.data)}
+      handleEdit={() => manageListDialogs.upsertUserList(listQuery.data)}
     />
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?

- Closes https://github.com/mitodl/hq/issues/4737

### Description (What does it do?)
Increases learning path page size to 100 and fixes the item count.

### How can this be tested?
1. Create a learning path with more than 10 items. (But less than 100!).
    - as a staff member, use the left "list" button on search page cards.
2. View that learning path at /learningpaths/... click into it for the "Details" view.
    - The "Items <NUMBER>" should accurately reflect the number of items. (Before it was capped at the page size).
    - All the items should display.
