### PR TITLE
Fix channel views test

### DIFF
--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.django_db
 
 def test_list_channels(user_client):
     """Test that all channels are returned"""
-    channels = sorted(ChannelFactory.create_batch(15), key=lambda f: f.id)
+    channels = sorted(ChannelFactory.create_batch(10), key=lambda f: f.id)
     url = reverse("channels:v0:channels_api-list")
     channel_list = sorted(user_client.get(url).json()["results"], key=lambda f: f["id"])
     assert len(channel_list) == 10


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4982

### Description (What does it do?)
Fixes a flaky test in channels/views_test.py


### How can this be tested?
Run `pytest channels/views_test.py` multiple times, all tests should always pass.
