### PR TITLE
Update search term event handler to clear page if the term changes

### DIFF
--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.test.tsx
@@ -200,19 +200,25 @@ describe("SearchPage", () => {
     await within(facetsContainer).findByText("Resource Type")
   })
 
-  test("Submitting text updates URL", async () => {
-    setMockApiResponses({})
-    const { location } = renderWithProviders(<SearchPage />, { url: "?q=meow" })
-    const queryInput = await screen.findByRole<HTMLInputElement>("textbox", {
-      name: "Search for",
-    })
-    expect(queryInput.value).toBe("meow")
-    await user.clear(queryInput)
-    await user.paste("woof")
-    expect(location.current.search).toBe("?q=meow")
-    await user.click(screen.getByRole("button", { name: "Search" }))
-    expect(location.current.search).toBe("?q=woof")
-  })
+  test.each([{ withPage: false }, { withPage: true }])(
+    "Submitting text updates URL",
+    async ({ withPage }) => {
+      setMockApiResponses({})
+      const urlQueryString = withPage ? "?q=meow&page=2" : "?q=meow"
+      const { location } = renderWithProviders(<SearchPage />, {
+        url: urlQueryString,
+      })
+      const queryInput = await screen.findByRole<HTMLInputElement>("textbox", {
+        name: "Search for",
+      })
+      expect(queryInput.value).toBe("meow")
+      await user.clear(queryInput)
+      await user.paste("woof")
+      expect(location.current.search).toBe(urlQueryString)
+      await user.click(screen.getByRole("button", { name: "Search" }))
+      expect(location.current.search).toBe("?q=woof")
+    },
+  )
 
   test("unathenticated users do not see admin options", async () => {
     setMockApiResponses({

--- a/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-open/src/pages/SearchPage/SearchPage.tsx
@@ -198,6 +198,14 @@ const SearchPage: React.FC = () => {
     onFacetsChange,
   })
 
+  const onSearchTermSubmit = useCallback(
+    (term: string) => {
+      setCurrentTextAndQuery(term)
+      setPage(1)
+    },
+    [setPage, setCurrentTextAndQuery],
+  )
+
   const page = +(searchParams.get("page") ?? "1")
 
   return (
@@ -212,10 +220,10 @@ const SearchPage: React.FC = () => {
                 value={currentText}
                 onChange={(e) => setCurrentText(e.target.value)}
                 onSubmit={(e) => {
-                  setCurrentTextAndQuery(e.target.value)
+                  onSearchTermSubmit(e.target.value)
                 }}
                 onClear={() => {
-                  setCurrentTextAndQuery("")
+                  onSearchTermSubmit("")
                 }}
                 placeholder="What do you want to learn?"
               />


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#5170

### Description (What does it do?)

If the search term changes and you've paged past the first page of search results, you will remain on that page when you submit your new search term. This fixes that; the page should now clear when you submit a new search term.

### How can this be tested?

Automated tests should pass.

Search for something that will return multiple pages of results - the issue uses "art history" for this. Navigate to a different page of search results (it doesn't matter how - either using the left/right buttons or clicking on a page number will work). Then, search for something else (like "manufacturing") and submit the query. You should be delivered back to the first page of results. 

You can also test the empty page issue: if you search for "art history", you should get ~50 pages of results. Navigate to the last page, then search for "manufacturing" (which should return ~34 pages of results). You should not get an empty page as you should be back at page 1.

### Additional Context

This operates in the same manner that the facets do - they also reset the page selector - so if there are other options selected, they shouldn't be affected. (In other words, searching for "art history" with "No Certificate" and "Humanities" selected, navigating to page 4, and then searching for "manufacturing" should leave "No Certificate" and "Humanities" selected.)