### PR TITLE
Remap topic icons according to what's in the topics listing

### DIFF
--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
@@ -10,7 +10,7 @@ describe("TopicIcon", () => {
    * at least make sure we have an icon for each of them.
    */
   test.each(rootTopicNames)("Root topics all have an icon", (name) => {
-    expect(rootTopicNames.length).toBe(11)
+    expect(rootTopicNames.length).toBe(12)
     render(<RootTopicIcon name={name} />)
     const svg = document.querySelector("svg")
     expect(svg).toBeVisible()

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
@@ -15,17 +15,18 @@ import React from "react"
 
 /* TODO Using any icons until we have a solution for specifying them */
 export const ICON_MAP = {
-  Business: RiBriefcase3Line,
-  Energy: RiLightbulbFlashLine,
-  Engineering: RiRobot2Line,
-  "Fine Arts": RiPaletteLine,
-  "Health and Medicine": RiStethoscopeLine,
+  "Business & Management": RiBriefcase3Line,
+  "Energy, Climate & Sustainability": RiLightbulbFlashLine,
+  "Data Science, Analytics & Computer Technology": RiRobot2Line,
+  "Art, Design & Architecture": RiPaletteLine,
+  "Health & Medicine": RiStethoscopeLine,
   Humanities: RiQuillPenLine,
   Mathematics: RiInfinityLine,
-  Science: RiTestTubeLine,
-  "Social Science": RiUserSearchLine,
+  "Science & Math": RiTestTubeLine,
+  "Social Sciences": RiUserSearchLine,
   Society: RiEarthLine,
-  "Teaching and Education": RiShakeHandsLine,
+  "Education & Teaching": RiShakeHandsLine,
+  Engineering: RiRobot2Line,
 }
 
 type RootTopicIconProps = { name: string }


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

The topic icons are hard-coded in the `RootTopicIcon` component. Those topics have changed, though - in https://github.com/mitodl/mit-open/pull/1275 we've changed the name of some root topics and added others, so this fixes the map in `RootTopicIcon` so that it matches the new setup.

### How can this be tested?

Load the homepage. You should see icons in the Browse by Topic section and they should match the root icons listed in the topics.yaml file (or in the database).
