### PR TITLE
fix keyboard drag and drop

### DIFF
--- a/frontends/ol-components/src/components/SortableList/SortableList.tsx
+++ b/frontends/ol-components/src/components/SortableList/SortableList.tsx
@@ -69,16 +69,17 @@ const SortableItem = <I extends UniqueIdentifier = UniqueIdentifier>(
   const handleProps: HandleProps = useMemo(
     () => ({
       ...listeners,
+      ...attributes,
       ref: setActivatorNodeRef,
       className: !props.disabled ? "ol-draggable" : undefined,
     }),
-    [setActivatorNodeRef, listeners, props.disabled],
+    [setActivatorNodeRef, attributes, listeners, props.disabled],
   )
 
   const { Component = "div" } = props
 
   return (
-    <Component ref={setNodeRef} style={style} {...attributes}>
+    <Component ref={setNodeRef} style={style}>
       <DragStyles>{props.children && props.children(handleProps)}</DragStyles>
     </Component>
   )


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/4861

### Description (What does it do?)
Makes sortable lists sortable via keyboard interactions

### Screenshots (if appropriate):
Note: The drag styling still is being updated as part of 
- https://github.com/mitodl/hq/issues/4859

https://github.com/user-attachments/assets/d9caa9ad-72ce-4323-8c24-2dd3f24c1ce4


### How can this be tested?
1. View a sortable list (example: dashboard page userlists or learning paths)
2. With keyboard:
    1. Tab to "Reorder" and press spacebar
    2. Tab to one of the list items and press spacebar
    3. use up/down keys to reorder
    4. Press spacebar to drop or escape to cancel the sorting

If you would like some... pretty verbose... instructions, enable a screen reader while you do the above.

