### PR TITLE
fix banner background width

### DIFF
--- a/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
+++ b/frontends/mit-open/src/pages/ChannelPage/UnitChannelTemplate.tsx
@@ -110,7 +110,6 @@ const UnitChannelTemplate: React.FC<UnitChannelTemplateProps> = ({
           displayConfiguration?.banner_background ??
           "/static/images/background_steps.jpeg"
         }
-        backgroundSize="2000px auto"
         backgroundDim={30}
       >
         <Container>

--- a/frontends/ol-components/src/components/Banner/Banner.tsx
+++ b/frontends/ol-components/src/components/Banner/Banner.tsx
@@ -20,12 +20,12 @@ type BannerBackgroundProps = {
  * This is a full-width banner component that takes a background image URL.
  */
 const BannerBackground = styled.div<BannerBackgroundProps>(
-  ({ theme, backgroundUrl, backgroundSize = "cover", backgroundDim = 0 }) => ({
+  ({ theme, backgroundUrl, backgroundDim = 0 }) => ({
     backgroundAttachment: "fixed",
     backgroundImage: backgroundDim
       ? `linear-gradient(rgba(0 0 0 / ${backgroundDim}%), rgba(0 0 0 / ${backgroundDim}%)), url('${backgroundUrl}')`
       : `url(${backgroundUrl})`,
-    backgroundSize: backgroundSize,
+    backgroundSize: "cover",
     backgroundRepeat: "no-repeat",
     color: theme.custom.colors.white,
     padding: "48px 0 48px 0",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4958

### Description (What does it do?)
Allows unit page banner background image to take up whole width

### Screenshots (if appropriate):
![Screenshot 2024-07-24 at 2 57 55 PM](https://github.com/user-attachments/assets/be3c7ae1-66dd-47bb-8bf8-6e33566f8a47)
![Screenshot 2024-07-24 at 2 58 04 PM](https://github.com/user-attachments/assets/d447c2fb-96de-4c01-80ff-842e097df591)
![Screenshot 2024-07-24 at 2 58 19 PM](https://github.com/user-attachments/assets/cc79f247-2195-4c79-9b1f-3d49ab49a934)


### How can this be tested?
View a unit page (e.g., http://localhost:8062/c/unit/ocw, http://localhost:8062/c/unit/mitx) at a variety of widths, including very wide screens (zoom out).
