### PR TITLE
Revert "Fix bug with background image obscuring search controls"

### DIFF
--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -26,8 +26,6 @@ const ColoredHeader = styled.div`
     height: 75px;
   }
 
-  position: relative;
-  z-index: -1;
   display: flex;
   align-items: center;
   background: #eb01a5;
@@ -42,7 +40,7 @@ const BackgroundImage = styled.img`
   position: absolute;
   float: left;
   width: 35%;
-  top: 0;
+  top: 60px;
   left: 0;
   ${({ theme }) => theme.breakpoints.down("md")} {
     display: none;


### PR DESCRIPTION
Reverts mitodl/mit-open#1286

This fixes the searh input, which is broken on production.

### How should this be tested 
1. On `main`, visit the search page, and try to click the input box on top of page. You won't be able to.
2. Try on this branch.