### PR TITLE
fix price display and update vertical cards

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -1,60 +1,27 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceCard } from "./LearningResourceCard"
-import { ResourceTypeEnum } from "api"
+import {
+  LearningResourceCard,
+  LearningResourceCardProps,
+} from "./LearningResourceCard"
+import { LearningResource } from "api"
 import styled from "@emotion/styled"
-import { factories } from "api/test-utils"
 import { withRouter } from "storybook-addon-react-router-v6"
-
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  if (resource.image) {
-    resource.image.url =
-      "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  }
-  return resource
-}
+import Stack from "@mui/system/Stack"
+import _ from "lodash"
+import { resources, courses, resourceArgType } from "./story_utils"
 
 const LearningResourceCardStyled = styled(LearningResourceCard)`
   width: 300px;
 `
+type StoryProps = LearningResourceCardProps & {
+  excerpt: (keyof LearningResource)[]
+}
 
-const meta: Meta<typeof LearningResourceCard> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceCard",
   argTypes: {
-    resource: {
-      options: ["Loading", "Without Image", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        "Without Image": makeResource({
-          image: null,
-        }),
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     size: {
       options: ["small", "medium"],
       control: { type: "select" },
@@ -66,165 +33,118 @@ const meta: Meta<typeof LearningResourceCard> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    size,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-  }) => (
-    <LearningResourceCardStyled
-      resource={resource}
-      isLoading={isLoading}
-      size={size}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-    />
-  ),
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
+    return (
+      <Stack direction="row" gap="16px">
+        <LearningResourceCardStyled {...args} />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceCard>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Podcast }),
+    resource: resources.podcast,
     size: "small",
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.PodcastEpisode }),
+    resource: resources.podcastEpisode,
     size: "small",
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-    }),
+    resource: resources.video,
     size: "small",
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-    }),
+    resource: resources.videoPlaylist,
     size: "small",
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -88,11 +88,98 @@ export default meta
 
 type Story = StoryObj<typeof LearningResourceCard>
 
-export const Course: Story = {
+export const FreeCourseNoCertificate: Story = {
   args: {
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
+      free: true,
+      certification: false,
+      prices: [],
+    }),
+  },
+}
+
+export const FreeCourseWithCertificateOnePrice: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["250"],
+    }),
+  },
+}
+
+export const FreeCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["250", "1000"],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: [],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: [],
+    }),
+  },
+}
+
+export const PaidCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificateOnePrice: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["250", "1000"],
     }),
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -70,6 +70,7 @@ const Info = ({
       : prices?.certificate
         ? prices?.certificate
         : ""
+  const separator = size === "small" ? "" : ": "
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
@@ -86,7 +87,7 @@ const Info = ({
               <RiAwardFill />
             )}
             {size === "small" ? "" : "Certificate"}
-            {certificatePrice ? `: ${certificatePrice}` : ""}
+            {certificatePrice ? `${separator}${certificatePrice}` : ""}
           </Certificate>
         )}
         <Price>{prices?.course}</Price>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -21,6 +21,7 @@ import { TruncateText } from "../TruncateText/TruncateText"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { imgConfigs } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
