### PR TITLE
Update topic boxes to support multiple lines

### DIFF
--- a/data_fixtures/migrations/0010_topics_update_icons_for_innovation_data_science.py
+++ b/data_fixtures/migrations/0010_topics_update_icons_for_innovation_data_science.py
@@ -1,0 +1,60 @@
+"""
+Update the topics; update the icons for Data Science, Analytics & Computer
+Technology and the Innovation & Entrepreneurship topics.
+
+This is just an icon revision so doing it directly.
+"""
+
+from django.db import migrations
+
+
+def _update_icons(model, topic, icon):
+    """Perform the update."""
+
+    topic = model.objects.get(topic_uuid=topic)
+    topic.icon = icon
+    topic.save()
+
+
+def update_topic_icons(apps, schema_editor):
+    """Update topic icons."""
+
+    LearningResourceTopic = apps.get_model(
+        "learning_resources", "LearningResourceTopic"
+    )
+
+    # Data Science, Analytics & Computer Technology
+    _update_icons(
+        LearningResourceTopic, "c06109bf-cff8-4873-b04b-f5e66e3e1764", "RiLineChartLine"
+    )
+    # Innovation & Entrepreneurship
+    _update_icons(
+        LearningResourceTopic, "c0f67cd5-c3f2-458c-85e7-a2144c6e5e9d", "RiSpaceShipLine"
+    )
+
+
+def unupdate_topic_icons(apps, schema_editor):
+    """Roll back topic icons update."""
+
+    LearningResourceTopic = apps.get_model(
+        "learning_resources", "LearningResourceTopic"
+    )
+
+    # Data Science, Analytics & Computer Technology
+    _update_icons(
+        LearningResourceTopic, "c06109bf-cff8-4873-b04b-f5e66e3e1764", "RiRobot2Line"
+    )
+    # Innovation & Entrepreneurship
+    _update_icons(
+        LearningResourceTopic, "c0f67cd5-c3f2-458c-85e7-a2144c6e5e9d", "RiTeamLine"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_fixtures", "0009_topics_update_engineering_add_manufacturing"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_topic_icons, unupdate_topic_icons),
+    ]

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.test.tsx
@@ -11,13 +11,13 @@ describe("TopicIcon", () => {
    */
   test.each(rootTopicNames)("Root topics all have an icon", (name) => {
     expect(rootTopicNames.length).toBe(13)
-    render(<RootTopicIcon name={name} />)
+    render(<RootTopicIcon icon={name} />)
     const svg = document.querySelector("svg")
     expect(svg).toBeVisible()
   })
 
   test("Unknown topics have a visibly hidden icon", () => {
-    render(<RootTopicIcon name="Unknown Topic" />)
+    render(<RootTopicIcon icon="Unknown Topic" />)
     const svg = document.querySelector("svg")
     expect(svg).not.toBeVisible()
   })

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
@@ -1,38 +1,33 @@
 import {
-  RiPaletteLine,
-  RiSeedlingLine,
-  RiEarthLine,
-  RiQuillPenLine,
-  RiBriefcase3Line,
-  RiLightbulbFlashLine,
-  RiRobot2Line,
-  RiStethoscopeLine,
-  RiInfinityLine,
   RiTestTubeLine,
   RiUserSearchLine,
-  RiTeamLine,
-  RiLineChartLine,
+  RiLightbulbFlashLine,
+  RiBriefcase3Line,
+  RiStethoscopeLine,
+  RiPaletteLine,
+  RiQuillPenLine,
+  RiShakeHandsLine,
+  RiRobot2Line,
+  RiEarthLine,
+  RiSpaceShipLine,
 } from "@remixicon/react"
 import React from "react"
 
-/* TODO Using any icons until we have a solution for specifying them */
 export const ICON_MAP = {
-  "Business & Management": RiBriefcase3Line,
-  "Energy, Climate & Sustainability": RiLightbulbFlashLine,
-  "Data Science, Analytics & Computer Technology": RiLineChartLine,
-  "Art, Design & Architecture": RiPaletteLine,
-  "Health & Medicine": RiStethoscopeLine,
-  Humanities: RiQuillPenLine,
-  Mathematics: RiInfinityLine,
-  "Science & Math": RiTestTubeLine,
-  "Social Sciences": RiUserSearchLine,
-  Society: RiEarthLine,
-  "Education & Teaching": RiSeedlingLine,
-  Engineering: RiRobot2Line,
-  "Innovation & Entrepreneurship": RiTeamLine,
+  RiTestTubeLine: RiTestTubeLine,
+  RiUserSearchLine: RiUserSearchLine,
+  RiLightbulbFlashLine: RiLightbulbFlashLine,
+  RiBriefcase3Line: RiBriefcase3Line,
+  RiStethoscopeLine: RiStethoscopeLine,
+  RiPaletteLine: RiPaletteLine,
+  RiQuillPenLine: RiQuillPenLine,
+  RiShakeHandsLine: RiShakeHandsLine,
+  RiRobot2Line: RiRobot2Line,
+  RiEarthLine: RiEarthLine,
+  RiSpaceShipLine: RiSpaceShipLine,
 }
 
-type RootTopicIconProps = { name: string }
+type RootTopicIconProps = { icon: string | undefined }
 
 /**
  * Render an icon for a root-level topic.
@@ -42,8 +37,8 @@ type RootTopicIconProps = { name: string }
  *  2. There are only about a dozen root-level topics.
  *  3. We have a test in place to ensure all root-level topics have an icon.
  */
-const RootTopicIcon: React.FC<RootTopicIconProps> = ({ name }) => {
-  const Icon = ICON_MAP[name as keyof typeof ICON_MAP]
+const RootTopicIcon: React.FC<RootTopicIconProps> = ({ icon }) => {
+  const Icon = ICON_MAP[icon as keyof typeof ICON_MAP]
   if (Icon) {
     return <Icon aria-hidden="true" />
   } else {

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
@@ -10,6 +10,7 @@ import {
   RiRobot2Line,
   RiEarthLine,
   RiSpaceShipLine,
+  RiLineChartLine,
 } from "@remixicon/react"
 import React from "react"
 
@@ -25,6 +26,7 @@ export const ICON_MAP = {
   RiRobot2Line: RiRobot2Line,
   RiEarthLine: RiEarthLine,
   RiSpaceShipLine: RiSpaceShipLine,
+  RiLineChartLine: RiLineChartLine,
 }
 
 type RootTopicIconProps = { icon: string | undefined }

--- a/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
+++ b/frontends/mit-open/src/components/RootTopicIcon/RootTopicIcon.tsx
@@ -11,9 +11,14 @@ import {
   RiEarthLine,
   RiSpaceShipLine,
   RiLineChartLine,
+  RiTeamLine,
 } from "@remixicon/react"
 import React from "react"
 
+/**
+ * These are all the icons we've used (and therefore all the icons that may
+ * appear depending on the state of the data_fixtures migrations).
+ */
 export const ICON_MAP = {
   RiTestTubeLine: RiTestTubeLine,
   RiUserSearchLine: RiUserSearchLine,
@@ -27,6 +32,7 @@ export const ICON_MAP = {
   RiEarthLine: RiEarthLine,
   RiSpaceShipLine: RiSpaceShipLine,
   RiLineChartLine: RiLineChartLine,
+  RiTeamLine: RiTeamLine,
 }
 
 type RootTopicIconProps = { icon: string | undefined }

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -50,7 +50,7 @@ const TopicBox = styled(Link)`
   display: flex;
 
   svg:last-child {
-    color: ${theme.custom.colors.black};
+    color: ${theme.custom.colors.white};
     flex: 0 0 20px;
     margin-top: auto;
     margin-bottom: auto;

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -46,7 +46,6 @@ const TopicBox = styled(Link)`
   border: 1px solid ${theme.custom.colors.lightGray2};
   background: ${theme.custom.colors.white};
   overflow: hidden;
-
   display: flex;
 
   svg:last-child {

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -47,7 +47,7 @@ const TopicBox = styled(Link)`
   overflow: hidden;
 
   svg:last-child {
-    display: none;
+    color: ${theme.custom.colors.white};
     flex: 0 0 20px;
   }
 
@@ -65,7 +65,7 @@ const TopicBox = styled(Link)`
 const TopicBoxContent = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: start;
   gap: 10px;
 
   svg {
@@ -78,10 +78,6 @@ const TopicBoxContent = styled.div`
   }}
 `
 
-// This should have these rules - temporarily disabled for now:
-// white-space: nowrap;
-// text-overflow: ellipsis;
-// overflow: hidden;
 const TopicBoxName = styled.p`
   flex-grow: 1;
   margin: 0;
@@ -102,17 +98,19 @@ const BrowseTopicsSection: React.FC = () => {
       <Container>
         <Title variant="h2">Browse by Topic</Title>
         <Topics>
-          {topics?.results.map(({ id, name, channel_url: channelUrl }) => {
-            return (
-              <TopicBox key={id} to={channelUrl!}>
-                <TopicBoxContent>
-                  <RootTopicIcon name={name} />
-                  <TopicBoxName>{name}</TopicBoxName>
-                  <RiArrowRightLine />
-                </TopicBoxContent>
-              </TopicBox>
-            )
-          })}
+          {topics?.results.map(
+            ({ id, name, channel_url: channelUrl, icon }) => {
+              return (
+                <TopicBox key={id} to={channelUrl!}>
+                  <TopicBoxContent>
+                    <RootTopicIcon icon={icon} />
+                    <TopicBoxName>{name}</TopicBoxName>
+                    <RiArrowRightLine />
+                  </TopicBoxContent>
+                </TopicBox>
+              )
+            },
+          )}
         </Topics>
         <SeeAllButton href="/topics/" size="large" responsive>
           See all

--- a/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-open/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -27,6 +27,7 @@ const Topics = styled.div`
   flex-wrap: wrap;
   gap: 16px 24px;
   margin: 40px 0;
+
   ${theme.breakpoints.down("md")} {
     gap: 5px;
     margin: 24px 0;
@@ -46,9 +47,14 @@ const TopicBox = styled(Link)`
   background: ${theme.custom.colors.white};
   overflow: hidden;
 
+  display: flex;
+
   svg:last-child {
-    color: ${theme.custom.colors.white};
+    color: ${theme.custom.colors.black};
     flex: 0 0 20px;
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-left: 8px;
   }
 
   :hover {
@@ -67,6 +73,7 @@ const TopicBoxContent = styled.div`
   justify-content: space-between;
   align-items: start;
   gap: 10px;
+  width: 100%;
 
   svg {
     flex: 0 0 22px;

--- a/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.tsx
+++ b/frontends/mit-open/src/pages/TopicListingPage/TopicsListingPage.tsx
@@ -34,15 +34,16 @@ type ChannelSummary = {
 
 type TopicBoxHeaderProps = {
   title: string
+  icon?: string
   href?: string
   className?: string
 }
 const TopicBoxHeader = styled(
-  ({ title, href, className }: TopicBoxHeaderProps) => {
+  ({ title, icon, href, className }: TopicBoxHeaderProps) => {
     return (
       <Typography variant="h5" component="h3" className={className}>
         <Link to={href ?? ""}>
-          <RootTopicIcon name={title} aria-hidden="true" />
+          <RootTopicIcon icon={icon} aria-hidden="true" />
           <span>
             <span className="topic-title">{title}</span>
             <span className="view-topic" aria-hidden="true">
@@ -128,10 +129,10 @@ const TopicBox = ({
     { label: "Courses", count: courseCount },
     { label: "Programs", count: programCount },
   ].filter((item) => item.count)
-  const { title, href, channels } = topicGroup
+  const { title, href, icon, channels } = topicGroup
   return (
     <li className={className}>
-      <TopicBoxHeader title={title} href={href} />
+      <TopicBoxHeader title={title} href={href} icon={icon} />
       <TopicBoxBody>
         <TopicCounts>
           {counts.map((item) => (
@@ -194,6 +195,7 @@ const aggregateByTopic = (
 type TopicGroup = {
   id: number
   title: string
+  icon?: string
   href?: string
   courses: number
   programs: number
@@ -219,6 +221,7 @@ const groupTopics = (
           programs: programCounts[topic.name],
           title: topic.name,
           href: topic.channel_url,
+          icon: topic.icon,
         },
       ]),
   )

--- a/learning_resources/admin.py
+++ b/learning_resources/admin.py
@@ -22,6 +22,18 @@ class LearningResourceTopicAdmin(admin.ModelAdmin):
         "parent",
     )
     search_fields = ("name",)
+    fields = (
+        "name",
+        "parent",
+        "topic_uuid",
+        "icon",
+    )
+    readonly_fields = (
+        "name",
+        "parent",
+        "topic_uuid",
+        "icon",
+    )
 
 
 class LearningResourceDepartmentAdmin(admin.ModelAdmin):


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#5016

### Description (What does it do?)

This does a handful of things:
- Adjusts the styling of the topic boxes on the homepage to better match the Figma design
- Adjusts the icons for "Data Science, Analytics & Computer Technology" (to RiLineChartLine) and "Innovation & Entrepreneurship" (to RiSpaceShipLine)
- Updates the BrowseTopicsSection and TopicsListingPage to include icon data so they display correctly
- Updates the Django Admin for topics to show the UUID, mark the fields as read-only

### Screenshots (if appropriate):

Tablet view (desktop is very similar but this shows the wrapping more effectively):
![Screenshot 2024-08-07 at 11 52 03 AM](https://github.com/user-attachments/assets/71c36cf8-7b4f-4ea3-be92-dfbd1e849ea9)
![onhover](https://github.com/user-attachments/assets/247b282b-a76c-405f-af1a-7e8f84610ab0)
![image](https://github.com/user-attachments/assets/4cdd6dd6-7824-45e4-bd02-4af9e145f12f)


### How can this be tested?

For best results, put your browser in responsive mode and grab a tablet-sized preview. (Screenshots are at 994x800 resolution. In Firefox, grabbing "iPad" also disables hover because it enables touch emulation.) The design of the boxes in the Browse by Topic section should match the design (and also the notes in the issue). Additionally, the icons for Data Science and Innovation should be correct.

Also:
- The topics on the listing page should have icons and they should be the correct ones (i.e. they should match the homepage).
- Go into Django Admin and load a Learning Resource Topic. The fields should be read-only and you should now see the UUID for the topic.