### PR TITLE
Fix logout view

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth import views
-from django.http import Http404
 from django.shortcuts import redirect
 from social_django.utils import load_strategy
 
@@ -37,25 +36,30 @@ class CustomLogoutView(views.LogoutView):
         qs = urlencode(
             {
                 "id_token_hint": id_token,
-                "post_logout_redirect_uri": settings.LOGOUT_REDIRECT_URL,
+                "post_logout_redirect_uri": self.request.build_absolute_uri(
+                    settings.LOGOUT_REDIRECT_URL
+                ),
             }
         )
-        return f"{settings.KEYCLOAK_BASE_URL}/realms/{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/logout?{qs}"  # noqa: E501
+
+        return (
+            f"{settings.KEYCLOAK_BASE_URL}/realms/"
+            f"{settings.KEYCLOAK_REALM_NAME}/protocol/openid-connect/logout"
+            f"?{qs}"
+        )
 
     def get(
         self,
         request,
         *args,  # noqa: ARG002
         **kwargs,  # noqa: ARG002
-    ):  # pylint:disable=unused-argument
+    ):
         """
-        GET endpoint for loggin a user out.
-        Raises 404 if the user is not included in the request.
+        POST endpoint for loggin a user out.
         """
         user = getattr(request, "user", None)
         if user and user.is_authenticated:
-            super().get(request)
+            super().post(request)
             return redirect(self._keycloak_logout_url(user))
         else:
-            msg = "Not currently logged in."
-            raise Http404(msg)
+            return redirect("/app")

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -55,11 +55,19 @@ class CustomLogoutView(views.LogoutView):
         **kwargs,  # noqa: ARG002
     ):
         """
-        POST endpoint for loggin a user out.
+        GET endpoint for loggin a user out.
+
+        The logout redirect path the user follows is:
+
+        - api.example.com/logout (this view)
+        - keycloak.example.com/realms/REALM/protocol/openid-connect/logout
+        - api.example.com/app (see main/urls.py)
+        - app.example.com
+
         """
         user = getattr(request, "user", None)
         if user and user.is_authenticated:
-            super().post(request)
+            super().get(request)
             return redirect(self._keycloak_logout_url(user))
         else:
             return redirect("/app")


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/4831

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Updates the code to ensure the redirect url is absolute again.
- Removes the 404 error in favor of a redirect so this url behaves in an idempotent manner.

NOTE: I tried to add some tests for this, but they fail because we're using logout via a GET request, which is deprecated and removed in django 5+. I tried to fix *that* so we could just be done with logout for a good while but that spiraled into CSRF errors and it's not worth that level of effort at this time.