### PR TITLE
restoring redirect route

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -18,6 +18,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
+from django.views.generic.base import RedirectView
 from rest_framework.routers import DefaultRouter
 
 from main.views import FeaturesViewSet
@@ -54,6 +55,7 @@ urlpatterns = (
         re_path(r"", include("news_events.urls")),
         re_path(r"", include(features_router.urls)),
         re_path(r"^silk/", include("silk.urls", namespace="silk")),
+        re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
         # Hijack
         re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
     ]


### PR DESCRIPTION


### Description (What does it do?)
Restores our catch all redirect view at /app

### How can this be tested?
1. checkout this branch.