+import { getDisplayPrices } from "./utils"
 
 const EllipsisTitle = styled(TruncateText)({
   margin: 0,
@@ -55,22 +56,30 @@ type ResourceIdCallback = (
 ) => void
 
 const Info = ({ resource }: { resource: LearningResource }) => {
+  const prices = getDisplayPrices(resource)
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
-      {resource.certification && (
-        <Certificate>
-          <RiAwardFill />
-          Certificate
-        </Certificate>
-      )}
+      <PriceContainer>
+        {resource.certification && (
+          <Certificate>
+            <RiAwardFill />
+            Certificate{prices?.certificate ? ":" : ""} {prices?.certificate}
+          </Certificate>
+        )}
+        <Price>{prices?.course}</Price>
+      </PriceContainer>
     </>
   )
 }
 
+const PriceContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`
+
 const Certificate = styled.div`
-  border-radius: 4px;
-  background-color: ${theme.custom.colors.lightGray1};
   padding: 2px 4px;
   color: ${theme.custom.colors.silverGrayDark};
 
@@ -83,6 +92,11 @@ const Certificate = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+`
+
+export const Price = styled.div`
+  ${{ ...theme.typography.subtitle3 }}
+  color: ${theme.custom.colors.darkGray2};
 `
 
 const isOcw = (resource: LearningResource) =>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -108,7 +108,9 @@ const PriceContainer = styled.div`
 
 const Certificate = styled.div`
   padding: 2px 4px;
+  border-radius: 4px;
   color: ${theme.custom.colors.silverGrayDark};
+  background-color: ${theme.custom.colors.lightGray1};
 
   ${{ ...theme.typography.subtitle4 }}
   svg {

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -22,6 +22,7 @@ import { ActionButton, ActionButtonProps } from "../Button/Button"
 import { imgConfigs } from "../../constants/imgConfigs"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { getDisplayPrices } from "./utils"
+import Tooltip from "@mui/material/Tooltip"
 
 const EllipsisTitle = styled(TruncateText)({
   margin: 0,
@@ -55,16 +56,37 @@ type ResourceIdCallback = (
   resourceId: number,
 ) => void
 
-const Info = ({ resource }: { resource: LearningResource }) => {
+const Info = ({
+  resource,
+  size,
+}: {
+  resource: LearningResource
+  size: Size
+}) => {
   const prices = getDisplayPrices(resource)
+  const certificatePrice =
+    size === "small" && prices?.certificate?.includes("–")
+      ? ""
+      : prices?.certificate
+        ? prices?.certificate
+        : ""
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
       <PriceContainer>
         {resource.certification && (
           <Certificate>
-            <RiAwardFill />
-            Certificate{prices?.certificate ? ":" : ""} {prices?.certificate}
+            {size === "small" ? (
+              <Tooltip title="Certificate">
+                <CertificateIconContainer>
+                  <RiAwardFill />
+                </CertificateIconContainer>
+              </Tooltip>
+            ) : (
+              <RiAwardFill />
+            )}
+            {size === "small" ? "" : "Certificate"}
+            {certificatePrice ? `: ${certificatePrice}` : ""}
           </Certificate>
         )}
         <Price>{prices?.course}</Price>
@@ -72,6 +94,11 @@ const Info = ({ resource }: { resource: LearningResource }) => {
     </>
   )
 }
+
+const CertificateIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+`
 
 const PriceContainer = styled.div`
   display: flex;
@@ -209,7 +236,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
         height={getImageDimensions(size, isMedia).height}
       />
       <Card.Info>
-        <Info resource={resource} />
+        <Info resource={resource} size={size} />
       </Card.Info>
       <Card.Title>
         <EllipsisTitle lineClamp={size === "small" ? 2 : 3}>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -87,7 +87,9 @@ const Info = ({
               <RiAwardFill />
             )}
             {size === "small" ? "" : "Certificate"}
-            {certificatePrice ? `${separator}${certificatePrice}` : ""}
+            <CertificatePrice>
+              {certificatePrice ? `${separator}${certificatePrice}` : ""}
+            </CertificatePrice>
           </Certificate>
         )}
         <Price>{prices?.course}</Price>
@@ -122,6 +124,10 @@ const Certificate = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+`
+
+const CertificatePrice = styled.div`
+  ${{ ...theme.typography.body4 }}
 `
 
 export const Price = styled.div`

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
@@ -1,50 +1,23 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceListCard } from "./LearningResourceListCard"
-import { ResourceTypeEnum } from "api"
-import { factories } from "api/test-utils"
+import {
+  LearningResourceListCard,
+  LearningResourceListCardProps,
+} from "./LearningResourceListCard"
+import { LearningResource } from "api"
 import { withRouter } from "storybook-addon-react-router-v6"
+import { resources, resourceArgType, courses } from "./story_utils"
+import Stack from "@mui/system/Stack"
+import _ from "lodash"
 
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  resource.image!.url =
-    "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  return resource
+type StoryProps = LearningResourceListCardProps & {
+  excerpt: (keyof LearningResource)[]
 }
 
-const meta: Meta<typeof LearningResourceListCard> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceListCard",
   argTypes: {
-    resource: {
-      options: ["Loading", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     onAddToLearningPathClick: {
       action: "click-add-to-learning-path",
     },
@@ -52,171 +25,118 @@ const meta: Meta<typeof LearningResourceListCard> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-    draggable,
-  }) => (
-    <LearningResourceListCard
-      resource={resource}
-      isLoading={isLoading}
-      href={`/?resource=${resource?.id}`}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-      draggable={draggable}
-    />
-  ),
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
+    return (
+      <Stack gap="16px">
+        <LearningResourceListCard
+          {...args}
+          href={`?resource=${args.resource?.id}`}
+        />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceListCard>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Podcast,
-      free: true,
-    }),
+    resource: resources.podcast,
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.PodcastEpisode,
-      free: true,
-    }),
+    resource: resources.podcastEpisode,
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-      free: true,
-    }),
+    resource: resources.video,
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-      free: true,
-    }),
+    resource: resources.videoPlaylist,
   },
 }
 
@@ -228,10 +148,7 @@ export const Loading: Story = {
 
 export const Draggable: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-    }),
+    resource: resources.course,
     draggable: true,
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
@@ -75,26 +75,98 @@ export default meta
 
 type Story = StoryObj<typeof LearningResourceListCard>
 
-export const PaidCourse: Story = {
+export const FreeCourseNoCertificate: Story = {
   args: {
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["999"],
+      free: true,
+      certification: false,
+      prices: [],
     }),
   },
 }
 
-export const FreeCourse: Story = {
+export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
       free: true,
       certification: true,
-      prices: ["0", "400"],
+      prices: ["250"],
+    }),
+  },
+}
+
+export const FreeCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["250", "1000"],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: [],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: [],
+    }),
+  },
+}
+
+export const PaidCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificateOnePrice: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["250", "1000"],
     }),
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -211,7 +211,7 @@ describe("Learning Resource List Card", () => {
       })
       setup(resource)
       screen.getByText("Certificate")
-      screen.getByText(": $49 - $99")
+      screen.getByText(": $49 – $99")
       screen.getByText("Free")
     })
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -198,7 +198,8 @@ describe("Learning Resource List Card", () => {
         prices: ["0", "49"],
       })
       setup(resource)
-      screen.getByText("Certificate: $49")
+      screen.getByText("Certificate")
+      screen.getByText(": $49")
       screen.getByText("Free")
     })
 
@@ -209,7 +210,8 @@ describe("Learning Resource List Card", () => {
         prices: ["0", "99", "49"],
       })
       setup(resource)
-      screen.getByText("Certificate: $49 – $99")
+      screen.getByText("Certificate")
+      screen.getByText(": $49 - $99")
       screen.getByText("Free")
     })
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -209,7 +209,7 @@ describe("Learning Resource List Card", () => {
         prices: ["0", "99", "49"],
       })
       setup(resource)
-      screen.getByText("Certificate: $49 - $99")
+      screen.getByText("Certificate: $49 – $99")
       screen.getByText("Free")
     })
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -40,7 +40,7 @@ export const Certificate = styled.div`
   padding: 4px;
   color: ${theme.custom.colors.silverGrayDark};
   gap: 4px;
-  margin: 0 8px 0 auto;
+  margin: 0 16px 0 auto;
 
   ${{ ...theme.typography.subtitle3 }}
 
@@ -65,6 +65,13 @@ export const Certificate = styled.div`
 
   display: flex;
   align-items: center;
+`
+
+const CertificatePrice = styled.div`
+  ${{ ...theme.typography.body3 }}
+  ${theme.breakpoints.down("md")} {
+    ${{ ...theme.typography.body4 }}
+  }
 `
 
 export const Price = styled.div`
@@ -112,7 +119,10 @@ const Info = ({ resource }: { resource: LearningResource }) => {
       {resource.certification && (
         <Certificate>
           <RiAwardFill />
-          Certificate{prices?.certificate ? ":" : ""} {prices?.certificate}
+          Certificate
+          <CertificatePrice>
+            {prices?.certificate ? ":" : ""} {prices?.certificate}
+          </CertificatePrice>
         </Certificate>
       )}
       <Price>{prices?.course}</Price>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -67,6 +67,10 @@ export const Certificate = styled.div`
   align-items: center;
 `
 
+const CertificateText = styled.div`
+  display: flex;
+`
+
 const CertificatePrice = styled.div`
   ${{ ...theme.typography.body3 }}
   ${theme.breakpoints.down("md")} {
@@ -119,10 +123,12 @@ const Info = ({ resource }: { resource: LearningResource }) => {
       {resource.certification && (
         <Certificate>
           <RiAwardFill />
-          Certificate
-          <CertificatePrice>
-            {prices?.certificate ? ":" : ""} {prices?.certificate}
-          </CertificatePrice>
+          <CertificateText>
+            Certificate
+            <CertificatePrice>
+              {prices?.certificate ? ": " : ""} {prices?.certificate}
+            </CertificatePrice>
+          </CertificateText>
         </Certificate>
       )}
       <Price>{prices?.course}</Price>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -20,7 +20,7 @@ import { ListCard } from "../Card/ListCard"
 import { ActionButtonProps } from "../Button/Button"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { useMuiBreakpointAtLeast } from "../../hooks/useBreakpoint"
-import { getPrices } from "./utils"
+import { getDisplayPrices } from "./utils"
 
 const IMAGE_SIZES = {
   mobile: { width: 116, height: 104 },
@@ -99,47 +99,23 @@ const getEmbedlyUrl = (url: string, isMobile: boolean) => {
   })
 }
 
-const getDisplayPrecision = (price: number) => {
-  if (Number.isInteger(price)) {
-    return price.toFixed(0)
-  }
-  return price.toFixed(2)
-}
-
-export const getDisplayPrice = (price: number | number[] | null) => {
-  if (price === null) {
-    return null
-  }
-  if (price === 0) {
-    return "Free"
-  }
-  if (price === +Infinity) {
-    return "Paid"
-  }
-  if (Array.isArray(price)) {
-    return `$${getDisplayPrecision(price[0])} - $${getDisplayPrecision(price[1])}`
-  }
-  return `$${getDisplayPrecision(price)}`
-}
-
 /* This displays a single price for courses with no free option
  * (price includes the certificate). For free courses with the
  * option of a paid certificate, the certificate price displayed
  * in the certificate badge alongside the course "Free" price.
  */
 const Info = ({ resource }: { resource: LearningResource }) => {
-  const prices = getPrices(resource)
+  const prices = getDisplayPrices(resource)
   return (
     <>
       <span>{getReadableResourceType(resource.resource_type)}</span>
       {resource.certification && (
         <Certificate>
           <RiAwardFill />
-          Certificate{prices?.certificate ? ":" : ""}{" "}
-          {getDisplayPrice(prices?.certificate)}
+          Certificate{prices?.certificate ? ":" : ""} {prices?.certificate}
         </Certificate>
       )}
-      <Price>{getDisplayPrice(prices?.course)}</Price>
+      <Price>{prices?.course}</Price>
     </>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -20,6 +20,7 @@ import { ListCard } from "../Card/ListCard"
 import { ActionButtonProps } from "../Button/Button"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { useMuiBreakpointAtLeast } from "../../hooks/useBreakpoint"
+import { getPrices } from "./utils"
 
 const IMAGE_SIZES = {
   mobile: { width: 116, height: 104 },
@@ -96,100 +97,6 @@ const getEmbedlyUrl = (url: string, isMobile: boolean) => {
     key: APP_SETTINGS.embedlyKey || process.env.EMBEDLY_KEY!,
     ...IMAGE_SIZES[isMobile ? "mobile" : "desktop"],
   })
-}
-
-type Prices = {
-  course: null | number
-  certificate: null | number
-}
-
-export const getPrices = (resource: LearningResource) => {
-  const prices: Prices = {
-    course: null,
-    certificate: null,
-  }
-
-  if (!resource) {
-    return prices
-  }
-
-  const resourcePrices = resource.prices
-    .map((price) => Number(price))
-    .sort((a, b) => a - b)
-
-  if (resourcePrices.length > 1) {
-    /* The resource is free and offers a paid certificate option, e.g.
-     * { prices: [0, 49], free: true, certification: true }
-     */
-    if (resource.certification && resource.free) {
-      const certificatedPrices = resourcePrices.filter((price) => price > 0)
-      return {
-        course: 0,
-        certificate:
-          certificatedPrices.length === 1
-            ? certificatedPrices[0]
-            : [
-                certificatedPrices[0],
-                certificatedPrices[certificatedPrices.length - 1],
-              ],
-      }
-    }
-
-    /* The resource is not free and has a range of prices, e.g.
-     * { prices: [950, 999], free: false, certification: true|false }
-     */
-    if (resource.certification && !resource.free && Number(resourcePrices[0])) {
-      return {
-        course: [resourcePrices[0], resourcePrices[resourcePrices.length - 1]],
-        certificate: null,
-      }
-    }
-
-    /* The resource is not free but has a zero price option (prices not ingested correctly)
-     * { prices: [0, 999], free: false, certification: true|false }
-     */
-    if (!resource.free && !Number(resourcePrices[0])) {
-      return {
-        course: +Infinity,
-        certificate: null,
-      }
-    }
-
-    /* We are not expecting multiple prices for courses with no certificate option.
-     * For resourses always certificated, there is one price that includes the certificate.
-     */
-  } else if (resourcePrices.length === 1) {
-    if (!Number(resourcePrices[0])) {
-      /* Sometimes price info is missing, but the free flag is reliable.
-       */
-      if (!resource.free) {
-        return {
-          course: +Infinity,
-          certificate: null,
-        }
-      }
-
-      return {
-        course: 0,
-        certificate: null,
-      }
-    } else {
-      /* If the course has no free option, the price of the certificate
-       * is included in the price of the course.
-       */
-      return {
-        course: Number(resourcePrices[0]),
-        certificate: null,
-      }
-    }
-  } else if (resourcePrices.length === 0) {
-    return {
-      course: resource.free ? 0 : +Infinity,
-      certificate: null,
-    }
-  }
-
-  return prices
 }
 
 const getDisplayPrecision = (price: number) => {

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
@@ -1,50 +1,23 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceListCardCondensed } from "./LearningResourceListCardCondensed"
-import { ResourceTypeEnum } from "api"
-import { factories } from "api/test-utils"
+import {
+  LearningResourceListCardCondensed,
+  LearningResourceListCardCondensedProps,
+} from "./LearningResourceListCardCondensed"
+import { LearningResource } from "api"
 import { withRouter } from "storybook-addon-react-router-v6"
+import _ from "lodash"
+import Stack from "@mui/system/Stack"
+import { resourceArgType, resources, courses } from "./story_utils"
 
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  resource.image!.url =
-    "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  return resource
+type StoryProps = LearningResourceListCardCondensedProps & {
+  excerpt: (keyof LearningResource)[]
 }
 
-const meta: Meta<typeof LearningResourceListCardCondensed> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceListCardCondensed",
   argTypes: {
-    resource: {
-      options: ["Loading", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     onAddToLearningPathClick: {
       action: "click-add-to-learning-path",
     },
@@ -52,171 +25,118 @@ const meta: Meta<typeof LearningResourceListCardCondensed> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-    draggable,
-  }) => (
-    <LearningResourceListCardCondensed
-      resource={resource}
-      isLoading={isLoading}
-      href={`/?resource=${resource?.id}`}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-      draggable={draggable}
-    />
-  ),
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
+    return (
+      <Stack gap="16px">
+        <LearningResourceListCardCondensed
+          {...args}
+          href={`?resource=${args.resource?.id}`}
+        />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceListCardCondensed>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Podcast,
-      free: true,
-    }),
+    resource: resources.podcast,
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.PodcastEpisode,
-      free: true,
-    }),
+    resource: resources.podcastEpisode,
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-      free: true,
-    }),
+    resource: resources.video,
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-      free: true,
-    }),
+    resource: resources.videoPlaylist,
   },
 }
 
