### PR TITLE
update suppport email

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -47,7 +47,7 @@ jobs:
           SENTRY_ENV: ${{ secrets.MITOPEN_ENV_PROD }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_API_BASE_URL: https://api.mitopen.odl.mit.edu
-          MITOPEN_SUPPORT_EMAIL: mitopen-support@mit.edu
+          MITOPEN_SUPPORT_EMAIL: mitlearn-support@mit.edu
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -47,7 +47,7 @@ jobs:
           SENTRY_ENV: ${{ secrets.MITOPEN_ENV_RC }}
           MITOPEN_AXIOS_WITH_CREDENTIALS: true
           MITOPEN_API_BASE_URL: https://api.mitopen-rc.odl.mit.edu
-          MITOPEN_SUPPORT_EMAIL: odl-mitopen-rc-support@mit.edu
+          MITOPEN_SUPPORT_EMAIL: mitlearn-support@mit.edu
 
       - uses: akhileshns/heroku-deploy@581dd286c962b6972d427fcf8980f60755c15520
         with:

--- a/frontends/mit-open/src/common/urls.ts
+++ b/frontends/mit-open/src/common/urls.ts
@@ -89,7 +89,7 @@ export const TERMS = "/terms/"
 
 export const UNITS = "/units/"
 
-export const CONTACT = "mailto:odl-discussions-support@mit.edu"
+export const CONTACT = "mailto:mitlearn-support@mit.edu"
 
 export const RESOURCE_DRAWER_QUERY_PARAM = "resource"
 

--- a/frontends/mit-open/webpack.config.js
+++ b/frontends/mit-open/webpack.config.js
@@ -75,7 +75,7 @@ const {
   }),
   MITOPEN_SUPPORT_EMAIL: str({
     desc: "Email address for support",
-    default: "mitopen-support@mit.edu",
+    default: "mitlearn-support@mit.edu",
   }),
   MITOPEN_AXIOS_WITH_CREDENTIALS: bool({
     desc: "Instructs the Axios API client to send credentials with requests",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5024

### Description (What does it do?)
This PR updates the support email address to `mitlearn-support@mit.edu` anywhere on the site where a contact / support email is used.

### How can this be tested?
 - Spin up `mit-open` on this branch
 - Confirm that anywhere a contact email is provided, it matches the address above