### PR TITLE
Flatten OCW topics so all of them get mapped to PWT topics when running the ETL pipeline

### DIFF
--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -302,8 +302,6 @@ def transform_course(course_data: dict) -> dict:
     readable_term = f"+{slugify(term)}" if term else ""
     readable_year = f"_{course_data.get('year')}" if year else ""
     readable_id = f"{course_data[PRIMARY_COURSE_ID]}{readable_term}{readable_year}"
-    # The json returns basically a tuple of topics with subtopics - we only need
-    # to care about the subtopic, unless there's not one.
     topics = transform_topics(
         [{"name": topic} for topics in course_data.get("topics") for topic in topics],
         OFFERED_BY["code"],

--- a/learning_resources/etl/ocw.py
+++ b/learning_resources/etl/ocw.py
@@ -305,10 +305,7 @@ def transform_course(course_data: dict) -> dict:
     # The json returns basically a tuple of topics with subtopics - we only need
     # to care about the subtopic, unless there's not one.
     topics = transform_topics(
-        [
-            {"name": topic[1] if len(topic) > 1 else topic[0]}
-            for topic in course_data.get("topics")
-        ],
+        [{"name": topic} for topics in course_data.get("topics") for topic in topics],
         OFFERED_BY["code"],
     )
     image_src = course_data.get("image_src")

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -70,7 +70,10 @@ def load_offeror_topic_map(offeror_code: str):
     mappings = {}
 
     for pmt_mapping in pmt_mappings:
-        mappings[pmt_mapping.topic_name] = pmt_mapping.topic.name
+        if pmt_mapping.topic_name not in mappings:
+            mappings[pmt_mapping.topic_name] = []
+
+        mappings[pmt_mapping.topic_name].append(pmt_mapping.topic.name)
 
     return mappings
 
@@ -93,7 +96,10 @@ def transform_topics(topics: list, offeror_code: str):
 
     for topic in topics:
         if topic["name"] in topic_mappings:
-            transformed_topics.append({"name": topic_mappings.get(topic["name"])})
+            [
+                transformed_topics.append({"name": mapped_topic})
+                for mapped_topic in topic_mappings.get(topic["name"])
+            ]
         else:
             base_topic = LearningResourceTopic.objects.filter(
                 name=topic["name"]


### PR DESCRIPTION
### What are the relevant tickets?

Closes #1339

### Description (What does it do?)

The OCW pipeline only considered the first two topics from each set of topics that were returned for a given course, leading to some topics not being mapped to courses. This fixes that to instead just flatten the topics so all of them get mapped if there's a valid mapping. 

In addition, some topics were mapped to >1 PMT topic and the code to resolve that did not handle it properly, so only the last of the PMT topics would get the mapping. (An example of this is the "AI" topic, which maps to "Artificial Intelligence" and "Machine Learning" for OCW.) This also includes a fix for that.

### How can this be tested?

There are two test case OCW courses for this. The links to those are here (in OCW, in JSON):
* https://ocw.mit.edu/courses/6-189-a-gentle-introduction-to-programming-using-python-january-iap-2008/data.json
* https://ocw.mit.edu/courses/16-410-principles-of-autonomy-and-decision-making-fall-2010/data.json

To test, ensure you have OCW support set up and run the backpopulate command for each:
* `./manage.py backpopulate_ocw_data --overwrite --skip-contentfiles --course-name 6-189-a-gentle-introduction-to-programming-using-python-january-iap-2008`
* `./manage.py backpopulate_ocw_data --overwrite --skip-contentfiles --course-name 16-410-principles-of-autonomy-and-decision-making-fall-2010`

_For 6.189_, you should see these topics listed in Django Admin:

![image](https://github.com/user-attachments/assets/60826b57-98c8-4984-8c5a-ebbf24d1c4a4)

You should also be able to navigate to the Programming & Coding topic in the frontend and see the course listed there: `http://your-url/c/topic/programming-coding/` 

_For 16.410_, you should see these topics listed:

![image](https://github.com/user-attachments/assets/39d0217b-8f00-4b6c-a933-add600f95b8e)

You should also be able to navigate to the AI topic in the frontend and see this course (again, it may be the only one).

You should also be able to manually map the topics here to PMT topics using the topic mapping Google Sheet in https://github.com/mitodl/hq/issues/4553 . There may be more PMT topics than OCW topics - 16.410 has "Artificial Intelligence", which maps to two PMT topics.

_if you don't see anything in the frontend,_ you may also want to run `backpopulate_resource_channels --topic --overwrite` - if your channels are sufficiently old, they may have been created without the fixes in https://github.com/mitodl/mit-open/pull/1326 and so have a search filter setting that doesn't work properly. (The backpopulate command will only update channels that have things in them - so now it should update the Programming & Coding channel, since it was empty before.) 
