### PR TITLE
Unit Detail Banner Updates

### DIFF
--- a/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
+++ b/frontends/mit-open/src/page-components/ChannelDetails/ChannelDetails.tsx
@@ -152,6 +152,7 @@ const ChannelDetailsCard = styled(Box)(({ theme }) => ({
   },
   [theme.breakpoints.down("md")]: {
     padding: "16px",
+    marginTop: "16px",
     width: "100%",
   },
 }))

--- a/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
+++ b/frontends/mit-open/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.tsx
@@ -5,13 +5,17 @@ import {
   useSearchSubscriptionDelete,
   useSearchSubscriptionList,
 } from "api/hooks/searchSubscription"
-import { Button, SimpleMenu } from "ol-components"
+import { Button, SimpleMenu, styled } from "ol-components"
 import type { SimpleMenuItem } from "ol-components"
 import { RiArrowDownSLine, RiMailLine } from "@remixicon/react"
 import { useUserMe } from "api/hooks/user"
 import { SourceTypeEnum } from "api"
 
 import { SignupPopover } from "../SignupPopover/SignupPopover"
+
+const StyledButton = styled(Button)({
+  minWidth: "130px",
+})
 
 type SearchSubscriptionToggleProps = {
   searchParams: URLSearchParams
@@ -54,9 +58,9 @@ const SearchSubscriptionToggle: React.FC<SearchSubscriptionToggleProps> = ({
     return (
       <SimpleMenu
         trigger={
-          <Button variant="primary" endIcon={<RiArrowDownSLine />}>
+          <StyledButton variant="primary" endIcon={<RiArrowDownSLine />}>
             Following
-          </Button>
+          </StyledButton>
         }
         items={unsubscribeItems}
       />
@@ -64,7 +68,7 @@ const SearchSubscriptionToggle: React.FC<SearchSubscriptionToggleProps> = ({
   }
   return (
     <>
-      <Button
+      <StyledButton
         variant="primary"
         disabled={subscriptionCreate.isLoading}
         startIcon={<RiMailLine />}
@@ -79,7 +83,7 @@ const SearchSubscriptionToggle: React.FC<SearchSubscriptionToggleProps> = ({
         }}
       >
         Follow
-      </Button>
+      </StyledButton>
       <SignupPopover anchorEl={buttonEl} onClose={() => setButtonEl(null)} />
     </>
   )

--- a/frontends/mit-open/src/pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/ChannelPage.test.tsx
@@ -106,24 +106,10 @@ describe("ChannelPage", () => {
       channel_type: "unit",
     })
     renderTestApp({ url: `/c/${channel.channel_type}/${channel.name}` })
-    const findTitle = (titles: HTMLElement[]) => {
-      return titles[
-        titles.findIndex(
-          (title: HTMLElement) =>
-            title.textContent === channel.title ||
-            title.textContent === channel.configuration.heading,
-        )
-      ]
-    }
-    await waitFor(() => {
-      const titles = screen.getAllByRole("heading")
-      const title = findTitle(titles)
-      expect(title).toBeInTheDocument()
-    })
-    const titles = screen.getAllByRole("heading")
-    const title = findTitle(titles)
-    expect(title).toBeInTheDocument()
+
+    const title = await screen.findByRole("heading", { name: channel.title })
     const header = title.closest("header")
+    expect(title).toBeInTheDocument()
     assertInstanceOf(header, HTMLElement)
     const images = within(header).getAllByRole("img") as HTMLImageElement[]
     const headerStyles = getComputedStyle(header)

--- a/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
@@ -13,7 +13,6 @@ import { SearchSubscriptionToggle } from "@/page-components/SearchSubscriptionTo
 import { ChannelDetails } from "@/page-components/ChannelDetails/ChannelDetails"
 import { useChannelDetail } from "api/hooks/channels"
 import ChannelMenu from "@/components/ChannelMenu/ChannelMenu"
-import ChannelAvatar from "@/components/ChannelAvatar/ChannelAvatar"
 import ResourceCarousel, {
   ResourceCarouselProps,
 } from "@/page-components/ResourceCarousel/ResourceCarousel"
@@ -25,7 +24,7 @@ import { ChannelControls, UNITS_LABEL } from "./ChannelPageTemplate"
 
 const StyledBannerBackground = styled(BannerBackground)(({ theme }) => ({
   padding: "48px 0 64px 0",
-  [theme.breakpoints.down("sm")]: {
+  [theme.breakpoints.down("md")]: {
     padding: "32px 0 16px 0",
   },
 }))
@@ -35,6 +34,16 @@ const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {
     marginTop: "32px",
     marginBottom: "32px",
+  },
+}))
+
+const UnitLogo = styled.img(({ theme }) => ({
+  filter: "saturate(0%) invert(100%)",
+  maxWidth: "100%",
+  width: "auto",
+  height: "50px",
+  [theme.breakpoints.down("md")]: {
+    height: "40px",
   },
 }))
 
@@ -120,12 +129,7 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
             <Stack gap={{ xs: "16px", lg: "24px" }}>
               <ChannelHeader aria-label={channel.data?.title}>
                 {channel.data ? (
-                  <ChannelAvatar
-                    imageVariant="inverted"
-                    formImageUrl={displayConfiguration.logo}
-                    imageSize="medium"
-                    channel={channel.data}
-                  />
+                  <UnitLogo alt="" src={displayConfiguration.logo} />
                 ) : null}
               </ChannelHeader>
               <Stack gap={{ xs: "16px", lg: "32px" }}>

--- a/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
@@ -1,5 +1,13 @@
 import React, { useMemo } from "react"
-import { styled, Container, Box, Breadcrumbs, Banner } from "ol-components"
+import {
+  styled,
+  Container,
+  Box,
+  Breadcrumbs,
+  Stack,
+  BannerBackground,
+  Typography,
+} from "ol-components"
 import { MetaTags } from "ol-utilities"
 import { SearchSubscriptionToggle } from "@/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle"
 import { ChannelDetails } from "@/page-components/ChannelDetails/ChannelDetails"
@@ -15,6 +23,13 @@ import { HOME as HOME_URL, UNITS as UNITS_URL } from "../../common/urls"
 import { ChannelTypeEnum } from "api/v0"
 import { ChannelControls, UNITS_LABEL } from "./ChannelPageTemplate"
 
+const StyledBannerBackground = styled(BannerBackground)(({ theme }) => ({
+  padding: "48px 0 64px 0",
+  [theme.breakpoints.down("sm")]: {
+    padding: "32px 0 16px 0",
+  },
+}))
+
 const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
   margin: "80px 0",
   [theme.breakpoints.down("sm")]: {
@@ -22,6 +37,27 @@ const FeaturedCoursesCarousel = styled(ResourceCarousel)(({ theme }) => ({
     marginBottom: "32px",
   },
 }))
+
+const BannerContent = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  [theme.breakpoints.down("md")]: {
+    flexDirection: "column",
+  },
+}))
+
+const ChannelHeader = styled.h1({
+  margin: 0,
+  display: "flex",
+  flexGrow: 1,
+  flexShrink: 0,
+})
+
+const HEADER_STYLES = {
+  width: { md: "80%", sm: "100%" },
+}
 
 interface UnitChannelTemplateProps {
   children: React.ReactNode
@@ -57,23 +93,18 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
     },
   ]
 
