### PR TITLE
allow hitting local edx datafile in dev mode

### DIFF
--- a/learning_resources/etl/mit_edx.py
+++ b/learning_resources/etl/mit_edx.py
@@ -101,6 +101,7 @@ def get_open_edx_config():
         settings.EDX_API_URL,
         settings.EDX_BASE_URL,
         settings.EDX_ALT_URL,
+        settings.EDX_LOCAL_API_DATAFILE,
         PlatformType.edx.name,
         OfferedBy.mitx.name,
         ETLSource.mit_edx.name,

--- a/learning_resources/etl/oll.py
+++ b/learning_resources/etl/oll.py
@@ -36,6 +36,7 @@ def get_open_edx_config():
         settings.OLL_API_URL,
         settings.OLL_BASE_URL,
         settings.OLL_ALT_URL,
+        settings.OLL_LOCAL_API_DATAFILE,
         PlatformType.oll.name,
         OfferedBy.mitx.name,
         ETLSource.oll.name,

--- a/learning_resources/etl/openedx_test.py
+++ b/learning_resources/etl/openedx_test.py
@@ -27,6 +27,7 @@ def openedx_config():
         "http://localhost/fake-api-url/",
         "http://localhost/fake-base-url/",
         "http://localhost/fake-alt-url/",
+        "",  # OLL_LOCAL_API_DATAFILE,
         "fake-platform-type",
         "fake-offered-by",
         "fake-etl-source",

--- a/learning_resources/management/commands/backpopulate_oll_data.py
+++ b/learning_resources/management/commands/backpopulate_oll_data.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Run Populate oll courses"""
+
         if options["delete"]:
             self.stdout.write(
                 "Deleting all existing OLL courses from database and opensearch"

--- a/learning_resources/management/commands/extract_openedx_data.py
+++ b/learning_resources/management/commands/extract_openedx_data.py
@@ -1,0 +1,59 @@
+"""Management command for populating oll course data"""
+
+import json
+from pathlib import Path
+
+from django.core.management import BaseCommand
+
+from learning_resources.etl import mit_edx, oll
+from learning_resources.etl.constants import ETLSource
+from main.utils import now_in_utc
+
+EXTRACTORS = {
+    ETLSource.oll.name: oll.extract,
+    ETLSource.mit_edx.name: mit_edx.extract,
+}
+
+
+def extract_data(etl_source):
+    """Extract data from the given source"""
+
+    return EXTRACTORS[etl_source]()
+
+
+class Command(BaseCommand):
+    """Populate oll courses"""
+
+    help = "Populate oll courses"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--etl_source",
+            dest="etl_source",
+            required=True,
+            choices=list(EXTRACTORS),
+            help="The ETL source data to extract",
+        )
+        parser.add_argument(
+            "--output",
+            dest="outfile",
+            required=True,
+            help="The ETL source data to extract",
+        )
+        super().add_arguments(parser)
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Run Populate oll courses"""
+        etl_source = options["etl_source"]
+        outfile = options["outfile"]
+        self.stdout.write(f"Starting to get {etl_source} course data")
+        start = now_in_utc()
+        data = extract_data(etl_source)
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            f"Extraction of {etl_source} data finished, took {total_seconds} seconds"
+        )
+        self.stdout.write(f"Writing data to {outfile}")
+        with Path(outfile).open("w") as f:
+            json.dump(data, f)
+        self.stdout.write(f"Data written to {outfile}")

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -13,6 +13,7 @@ EDX_LEARNING_COURSE_BUCKET_NAME = get_string("EDX_LEARNING_COURSE_BUCKET_NAME", 
 EDX_LEARNING_COURSE_BUCKET_PREFIX = get_string(
     "EDX_LEARNING_COURSE_BUCKET_PREFIX", "simeon-mitx-course-tarballs"
 )
+EDX_LOCAL_API_DATAFILE = get_string("EDX_LOCAL_API_DATAFILE", None)
 # Authentication for the github api
 GITHUB_ACCESS_TOKEN = get_string("GITHUB_ACCESS_TOKEN", None)
 
@@ -67,6 +68,7 @@ OLL_LEARNING_COURSE_BUCKET_NAME = get_string("OLL_LEARNING_COURSE_BUCKET_NAME", 
 OLL_LEARNING_COURSE_BUCKET_PREFIX = get_string(
     "OLL_LEARNING_COURSE_BUCKET_PREFIX", "open-learning-library/courses"
 )
+OLL_LOCAL_API_DATAFILE = get_string("OLL_LOCAL_API_DATAFILE", None)
 # More MIT URLs
 SEE_BASE_URL = get_string("SEE_BASE_URL", None)
 MITPE_BASE_URL = get_string("MITPE_BASE_URL", None)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4949

### Description (What does it do?)
This PR 
1. Adds two settings `EDX_LOCAL_API_DATAFILE`, `OLL_LOCAL_API_DATAFILE` that, if set, cause edX ETL pipelines to read from a  local file rather than API during development.
    - if set in production, the pipeline will error
2. that ca

### How can this be tested?
1. Ensure you have the ETL settings for OLL from RC (and/or EDX Settings).
1. Locally, run `./manage.py extract_openedx_data --etl_source oll --output SOME_FILE_PATH_PREFERABLY_GIT_IGNORED` This should write the raw OLL data to the specified file.
2. Now set that filepath as `OLL_LOCAL_API_DATAFILE` in `env/backend.local.env` and change `OLL_API_URL` to something bogus.
3. Restart docker to pick up new env vars
4. Run `./manage.py backpopulate_oll_data` ... it should backpopulate ~62 courses. 
5. Optionally repeat with  `etl_source mit_edx` and `backpopulate_mit_edx_data`
