### PR TITLE
remove erronous export string

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -445,12 +445,10 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
         {editMenu}
       </ListCard.Actions>
       <ListCard.Footer>
-        export{" "}
         <BorderSeparator>
           <Count resource={resource} />
           <StartDate resource={resource} />
           <Format resource={resource} />
-          export{" "}
         </BorderSeparator>
       </ListCard.Footer>
     </ListCard>


### PR DESCRIPTION
### What are the relevant tickets?
Follow up to #1251 

### Description (What does it do?)
Fixes a typo

### Screenshots
<img width="682" alt="Screenshot 2024-07-11 at 3 08 55 PM" src="https://github.com/mitodl/mit-open/assets/9010790/65aabf2a-11b6-461b-9eb4-e533ce70a616">

### How can this be tested?
View the search page on RC vs on this branch. notice the lack of erroneous "export"

