### PR TITLE
urlencode search_filter

### DIFF
--- a/channels/plugins.py
+++ b/channels/plugins.py
@@ -1,5 +1,7 @@
 """Plugins for channels"""
 
+from urllib.parse import urlencode
+
 from django.apps import apps
 from django.utils.text import slugify
 
@@ -34,7 +36,10 @@ class ChannelPlugin:
             channel, _ = Channel.objects.update_or_create(
                 name=slugify(topic.name),
                 channel_type=ChannelType.topic.name,
-                defaults={"title": topic.name, "search_filter": f"topic={topic.name}"},
+                defaults={
+                    "title": topic.name,
+                    "search_filter": urlencode({"topic": topic.name}),
+                },
             )
             ChannelTopicDetail.objects.update_or_create(channel=channel, topic=topic)
             return channel, True
@@ -73,7 +78,7 @@ class ChannelPlugin:
             channel = None
         elif department.school and (overwrite or not channel):
             channel, _ = Channel.objects.update_or_create(
-                search_filter=f"department={department.department_id}",
+                search_filter=urlencode({"department": department.department_id}),
                 channel_type=ChannelType.department.name,
                 defaults={
                     "name": slugify(department.name),
@@ -117,7 +122,7 @@ class ChannelPlugin:
                 channel_type=ChannelType.unit.name,
                 defaults={
                     "title": offeror.name,
-                    "search_filter": f"offered_by={offeror.code}",
+                    "search_filter": urlencode({"offered_by": offeror.code}),
                 },
             )
             ChannelUnitDetail.objects.update_or_create(channel=channel, unit=offeror)

--- a/channels/plugins_test.py
+++ b/channels/plugins_test.py
@@ -23,13 +23,13 @@ from learning_resources.models import (
 @pytest.mark.parametrize("overwrite", [True, False])
 def test_search_index_plugin_topic_upserted(overwrite):
     """The plugin function should create a topic channel"""
-    topic = LearningResourceTopicFactory.create()
+    topic = LearningResourceTopicFactory.create(name="Test & Testing Topic")
     channel, created = ChannelPlugin().topic_upserted(topic, overwrite)
     assert created is True
     assert channel.topic_detail.topic == topic
     assert channel.title == topic.name
     assert channel.channel_type == ChannelType.topic.name
-    assert channel.search_filter == f"topic={topic.name}"
+    assert channel.search_filter == "topic=Test+%26+Testing+Topic"
     same_channel, upserted = ChannelPlugin().topic_upserted(topic, overwrite)
     assert channel == same_channel
     assert upserted is overwrite

--- a/learning_resources/management/commands/backpopulate_resource_channels.py
+++ b/learning_resources/management/commands/backpopulate_resource_channels.py
@@ -105,7 +105,7 @@ class Command(BaseCommand):
             self.stdout.write("Creating topic channels")
             for topic in LearningResourceTopic.objects.filter(
                 learningresource__isnull=False
-            ):
+            ).distinct():
                 if hook.topic_upserted(topic=topic, overwrite=overwrite)[0][1]:
                     created += 1
             self.stdout.write(f"Finished creating channels for {created} topics")


### PR DESCRIPTION
### What are the relevant tickets?
Fixes a bug exposed during https://github.com/mitodl/mit-open/pull/1323

### Description (What does it do?)
Starting with https://github.com/mitodl/mit-open/pull/1275, some of our topic names have ampersands. The current channel creation code was creating search filters like
```json
{
   "search_filter": "topic=Education & Teaching"
}
```
The frontend expects `search_filter` to be parseable as a URLSearchParams, so ampersands were being interpreted as separate parameters: `topic=Education&topic=Teaching`.

This PR ensures that the search filter is urlencoded .

### How can this be tested?
1. Make sure that you've run the data migration from  https://github.com/mitodl/mit-open/pull/1323 and re-run the ETL pipelines to associate resources with topics.
2. **Suggested:** On `main`, go to `/topics` on the frontend. Click any topic that has an ampersand in its title. You will be navigated to the topic detail page.
    - expected: On `main`, the search results are empty.
    - compare to the API search results,  e.g., http://localhost:8063/api/v1/learning_resources_search/?topic=Education+%26+Teaching ... it should have results 
3. Now on this branch (restart docker, or at least celery!), run `./manage.py backpopulate_resource_channels --topic --overwrite` 
    - **Note:** this command only creates a channel if some resource uses that topic. So you need to make sure you're testing a topic that actually has resources associated with it.
4. Check the topic detail page from (2) again. It should have search results.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
