### PR TITLE
allow empty APPZI_URL

### DIFF
--- a/frontends/mit-learn/webpack.config.js
+++ b/frontends/mit-learn/webpack.config.js
@@ -23,7 +23,7 @@ const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin")
 const HtmlWebpackPlugin = require("html-webpack-plugin")
 const CopyPlugin = require("copy-webpack-plugin")
 const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin")
-const { cleanEnv, str, bool, port, url } = require("envalid")
+const { cleanEnv, str, bool, port } = require("envalid")
 
 const {
   NODE_ENV,
@@ -104,7 +104,8 @@ const {
     desc: "Name of the CSRF cookie",
     default: "csrftoken",
   }),
-  APPZI_URL: url({
+  APPZI_URL: str({
+    // use str() not url() to allow empty string
     desc: "URL for the Appzi feedback widget",
     default: "",
   }),


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #1435 

### Description (What does it do?)
This changes the env var validation to allow empty string, which is what RC uses.

### How can this be tested?
1. On `main`, run ` APPZI_URL="" yarn build` (or watch / docker ccompose up). It will fail.
    - `main` allows for no env var, but not empty string.
2. On this branch, do the same, it will succeed.

