### PR TITLE
extra weight for instructors

### DIFF
--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -229,8 +229,8 @@ def test_generate_learning_resources_text_clause():
                                                             "query": "math",
                                                             "fields": [
                                                                 "runs.instructors.first_name",
-                                                                "runs.instructors.last_name",
-                                                                "runs.instructors.full_name",
+                                                                "runs.instructors.last_name^5",
+                                                                "runs.instructors.full_name^5",
                                                             ],
                                                         }
                                                     },
@@ -338,8 +338,8 @@ def test_generate_learning_resources_text_clause():
                                         "query": "math",
                                         "fields": [
                                             "runs.instructors.first_name",
-                                            "runs.instructors.last_name",
-                                            "runs.instructors.full_name",
+                                            "runs.instructors.last_name^5",
+                                            "runs.instructors.full_name^5",
                                         ],
                                     }
                                 },
@@ -463,8 +463,8 @@ def test_generate_learning_resources_text_clause():
                                                             "query": '"math"',
                                                             "fields": [
                                                                 "runs.instructors.first_name",
-                                                                "runs.instructors.last_name",
-                                                                "runs.instructors.full_name",
+                                                                "runs.instructors.last_name^5",
+                                                                "runs.instructors.full_name^5",
                                                             ],
                                                         }
                                                     },
@@ -575,8 +575,8 @@ def test_generate_learning_resources_text_clause():
                                         "query": '"math"',
                                         "fields": [
                                             "runs.instructors.first_name",
-                                            "runs.instructors.last_name",
-                                            "runs.instructors.full_name",
+                                            "runs.instructors.last_name^5",
+                                            "runs.instructors.full_name^5",
                                         ],
                                     }
                                 },
@@ -1144,8 +1144,8 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                                 "query": "math",
                                                                                 "fields": [
                                                                                     "runs.instructors.first_name",
-                                                                                    "runs.instructors.last_name",
-                                                                                    "runs.instructors.full_name",
+                                                                                    "runs.instructors.last_name^5",
+                                                                                    "runs.instructors.full_name^5",
                                                                                 ],
                                                                             }
                                                                         },
@@ -1264,8 +1264,8 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                         "query": "math",
                                                         "fields": [
                                                             "runs.instructors.first_name",
-                                                            "runs.instructors.last_name",
-                                                            "runs.instructors.full_name",
+                                                            "runs.instructors.last_name^5",
+                                                            "runs.instructors.full_name^5",
                                                         ],
                                                     }
                                                 },

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -338,8 +338,8 @@ RUNS_QUERY_FIELDS = [
 
 RUN_INSTRUCTORS_QUERY_FIELDS = [
     "runs.instructors.first_name",
-    "runs.instructors.last_name",
-    "runs.instructors.full_name",
+    "runs.instructors.last_name^5",
+    "runs.instructors.full_name^5",
 ]
 
 RESOURCEFILE_QUERY_FIELDS = [


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4799

### Description (What does it do?)
This PR updates the weight of instructor names in the search query so that searching by instructor works better


### How can this be tested?
If you do not already have Eric Grimson's ocw courses in your search index run

docker-compose run web ./manage.py backpopulate_ocw_data --course-name 6-001-structure-and-interpretation-of-computer-programs-spring-2005 --skip-content-files
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 6-00-introduction-to-computer-science-and-programming-fall-2008 --skip-content-files
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 6-0002-introduction-to-computational-thinking-and-data-science-fall-2016 --skip-content-files
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 --skip-content-files

Go to http://localhost:8062/search/?q=Eric+Grimson

Verify that the four ocw courses above are the first four results 

