### PR TITLE
Update the mappings for PWT topic "Programming & Coding" 

### DIFF
--- a/data_fixtures/migrations/0006_topic_mappings_edx_add_programming_coding_to_computer_science.py
+++ b/data_fixtures/migrations/0006_topic_mappings_edx_add_programming_coding_to_computer_science.py
@@ -25,6 +25,7 @@ topics:
         mappings:
           ocw:
             - Programming Languages
+            - Software Design and Engineering
           mitx:
             - Computer Science
         name: Programming & Coding

--- a/data_fixtures/migrations/0006_topic_mappings_edx_add_programming_coding_to_computer_science.py
+++ b/data_fixtures/migrations/0006_topic_mappings_edx_add_programming_coding_to_computer_science.py
@@ -1,0 +1,74 @@
+"""
+Update the topic map for edX; resolve Computer Science (in edX) to both
+Computer Science and Programming & Coding.
+"""
+
+from django.db import migrations
+
+from learning_resources.utils import upsert_topic_data_string
+
+map_changes = """
+---
+topics:
+    - icon: RiRobot2Line
+      id: c06109bf-cff8-4873-b04b-f5e66e3e1764
+      mappings:
+        mitx:
+          - Electronics
+        ocw:
+          - Technology
+      name: Data Science, Analytics & Computer Technology
+      children:
+      - children: []
+        icon: RiRobot2Line
+        id: 4cd6156e-51a0-4da4-add4-6f81e106cd43
+        mappings:
+          ocw:
+            - Programming Languages
+          mitx:
+            - Computer Science
+        name: Programming & Coding
+"""
+
+rollback_map_changes = """
+---
+topics:
+    - icon: RiRobot2Line
+      id: c06109bf-cff8-4873-b04b-f5e66e3e1764
+      mappings:
+        mitx:
+          - Electronics
+        ocw:
+          - Technology
+      name: Data Science, Analytics & Computer Technology
+      children:
+      - children: []
+        icon: RiRobot2Line
+        id: 4cd6156e-51a0-4da4-add4-6f81e106cd43
+        mappings:
+          ocw:
+            - Programming Languages
+        name: Programming & Coding
+"""
+
+
+def add_new_mapping(apps, schema_editor):
+    """Upsert the map_changes data above."""
+
+    upsert_topic_data_string(map_changes)
+
+
+def rollback_new_mapping(apps, schema_editor):
+    """Upsert the rollback_map_changes data above."""
+
+    upsert_topic_data_string(rollback_map_changes)
+
+
+class Migration(migrations.Migration):
+    """Perform the migration."""
+
+    dependencies = [
+        ("data_fixtures", "0005_unit_page_copy_updates"),
+    ]
+
+    operations = [migrations.RunPython(add_new_mapping, rollback_new_mapping)]


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#5080

### Description (What does it do?)

Adds a mapping from edX topic "Computer Science" to the "Programming & Coding" PWT topic. Per https://github.com/mitodl/hq/issues/4553 , this is the "mitx" offeror code.

Adds an additional mapping from OCW topic "Software Design and Engineering" to "Programming & Coding". 

### How can this be tested?

Run the data migrations: `docker compose run --rm -e "RUN_DATA_MIGRATIONS=True" web ./manage.py migrate data_fixtures`

You should see two new mappings for the "Programming & Coding" topic. Rerunning the backpopulate for courses that use the mitx offeror code (mit_edx, mitxonline) should result in some resources being assigned that topic. You should also see some courses filter into the topic page for "Programming & Coding" but be advised that you may have to [backpopulate the resource channels for topics first. ](https://github.com/mitodl/mit-open/pull/1326) In addition, running the ocw backpopulate should also assign courses to Programming & Coding.

For completeness, also:
- Make sure the root topic - "Data Science, Analytics & Computer Technology" - doesn't change (other than the "updated_at" field)
- Roll back the migration. The topic mapping that was added should be removed, and everything else should be OK. Note that learning resources that were mapped to the topic won't change - they'll continue to be mapped until/unless you run backpopulate again.

### Additional Context

Two things of note:
- I'm hoping this will be a good template for doing smaller topic updates in future. This migration is self-contained (requires no additional data files) and can be rolled back.
- Since this is a subtopic, you have to include the topic it belongs to when doing these sorts of updates. (You don't have to pull in child topics other than the one that you're changing. No harm in doing that though, other than making the migration harder to read.) 
