### PR TITLE
No prices for archived runs or resources w/out certificates

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -9,6 +9,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 
 from learning_resources.constants import (
+    AvailabilityType,
     LearningResourceFormat,
     LearningResourceRelationTypes,
     LearningResourceType,
@@ -227,8 +228,14 @@ def load_run(
     image_data = run_data.pop("image", None)
     instructors_data = run_data.pop("instructors", [])
 
-    # Make sure any prices are unique and sorted in ascending order
-    run_data["prices"] = sorted(set(run_data.get("prices", [])), key=lambda x: float(x))
+    if run_data.get("availability") == AvailabilityType.archived.value:
+        # Archived runs should not have prices
+        run_data["prices"] = []
+    else:
+        # Make sure any prices are unique and sorted in ascending order
+        run_data["prices"] = sorted(
+            set(run_data.get("prices", [])), key=lambda x: float(x)
+        )
 
     with transaction.atomic():
         (

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -228,8 +228,11 @@ def load_run(
     image_data = run_data.pop("image", None)
     instructors_data = run_data.pop("instructors", [])
 
-    if run_data.get("availability") == AvailabilityType.archived.value:
-        # Archived runs should not have prices
+    if (
+        run_data.get("availability") == AvailabilityType.archived.value
+        or learning_resource.certification is False
+    ):
+        # Archived runs or runs of resources w/out certificates should not have prices
         run_data["prices"] = []
     else:
         # Make sure any prices are unique and sorted in ascending order

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -126,7 +126,11 @@ def load_next_start_date_and_prices(
         next_upcoming_run
         or resource.runs.filter(published=True).order_by("-start_date").first()
     )
-    resource.prices = best_run.prices if best_run and best_run.prices else []
+    resource.prices = (
+        best_run.prices
+        if resource.certification and best_run and best_run.prices
+        else []
+    )
     resource.save()
     return resource.next_start_date, resource.prices
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -392,7 +392,9 @@ def test_load_course(  # noqa: PLR0913
     )
     assert result.next_start_date == expected_next_start_date
     assert result.prices == (
-        [Decimal(0.00), Decimal(49.00)] if is_run_published else []
+        [Decimal(0.00), Decimal(49.00)]
+        if is_run_published and result.certification
+        else []
     )
 
     if course_exists and ((not is_published or not is_run_published) or blocklisted):
@@ -597,11 +599,14 @@ def test_load_course_dupe_urls(unique_url):
 @pytest.mark.parametrize(
     "availability", [AvailabilityType.archived.value, AvailabilityType.current.value]
 )
-def test_load_run(run_exists, availability):
+@pytest.mark.parametrize("certification", [True, False])
+def test_load_run(run_exists, availability, certification):
     """Test that load_run loads the course run"""
-    course = CourseFactory.create(learning_resource__runs=[])
+    course = LearningResourceFactory.create(
+        is_course=True, runs=[], certification=certification
+    )
     learning_resource_run = (
-        LearningResourceRunFactory.create(learning_resource=course.learning_resource)
+        LearningResourceRunFactory.create(learning_resource=course)
         if run_exists
         else LearningResourceRunFactory.build()
     )
@@ -617,18 +622,19 @@ def test_load_run(run_exists, availability):
     del props["learning_resource"]
 
     assert LearningResourceRun.objects.count() == (1 if run_exists else 0)
+    assert course.certification == certification
 
-    result = load_run(course.learning_resource, props)
+    result = load_run(course, props)
 
     assert LearningResourceRun.objects.count() == 1
 
-    assert result.learning_resource == course.learning_resource
+    assert result.learning_resource == course
 
     assert isinstance(result, LearningResourceRun)
 
     assert result.prices == (
         []
-        if availability == AvailabilityType.archived.value
+        if (availability == AvailabilityType.archived.value or certification is False)
         else sorted(props["prices"])
     )
     props.pop("prices")


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4931

### Description (What does it do?)
Adjusts  the function`learning_resources.etl.load_runs` so that archived runs have no prices.


### How can this be tested?
- Set `EDX_API_` env values to the same as on RC
- Run `./manage.py backpopulate_mit_edx_data` (use the --api_datafile option if you already have a local json file of the mit_edx data).
- Check that the following query returns just an empty list:
  ```python
  from learning_resources.models import *
  LearningResourceRun.objects.filter(
    availability="Archived", 
    published=True, 
    learning_resource__etl_source="mit_edx"
  ).values_list("prices", flat=True).distinct()

  Out[3]: <TimestampedModelQuerySet [[]]>
  ```

### Additional Context
I thought about adding a migration to set prices = [] for published runs with "Archived" availability, but for now I decided it would be a bit redundant since the ETL scripts run every day.  

