### PR TITLE
remove privacy chip from add to user list dialog

### DIFF
--- a/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.tsx
+++ b/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.tsx
@@ -17,7 +17,6 @@ import { RiLockLine, RiLockUnlockLine, RiAddLine } from "@remixicon/react"
 import * as NiceModal from "@ebay/nice-modal-react"
 
 import {
-  PrivacyLevelEnum,
   type LearningPathResource,
   type LearningResource,
   type UserList,
@@ -326,25 +325,8 @@ const UserListToggleList: React.FC<UserListToggleListProps> = ({
     const adding = isAdding(list)
     const removing = isRemoving(list)
     const disabled = adding || removing
-    const privateLevel = PrivacyLevelEnum.Private[0]
-      .toUpperCase()
-      .concat(PrivacyLevelEnum.Private.slice(1))
-    const unlistedLevel = PrivacyLevelEnum.Unlisted[0]
-      .toUpperCase()
-      .concat(PrivacyLevelEnum.Unlisted.slice(1))
-    const privacyLevel = list.privacy_level
-      ? list.privacy_level[0].toUpperCase().concat(list.privacy_level.slice(1))
-      : privateLevel
     return (
-      <ListItem
-        key={list.id}
-        secondaryAction={
-          <PrivacyChip
-            publicOption={unlistedLevel}
-            selectedOption={privacyLevel}
-          />
-        }
-      >
+      <ListItem key={list.id}>
         <ListItemButton
           aria-disabled={disabled}
           onClick={disabled ? undefined : handleToggle(list)}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5251

### Description (What does it do?)
This PR simply removes the "privacy chip" from the Add to User List dialog.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6cd54ce6-59bf-4d92-9c9c-800890ffe3a6)
![image](https://github.com/user-attachments/assets/4fc82785-d19f-4b1e-b741-b6753369b8fd)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit http://localhost:8063/search/
 - Click on the bookmark icon on any search result to bring up the "Add to User List" modal
 - If you don't have any lists, use the "Create a new list" button to create some
 - Verify that the privacy level indicator is not present (this still displays on the "Add to Learning List" dialog, shown below)
 
![image](https://github.com/user-attachments/assets/56d33b83-8261-44bf-8a87-fb6f566537d0)