### PR TITLE
Expose the SESSION_COOKIE_NAME setting

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -165,13 +165,14 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = get_string(
 )
 
 CSRF_COOKIE_SECURE = get_bool("CSRF_COOKIE_SECURE", True)  # noqa: FBT003
-SESSION_COOKIE_DOMAIN = get_string("SESSION_COOKIE_DOMAIN", None)
 CSRF_COOKIE_DOMAIN = get_string("CSRF_COOKIE_DOMAIN", None)
 
 CSRF_HEADER_NAME = get_string("CSRF_HEADER_NAME", "HTTP_X_CSRFTOKEN")
 
-
 CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
+
+SESSION_COOKIE_DOMAIN = get_string("SESSION_COOKIE_DOMAIN", None)
+SESSION_COOKIE_NAME = get_string("SESSION_COOKIE_NAME", "sessionid")
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
If we have this app hosted at a subdomain under another instance of the app, the high level domain session cookies will occlude the one from the subdomain, breaking sessions. The browser only sends 1 cookie per name and at least in practice sends the cookie from the highest level domain. So to address this we need to be able to change the cookie name for sessions.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Set `SESSION_COOKIE_NAME` in your `.env` and verify that when you login your session cooke gets set with that name
