### PR TITLE
fix bug with content file search

### DIFF
--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -245,7 +245,7 @@ class ContentFileSearchView(ESView):
                 return Response(response)
             else:
                 return Response(
-                    LearningResourcesSearchResponseSerializer(
+                    ContentFileSearchResponseSerializer(
                         response, context={"request": request}
                     ).data
                 )


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/mit-open/pull/1333 introduced a bug to api/v1/content_file_search

this fixes it

### How can this be tested?
Log in 
Verify that api/v1/content_file_search loads