### PR TITLE
adding test for redirect view

### DIFF
--- a/main/views_test.py
+++ b/main/views_test.py
@@ -17,3 +17,13 @@ def test_authed_error(user_client):
     response = user_client.get(f"/{uuid.uuid4()}")
 
     assert response.status_code == 404
+
+
+def test_redirect_route(settings, user_client):
+    """
+    Simple Test that checks that we have a catch all redirect view
+    so that is not accidently removed
+    """
+    response = user_client.get("/app", follow=True)
+    assert response.redirect_chain[0][0] == settings.APP_BASE_URL
+    assert response.redirect_chain[0][1] == 302


### PR DESCRIPTION
### Description (What does it do?)
Adds a very simple test so that the catch all redirect view is not accidentally removed

### How can this be tested?
1. tests should pass
2. locally if you remove /app from [main/urls.py](https://github.com/mitodl/mit-open/blob/main/main/urls.py#L58) and then run the tests (via ```pytest main/views_test.py -s -vvv```) it should fail.

