### PR TITLE
Fix homepage contrast issues

### DIFF
--- a/frontends/mit-open/src/page-components/TestimonialDisplay/AttestantBlock.tsx
+++ b/frontends/mit-open/src/page-components/TestimonialDisplay/AttestantBlock.tsx
@@ -77,7 +77,7 @@ const AttestantNameBlock = styled.div<AttestantBlockChildProps>((props) => {
       color:
         props.color === "light"
           ? theme.custom.colors.lightGray2
-          : theme.custom.colors.silverGray,
+          : theme.custom.colors.silverGrayDark,
     },
   ]
 })

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -40,8 +40,7 @@ const baseInputStyles = (theme: Theme) => ({
     borderColor: theme.custom.colors.red,
   },
   "& input::placeholder": {
-    opacity: "0.3",
-    color: theme.custom.colors.black,
+    color: theme.custom.colors.silverGrayDark,
   },
   "& input:placeholder-shown": {
     textOverflow: "ellipsis",

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -41,6 +41,7 @@ const baseInputStyles = (theme: Theme) => ({
   },
   "& input::placeholder": {
     color: theme.custom.colors.silverGrayDark,
+    opacity: 1, // some browsers apply opacity to placeholder text
   },
   "& input:placeholder-shown": {
     textOverflow: "ellipsis",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5118

### Description (What does it do?)
Increases contrast on homepage input placeholder and testimonials.

### Screenshots (if appropriate):
**Before / After**
<img width="300" alt="Screenshot 2024-08-06 at 11 15 26 AM" src="https://github.com/user-attachments/assets/8f0894a4-39f5-4e4e-93ae-9783605c4931"> <img width="300" alt="Screenshot 2024-08-06 at 11 14 12 AM" src="https://github.com/user-attachments/assets/e0b7bf53-289c-4c04-bb9d-c73c388e398a">

**Before / After**:
<img width="209" alt="Screenshot 2024-08-06 at 11 16 00 AM" src="https://github.com/user-attachments/assets/de55e2c7-769d-45ba-bce6-656b74290929">  <img width="143" alt="Screenshot 2024-08-06 at 11 16 22 AM" src="https://github.com/user-attachments/assets/3a3e20c2-aa38-44d5-a3a4-28c706c18ae9">

### How can this be tested?
1. Confirm that the placeholder text is darker 
    - if you actually want to see the color value in dev tools... I'm not sure how to do it in Firefox. In Chrome, you need to enable "Show Browser Shadow DOM". https://stackoverflow.com/a/26853319
2. Confirm the testimonial learner "title" is darker

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
