### PR TITLE
Enable User List sorting for non Learning Path editors

### DIFF
--- a/frontends/mit-open/src/page-components/ItemsListing/ItemsListingComponent.tsx
+++ b/frontends/mit-open/src/page-components/ItemsListing/ItemsListingComponent.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { Grid, Button, Typography, styled } from "ol-components"
 import { RiPencilFill, RiArrowUpDownLine } from "@remixicon/react"
-import { useUserMe } from "api/hooks/user"
 import { useToggle, pluralize } from "ol-utilities"
 import { GridColumn, GridContainer } from "@/components/GridLayout/GridLayout"
 import ItemsListing from "./ItemsListing"
@@ -28,6 +27,8 @@ type ItemsListingComponentProps = {
   listType: string
   list?: ListData
   items: LearningResourceListItem[]
+  showSort: boolean
+  canEdit: boolean
   isLoading: boolean
   isFetching: boolean
   handleEdit: OnEdit
@@ -38,16 +39,15 @@ const ItemsListingComponent: React.FC<ItemsListingComponentProps> = ({
   listType,
   list,
   items,
+  showSort,
+  canEdit,
   isLoading,
   isFetching,
   handleEdit,
   condensed = false,
 }) => {
-  const { data: user } = useUserMe()
   const [isSorting, toggleIsSorting] = useToggle(false)
 
-  const canEdit = user?.is_learning_path_editor
-  const showSort = canEdit && !!items.length
   const count = list?.item_count
 
   return (
@@ -67,7 +67,7 @@ const ItemsListingComponent: React.FC<ItemsListingComponentProps> = ({
             alignItems="center"
             justifyContent="space-between"
           >
-            {showSort && (
+            {showSort && !!items.length && (
               <Button
                 variant="text"
                 disabled={count === 0}

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -238,11 +238,11 @@ describe("manageListDialogs.upsertUserList", () => {
   test.each([
     {
       userList: undefined,
-      expectedTitle: "Create User List",
+      expectedTitle: "Create List",
     },
     {
       userList: factories.userLists.userList(),
-      expectedTitle: "Edit User List",
+      expectedTitle: "Edit List",
     },
   ])(
     "Dialog title is $expectedTitle when userList=$userList",

--- a/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
+++ b/frontends/mit-open/src/page-components/ManageListDialogs/ManageListDialogs.tsx
@@ -400,7 +400,7 @@ const manageListDialogs = {
   destroyLearningPath: (resource: LearningPathResource) =>
     NiceModal.show(DeleteLearningPathDialog, { resource }),
   upsertUserList: (userList?: UserList) => {
-    const title = userList ? "Edit User List" : "Create User List"
+    const title = userList ? "Edit List" : "Create List"
     NiceModal.show(UpsertUserListDialog, { title, userList })
   },
   destroyUserList: (userList: UserList) =>

--- a/frontends/mit-open/src/pages/DashboardPage/UserListDetailsTab.tsx
+++ b/frontends/mit-open/src/pages/DashboardPage/UserListDetailsTab.tsx
@@ -4,6 +4,7 @@ import {
   useUserListsDetail,
 } from "api/hooks/learningResources"
 import { ListType } from "api/constants"
+import { useUserMe } from "api/hooks/user"
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import ItemsListingComponent from "@/page-components/ItemsListing/ItemsListingComponent"
 
@@ -13,6 +14,8 @@ interface UserListDetailsTabProps {
 
 const UserListDetailsTab: React.FC<UserListDetailsTabProps> = (props) => {
   const { userListId } = props
+
+  const { data: user } = useUserMe()
   const listQuery = useUserListsDetail(userListId)
   const itemsQuery = useInfiniteUserListItems({ userlist_id: userListId })
 
@@ -28,6 +31,8 @@ const UserListDetailsTab: React.FC<UserListDetailsTabProps> = (props) => {
       items={items}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
+      showSort={!!user?.is_authenticated}
+      canEdit={!!user?.is_authenticated}
       handleEdit={() => manageListDialogs.upsertUserList(listQuery.data)}
       condensed
     />

--- a/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/LearningPathDetailsPage.tsx
@@ -1,21 +1,21 @@
 import React, { useMemo } from "react"
-
 import { useParams } from "react-router"
-
+import { useUserMe } from "api/hooks/user"
 import {
   useInfiniteLearningPathItems,
   useLearningPathsDetail,
 } from "api/hooks/learningResources"
-
-import { ListDetailsPage } from "./ListDetailsPage"
-import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import { ListType } from "api/constants"
+import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { ListDetailsPage } from "./ListDetailsPage"
 
 type RouteParams = {
   id: string
 }
 
 const LearningPathDetailsPage: React.FC = () => {
+  const { data: user } = useUserMe()
+
   const id = Number(useParams<RouteParams>().id)
   const pathQuery = useLearningPathsDetail(id)
   const itemsQuery = useInfiniteLearningPathItems({
@@ -42,6 +42,8 @@ const LearningPathDetailsPage: React.FC = () => {
       listType={ListType.LearningPath}
       list={list}
       items={items}
+      showSort={!!user?.is_authenticated}
+      canEdit={!!user?.is_learning_path_editor}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
       handleEdit={() => manageListDialogs.upsertLearningPath(pathQuery.data)}

--- a/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
+++ b/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.test.ts
@@ -94,7 +94,7 @@ describe("ListDetailsPage", () => {
       canEdit: true,
     },
   ])(
-    "Users can edit/reorder if and only if is_learning_path_editor=true",
+    "Users can edit if and only if is_learning_path_editor",
     async ({ userSettings, canEdit }) => {
       const path = factories.learningResources.learningPath()
       setup({ path, userSettings })
@@ -102,8 +102,27 @@ describe("ListDetailsPage", () => {
 
       const editButton = screen.queryByRole("button", { name: "Edit" })
       expect(!!editButton).toBe(canEdit)
+    },
+  )
+
+  test.each([
+    {
+      userSettings: { is_authenticated: false },
+      canSort: false,
+    },
+    {
+      userSettings: { is_authenticated: true },
+      canSort: true,
+    },
+  ])(
+    "Users can reorder if and only if authenticated",
+    async ({ userSettings, canSort }) => {
+      const path = factories.learningResources.learningPath()
+      setup({ path, userSettings })
+      await screen.findByRole("heading", { name: path.title })
+
       const reorderButton = screen.queryByRole("button", { name: "Reorder" })
-      expect(!!reorderButton).toBe(canEdit)
+      expect(!!reorderButton).toBe(canSort)
     },
   )
 

--- a/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/ListDetailsPage.tsx
@@ -8,6 +8,8 @@ const ListDetailsPage: React.FC<ItemsListingComponentProps> = ({
   listType,
   list,
   items,
+  showSort,
+  canEdit,
   isLoading,
   isFetching,
   handleEdit,
@@ -23,6 +25,8 @@ const ListDetailsPage: React.FC<ItemsListingComponentProps> = ({
           listType={listType}
           list={list}
           items={items}
+          showSort={showSort}
+          canEdit={canEdit}
           isLoading={isLoading}
           isFetching={isFetching}
           handleEdit={handleEdit}

--- a/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
+++ b/frontends/mit-open/src/pages/ListDetailsPage/UserListDetailsPage.tsx
@@ -1,24 +1,25 @@
 import React, { useMemo } from "react"
-
 import { useParams } from "react-router"
-
+import { useUserMe } from "api/hooks/user"
 import {
   useInfiniteUserListItems,
   useUserListsDetail,
 } from "api/hooks/learningResources"
-
 import { ListType } from "api/constants"
-import { ListDetailsPage } from "./ListDetailsPage"
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
+import { ListDetailsPage } from "./ListDetailsPage"
 
 type RouteParams = {
   id: string
 }
 
 const UserListDetailsPage: React.FC = () => {
+  const { data: user } = useUserMe()
+
   const id = Number(useParams<RouteParams>().id)
   const listQuery = useUserListsDetail(id)
   const itemsQuery = useInfiniteUserListItems({ userlist_id: id })
+
   const items = useMemo(() => {
     const pages = itemsQuery.data?.pages
     return pages?.flatMap((p) => p.results ?? []) ?? []
@@ -29,6 +30,8 @@ const UserListDetailsPage: React.FC = () => {
       listType={ListType.UserList}
       list={listQuery.data}
       items={items}
+      showSort={!!user?.is_authenticated}
+      canEdit={!!user?.is_authenticated}
       isLoading={itemsQuery.isLoading}
       isFetching={itemsQuery.isFetching}
       handleEdit={() => manageListDialogs.upsertUserList(listQuery.data)}


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/4936

### Description (What does it do?)
<!--- Describe your changes in detail -->

Gives the ItemsListingComponent `canEdit` and `showSort` props to move the conditions to determine whether a user can edit or reorder items listings to the calling components for variation depending on use and applies as follows:

|Page|Permission|canEdit|showSort|
|----|---|---|---|
|User List Details|Not Authenticated|N/A|N/A|
|User List Details|Authenticated|✓|✓|
|User List Details|Learning path editor|✓|✓|
|Learning Path Details|Not Authenticated|✗|✗|
|Learning Path Details|Authenticated|✗|✗|
|Learning Path Details|Learning path editor|✓|✓|

The change is that a user who is not a Learning Path editor can now reorder.

### How can this be tested?

Navigate to the following:
- a Dashboard "My Lists" User List Details page (e.g. "Favorites")
- a User List Details page at e.g. `/userlists/2`
- a Learning Path Details page at e.g. `/learningpaths/1`

Confirm the abilities to edit and reorder are applied according to the table above.