### PR TITLE
Reorder where the testimonial displays in the unit/offeror page to fix spacing and background

### DIFF
--- a/frontends/mit-open/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
+++ b/frontends/mit-open/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
@@ -56,7 +56,7 @@ const QuoteBlock = styled.div(() => ({
   width: "100%",
   maxWidth: "1328px",
   margin: "0 auto",
-  padding: "0 22px",
+  padding: "0 28px",
 }))
 
 const QuoteLeader = styled.div(({ theme }) => ({

--- a/frontends/mit-open/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/ChannelPage.tsx
@@ -9,12 +9,6 @@ import {
   type BooleanFacets,
 } from "@mitodl/course-search-utils"
 import { ChannelTypeEnum } from "api/v0"
-import TestimonialDisplay from "@/page-components/TestimonialDisplay/TestimonialDisplay"
-import { styled } from "ol-components"
-
-export const StyledTestimonialDisplay = styled(TestimonialDisplay)`
-  margin-bottom: 80px;
-`
 
 type RouteParams = {
   channelType: ChannelTypeEnum
@@ -41,18 +35,17 @@ const ChannelPage: React.FC = () => {
   return (
     name &&
     channelType && (
-      <ChannelPageTemplate name={name} channelType={channelType}>
-        <p>{channelQuery.data?.public_description}</p>
-        {channelType === "unit" ? (
-          <StyledTestimonialDisplay offerors={[name]} />
-        ) : null}
-        {channelQuery.data?.search_filter && (
-          <FieldSearch
-            constantSearchParams={searchParams}
-            channelType={channelType}
-          />
-        )}
-      </ChannelPageTemplate>
+      <>
+        <ChannelPageTemplate name={name} channelType={channelType}>
+          <p>{channelQuery.data?.public_description}</p>
+          {channelQuery.data?.search_filter && (
+            <FieldSearch
+              constantSearchParams={searchParams}
+              channelType={channelType}
+            />
+          )}
+        </ChannelPageTemplate>
+      </>
     )
   )
 }

--- a/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
@@ -21,6 +21,7 @@ import { getSearchParamMap } from "@/common/utils"
 import { HOME as HOME_URL, UNITS as UNITS_URL } from "../../common/urls"
 import { ChannelTypeEnum } from "api/v0"
 import { ChannelControls, UNITS_LABEL } from "./ChannelPageTemplate"
+import TestimonialDisplay from "@/page-components/TestimonialDisplay/TestimonialDisplay"
 
 const StyledBannerBackground = styled(BannerBackground)(({ theme }) => ({
   padding: "48px 0 64px 0",
@@ -182,8 +183,9 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
           config={FEATURED_RESOURCES_CAROUSEL}
           isLoading={channel.isLoading}
         />
-        {children}
       </Container>
+      <TestimonialDisplay offerors={[name]} />
+      <Container>{children}</Container>
     </>
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4968

### Description (What does it do?)

This PR does two things:
- Moves the `TestmonialDisplay` component to the `UnitChannelTemplate` from where it was in `ChannelPage` so that it's not constrained by the component it was residing in.
- Adds a minor tweak to the left/right padding so that the testimonial display is even with the header components.

### Screenshots (if appropriate):

Desktop:

![image](https://github.com/user-attachments/assets/2d417bcc-0be6-492c-b1a2-f5cbd07463b1)
![image](https://github.com/user-attachments/assets/9afcdcbf-14c6-47b2-9448-8b7347399a36)

(Green lines provided by xScope to show alignment.)

Mobile:

![image](https://github.com/user-attachments/assets/2f3628a6-d91f-4873-966f-31acb584280a)
![image](https://github.com/user-attachments/assets/8456742e-e0dc-4988-8a2a-9107293f93e8)

### How can this be tested?

Load a unit page. The testimonial display should look correct according to the design in FIgma.
