### PR TITLE
Avoid course overwrites in program ETL pipelines

### DIFF
--- a/learning_resources/etl/constants.py
+++ b/learning_resources/etl/constants.py
@@ -26,8 +26,8 @@ LearningResourceRunLoaderConfig = namedtuple(  # noqa: PYI024
 
 CourseLoaderConfig = namedtuple(  # noqa: PYI024
     "CourseLoaderConfig",
-    ["prune", "offered_by", "runs"],
-    defaults=[True, OfferedByLoaderConfig(), LearningResourceRunLoaderConfig()],
+    ["prune", "offered_by", "runs", "fetch_only"],
+    defaults=[True, OfferedByLoaderConfig(), LearningResourceRunLoaderConfig(), False],
 )
 
 ProgramLoaderConfig = namedtuple(  # noqa: PYI024

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -339,11 +339,15 @@ def load_course(  # noqa: C901
         if config.fetch_only:
             # Do not upsert the course, it should already exist.
             # Just find it and return it.
-            return LearningResource.objects.filter(
+            resource = LearningResource.objects.filter(
                 readable_id=resource_id,
                 platform=platform,
                 resource_type=LearningResourceType.course.name,
+                published=True,
             ).first()
+            if not resource:
+                log.warning("No published resource found for %s", resource_id)
+            return resource
 
         if unique_field_name != READABLE_ID_FIELD:
             # Some dupes may result, so we need to unpublish resources

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -335,6 +335,16 @@ def load_course(  # noqa: C901
             unique_field_value,
         )
         resource_id = deduplicated_course_id or readable_id
+
+        if config.fetch_only:
+            # Do not upsert the course, it should already exist.
+            # Just find it and return it.
+            return LearningResource.objects.filter(
+                readable_id=resource_id,
+                platform=platform,
+                resource_type=LearningResourceType.course.name,
+            ).first()
+
         if unique_field_name != READABLE_ID_FIELD:
             # Some dupes may result, so we need to unpublish resources
             # with matching unique values and different readable_ids
@@ -346,16 +356,6 @@ def load_course(  # noqa: C901
                 resource.published = False
                 resource.save()
                 resource_unpublished_actions(resource)
-
-        if config.fetch_only:
-            # Do not upsert the course, it should already exist.
-            # Just find it and return it.
-            return LearningResource.objects.filter(
-                readable_id=resource_id,
-                platform=platform,
-                resource_type=LearningResourceType.course.name,
-            ).first()
-
         (
             learning_resource,
             created,

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -259,7 +259,7 @@ def load_run(
     return learning_resource_run
 
 
-def load_course(
+def load_course(  # noqa: C901
     resource_data: dict,
     blocklist: list[str],
     duplicates: list[dict],
@@ -346,6 +346,16 @@ def load_course(
                 resource.published = False
                 resource.save()
                 resource_unpublished_actions(resource)
+
+        if config.fetch_only:
+            # Do not upsert the course, it should already exist.
+            # Just find it and return it.
+            return LearningResource.objects.filter(
+                readable_id=resource_id,
+                platform=platform,
+                resource_type=LearningResourceType.course.name,
+            ).first()
+
         (
             learning_resource,
             created,

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -528,8 +528,6 @@ def load_program(
             )
             if course_resource:
                 course_resources.append(course_resource)
-            else:
-                log.warning("Program course not found: %s", course_data["readable_id"])
         program.learning_resource.resources.set(
             course_resources,
             through_defaults={

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -599,8 +599,9 @@ def test_load_course_dupe_urls(unique_url):
 
 
 @pytest.mark.parametrize("course_exists", [True, False])
-def test_load_course_no_fetch(mocker, course_exists):
-    """When no_fetch is True, course should just be fetched from db"""
+def test_load_course_fetch_only(mocker, course_exists):
+    """When fetch_only is True, course should just be fetched from db"""
+    mock_warn = mocker.patch("learning_resources.etl.loaders.log.warning")
     mock_next_runs_prices = mocker.patch(
         "learning_resources.etl.loaders.load_next_start_date_and_prices"
     )
@@ -619,6 +620,7 @@ def test_load_course_no_fetch(mocker, course_exists):
         assert result == resource
     else:
         assert result is None
+    assert mock_warn.call_count == (0 if course_exists else 1)
     mock_next_runs_prices.assert_not_called()
 
 

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -95,7 +95,9 @@ prolearn_courses_etl = compose(
 xpro_programs_etl = compose(
     load_programs(
         ETLSource.xpro.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(fetch_only=True)),
+        config=ProgramLoaderConfig(
+            courses=CourseLoaderConfig(fetch_only=True), prune=True
+        ),
     ),
     xpro.transform_programs,
     xpro.extract_programs,

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -35,7 +35,9 @@ load_courses = curry(loaders.load_courses)
 micromasters_etl = compose(
     load_programs(
         ETLSource.micromasters.name,
-        config=ProgramLoaderConfig(prune=True, courses=CourseLoaderConfig(prune=False)),
+        config=ProgramLoaderConfig(
+            prune=True, courses=CourseLoaderConfig(fetch_only=True)
+        ),
     ),
     micromasters.transform,
     micromasters.extract,
@@ -53,7 +55,9 @@ mit_edx_etl = compose(
 mitxonline_programs_etl = compose(
     load_programs(
         ETLSource.mitxonline.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False), prune=True),
+        config=ProgramLoaderConfig(
+            courses=CourseLoaderConfig(fetch_only=True), prune=True
+        ),
     ),
     mitxonline.transform_programs,
     mitxonline.extract_programs,
@@ -74,7 +78,7 @@ oll_etl = compose(
 prolearn_programs_etl = compose(
     load_programs(
         ETLSource.prolearn.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(fetch_only=True)),
     ),
     prolearn.transform_programs,
     prolearn.extract_programs,
@@ -91,7 +95,7 @@ prolearn_courses_etl = compose(
 xpro_programs_etl = compose(
     load_programs(
         ETLSource.xpro.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(fetch_only=True)),
     ),
     xpro.transform_programs,
     xpro.extract_programs,

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -35,7 +35,7 @@ load_courses = curry(loaders.load_courses)
 micromasters_etl = compose(
     load_programs(
         ETLSource.micromasters.name,
-        config=ProgramLoaderConfig(prune=True, courses=CourseLoaderConfig()),
+        config=ProgramLoaderConfig(prune=True, courses=CourseLoaderConfig(prune=False)),
     ),
     micromasters.transform,
     micromasters.extract,
@@ -53,7 +53,7 @@ mit_edx_etl = compose(
 mitxonline_programs_etl = compose(
     load_programs(
         ETLSource.mitxonline.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True), prune=True),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False), prune=True),
     ),
     mitxonline.transform_programs,
     mitxonline.extract_programs,
@@ -74,7 +74,7 @@ oll_etl = compose(
 prolearn_programs_etl = compose(
     load_programs(
         ETLSource.prolearn.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False)),
     ),
     prolearn.transform_programs,
     prolearn.extract_programs,
@@ -91,7 +91,7 @@ prolearn_courses_etl = compose(
 xpro_programs_etl = compose(
     load_programs(
         ETLSource.xpro.name,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=False)),
     ),
     xpro.transform_programs,
     xpro.extract_programs,

--- a/learning_resources/etl/pipelines_test.py
+++ b/learning_resources/etl/pipelines_test.py
@@ -79,7 +79,9 @@ def test_mitxonline_programs_etl():
     mock_load_programs.assert_called_once_with(
         ETLSource.mitxonline.name,
         mock_transform.return_value,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True), prune=True),
+        config=ProgramLoaderConfig(
+            courses=CourseLoaderConfig(fetch_only=True), prune=True
+        ),
     )
 
     assert result == mock_load_programs.return_value
@@ -146,7 +148,9 @@ def test_xpro_programs_etl():
     mock_load_programs.assert_called_once_with(
         ETLSource.xpro.name,
         mock_transform.return_value,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(
+            courses=CourseLoaderConfig(fetch_only=True), prune=True
+        ),
     )
 
     assert result == mock_load_programs.return_value
@@ -296,7 +300,9 @@ def test_micromasters_etl():
     mock_load_programs.assert_called_once_with(
         ETLSource.micromasters.name,
         mock_transform.return_value,
-        config=ProgramLoaderConfig(prune=True, courses=CourseLoaderConfig()),
+        config=ProgramLoaderConfig(
+            prune=True, courses=CourseLoaderConfig(fetch_only=True)
+        ),
     )
 
     assert result == mock_load_programs.return_value
@@ -317,7 +323,7 @@ def test_prolearn_programs_etl():
     mock_load_programs.assert_called_once_with(
         ETLSource.prolearn.name,
         mock_transform.return_value,
-        config=ProgramLoaderConfig(courses=CourseLoaderConfig(prune=True)),
+        config=ProgramLoaderConfig(courses=CourseLoaderConfig(fetch_only=True)),
     )
 
     assert result == mock_load_programs.return_value


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4960

### Description (What does it do?)
Adds a new course config option, "fetch_only",  meant to be used in program ETL pipelines, that when True will prevent any courses included in the program from being upserted.  Only existing courses will be added to the program.



### How can this be tested?
- Set the `EDX_API_` and `MICROMASTERS_` env variables to the same values as RC
- Run `./manage.py backpopulate_mit_edx_data` (with `--api_datafile <mit_edx.json file>` if you've previously saved the output).
- Go to http://open.odl.local:8062/search?offered_by=mitx&q=%22Supply+Chain+Design%22 and click the top result, you should see a start date of "January 08, 2025" on both the card and drawer.
-  Run `./manage.py backpopulate_micromasters_data 
- Go back to the url above, the start date should still be there in both the card and drawer.
- Find the id for the program "Supply Chain Management".  Then go to http://api.open.odl.local:8063/api/v1/learning_resources/<program_id>/items/ and make sure that the course "Supply Chain Design" is included.

