### PR TITLE
Fix bug with background image obscuring search controls

### DIFF
--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -26,6 +26,8 @@ const ColoredHeader = styled.div`
     height: 75px;
   }
 
+  position: relative;
+  z-index: -1;
   display: flex;
   align-items: center;
   background: #eb01a5;
@@ -40,7 +42,7 @@ const BackgroundImage = styled.img`
   position: absolute;
   float: left;
   width: 35%;
-  top: 60px;
+  top: 0;
   left: 0;
   ${({ theme }) => theme.breakpoints.down("md")} {
     display: none;


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/4808

### Description (What does it do?)
<!--- Describe your changes in detail -->

Gives the offending image container a z-index of -1 so it lives behind the search utils.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

The bug was present at screen widths where the background image looks like this:

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/dd87a083-8352-4a52-bf48-9b553bf5aafa">

- Navigate to e.g. /search/?certification_type=none

- Confirm that the page renders as previously at all screen widths.

- Confirm the "Clear all" is clickable.