### PR TITLE
reindexing changes

### DIFF
--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -514,20 +514,46 @@ def switch_indices(backing_index, object_type):
     )
 
 
-def delete_orphaned_indices():
+def delete_orphaned_indexes(obj_types, delete_reindexing_tags):
     """
-    Delete any indices without aliases and any reindexing aliases
+    Delete any indices without aliases
     """
     conn = get_conn()
     indices = conn.indices.get_alias(index="*")
     for index in indices:
         aliases = indices[index]["aliases"]
         keys = list(aliases)
+
+        if delete_reindexing_tags:
+            for alias in aliases:
+                if "reindexing" in alias:
+                    log.info("Deleting alias %s for index %s", alias, index)
+                    conn.indices.delete_alias(name=alias, index=index)
+                    keys.remove(alias)
+
+        if not keys and not index.startswith("."):
+            for object_type in obj_types:
+                if object_type in index:
+                    log.info("Deleting orphaned index %s", index)
+                    conn.indices.delete(index)
+                    break
+
+
+def get_existing_reindexing_indexes(obj_types):
+    """
+    Check for existing indexes with reindexing tag
+    """
+    conn = get_conn()
+    reindexing_indexes = []
+    indices = conn.indices.get_alias(index="*")
+    for index in indices:
+        aliases = indices[index]["aliases"]
+
         for alias in aliases:
             if "reindexing" in alias:
-                log.info("Deleting alias %s for index %s", alias, index)
-                conn.indices.delete_alias(name=alias, index=index)
-                keys.remove(alias)
-        if not keys:
-            log.info("Deleting index %s", index)
-            conn.indices.delete(index)
+                for object_type in obj_types:
+                    if object_type in index:
+                        reindexing_indexes.append(index)
+                        break
+
+    return reindexing_indexes


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4798

### Description (What does it do?)
If a recreate_index jobs is currently started before a different recreate_index job is finished, the [create_backing_index](https://github.com/mitodl/mit-open/blob/main/learning_resources_search/indexing_api.py#L446) function creates a new index and removes the reindexing tag from the first reindexing index that was created. The first reindexing index is then never deleted and left orphaned. 

This PR adds a check for an existing reindexing tag before starting a new reindexing job. In the default state, the job fails if there is an existing reindexing tag. In case something went wrong on a previous run and a current reindexing tag shouldn't exist, there is a --remove_existing_reindexing_tags option to force removing the existing reindexing tag

In addition, this pr deletes any orphaned indexes every time the recreate_index job runs


### How can this be tested?
From the command line run 
```
from learning_resources_search.indexing_api import create_backing_index
create_backing_index("program") 
create_backing_index("program") 
```
This creates an index with the reindexing tag and another orphaned index for programs


Run 
docker-compose run web ./manage.py recreate_index --program
You should see an error saying "Reindexing in progress. Reindexing indexes already exist"

Run 
docker-compose run web ./manage.py recreate_index --program --remove_existing_reindexing_tags

and the reindexing should finish

From the command line run 
```
from learning_resources_search.indexing_api import get_conn
conn = get_conn()
conn.indices.get_alias(index="*")
```

Check that there is only one index with "program" in the name

Additionally run docker-compose run web ./manage.py recreate_index --all and verify that everything looks normal


