### PR TITLE
free section css

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -250,13 +250,13 @@ const FacetStyles = styled.div`
   }
 
   .multi-facet-group {
-    background: none;
+    background: white;
     margin-top: 8px;
     margin-bottom: 8px;
     border-radius: 8px;
     border-bottom: solid 1px ${({ theme }) => theme.custom.colors.lightGray2};
     padding-bottom: 12px;
-    padding-top: 10px;
+    padding-top: 5px;
 
     /* stylelint-disable no-descending-specificity */
     .facet-visible {


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4975

### Description (What does it do?)
This pr updates the styling of the free section on the search page

### Screenshots (if appropriate):
<img width="1724" alt="Screenshot 2024-07-24 at 10 59 27 AM" src="https://github.com/user-attachments/assets/f6b8e1de-1ae2-4340-8e23-0ddc00c38ce7">
<img width="329" alt="Screenshot 2024-07-24 at 10 59 44 AM" src="https://github.com/user-attachments/assets/056ada09-e67d-48c0-89d0-169fbf3f1526">


### How can this be tested?
Go to http://localhost:8062/search. Confirm that the free facet looks like the designs. I confirmed with Bilal that the parens around the count in the ticket are a typo from a previous design, ignore them