### PR TITLE
Remove remaining frontend routes

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -21,7 +21,7 @@ from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from rest_framework.routers import DefaultRouter
 
-from main.views import FeaturesViewSet, index
+from main.views import FeaturesViewSet
 
 # Post slugs can contain unicode characters, so a letter-matching pattern like [A-Za-z] doesn't work.  # noqa: E501
 # "[^\W]" Matches any character that is NOT a non-alphanumeric character, including underscores.  # noqa: E501
@@ -54,18 +54,9 @@ urlpatterns = (
         re_path(r"", include("testimonials.urls")),
         re_path(r"", include("news_events.urls")),
         # React App
-        re_path(r"^$", index, name="main-index"),
-        re_path(r"^privacy-statement/", index, name="privacy-statement"),
-        re_path(r"^search/", index, name="site-search"),
-        re_path(r"^departments/", index, name="departments"),
-        re_path(r"^learningpaths/", index, name="learningpaths"),
-        re_path(r"^userlists/", index, name="userlists"),
-        re_path(r"^articles/", index, name="articles"),
-        re_path(r"^dashboard/", index, name="dashboard"),
-        re_path(r"^program_letter/", index, name="programletter"),
-        re_path(r"^c/", index, name="channels"),
-        re_path(r"", include(features_router.urls)),
+        re_path(r"^$", RedirectView.as_view(url=settings.APP_BASE_URL)),
         re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
+        re_path(r"", include(features_router.urls)),
         re_path(r"^silk/", include("silk.urls", namespace="silk")),
         # Hijack
         re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),

--- a/main/urls.py
+++ b/main/urls.py
@@ -29,9 +29,9 @@ from main.views import FeaturesViewSet
 # as well, that character is added to the pattern via an alternation (|).
 POST_SLUG_PATTERN = "([^\\W]|-)+"
 
-handler400 = "main.views.handle_400"
-handler403 = "main.views.handle_403"
-handler404 = "main.views.handle_404"
+handler400 = "main.views.handle_error"
+handler403 = "main.views.handle_error"
+handler404 = "main.views.handle_error"
 
 features_router = DefaultRouter()
 features_router.register(r"_/features", FeaturesViewSet, basename="features")

--- a/main/urls.py
+++ b/main/urls.py
@@ -18,7 +18,6 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
-from django.views.generic.base import RedirectView
 from rest_framework.routers import DefaultRouter
 
 from main.views import FeaturesViewSet