-  const headerStyles = {
-    width: { md: "80%", sm: "100%" },
-    my: 1,
-  }
-
   return (
     <>
       <MetaTags title={channel.data?.title || UNITS_LABEL} />
-      <Banner
+      <StyledBannerBackground
         backgroundUrl={
           displayConfiguration?.banner_background ??
           "/static/images/background_steps.jpeg"
         }
         backgroundSize="2000px auto"
         backgroundDim={30}
-        containerPadding={"48px 0 64px 0"}
-        navText={
+      >
+        <Container>
           <Breadcrumbs
             variant="dark"
             ancestors={[
@@ -85,90 +116,62 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
             ]}
             current={channel.data?.title}
           />
-        }
-        avatar={
-          displayConfiguration?.logo && channel.data ? (
-            <Box
-              display="flex"
-              flexDirection="row"
-              alignItems="center"
-              sx={(theme) => ({
-                flexGrow: 1,
-                flexShrink: 0,
-                order: 1,
-                py: "24px",
-
-                [theme.breakpoints.down("md")]: {
-                  py: 0,
-                  pb: "8px",
-                },
-                [theme.breakpoints.down("sm")]: {
-                  pt: "32px",
+          <BannerContent>
+            <Stack gap={{ xs: "16px", lg: "24px" }}>
+              <ChannelHeader aria-label={channel.data?.title}>
+                {channel.data ? (
+                  <ChannelAvatar
+                    imageVariant="inverted"
+                    formImageUrl={displayConfiguration.logo}
+                    imageSize="medium"
+                    channel={channel.data}
+                  />
+                ) : null}
+              </ChannelHeader>
+              <Stack gap={{ xs: "16px", lg: "32px" }}>
+                <Typography
+                  typography={{ xs: "h5", md: "h4" }}
+                  sx={HEADER_STYLES}
+                >
+                  {displayConfiguration?.heading}
+                </Typography>
+                <Typography
+                  typography={{ xs: "body2", md: "body1" }}
+                  sx={HEADER_STYLES}
+                >
+                  {displayConfiguration?.sub_heading}
+                </Typography>
+              </Stack>
+              <Box
+                display="flex"
+                flexDirection="row"
+                alignItems="end"
+                sx={{
+                  flexGrow: 0,
                   width: "100%",
-                },
-              })}
-            >
-              <ChannelAvatar
-                imageVariant="inverted"
-                formImageUrl={displayConfiguration.logo}
-                imageSize="medium"
-                channel={channel.data}
-              />
-            </Box>
-          ) : null
-        }
-        header={displayConfiguration?.heading}
-        headerTypography={{ xs: "h5", md: "h4" }}
-        headerStyles={headerStyles}
-        subheader={displayConfiguration?.sub_heading}
-        subheaderStyles={headerStyles}
-        subheaderTypography={{ xs: "body2", md: "body1" }}
-        extraHeader={
-          <Box
-            display="flex"
-            flexDirection="row"
-            alignItems="end"
-            sx={{
-              flexGrow: 0,
-              width: "100%",
-              flexShrink: 1,
-              order: 3,
-              mt: { xs: "8px" },
-              mb: { xs: "48px" },
-            }}
-          >
-            <ChannelControls>
-              {channel.data?.search_filter ? (
-                <SearchSubscriptionToggle
-                  sourceType={SourceTypeEnum.ChannelSubscriptionType}
-                  searchParams={urlParams}
-                />
-              ) : null}
-              {channel.data?.is_moderator ? (
-                <ChannelMenu
-                  channelType={ChannelTypeEnum.Unit}
-                  name={String(name)}
-                />
-              ) : null}
-            </ChannelControls>
-          </Box>
-        }
-        extraRight={
-          channel.data && (
-            <Box
-              flexDirection="row"
-              alignItems="end"
-              alignSelf="center"
-              display="flex"
-              sx={{
-                width: { md: "408px", xs: "100%" },
-              }}
-            >
-              <ChannelDetails channel={channel.data} />
-            </Box>
-          )
-        }
-      />
+                  flexShrink: 1,
+                }}
+              >
+                <ChannelControls>
+                  {channel.data?.search_filter ? (
+                    <SearchSubscriptionToggle
+                      sourceType={SourceTypeEnum.ChannelSubscriptionType}
+                      searchParams={urlParams}
+                    />
+                  ) : null}
+                  {channel.data?.is_moderator ? (
+                    <ChannelMenu
+                      channelType={ChannelTypeEnum.Unit}
+                      name={String(name)}
+                    />
+                  ) : null}
+                </ChannelControls>
+              </Box>
+            </Stack>
+            {channel.data ? <ChannelDetails channel={channel.data} /> : null}
+          </BannerContent>
+        </Container>
+      </StyledBannerBackground>
       <Container>
         <FeaturedCoursesCarousel
           title="Featured Courses"

--- a/frontends/ol-components/src/components/Banner/Banner.tsx
+++ b/frontends/ol-components/src/components/Banner/Banner.tsx
@@ -10,24 +10,17 @@ const SubHeader = styled(Typography)({
   marginTop: "8px",
 })
 
-type BannerWrapperProps = {
+type BannerBackgroundProps = {
   backgroundUrl: string
   backgroundSize?: string
   backgroundDim?: number
-  containerPadding?: string
 }
 
 /**
  * This is a full-width banner component that takes a background image URL.
  */
-const BannerWrapper = styled.header<BannerWrapperProps>(
-  ({
-    theme,
-    backgroundUrl,
-    backgroundSize = "cover",
-    backgroundDim = 0,
-    containerPadding = "48px 0 48px 0",
-  }) => ({
+const BannerBackground = styled.header<BannerBackgroundProps>(
+  ({ theme, backgroundUrl, backgroundSize = "cover", backgroundDim = 0 }) => ({
     backgroundAttachment: "fixed",
     backgroundImage: backgroundDim
       ? `linear-gradient(rgba(0 0 0 / ${backgroundDim}%), rgba(0 0 0 / ${backgroundDim}%)), url('${backgroundUrl}')`
@@ -35,7 +28,7 @@ const BannerWrapper = styled.header<BannerWrapperProps>(
     backgroundSize: backgroundSize,
     backgroundRepeat: "no-repeat",
     color: theme.custom.colors.white,
-    padding: containerPadding,
+    padding: "48px 0 48px 0",
     [theme.breakpoints.down("sm")]: {
       padding: "32px 0 32px 0",
     },
@@ -65,11 +58,10 @@ const RightContainer = styled.div(({ theme }) => ({
   },
 }))
 
-type BannerProps = BannerWrapperProps & {
+type BannerProps = BannerBackgroundProps & {
   backgroundUrl: string
   backgroundSize?: string
   backgroundDim?: number
-  containerPadding?: string
   navText: React.ReactNode
   avatar?: React.ReactNode
   header: React.ReactNode
@@ -90,7 +82,6 @@ const Banner = ({
   backgroundUrl,
   backgroundSize = "cover",
   backgroundDim = 0,
-  containerPadding = "48px 0 48px 0",
   navText,
   avatar,
   header,
@@ -105,11 +96,10 @@ const Banner = ({
   const defaultHeaderTypography = { xs: "h2", md: "h1" }
   const defaultSubHeaderTypography = { xs: "body2", md: "body1" }
   return (
-    <BannerWrapper
+    <BannerBackground
       backgroundUrl={backgroundUrl}
       backgroundSize={backgroundSize}
       backgroundDim={backgroundDim}
-      containerPadding={containerPadding}
     >
       <Container>
         {navText}
@@ -135,9 +125,9 @@ const Banner = ({
           <RightContainer>{extraRight}</RightContainer>
         </InnerContainer>
       </Container>
-    </BannerWrapper>
+    </BannerBackground>
   )
 }
 
-export { Banner }
-export type { BannerProps }
+export { Banner, BannerBackground }
+export type { BannerProps, BannerBackgroundProps }

--- a/frontends/ol-components/src/components/Banner/Banner.tsx
+++ b/frontends/ol-components/src/components/Banner/Banner.tsx
@@ -19,7 +19,7 @@ type BannerBackgroundProps = {
 /**
  * This is a full-width banner component that takes a background image URL.
  */
-const BannerBackground = styled.header<BannerBackgroundProps>(
+const BannerBackground = styled.div<BannerBackgroundProps>(
   ({ theme, backgroundUrl, backgroundSize = "cover", backgroundDim = 0 }) => ({
     backgroundAttachment: "fixed",
     backgroundImage: backgroundDim

--- a/frontends/ol-components/src/components/Button/Button.stories.tsx
+++ b/frontends/ol-components/src/components/Button/Button.stories.tsx
@@ -8,18 +8,22 @@ import {
   RiArrowRightLine,
   RiDeleteBinLine,
   RiEditLine,
+  RiTestTubeLine,
+  RiMailLine,
 } from "@remixicon/react"
 
 import { withRouter } from "storybook-addon-react-router-v6"
 import { fn } from "@storybook/test"
 import { capitalize } from "ol-utilities"
 
-const icons = {
+const ICONS = {
   None: undefined,
   ArrowForwardIcon: <RiArrowRightLine />,
   ArrowBackIcon: <RiArrowLeftLine />,
   DeleteIcon: <RiDeleteBinLine />,
   EditIcon: <RiEditLine />,
+  TestTubeIcon: <RiTestTubeLine />,
+  MailIcon: <RiMailLine />,
 }
 
 const meta: Meta<typeof Button> = {
@@ -46,12 +50,12 @@ const meta: Meta<typeof Button> = {
       control: { type: "select" },
     },
     startIcon: {
-      options: Object.keys(icons),
-      mapping: icons,
+      options: Object.keys(ICONS),
+      mapping: ICONS,
     },
     endIcon: {
-      options: Object.keys(icons),
-      mapping: icons,
+      options: Object.keys(ICONS),
+      mapping: ICONS,
     },
   },
   args: {
@@ -184,19 +188,12 @@ export const EdgeStory: Story = {
 
 export const WithIconStory: Story = {
   render: (args) => (
-    <Stack direction="row" gap={2} sx={{ my: 2 }}>
-      <Button {...args} startIcon={<RiArrowLeftLine />}>
-        Back
-      </Button>
-      <Button {...args} startIcon={<RiDeleteBinLine />}>
-        Delete
-      </Button>
-      <Button {...args} startIcon={<RiEditLine />}>
-        Edit
-      </Button>
-      <Button {...args} endIcon={<RiArrowRightLine />}>
-        Forward
-      </Button>
+    <Stack direction="column" alignItems="start" gap={2} sx={{ my: 2 }}>
+      {Object.entries(ICONS).map(([key, icon]) => (
+        <Button {...args} startIcon={icon} key={key}>
+          {key}
+        </Button>
+      ))}
     </Stack>
   ),
 }
@@ -225,8 +222,16 @@ const EDGES = ["rounded", "circular", "none"] as const
 const VARIANTS = ["primary", "secondary", "tertiary", "text"] as const
 const EXTRA_PROPS = [
   {},
-  { startIcon: <RiArrowLeftLine /> },
-  { endIcon: <RiArrowRightLine /> },
+  /**
+   * Show RiTestTubeLine because it is a fairly thin icon
+   */
+  { startIcon: <RiTestTubeLine /> },
+  /**
+   * Show RiTestTubeLine because it is a fairly thick icon
+   */
+  { startIcon: <RiMailLine /> },
+  { endIcon: <RiTestTubeLine /> },
+  { endIcon: <RiMailLine /> },
 ]
 
 export const LinkStory: Story = {
@@ -302,24 +307,6 @@ export const WrappingButtonShowcase: Story = {
   },
 }
 
-const ICONS = [
-  {
-    component: <RiArrowLeftLine />,
-    key: "back",
-  },
-  {
-    component: <RiDeleteBinLine />,
-    key: "delete",
-  },
-  {
-    component: <RiEditLine />,
-    key: "edit",
-  },
-  {
-    component: <RiArrowRightLine />,
-    key: "forward",
-  },
-]
 export const ActionButtonsShowcase: Story = {
   render: (args) => (
     <>
@@ -339,15 +326,15 @@ export const ActionButtonsShowcase: Story = {
             </pre>
             {SIZES.map((size) => (
               <React.Fragment key={size}>
-                {ICONS.map((icon) => (
+                {Object.entries(ICONS).map(([key, icon]) => (
                   <ActionButton
-                    key={icon.key}
+                    key={key}
                     variant={variant}
                     edge={edge}
                     size={size}
                     {...args}
                   >
-                    {icon.component}
+                    {icon}
                   </ActionButton>
                 ))}
               </React.Fragment>

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -209,10 +209,10 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
        * With icons, the left space is 20/12/8 px.
        */
       marginLeft: "-4px",
-      marginRight: "4px",
+      marginRight: "8px",
     },
     side === "end" && {
-      marginLeft: "4px",
+      marginLeft: "8px",
       marginRight: "-4px",
     },
     {

--- a/frontends/ol-components/src/components/Button/Button.tsx
+++ b/frontends/ol-components/src/components/Button/Button.tsx
@@ -195,14 +195,6 @@ const ButtonStyled = styled.button<ButtonStyleProps>((props) => {
   ]
 })
 
-/**
- * Typically, SVG Icons are structured as `<svg> <path/> </svg>`; the svg is
- * 24x24px by default, but the path may be smaller. I.e., there is generally
- * whitespace around the path.
- *
- * The negative margin below accounts (approximately) for this whitespace.
- * The whitespace varies by icon, so it's not perfect.
- */
 const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
   ({ size, side }) => [
     {
@@ -211,6 +203,11 @@ const IconContainer = styled.span<{ side: "start" | "end"; size: ButtonSize }>(
       alignItems: "center",
     },
     side === "start" && {
+      /**
+       * The negative margin is to counteract the padding on the button itself.
+       * Without icons, the left space is 24/16/12 px.
+       * With icons, the left space is 20/12/8 px.
+       */
       marginLeft: "-4px",
       marginRight: "4px",
     },

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -19,8 +19,11 @@ export type { BadgeProps } from "@mui/material/Badge"
 export { default as AppBar } from "@mui/material/AppBar"
 export type { AppBarProps } from "@mui/material/AppBar"
 
-export { Banner } from "./components/Banner/Banner"
-export type { BannerProps } from "./components/Banner/Banner"
+export { Banner, BannerBackground } from "./components/Banner/Banner"
+export type {
+  BannerProps,
+  BannerBackgroundProps,
+} from "./components/Banner/Banner"
 
 export {
   Button,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4784

### Description (What does it do?)
Aligns unit channel banner with designs.

### Screenshots (if appropriate):
<img width="1612" alt="Screenshot 2024-07-16 at 8 35 58 PM" src="https://github.com/user-attachments/assets/5a86fcb3-bc61-4613-b40b-f5c610c08b24">

<img width="350" alt="Screenshot 2024-07-16 at 8 35 32 PM" src="https://github.com/user-attachments/assets/30729c47-a492-4b97-9f59-262a1df23906"> <img width="350" alt="Screenshot 2024-07-16 at 8 35 48 PM" src="https://github.com/user-attachments/assets/2dc2053d-9944-4de3-bca6-c2d520c8f415">

<img width="350" alt="Screenshot 2024-07-16 at 8 35 24 PM" src="https://github.com/user-attachments/assets/cc6fcadc-224a-4131-a7b0-4b476efe3454"> 

### How can this be tested?
1. Compare with designs, in particular the spacing between logo / header / subheader / description and the alignment relative to the "info box".

