### PR TITLE
Shanbady/clicking item routes away from list

### DIFF
--- a/frontends/mit-open/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/mit-open/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -6,7 +6,7 @@ import {
 } from "ol-components"
 import type { RoutedDrawerProps } from "ol-components"
 import { useLearningResourcesDetail } from "api/hooks/learningResources"
-import { useSearchParams } from "react-router-dom"
+import { useSearchParams, useLocation } from "react-router-dom"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 import { usePostHog } from "posthog-js/react"
 
@@ -95,13 +95,15 @@ const useOpenLearningResourceDrawer = () => {
 
 const useResourceDrawerHref = () => {
   const [search] = useSearchParams()
+  const { hash } = useLocation()
 
   return useCallback(
     (id: number) => {
       search.set(RESOURCE_DRAWER_QUERY_PARAM, id.toString())
-      return `?${search.toString()}`
+
+      return `?${search.toString()}${hash}`
     },
-    [search],
+    [search, hash],
   )
 }
 

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -69,7 +69,7 @@ const RoutedDrawer = <K extends string, R extends K = K>(
       })
       return newSearchParams
     })
-    document.location.hash = hash.trimStart("#")
+    document.location.hash = hash.substring(1)
   }, [setSearchParams, params, hash])
 
   return (

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled"
 import type { DrawerProps } from "@mui/material/Drawer"
 import { ActionButton } from "../Button/Button"
 import { RiCloseLargeLine } from "@remixicon/react"
-import { useSearchParams } from "react-router-dom"
+import { useSearchParams, useLocation } from "react-router-dom"
 import { useToggle } from "ol-utilities"
 
 const closeSx: React.CSSProperties = {
@@ -39,7 +39,9 @@ const RoutedDrawer = <K extends string, R extends K = K>(
   const { requiredParams, children, onView, ...others } = props
   const { params = requiredParams } = props
   const [searchParams, setSearchParams] = useSearchParams()
+
   const [open, setOpen] = useToggle(false)
+  const { hash } = useLocation()
 
   const childParams = useMemo(() => {
     return Object.fromEntries(
@@ -67,7 +69,8 @@ const RoutedDrawer = <K extends string, R extends K = K>(
       })
       return newSearchParams
     })
-  }, [setSearchParams, params])
+    document.location.hash = hash.trimStart("#")
+  }, [setSearchParams, params, hash])
 
   return (
     <Drawer


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4879

### Description (What does it do?)
The changes in this PR allow for hash params in the url to be preserved when navigating to and from learning resource panels. 

### How can this be tested?
1. checkout this branch
2. navigate to /search
3.  add some hash paramters to the url (/search#test=123)
4. click on a learning resource and then close out the panel
5. note that the hash parameter is preserved

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
