### PR TITLE
Ab/revert featured sort

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["featured_rank", "is_learning_material"]
+DEFAULT_SORT = ["is_learning_material", "-views"]
 
 
 def gen_content_file_id(content_file_id):

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2202,7 +2202,7 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, ["featured_rank", "is_learning_material"]),
+        (None, None, ["is_learning_material", {"views": {"order": "desc"}}]),
         (None, "text", None),
     ],
 )


### PR DESCRIPTION
### What are the relevant tickets?
This undoes the change to the default sort from https://github.com/mitodl/mit-open/pull/1377/files

It keeps the change that changed LEARNING_RESOURCE_SORTBY_OPTIONS to LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS. That should have been part of https://github.com/mitodl/mit-open/pull/1381. It will make it easier to check if the recreate_index job successfully updated all the data

### How to test
Checkout the last commit before featured_ranks were merged into main
 git checkout cc86e41d53052e630f2cdc44d29c9f6124b8d847

Run 
./manage.py recreate_index --podcasts so you have an index without the featured_rank column

Checkout this branch
Go to http://open.odl.local:8062/search
Verify select the "learning materials" tab
Verify that you see "podcast" under resource types and that search generally works fine