### PR TITLE
fix restricted redirect

### DIFF
--- a/frontends/mit-open/package.json
+++ b/frontends/mit-open/package.json
@@ -9,8 +9,7 @@
   },
   "scripts": {
     "watch": "NODE_ENV=development ENVIRONMENT=local webpack serve",
-    "watch:docker": "API_DEV_PROXY_BASE_URL=http://nginx:8063 NODE_ENV=development ENVIRONMENT=docker webpack serve",
-    "watch:rc": "API_DEV_PROXY_BASE_URL=https://api.mitopen-rc.odl.mit.edu/ NODE_ENV=development ENVIRONMENT=local webpack serve",
+    "watch:docker": "NODE_ENV=development ENVIRONMENT=docker webpack serve",
     "build": "webpack --config webpack.config.js --bail",
     "build-exports": "webpack --config webpack.exports.js --bail",
     "storybook": "storybook dev -p 6006",

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -66,6 +66,13 @@ export const login = ({
   return `${LOGIN}?next=${next}`
 }
 
+export const next = () => {
+  const path = window.location.pathname
+  const search = window.location.search
+  const hash = window.location.hash
+  return encodeURIComponent(`${path}${search}${hash}`)
+}
+
 export const DASHBOARD = "/dashboard/"
 
 export const SEARCH = "/search/"

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -50,9 +50,11 @@ export const LOGOUT = `${process.env.MITOPEN_API_BASE_URL}/logout/`
 export const login = ({
   pathname = "/",
   search = "",
+  hash = "",
 }: {
   pathname?: string
   search?: string
+  hash?: string
 } = {}) => {
   /**
    * To include search parameters in the next URL, we need to encode them.
@@ -62,15 +64,8 @@ export const login = ({
    * There's no need to encode the path parameter (it might contain slashes,
    * but those are allowed in search parameters) so let's keep it readable.
    */
-  const next = `${window.location.origin}${pathname}${encodeURIComponent(search)}`
+  const next = `${window.location.origin}${pathname}${encodeURIComponent(search)}${encodeURIComponent(hash)}`
   return `${LOGIN}?next=${next}`
-}
-
-export const next = () => {
-  const path = window.location.pathname
-  const search = window.location.search
-  const hash = window.location.hash
-  return encodeURIComponent(`${path}${search}${hash}`)
 }
 
 export const DASHBOARD = "/dashboard/"

--- a/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.test.tsx
+++ b/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.test.tsx
@@ -65,6 +65,10 @@ test("Renders child routes if permission check satisfied.", () => {
 test.each(Object.values(Permissions))(
   "Throws error if and only if lacking required permission",
   async (permission) => {
+    // if a user is not authenticated they are redirected to login before an error is thrown
+    if (permission === Permissions.Authenticated) {
+      return
+    }
     const errors: unknown[] = []
 
     allowConsoleErrors()

--- a/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
+++ b/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
@@ -1,8 +1,8 @@
 import React from "react"
-import { Outlet } from "react-router"
+import { Outlet, useLocation } from "react-router"
 import { ForbiddenError, Permissions } from "@/common/permissions"
 import { useUserMe } from "api/hooks/user"
-import { login, next } from "@/common/urls"
+import { login } from "@/common/urls"
 
 type RestrictedRouteProps = {
   children?: React.ReactNode
@@ -39,11 +39,12 @@ const RestrictedRoute: React.FC<RestrictedRouteProps> = ({
   children,
   requires,
 }) => {
+  const location = useLocation()
   const { isLoading, data: user } = useUserMe()
   if (isLoading) return null
   if (!user?.is_authenticated) {
     // Redirect unauthenticated users to login
-    window.location.assign(login({ pathname: next() }))
+    window.location.assign(login(location))
     return null
   }
   if (!isLoading && !user?.[requires]) {

--- a/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
+++ b/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { Outlet } from "react-router"
 import { ForbiddenError, Permissions } from "@/common/permissions"
 import { useUserMe } from "api/hooks/user"
-import { login } from "@/common/urls"
+import { login, next } from "@/common/urls"
 
 type RestrictedRouteProps = {
   children?: React.ReactNode
@@ -43,9 +43,7 @@ const RestrictedRoute: React.FC<RestrictedRouteProps> = ({
   if (isLoading) return null
   if (!user?.is_authenticated) {
     // Redirect unauthenticated users to login
-    window.location.assign(
-      login({ pathname: `/login/ol-oidc/?next=${location.pathname}` }),
-    )
+    window.location.assign(login({ pathname: next() }))
     return null
   }
   if (!isLoading && !user?.[requires]) {

--- a/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
+++ b/frontends/mit-open/src/components/RestrictedRoute/RestrictedRoute.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Outlet } from "react-router"
 import { ForbiddenError, Permissions } from "@/common/permissions"
 import { useUserMe } from "api/hooks/user"
+import { login } from "@/common/urls"
 
 type RestrictedRouteProps = {
   children?: React.ReactNode
@@ -40,6 +41,13 @@ const RestrictedRoute: React.FC<RestrictedRouteProps> = ({
 }) => {
   const { isLoading, data: user } = useUserMe()
   if (isLoading) return null
+  if (!user?.is_authenticated) {
+    // Redirect unauthenticated users to login
+    window.location.assign(
+      login({ pathname: `/login/ol-oidc/?next=${location.pathname}` }),
+    )
+    return null
+  }
   if (!isLoading && !user?.[requires]) {
     // This error should be caught by an [`errorElement`](https://reactrouter.com/en/main/route/error-element).
     throw new ForbiddenError("Not allowed.")

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { waitFor } from "@testing-library/react"
 import { renderWithProviders, screen } from "../../test-utils"
-import { HOME, login } from "@/common/urls"
+import { HOME, login, next } from "@/common/urls"
 import ForbiddenPage from "./ForbiddenPage"
 import { setMockResponse, urls } from "api/test-utils"
 import { Permissions } from "@/common/permissions"
@@ -62,7 +62,7 @@ test("Redirects unauthenticated users to login", async () => {
   renderWithProviders(<ForbiddenPage />)
 
   const expectedUrl = login({
-    pathname: `/login/ol-oidc/?next=${location.pathname}`,
+    pathname: next(),
   })
   expect(window.location.assign).toHaveBeenCalledWith(expectedUrl)
 })

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { waitFor } from "@testing-library/react"
 import { renderWithProviders, screen } from "../../test-utils"
-import { HOME } from "@/common/urls"
+import { HOME, login } from "@/common/urls"
 import ForbiddenPage from "./ForbiddenPage"
 import { setMockResponse, urls } from "api/test-utils"
 import { Permissions } from "@/common/permissions"
@@ -61,5 +61,8 @@ test("Redirects unauthenticated users to login", async () => {
   })
   renderWithProviders(<ForbiddenPage />)
 
-  expect(window.location.assign).toHaveBeenCalledWith("/login/ol-oidc/?next=/")
+  const expectedUrl = login({
+    pathname: `/login/ol-oidc/?next=${location.pathname}`,
+  })
+  expect(window.location.assign).toHaveBeenCalledWith(expectedUrl)
 })

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { waitFor } from "@testing-library/react"
 import { renderWithProviders, screen } from "../../test-utils"
-import { HOME, login, next } from "@/common/urls"
+import { HOME, login } from "@/common/urls"
 import ForbiddenPage from "./ForbiddenPage"
 import { setMockResponse, urls } from "api/test-utils"
 import { Permissions } from "@/common/permissions"
@@ -59,10 +59,12 @@ test("Redirects unauthenticated users to login", async () => {
   setMockResponse.get(urls.userMe.get(), {
     [Permissions.Authenticated]: false,
   })
-  renderWithProviders(<ForbiddenPage />)
+  renderWithProviders(<ForbiddenPage />, { url: "/some/url?foo=bar#baz" })
 
   const expectedUrl = login({
-    pathname: next(),
+    pathname: "/some/url",
+    search: "?foo=bar",
+    hash: "#baz",
   })
   expect(window.location.assign).toHaveBeenCalledWith(expectedUrl)
 })

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
@@ -2,14 +2,16 @@ import React, { useEffect } from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
 import { useUserMe } from "api/hooks/user"
 import { Typography } from "ol-components"
-import { login, next } from "@/common/urls"
+import { login } from "@/common/urls"
+import { useLocation } from "react-router"
 
 const ForbiddenPage: React.FC = () => {
+  const location = useLocation()
   const { data: user } = useUserMe()
 
   useEffect(() => {
     if (!user?.is_authenticated) {
-      window.location.assign(login({ pathname: next() }))
+      window.location.assign(login(location))
     }
   })
   return (

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
@@ -1,19 +1,15 @@
 import React, { useEffect } from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
-import { useLocation } from "react-router"
 import { useUserMe } from "api/hooks/user"
 import { Typography } from "ol-components"
-import { login } from "@/common/urls"
+import { login, next } from "@/common/urls"
 
 const ForbiddenPage: React.FC = () => {
   const { data: user } = useUserMe()
-  const location = useLocation()
 
   useEffect(() => {
     if (!user?.is_authenticated) {
-      window.location.assign(
-        login({ pathname: `/login/ol-oidc/?next=${location.pathname}` }),
-      )
+      window.location.assign(login({ pathname: next() }))
     }
   })
   return (

--- a/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
+++ b/frontends/mit-open/src/pages/ErrorPage/ForbiddenPage.tsx
@@ -3,6 +3,7 @@ import ErrorPageTemplate from "./ErrorPageTemplate"
 import { useLocation } from "react-router"
 import { useUserMe } from "api/hooks/user"
 import { Typography } from "ol-components"
+import { login } from "@/common/urls"
 
 const ForbiddenPage: React.FC = () => {
   const { data: user } = useUserMe()
@@ -10,7 +11,9 @@ const ForbiddenPage: React.FC = () => {
 
   useEffect(() => {
     if (!user?.is_authenticated) {
-      window.location.assign(`/login/ol-oidc/?next=${location.pathname}`)
+      window.location.assign(
+        login({ pathname: `/login/ol-oidc/?next=${location.pathname}` }),
+      )
     }
   })
   return (

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -30,7 +30,6 @@ const {
   ENVIRONMENT,
   PORT,
   MITOPEN_API_BASE_URL,
-  API_DEV_PROXY_BASE_URL,
   WEBPACK_ANALYZE,
   SITE_NAME,
   MITOPEN_SUPPORT_EMAIL,
@@ -50,11 +49,6 @@ const {
   MITOPEN_API_BASE_URL: str({
     desc: "Base URL for API requests",
     devDefault: "",
-  }),
-  API_DEV_PROXY_BASE_URL: str({
-    desc: "API base URL to proxy to in development mode",
-    default: "",
-    devDefault: process.env.MITOPEN_APP_BASE_URL,
   }),
   WEBPACK_ANALYZE: bool({
     desc: "Whether to run webpack bundle analyzer",
@@ -269,24 +263,6 @@ module.exports = (env, argv) => {
         writeToDisk: true,
       },
       host: "0.0.0.0",
-      proxy: [
-        {
-          context: [
-            "/api",
-            "/login",
-            "/logout",
-            "/admin",
-            "/static/admin",
-            "/static/hijack",
-          ],
-          target: API_DEV_PROXY_BASE_URL || MITOPEN_API_BASE_URL,
-          changeOrigin: true,
-          secure: false,
-          headers: {
-            Origin: API_DEV_PROXY_BASE_URL || MITOPEN_API_BASE_URL,
-          },
-        },
-      ],
     },
   }
   return withCKEditor(config)

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -30,6 +30,7 @@ const {
   ENVIRONMENT,
   PORT,
   MITOPEN_API_BASE_URL,
+  API_DEV_PROXY_BASE_URL,
   WEBPACK_ANALYZE,
   SITE_NAME,
   MITOPEN_SUPPORT_EMAIL,
@@ -48,6 +49,11 @@ const {
   }),
   MITOPEN_API_BASE_URL: str({
     desc: "Base URL for API requests",
+    devDefault: "",
+  }),
+  API_DEV_PROXY_BASE_URL: str({
+    desc: "API base URL to proxy to in development mode",
+    default: "",
     devDefault: "",
   }),
   WEBPACK_ANALYZE: bool({
@@ -263,6 +269,26 @@ module.exports = (env, argv) => {
         writeToDisk: true,
       },
       host: "0.0.0.0",
+      proxy: API_DEV_PROXY_BASE_URL
+        ? [
+            {
+              context: [
+                "/api",
+                "/login",
+                "/logout",
+                "/admin",
+                "/static/admin",
+                "/static/hijack",
+              ],
+              target: API_DEV_PROXY_BASE_URL,
+              changeOrigin: true,
+              secure: false,
+              headers: {
+                Origin: API_DEV_PROXY_BASE_URL,
+              },
+            },
+          ]
+        : [],
     },
   }
   return withCKEditor(config)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4888

### Description (What does it do?)
This PR makes some changes to the login / routing process:

 - The `proxy` section of the Webpack configuration for `webpack-dev-server` has been removed. Since the stock env files for local dev set `MITOPEN_API_BASE_URL` and `MITOPEN_APP_BASE_URL` to sane defaults, most people shouldn't have trouble and requests should be sent to the proper URL, rather than relying on `webpack-dev-server` proxying the request.
 - Instead of throwing a `ForbiddenError` in `RestrictedRoute` when `Permissions.Authenticated` is required and a user isn't logged in, they are simply redirected to the login flow.
 - Calls to the login redirect now include the query string and hash (document fragment) so if the user is on a page like `/dashboard#profile` or on a search page with filters applied (or they are sent a link), they will be properly brought back to where they were intending to go.

### How can this be tested?
 - Make sure you have Keycloak configured to point at a valid running instance. This could be https://sso-qa.ol.mit.edu, and if you need help setting it up just ask.
 - Make sure you have a local domain set up for your instance of `mit-open`. There are the default values, but you can create your own `shared.local.env` file (see readme for more info) to customize them:
```
MITOPEN_API_BASE_URL=http://api.open.odl.local:8063
MITOPEN_APP_BASE_URL=http://open.odl.local:8062
```
 - Open an incognito window, put http://open.odl.local:8062/dashboard#profile into your URL bar and hit enter
 - You should be brought to Keycloak. Proceed to enter your login details and complete the login process.
 - Verify that after logging in, you are properly brought to http://open.odl.local:8062/dashboard/#profile
