### PR TITLE
Add migration to adjust mappings, make some minor changes to the dump to yaml util function

### DIFF
--- a/data_fixtures/migrations/0012_topic_mappings_adjust_sustainable_business_finance_accounting.py
+++ b/data_fixtures/migrations/0012_topic_mappings_adjust_sustainable_business_finance_accounting.py
@@ -1,0 +1,90 @@
+"""
+Update the topics:
+- Add mapping "Sustainability" to "Sustainable Business" for mitxpro, mitpe, see
+- Add mapping "Economics & Finance" to "Finance & Accounting" for mitx
+
+"""
+
+from django.db import migrations
+
+from learning_resources.utils import upsert_topic_data_string
+
+forward_map_changes = """
+---
+topics:
+    - children: []
+      icon: RiLightbulbFlashLine
+      id: d18ae735-9eb0-42ec-982d-798590f78b68
+      mappings:
+        mitxpro:
+        - Sustainability
+        mitpe:
+        - Sustainability
+        see:
+        - Sustainability
+      name: Sustainable Business
+      parent: 58eeca97-031c-432f-89f5-5b6493bf0dd2
+    - children: []
+      icon: RiBriefcase3Line
+      id: b84810f6-b232-4443-9471-eff7823a5f93
+      mappings:
+        mitpe:
+        - Finance
+        ocw:
+        - Accounting
+        - Finance
+        see:
+        - Finance
+        xpro:
+        - Finance
+        mitx:
+        - Economics & Finance
+      name: Finance & Accounting
+      parent: 99ec5b40-e929-4ad9-bccf-7305ef6938b1
+"""
+
+reverse_map_changes = """
+---
+topics:
+    - children: []
+      icon: RiLightbulbFlashLine
+      id: d18ae735-9eb0-42ec-982d-798590f78b68
+      mappings: {}
+      name: Sustainable Business
+      parent: 58eeca97-031c-432f-89f5-5b6493bf0dd2
+    - children: []
+      icon: RiBriefcase3Line
+      id: b84810f6-b232-4443-9471-eff7823a5f93
+      mappings:
+        mitpe:
+        - Finance
+        ocw:
+        - Accounting
+        - Finance
+        see:
+        - Finance
+        xpro:
+        - Finance
+      name: Finance & Accounting
+      parent: 99ec5b40-e929-4ad9-bccf-7305ef6938b1
+"""
+
+
+def add_new_mapping(apps, schema_editor):
+    """Upsert the forward_map_changes data above."""
+
+    upsert_topic_data_string(forward_map_changes)
+
+
+def rollback_new_mapping(apps, schema_editor):
+    """Upsert the reverse_map_changes data above."""
+
+    upsert_topic_data_string(reverse_map_changes)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("data_fixtures", "0011_unit_page_copy_updates"),
+    ]
+
+    operations = [migrations.RunPython(add_new_mapping, rollback_new_mapping)]

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -691,6 +691,7 @@ def dump_topics_to_yaml(topic_id: int | None = None):
             "icon": topic.icon,
             "mappings": {},
             "children": [],
+            "parent": str(topic.parent.topic_uuid) if topic.parent else None,
         }
 
         for mapping in LearningResourceTopicMapping.objects.filter(topic=topic).all():
@@ -705,7 +706,7 @@ def dump_topics_to_yaml(topic_id: int | None = None):
         return yaml_ready_data
 
     if topic_id:
-        parent_topics = LearningResourceTopic.objects.get(pk=topic_id)
+        parent_topics = [LearningResourceTopic.objects.get(pk=topic_id)]
     else:
         parent_topics = LearningResourceTopic.objects.filter(parent__isnull=True).all()
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#5202

### Description (What does it do?)

Updates the mappings as described in mitodl/hq#5202 .

Also, discovered and fixed a couple bugs in the `dump_topics_to_yaml`:
- Running with a single topic fails, because the fetch returns a single model object rather than a list of them.
- Topic data did not include the "parent" element. (This is more of an issue for a single topic - topics are usually defined by their hierarchy in the yaml file, but if you're dumping a single topic for, say, a migration like this, you _do_ need the parent so it will be in the right place afterwards.) 

### How can this be tested?

Test running `dump_topics_to_yaml` on a single topic - it should be correct, and the `parent` element should be there and set properly.

The migration should run with `RUN_DATA_MIGRATIONS=true` and the changes should take effect as expected. Rolling back the migration should also work. 

### Additional Context

As per usual, this will not update existing learning resources. To see resources mapped using these new mappings, you will need to run the appropriate backpopulate commands. 
