### PR TITLE
Show "Start Anytime" based on resource "availability" property

### DIFF
--- a/frontends/mit-open/.storybook/main.ts
+++ b/frontends/mit-open/.storybook/main.ts
@@ -1,5 +1,6 @@
 import { resolve, join, dirname } from "path"
 import * as dotenv from "dotenv"
+import * as webpack from "webpack"
 
 dotenv.config({ path: resolve(__dirname, "../../../.env") })
 
@@ -32,13 +33,17 @@ const config = {
   docs: {
     autodocs: "tag",
   },
-  env: (config: any) => ({
-    ...config,
-    APP_SETTINGS: {
-      PUBLIC_URL: process.env.PUBLIC_URL || "",
-      EMBEDLY_KEY: process.env.EMBEDLY_KEY || "",
-    },
-  }),
+  webpackFinal: async (config: any) => {
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        APP_SETTINGS: {
+          EMBEDLY_KEY: JSON.stringify(process.env.EMBEDLY_KEY),
+          PUBLIC_URL: JSON.stringify(process.env.PUBLIC_URL),
+        },
+      }),
+    )
+    return config
+  },
 }
 
 export default config

--- a/frontends/mit-open/.storybook/preview-head.html
+++ b/frontends/mit-open/.storybook/preview-head.html
@@ -3,8 +3,3 @@
       WARNING: This is linked to chudzick@mit.edu's Adobe account.
   -->
 <link rel="stylesheet" href="https://use.typekit.net/lbk1xay.css" />
-<script>
-  window.APP_SETTINGS = {
-    embedlyKey: null,
-  }
-</script>

--- a/frontends/ol-components/src/components/Card/Card.test.tsx
+++ b/frontends/ol-components/src/components/Card/Card.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react"
+import { Card } from "./Card"
+import React from "react"
+
+describe("Card", () => {
+  test("has class MitCard-root on root element", () => {
+    const { container } = render(
+      <Card className="Foo">
+        <Card.Content>Hello world</Card.Content>
+      </Card>,
+    )
+    const card = container.firstChild
+
+    expect(card).toHaveClass("MitCard-root")
+    expect(card).toHaveClass("Foo")
+  })
+})

