### PR TITLE
Renaming my topic update migration from 0006 to 0007

### DIFF
--- a/data_fixtures/migrations/0007_topic_mappings_edx_add_programming_coding_to_computer_science.py
+++ b/data_fixtures/migrations/0007_topic_mappings_edx_add_programming_coding_to_computer_science.py
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
     """Perform the migration."""
 
     dependencies = [
-        ("data_fixtures", "0005_unit_page_copy_updates"),
+        ("data_fixtures", "0006_update_parent_topic_channel_descriptions"),
     ]
 
     operations = [migrations.RunPython(add_new_mapping, rollback_new_mapping)]


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#5080

### Description (What does it do?)

There ended up being two 0006 migrations in data_fixtures; this renames mine to 0007 so the graph is right.

### How can this be tested?

Roll back your data_fixtures to migration 0005 before checking out this branch. Then, check it out and migrate. Everything should be as expected. (You can re-populate courses if you want and they should work OK, per https://github.com/mitodl/mit-open/pull/1344 .)
