### PR TITLE
change xpro ETL dict key back

### DIFF
--- a/learning_resources/etl/xpro.py
+++ b/learning_resources/etl/xpro.py
@@ -33,7 +33,7 @@ XPRO_PLATFORM_TRANSFORM = {
     "Simplilearn": PlatformType.simplilearn.name,
     "Susskind": PlatformType.susskind.name,
     "WHU": PlatformType.whu.name,
-    "MIT xPRO": PlatformType.xpro.name,
+    "xPRO": PlatformType.xpro.name,
 }
 
 

--- a/test_json/xpro_courses.json
+++ b/test_json/xpro_courses.json
@@ -8,7 +8,7 @@
     "readable_id": "course-v1:xPRO+SysEngxB1",
     "courseruns": [],
     "next_run_id": null,
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "format": "Online"
   },
@@ -18,7 +18,7 @@
     "description": "<p>Course 3 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program. This course may be taken individually, without enrolling in the professional certificate program.</p>",
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+SysEngxB3",
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "courseruns": [
       {
         "title": "SEED Model-Based Systems Engineering: Documentation and Analysis - Fall 2020",
@@ -46,7 +46,7 @@
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+SysEngxB2",
     "url": "https://xpro.mit.edu/courses/course-v1:xPRO+SysEngxB2",
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "courseruns": [
       {
         "title": "SEED Models in Engineering - Spring 2020",
@@ -76,7 +76,7 @@
     "courseruns": [],
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "format": "Online"
   },
   {
@@ -85,7 +85,7 @@
     "description": "<p>An introductory course to Digital Learning</p>",
     "thumbnail_url": "/static/images/mit-dome.png",
     "readable_id": "course-v1:xPRO+DgtlLearn1",
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "format": "Online",
     "courseruns": [
       {
@@ -138,7 +138,7 @@
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "format": "Online",
-    "platform": "MIT xPRO"
+    "platform": "xPRO"
   },
   {
     "id": 32,
@@ -150,6 +150,6 @@
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "format": "Online",
-    "platform": "MIT xPRO"
+    "platform": "xPRO"
   }
 ]

--- a/test_json/xpro_programs.json
+++ b/test_json/xpro_programs.json
@@ -11,11 +11,15 @@
     "end_date": "2019-12-01T00:00:00Z",
     "enrollment_start": "2019-08-01T00:00:00Z",
     "topics": [
-      { "name": "Business:Leadership & Organizations" },
-      { "name": "Planning" }
+      {
+        "name": "Business:Leadership & Organizations"
+      },
+      {
+        "name": "Planning"
+      }
     ],
     "format": "Online",
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "courses": [
       {
         "id": 18,
@@ -25,8 +29,12 @@
         "readable_id": "course-v1:xPRO+SysEngxB1",
         "courseruns": [],
         "next_run_id": null,
-        "topics": [{ "name": "Business:Leadership & Organizations" }],
-        "platform": "MIT xPRO",
+        "topics": [
+          {
+            "name": "Business:Leadership & Organizations"
+          }
+        ],
+        "platform": "xPRO",
         "format": "Online"
       },
       {
@@ -36,7 +44,7 @@
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB3",
         "topics": [],
-        "platform": "MIT xPRO",
+        "platform": "xPRO",
         "format": "Online",
         "courseruns": [
           {
@@ -62,8 +70,12 @@
         "description": "<p>Course 2 of 4 that comprises the Architecture and Systems Engineering Professional Certificate Program. This course may be taken individually, without enrolling in the professional certificate program.</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+SysEngxB2",
-        "topics": [{ "name": "Business:Leadership & Organizations" }],
-        "platform": "MIT xPRO",
+        "topics": [
+          {
+            "name": "Business:Leadership & Organizations"
+          }
+        ],
+        "platform": "xPRO",
         "format": "Online",
         "courseruns": [
           {
@@ -92,7 +104,7 @@
         "courseruns": [],
         "next_run_id": null,
         "topics": [],
-        "platform": "MIT xPRO"
+        "platform": "xPRO"
       }
     ]
   },
@@ -107,9 +119,13 @@
     "start_date": "2019-09-10T00:00:00Z",
     "end_date": "2019-12-10T00:00:00Z",
     "enrollment_start": null,
-    "topics": [{ "name": "Business:Leadership & Organizations" }],
+    "topics": [
+      {
+        "name": "Business:Leadership & Organizations"
+      }
+    ],
     "format": "In person",
-    "platform": "MIT xPRO",
+    "platform": "xPRO",
     "courses": [
       {
         "id": 30,
@@ -117,8 +133,12 @@
         "description": "<p>An introductory course to Digital Learning</p>",
         "thumbnail_url": "/static/images/mit-dome.png",
         "readable_id": "course-v1:xPRO+DgtlLearn1",
-        "topics": [{ "name": "Business:Leadership & Organizations" }],
-        "platform": "MIT xPRO",
+        "topics": [
+          {
+            "name": "Business:Leadership & Organizations"
+          }
+        ],
+        "platform": "xPRO",
         "courseruns": [
           {
             "title": "SEED Digital Learning 100 - August 2020",
@@ -167,8 +187,12 @@
         "readable_id": "course-v1:xPRO+DgtlLearn2",
         "courseruns": [],
         "next_run_id": null,
-        "topics": [{ "name": "Business:Leadership & Organizations" }],
-        "platform": "MIT xPRO"
+        "topics": [
+          {
+            "name": "Business:Leadership & Organizations"
+          }
+        ],
+        "platform": "xPRO"
       },
       {
         "id": 32,
@@ -179,7 +203,7 @@
         "courseruns": [],
         "next_run_id": null,
         "topics": [],
-        "platform": "MIT xPRO"
+        "platform": "xPRO"
       }
     ]
   }


### PR DESCRIPTION
### What are the relevant tickets?
- closes https://github.com/mitodl/hq/issues/4866

### Description (What does it do?)
Reverts a [change](https://github.com/mitodl/mit-open/pull/1198/files#diff-b2ab363ded7d2802140d4dbe1be8b83b951213cd6ab495bcf1bef9af37b9f1fbL36-R36) from #1198... `XPRO_PLATFORM_TRANSFORM` keys should not have been updated.

### How can this be tested?
1. Locally on main, run `./manage.py backpopulate_xpro_data` and check `/api/v1/courses?platform=xpro`. There should be none. (bug)
2. On this branch, run `./manage.py backpopulate_xpro_data`. You should now have several courses.



