### PR TITLE
add a bullet about collecting demographics to PrivacyPage.tsx

### DIFF
--- a/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
+++ b/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
@@ -87,6 +87,10 @@ const PrivacyPage: React.FC = () => {
               Biographic information – name, email address, education level and
               other demographic info
             </li>
+            <li>
+              Demographics and Interests - Affinity categories, Product Purchase 
+              Interests, and Other Categories of interest
+            </li>
             <li>IP addresses</li>
             <li>Course progress and performance</li>
           </UnorderedList>

--- a/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
+++ b/frontends/mit-open/src/pages/PrivacyPage/PrivacyPage.tsx
@@ -88,7 +88,7 @@ const PrivacyPage: React.FC = () => {
               other demographic info
             </li>
             <li>
-              Demographics and Interests - Affinity categories, Product Purchase 
+              Demographics and Interests - Affinity categories, Product Purchase
               Interests, and Other Categories of interest
             </li>
             <li>IP addresses</li>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

I accidentally removed a bullet from the list "What personal information we collect"

The current copy for the privacy page is at https://docs.google.com/document/d/1jIZytUsHp4BB0eE5rTRWdEjj30w1kt4Z 