### PR TITLE
Get availability value from xpro api

### DIFF
--- a/learning_resources/etl/xpro.py
+++ b/learning_resources/etl/xpro.py
@@ -9,7 +9,6 @@ from dateutil.parser import parse
 from django.conf import settings
 
 from learning_resources.constants import (
-    Availability,
     CertificationType,
     LearningResourceType,
     OfferedBy,
@@ -154,7 +153,7 @@ def _transform_learning_resource_course(course):
         },
         "certification": True,
         "certification_type": CertificationType.professional.name,
-        "availability": Availability.dated.name,
+        "availability": course["availability"],
     }
 
 
@@ -216,7 +215,7 @@ def transform_programs(programs):
             "courses": transform_courses(program["courses"]),
             "certification": True,
             "certification_type": CertificationType.professional.name,
-            "availability": Availability.dated.name,
+            "availability": program["availability"],
         }
         for program in programs
     ]

--- a/test_json/xpro_courses.json
+++ b/test_json/xpro_courses.json
@@ -10,7 +10,8 @@
     "next_run_id": null,
     "platform": "xPRO",
     "topics": [{ "name": "Business:Leadership & Organizations" }],
-    "format": "Online"
+    "format": "Online",
+    "availability": "dated"
   },
   {
     "id": 20,
@@ -37,7 +38,8 @@
     ],
     "next_run_id": 49,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
-    "format": "In person"
+    "format": "In person",
+    "availability": "dated"
   },
   {
     "id": 19,
@@ -65,7 +67,8 @@
     ],
     "next_run_id": 48,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
-    "format": "Online"
+    "format": "Online",
+    "availability": "dated"
   },
   {
     "id": 21,
@@ -77,7 +80,8 @@
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "platform": "xPRO",
-    "format": "Online"
+    "format": "Online",
+    "availability": "dated"
   },
   {
     "id": 30,
@@ -126,7 +130,8 @@
       }
     ],
     "next_run_id": 73,
-    "topics": [{ "name": "Business:Leadership & Organizations" }]
+    "topics": [{ "name": "Business:Leadership & Organizations" }],
+    "availability": "dated"
   },
   {
     "id": 31,
@@ -138,7 +143,8 @@
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "format": "Online",
-    "platform": "xPRO"
+    "platform": "xPRO",
+    "availability": "dated"
   },
   {
     "id": 32,
@@ -150,6 +156,7 @@
     "next_run_id": null,
     "topics": [{ "name": "Business:Leadership & Organizations" }],
     "format": "Online",
-    "platform": "xPRO"
+    "platform": "xPRO",
+    "availability": "dated"
   }
 ]

--- a/test_json/xpro_programs.json
+++ b/test_json/xpro_programs.json
@@ -35,7 +35,8 @@
           }
         ],
         "platform": "xPRO",
-        "format": "Online"
+        "format": "Online",
+        "availability": "dated"
       },
       {
         "id": 20,
@@ -62,7 +63,8 @@
             "product_id": 13
           }
         ],
-        "next_run_id": 49
+        "next_run_id": 49,
+        "availability": "dated"
       },
       {
         "id": 19,
@@ -93,7 +95,8 @@
             "product_id": 12
           }
         ],
-        "next_run_id": 48
+        "next_run_id": 48,
+        "availability": "dated"
       },
       {
         "id": 21,
@@ -104,9 +107,11 @@
         "courseruns": [],
         "next_run_id": null,
         "topics": [],
-        "platform": "xPRO"
+        "platform": "xPRO",
+        "availability": "dated"
       }
-    ]
+    ],
+    "availability": "dated"
   },
   {
     "title": "SEED Digital Learning",
@@ -156,7 +161,8 @@
               }
             ],
             "id": 73,
-            "product_id": null
+            "product_id": null,
+            "availability": "dated"
           },
           {
             "title": "SEED Digital Learning 100 - August 2021",
@@ -177,7 +183,8 @@
             "product_id": null
           }
         ],
-        "next_run_id": 73
+        "next_run_id": 73,
+        "availability": "dated"
       },
       {
         "id": 31,
@@ -192,7 +199,8 @@
             "name": "Business:Leadership & Organizations"
           }
         ],
-        "platform": "xPRO"
+        "platform": "xPRO",
+        "availability": "dated"
       },
       {
         "id": 32,
@@ -203,8 +211,10 @@
         "courseruns": [],
         "next_run_id": null,
         "topics": [],
-        "platform": "xPRO"
+        "platform": "xPRO",
+        "availability": "dated"
       }
-    ]
+    ],
+    "availability": "dated"
   }
 ]


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5232

### Description (What does it do?)
Assigns the value of course/program availability based on the xpro api field of the same name


### How can this be tested?
- Set `XPRO_*` values to the same as RC 
- Run `./manage.py backpopulate_xpro_data`
- Check that course/program availability field for xpro courses and programs have the same values as what's returned in the xpro API responses.