@@ -228,10 +148,7 @@ export const Loading: Story = {
 
 export const Draggable: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-    }),
+    resource: resources.course,
     draggable: true,
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
@@ -75,26 +75,98 @@ export default meta
 
 type Story = StoryObj<typeof LearningResourceListCardCondensed>
 
-export const PaidCourse: Story = {
+export const FreeCourseNoCertificate: Story = {
   args: {
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["999"],
+      free: true,
+      certification: false,
+      prices: [],
     }),
   },
 }
 
-export const FreeCourse: Story = {
+export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
       free: true,
       certification: true,
-      prices: ["0", "400"],
+      prices: ["250"],
+    }),
+  },
+}
+
+export const FreeCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["250", "1000"],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: [],
+    }),
+  },
+}
+
+export const UnknownPriceCourseWithCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: [],
+    }),
+  },
+}
+
+export const PaidCourseWithoutCertificate: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificateOnePrice: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["1000"],
+    }),
+  },
+}
+
+export const PaidCourseWithCertificatePriceRange: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["250", "1000"],
     }),
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -15,7 +15,6 @@ import {
   Certificate,
   Price,
   BorderSeparator,
-  getPrices,
   getDisplayPrice,
   Count,
   StartDate,
@@ -23,6 +22,7 @@ import {
 } from "./LearningResourceListCard"
 import type { LearningResourceListCardProps } from "./LearningResourceListCard"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
+import { getPrices } from "./utils"
 
 const ResourceType = styled.span`
   align-self: flex-start;

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -15,14 +15,13 @@ import {
   Certificate,
   Price,
   BorderSeparator,
-  getDisplayPrice,
   Count,
   StartDate,
   Format,
 } from "./LearningResourceListCard"
 import type { LearningResourceListCardProps } from "./LearningResourceListCard"
 import { ActionButton, ActionButtonProps } from "../Button/Button"
-import { getPrices } from "./utils"
+import { getDisplayPrices } from "./utils"
 
 const ResourceType = styled.span`
   align-self: flex-start;
@@ -32,7 +31,7 @@ const ResourceType = styled.span`
  * Info is the ResourceType flex alignment
  */
 const Info = ({ resource }: { resource: LearningResource }) => {
-  const prices = getPrices(resource)
+  const prices = getDisplayPrices(resource)
   return (
     <>
       <ResourceType>
@@ -41,11 +40,10 @@ const Info = ({ resource }: { resource: LearningResource }) => {
       {resource.certification && (
         <Certificate>
           <RiAwardFill />
-          Certificate{prices?.certificate ? ":" : ""}{" "}
-          {getDisplayPrice(prices?.certificate)}
+          Certificate{prices?.certificate ? ":" : ""} {prices?.certificate}
         </Certificate>
       )}
-      <Price>{getDisplayPrice(prices?.course)}</Price>
+      <Price>{prices?.course}</Price>
     </>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
@@ -1,0 +1,124 @@
+import { ResourceTypeEnum } from "api"
+import { factories } from "api/test-utils"
+
+const _makeResource = factories.learningResources.resource
+
+const makeResource: typeof _makeResource = (overrides) => {
+  const resource = _makeResource(overrides)
+  if (resource.image) {
+    resource.image.url =
+      "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
+  }
+  if (resource.resource_type === ResourceTypeEnum.Video) {
+    resource.url = "https://www.youtube.com/watch?v=4A9bGL-_ilA"
+  }
+  return resource
+}
+
+const resources = {
+  withoutImage: makeResource({ image: null }),
+  course: makeResource({
+    resource_type: ResourceTypeEnum.Course,
+  }),
+  program: makeResource({
+    resource_type: ResourceTypeEnum.Program,
+  }),
+  video: makeResource({
+    resource_type: ResourceTypeEnum.Video,
+    url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
+  }),
+  videoPlaylist: makeResource({
+    resource_type: ResourceTypeEnum.VideoPlaylist,
+  }),
+  podcast: makeResource({
+    resource_type: ResourceTypeEnum.Podcast,
+  }),
+  podcastEpisode: makeResource({
+    resource_type: ResourceTypeEnum.PodcastEpisode,
+  }),
+  learningPath: makeResource({
+    resource_type: ResourceTypeEnum.LearningPath,
+  }),
+}
+
+const courses = {
+  free: {
+    noCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: false,
+      prices: ["0"],
+    }),
+    withCertificateOnePrice: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["0", "49"],
+    }),
+    withCertificatePriceRange: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["0", "99", "49"],
+    }),
+  },
+  unknownPrice: {
+    noCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: [],
+    }),
+    withCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: [],
+    }),
+  },
+  paid: {
+    withoutCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: ["49"],
+    }),
+    withCerticateOnePrice: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["49"],
+    }),
+    withCertificatePriceRange: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["49", "99"],
+    }),
+  },
+}
+
+const resourceArgType = {
+  options: ["Loading", "Without Image", ...Object.values(ResourceTypeEnum)],
+  mapping: {
+    Loading: null,
+    "Without Image": resources.withoutImage,
+    [ResourceTypeEnum.Course]: resources.course,
+    [ResourceTypeEnum.Program]: resources.program,
+    [ResourceTypeEnum.Video]: resources.video,
+    [ResourceTypeEnum.VideoPlaylist]: resources.videoPlaylist,
+    [ResourceTypeEnum.Podcast]: resources.podcast,
+    [ResourceTypeEnum.PodcastEpisode]: resources.podcastEpisode,
+    [ResourceTypeEnum.LearningPath]: resources.learningPath,
+  },
+}
+
+export { resourceArgType, resources, courses }

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.test.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.test.ts
@@ -1,0 +1,58 @@
+import { factories } from "api/test-utils"
+import { getPrices } from "./utils"
+
+describe("getPrices", () => {
+  it("free course with no certificate", async () => {
+    const resource = factories.learningResources.resource({
+      free: true,
+      certification: false,
+      prices: ["0"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [0], certificate: null })
+  })
+
+  it("free course with certificate", async () => {
+    const resource = factories.learningResources.resource({
+      free: true,
+      certification: true,
+      prices: ["0", "49"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [0], certificate: [49] })
+  })
+
+  it("free course with certificate range", async () => {
+    const resource = factories.learningResources.resource({
+      free: true,
+      certification: true,
+      prices: ["0", "99", "49"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [0], certificate: [49, 99] })
+  })
+
+  it("paid course without certificate", async () => {
+    const resource = factories.learningResources.resource({
+      free: false,
+      certification: false,
+      prices: ["49"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [49], certificate: null })
+  })
+
+  it("paid course with certificate", async () => {
+    const resource = factories.learningResources.resource({
+      free: false,
+      certification: true,
+      prices: ["49"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [49], certificate: null })
+  })
+
+  it("paid course with certificate range", async () => {
+    const resource = factories.learningResources.resource({
+      free: false,
+      certification: true,
+      prices: ["49", "99"],
+    })
+    expect(getPrices(resource)).toEqual({ course: [49, 99], certificate: null })
+  })
+})

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -1,9 +1,30 @@
 import { LearningResource } from "api"
 
+/*
+ * This constant represents the value displayed when a course is free.
+ */
+const FREE = "Free"
+
+/*
+ * This constant represents the value displayed when a course is paid, but the price is not specified.
+ */
 const PAID = "Paid"
 
 type Prices = {
+  /**
+   * The price of the course, which can be a number or a range of numbers.
+   * If the course is free, the value is 0. If the course is paid, the value is "Paid".
+   *
+   * @type {null | number | number[] | typeof PAID}
+   * @memberof Prices
+   */
   course: null | number | number[] | typeof PAID
+  /**
+   * The price of the certificate, which can be a number or a range of numbers.
+   *
+   * @type {null | number | number[]}
+   * @memberof Prices
+   */
   certificate: null | number | number[]
 }
 
@@ -18,6 +39,9 @@ const getPrices = (resource: LearningResource): Prices => {
   }
 
   if (resource.free && !resource.certification) {
+    /* The resource is free and does not offer a paid certificate option, e.g.
+     * { prices: [0], free: true, certification: false }
+     */
     return {
       course: 0,
       certificate: null,
@@ -110,12 +134,12 @@ const getDisplayPrecision = (price: number) => {
   return price.toFixed(2)
 }
 
-const getDisplayPrice = (price: Prices["course"]) => {
+const getDisplayPrice = (price: Prices["course"] | Prices["certificate"]) => {
   if (price === null) {
     return null
   }
   if (price === 0) {
-    return "Free"
+    return FREE
   }
   if (price === PAID) {
     return PAID

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -130,7 +130,7 @@ const getDisplayPrice = (price: Prices["course"] | Prices["certificate"]) => {
     return PAID
   }
   if (price.length > 1) {
-    return `$${getDisplayPrecision(price[0])} - $${getDisplayPrecision(price[1])}`
+    return `$${getDisplayPrecision(price[0])} – $${getDisplayPrecision(price[1])}`
   } else if (price.length === 1) {
     if (price[0] === 0) {
       return FREE

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -29,90 +29,25 @@ type Prices = {
 }
 
 export const getPrices = (resource: LearningResource): Prices => {
-  const prices: Prices = {
-    course: null,
-    certificate: null,
-  }
-
-  if (!resource) {
-    return prices
-  }
-
-  if (resource.free && !resource.certification) {
-    /* The resource is free and does not offer a paid certificate option, e.g.
-     * { prices: [0], free: true, certification: false }
-     */
-    return {
-      course: [0],
-      certificate: null,
-    }
-  }
-
-  const resourcePrices = resource.prices
+  const sortedNonzero = resource.prices
     .map((price) => Number(price))
     .sort((a, b) => a - b)
     .filter((price) => price > 0)
 
-  if (resourcePrices.length > 0) {
-    /* The resource is free and offers a paid certificate option, e.g.
-     * { prices: [49, 249], free: true, certification: true }
-     */
-    if (resource.certification && resource.free) {
-      return {
-        course: [0],
-        certificate:
-          resourcePrices.length === 1
-            ? [resourcePrices[0]]
-            : [resourcePrices[0], resourcePrices[resourcePrices.length - 1]],
-      }
-    }
+  const priceRange = sortedNonzero.filter(
+    (price, index, arr) => index === 0 || index === arr.length - 1,
+  )
+  const prices = priceRange.length > 0 ? priceRange : null
 
-    /* The resource is not free and has a range of prices, e.g.
-     * { prices: [950, 999], free: false, certification: true|false }
-     */
-    if (resource.certification && !resource.free && resourcePrices.length > 1) {
-      return {
-        course: [resourcePrices[0], resourcePrices[resourcePrices.length - 1]],
-        certificate: null,
-      }
-    }
-
-    /* We are not expecting multiple prices for courses with no certificate option.
-     * For resources always certificated, there is one price that includes the certificate.
-     */
-    if (resourcePrices.length === 1) {
-      if (!Number(resourcePrices[0])) {
-        /* Sometimes price info is missing, but the free flag is reliable.
-         */
-        if (!resource.free) {
-          return {
-            course: PAID,
-            certificate: null,
-          }
-        }
-
-        return {
-          course: [0],
-          certificate: null,
-        }
-      } else {
-        /* If the course has no free option, the price of the certificate
-         * is included in the price of the course.
-         */
-        return {
-          course: [Number(resourcePrices[0])],
-          certificate: null,
-        }
-      }
-    }
-  } else if (resourcePrices.length === 0) {
-    return {
-      course: resource.free ? [0] : PAID,
-      certificate: null,
-    }
+  if (resource.free) {
+    return resource.certification
+      ? { course: [0], certificate: prices }
+      : { course: [0], certificate: null }
   }
-
-  return prices
+  return {
+    course: prices ?? PAID,
+    certificate: null,
+  }
 }
 
 const getDisplayPrecision = (price: number) => {

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -28,7 +28,7 @@ type Prices = {
   certificate: null | number[]
 }
 
-const getPrices = (resource: LearningResource): Prices => {
+export const getPrices = (resource: LearningResource): Prices => {
   const prices: Prices = {
     course: null,
     certificate: null,

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -1,0 +1,95 @@
+import { LearningResource } from "api"
+
+export type Prices = {
+  course: null | number
+  certificate: null | number
+}
+
+export const getPrices = (resource: LearningResource) => {
+  const prices: Prices = {
+    course: null,
+    certificate: null,
+  }
+
+  if (!resource) {
+    return prices
+  }
+
+  const resourcePrices = resource.prices
+    .map((price) => Number(price))
+    .sort((a, b) => a - b)
+
+  if (resourcePrices.length > 1) {
+    /* The resource is free and offers a paid certificate option, e.g.
+     * { prices: [0, 49], free: true, certification: true }
+     */
+    if (resource.certification && resource.free) {
+      const certificatedPrices = resourcePrices.filter((price) => price > 0)
+      return {
+        course: 0,
+        certificate:
+          certificatedPrices.length === 1
+            ? certificatedPrices[0]
+            : [
+                certificatedPrices[0],
+                certificatedPrices[certificatedPrices.length - 1],
+              ],
+      }
+    }
+
+    /* The resource is not free and has a range of prices, e.g.
+     * { prices: [950, 999], free: false, certification: true|false }
+     */
+    if (resource.certification && !resource.free && Number(resourcePrices[0])) {
+      return {
+        course: [resourcePrices[0], resourcePrices[resourcePrices.length - 1]],
+        certificate: null,
+      }
+    }
+
+    /* The resource is not free but has a zero price option (prices not ingested correctly)
+     * { prices: [0, 999], free: false, certification: true|false }
+     */
+    if (!resource.free && !Number(resourcePrices[0])) {
+      return {
+        course: +Infinity,
+        certificate: null,
+      }
+    }
+
+    /* We are not expecting multiple prices for courses with no certificate option.
+     * For resourses always certificated, there is one price that includes the certificate.
+     */
+  } else if (resourcePrices.length === 1) {
+    if (!Number(resourcePrices[0])) {
+      /* Sometimes price info is missing, but the free flag is reliable.
+       */
+      if (!resource.free) {
+        return {
+          course: +Infinity,
+          certificate: null,
+        }
+      }
+
+      return {
+        course: 0,
+        certificate: null,
+      }
+    } else {
+      /* If the course has no free option, the price of the certificate
+       * is included in the price of the course.
+       */
+      return {
+        course: Number(resourcePrices[0]),
+        certificate: null,
+      }
+    }
+  } else if (resourcePrices.length === 0) {
+    return {
+      course: resource.free ? 0 : +Infinity,
+      certificate: null,
+    }
+  }
+
+  return prices
+}

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -15,6 +15,13 @@ export const getPrices = (resource: LearningResource) => {
     return prices
   }
 
+  if (resource.free && !resource.certification) {
+    return {
+      course: 0,
+      certificate: null,
+    }
+  }
+
   const resourcePrices = resource.prices
     .map((price) => Number(price))
     .sort((a, b) => a - b)

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -1,11 +1,13 @@
 import { LearningResource } from "api"
 
-export type Prices = {
-  course: null | number
-  certificate: null | number
+const PAID = "Paid"
+
+type Prices = {
+  course: null | number | number[] | typeof PAID
+  certificate: null | number | number[]
 }
 
-export const getPrices = (resource: LearningResource) => {
+const getPrices = (resource: LearningResource): Prices => {
   const prices: Prices = {
     course: null,
     certificate: null,
@@ -59,7 +61,7 @@ export const getPrices = (resource: LearningResource) => {
      */
     if (!resource.free && !Number(resourcePrices[0])) {
       return {
-        course: +Infinity,
+        course: PAID,
         certificate: null,
       }
     }
@@ -73,7 +75,7 @@ export const getPrices = (resource: LearningResource) => {
        */
       if (!resource.free) {
         return {
-          course: +Infinity,
+          course: PAID,
           certificate: null,
         }
       }
@@ -93,10 +95,41 @@ export const getPrices = (resource: LearningResource) => {
     }
   } else if (resourcePrices.length === 0) {
     return {
-      course: resource.free ? 0 : +Infinity,
+      course: resource.free ? 0 : PAID,
       certificate: null,
     }
   }
 
   return prices
+}
+
+const getDisplayPrecision = (price: number) => {
+  if (Number.isInteger(price)) {
+    return price.toFixed(0)
+  }
+  return price.toFixed(2)
+}
+
+const getDisplayPrice = (price: Prices["course"]) => {
+  if (price === null) {
+    return null
+  }
+  if (price === 0) {
+    return "Free"
+  }
+  if (price === PAID) {
+    return PAID
+  }
+  if (Array.isArray(price)) {
+    return `$${getDisplayPrecision(price[0])} - $${getDisplayPrecision(price[1])}`
+  }
+  return `$${getDisplayPrecision(price)}`
+}
+
+export const getDisplayPrices = (resource: LearningResource) => {
+  const prices = getPrices(resource)
+  return {
+    course: getDisplayPrice(prices.course),
+    certificate: getDisplayPrice(prices.certificate),
+  }
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4934
Closes https://github.com/mitodl/hq/issues/4924

### Description (What does it do?)
This PR updates the logic for fetching and displaying prices on `LearningResourceCard` and its variants. Price display was added to the horizontal cards, styling and displaying the information as applicable per the designs based on the size of the card.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/d9d2edf9-8aab-4403-90dd-ecab7dff7c69)
![image](https://github.com/user-attachments/assets/95ad9cc7-40f1-47e1-99aa-9a4ff6173f46)
![image](https://github.com/user-attachments/assets/9aa92295-d04c-47dd-9d07-dd16b13851e4)
![image](https://github.com/user-attachments/assets/efbe34ae-d657-4639-9667-2dabd8996c70)
![image](https://github.com/user-attachments/assets/fa90e78d-0d2c-46e5-95cd-2361dd2f5b41)
![image](https://github.com/user-attachments/assets/6e676321-9562-4e4e-8f05-0d82cac9545b)

### How can this be tested?
 - Spin up this branch of `mit-open`
 - Ensure you have a variety of courses (free, not free, with certificate), probably best done by backpopulating OCW and MITx
 - Ensure that you are logged in and that your user has a profile with some topics selected
 - Visit the home page at http://localhost:8063/ and take a look at the medium sized cards there, ensuring that they follow the designs
 - Visit http://localhost:8063/search and browse around, changing the search filters to display different results
   - Ensure that the cards look like the designs
   - Ensure that all free courses properly display "Free" where the price would normally be
 - Visit https://localhost:8063/dashboard/ to view the small cards there, ensuring that they are consistent with the designs
