### PR TITLE
set search page size to 20

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -408,7 +408,7 @@ const StyledGridContainer = styled(GridContainer)`
   width: 100% !important;
 `
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 20
 const MAX_PAGE = 50
 
 const getLastPage = (count: number): number => {
@@ -523,6 +523,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
         "resource_category",
       ]) as LRSearchRequest["aggregations"],
       offset: (page - 1) * PAGE_SIZE,
+      limit: PAGE_SIZE,
     }
   }, [
     requestParams,

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -491,10 +491,10 @@ describe("Search Page pagination controls", () => {
     renderWithProviders(<SearchPage />, { url: "?page=3" })
     const pagination = getPagination()
     // p14 exists
-    await within(pagination).findByRole("button", { name: "Go to page 14" })
+    await within(pagination).findByRole("button", { name: "Go to page 7" })
     // items
     const items = await within(pagination).findAllByRole("listitem")
-    expect(items.at(-2)?.textContent).toBe("14") // "Last page"
+    expect(items.at(-2)?.textContent).toBe("7") // "Last page"
     expect(items.at(-1)?.textContent).toBe("") // "Next" button
   })
 })


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/4954

### Description (What does it do?)
Sets search page size to 20 items per page

### Screenshots (if appropriate):

My screen isn't tall enough to show 20:

<img width="200" alt="Screenshot 2024-07-22 at 11 27 49 AM" src="https://github.com/user-attachments/assets/e604d8b6-873e-451f-9112-4c6539d46cef">


### How can this be tested?
1. Visit http://localhost:8062/search and http://localhost:8062/c/unit/ocw You should get 20 results per page.
    - you could count by eye and or with `document.querySelectorAll('.MuiTabPanel-root a')` in dev console.
    - also check the network tab API url ... it should have `?limit=20`
 2. Check pages 2, 3, 4, etc. The API calls should be as expected (e.g., `?offset=20&limit=20`, `?offset=40&limit=20`, etc.)

