### PR TITLE
Fix issue with User List cards not updating on edit

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -32,6 +32,7 @@ import type {
 import learningResources, {
   invalidateResourceQueries,
   invalidateUserListQueries,
+  invalidateResourceWithUserListQueries,
   updateListParentsOnAdd,
   updateListParentsOnDestroy,
 } from "./keyFactory"
@@ -251,8 +252,10 @@ const useUserListUpdate = () => {
         PatchedUserListRequest: params,
       }),
     onSettled: (_data, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.id)
       queryClient.invalidateQueries(learningResources.userlists._ctx.list._def)
+      queryClient.invalidateQueries(
+        learningResources.userlists._ctx.detail(vars.id).queryKey,
+      )
     },
   })
 }
@@ -262,8 +265,9 @@ const useUserListDestroy = () => {
   return useMutation({
     mutationFn: (params: ULDestroyRequest) =>
       userListsApi.userlistsDestroy(params),
-    onSettled: (_data, _err) => {
-      queryClient.invalidateQueries(learningResources.userlists._ctx.list._def)
+    onSettled: (_data, _err, vars) => {
+      invalidateUserListQueries(queryClient, vars.id)
+      invalidateResourceWithUserListQueries(queryClient, vars.id)
     },
   })
 }

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -252,6 +252,7 @@ const useUserListUpdate = () => {
       }),
     onSettled: (_data, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.id)
+      queryClient.invalidateQueries(learningResources.userlists._ctx.list._def)
     },
   })
 }
@@ -261,8 +262,8 @@ const useUserListDestroy = () => {
   return useMutation({
     mutationFn: (params: ULDestroyRequest) =>
       userListsApi.userlistsDestroy(params),
-    onSettled: (_data, _err, vars) => {
-      invalidateResourceQueries(queryClient, vars.id)
+    onSettled: (_data, _err) => {
+      queryClient.invalidateQueries(learningResources.userlists._ctx.list._def)
     },
   })
 }

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -155,7 +155,24 @@ const listHasResource =
           (page: PaginatedLearningResourceList) => page.results,
         )
       : data.results
+
     return resources.some((res) => res.id === resourceId)
+  }
+
+const resourceHasUserList =
+  (userListId: number) =>
+  (query: Query): boolean => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data = query.state.data as any
+    const resources: LearningResource[] = data.pages
+      ? data.pages.flatMap(
+          (page: PaginatedLearningResourceList) => page.results,
+        )
+      : data.results
+
+    return resources?.some((res) =>
+      res.user_list_parents?.some((userList) => userList.parent === userListId),
+    )
   }
 
 /**
@@ -202,6 +219,31 @@ const invalidateResourceQueries = (
   })
 }
 
+/**
+ * Invalidate Resource queries that a resource that belongs to user list appears in.
+ */
+const invalidateResourceWithUserListQueries = (
+  queryClient: QueryClient,
+  userListId: LearningResource["id"],
+  { skipFeatured = false } = {},
+) => {
+  /**
+   * Invalidate lists with a resource that is in the user list.
+   */
+  const lists = [
+    learningResources.list._def,
+    learningResources.learningpaths._ctx.list._def,
+    learningResources.search._def,
+    ...(skipFeatured ? [] : [learningResources.featured._def]),
+  ]
+  lists.forEach((queryKey) => {
+    queryClient.invalidateQueries({
+      queryKey,
+      predicate: resourceHasUserList(userListId),
+    })
+  })
+}
+
 const invalidateUserListQueries = (
   queryClient: QueryClient,
   userListId: UserList["id"],
@@ -210,6 +252,7 @@ const invalidateUserListQueries = (
     learningResources.userlists._ctx.detail(userListId).queryKey,
   )
   const lists = [learningResources.userlists._ctx.list._def]
+
   lists.forEach((queryKey) => {
     queryClient.invalidateQueries({
       queryKey,
@@ -275,6 +318,7 @@ export default learningResources
 export {
   invalidateResourceQueries,
   invalidateUserListQueries,
+  invalidateResourceWithUserListQueries,
   updateListParentsOnAdd,
   updateListParentsOnDestroy,
 }


### PR DESCRIPTION
### What are the relevant tickets?

Fixes https://github.com/mitodl/hq/issues/5100

### Description (What does it do?)
<!--- Describe your changes in detail -->

Fixes the issue that User List cards do not update when edited.
- Invalidates the list query cache after the user list update mutation so that the useUserListList() hook triggers render of the User List page.

### How can this be tested?

While authenticated, navigate to /dashboard/#my-lists

- Edit a list item
   - Confirm that the card updates without navigation or refresh.
- Delete a list item
   - Confirm that the card is removed navigation or refresh.

Regression check:
- Click a list item to open its detail page
- Edit the item
  - Confirm that the page updates with changes
 