### PR TITLE
department is optional

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -102,15 +102,17 @@ def load_departments(
     resource: LearningResource, department_data: list[str]
 ) -> list[LearningResourceDepartment]:
     """Load the departments for a resource into the database"""
-    if department_data:
-        departments = []
+    departments = []
 
+    if department_data:
         for department_id in department_data:
             department = LearningResourceDepartment.objects.get(
                 department_id=department_id
             )
             departments.append(department)
-        resource.departments.set(departments)
+
+    resource.departments.set(departments)
+
     return resource.departments.all()
 
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -50,6 +50,7 @@ from learning_resources.etl.xpro import _parse_datetime
 from learning_resources.factories import (
     ContentFileFactory,
     CourseFactory,
+    LearningResourceDepartmentFactory,
     LearningResourceFactory,
     LearningResourceInstructorFactory,
     LearningResourceOfferorFactory,
@@ -301,7 +302,8 @@ def test_load_program_bad_platform(mocker):
 @pytest.mark.parametrize("blocklisted", [True, False])
 @pytest.mark.parametrize("resource_format", [LearningResourceFormat.hybrid.name, None])
 @pytest.mark.parametrize("has_upcoming_run", [True, False])
-def test_load_course(  # noqa: PLR0913
+@pytest.mark.parametrize("has_departments", [True, False])
+def test_load_course(  # noqa: PLR0913,PLR0912,PLR0915
     mock_upsert_tasks,
     course_exists,
     is_published,
@@ -309,6 +311,7 @@ def test_load_course(  # noqa: PLR0913
     blocklisted,
     resource_format,
     has_upcoming_run,
+    has_departments,
 ):
     """Test that load_course loads the course"""
     platform = LearningResourcePlatformFactory.create()
@@ -349,7 +352,11 @@ def test_load_course(  # noqa: PLR0913
             start_date=old_start_date,
         )
     assert Course.objects.count() == (1 if course_exists else 0)
-
+    if has_departments:
+        department = LearningResourceDepartmentFactory.create()
+        departments = [department.department_id]
+    else:
+        departments = []
     format_data = {"learning_format": [resource_format]} if resource_format else {}
     props = {
         "readable_id": learning_resource.readable_id,
@@ -360,6 +367,7 @@ def test_load_course(  # noqa: PLR0913
         "description": learning_resource.description,
         "url": learning_resource.url,
         "published": is_published,
+        "departments": departments,
         **format_data,
     }
 
@@ -434,6 +442,12 @@ def test_load_course(  # noqa: PLR0913
             else LearningResourceFormat.online.name
         ]
     )
+
+    if departments == []:
+        assert result.departments.count() == 0
+    else:
+        assert result.departments.count() == 1
+        assert result.departments.first().department_id == departments[0]
 
     props.pop("learning_format")
     for key, value in props.items():


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Department is now optional in ocw and RES has been removed as a department. However the loader code currently assumes that there are departments and skips department update if there is no department in the data. This prevented the department (RES) from being removed from the courses that no longer have a department

### How can this be tested?
Run 
docker-compose run web ./manage.py backpopulate_ocw_data --course-name res-tll-004-stem-concept-videos-fall-2013  --overwrite

(or --course-name any ocw course in https://learn.mit.edu/search/?department=RES, ideally one that already exists in your local database with RES set as the db)

Go to 
http://api.open.odl.local:8063/api/v1/learning_resources_search/?q=%22stem%20concept%20videos%22 (or search for the course you used)
Verify that departments are empty for the course