### PR TITLE
Rename my 0008 to 0009 to prevent conflict

### DIFF
--- a/data_fixtures/migrations/0009_topics_update_engineering_add_manufacturing.py
+++ b/data_fixtures/migrations/0009_topics_update_engineering_add_manufacturing.py
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
     dependencies = [
         (
             "data_fixtures",
-            "0007_topic_mappings_edx_add_programming_coding_to_computer_science",
+            "0008_unpublish_empty_topic_channels",
         ),
     ]
 


### PR DESCRIPTION
### What are the relevant tickets?

#1364 

### Description (What does it do?)

There was an `0008` migration merged in so now there's a conflict - renaming mine to `0009`.

### How can this be tested?

Migrations should run successfully.