@@ -53,11 +52,6 @@ urlpatterns = (
         re_path(r"", include("articles.urls")),
         re_path(r"", include("testimonials.urls")),
         re_path(r"", include("news_events.urls")),
-        # React App
-        re_path(
-            r"^$", RedirectView.as_view(url=settings.APP_BASE_URL), name="main-index"
-        ),
-        re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
         re_path(r"", include(features_router.urls)),
         re_path(r"^silk/", include("silk.urls", namespace="silk")),
         # Hijack

--- a/main/urls.py
+++ b/main/urls.py
@@ -54,7 +54,9 @@ urlpatterns = (
         re_path(r"", include("testimonials.urls")),
         re_path(r"", include("news_events.urls")),
         # React App
-        re_path(r"^$", RedirectView.as_view(url=settings.APP_BASE_URL)),
+        re_path(
+            r"^$", RedirectView.as_view(url=settings.APP_BASE_URL), name="main-index"
+        ),
         re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
         re_path(r"", include(features_router.urls)),
         re_path(r"^silk/", include("silk.urls", namespace="silk")),

--- a/main/urls_test.py
+++ b/main/urls_test.py
@@ -1,8 +1,0 @@
-"""Tests for URLs"""
-
-from django.urls import reverse
-
-
-def test_index():
-    """Test that the index URL is set correctly"""
-    assert reverse("main-index") == "/"

--- a/main/views.py
+++ b/main/views.py
@@ -3,7 +3,8 @@ Base utility views. Handles errors and feature list views.
 """
 
 from rest_framework import status
-from rest_framework.decorators import api_view
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
@@ -11,6 +12,7 @@ from main.features import get_all_feature_flags, is_enabled
 
 
 @api_view()
+@permission_classes([AllowAny])
 def handle_error(
     request,  # noqa: ARG001
     exception=None,  # noqa: ARG001

--- a/main/views.py
+++ b/main/views.py
@@ -1,52 +1,33 @@
 """
-main views
+Base utility views. Handles errors and feature list views.
 """
 
-from django.http import (
-    HttpResponseBadRequest,
-    HttpResponseForbidden,
-    HttpResponseNotFound,
-)
-from django.shortcuts import render
+from rest_framework import status
+from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from main.features import get_all_feature_flags, is_enabled
 
 
-def index(request, **kwargs):  # pylint: disable=unused-argument  # noqa: ARG001
-    """
-    Return the static HTML index file for our react app.
-
-    In general, this should not be served by Django, but directly by nginx or
-    another web server. However, if a route that nginx sends to Django is a 404,
-    then we return the react app via Django.
-    """
-    return render(request, "index.html")
-
-
-def handle_400(
-    request,
+@api_view()
+def handle_error(
+    request,  # noqa: ARG001
     exception=None,  # noqa: ARG001
 ):
-    """400 error handler"""
-    return HttpResponseBadRequest(index(request))
+    """Client Error"""
 
+    # This is a generic handler, since the api_view decorator means DRF will
+    # usurp error handling and provide whatever response is actually necessary.
+    # There's a 404 here just as a fallback.
 
-def handle_403(
-    request,
-    exception=None,  # noqa: ARG001
-):
-    """403 error handler"""
-    return HttpResponseForbidden(index(request))
-
-
-def handle_404(
-    request,
-    exception=None,  # noqa: ARG001
-):
-    """404 error handler"""
-    return HttpResponseNotFound(index(request))
+    return Response(
+        {
+            "detail": "The specified resource was not found.",
+            "error_type": "Http404",
+        },
+        status=status.HTTP_404_NOT_FOUND,
+    )
 
 
 class FeaturesViewSet(ViewSet):

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -1,0 +1,20 @@
+"""Tests for the utility views"""
+
+import uuid
+
+
+def test_anon_error(client, mocker):
+    """Test that we get an error as we expect from a nonsense URL with an anonymous session."""
+
+    response = client.get(f"/{uuid.uuid4()}")
+
+    # Silk tends to grab bad URLs and then complains because there's no credentials..
+    assert response.status_code == 403
+
+
+def test_authed_error(user_client, mocker):
+    """Test that we get an error as we expect from a nonsense URL with a session."""
+
+    response = user_client.get(f"/{uuid.uuid4()}")
+
+    assert response.status_code == 404

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -3,16 +3,15 @@
 import uuid
 
 
-def test_anon_error(client, mocker):
+def test_anon_error(client):
     """Test that we get an error as we expect from a nonsense URL with an anonymous session."""
 
     response = client.get(f"/{uuid.uuid4()}")
 
-    # Silk tends to grab bad URLs and then complains because there's no credentials..
-    assert response.status_code == 403
+    assert response.status_code == 404
 
 
-def test_authed_error(user_client, mocker):
+def test_authed_error(user_client):
     """Test that we get an error as we expect from a nonsense URL with a session."""
 
     response = user_client.get(f"/{uuid.uuid4()}")


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4611

### Description (What does it do?)

This PR:
- Removes the remaining routes for frontend URLs
- Adds a route for `/` that should bounce you back into the React app. (This is the same as `/app`.)
- Updates the error page handlers to be a single one that uses `api_view` so DRF will throw back a RESTful response

### How can this be tested?

Automated tests should pass. (There's a couple of new ones that will test the error handling too.)

Set `DEBUG=False` in your `.env` (otherwise Django's error handler will take over), then try to navigate to some bad URLs in the Django app. One of two things should happen:
- You'll get a generic 404 response when the route doesn't match anything at all.
- You'll get the normal 404 message for routes that are technically correct but return no data (i.e., pulling up a topic with a bad ID).

For example, navigating to http://api.learn.odl.local:8063/7716c6c8-1873-4857-b4eb-b4f8a1189896 should get you a generic 404 error, but navigating to http://api.learn.odl.local:8063/api/v1/topics/-9/ should give you a 404 that says that it can't find a LearningResourceTopic. 

