### PR TITLE
Make static/hash.txt served again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ codekit-config.json
 
 # Django static
 staticfiles/
+static/hash.txt
 
 .venv
 release-notes-checklist

--- a/bin/pre_compile
+++ b/bin/pre_compile
@@ -2,6 +2,8 @@
 
 # Syntax bin/compile <build-dir> <cache-dir>
 
-echo "-----> Writing out SOURCE_VERSION ($SOURCE_VERSION) to $BUILD_DIR/frontends/mit-open/build/static"
-mkdir -p $BUILD_DIR/frontends/mit-open/build/static
-echo $SOURCE_VERSION >$BUILD_DIR/frontends/mit-open/build/static/hash.txt
+STATIC_DIR="$BUILD_DIR/static"
+
+echo "-----> Writing out SOURCE_VERSION ($SOURCE_VERSION) to $STATIC_DIR"
+mkdir -p $STATIC_DIR
+echo $SOURCE_VERSION >$STATIC_DIR/hash.txt

--- a/main/settings.py
+++ b/main/settings.py
@@ -357,7 +357,7 @@ AUTHORIZATION_URL = get_string(
 STATIC_URL = "/static/"
 
 STATIC_ROOT = "staticfiles"
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "frontends/mit-open/public")]  # noqa: PTH118
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]  # noqa: PTH118
 
 # Important to define this so DEBUG works properly
 INTERNAL_IPS = (get_string("HOST_IP", "127.0.0.1"),)

--- a/main/urls.py
+++ b/main/urls.py
@@ -36,39 +36,43 @@ handler404 = "main.views.handle_404"
 features_router = DefaultRouter()
 features_router.register(r"_/features", FeaturesViewSet, basename="features")
 
-urlpatterns = [  # noqa: RUF005
-    path("scim/v2/", include("django_scim.urls")),
-    re_path(r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
-    re_path(r"^admin/", admin.site.urls),
-    re_path(r"", include("authentication.urls")),
-    re_path(r"", include("channels.urls")),
-    re_path(r"", include("profiles.urls")),
-    re_path(r"", include("embedly.urls")),
-    re_path(r"", include("learning_resources_search.urls")),
-    re_path(r"", include("ckeditor.urls")),
-    re_path(r"", include("widgets.urls")),
-    re_path(r"", include("openapi.urls")),
-    re_path(r"", include("learning_resources.urls")),
-    re_path(r"", include("articles.urls")),
-    re_path(r"", include("testimonials.urls")),
-    # React App
-    re_path(r"^$", index, name="main-index"),
-    re_path(r"^privacy-statement/", index, name="privacy-statement"),
-    re_path(r"^search/", index, name="site-search"),
-    re_path(r"^departments/", index, name="departments"),
-    re_path(r"^learningpaths/", index, name="learningpaths"),
-    re_path(r"^userlists/", index, name="userlists"),
-    re_path(r"^articles/", index, name="articles"),
-    re_path(r"^dashboard/", index, name="dashboard"),
-    re_path(r"^program_letter/", index, name="programletter"),
-    re_path(r"^c/", index, name="channels"),
-    re_path(r"", include(features_router.urls)),
-    # Hijack
-    re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
-    re_path(r"", include("news_events.urls")),
-    re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
-    re_path(r"^silk/", include("silk.urls", namespace="silk")),
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns = (
+    [  # noqa: RUF005
+        path("scim/v2/", include("django_scim.urls")),
+        re_path(r"^o/", include("oauth2_provider.urls", namespace="oauth2_provider")),
+        re_path(r"^admin/", admin.site.urls),
+        re_path(r"", include("authentication.urls")),
+        re_path(r"", include("channels.urls")),
+        re_path(r"", include("profiles.urls")),
+        re_path(r"", include("embedly.urls")),
+        re_path(r"", include("learning_resources_search.urls")),
+        re_path(r"", include("ckeditor.urls")),
+        re_path(r"", include("widgets.urls")),
+        re_path(r"", include("openapi.urls")),
+        re_path(r"", include("learning_resources.urls")),
+        re_path(r"", include("articles.urls")),
+        re_path(r"", include("testimonials.urls")),
+        re_path(r"", include("news_events.urls")),
+        # React App
+        re_path(r"^$", index, name="main-index"),
+        re_path(r"^privacy-statement/", index, name="privacy-statement"),
+        re_path(r"^search/", index, name="site-search"),
+        re_path(r"^departments/", index, name="departments"),
+        re_path(r"^learningpaths/", index, name="learningpaths"),
+        re_path(r"^userlists/", index, name="userlists"),
+        re_path(r"^articles/", index, name="articles"),
+        re_path(r"^dashboard/", index, name="dashboard"),
+        re_path(r"^program_letter/", index, name="programletter"),
+        re_path(r"^c/", index, name="channels"),
+        re_path(r"", include(features_router.urls)),
+        re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
+        re_path(r"^silk/", include("silk.urls", namespace="silk")),
+        # Hijack
+        re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
+    ]
+    + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+)
 
 if settings.DEBUG:
     import debug_toolbar  # pylint: disable=wrong-import-position, wrong-import-order


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

This is a follow up to #1179, which removed the serving of the frontend via nginx - the side effect of this is `hash.txt` was no longer being served so our release-script bot can't detect when deployments happen anymore

### How do I test it?

Run `echo "abc" > static/hash.txt` and then `docker compose up`. You should then be able to see this dummy file at http://api.open.odl.local:8063/static/hash.txt