### PR TITLE
Align departments listing colors to designs

### DIFF
--- a/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
+++ b/frontends/mit-open/src/pages/DepartmentListingPage/DepartmentListingPage.tsx
@@ -44,10 +44,6 @@ const SCHOOL_ICONS: Record<string, React.ReactNode> = {
   "https://computing.mit.edu/": <RiTerminalBoxLine />,
 }
 
-const Page = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.white,
-}))
-
 const SchoolTitle = styled.h2(({ theme }) => {
   return {
     marginBottom: "10px",
@@ -105,7 +101,7 @@ const DepartmentLink = styled(ListItemLink)(({ theme }) => ({
     },
   },
   "&:hover": {
-    backgroundColor: theme.custom.colors.lightGray1,
+    backgroundColor: theme.custom.colors.white,
     ".hover-dark, .MuiListItemText-secondary": {
       color: theme.custom.colors.darkGray1,
     },
@@ -217,7 +213,7 @@ const DepartmentListingPage: React.FC = () => {
     : {}
 
   return (
-    <Page>
+    <>
       <MetaTags title="Departments" />
       <Banner
         backgroundUrl="/static/images/background_steps.jpeg"
@@ -249,7 +245,7 @@ const DepartmentListingPage: React.FC = () => {
           </Grid>
         </Grid>
       </Container>
-    </Page>
+    </>
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/4780

### Description (What does it do?)
<!--- Describe your changes in detail -->
Tweaks a few of the colors on the departments listing page. The header background looks like it was probably already addressed.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
![Screenshot 2024-07-09 at 15-30-47 Departments MIT Open](https://github.com/mitodl/mit-open/assets/28598/8a6f631b-ad8b-4968-98f2-7357c47e8bb7)

- [x] Mobile width screenshots
![Screen Shot 2024-07-09 at 15 49 58](https://github.com/mitodl/mit-open/assets/28598/697d8eda-60fe-4235-ae9e-ebee614d5ca6)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Go to the departments listing page and verify the background and item highlight colors match the designs.