### PR TITLE
dev mode for search

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3402,6 +3402,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   topic?: Array<string>
   /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  dev_mode?: boolean | null
+  /**
    * The id value for the learning resource
    * @type {Array<number>}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -6612,6 +6618,7 @@ export const ContentFileSearchApiAxiosParamCreator = function (
      * @summary Search
      * @param {Array<ContentFileSearchRetrieveAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {Array<string>} [content_feature_type] The feature type of the content file. Possible options are at api/v1/course_features/
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {Array<number>} [id] The id value for the content file
      * @param {number} [limit] Number of results to return per page
      * @param {Array<ContentFileSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
@@ -6628,6 +6635,7 @@ export const ContentFileSearchApiAxiosParamCreator = function (
     contentFileSearchRetrieve: async (
       aggregations?: Array<ContentFileSearchRetrieveAggregationsEnum>,
       content_feature_type?: Array<string>,
+      dev_mode?: boolean | null,
       id?: Array<number>,
       limit?: number,
       offered_by?: Array<ContentFileSearchRetrieveOfferedByEnum>,
@@ -6662,6 +6670,10 @@ export const ContentFileSearchApiAxiosParamCreator = function (
 
       if (content_feature_type) {
         localVarQueryParameter["content_feature_type"] = content_feature_type
+      }
+
+      if (dev_mode !== undefined) {
+        localVarQueryParameter["dev_mode"] = dev_mode
       }
 
       if (id) {
@@ -6734,6 +6746,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
      * @summary Search
      * @param {Array<ContentFileSearchRetrieveAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {Array<string>} [content_feature_type] The feature type of the content file. Possible options are at api/v1/course_features/
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {Array<number>} [id] The id value for the content file
      * @param {number} [limit] Number of results to return per page
      * @param {Array<ContentFileSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
@@ -6750,6 +6763,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
     async contentFileSearchRetrieve(
       aggregations?: Array<ContentFileSearchRetrieveAggregationsEnum>,
       content_feature_type?: Array<string>,
+      dev_mode?: boolean | null,
       id?: Array<number>,
       limit?: number,
       offered_by?: Array<ContentFileSearchRetrieveOfferedByEnum>,
@@ -6771,6 +6785,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
         await localVarAxiosParamCreator.contentFileSearchRetrieve(
           aggregations,
           content_feature_type,
+          dev_mode,
           id,
           limit,
           offered_by,
@@ -6825,6 +6840,7 @@ export const ContentFileSearchApiFactory = function (
         .contentFileSearchRetrieve(
           requestParameters.aggregations,
           requestParameters.content_feature_type,
+          requestParameters.dev_mode,
           requestParameters.id,
           requestParameters.limit,
           requestParameters.offered_by,
@@ -6861,6 +6877,13 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
   readonly content_feature_type?: Array<string>
+
+  /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly dev_mode?: boolean | null
 
   /**
    * The id value for the content file
@@ -6956,6 +6979,7 @@ export class ContentFileSearchApi extends BaseAPI {
       .contentFileSearchRetrieve(
         requestParameters.aggregations,
         requestParameters.content_feature_type,
+        requestParameters.dev_mode,
         requestParameters.id,
         requestParameters.limit,
         requestParameters.offered_by,
@@ -11642,6 +11666,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -11666,6 +11691,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       certification_type?: Array<LearningResourcesSearchRetrieveCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
@@ -11717,6 +11743,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (department) {
         localVarQueryParameter["department"] = department
+      }
+
+      if (dev_mode !== undefined) {
+        localVarQueryParameter["dev_mode"] = dev_mode
       }
 
       if (free !== undefined) {
@@ -11814,6 +11844,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -11838,6 +11869,7 @@ export const LearningResourcesSearchApiFp = function (
       certification_type?: Array<LearningResourcesSearchRetrieveCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
@@ -11867,6 +11899,7 @@ export const LearningResourcesSearchApiFp = function (
           certification_type,
           course_feature,
           department,
+          dev_mode,
           free,
           id,
           learning_format,
@@ -11929,6 +11962,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.certification_type,
           requestParameters.course_feature,
           requestParameters.department,
+          requestParameters.dev_mode,
           requestParameters.free,
           requestParameters.id,
           requestParameters.learning_format,
@@ -11991,6 +12025,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>
+
+  /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly dev_mode?: boolean | null
 
   /**
    *
@@ -12124,6 +12165,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.certification_type,
         requestParameters.course_feature,
         requestParameters.department,
+        requestParameters.dev_mode,
         requestParameters.free,
         requestParameters.id,
         requestParameters.learning_format,
@@ -12344,6 +12386,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -12369,6 +12412,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       certification_type?: Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
@@ -12421,6 +12465,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (department) {
         localVarQueryParameter["department"] = department
+      }
+
+      if (dev_mode !== undefined) {
+        localVarQueryParameter["dev_mode"] = dev_mode
       }
 
       if (free !== undefined) {
@@ -12509,6 +12557,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -12533,6 +12582,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       certification_type?: Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
@@ -12584,6 +12634,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (department) {
         localVarQueryParameter["department"] = department
+      }
+
+      if (dev_mode !== undefined) {
+        localVarQueryParameter["dev_mode"] = dev_mode
       }
 
       if (free !== undefined) {
@@ -12668,6 +12722,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -12694,6 +12749,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       certification_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
@@ -12747,6 +12803,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (department) {
         localVarQueryParameter["department"] = department
+      }
+
+      if (dev_mode !== undefined) {
+        localVarQueryParameter["dev_mode"] = dev_mode
       }
 
       if (free !== undefined) {
@@ -12906,6 +12966,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -12931,6 +12992,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       certification_type?: Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
@@ -12961,6 +13023,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           certification_type,
           course_feature,
           department,
+          dev_mode,
           free,
           id,
           learning_format,
@@ -13000,6 +13063,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13024,6 +13088,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       certification_type?: Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
@@ -13053,6 +13118,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           certification_type,
           course_feature,
           department,
+          dev_mode,
           free,
           id,
           learning_format,
@@ -13091,6 +13157,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;RES&#x60; - Supplemental Resources * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [dev_mode] If true return raw open search results with score explanations
      * @param {boolean | null} [free]
      * @param {Array<number>} [id] The id value for the learning resource
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
@@ -13117,6 +13184,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       certification_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>,
       course_feature?: Array<string>,
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
+      dev_mode?: boolean | null,
       free?: boolean | null,
       id?: Array<number>,
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
@@ -13145,6 +13213,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           certification_type,
           course_feature,
           department,
+          dev_mode,
           free,
           id,
           learning_format,
@@ -13240,6 +13309,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.certification_type,
           requestParameters.course_feature,
           requestParameters.department,
+          requestParameters.dev_mode,
           requestParameters.free,
           requestParameters.id,
           requestParameters.learning_format,
@@ -13278,6 +13348,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.certification_type,
           requestParameters.course_feature,
           requestParameters.department,
+          requestParameters.dev_mode,
           requestParameters.free,
           requestParameters.id,
           requestParameters.learning_format,
@@ -13315,6 +13386,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.certification_type,
           requestParameters.course_feature,
           requestParameters.department,
+          requestParameters.dev_mode,
           requestParameters.free,
           requestParameters.id,
           requestParameters.learning_format,
@@ -13397,6 +13469,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>
+
+  /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly dev_mode?: boolean | null
 
   /**
    *
@@ -13553,6 +13632,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>
 
   /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly dev_mode?: boolean | null
+
+  /**
    *
    * @type {boolean}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
@@ -13698,6 +13784,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>
+
+  /**
+   * If true return raw open search results with score explanations
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly dev_mode?: boolean | null
 
   /**
    *
@@ -13859,6 +13952,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.certification_type,
         requestParameters.course_feature,
         requestParameters.department,
+        requestParameters.dev_mode,
         requestParameters.free,
         requestParameters.id,
         requestParameters.learning_format,
@@ -13899,6 +13993,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.certification_type,
         requestParameters.course_feature,
         requestParameters.department,
+        requestParameters.dev_mode,
         requestParameters.free,
         requestParameters.id,
         requestParameters.learning_format,
@@ -13938,6 +14033,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.certification_type,
         requestParameters.course_feature,
         requestParameters.department,
+        requestParameters.dev_mode,
         requestParameters.free,
         requestParameters.id,
         requestParameters.learning_format,

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -21,11 +21,11 @@ from learning_resources_search.constants import (
     DEPARTMENT_QUERY_FIELDS,
     LEARNING_RESOURCE,
     LEARNING_RESOURCE_QUERY_FIELDS,
-    LEARNING_RESOURCE_SEARCH_FILTERS,
     LEARNING_RESOURCE_TYPES,
     RESOURCEFILE_QUERY_FIELDS,
     RUN_INSTRUCTORS_QUERY_FIELDS,
     RUNS_QUERY_FIELDS,
+    SEARCH_FILTERS,
     SOURCE_EXCLUDED_FIELDS,
     TOPICS_QUERY_FIELDS,
 )
@@ -340,7 +340,7 @@ def generate_filter_clauses(search_params):
     """
     all_filter_clauses = {}
 
-    for filter_name, filter_config in LEARNING_RESOURCE_SEARCH_FILTERS.items():
+    for filter_name, filter_config in SEARCH_FILTERS.items():
         if search_params.get(filter_name):
             clauses_for_filter = [
                 generate_filter_clause(
@@ -447,7 +447,7 @@ def generate_aggregation_clauses(search_params, filter_clauses):
         for aggregation in search_params.get("aggregations"):
             # Each aggregation clause contains a filter which includes all the filters
             # except it's own
-            path = LEARNING_RESOURCE_SEARCH_FILTERS[aggregation].path
+            path = SEARCH_FILTERS[aggregation].path
             unfiltered_aggs = generate_aggregation_clause(aggregation, path)
             other_filters = [
                 filter_clauses[key] for key in filter_clauses if key != aggregation
@@ -486,7 +486,7 @@ def adjust_original_query_for_percolate(query):
     Remove keys that are irrelevent when storing original queries
     for percolate uniqueness such as "limit" and "offset"
     """
-    for key in ["limit", "offset", "sortby", "yearly_decay_percent"]:
+    for key in ["limit", "offset", "sortby", "yearly_decay_percent", "dev_mode"]:
         query.pop(key, None)
     return order_params(query)
 
@@ -621,6 +621,9 @@ def construct_search(search_params):
             search_params, filter_clauses
         )
         search = search.extra(aggs=aggregation_clauses)
+
+    if search_params.get("dev_mode"):
+        search = search.extra(explain=True)
 
     return search
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2214,3 +2214,23 @@ def test_default_sort(sortby, q, result):
     }
 
     assert construct_search(search_params).to_dict().get("sort") == result
+
+
+@pytest.mark.parametrize(
+    "dev_mode",
+    [True, False],
+)
+def test_dev_mode(dev_mode):
+    search_params = {
+        "aggregations": [],
+        "q": "text",
+        "limit": 1,
+        "offset": 1,
+        "dev_mode": dev_mode,
+        "endpoint": LEARNING_RESOURCE,
+    }
+
+    if dev_mode:
+        assert construct_search(search_params).to_dict().get("explain")
+    else:
+        assert construct_search(search_params).to_dict().get("explain") is None

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -57,7 +57,7 @@ class FilterConfig:
     case_sensitive: bool = False
 
 
-LEARNING_RESOURCE_SEARCH_FILTERS = {
+SEARCH_FILTERS = {
     "resource_type": FilterConfig("resource_type"),
     "certification": FilterConfig("certification"),
     "certification_type": FilterConfig("certification_type.code"),
@@ -67,7 +67,7 @@ LEARNING_RESOURCE_SEARCH_FILTERS = {
     "course_feature": FilterConfig("course_feature"),
     "content_feature_type": FilterConfig("content_feature_type"),
     "run_id": FilterConfig("run_id", case_sensitive=True),
-    "resource_id": FilterConfig("resource_id"),
+    "resource_id": FilterConfig("resource_id", case_sensitive=True),
     "topic": FilterConfig("topics.name"),
     "level": FilterConfig("runs.level.code"),
     "department": FilterConfig("departments.department_id"),

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -259,6 +259,12 @@ class SearchRequestSerializer(serializers.Serializer):
         child=serializers.CharField(),
         help_text="The topic name. To see a list of options go to api/v1/topics/",
     )
+    dev_mode = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=False,
+        help_text="If true return raw open search results with score explanations",
+    )
 
     def validate(self, attrs):
         unknown = set(self.initial_data) - set(self.fields)

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -831,6 +831,7 @@ def test_learning_resources_search_request_serializer():
         "course_feature": ["Lecture Videos"],
         "aggregations": ["resource_type", "platform", "level", "resource_category"],
         "yearly_decay_percent": 0.25,
+        "dev_mode": False,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)
@@ -867,6 +868,7 @@ def test_content_file_search_request_serializer():
         "resource_id": [1, 2, 3],
         "offered_by": ["xpro", "ocw"],
         "platform": ["xpro", "edx", "ocw"],
+        "dev_mode": False,
     }
 
     serialized = ContentFileSearchRequestSerializer(data=data)

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -71,11 +71,15 @@ class LearningResourcesSearchView(ESView):
             response = execute_learn_search(
                 request_data.data | {"endpoint": LEARNING_RESOURCE}
             )
-            return Response(
-                LearningResourcesSearchResponseSerializer(
-                    response, context={"request": request}
-                ).data
-            )
+
+            if request_data.data.get("dev_mode"):
+                return Response(response)
+            else:
+                return Response(
+                    LearningResourcesSearchResponseSerializer(
+                        response, context={"request": request}
+                    ).data
+                )
         else:
             errors = {}
             for key, errors_obj in request_data.errors.items():
@@ -237,11 +241,14 @@ class ContentFileSearchView(ESView):
             response = execute_learn_search(
                 request_data.data | {"endpoint": CONTENT_FILE_TYPE}
             )
-            return Response(
-                ContentFileSearchResponseSerializer(
-                    response, context={"request": request}
-                ).data
-            )
+            if request_data.data.get("dev_mode"):
+                return Response(response)
+            else:
+                return Response(
+                    LearningResourcesSearchResponseSerializer(
+                        response, context={"request": request}
+                    ).data
+                )
         else:
             errors = {}
             for key, errors_obj in request_data.errors.items():

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -157,6 +157,13 @@ paths:
         description: The feature type of the content file. Possible options are at
           api/v1/course_features/
       - in: query
+        name: dev_mode
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true return raw open search results with score explanations
+      - in: query
         name: id
         schema:
           type: array
@@ -2299,6 +2306,13 @@ paths:
           \ Education and Recreation\n* `RES` - Supplemental Resources\n* `STS` -\
           \ Science, Technology, and Society\n* `WGS` - Women's and Gender Studies"
       - in: query
+        name: dev_mode
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true return raw open search results with score explanations
+      - in: query
         name: free
         schema:
           type: boolean
@@ -2728,6 +2742,13 @@ paths:
           \ Society\n* `MAS` - Media Arts and Sciences\n* `PE` - Athletics, Physical\
           \ Education and Recreation\n* `RES` - Supplemental Resources\n* `STS` -\
           \ Science, Technology, and Society\n* `WGS` - Women's and Gender Studies"
+      - in: query
+        name: dev_mode
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true return raw open search results with score explanations
       - in: query
         name: free
         schema:
@@ -3184,6 +3205,13 @@ paths:
           \ Education and Recreation\n* `RES` - Supplemental Resources\n* `STS` -\
           \ Science, Technology, and Society\n* `WGS` - Women's and Gender Studies"
       - in: query
+        name: dev_mode
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true return raw open search results with score explanations
+      - in: query
         name: free
         schema:
           type: boolean
@@ -3629,6 +3657,13 @@ paths:
           \ Society\n* `MAS` - Media Arts and Sciences\n* `PE` - Athletics, Physical\
           \ Education and Recreation\n* `RES` - Supplemental Resources\n* `STS` -\
           \ Science, Technology, and Society\n* `WGS` - Women's and Gender Studies"
+      - in: query
+        name: dev_mode
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true return raw open search results with score explanations
       - in: query
         name: free
         schema:
@@ -9500,6 +9535,11 @@ components:
             type: string
             minLength: 1
           description: The topic name. To see a list of options go to api/v1/topics/
+        dev_mode:
+          type: boolean
+          nullable: true
+          default: false
+          description: If true return raw open search results with score explanations
         id:
           type: array
           items:


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4984
closes https://github.com/mitodl/hq/issues/5023

### Description (What does it do?)
This pr adds a dev_mode parameter to both the learning resource and content file searches. If dev_mode=True the api returns raw open search results with explain=True set. This will allow us to more easily troubleshoot search issues and understand the search results better.

It also fixes a bug that breaks searching content files by resource_id

### How can this be tested?
Search for http://localhost:8063/api/v1/content_file_search/?dev_mode=True&q=nutrition
Search for http://localhost:8063/api/v1/learning_resources_search/?dev_mode=True&q=nutrition

Verify that both searches work and you see the raw open search results and explanation.

Additionally try searching for
http://localhost:8063/api/v1/content_file_search/?resource_id=3669
this should not throw an error

Finally,
http://localhost:8062/search should work the same as previously

### Additional Context
One of the motivating reasons for this PR was to see why "Nuclear Energy: Science, Systems and Society" was showing up when you search for "nutrition". This turned out to be an ok result - that course had a two content files that addressed the consequences of nuclear poisoning on the gi track. The explain function does not actually give a good explanation when the score comes from content files, all you get is
```
 {
            "value": 8.823367,
             "description": "A match, join value 3669",
              "details": []
 },
```
to let you know that the score is coming from the join but
Search for http://localhost:8063/api/v1/learning_resources_search/?dev_mode=True&q=nutrition&resource_id=3669 returns more details about where the match is coming from
