### PR TITLE
Shanbady/clicking item routes away from list fix

### DIFF
--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -63,7 +63,7 @@ const RoutedDrawer = <K extends string, R extends K = K>(
   }, [requiredArePresent, setOpen, requiredParams])
 
   const removeUrlParams = useCallback(() => {
-    const getNewParams = (current) => {
+    const getNewParams = (current: string) => {
       const newSearchParams = new URLSearchParams(current)
       params.forEach((param) => {
         newSearchParams.delete(param)

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled"
 import type { DrawerProps } from "@mui/material/Drawer"
 import { ActionButton } from "../Button/Button"
 import { RiCloseLargeLine } from "@remixicon/react"
-import { useSearchParams, useLocation, useNavigate } from "react-router-dom"
+import { useLocation, useNavigate } from "react-router-dom"
 import { useToggle } from "ol-utilities"
 
 const closeSx: React.CSSProperties = {
@@ -38,17 +38,17 @@ const RoutedDrawer = <K extends string, R extends K = K>(
 ) => {
   const { requiredParams, children, onView, ...others } = props
   const { params = requiredParams } = props
-  const [searchParams, setSearchParams] = useSearchParams()
 
   const [open, setOpen] = useToggle(false)
   const location = useLocation()
   const navigate = useNavigate()
 
   const childParams = useMemo(() => {
+    const searchParams = new URLSearchParams(location.search)
     return Object.fromEntries(
       params.map((name) => [name, searchParams.get(name)] as const),
     ) as Record<K, string | null>
-  }, [searchParams, params])
+  }, [location, params])
 
   const requiredArePresent = requiredParams.every(
     (name) => childParams[name] !== null,
@@ -71,12 +71,11 @@ const RoutedDrawer = <K extends string, R extends K = K>(
       return newSearchParams
     }
     const newParams = getNewParams(location.search)
-    setSearchParams(newParams)
     navigate({
       ...location,
       search: newParams.toString(),
     })
-  }, [setSearchParams, params, navigate, location])
+  }, [params, navigate, location])
 
   return (
     <Drawer

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled"
 import type { DrawerProps } from "@mui/material/Drawer"
 import { ActionButton } from "../Button/Button"
 import { RiCloseLargeLine } from "@remixicon/react"
-import { useSearchParams, useLocation } from "react-router-dom"
+import { useSearchParams, useLocation, useNavigate } from "react-router-dom"
 import { useToggle } from "ol-utilities"
 
 const closeSx: React.CSSProperties = {
@@ -41,7 +41,8 @@ const RoutedDrawer = <K extends string, R extends K = K>(
   const [searchParams, setSearchParams] = useSearchParams()
 
   const [open, setOpen] = useToggle(false)
-  const { hash } = useLocation()
+  const location = useLocation()
+  const navigate = useNavigate()
 
   const childParams = useMemo(() => {
     return Object.fromEntries(
@@ -69,8 +70,11 @@ const RoutedDrawer = <K extends string, R extends K = K>(
       })
       return newSearchParams
     })
-    document.location.hash = hash.substring(1)
-  }, [setSearchParams, params, hash])
+    navigate({
+      ...location,
+      search: searchParams.toString(),
+    })
+  }, [setSearchParams, params, navigate, location])
 
   return (
     <Drawer

--- a/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
+++ b/frontends/ol-components/src/components/RoutedDrawer/RoutedDrawer.tsx
@@ -63,16 +63,18 @@ const RoutedDrawer = <K extends string, R extends K = K>(
   }, [requiredArePresent, setOpen, requiredParams])
 
   const removeUrlParams = useCallback(() => {
-    setSearchParams((current) => {
+    const getNewParams = (current) => {
       const newSearchParams = new URLSearchParams(current)
       params.forEach((param) => {
         newSearchParams.delete(param)
       })
       return newSearchParams
-    })
+    }
+    const newParams = getNewParams(location.search)
+    setSearchParams(newParams)
     navigate({
       ...location,
-      search: searchParams.toString(),
+      search: newParams.toString(),
     })
   }, [setSearchParams, params, navigate, location])
 


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4879

### Description (What does it do?)
The changes in this PR allow for hash params in the url to be preserved when navigating to and from learning resource panels. 

### How can this be tested?
1. checkout this branch
2. navigate to /search
3.  add some hash paramters to the url (/search#test=123)
4. click on a learning resource and then close out the panel
5. note that the hash parameter is preserved

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
