### PR TITLE
display excerpt of resources

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -4,23 +4,12 @@ import {
   LearningResourceCard,
   LearningResourceCardProps,
 } from "./LearningResourceCard"
-import { LearningResource, ResourceTypeEnum } from "api"
+import { LearningResource } from "api"
 import styled from "@emotion/styled"
-import { factories } from "api/test-utils"
 import { withRouter } from "storybook-addon-react-router-v6"
 import Stack from "@mui/system/Stack"
 import _ from "lodash"
-
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  if (resource.image) {
-    resource.image.url =
-      "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  }
-  return resource
-}
+import { resources, courses, resourceArgType } from "./story_utils"
 
 const LearningResourceCardStyled = styled(LearningResourceCard)`
   width: 300px;
@@ -32,37 +21,7 @@ type StoryProps = LearningResourceCardProps & {
 const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceCard",
   argTypes: {
-    resource: {
-      options: ["Loading", "Without Image", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        "Without Image": makeResource({
-          image: null,
-        }),
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     size: {
       options: ["small", "medium"],
       control: { type: "select" },
@@ -74,24 +33,11 @@ const meta: Meta<StoryProps> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    size,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-    excerpt,
-  }) => {
-    const excerptObj = _.pick(resource, excerpt)
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
     return (
       <Stack direction="row" gap="16px">
-        <LearningResourceCardStyled
-          resource={resource}
-          isLoading={isLoading}
-          size={size}
-          onAddToLearningPathClick={onAddToLearningPathClick}
-          onAddToUserListClick={onAddToUserListClick}
-        />
+        <LearningResourceCardStyled {...args} />
         {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
       </Stack>
     )
@@ -110,148 +56,95 @@ const priceArgs: Partial<Story["args"]> = {
 export const FreeCourseNoCertificate: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
     ...priceArgs,
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Podcast }),
+    resource: resources.podcast,
     size: "small",
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.PodcastEpisode }),
+    resource: resources.podcastEpisode,
     size: "small",
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-    }),
+    resource: resources.video,
     size: "small",
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-    }),
+    resource: resources.videoPlaylist,
     size: "small",
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -1,10 +1,15 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceCard } from "./LearningResourceCard"
-import { ResourceTypeEnum } from "api"
+import {
+  LearningResourceCard,
+  LearningResourceCardProps,
+} from "./LearningResourceCard"
+import { LearningResource, ResourceTypeEnum } from "api"
 import styled from "@emotion/styled"
 import { factories } from "api/test-utils"
 import { withRouter } from "storybook-addon-react-router-v6"
+import Stack from "@mui/system/Stack"
+import _ from "lodash"
 
 const _makeResource = factories.learningResources.resource
 
@@ -20,8 +25,11 @@ const makeResource: typeof _makeResource = (overrides) => {
 const LearningResourceCardStyled = styled(LearningResourceCard)`
   width: 300px;
 `
+type StoryProps = LearningResourceCardProps & {
+  excerpt: (keyof LearningResource)[]
+}
 
-const meta: Meta<typeof LearningResourceCard> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceCard",
   argTypes: {
     resource: {
@@ -72,24 +80,36 @@ const meta: Meta<typeof LearningResourceCard> = {
     size,
     onAddToLearningPathClick,
     onAddToUserListClick,
-  }) => (
-    <LearningResourceCardStyled
-      resource={resource}
-      isLoading={isLoading}
-      size={size}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-    />
-  ),
+    excerpt,
+  }) => {
+    const excerptObj = _.pick(resource, excerpt)
+    return (
+      <Stack direction="row" gap="16px">
+        <LearningResourceCardStyled
+          resource={resource}
+          isLoading={isLoading}
+          size={size}
+          onAddToLearningPathClick={onAddToLearningPathClick}
+          onAddToUserListClick={onAddToUserListClick}
+        />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceCard>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -102,6 +122,7 @@ export const FreeCourseNoCertificate: Story = {
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -114,6 +135,7 @@ export const FreeCourseWithCertificateOnePrice: Story = {
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -126,6 +148,7 @@ export const FreeCourseWithCertificatePriceRange: Story = {
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -138,6 +161,7 @@ export const UnknownPriceCourseWithoutCertificate: Story = {
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -150,6 +174,7 @@ export const UnknownPriceCourseWithCertificate: Story = {
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -162,6 +187,7 @@ export const PaidCourseWithoutCertificate: Story = {
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],
@@ -174,6 +200,7 @@ export const PaidCourseWithCertificateOnePrice: Story = {
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
+    ...priceArgs,
     resource: makeResource({
       resource_type: ResourceTypeEnum.Course,
       runs: [factories.learningResources.run()],

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
@@ -1,50 +1,23 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceListCard } from "./LearningResourceListCard"
-import { ResourceTypeEnum } from "api"
-import { factories } from "api/test-utils"
+import {
+  LearningResourceListCard,
+  LearningResourceListCardProps,
+} from "./LearningResourceListCard"
+import { LearningResource } from "api"
 import { withRouter } from "storybook-addon-react-router-v6"
+import { resources, resourceArgType, courses } from "./story_utils"
+import Stack from "@mui/system/Stack"
+import _ from "lodash"
 
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  resource.image!.url =
-    "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  return resource
+type StoryProps = LearningResourceListCardProps & {
+  excerpt: (keyof LearningResource)[]
 }
 
-const meta: Meta<typeof LearningResourceListCard> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceListCard",
   argTypes: {
-    resource: {
-      options: ["Loading", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     onAddToLearningPathClick: {
       action: "click-add-to-learning-path",
     },
@@ -52,171 +25,118 @@ const meta: Meta<typeof LearningResourceListCard> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-    draggable,
-  }) => (
-    <LearningResourceListCard
-      resource={resource}
-      isLoading={isLoading}
-      href={`/?resource=${resource?.id}`}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-      draggable={draggable}
-    />
-  ),
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
+    return (
+      <Stack gap="16px">
+        <LearningResourceListCard
+          {...args}
+          href={`?resource=${args.resource?.id}`}
+        />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceListCard>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Podcast,
-      free: true,
-    }),
+    resource: resources.podcast,
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.PodcastEpisode,
-      free: true,
-    }),
+    resource: resources.podcastEpisode,
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-      free: true,
-    }),
+    resource: resources.video,
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-      free: true,
-    }),
+    resource: resources.videoPlaylist,
   },
 }
 
@@ -228,10 +148,7 @@ export const Loading: Story = {
 
 export const Draggable: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-    }),
+    resource: resources.course,
     draggable: true,
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.stories.tsx
@@ -1,50 +1,23 @@
 import React from "react"
 import type { Meta, StoryObj } from "@storybook/react"
-import { LearningResourceListCardCondensed } from "./LearningResourceListCardCondensed"
-import { ResourceTypeEnum } from "api"
-import { factories } from "api/test-utils"
+import {
+  LearningResourceListCardCondensed,
+  LearningResourceListCardCondensedProps,
+} from "./LearningResourceListCardCondensed"
+import { LearningResource } from "api"
 import { withRouter } from "storybook-addon-react-router-v6"
+import _ from "lodash"
+import Stack from "@mui/system/Stack"
+import { resourceArgType, resources, courses } from "./story_utils"
 
-const _makeResource = factories.learningResources.resource
-
-const makeResource: typeof _makeResource = (overrides) => {
-  const resource = _makeResource(overrides)
-  resource.image!.url =
-    "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
-  return resource
+type StoryProps = LearningResourceListCardCondensedProps & {
+  excerpt: (keyof LearningResource)[]
 }
 
-const meta: Meta<typeof LearningResourceListCardCondensed> = {
+const meta: Meta<StoryProps> = {
   title: "smoot-design/Cards/LearningResourceListCardCondensed",
   argTypes: {
-    resource: {
-      options: ["Loading", ...Object.values(ResourceTypeEnum)],
-      mapping: {
-        Loading: undefined,
-        [ResourceTypeEnum.Course]: makeResource({
-          resource_type: ResourceTypeEnum.Course,
-        }),
-        [ResourceTypeEnum.Program]: makeResource({
-          resource_type: ResourceTypeEnum.Program,
-        }),
-        [ResourceTypeEnum.Video]: makeResource({
-          resource_type: ResourceTypeEnum.Video,
-          url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
-        }),
-        [ResourceTypeEnum.VideoPlaylist]: makeResource({
-          resource_type: ResourceTypeEnum.VideoPlaylist,
-        }),
-        [ResourceTypeEnum.Podcast]: makeResource({
-          resource_type: ResourceTypeEnum.Podcast,
-        }),
-        [ResourceTypeEnum.PodcastEpisode]: makeResource({
-          resource_type: ResourceTypeEnum.PodcastEpisode,
-        }),
-        [ResourceTypeEnum.LearningPath]: makeResource({
-          resource_type: ResourceTypeEnum.LearningPath,
-        }),
-      },
-    },
+    resource: resourceArgType,
     onAddToLearningPathClick: {
       action: "click-add-to-learning-path",
     },
@@ -52,171 +25,118 @@ const meta: Meta<typeof LearningResourceListCardCondensed> = {
       action: "click-add-to-user-list",
     },
   },
-  render: ({
-    resource,
-    isLoading,
-    onAddToLearningPathClick,
-    onAddToUserListClick,
-    draggable,
-  }) => (
-    <LearningResourceListCardCondensed
-      resource={resource}
-      isLoading={isLoading}
-      href={`/?resource=${resource?.id}`}
-      onAddToLearningPathClick={onAddToLearningPathClick}
-      onAddToUserListClick={onAddToUserListClick}
-      draggable={draggable}
-    />
-  ),
+  render: ({ excerpt, ...args }) => {
+    const excerptObj = _.pick(args.resource, excerpt)
+    return (
+      <Stack gap="16px">
+        <LearningResourceListCardCondensed
+          {...args}
+          href={`?resource=${args.resource?.id}`}
+        />
+        {excerpt && <pre>{JSON.stringify(excerptObj, null, 2)}</pre>}
+      </Stack>
+    )
+  },
   decorators: [withRouter],
 }
 
 export default meta
 
-type Story = StoryObj<typeof LearningResourceListCardCondensed>
+type Story = StoryObj<StoryProps>
+
+const priceArgs: Partial<Story["args"]> = {
+  excerpt: ["certification", "free", "prices"],
+}
 
 export const FreeCourseNoCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.free.noCertificate,
   },
 }
 
 export const FreeCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificateOnePrice,
   },
 }
 
 export const FreeCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: true,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.free.withCertificatePriceRange,
   },
 }
 
 export const UnknownPriceCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.noCertificate,
   },
 }
 
 export const UnknownPriceCourseWithCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: [],
-    }),
+    ...priceArgs,
+    resource: courses.unknownPrice.withCertificate,
   },
 }
 
 export const PaidCourseWithoutCertificate: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: false,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withoutCertificate,
   },
 }
 
 export const PaidCourseWithCertificateOnePrice: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCerticateOnePrice,
   },
 }
 
 export const PaidCourseWithCertificatePriceRange: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-      free: false,
-      certification: true,
-      prices: ["250", "1000"],
-    }),
+    ...priceArgs,
+    resource: courses.paid.withCertificatePriceRange,
   },
 }
 
 export const LearningPath: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.LearningPath }),
+    resource: resources.learningPath,
   },
 }
 
 export const Program: Story = {
   args: {
-    resource: makeResource({ resource_type: ResourceTypeEnum.Program }),
+    resource: resources.program,
   },
 }
 
 export const Podcast: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Podcast,
-      free: true,
-    }),
+    resource: resources.podcast,
   },
 }
 
 export const PodcastEpisode: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.PodcastEpisode,
-      free: true,
-    }),
+    resource: resources.podcastEpisode,
   },
 }
 
 export const Video: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Video,
-      url: "https://www.youtube.com/watch?v=4A9bGL-_ilA",
-      free: true,
-    }),
+    resource: resources.video,
   },
 }
 
 export const VideoPlaylist: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.VideoPlaylist,
-      free: true,
-    }),
+    resource: resources.videoPlaylist,
   },
 }
 
@@ -228,10 +148,7 @@ export const Loading: Story = {
 
 export const Draggable: Story = {
   args: {
-    resource: makeResource({
-      resource_type: ResourceTypeEnum.Course,
-      runs: [factories.learningResources.run()],
-    }),
+    resource: resources.course,
     draggable: true,
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
@@ -1,0 +1,124 @@
+import { ResourceTypeEnum } from "api"
+import { factories } from "api/test-utils"
+
+const _makeResource = factories.learningResources.resource
+
+const makeResource: typeof _makeResource = (overrides) => {
+  const resource = _makeResource(overrides)
+  if (resource.image) {
+    resource.image.url =
+      "https://ocw.mit.edu/courses/res-hso-001-mit-haystack-observatory-k12-stem-lesson-plans/mitres_hso_001.jpg"
+  }
+  if (resource.resource_type === ResourceTypeEnum.Video) {
+    resource.url = "https://www.youtube.com/watch?v=4A9bGL-_ilA"
+  }
+  return resource
+}
+
+const resources = {
+  withoutImage: makeResource({ image: null }),
+  course: makeResource({
+    resource_type: ResourceTypeEnum.Course,
+  }),
+  program: makeResource({
+    resource_type: ResourceTypeEnum.Program,
+  }),
+  video: makeResource({
+    resource_type: ResourceTypeEnum.Video,
+    url: "https://www.youtube.com/watch?v=-E9hf5RShzQ",
+  }),
+  videoPlaylist: makeResource({
+    resource_type: ResourceTypeEnum.VideoPlaylist,
+  }),
+  podcast: makeResource({
+    resource_type: ResourceTypeEnum.Podcast,
+  }),
+  podcastEpisode: makeResource({
+    resource_type: ResourceTypeEnum.PodcastEpisode,
+  }),
+  learningPath: makeResource({
+    resource_type: ResourceTypeEnum.LearningPath,
+  }),
+}
+
+const courses = {
+  free: {
+    noCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: false,
+      prices: ["0"],
+    }),
+    withCertificateOnePrice: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["0", "49"],
+    }),
+    withCertificatePriceRange: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: true,
+      certification: true,
+      prices: ["0", "99", "49"],
+    }),
+  },
+  unknownPrice: {
+    noCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: [],
+    }),
+    withCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: [],
+    }),
+  },
+  paid: {
+    withoutCertificate: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: false,
+      prices: ["49"],
+    }),
+    withCerticateOnePrice: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["49"],
+    }),
+    withCertificatePriceRange: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      runs: [factories.learningResources.run()],
+      free: false,
+      certification: true,
+      prices: ["49", "99"],
+    }),
+  },
+}
+
+const resourceArgType = {
+  options: ["Loading", "Without Image", ...Object.values(ResourceTypeEnum)],
+  mapping: {
+    Loading: null,
+    "Without Image": resources.withoutImage,
+    [ResourceTypeEnum.Course]: resources.course,
+    [ResourceTypeEnum.Program]: resources.program,
+    [ResourceTypeEnum.Video]: resources.video,
+    [ResourceTypeEnum.VideoPlaylist]: resources.videoPlaylist,
+    [ResourceTypeEnum.Podcast]: resources.podcast,
+    [ResourceTypeEnum.PodcastEpisode]: resources.podcastEpisode,
+    [ResourceTypeEnum.LearningPath]: resources.learningPath,
+  },
+}
+
+export { resourceArgType, resources, courses }


### PR DESCRIPTION
### Description (What does it do?)
Adds a way to display an excerpt of the learning resource to learning resource card stories

### Screenshots (if appropriate):
![Screenshot 2024-07-24 at 11 55 50 AM](https://github.com/user-attachments/assets/bd429f07-049b-4af5-a922-05d1eaf8b6e1)


### How can this be tested?
View, e.g., http://localhost:6006/?path=/story/smoot-design-cards-learningresourcecard--paid-course-without-certificate