### PR TITLE
Extract department info for mitxonline from correct external API fields

### DIFF
--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -31,7 +31,7 @@ from learning_resources.etl.mitxonline import (
 )
 from learning_resources.etl.utils import (
     UCC_TOPIC_MAPPINGS,
-    extract_valid_department_from_id,
+    get_department_id_by_name,
     parse_certification,
 )
 from main.test_utils import any_instance_of
@@ -127,9 +127,9 @@ def test_mitxonline_transform_programs(
             "etl_source": ETLSource.mitxonline.name,
             "platform": PlatformType.mitxonline.name,
             "resource_type": LearningResourceType.program.name,
-            "departments": extract_valid_department_from_id(
-                program_data["readable_id"]
-            ),
+            "departments": [get_department_id_by_name(program_data["departments"][0])]
+            if program_data["departments"]
+            else [],
             "professional": False,
             "certification": bool(
                 program_data.get("page", {}).get("page_url", None) is not None
@@ -184,9 +184,9 @@ def test_mitxonline_transform_programs(
                     "resource_type": LearningResourceType.course.name,
                     "professional": False,
                     "etl_source": ETLSource.mitxonline.value,
-                    "departments": extract_valid_department_from_id(
-                        course_data["readable_id"]
-                    ),
+                    "departments": [
+                        get_department_id_by_name(course_data["departments"][0]["name"])
+                    ],
                     "title": course_data["title"],
                     "image": _transform_image(course_data),
                     "description": clean_data(
@@ -306,7 +306,9 @@ def test_mitxonline_transform_courses(settings, mock_mitxonline_courses_data):
             "platform": PlatformType.mitxonline.name,
             "etl_source": ETLSource.mitxonline.name,
             "resource_type": LearningResourceType.course.name,
-            "departments": extract_valid_department_from_id(course_data["readable_id"]),
+            "departments": [
+                get_department_id_by_name(course_data["departments"][0]["name"])
+            ],
             "title": course_data["title"],
             "image": _transform_image(course_data),
             "description": clean_data(

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -555,6 +555,20 @@ def extract_valid_department_from_id(
     return []
 
 
+def get_department_id_by_name(name: str) -> str:
+    """
+    Return a department id based on provided name
+
+    Args:
+        name (str): The department name
+
+    Returns:
+        str: The department id
+    """
+    reverse_dept_map = {v: k for k, v in DEPARTMENTS.items()}
+    return reverse_dept_map.get(name)
+
+
 def generate_course_numbers_json(
     course_num: str,
     extra_nums: list[str] | None = None,

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -452,3 +452,11 @@ def test_calc_checksum(previous_archive, identical):
         "test_json/course-v1:MITxT+8.01.3x+3T2022.tar.gz"
     )
     assert (utils.calc_checksum(previous_archive) == reference_checksum) is identical
+
+
+@pytest.mark.parametrize(
+    ("dept_name", "dept_id"), [("Biology", "7"), ("Metaphysics", None)]
+)
+def test_get_department_id_by_name(dept_name, dept_id):
+    """Test that the correct department ID (if any) is returned"""
+    assert utils.get_department_id_by_name(dept_name) == dept_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Assigns department ids in the mitxonline ETL pipeline based on the "departments" field in the MITx Online course/program API endpoints.


### How can this be tested?
- Set the `MITX_ONLINE_` env values based on RC
- Run `./manage.py backpopulate_mitxonline_data`
- Go to http://open.odl.local:8062/search/?resource_category=program&topic=Economics, you should get these 2 results:

![Screenshot 2024-07-23 at 3 31 40 PM](https://github.com/user-attachments/assets/a8200c2c-7ab7-4f2e-8fd8-d9bd54fb1340)


### Additional Context
The MITx Online course and program API endpoints [return department info in different formats](https://github.com/mitodl/hq/issues/4970), so I wrote the function to parse them in a way that handles both.