--- a/frontends/ol-components/src/components/Card/Card.test.tsx
+++ b/frontends/ol-components/src/components/Card/Card.test.tsx
@@ -6,12 +6,27 @@ describe("Card", () => {
   test("has class MitCard-root on root element", () => {
     const { container } = render(
       <Card className="Foo">
-        <Card.Content>Hello world</Card.Content>
+        <Card.Title>Title</Card.Title>
+        <Card.Image src="https://via.placeholder.com/150" alt="placeholder" />
+        <Card.Info>Info</Card.Info>
+        <Card.Footer>Footer</Card.Footer>
+        <Card.Actions>Actions</Card.Actions>
       </Card>,
     )
-    const card = container.firstChild
+    const card = container.firstChild as HTMLElement
+    const title = card.querySelector(".MitCard-title")
+    const image = card.querySelector(".MitCard-image")
+    const info = card.querySelector(".MitCard-info")
+    const footer = card.querySelector(".MitCard-footer")
+    const actions = card.querySelector(".MitCard-actions")
 
     expect(card).toHaveClass("MitCard-root")
     expect(card).toHaveClass("Foo")
+    expect(title).toHaveTextContent("Title")
+    expect(image).toHaveAttribute("src", "https://via.placeholder.com/150")
+    expect(image).toHaveAttribute("alt", "placeholder")
+    expect(info).toHaveTextContent("Info")
+    expect(footer).toHaveTextContent("Footer")
+    expect(actions).toHaveTextContent("Actions")
   })
 })

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -117,10 +117,6 @@ const Footer = styled.span`
     ...theme.typography.body3,
     color: theme.custom.colors.silverGrayDark,
   }}
-
-  span {
-    color: ${theme.custom.colors.black};
-  }
 `
 
 const Bottom = styled.div`
@@ -200,9 +196,11 @@ const Card: Card = ({ children, className, size, href }) => {
     else if (child.type === Actions) actions = child.props
   })
 
+  const allClassNames = `MitCard-root ${className}`
+
   if (content) {
     return (
-      <Wrapper className={className} size={size}>
+      <Wrapper className={allClassNames} size={size}>
         <_Container className={className} to={href!}>
           {content}
         </_Container>
@@ -211,7 +209,7 @@ const Card: Card = ({ children, className, size, href }) => {
   }
 
   return (
-    <Wrapper className={className} size={size}>
+    <Wrapper className={allClassNames} size={size}>
       <_Container to={href!}>
         {image && (
           <Image

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -213,6 +213,7 @@ const Card: Card = ({ children, className, size, href }) => {
       <_Container to={href!}>
         {image && (
           <Image
+            className="MitCard-image"
             size={size}
             height={image.height}
             {...(image as ImgHTMLAttributes<HTMLImageElement>)}
@@ -220,19 +221,25 @@ const Card: Card = ({ children, className, size, href }) => {
         )}
         <Body>
           {info.children && (
-            <Info size={size} {...info}>
+            <Info className="MitCard-info" size={size} {...info}>
               {info.children}
             </Info>
           )}
-          <Title size={size} {...title}>
+          <Title className="MitCard-title" size={size} {...title}>
             {title.children}
           </Title>
         </Body>
         <Bottom>
-          <Footer {...footer}>{footer.children}</Footer>
+          <Footer className="MitCard-footer" {...footer}>
+            {footer.children}
+          </Footer>
         </Bottom>
       </_Container>
-      {actions.children && <Actions {...actions}>{actions.children}</Actions>}
+      {actions.children && (
+        <Actions className="MitCard-actions" {...actions}>
+          {actions.children}
+        </Actions>
+      )}
     </Wrapper>
   )
 }

--- a/frontends/ol-components/src/components/Card/Card.tsx
+++ b/frontends/ol-components/src/components/Card/Card.tsx
@@ -196,7 +196,7 @@ const Card: Card = ({ children, className, size, href }) => {
     else if (child.type === Actions) actions = child.props
   })
 
-  const allClassNames = `MitCard-root ${className}`
+  const allClassNames = ["MitCard-root", className ?? ""].join(" ")
 
   if (content) {
     return (

--- a/frontends/ol-components/src/components/Card/ListCard.test.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react"
+import { ListCard } from "./ListCard"
+import React from "react"
+
+describe("ListCard", () => {
+  test("has class MitCard-root on root element", () => {
+    const { container } = render(
+      <ListCard className="Foo">
+        <ListCard.Content>Hello world</ListCard.Content>
+      </ListCard>,
+    )
+    const card = container.firstChild
+
+    expect(card).toHaveClass("MitListCard-root")
+    expect(card).toHaveClass("Foo")
+  })
+})

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -205,16 +205,17 @@ const ListCard: Card = ({ children, className, href, draggable }) => {
     else if (child.type === Actions) actions = child.props.children
   })
 
+  const classNames = ["MitListCard-root", className ?? ""].join(" ")
   if (content) {
     return (
-      <_Container className={className} to={href!}>
+      <_Container className={classNames} to={href!}>
         {content}
       </_Container>
     )
   }
 
   return (
-    <Wrapper className={`MitListCard-root ${className}`}>
+    <Wrapper className={classNames}>
       <_Container to={href!}>
         {draggable && (
           <DragArea>

--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -214,7 +214,7 @@ const ListCard: Card = ({ children, className, href, draggable }) => {
   }
 
   return (
-    <Wrapper className={className}>
+    <Wrapper className={`MitListCard-root ${className}`}>
       <_Container to={href!}>
         {draggable && (
           <DragArea>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.stories.tsx
@@ -154,3 +154,15 @@ export const Loading: Story = {
     isLoading: true,
   },
 }
+
+export const StartAnytime: Story = {
+  args: {
+    resource: courses.start.anytime,
+  },
+}
+
+export const StartDated: Story = {
+  args: {
+    resource: courses.start.dated,
+  },
+}

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -2,17 +2,18 @@ import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { screen, render, act } from "@testing-library/react"
 import { LearningResourceCard } from "./LearningResourceCard"
+import type { LearningResourceCardProps } from "./LearningResourceCard"
 import { DEFAULT_RESOURCE_IMG, embedlyCroppedImage } from "ol-utilities"
-import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
+import { ResourceTypeEnum, PlatformEnum, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
-const setup = (resource: LearningResource) => {
+const setup = (props: LearningResourceCardProps) => {
   return render(
     <BrowserRouter>
       <LearningResourceCard
-        resource={resource}
-        href={`?resource=${resource.id}`}
+        resource={props.resource}
+        href={`?resource=${props.resource?.id}`}
       />
     </BrowserRouter>,
     { wrapper: ThemeProvider },
@@ -26,7 +27,7 @@ describe("Learning Resource Card", () => {
       next_start_date: "2026-01-01",
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Course")
     screen.getByRole("heading", { name: resource.title })
@@ -45,29 +46,53 @@ describe("Learning Resource Card", () => {
       ],
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Starts:")
     screen.getByText("January 01, 2026")
   })
 
-  test("Displays taught in date for OCW", () => {
-    const resource = factories.learningResources.resource({
-      resource_type: ResourceTypeEnum.Course,
-      platform: { code: PlatformEnum.Ocw },
-      runs: [
-        factories.learningResources.run({
-          semester: "Fall",
-          year: 2002,
-        }),
-      ],
-    })
+  test.each([
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Course,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: true,
+    },
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Course,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      size: "small",
+      showsAnytime: true,
+    },
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Program,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: true,
+    },
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Video,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: false,
+    },
+  ] as const)(
+    "Displays 'Anytime' for availability 'Anytime' courses and programs",
+    ({ resource, size, showsAnytime }) => {
+      setup({ resource, size })
 
-    setup(resource)
-
-    expect(screen.getByRole("link")).toHaveTextContent("As taught in:")
-    expect(screen.getByRole("link")).toHaveTextContent("Fall 2002")
-  })
+      const anytime = screen.queryByText("Anytime")
+      const starts = screen.queryByText("Starts:")
+      expect(!!anytime).toEqual(showsAnytime)
+      expect(!!starts).toBe(showsAnytime)
+    },
+  )
 
   test("Click to navigate", async () => {
     const resource = factories.learningResources.resource({
@@ -75,7 +100,7 @@ describe("Learning Resource Card", () => {
       platform: { code: PlatformEnum.Ocw },
     })
 
-    setup(resource)
+    setup({ resource })
 
     const heading = screen.getByRole("heading", { name: resource.title })
     await act(async () => {
@@ -134,7 +159,7 @@ describe("Learning Resource Card", () => {
       certification: true,
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Certificate")
   })
@@ -144,7 +169,7 @@ describe("Learning Resource Card", () => {
       certification: false,
     })
 
-    setup(resource)
+    setup({ resource })
 
     const badge = screen.queryByText("Certificate")
 
@@ -175,7 +200,7 @@ describe("Learning Resource Card", () => {
   ])("Image is displayed if present", ({ expected, image }) => {
     const resource = factories.learningResources.resource({ image })
 
-    setup(resource)
+    setup({ resource })
 
     const imageEls = screen.getAllByRole<HTMLImageElement>(expected.role)
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -201,6 +201,14 @@ const CardActionButton: React.FC<
   )
 }
 
+const StyledCard = styled(Card)<{ size: Size }>(({ size }) => [
+  size === "medium" && {
+    ".MitCard-info": {
+      height: "18px",
+    },
+  },
+])
+
 const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
   isLoading,
   resource,
@@ -217,21 +225,21 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
     const { width, height } = imgConfigs["column"]
     const aspect = isMedia ? 1 : width / height
     return (
-      <Card className={className} size={size}>
+      <StyledCard className={className} size={size}>
         <Card.Content>
           <SkeletonImage variant="rectangular" aspect={aspect} />
           <Skeleton height={25} width="65%" sx={{ margin: "23px 16px 0" }} />
           <Skeleton height={25} width="80%" sx={{ margin: "0 16px 35px" }} />
           <Skeleton height={25} width="30%" sx={{ margin: "0 16px 16px" }} />
         </Card.Content>
-      </Card>
+      </StyledCard>
     )
   }
   if (!resource) {
     return null
   }
   return (
-    <Card href={href} className={className} size={size}>
+    <StyledCard href={href} className={className} size={size}>
       <Card.Image
         src={
           resource.image?.url
@@ -272,7 +280,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
       <Card.Footer>
         <StartDate resource={resource} size={size} />
       </Card.Footer>
-    </Card>
+    </StyledCard>
   )
 }
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.stories.tsx
@@ -152,3 +152,15 @@ export const Draggable: Story = {
     draggable: true,
   },
 }
+
+export const StartAnytime: Story = {
+  args: {
+    resource: courses.start.anytime,
+  },
+}
+
+export const StartDated: Story = {
+  args: {
+    resource: courses.start.dated,
+  },
+}

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -2,17 +2,18 @@ import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { screen, render, act } from "@testing-library/react"
 import { LearningResourceListCard } from "./LearningResourceListCard"
+import type { LearningResourceListCardProps } from "./LearningResourceListCard"
 import { DEFAULT_RESOURCE_IMG, embedlyCroppedImage } from "ol-utilities"
-import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
+import { ResourceTypeEnum, PlatformEnum, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 
-const setup = (resource: LearningResource) => {
+const setup = (props: LearningResourceListCardProps) => {
   return render(
     <BrowserRouter>
       <LearningResourceListCard
-        resource={resource}
-        href={`?resource=${resource.id}`}
+        resource={props.resource}
+        href={`?resource=${props.resource?.id}`}
       />
     </BrowserRouter>,
     { wrapper: ThemeProvider },
@@ -26,7 +27,7 @@ describe("Learning Resource List Card", () => {
       next_start_date: "2026-01-01",
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Course")
     screen.getByRole("heading", { name: resource.title })
@@ -45,29 +46,45 @@ describe("Learning Resource List Card", () => {
       ],
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Starts:")
     screen.getByText("January 01, 2026")
   })
 
-  test("Displays taught in date for OCW", () => {
-    const resource = factories.learningResources.resource({
-      resource_type: ResourceTypeEnum.Course,
-      platform: { code: PlatformEnum.Ocw },
-      runs: [
-        factories.learningResources.run({
-          semester: "Fall",
-          year: 2002,
-        }),
-      ],
-    })
+  test.each([
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Course,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: true,
+    },
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Program,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: true,
+    },
+    {
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Video,
+        availability: AvailabilityEnum.Anytime,
+      }),
+      showsAnytime: false,
+    },
+  ] as const)(
+    "Displays 'Anytime' for availability 'Anytime' courses and programs",
+    ({ resource, showsAnytime }) => {
+      setup({ resource })
 
-    setup(resource)
-
-    expect(screen.getByRole("link")).toHaveTextContent("As taught in:")
-    expect(screen.getByRole("link")).toHaveTextContent("Fall 2002")
-  })
+      const anytime = screen.queryByText("Anytime")
+      const starts = screen.queryByText("Starts:")
+      expect(!!anytime).toEqual(showsAnytime)
+      expect(!!starts).toBe(showsAnytime)
+    },
+  )
 
   test("Click to navigate", async () => {
     const resource = factories.learningResources.resource({
@@ -75,7 +92,7 @@ describe("Learning Resource List Card", () => {
       platform: { code: PlatformEnum.Ocw },
     })
 
-    setup(resource)
+    setup({ resource })
 
     const heading = screen.getByRole("heading", { name: resource.title })
     await act(async () => {
@@ -132,7 +149,7 @@ describe("Learning Resource List Card", () => {
       certification: true,
     })
 
-    setup(resource)
+    setup({ resource })
 
     screen.getByText("Certificate")
   })
@@ -142,7 +159,7 @@ describe("Learning Resource List Card", () => {
       certification: false,
     })
 
-    setup(resource)
+    setup({ resource })
 
     const badge = screen.queryByText("Certificate")
 
@@ -173,7 +190,7 @@ describe("Learning Resource List Card", () => {
   ])("Image is displayed if present", ({ expected, image }) => {
     const resource = factories.learningResources.resource({ image })
 
-    setup(resource)
+    setup({ resource })
 
     const imageEls = screen.getAllByRole<HTMLImageElement>(expected.role)
 
@@ -198,7 +215,7 @@ describe("Learning Resource List Card", () => {
         free: true,
         prices: ["0"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("Free")
     })
 
@@ -208,7 +225,7 @@ describe("Learning Resource List Card", () => {
         free: true,
         prices: ["0", "49"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("Certificate")
       screen.getByText(": $49")
       screen.getByText("Free")
@@ -220,7 +237,7 @@ describe("Learning Resource List Card", () => {
         free: true,
         prices: ["0", "99", "49"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("Certificate")
       screen.getByText(": $49 – $99")
       screen.getByText("Free")
@@ -232,7 +249,7 @@ describe("Learning Resource List Card", () => {
         free: false,
         prices: ["49"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("$49")
     })
 
@@ -242,7 +259,7 @@ describe("Learning Resource List Card", () => {
         free: false,
         prices: ["49.50"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("$49.50")
     })
 
@@ -252,7 +269,7 @@ describe("Learning Resource List Card", () => {
         free: true,
         prices: [],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("Free")
     })
 
@@ -262,7 +279,7 @@ describe("Learning Resource List Card", () => {
         free: false,
         prices: ["0"],
       })
-      setup(resource)
+      setup({ resource })
       screen.getByText("Paid")
     })
   })

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -7,9 +7,8 @@ import {
   RiAwardFill,
   RiBookmarkFill,
 } from "@remixicon/react"
-import { LearningResource, ResourceTypeEnum, PlatformEnum } from "api"
+import { LearningResource, ResourceTypeEnum } from "api"
 import {
-  findBestRun,
   formatDate,
   getReadableResourceType,
   embedlyCroppedImage,
@@ -20,7 +19,7 @@ import { ListCard } from "../Card/ListCard"
 import { ActionButtonProps } from "../Button/Button"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import { useMuiBreakpointAtLeast } from "../../hooks/useBreakpoint"
-import { getDisplayPrices } from "./utils"
+import { getDisplayPrices, getResourceDate, showStartAnytime } from "./utils"
 
 const IMAGE_SIZES = {
   mobile: { width: 116, height: 104 },
@@ -33,6 +32,9 @@ export const CardLabel = styled.span`
     display: none;
   }
 `
+const CardValue = styled.span(({ theme }) => ({
+  color: theme.custom.colors.darkGray2,
+}))
 
 export const Certificate = styled.div`
   border-radius: 4px;
