### PR TITLE
add appzi for feedback

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -45,6 +45,7 @@ jobs:
           POSTHOG_PROJECT_API_KEY: ${{ secrets.POSTHOG_PROJECT_API_KEY_PROD }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_PROD }}
           SENTRY_ENV: ${{ secrets.MITOL_ENVIRONMENT_PROD }}
+          APPZI_URL: ${{ secrets.APPZI_URL_PROD }}
           CSRF_COOKIE_NAME: ${{ secrets.CSRF_COOKIE_NAME_PROD }}
           MITOL_AXIOS_WITH_CREDENTIALS: true
           MITOL_API_BASE_URL: https://api.learn.mit.edu

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -46,6 +46,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN_RC }}
           SENTRY_ENV: ${{ secrets.MITOL_ENVIRONMENT_RC }}
           CSRF_COOKIE_NAME: ${{ secrets.CSRF_COOKIE_NAME_RC }}
+          APPZI_URL: ${{ secrets.APPZI_URL_RC }}
           MITOL_AXIOS_WITH_CREDENTIALS: true
           MITOL_API_BASE_URL: https://api.rc.learn.mit.edu
           MITOL_SUPPORT_EMAIL: mitlearn-support@mit.edu

--- a/frontends/mit-learn/public/index.html
+++ b/frontends/mit-learn/public/index.html
@@ -13,6 +13,7 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
     />
     <link rel="favicon" href="/favicon.svg" type="image/svg+xml" />
+    <script async src="https://w.appzi.io/w.js?token=Q2pSI"></script>
   </head>
 
   <body>

--- a/frontends/mit-learn/public/index.html
+++ b/frontends/mit-learn/public/index.html
@@ -13,7 +13,9 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
     />
     <link rel="favicon" href="/favicon.svg" type="image/svg+xml" />
-    <script async src="https://w.appzi.io/w.js?token=Q2pSI"></script>
+    <% if (APPZI_URL) { %>
+    <script async src="<%= APPZI_URL %>"></script>
+    <% } %>
   </head>
 
   <body>

--- a/frontends/mit-learn/webpack.config.js
+++ b/frontends/mit-learn/webpack.config.js
@@ -23,7 +23,7 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
 const HtmlWebpackPlugin = require("html-webpack-plugin")
 const CopyPlugin = require("copy-webpack-plugin")
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin")
-const { cleanEnv, str, bool, port } = require("envalid")
+const { cleanEnv, str, bool, port, url } = require("envalid")
 
 const {
   NODE_ENV,
@@ -41,6 +41,7 @@ const {
   SENTRY_DSN,
   SENTRY_ENV,
   CSRF_COOKIE_NAME,
+  APPZI_URL,
 } = cleanEnv(process.env, {
   NODE_ENV: str({
     choices: ["development", "production", "test"],
@@ -103,6 +104,14 @@ const {
     desc: "Name of the CSRF cookie",
     default: "csrftoken",
   }),
+  APPZI_URL: url({
+    desc: "URL for the Appzi feedback widget",
+    default: "",
+  }),
+})
+
+console.log({
+  APPZI_URL,
 })
 
 const MITOL_FEATURES_PREFIX = "FEATURE_"
@@ -189,6 +198,9 @@ module.exports = (env, argv) => {
     plugins: [
       new HtmlWebpackPlugin({
         template: "public/index.html",
+        templateParameters: {
+          APPZI_URL,
+        },
       }),
       new CopyPlugin({
         patterns: [

--- a/frontends/mit-learn/webpack.config.js
+++ b/frontends/mit-learn/webpack.config.js
@@ -110,10 +110,6 @@ const {
   }),
 })
 
-console.log({
-  APPZI_URL,
-})
-
 const MITOL_FEATURES_PREFIX = "FEATURE_"
 
 const getFeatureFlags = () => {


### PR DESCRIPTION
### What are the relevant tickets?


### Description (What does it do?)
This PR adds appzi for feedback, like we use on https://ocw.mit.edu/


### Screenshots (if appropriate):
<img width="1626" alt="Screenshot 2024-08-19 at 2 50 21 PM" src="https://github.com/user-attachments/assets/eeecaa7d-b2f8-4427-a056-174fd0f267b0">
<img width="1636" alt="Screenshot 2024-08-19 at 2 50 33 PM" src="https://github.com/user-attachments/assets/53bb4c37-2cd8-49ac-802d-746605069869">


### How can this be tested?
1. Spin up the frontend on this branch with `APPZI_URL="https://w.appzi.io/w.js?token=Q2pSI"` in your `frontend.local.env` file. You should see the "Feedback" button like in screenshots above. (Middle right of screen)
2. Repeat (1) without `APPZI_URL` env var. The feedback button should go away.

### Additional Context
- ol-infrastructure PR: https://github.com/mitodl/ol-infrastructure/pull/2619
