### PR TITLE
enable mailgun and analytics

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -395,6 +395,9 @@ ANYMAIL = {
     "MAILGUN_SENDER_DOMAIN": MAILGUN_SENDER_DOMAIN,
 }
 
+NOTIFICATION_EMAIL_BACKEND = get_string(
+    "MITOPEN_NOTIFICATION_EMAIL_BACKEND", "anymail.backends.test.EmailBackend"
+)
 # e-mail configurable admins
 ADMIN_EMAIL = get_string("MITOPEN_ADMIN_EMAIL", "")
 ADMINS = (("Admins", ADMIN_EMAIL),) if ADMIN_EMAIL != "" else ()

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -9,10 +9,11 @@ from urllib.parse import quote, urljoin
 from xml.sax.saxutils import escape as xml_escape
 
 import requests
+from anymail.message import AnymailMessage
 from bs4 import BeautifulSoup
 from django.conf import settings
+from django.core import mail
 from django.core.files.temp import NamedTemporaryFile
-from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 from PIL import Image
 
@@ -411,9 +412,14 @@ def send_email(recipients, subject, content, text_only):
         for link in soup.find_all("a"):
             link.replace_with(link.attrs["href"])
         text_content = soup.get_text().strip()
-    msg = EmailMultiAlternatives(
-        subject, text_content, settings.DEFAULT_FROM_EMAIL, recipients
-    )
-    if not text_only:
-        msg.attach_alternative(content, "text/html")
+    with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
+        msg = AnymailMessage(
+            subject=subject,
+            body=text_content,
+            to=recipients,
+            from_email=settings.MAILGUN_FROM_EMAIL,
+            connection=connection,
+        )
+        if not text_only:
+            msg.attach_alternative(content, "text/html")
     return msg.send()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/5136


### Description (What does it do?)
The changes in this PR switch us to using mailgun via anymail for sending email

### How can this be tested?
1. go to heroku and copy the following settings from rc into your settings.py:
  - MAILGUN_KEY
  - MAILGUN_SENDER_DOMAIN
  - MAILGUN_FROM_EMAIL
2. set NOTIFICATION_EMAIL_BACKEND to "anymail.backends.mailgun.EmailBackend" in settings.py
3. restart celery ```docker compose restart celery```
4. manually trigger an email (make sure you change the recipient email) via django shell and verify you receive it:
```
from profiles.utils import send_email
send_email(['ambady@mit.edu'], 'test email', 'test', True)
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
