### PR TITLE
remove manage widgets

### DIFF
--- a/frontends/mit-open/src/components/ChannelMenu/ChannelMenu.test.tsx
+++ b/frontends/mit-open/src/components/ChannelMenu/ChannelMenu.test.tsx
@@ -9,7 +9,7 @@ import { channels as factory } from "api/test-utils/factories"
 import { ThemeProvider } from "ol-components"
 
 describe("ChannelMenu", () => {
-  it("Includes links to channel management and widget management", async () => {
+  it("Includes links to channel management", async () => {
     const channel = factory.channel()
     setMockResponse.get(
       urls.channels.details(channel.channel_type, channel.name),
@@ -28,11 +28,6 @@ describe("ChannelMenu", () => {
     const item1 = screen.getByRole("menuitem", { name: "Channel Settings" })
     expect((item1 as HTMLAnchorElement).href).toContain(
       `/c/${channel.channel_type}/${channel.name}/manage`,
-    )
-
-    const item2 = screen.getByRole("menuitem", { name: "Manage Widgets" })
-    expect((item2 as HTMLAnchorElement).href).toContain(
-      `/c/${channel.channel_type}/${channel.name}/manage/widgets`,
     )
   })
 })

--- a/frontends/mit-open/src/components/ChannelMenu/ChannelMenu.tsx
+++ b/frontends/mit-open/src/components/ChannelMenu/ChannelMenu.tsx
@@ -17,11 +17,6 @@ const ChannelMenu: React.FC<{ channelType: string; name: string }> = ({
         label: "Channel Settings",
         href: routes.makeChannelEditPath(channelType, name),
       },
-      {
-        key: "widget",
-        label: "Manage Widgets",
-        href: routes.makeChannelManageWidgetsPath(channelType, name),
-      },
     ]
   }, [channelType, name])
   return (


### PR DESCRIPTION
### What are the relevant tickets?

- Closes https://github.com/mitodl/hq/issues/4730

### Description (What does it do?)
Removes a menu item we don't use anymore.

### Screenshots (if appropriate):
Now admins see:
<img width="633" alt="Screenshot 2024-07-09 at 4 22 42 PM" src="https://github.com/mitodl/mit-open/assets/9010790/c1f432b6-515c-4267-afd6-7f012dbdcf56">


### How can this be tested?
As an admin, view http://localhost:8062/c/unit/ocw and verify you don't see "Manage Widgets"

