### PR TITLE
show featured resources first

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -9,7 +9,6 @@ from opensearch_dsl import Search
 from opensearch_dsl.query import MoreLikeThis, Percolate
 from opensearchpy.exceptions import NotFoundError
 
-from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
 from learning_resources.models import LearningResource
 from learning_resources_search.connection import (
     get_default_alias_name,
@@ -21,6 +20,7 @@ from learning_resources_search.constants import (
     DEPARTMENT_QUERY_FIELDS,
     LEARNING_RESOURCE,
     LEARNING_RESOURCE_QUERY_FIELDS,
+    LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS,
     LEARNING_RESOURCE_TYPES,
     RESOURCEFILE_QUERY_FIELDS,
     RUN_INSTRUCTORS_QUERY_FIELDS,
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["is_learning_material", "-views"]
+DEFAULT_SORT = ["featured_rank", "is_learning_material"]
 
 
 def gen_content_file_id(content_file_id):
@@ -89,7 +89,7 @@ def generate_sort_clause(search_params):
     """
 
     sort = (
-        LEARNING_RESOURCE_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
+        LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS.get(search_params.get("sortby"), {})
         .get("sort")
         .replace("0__", "")
         .replace("__", ".")

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2202,7 +2202,7 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, ["is_learning_material", {"views": {"order": "desc"}}]),
+        (None, None, ["featured_rank", "is_learning_material"]),
         (None, "text", None),
     ],
 )


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4986

### Description (What does it do?)
This updates the default sort to show featured resources first. The resources are shown in order of their position in channel featured lists, with the order of resources with the same position randomized.  The order (including the random part) is hard coded in the index and updated each night

For non-featured resources, courses/programs should continue to be shown before learning resources.

The default sort only affects the order if there is no search term

### How can this be tested?
Check out the branch in https://github.com/mitodl/mit-open/pull/1381 which includes everything except the search query change so that the front end does not break during reindexing

Go to http://open.odl.local:8062/search/ and ensure that search works as expected 

Run docker-compose run web ./manage.py recreate_index --all

Go to http://open.odl.local:8062/search/ and ensure that search works as expected 

Check out this branch 

Go to http://open.odl.local:8062/search/ and check that you see resources from the front end featured carousel first. The order will be slightly different from the carousel order since the order is randomized for resources that have the same position with in the featured list for different units

Run
docker-compose run web ./manage.py update_featured_rank
docker-compose run web ./manage.py update_index --courses
docker-compose run web ./manage.py backpopulate_mitxonline_data

After each command go to http://open.odl.local:8062/search/  and ensure that the featured resources remain the first results


**This pr should not be released until https://github.com/mitodl/mit-open/pull/1381 is released and the index is updated**
