### PR TITLE
adding fix for logo in email

### DIFF
--- a/main/templates/email/email_base.html
+++ b/main/templates/email/email_base.html
@@ -265,7 +265,7 @@
               {% block logo %}
               <h1 style="text-align: center">
                 <img
-                  src="{{APP_BASE_URL}}{{STATIC_URL}}/images/mit-logo-learn.jpg"
+                  src="{{ABSOLUTE_STATIC_URL}}images/mit-logo-learn.jpg"
                   width="113"
                   height="32"
                   alt="MIT-Open"
@@ -332,7 +332,7 @@
 
               If you don't want to receive these emails in the future, you can
               <a
-                href="{{APP_BASE_URL}}/dashboard/settings"
+                href="{{APP_BASE_URL}}dashboard/settings"
                 style="text-decoration: underline"
                 >unsubscribe</a
               >. <br /><br />

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -392,7 +392,7 @@ def send_template_email(recipients, subject, template, context):
     if not context:
         context = {}
     context["APP_BASE_URL"] = settings.APP_BASE_URL
-    context["STATIC_URL"] = settings.STATIC_URL
+    context["ABSOLUTE_STATIC_URL"] = urljoin(settings.APP_BASE_URL, settings.STATIC_URL)
     html_content = render_to_string(template, context)
     return send_email(recipients, subject, html_content, text_only=False)
 


### PR DESCRIPTION
This PR fixes an issue with the logo not displaying for subscription emails. This was due to the static path having an extra slash when combining it with the app url

### Description (What does it do?)
fixes the display of the main logo in subscription emails for live environments

### How can this be tested?
testing instructions are the same as [described here](https://github.com/mitodl/mit-open/pull/1390#issue-2456564754) - validate that the mit learn logo appears. 

### Additional Context
We wont fully be able to validate until this gets deployed and we see emails from a live environment.

