### PR TITLE
prevent renovate django 5 updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
     {
       "groupName": "ckeditor5",
       "matchSourceUrls": ["https://github.com/ckeditor/ckeditor5/{/,}**"]
+    },
+    {
+      "allowedVersions": "<5",
+      "matchPackageNames": ["django", "Django"]
     }
   ]
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/mit-open/issues/1373

### Description (What does it do?)
This PR prevents renovate from suggesting django 5 updates/restricts us to just django 4

### How can this be tested?
Not entirely sure how to test this other than merging this in and seeing the updates from renovate. Locally I did run the config through the [renotate config validator](https://docs.renovatebot.com/config-validation/)
