### PR TITLE
Take is_enrollable attribute into account for publish status of edx resources

### DIFF
--- a/learning_resources/etl/openedx.py
+++ b/learning_resources/etl/openedx.py
@@ -220,8 +220,10 @@ def _transform_course_run(config, course_run, course_last_modified, marketing_ur
         "start_date": course_run.get("start") or course_run.get("enrollment_start"),
         "end_date": course_run.get("end"),
         "last_modified": last_modified,
-        "published": course_run.get("status", "") == "published"
-        and course_run.get("is_enrollable", False),
+        "published": (
+            course_run.get("status", "") == "published"
+            and course_run.get("is_enrollable", False)
+        ),
         "enrollment_start": course_run.get("enrollment_start"),
         "enrollment_end": course_run.get("enrollment_end"),
         "image": _transform_image(course_run.get("image")),

--- a/learning_resources/etl/openedx.py
+++ b/learning_resources/etl/openedx.py
@@ -220,7 +220,8 @@ def _transform_course_run(config, course_run, course_last_modified, marketing_ur
         "start_date": course_run.get("start") or course_run.get("enrollment_start"),
         "end_date": course_run.get("end"),
         "last_modified": last_modified,
-        "published": course_run.get("status", "") == "published",
+        "published": course_run.get("status", "") == "published"
+        and course_run.get("is_enrollable", False),
         "enrollment_start": course_run.get("enrollment_start"),
         "enrollment_end": course_run.get("enrollment_end"),
         "image": _transform_image(course_run.get("image")),
@@ -280,9 +281,7 @@ def _transform_course(config, course):
         "course": {
             "course_numbers": generate_course_numbers_json(course.get("key")),
         },
-        "published": any(
-            run["status"] == "published" for run in course.get("course_runs", [])
-        ),
+        "published": any(run["published"] is True for run in runs),
         "certification": has_certification,
         "certification_type": CertificationType.completion.name
         if has_certification

--- a/learning_resources/etl/openedx_test.py
+++ b/learning_resources/etl/openedx_test.py
@@ -99,7 +99,15 @@ def test_extract_disabled(openedx_config, config_arg_idx):
 
 @pytest.mark.parametrize("has_runs", [True, False])
 @pytest.mark.parametrize("is_course_deleted", [True, False])
-@pytest.mark.parametrize("is_course_run_deleted", [True, False])
+@pytest.mark.parametrize(
+    ("is_run_deleted", "is_run_enrollable", "is_run_published"),
+    [
+        (False, False, True),
+        (True, False, True),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
 @pytest.mark.parametrize(
     ("start_dt", "enrollment_dt", "expected_dt"),
     [
@@ -115,7 +123,9 @@ def test_transform_course(  # noqa: PLR0913
     mitx_course_data,
     has_runs,
     is_course_deleted,
-    is_course_run_deleted,
+    is_run_deleted,
+    is_run_enrollable,
+    is_run_published,
     start_dt,
     enrollment_dt,
     expected_dt,
@@ -123,17 +133,19 @@ def test_transform_course(  # noqa: PLR0913
     """Test that the transform function normalizes and filters out data"""
     extracted = mitx_course_data["results"]
     for course in extracted:
+        if is_course_deleted:
+            course["title"] = f"[delete] {course['title']}"
         if not has_runs:
             course["course_runs"] = []
         else:
             for run in course["course_runs"]:
                 run["start"] = start_dt
                 run["enrollment_start"] = enrollment_dt
-        if is_course_deleted:
-            course["title"] = f"[delete] {course['title']}"
-        if is_course_run_deleted:
-            for run in course["course_runs"]:
-                run["title"] = f"[delete] {run['title']}"
+                run["is_enrollable"] = is_run_enrollable
+                run["status"] = "published" if is_run_published else "unpublished"
+                if is_run_deleted:
+                    run["title"] = f"[delete] {run['title']}"
+
     transformed_courses = openedx_extract_transform.transform(extracted)
     if is_course_deleted or not has_runs:
         assert transformed_courses == []
@@ -155,12 +167,15 @@ def test_transform_course(  # noqa: PLR0913
             "last_modified": any_instance_of(datetime),
             "topics": [{"name": "Data Analysis & Statistics"}],
             "url": "http://localhost/fake-alt-url/this_course",
-            "published": True,
+            "published": is_run_published
+            and is_run_enrollable
+            and not is_run_deleted
+            and has_runs,
             "certification": False,
             "certification_type": CertificationType.none.name,
             "runs": (
                 []
-                if is_course_run_deleted or not has_runs
+                if is_run_deleted or not has_runs
                 else [
                     {
                         "availability": "Starting Soon",
@@ -187,7 +202,7 @@ def test_transform_course(  # noqa: PLR0913
                         "title": "The Analytics Edge",
                         "url": "http://localhost/fake-alt-url/this_course",
                         "year": 2019,
-                        "published": True,
+                        "published": is_run_enrollable and is_run_published,
                     }
                 ]
             ),
@@ -206,6 +221,10 @@ def test_transform_course(  # noqa: PLR0913
                 ]
             },
         }
-        if not is_course_run_deleted:
-            assert transformed_courses[1]["published"] is False
-            assert transformed_courses[1]["runs"][0]["published"] is False
+        if not is_run_deleted:
+            assert transformed_courses[1]["published"] is (
+                is_run_enrollable and is_run_published
+            )
+            assert transformed_courses[1]["runs"][0]["published"] is (
+                is_run_enrollable and is_run_published
+            )


### PR DESCRIPTION

### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4873

### Description (What does it do?)
For every edx run, sets the `published` value based on both `status` ("published" or not) and `is_enrollable` (must be true to be published).  The course publish status depends on whether any of its runs are published.



### How can this be tested?
- Set required backend .env variables for `EDX_API_*` and `OLL_API_*` based on RC values.
- If you have already populated MIT edX and mitxonline courses before, you might have 2 published courses returned by this search: http://open.odl.local:8062/search?platform=mitx&q=%22Linear+Elastic+Behavior%22 - one from MITx Online and another from edX.
- Run `./manage.py backpopulate_mit_edx_data` and `./manage.py backpopulate_oll_data`
- Once complete, The above search should return only one result, from MITx Online, if you've ingested those courses recently.  Otherwise it should return no results. 
- You should get very similar counts by running these commands in a shell:
  ```
    from learning_resources.models import *
    LearningResource.objects.filter(etl_source="mit_edx", published=True).count()
    
    Out[2]: 111
    
    LearningResource.objects.filter(etl_source="oll", published=True).count()

    Out[2]: 61
  ```  