### PR TITLE
for github pages, use main not "$default-branch"

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,7 +1,7 @@
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
### What are the relevant tickets?
Fixes storybook publishing 🤦 

### Description (What does it do?)
Changes `$default-branch` to `main`.

Apparently`$default-branch` can be used in workflow templates but not workflows.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Can't really be tested without merging.