@@ -148,39 +150,19 @@ export const Count = ({ resource }: { resource: LearningResource }) => {
   )
 }
 
-const isOcw = (resource: LearningResource) =>
-  resource.resource_type === ResourceTypeEnum.Course &&
-  resource.platform?.code === PlatformEnum.Ocw
-
-const getStartDate = (resource: LearningResource) => {
-  let startDate = resource.next_start_date
-
-  if (!startDate) {
-    const bestRun = findBestRun(resource.runs ?? [])
-
-    if (isOcw(resource) && bestRun?.semester && bestRun?.year) {
-      return `${bestRun?.semester} ${bestRun?.year}`
-    }
-    startDate = bestRun?.start_date
-  }
-
-  if (!startDate) return null
-
-  return formatDate(startDate, "MMMM DD, YYYY")
-}
-
 export const StartDate: React.FC<{ resource: LearningResource }> = ({
   resource,
 }) => {
-  const startDate = getStartDate(resource)
-
-  if (!startDate) return null
-
-  const label = isOcw(resource) ? "As taught in:" : "Starts:"
+  const anytime = showStartAnytime(resource)
+  const startDate = getResourceDate(resource)
+  const formatted = anytime
+    ? "Anytime"
+    : startDate && formatDate(startDate, "MMMM DD, YYYY")
+  if (!formatted) return null
 
   return (
     <div>
-      <CardLabel>{label}</CardLabel> <span>{startDate}</span>
+      <CardLabel>Starts:</CardLabel> <CardValue>{formatted}</CardValue>
     </div>
   )
 }
