### PR TITLE
Remove some styling for topic box names so they wrap, adjusting icons

### DIFF
--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
@@ -10,7 +10,7 @@ describe("TopicIcon", () => {
    * at least make sure we have an icon for each of them.
    */
   test.each(rootTopicNames)("Root topics all have an icon", (name) => {
-    expect(rootTopicNames.length).toBe(12)
+    expect(rootTopicNames.length).toBe(13)
     render(<RootTopicIcon name={name} />)
     const svg = document.querySelector("svg")
     expect(svg).toBeVisible()

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
@@ -10,6 +10,8 @@ import {
   RiInfinityLine,
   RiTestTubeLine,
   RiUserSearchLine,
+  RiTeamLine,
+  RiLineChartLine,
 } from "@remixicon/react"
 import React from "react"
 
@@ -17,7 +19,7 @@ import React from "react"
 export const ICON_MAP = {
   "Business & Management": RiBriefcase3Line,
   "Energy, Climate & Sustainability": RiLightbulbFlashLine,
-  "Data Science, Analytics & Computer Technology": RiRobot2Line,
+  "Data Science, Analytics & Computer Technology": RiLineChartLine,
   "Art, Design & Architecture": RiPaletteLine,
   "Health & Medicine": RiStethoscopeLine,
   Humanities: RiQuillPenLine,
@@ -27,6 +29,7 @@ export const ICON_MAP = {
   Society: RiEarthLine,
   "Education & Teaching": RiShakeHandsLine,
   Engineering: RiRobot2Line,
+  "Innovation & Entrepreneurship": RiTeamLine,
 }
 
 type RootTopicIconProps = { name: string }

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -78,11 +78,12 @@ const TopicBoxContent = styled.div`
   }}
 `
 
+// This should have these rules - temporarily disabled for now:
+// white-space: nowrap;
+// text-overflow: ellipsis;
+// overflow: hidden;
 const TopicBoxName = styled.p`
   flex-grow: 1;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
   margin: 0;
 `
 


### PR DESCRIPTION
These are some very temporary changes to make this look better before it hits prod.

### What are the relevant tickets?

n/a

### Description (What does it do?)

Makes the topic name wrap and changes the icons for Data Science (which had a duplicate icon) and Innovation & Entrepreneurship (which did not have one).

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/337a066d-e05e-4034-b104-22f4393c37f2)

### How can this be tested?

View the homepage. The topics should be listed as per the screenshot.

### Additional Context

This won't match the styling in Figma and it also doesn't fix the data issue for the icons for Data Science and Innovation. However, this is just to get things to look better before it hits prod.