### PR TITLE
Set default sort to featured (#1414)

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["is_learning_material", "-views"]
+DEFAULT_SORT = ["featured_rank", "is_learning_material"]
 
 
 def gen_content_file_id(content_file_id):

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2154,7 +2154,7 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, ["is_learning_material", {"views": {"order": "desc"}}]),
+        (None, None, ["featured_rank", "is_learning_material"]),
         (None, "text", None),
     ],
 )


### PR DESCRIPTION
This reverts commit 2c94718182cd0b458ae5b111d458f67188116f92.

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4986

### Description (What does it do?)
Sort by featured 

### How can this be tested?
Run ./manage.py recreate_index --all
Go to the search page. Verify that the first items you see are the same as the resources from the featured carousel on the front page
To be fair to all units the featured ranks resources with the same  order in a featured list are randomized, so the order of the featured resources will differ slightly from the featured carusel