### PR TITLE
Replace resource drawer topic chips with info section text

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -12,6 +12,7 @@ import {
   RiGraduationCapLine,
   RiTranslate2,
   RiAwardLine,
+  RiPresentationLine,
 } from "@remixicon/react"
 import { LearningResource, LearningResourceRun, ResourceTypeEnum } from "api"
 import {
@@ -108,7 +109,18 @@ const INFO_ITEMS: InfoItemConfig = [
       )
     },
   },
+  {
+    label: "Topics:",
+    Icon: RiPresentationLine,
+    selector: (resource: LearningResource) => {
+      const { topics } = resource
+      if (!topics?.length) {
+        return null
+      }
 
+      return topics.map((topic) => topic.name).join(", ")
+    },
+  },
   {
     label: "Level:",
     Icon: RiDashboard3Line,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -133,28 +133,6 @@ describe("Learning Resource Expanded", () => {
     },
   )
 
-  test.each(RESOURCE_TYPES.filter((type) => !isVideo(type)))(
-    'Renders topic section for resource type "%s"',
-    (resourceType) => {
-      const resource = factories.learningResources.resource({
-        resource_type: resourceType,
-      })
-
-      setup(resource)
-
-      const section = screen
-        .getByRole("heading", { name: "Topics" })!
-        .closest("section")!
-
-      const links = within(section).getAllByRole("link")
-
-      resource.topics!.forEach((topic, index) => {
-        expect(links[index]).toHaveAttribute("href", topic.channel_url)
-        expect(links[index]).toHaveTextContent(topic.name)
-      })
-    },
-  )
-
   test(`Renders info section for resource type "${ResourceTypeEnum.Video}"`, () => {
     const resource = factories.learningResources.resource({
       resource_type: ResourceTypeEnum.Video,
@@ -290,6 +268,25 @@ describe("Learning Resource Expanded", () => {
       })
     },
   )
+
+  test("Renders info section topics correctly", () => {
+    const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
+      topics: [
+        factories.learningResources.topic({ name: "Topic 1" }),
+        factories.learningResources.topic({ name: "Topic 2" }),
+        factories.learningResources.topic({ name: "Topic 3" }),
+      ],
+    })
+
+    setup(resource)
+
+    const section = screen
+      .getByRole("heading", { name: "Info" })!
+      .closest("section")!
+
+    within(section).getByText("Topic 1, Topic 2, Topic 3")
+  })
 
   test("Renders info section languages correctly", () => {
     const resource = factories.learningResources.resource({

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -3,12 +3,7 @@ import styled from "@emotion/styled"
 import Skeleton from "@mui/material/Skeleton"
 import Typography from "@mui/material/Typography"
 import { ButtonLink } from "../Button/Button"
-import Chip from "@mui/material/Chip"
-import type {
-  LearningResource,
-  LearningResourceRun,
-  LearningResourceTopic,
-} from "api"
+import type { LearningResource, LearningResourceRun } from "api"
 import { ResourceTypeEnum, PlatformEnum } from "api"
 import {
   formatDate,
@@ -24,7 +19,6 @@ import { SimpleSelect } from "../SimpleSelect/SimpleSelect"
 import type { SimpleSelectProps } from "../SimpleSelect/SimpleSelect"
 import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
-import { ChipLink } from "../Chips/ChipLink"
 import InfoSection from "./InfoSection"
 
 const Container = styled.div<{ padTop?: boolean }>`
@@ -140,20 +134,6 @@ const StyledPlatformLogo = styled(PlatformLogo)`
 const OnPlatform = styled.span`
   ${{ ...theme.typography.body2 }}
   color: ${theme.custom.colors.black};
-`
-
-const Topics = styled.section`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`
-
-const TopicsList = styled.ul`
-  display: flex;
-  flex-wrap: wrap;
-  padding: 0;
-  margin: 0;
-  gap: 8px;
 `
 
 type LearningResourceExpandedProps = {
@@ -298,41 +278,6 @@ const ResourceDescription = ({ resource }: { resource?: LearningResource }) => {
   )
 }
 
-const TopicsSection: React.FC<{ topics?: LearningResourceTopic[] }> = ({
-  topics,
-}) => {
-  if (!topics?.length) {
-    return null
-  }
-  return (
-    <Topics>
-      <Typography variant="subtitle2" component="h3">
-        Topics
-      </Typography>
-      <TopicsList>
-        {topics.map((topic) =>
-          topic.channel_url ? (
-            <ChipLink
-              key={topic.id}
-              size="medium"
-              label={topic.name}
-              href={topic.channel_url}
-              variant="outlined"
-            />
-          ) : (
-            <Chip
-              key={topic.id}
-              size="medium"
-              label={topic.name}
-              variant="outlined"
-            />
-          ),
-        )}
-      </TopicsList>
-    </Topics>
-  )
-}
-
 const formatRunDate = (
   run: LearningResourceRun,
   asTaughtIn: boolean,
@@ -437,7 +382,6 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       <ImageSection resource={resource} config={imgConfig} />
       <CallToActionSection resource={resource} hide={isVideo} />
       <DetailSection resource={resource} />
-      <TopicsSection topics={resource?.topics} />
       <InfoSection resource={resource} run={selectedRun} />
     </Container>
   )


### PR DESCRIPTION
### What are the relevant tickets?

Closes: https://github.com/mitodl/hq/issues/5004

### Description (What does it do?)
<!--- Describe your changes in detail -->

Removes the topic chips and chip links in the learning resource drawer, replacing them with an info section showing topics as text, comma separated, no links to channel URLs.

### Screenshots (if appropriate):

<img width="620" alt="image" src="https://github.com/user-attachments/assets/f426ce43-01cf-47d3-983b-9ad1e0dbdadf">


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Search for some learning resources with topic set, e.g. /search/?topic=Policy+and+Administration
- Click on a learning resource list card
- Check that the topics are displayed in the info section, after price, with the correct icon - [designs](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=2636-61635&t=vRxUPmlIc2lSocri-0).
