### PR TITLE
add staleness penalty slider

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3364,6 +3364,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   professional?: boolean | null
   /**
+   * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  yearly_decay_percent?: number | null
+  /**
    * True if the learning resource offers a certificate
    * @type {boolean}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -11517,6 +11523,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11540,6 +11547,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       resource_type?: Array<LearningResourcesSearchRetrieveResourceTypeEnum>,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources_search/`
@@ -11634,6 +11642,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (yearly_decay_percent !== undefined) {
+        localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
+      }
+
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -11683,6 +11695,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -11706,6 +11719,7 @@ export const LearningResourcesSearchApiFp = function (
       resource_type?: Array<LearningResourcesSearchRetrieveResourceTypeEnum>,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -11734,6 +11748,7 @@ export const LearningResourcesSearchApiFp = function (
           resource_type,
           sortby,
           topic,
+          yearly_decay_percent,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -11795,6 +11810,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
+          requestParameters.yearly_decay_percent,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -11940,6 +11956,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly topic?: Array<string>
+
+  /**
+   * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly yearly_decay_percent?: number | null
 }
 
 /**
@@ -11982,6 +12005,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
+        requestParameters.yearly_decay_percent,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -12202,6 +12226,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12226,6 +12251,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources_user_subscription/check/`
@@ -12324,6 +12350,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (yearly_decay_percent !== undefined) {
+        localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
+      }
+
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -12360,6 +12390,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12383,6 +12414,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       resource_type?: Array<LearningResourcesUserSubscriptionListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/learning_resources_user_subscription/`
@@ -12477,6 +12509,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (yearly_decay_percent !== undefined) {
+        localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
+      }
+
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -12514,6 +12550,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12539,6 +12576,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -12636,6 +12674,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (topic) {
         localVarQueryParameter["topic"] = topic
+      }
+
+      if (yearly_decay_percent !== undefined) {
+        localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
 
       localVarHeaderParameter["Content-Type"] = "application/json"
@@ -12746,6 +12788,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12770,6 +12813,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -12799,6 +12843,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
+          yearly_decay_percent,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -12836,6 +12881,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -12859,6 +12905,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       resource_type?: Array<LearningResourcesUserSubscriptionListResourceTypeEnum>,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -12887,6 +12934,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           resource_type,
           sortby,
           topic,
+          yearly_decay_percent,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -12925,6 +12973,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12950,6 +12999,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
+      yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -12977,6 +13027,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
+          yearly_decay_percent,
           PercolateQuerySubscriptionRequestRequest,
           options,
         )
@@ -13071,6 +13122,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
+          requestParameters.yearly_decay_percent,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -13107,6 +13159,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.resource_type,
           requestParameters.sortby,
           requestParameters.topic,
+          requestParameters.yearly_decay_percent,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -13144,6 +13197,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
+          requestParameters.yearly_decay_percent,
           requestParameters.PercolateQuerySubscriptionRequestRequest,
           options,
         )
@@ -13315,6 +13369,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly topic?: Array<string>
+
+  /**
+   * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly yearly_decay_percent?: number | null
 }
 
 /**
@@ -13455,6 +13516,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly topic?: Array<string>
+
+  /**
+   * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly yearly_decay_percent?: number | null
 }
 
 /**
@@ -13604,6 +13672,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly topic?: Array<string>
 
   /**
+   * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly yearly_decay_percent?: number | null
+
+  /**
    *
    * @type {PercolateQuerySubscriptionRequestRequest}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
@@ -13666,6 +13741,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
+        requestParameters.yearly_decay_percent,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13704,6 +13780,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.resource_type,
         requestParameters.sortby,
         requestParameters.topic,
+        requestParameters.yearly_decay_percent,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -13743,6 +13820,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
+        requestParameters.yearly_decay_percent,
         requestParameters.PercolateQuerySubscriptionRequestRequest,
         options,
       )

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -42,10 +42,13 @@ import type {
 import _ from "lodash"
 import { ResourceCategoryTabs } from "./ResourceCategoryTabs"
 import ProfessionalToggle from "./ProfessionalToggle"
+import StalenessPenaltySlider from "./StalenessPenaltySlider"
+
 import type { TabConfig } from "./ResourceCategoryTabs"
 
 import { ResourceListCard } from "../ResourceCard/ResourceCard"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
+import { useUserMe } from "api/hooks/user"
 
 export const StyledSelect = styled(SimpleSelect)`
   min-width: 160px;
@@ -280,6 +283,10 @@ const FilterTitle = styled.div`
   align-items: center;
   margin-bottom: 8px;
   color: ${({ theme }) => theme.custom.colors.darkGray2};
+`
+
+const AdminOptionsTitle = styled(FilterTitle)`
+  margin-top: 20px;
 `
 
 const FacetsTitleContainer = styled.div`
@@ -518,6 +525,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       resource_category: activeTab.resource_category
         ? [activeTab.resource_category]
         : undefined,
+      yearly_decay_percent: searchParams.get("yearly_decay_percent"),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",
@@ -525,6 +533,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       offset: (page - 1) * PAGE_SIZE,
     }
   }, [
+    searchParams,
     requestParams,
     constantSearchParams,
     activeTab?.resource_category,
@@ -536,6 +545,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     allParams as LRSearchRequest,
     { keepPreviousData: true },
   )
+
+  const { data: user } = useUserMe()
 
   const [mobileDrawerOpen, setMobileDrawerOpen] = React.useState(false)
 
@@ -601,6 +612,23 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               ) : null}
             </FacetsTitleContainer>
             {filterContents}
+            {user?.is_learning_path_editor ? (
+              <div>
+                <AdminOptionsTitle>
+                  <div>
+                    <Typography variant="subtitle1">Admin Options</Typography>
+                  </div>
+                </AdminOptionsTitle>
+                <StalenessPenaltySlider
+                  stalenessSliderSetting={
+                    searchParams.get("yearly_decay_percent")
+                      ? Number(searchParams.get("yearly_decay_percent"))
+                      : 0
+                  }
+                  setSearchParams={setSearchParams}
+                />
+              </div>
+            ) : null}
           </DesktopFiltersColumn>
           <StyledMainColumn variant="main-2">
             <DesktopSortContainer>{sortDropdown}</DesktopSortContainer>
@@ -656,6 +684,25 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                     </MobileFacetSearchButtons>
                   ) : null}
                   {filterContents}
+                  {user?.is_learning_path_editor ? (
+                    <div>
+                      <AdminOptionsTitle>
+                        <div>
+                          <Typography variant="subtitle3">
+                            Admin Options
+                          </Typography>
+                        </div>
+                      </AdminOptionsTitle>
+                      <StalenessPenaltySlider
+                        stalenessSliderSetting={
+                          searchParams.get("yearly_decay_percent")
+                            ? Number(searchParams.get("yearly_decay_percent"))
+                            : 0
+                        }
+                        setSearchParams={setSearchParams}
+                      />
+                    </div>
+                  ) : null}
                 </StyledDrawer>
                 <MobileSortContainer>{sortDropdown}</MobileSortContainer>
               </MobileFilter>

--- a/frontends/mit-open/src/page-components/SearchDisplay/StalenessPenaltySlider.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/StalenessPenaltySlider.tsx
@@ -1,0 +1,50 @@
+import * as React from "react"
+import { Slider, styled, css } from "ol-components"
+
+const ExplanationContainer = styled.div`
+  font-size: 0.875em;
+`
+const StalenessTitleContainer = styled.div`
+  ${({ theme }) => css({ ...theme.typography.subtitle2 })}
+  font-size: 0.875em;
+  font-style: normal;
+  margin-top: 10px;
+`
+
+const StalenessPenaltySlider: React.FC<{
+  stalenessSliderSetting: number
+  setSearchParams: (fn: (prev: URLSearchParams) => URLSearchParams) => void
+}> = ({ stalenessSliderSetting, setSearchParams }) => {
+  const handleChange = (event: Event, newValue: number | number[]) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev)
+      next.set("yearly_decay_percent", newValue.toString())
+      return next
+    })
+  }
+
+  return (
+    <div>
+      <StalenessTitleContainer>
+        Resource Score Staleness Penalty
+      </StalenessTitleContainer>
+      <div>
+        <Slider
+          data-testid="staleness-slider"
+          value={stalenessSliderSetting || 0}
+          onChange={handleChange}
+          valueLabelDisplay="auto"
+          min={0}
+          max={10}
+          step={0.2}
+        />
+        <ExplanationContainer>
+          Relavance score penalty percent per year for resources without
+          upcoming runs. Only affects results if there is a search term.
+        </ExplanationContainer>
+      </div>
+    </div>
+  )
+}
+
+export default StalenessPenaltySlider

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -213,6 +213,98 @@ describe("SearchPage", () => {
     await user.click(screen.getByRole("button", { name: "Search" }))
     expect(location.current.search).toBe("?q=woof")
   })
+
+  test("unathenticated users do not see admin options", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            resource_category: [
+              { key: "course", doc_count: 100 },
+              { key: "learning_material", doc_count: 200 },
+            ],
+            resource_type: [
+              { key: "course", doc_count: 100 },
+              { key: "podcast", doc_count: 100 },
+              { key: "video", doc_count: 100 },
+            ],
+          },
+          suggestions: [],
+        },
+      },
+    })
+
+    setMockResponse.get(urls.userMe.get(), {})
+
+    renderWithProviders(<SearchPage />)
+    await waitFor(() => {
+      const adminOptions = screen.queryByText("Admin Options")
+      expect(adminOptions).toBeNull()
+    })
+  })
+
+  test("non admin users do not see admin options", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            resource_category: [
+              { key: "course", doc_count: 100 },
+              { key: "learning_material", doc_count: 200 },
+            ],
+            resource_type: [
+              { key: "course", doc_count: 100 },
+              { key: "podcast", doc_count: 100 },
+              { key: "video", doc_count: 100 },
+            ],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    setMockResponse.get(urls.userMe.get(), {
+      is_authenticated: true,
+      is_learning_path_editor: false,
+    })
+    renderWithProviders(<SearchPage />)
+
+    await waitFor(() => {
+      const adminOptions = screen.queryByText("Admin Options")
+      expect(adminOptions).toBeNull()
+    })
+  })
+
+  test("admin users can set the staleness slider", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            resource_category: [
+              { key: "course", doc_count: 100 },
+              { key: "learning_material", doc_count: 200 },
+            ],
+            resource_type: [
+              { key: "course", doc_count: 100 },
+              { key: "podcast", doc_count: 100 },
+              { key: "video", doc_count: 100 },
+            ],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: true,
+    })
+    renderWithProviders(<SearchPage />)
+    await waitFor(() => {
+      screen.getByText("Admin Options")
+      screen.getByTestId("staleness-slider")
+    })
+  })
 })
 
 describe("Search Page Tabs", () => {

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -158,6 +158,7 @@ export type { StepIconProps } from "@mui/material/StepIcon"
 
 export { default as CircularProgress } from "@mui/material/CircularProgress"
 export { default as FormGroup } from "@mui/material/FormGroup"
+export { default as Slider } from "@mui/material/Slider"
 
 export * from "./components/Alert/Alert"
 export * from "./components/BasicDialog/BasicDialog"

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -248,6 +248,7 @@ LEARNING_RESOURCE_MAP = {
         },
     },
     "next_start_date": {"type": "date"},
+    "resource_age_date": {"type": "date"},
 }
 
 
@@ -372,4 +373,5 @@ SOURCE_EXCLUDED_FIELDS = [
     "course.course_numbers.primary",
     "resource_relations",
     "is_learning_material",
+    "resource_age_date",
 ]

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -2,10 +2,12 @@
 
 import logging
 from collections import OrderedDict, defaultdict
+from datetime import UTC, datetime
 from typing import TypedDict
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from drf_spectacular.plumbing import build_choice_description_list
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -50,11 +52,62 @@ from main.serializers import (
 log = logging.getLogger()
 
 
+OCW_SEMESTER_TO_MONTH_MAPPING = {
+    "Fall": 9,
+    "Spring": 3,
+    "January IAP": 1,
+    "Summer": 6,
+    None: 1,
+}
+
+
 class SearchCourseNumberSerializer(CourseNumberSerializer):
     """Serializer for CourseNumber, including extra fields for search"""
 
     primary = serializers.BooleanField()
     sort_coursenum = serializers.CharField()
+
+
+def get_resource_age_date(learning_resource_obj, resource_category):
+    """
+    Get the internal resource_age_date which measures how stale a resource is.
+    Resources with upcoming runs have a resource_age_date of null. Otherwise the
+    date is the last modified date for learning materials or the start date of the
+    last run for courses.
+    """
+
+    resource_age_date = None
+
+    if resource_category == LEARNING_MATERIAL_RESOURCE_CATEGORY:
+        resource_age_date = learning_resource_obj.last_modified
+    elif (
+        learning_resource_obj.resource_type == LearningResourceType.course.name
+        and not learning_resource_obj.next_start_date
+    ):
+        last_run = (
+            learning_resource_obj.runs.filter(Q(published=True))
+            .order_by("start_date")
+            .last()
+        )
+
+        if last_run:
+            if (
+                last_run.year is not None
+                and learning_resource_obj.offered_by
+                and learning_resource_obj.offered_by.code == OfferedBy.ocw.name
+            ):
+                resource_age_date = datetime(
+                    last_run.year,
+                    OCW_SEMESTER_TO_MONTH_MAPPING.get(last_run.semester),
+                    1,
+                    0,
+                    0,
+                    tzinfo=UTC,
+                )
+            else:
+                resource_age_date = last_run.start_date
+
+    return resource_age_date
 
 
 def serialize_learning_resource_for_update(
@@ -71,8 +124,7 @@ def serialize_learning_resource_for_update(
 
     """
     serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
-    # Note: this is an ES-specific field that is filtered out on retrieval
-    #       see SOURCE_EXCLUDED_FIELDS in learning_resources_search/constants.py
+
     if learning_resource_obj.resource_type == LearningResourceType.course.name:
         serialized_data["course"]["course_numbers"] = [
             SearchCourseNumberSerializer(instance=num).data
@@ -83,6 +135,9 @@ def serialize_learning_resource_for_update(
         "created_on": learning_resource_obj.created_on,
         "is_learning_material": serialized_data["resource_category"]
         == LEARNING_MATERIAL_RESOURCE_CATEGORY,
+        "resource_age_date": get_resource_age_date(
+            learning_resource_obj, serialized_data["resource_category"]
+        ),
         **serialized_data,
     }
 
@@ -248,6 +303,18 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         allow_null=True,
         default=None,
     )
+    yearly_decay_percent = serializers.FloatField(
+        max_value=10,
+        min_value=0,
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text=(
+            "Relevance score penalty percent per year for for resources without "
+            "upcoming runs. Only affects results if there is a search term."
+        ),
+    )
+
     certification = ArrayWrappedBoolean(
         required=False,
         allow_null=True,

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -1,6 +1,7 @@
 """Tests for opensearch serializers"""
 
 from copy import deepcopy
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 
@@ -15,6 +16,7 @@ from rest_framework.test import APIRequestFactory
 from learning_resources import factories
 from learning_resources.constants import (
     DEPARTMENTS,
+    LEARNING_MATERIAL_RESOURCE_CATEGORY,
     CertificationType,
     LearningResourceType,
 )
@@ -41,6 +43,7 @@ from learning_resources_search.serializers import (
     LearningResourcesSearchRequestSerializer,
     LearningResourcesSearchResponseSerializer,
     extract_values,
+    get_resource_age_date,
     serialize_percolate_query,
 )
 from main.factories import UserFactory
@@ -572,7 +575,9 @@ def test_serialize_bulk_learning_resources(mocker):
 )
 @pytest.mark.parametrize("is_professional", [True, False])
 @pytest.mark.parametrize("no_price", [True, False])
-def test_serialize_learning_resource_for_bulk(resource_type, is_professional, no_price):
+def test_serialize_learning_resource_for_bulk(
+    mocker, resource_type, is_professional, no_price
+):
     """
     Test that serialize_program_for_bulk yields a valid LearningResourceSerializer for resource types other than "course"
     The "course" resource type is tested by `test_serialize_course_numbers_for_bulk` below.
@@ -588,14 +593,86 @@ def test_serialize_learning_resource_for_bulk(resource_type, is_professional, no
         not in [LearningResourceType.program.name, LearningResourceType.course.name]
         or (no_price and not is_professional)
     }
+
+    mocker.patch(
+        "learning_resources_search.serializers.get_resource_age_date",
+        return_value=datetime(2024, 1, 1, 1, 1, 1, 0, tzinfo=UTC),
+    )
+
     assert serializers.serialize_learning_resource_for_bulk(resource) == {
         "_id": resource.id,
         "resource_relations": {"name": "resource"},
         "created_on": resource.created_on,
         "is_learning_material": resource.resource_type not in ["course", "program"],
+        "resource_age_date": datetime(2024, 1, 1, 1, 1, 1, 0, tzinfo=UTC),
         **free_dict,
         **LearningResourceSerializer(resource).data,
     }
+
+
+@pytest.mark.django_db()
+def test_get_resource_age_date():
+    ocw_offeror = factories.LearningResourceOfferorFactory.create(is_ocw=True)
+
+    mitx_offeror = factories.LearningResourceOfferorFactory.create(is_mitx=True)
+
+    podcast = factories.LearningResourceFactory.create(
+        resource_type=LearningResourceType.podcast_episode.name
+    )
+    assert (
+        get_resource_age_date(podcast, LEARNING_MATERIAL_RESOURCE_CATEGORY)
+        == podcast.last_modified
+    )
+
+    program = factories.LearningResourceFactory.create(
+        resource_type=LearningResourceType.program.name
+    )
+    assert get_resource_age_date(program, LearningResourceType.program.name) is None
+
+    upcoming_course = factories.LearningResourceFactory.create(
+        is_course=True,
+        next_start_date=datetime.now(tz=UTC) + timedelta(days=1),
+    )
+    assert (
+        get_resource_age_date(upcoming_course, LearningResourceType.course.name) is None
+    )
+
+    past_course = factories.LearningResourceFactory.create(
+        is_course=True, runs=[], offered_by=mitx_offeror, next_start_date=None
+    )
+    last_run = LearningResourceRunFactory.create(
+        learning_resource=past_course,
+        start_date=datetime.now(tz=UTC) - timedelta(days=1),
+    )
+    LearningResourceRunFactory.create(
+        learning_resource=past_course,
+        start_date=datetime.now(tz=UTC) - timedelta(days=100),
+    )
+    assert (
+        get_resource_age_date(past_course, LearningResourceType.course.name)
+        == last_run.start_date
+    )
+
+    ocw_course = factories.LearningResourceFactory.create(
+        is_course=True, runs=[], offered_by=ocw_offeror, next_start_date=None
+    )
+    ocw_run = LearningResourceRunFactory.create(
+        learning_resource=ocw_course,
+        start_date=datetime.now(tz=UTC) - timedelta(days=1),
+        semester="Spring",
+        year=2024,
+    )
+
+    assert get_resource_age_date(
+        ocw_course, LearningResourceType.course.name
+    ) == datetime(
+        ocw_run.year,
+        3,
+        1,
+        0,
+        0,
+        tzinfo=UTC,
+    )
 
 
 @pytest.mark.django_db()
@@ -606,7 +683,7 @@ def test_serialize_learning_resource_for_bulk(resource_type, is_professional, no
     ("extra_num", "sorted_extra_num"), [("2", "02"), ("16", "16"), ("CC", "CC")]
 )
 def test_serialize_course_numbers_for_bulk(
-    readable_id, sort_course_num, extra_num, sorted_extra_num
+    mocker, readable_id, sort_course_num, extra_num, sorted_extra_num
 ):
     """
     Test that serialize_course_for_bulk yields a valid LearningResourceSerializer
@@ -634,12 +711,18 @@ def test_serialize_course_numbers_for_bulk(
         course_numbers=course_numbers
     ).learning_resource
     assert resource.course.course_numbers == course_numbers
+
+    mocker.patch(
+        "learning_resources_search.serializers.get_resource_age_date",
+        return_value=datetime(2024, 1, 1, 1, 1, 1, 0, tzinfo=UTC),
+    )
     expected_data = {
         "_id": resource.id,
         "resource_relations": {"name": "resource"},
         "created_on": resource.created_on,
         "free": False,
         "is_learning_material": False,
+        "resource_age_date": datetime(2024, 1, 1, 1, 1, 1, 0, tzinfo=UTC),
         **LearningResourceSerializer(resource).data,
     }
     expected_data["course"]["course_numbers"][0] = {
@@ -726,6 +809,7 @@ def test_learning_resources_search_request_serializer():
         "level": ["high_school", "undergraduate"],
         "course_feature": ["Lecture Videos"],
         "aggregations": ["resource_type", "platform", "level", "resource_category"],
+        "yearly_decay_percent": "0.25",
     }
 
     cleaned = {
@@ -746,6 +830,7 @@ def test_learning_resources_search_request_serializer():
         "level": ["high_school", "undergraduate"],
         "course_feature": ["Lecture Videos"],
         "aggregations": ["resource_type", "platform", "level", "resource_category"],
+        "yearly_decay_percent": 0.25,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2534,6 +2534,16 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: yearly_decay_percent
+        schema:
+          type: number
+          format: double
+          maximum: 10
+          minimum: 0
+          nullable: true
+        description: Relevance score penalty percent per year for for resources without
+          upcoming runs. Only affects results if there is a search term.
       tags:
       - learning_resources_search
       responses:
@@ -2953,6 +2963,16 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: yearly_decay_percent
+        schema:
+          type: number
+          format: double
+          maximum: 10
+          minimum: 0
+          nullable: true
+        description: Relevance score penalty percent per year for for resources without
+          upcoming runs. Only affects results if there is a search term.
       tags:
       - learning_resources_user_subscription
       responses:
@@ -3411,6 +3431,16 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: yearly_decay_percent
+        schema:
+          type: number
+          format: double
+          maximum: 10
+          minimum: 0
+          nullable: true
+        description: Relevance score penalty percent per year for for resources without
+          upcoming runs. Only affects results if there is a search term.
       tags:
       - learning_resources_user_subscription
       responses:
@@ -3846,6 +3876,16 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: yearly_decay_percent
+        schema:
+          type: number
+          format: double
+          maximum: 10
+          minimum: 0
+          nullable: true
+        description: Relevance score penalty percent per year for for resources without
+          upcoming runs. Only affects results if there is a search term.
       tags:
       - learning_resources_user_subscription
       requestBody:
@@ -9460,6 +9500,14 @@ components:
         professional:
           type: boolean
           nullable: true
+        yearly_decay_percent:
+          type: number
+          format: double
+          maximum: 10
+          minimum: 0
+          nullable: true
+          description: Relevance score penalty percent per year for for resources
+            without upcoming runs. Only affects results if there is a search term.
         certification:
           type: boolean
           nullable: true


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4839

### Description (What does it do?)
This pr adds a parameter to search which adds a penalty to the scores of older resources when there is a search tearm. A toggle that is only visible to admins on the search page that makes it possible to control the size of the penalty. Resources with upcoming runs receive no penalty. For videos and podcast episodes the penalty is calculated from the last modified date received from the source. For courses the penalty is calculated from the start date of the last run. 

The penalty is in % per year (linear). So if the penalty is 5% and the resource is 2 years old then the relevance score for the resource is multiplied 0.9 to get the order that the resource is displayed in.

### Screenshots (if appropriate):
<img width="1698" alt="Screenshot 2024-07-19 at 10 48 39 AM" src="https://github.com/user-attachments/assets/692b154e-ffb7-4ed6-b8d5-08c5020e7f09">

### How can this be tested?
Run 
docker-compose run web ./manage.py recreate_index --all
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 18-417-introduction-to-computational-molecular-biology-fall-2004

Verify that you search for "Molecular Biology" in search the course from 2004 is shown as one of the first results.

Verify that you see a toggle for "Resource Score Staleness Penalty" when you log in as an admin but not when you log in as a non-admin or are not logged in. 

Search again for "Molecular Biology". As you move the slider the course from 2005 moves further down the ranking


### Additional Context
If you try to set the staleness penalty before you recreate the index you will see no results. I'm not sure if people outside our team have admin access to prod yet. I will talk to Ferdi about whether it makes sense to break the ui component into a separate PR so it's not visible until the recreate_index job adding `resource_age_date` to the index runs