### PR TITLE
Homepage and nav drawer copy edits

### DIFF
--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -178,7 +178,7 @@ const navData: NavData = {
           title: "Programs",
           icon: <RiStackLine />,
           description:
-            "Learn in-depth from a series of courses and earn a certificate",
+            "A series of courses for in-depth learning across a range of topics",
           href: querifiedSearchUrl({ resource_category: "program" }),
         },
         {

--- a/frontends/mit-open/src/page-components/Header/Header.tsx
+++ b/frontends/mit-open/src/page-components/Header/Header.tsx
@@ -170,7 +170,8 @@ const navData: NavData = {
         {
           title: "Courses",
           icon: <RiPencilRulerLine />,
-          description: "Learn with MIT instructors",
+          description:
+            "Single courses on a specific subject, taught by MIT instructors",
           href: querifiedSearchUrl({ resource_category: "course" }),
         },
         {
@@ -190,7 +191,7 @@ const navData: NavData = {
           title: "Learning Materials",
           icon: <RiBookMarkedLine />,
           description:
-            "Free teaching and learning materials including videos, podcasts, lecture notes, etc.",
+            "Free learning and teaching materials, including videos, podcasts, lecture notes, and more",
           href: querifiedSearchUrl({ resource_category: "learning_material" }),
         },
       ],
@@ -204,7 +205,7 @@ const navData: NavData = {
           href: TOPICS,
         },
         {
-          title: "By Departments",
+          title: "By Department",
           icon: <RiNodeTree />,
           href: DEPARTMENTS,
         },

--- a/frontends/mit-open/src/page-components/SearchDisplay/ProfessionalToggle.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/ProfessionalToggle.tsx
@@ -109,12 +109,12 @@ const ProfessionalToggle: React.FC<{
       </Collapse>
       <Collapse in={professionalSetting === "false"}>
         <ExplanationContainer>
-          Content developed from MIT’s academic curriculum
+          Content developed from MIT's academic curriculum
         </ExplanationContainer>
       </Collapse>
       <Collapse in={professionalSetting === "true"}>
         <ExplanationContainer>
-          Content developed from MIT’s professional curriculum
+          Content developed from MIT's professional curriculum
         </ExplanationContainer>
       </Collapse>
     </StyledButtonGroupContainer>

--- a/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
+++ b/frontends/mit-open/src/page-components/SignupPopover/SignupPopover.tsx
@@ -35,7 +35,7 @@ const SignupPopover: React.FC<SignupPopoverProps> = (props) => {
       </HeaderText>
       <BodyText variant="body2">
         As a member, get personalized recommendations, curate learning lists,
-        and follow your areas of interests.
+        and follow your areas of interest.
       </BodyText>
       <Footer>
         <ButtonLink

--- a/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HeroSearch.tsx
@@ -173,7 +173,7 @@ const HeroSearch: React.FC = () => {
           typography={{ xs: "h3", md: "h1" }}
           sx={{ paddingBottom: 1 }}
         >
-          Learn with MIT
+          Learn With MIT
         </Typography>
         <Typography>
           Explore MIT's{" "}

--- a/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.test.tsx
@@ -270,7 +270,7 @@ describe("Home Page personalize section", () => {
     renderWithProviders(<HomePage />)
     const personalize = (
       await screen.findByRole("heading", {
-        name: "Personalize Your Journey",
+        name: "Continue Your Journey",
       })
     ).closest("section")
     invariant(personalize)

--- a/frontends/mit-open/src/pages/HomePage/HomePage.tsx
+++ b/frontends/mit-open/src/pages/HomePage/HomePage.tsx
@@ -38,7 +38,7 @@ const MediaCarousel = styled(ResourceCarousel)(({ theme }) => ({
 const HomePage: React.FC = () => {
   return (
     <>
-      <MetaTags title="Learn with MIT" />
+      <MetaTags title="Learn With MIT" />
       <FullWidthBackground>
         <Container>
           <HeroSearch />

--- a/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/NewsEventsSection.tsx
@@ -231,8 +231,11 @@ const NewsEventsSection: React.FC = () => {
 
   return (
     <Section>
-      <Title variant="h2">Experience MIT</Title>
-      <StrapLine>See what's happening in the world of learning.</StrapLine>
+      <Title variant="h2">MIT Stories & Events</Title>
+      <StrapLine>
+        See what's happening in the world of learning with the latest news,
+        insights, and upcoming events at MIT.
+      </StrapLine>
       {isMobile ? (
         <MobileContent>
           <MobileContainer>

--- a/frontends/mit-open/src/pages/HomePage/PersonalizeSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/PersonalizeSection.tsx
@@ -61,18 +61,18 @@ const TextContainer = styled.div({
 
 const AUTH_TEXT_DATA = {
   authenticated: {
-    title: "Personalize Your Journey",
-    text: "Find your next course. Check your dashboard for personalized recommendations.",
+    title: "Continue Your Journey",
+    text: "Ready to keep learning? Choose from your saved courses, find personalized recommendations, and see what's trending on your dashboard.",
     linkProps: {
-      children: "Dashboard",
+      children: "My Dashboard",
       href: urls.DASHBOARD,
     },
   },
   anonymous: {
     title: "Personalize Your Journey",
-    text: "We can help find the courses for you. Tell us more about yourself to help you get started.",
+    text: "Find courses that match your interests and goals, get personalized recommendations, and save courses for later. Fill out a free profile to get started.",
     linkProps: {
-      children: "Sign Up to Get Started",
+      children: "Sign Up for Free",
       reloadDocument: true,
       href: urls.login({
         pathname: urls.DASHBOARD,

--- a/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/TestimonialsSection.tsx
@@ -283,9 +283,10 @@ const TestimonialsSection: React.FC = () => {
   return (
     <Section>
       <Container id="hamster-noises">
-        <Typography variant="h2">From our Community</Typography>
+        <Typography variant="h2">From Our Community</Typography>
         <Typography variant="h3">
-          Transforming education through the eyes of our learners
+          Millions of learners are reaching their goals with MIT's non-degree
+          learning resources. Here's what they're saying.
         </Typography>
       </Container>
       <SlickCarousel />

--- a/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
+++ b/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
@@ -271,7 +271,7 @@ const PrivacyPage: React.FC = () => {
             You have the right in certain circumstances to (1) access your
             personal information; (2) to correct or erase information; (3)
             restrict processing; and (4) object to communications, direct
-            marketing, or profiling. To the extent applicable, the EEA’s General
+            marketing, or profiling. To the extent applicable, the EEA's General
             Data Protection Regulation (GDPR) provides further information about
             your rights. You also have the right to lodge complaints with your
             national or regional data protection authority.


### PR DESCRIPTION
### What are the relevant tickets?

 - Closes https://github.com/mitodl/hq/issues/4806

### Description (What does it do?)
Updates homepage, nav drawer, popover with some copy edits.

### Screenshots (if appropriate):


### How can this be tested?

You could...

1. Compare homepage changes listed [here](https://docs.google.com/spreadsheets/d/1QGdAaAxnJidaI4cUG4u29wyCR5Yq494LsJe0pgRfJ5o/edit?pli=1&gid=1066967459#gid=1066967459) with actual homepage
    - as a logged-out user
    - as a logged-in user 
2. Compare nav drawer + popover changes listed [here](https://docs.google.com/spreadsheets/d/1QGdAaAxnJidaI4cUG4u29wyCR5Yq494LsJe0pgRfJ5o/edit?pli=1&gid=0#gid=0) with actual nav drawer / popover
    - open the popover by clicking on course card bookmark icon when logged out.
 
