### PR TITLE
Fix home page header capitalization

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -173,7 +173,7 @@ const HeroSearch: React.FC = () => {
           typography={{ xs: "h3", md: "h1" }}
           sx={{ paddingBottom: 1 }}
         >
-          Learn With MIT
+          Learn with MIT
         </Typography>
         <Typography>
           Explore MIT's{" "}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/1427

### Description (What does it do?)
This PR simply uncapitalizes the "with" in "Learn With MIT" on the home page

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7e9b2ce6-6b50-4c08-a722-210958571b23)
![image](https://github.com/user-attachments/assets/b46fa26a-cafe-4097-afe8-679f8aa5b974)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit the home page at http://localhost:8063/ and ensure that "with" is not capitalized