### PR TITLE
Fix podcast duration frontend display

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -126,7 +126,9 @@ const INFO_ITEMS: InfoItemConfig = [
           : null
       }
       if (resource.resource_type === ResourceTypeEnum.PodcastEpisode) {
-        return resource.podcast_episode.duration || null
+        return resource.podcast_episode.duration
+          ? formatDurationClockTime(resource.podcast_episode.duration)
+          : null
       }
       return null
     },

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -247,4 +247,19 @@ describe("Learning Resource Expanded", () => {
 
     within(section).getByText("1:13:44")
   })
+
+  test("Renders info section podcast episode duration correctly", () => {
+    const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.PodcastEpisode,
+      podcast_episode: { duration: "PT13M44S" },
+    })
+
+    setup(resource)
+
+    const section = screen
+      .getByRole("heading", { name: "Info" })!
+      .closest("section")!
+
+    within(section).getByText("13:44")
+  })
 })


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4432

### Description (What does it do?)
Updates the frontend to display podcast episode duration correctly based on the ISO-8601 format.


### How can this be tested?
- Run "./manage.py backpopulate_podcast_data" 
- Go to http://open.odl.local:8062/search/?resource_category=learning_material&resource_type=podcast_episode, lick on some episodes and make sure the duration appears in a readable format for those episodes that have a non-null/blnak duration.
- 
![Screenshot 2024-07-26 130250](https://github.com/user-attachments/assets/07994235-8eac-4f8f-a68e-3cd26395b801)

