### PR TITLE
Fix flaky test_serialize_bulk_learning_resources

### DIFF
--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -557,19 +557,19 @@ def test_serialize_bulk_learning_resources(mocker):
     every existing learning resource
     """
     # NOTE: explicitly creating a fixed number per type for a deterministic query count
-    resources = [
-        *factories.LearningResourceFactory.create_batch(5, is_course=True),
-        *factories.LearningResourceFactory.create_batch(5, is_program=True),
-        *factories.LearningResourceFactory.create_batch(5, is_podcast=True),
-        *factories.LearningResourceFactory.create_batch(5, is_podcast_episode=True),
-        *factories.LearningResourceFactory.create_batch(5, is_video=True),
-        *factories.LearningResourceFactory.create_batch(5, is_video_playlist=True),
-    ]
-    resources = LearningResource.objects.for_serialization()
-    results = list(
+    factories.LearningResourceFactory.create_batch(5, is_course=True)
+    factories.LearningResourceFactory.create_batch(5, is_program=True)
+    factories.LearningResourceFactory.create_batch(5, is_podcast=True)
+    factories.LearningResourceFactory.create_batch(5, is_podcast_episode=True)
+    factories.LearningResourceFactory.create_batch(5, is_video=True)
+    factories.LearningResourceFactory.create_batch(5, is_video_playlist=True)
+
+    resources = LearningResource.objects.order_by("id").for_serialization()
+    results = sorted(
         serializers.serialize_bulk_learning_resources(
             [resource.id for resource in resources]
-        )
+        ),
+        key=lambda x: x["id"],
     )
 
     expected = []


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5149

### Description (What does it do?)
Fixes flaky test by sorting before comparing arrays.

### How can this be tested?
To test this locally, I changed `test_serialize_bulk_learning_resources` to  
```python
@pytest.mark.parametrize("arg", range(10))
def test_serialize_bulk_learning_resources(mocker, arg):
```
and ran `pytest learning_resources_search/serializers_test.py::test_serialize_bulk_learning_resources --no-cov`.

On `main`, that should produce some failures. On this branch, it should not.

