### PR TITLE
tab widths

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/ResourceCategoryTabs.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/ResourceCategoryTabs.tsx
@@ -8,21 +8,27 @@ import {
 } from "ol-components"
 import { ResourceCategoryEnum, LearningResourcesSearchResponse } from "api"
 
-const TabsList = styled(TabButtonList)({
+const TabsList = styled(TabButtonList)(({ theme }) => ({
   ".MuiTabScrollButton-root.Mui-disabled": {
     display: "none",
   },
-})
+  [theme.breakpoints.down("md")]: {
+    "div div button": {
+      minWidth: "0 !important",
+    },
+  },
+}))
 
-const CountSpan = styled.span`
-  min-width: 35px;
-  text-align: left;
-`
+const CountSpan = styled.span(({ theme }) => ({
+  ...theme.typography.body3,
+}))
+
 type TabConfig = {
   label: string
   name: string
   defaultTab?: boolean
   resource_category: ResourceCategoryEnum | null
+  minWidth: number
 }
 
 type Aggregations = LearningResourcesSearchResponse["metadata"]["aggregations"]
@@ -110,6 +116,7 @@ const ResourceCategoryTabList: React.FC<ResourceCategoryTabsProps> = ({
         }
         return (
           <TabButton
+            style={{ minWidth: t.minWidth }}
             key={t.name}
             value={t.name}
             label={appendCount(t.label, count)}

--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -429,21 +429,25 @@ const TABS: TabConfig[] = [
     label: "All",
     defaultTab: true,
     resource_category: null,
+    minWidth: 85,
   },
   {
     name: "courses",
     label: "Courses",
     resource_category: ResourceCategoryEnum.Course,
+    minWidth: 112,
   },
   {
     name: "programs",
     label: "Programs",
     resource_category: ResourceCategoryEnum.Program,
+    minWidth: 118,
   },
   {
     name: "learning-materials",
     label: "Learning Materials",
     resource_category: ResourceCategoryEnum.LearningMaterial,
+    minWidth: 172,
   },
 ]
 


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4939

### Description (What does it do?)
1) Makes the resource tab widths fixed (in the desktop view)
2) Centers tab text in the resource tabs
3) Makes the text for resource count not bold

### Screenshots (if appropriate):
<img width="1699" alt="Screenshot 2024-07-23 at 4 24 56 PM" src="https://github.com/user-attachments/assets/fbe6387e-d022-41a0-8830-772fbcc6d2ab">
<img width="1694" alt="Screenshot 2024-07-23 at 4 25 09 PM" src="https://github.com/user-attachments/assets/eabc80e8-7bb2-454e-8d28-d22312bf0c08">
<img width="333" alt="Screenshot 2024-07-23 at 4 25 24 PM" src="https://github.com/user-attachments/assets/6939bbc0-5d10-48b3-974b-e8c1499fce4d">
<img width="326" alt="Screenshot 2024-07-23 at 4 25 41 PM" src="https://github.com/user-attachments/assets/ff4776a1-ef3e-4d2e-9fe2-8d5d9d4f2973">


### How can this be tested?
Go to http://localhost:8062/search. Select some facets. Make sure the text in the tabs is centered and the tabs remain the same width regardless of the number of resources in the facet selection (on desktop). Since the drawer covers the tabs at the time of facet changes on mobile, the tabs don't need to stay the same width