### PR TITLE
add default yearly_decay_percent

### DIFF
--- a/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-open/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -628,7 +628,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   stalenessSliderSetting={
                     searchParams.get("yearly_decay_percent")
                       ? Number(searchParams.get("yearly_decay_percent"))
-                      : 0
+                      : 2.5
                   }
                   setSearchParams={setSearchParams}
                 />

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -486,7 +486,7 @@ def adjust_original_query_for_percolate(query):
     Remove keys that are irrelevent when storing original queries
     for percolate uniqueness such as "limit" and "offset"
     """
-    for key in ["limit", "offset", "sortby"]:
+    for key in ["limit", "offset", "sortby", "yearly_decay_percent"]:
         query.pop(key, None)
     return order_params(query)
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -308,7 +308,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         min_value=0,
         required=False,
         allow_null=True,
-        default=None,
+        default=2.5,
         help_text=(
             "Relevance score penalty percent per year for for resources without "
             "upcoming runs. Only affects results if there is a search term."

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2542,6 +2542,7 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
+          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -2971,6 +2972,7 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
+          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -3439,6 +3441,7 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
+          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -3884,6 +3887,7 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
+          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -9541,6 +9545,7 @@ components:
           maximum: 10
           minimum: 0
           nullable: true
+          default: 2.5
           description: Relevance score penalty percent per year for for resources
             without upcoming runs. Only affects results if there is a search term.
         certification:


### PR DESCRIPTION
### What are the relevant tickets?
 closes https://github.com/mitodl/hq/issues/5018

### Description (What does it do?)
Sets the default yearly_decay_percent to 2.5. The parameter does not appear in the search unless it's set to something other than 2.5

### How can this be tested?
Run `docker-compose run web ./manage.py recreate_index --all` if you haven't recently
Log in as an admin.
Got to http://localhost:8062/search/?q=molecular+biology
Verify that by default the "Resource Score Staleness Penalty" slider is set to 2.5. Verify that you can change the value of the slider value and the larger the penalty the further down the the results older resources go
Log out
Verify that you get the same results at http://localhost:8062/search/?q=molecular+biology as you did as an admin with the default  "Resource Score Staleness Penalty" slider setting