@@ -190,7 +172,7 @@ export const Format = ({ resource }: { resource: LearningResource }) => {
   if (!format) return null
   return (
     <div>
-      <CardLabel>Format:</CardLabel> <span>{format}</span>
+      <CardLabel>Format:</CardLabel> <CardValue>{format}</CardValue>
     </div>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/story_utils.ts
@@ -104,6 +104,16 @@ const courses = {
       prices: ["49", "99"],
     }),
   },
+  start: {
+    anytime: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      availability: "anytime",
+    }),
+    dated: makeResource({
+      resource_type: ResourceTypeEnum.Course,
+      availability: "dated",
+    }),
+  },
 }
 
 const resourceArgType = {

--- a/frontends/ol-components/src/components/LearningResourceCard/utils.ts
+++ b/frontends/ol-components/src/components/LearningResourceCard/utils.ts
@@ -1,4 +1,5 @@
-import { LearningResource } from "api"
+import { LearningResource, ResourceTypeEnum } from "api"
+import { findBestRun } from "ol-utilities"
 
 /*
  * This constant represents the value displayed when a course is free.
@@ -81,4 +82,20 @@ export const getDisplayPrices = (resource: LearningResource) => {
     course: getDisplayPrice(prices.course),
     certificate: getDisplayPrice(prices.certificate),
   }
+}
+
+export const showStartAnytime = (resource: LearningResource) => {
+  return (
+    resource.availability === "anytime" &&
+    (
+      [ResourceTypeEnum.Course, ResourceTypeEnum.Program] as ResourceTypeEnum[]
+    ).includes(resource.resource_type)
+  )
+}
+
+export const getResourceDate = (resource: LearningResource): string | null => {
+  const startDate =
+    resource.next_start_date ?? findBestRun(resource.runs ?? [])?.start_date
+
+  return startDate ?? null
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.stories.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof LearningResourceExpanded> = {
   component: LearningResourceExpanded,
   args: {
     imgConfig: {
-      key: process.env.EMBEDLY_KEY!,
+      key: APP_SETTINGS.EMBEDLY_KEY,
       width: 385,
       height: 200,
     },
@@ -132,5 +132,31 @@ export const VideoPlaylist: Story = {
 export const Loading: Story = {
   args: {
     resource: undefined,
+  },
+}
+
+export const AsTaughtIn: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: LRT.Course,
+      availability: "anytime",
+      runs: [factories.learningResources.run()],
+    }),
+  },
+}
+
+export const AsTaughtInMultipleRuns: Story = {
+  args: {
+    resource: makeResource({
+      resource_type: LRT.Course,
+      availability: "anytime",
+      runs: [
+        factories.learningResources.run({
+          semester: "Fall",
+          year: 2023,
+        }),
+        factories.learningResources.run(),
+      ],
+    }),
   },
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -1,14 +1,16 @@
 import React from "react"
 import { BrowserRouter } from "react-router-dom"
 import { render, screen, within } from "@testing-library/react"
+import user from "@testing-library/user-event"
 import { LearningResourceExpanded } from "./LearningResourceExpanded"
 import type { LearningResourceExpandedProps } from "./LearningResourceExpanded"
-import { ResourceTypeEnum, PlatformEnum, PodcastEpisodeResource } from "api"
+import { ResourceTypeEnum, PodcastEpisodeResource, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import { getReadableResourceType } from "ol-utilities"
 import invariant from "tiny-invariant"
 import type { LearningResource } from "api"
+import { faker } from "@faker-js/faker/locale/en"
 
 const IMG_CONFIG: LearningResourceExpandedProps["imgConfig"] = {
   key: "fake-key",
@@ -189,30 +191,97 @@ describe("Learning Resource Expanded", () => {
     }
   })
 
-  test("Renders taught in date and price free for OCW courses", () => {
-    const resource = factories.learningResources.resource({
-      resource_type: ResourceTypeEnum.Course,
-      platform: { code: PlatformEnum.Ocw },
-      runs: [
-        factories.learningResources.run({
-          semester: "Fall",
-          year: 2002,
-        }),
-      ],
-    })
+  test.each([
+    {
+      run: factories.learningResources.run({ semester: "Fall", year: 2001 }),
+      expectedDate: "Fall 2001",
+    },
+    {
+      run: factories.learningResources.run({
+        semester: "Fall",
+        year: null,
+        start_date: "2002-09-01",
+      }),
+      expectedDate: "Fall 2002",
+    },
+    {
+      run: factories.learningResources.run({
+        semester: null,
+        year: null,
+        start_date: "2003-09-01",
+      }),
+      expectedDate: "September, 2003",
+    },
+  ])(
+    "Renders 'As taught in' and Month+Year for availability: anytime",
+    ({ run, expectedDate }) => {
+      const resource = factories.learningResources.resource({
+        resource_type: faker.helpers.arrayElement([
+          ResourceTypeEnum.Course,
+          ResourceTypeEnum.Program,
+        ]),
+        runs: [run],
+        availability: "anytime",
+      })
 
-    setup(resource)
+      setup(resource)
 
-    const dateSection = screen.getByText("As taught in:")!.closest("div")!
+      const dateSection = screen.getByText("As taught in:")!.closest("div")!
 
-    within(dateSection).getByText("Fall 2002")
+      within(dateSection).getByText(expectedDate)
+    },
+  )
 
-    const section = screen
-      .getByRole("heading", { name: "Info" })!
-      .closest("section")!
+  test.each([
+    {
+      expectedLabel: "Start Date:",
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Course,
+        availability: AvailabilityEnum.Dated,
+        runs: [
+          factories.learningResources.run({ start_date: "2024-02-03" }),
+          factories.learningResources.run({ start_date: "2024-04-05" }),
+        ],
+      }),
+      expectedDates: ["February 03, 2024", "April 05, 2024"],
+    },
+    {
+      expectedLabel: "As taught in:",
+      resource: factories.learningResources.resource({
+        resource_type: ResourceTypeEnum.Course,
+        availability: AvailabilityEnum.Anytime,
+        runs: [
+          factories.learningResources.run({ semester: "Fall", year: 2020 }),
+          factories.learningResources.run({
+            semester: "Spring",
+            year: null,
+            start_date: "2021-02-03",
+          }),
+          factories.learningResources.run({
+            semester: null,
+            year: null,
+            start_date: "2022-05-06",
+          }),
+        ],
+      }),
+      expectedDates: ["Fall 2020", "Spring 2021", "May, 2022"],
+    },
+  ])(
+    "Renders a dropdown for run picker",
+    async ({ resource, expectedDates, expectedLabel }) => {
+      setup(resource)
 
-    within(section).getByText("Free")
-  })
+      screen.getByText(expectedLabel)
+      const select = screen.getByRole("combobox")
+      await user.click(select)
+
+      const options = screen.getAllByRole("option")
+
+      expectedDates.forEach((date, index) => {
+        expect(options[index]).toHaveTextContent(date)
+      })
+    },
+  )
 
   test("Renders info section languages correctly", () => {
     const resource = factories.learningResources.resource({

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -206,6 +206,14 @@ describe("Learning Resource Expanded", () => {
     },
     {
       run: factories.learningResources.run({
+        semester: "fall",
+        year: null,
+        start_date: "2002-09-01",
+      }),
+      expectedDate: "Fall 2002", // capitalized
+    },
+    {
+      run: factories.learningResources.run({
         semester: null,
         year: null,
         start_date: "2003-09-01",

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -12,6 +12,7 @@ import type {
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import {
   formatDate,
+  capitalize,
   resourceThumbnailSrc,
   getReadableResourceType,
   DEFAULT_RESOURCE_IMG,
@@ -337,11 +338,12 @@ const formatRunDate = (
   asTaughtIn: boolean,
 ): string | null => {
   if (asTaughtIn) {
-    if (run.semester && run.year) {
-      return `${run.semester} ${run.year}`
+    const semester = capitalize(run.semester ?? "")
+    if (semester && run.year) {
+      return `${semester} ${run.year}`
     }
-    if (run.semester && run.start_date) {
-      return `${run.semester} ${formatDate(run.start_date, "YYYY")}`
+    if (semester && run.start_date) {
+      return `${semester} ${formatDate(run.start_date, "YYYY")}`
     }
     if (run.start_date) {
       return formatDate(run.start_date, "MMMM, YYYY")

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -4,7 +4,11 @@ import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import { ButtonLink } from "../Button/Button"
 import Chip from "@mui/material/Chip"
-import type { LearningResource, LearningResourceTopic } from "api"
+import type {
+  LearningResource,
+  LearningResourceRun,
+  LearningResourceTopic,
+} from "api"
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import {
   formatDate,
@@ -20,6 +24,7 @@ import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import { ChipLink } from "../Chips/ChipLink"
 import InfoSection from "./InfoSection"
+import { showStartAnytime } from "../LearningResourceCard/utils"
 
 const Container = styled.div<{ padTop?: boolean }>`
   display: flex;
@@ -327,6 +332,27 @@ const TopicsSection: React.FC<{ topics?: LearningResourceTopic[] }> = ({
   )
 }
 
+const formatRunDate = (
+  run: LearningResourceRun,
+  asTaughtIn: boolean,
+): string | null => {
+  if (asTaughtIn) {
+    if (run.semester && run.year) {
+      return `${run.semester} ${run.year}`
+    }
+    if (run.semester && run.start_date) {
+      return `${run.semester} ${formatDate(run.start_date, "YYYY")}`
+    }
+    if (run.start_date) {
+      return formatDate(run.start_date, "MMMM, YYYY")
+    }
+  }
+  if (run.start_date) {
+    return formatDate(run.start_date, "MMMM DD, YYYY")
+  }
+  return null
+}
+
 const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
   resource,
   imgConfig,
@@ -334,6 +360,8 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
   const [selectedRun, setSelectedRun] = useState(resource?.runs?.[0])
 
   const multipleRuns = resource?.runs && resource.runs.length > 1
+  const asTaughtIn = resource ? showStartAnytime(resource) : false
+  const label = asTaughtIn ? "As taught in:" : "Start Date:"
 
   useEffect(() => {
     if (resource) {
@@ -356,10 +384,12 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       return <Skeleton height={40} style={{ marginTop: 0, width: "60%" }} />
     }
     const dateOptions: SimpleSelectProps["options"] =
-      resource.runs?.map((run) => ({
-        value: run.id.toString(),
-        label: formatDate(run.start_date!, "MMMM DD, YYYY"),
-      })) ?? []
+      resource.runs?.map((run) => {
+        return {
+          value: run.id.toString(),
+          label: formatRunDate(run, asTaughtIn),
+        }
+      }) ?? []
 
     if (
       [ResourceTypeEnum.Course, ResourceTypeEnum.Program].includes(
@@ -369,7 +399,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     ) {
       return (
         <Date>
-          <DateLabel>Start Date:</DateLabel>
+          <DateLabel>{label}</DateLabel>
           <SimpleSelect
             value={selectedRun?.id.toString() ?? ""}
             onChange={onDateChange}
@@ -379,22 +409,17 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       )
     }
 
-    const isOcw =
-      resource.resource_type === ResourceTypeEnum.Course &&
-      resource.platform?.code === PlatformEnum.Ocw
+    if (!selectedRun) return <NoDateSpacer />
 
-    const nextStart = resource.next_start_date || selectedRun?.start_date
-
-    if (!isOcw && !nextStart && !(selectedRun?.semester && selectedRun?.year)) {
+    const formatted = formatRunDate(selectedRun, asTaughtIn)
+    if (!formatted) {
       return <NoDateSpacer />
     }
 
     return (
       <DateSingle>
-        <DateLabel>{isOcw ? "As taught in:" : "Start Date:"}</DateLabel>
-        {isOcw
-          ? `${selectedRun?.semester} ${selectedRun?.year}`
-          : formatDate(nextStart!, "MMMM DD, YYYY")}
+        <DateLabel>{label}</DateLabel>
+        {formatted}
       </DateSingle>
     )
   }

--- a/frontends/ol-utilities/src/date/format.ts
+++ b/frontends/ol-utilities/src/date/format.ts
@@ -1,5 +1,14 @@
 import moment from "moment"
 
-export const formatDate = (date: string | Date, format = "MMM D, YYYY") => {
+export const formatDate = (
+  /**
+   * Date string or date.
+   */
+  date: string | Date,
+  /**
+   * A momentjs format string. See https://momentjs.com/docs/#/displaying/format/
+   */
+  format = "MMM D, YYYY",
+) => {
   return moment(date).format(format)
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4743

### Description (What does it do?)
This uses the new "availability" property on resources to display "Starts: Anytime" on resource cards.

### Screenshots (if appropriate):

**Vertical Cards, small**
<img width="433" alt="Screenshot 2024-07-30 at 9 47 13 AM" src="https://github.com/user-attachments/assets/d6db9ae8-70a9-417e-9e0a-0a1a77d4542e">

**Vertical Cards, medium**
<img width="647" alt="Screenshot 2024-07-30 at 10 11 50 AM" src="https://github.com/user-attachments/assets/b0b5480f-95ca-41c0-ad60-673724da64b8">

**Horizontal, small screen**
<img width="367" alt="Screenshot 2024-07-30 at 11 05 13 AM" src="https://github.com/user-attachments/assets/3e217dca-5ff4-4f4c-a971-e015eddc0c20">

**Horizontal, wide screen**
<img width="1000" alt="Screenshot 2024-07-30 at 11 04 34 AM" src="https://github.com/user-attachments/assets/68647ddc-295e-4058-a631-612d18f11386">

**Drawer:**
<img width="350" alt="Screenshot 2024-07-30 at 9 55 34 AM" src="https://github.com/user-attachments/assets/94a477f6-dc8d-4f3d-ba19-9ee521be98fa"> <img width="350" alt="Screenshot 2024-07-30 at 9 56 04 AM" src="https://github.com/user-attachments/assets/e3386a6b-da89-44a7-b671-0858e93e4ac1">



### How can this be tested?
1. If you haven't re-run backpopulates since #1301 , run them using RC creds.
    ```sh
    ./manage.py backpopulate_ocw_data --skip-contentfiles
    ./manage.py backpopulate_mitxonline_data
    ./manage.py backpopulate_xpro_data
    ./manage.py backpopulate_prolearn_data
    ./manage.py backpopulate_oll_data
    # The edX API has a rate limit; this may 429 if other people (or RC) has run it recently.
    ./manage.py extract_openedx_data
    ```
2. View course cards and resource drawer. If the API returns `available: "anytime"` for courses, you should see "Starts: Anytime". Otherwise, you'll see a date like before. Notes:
    - We previously showed "As taught in..." on cards for OCW courses. We do not anymore.
    - "Starts Anytime" is NOT limited to OCW (but is limited to courses and programs in the UI).
    - Card locations:
        - vertical cards:  homepage, unit channel pages, and dashboard for **vertically oriented cards** (Dashboard has small cards)
        - horizontal cards: channel page, search page
3. Check the resource drawer (click any card). If a card displays "Start anytime", it should display "As taught in..." in the resource drawer.
4. View new storybook stories: http://localhost:6006/?path=/story/smoot-design-cards-learningresourcecard--start-anytime (and dated nearby), and similar stories for the list card.
