### PR TITLE
homepage hero search updates

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -102,7 +102,8 @@ const ControlsContainer = styled.div(({ theme }) => ({
   alignItems: "flex-start",
   justifyContent: "center",
   [theme.breakpoints.down("sm")]: {
-    padding: "12px",
+    marginTop: "12px",
+    padding: "0",
     gap: "16px",
   },
   [theme.breakpoints.up("sm")]: {
@@ -112,10 +113,13 @@ const ControlsContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const BrowseByTopicContainer = styled.div({
+const BrowseByTopicContainer = styled.div(({ theme }) => ({
   marginTop: "16px",
   marginBottom: "24px",
-})
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "0",
+  },
+}))
 
 const BrowseByTopicText = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -130,10 +130,12 @@ const TopicLink = styled(Link)({
   textDecoration: "underline",
 })
 
-const StyledChipLink = styled(ChipLink)(({ theme }) => ({
-  borderColor: theme.custom.colors.lightGray2,
-  color: theme.custom.colors.silverGrayDark,
-}))
+const StyledChipLink = styled(ChipLink)(({ theme, variant }) => [
+  variant === "outlinedWhite" ?? {
+    borderColor: theme.custom.colors.lightGray2,
+    color: theme.custom.colors.silverGrayDark,
+  },
+])
 
 const TrendingContainer = styled.div({
   display: "flex",
@@ -200,27 +202,16 @@ const HeroSearch: React.FC = () => {
               </BrowseByTopicText>
             </BrowseByTopicContainer>
             <TrendingContainer>
-              {SEARCH_CHIPS.map((chip) =>
-                chip.variant === "outlinedWhite" ? (
-                  <StyledChipLink
-                    key={chip.label}
-                    variant={chip.variant}
-                    size="medium"
-                    label={chip.label}
-                    href={chip.href}
-                    {...(chip.icon && { icon: chip.icon })}
-                  />
-                ) : (
-                  <ChipLink
-                    key={chip.label}
-                    variant={chip.variant}
-                    size="medium"
-                    label={chip.label}
-                    href={chip.href}
-                    {...(chip.icon && { icon: chip.icon })}
-                  />
-                ),
-              )}
+              {SEARCH_CHIPS.map((chip) => (
+                <StyledChipLink
+                  key={chip.label}
+                  variant={chip.variant}
+                  size="medium"
+                  label={chip.label}
+                  href={chip.href}
+                  {...(chip.icon && { icon: chip.icon })}
+                />
+              ))}
             </TrendingContainer>
           </>
         </ControlsContainer>

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -180,7 +180,7 @@ const HeroSearch: React.FC = () => {
         </Typography>
         <ControlsContainer>
           <SearchInput
-            placeholder="Search for courses, programs, learning, and teaching materials"
+            placeholder="Search for courses, programs, and learning materials..."
             size="hero"
             fullWidth
             value={searchText}

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -130,17 +130,6 @@ const TopicLink = styled(Link)({
   textDecoration: "underline",
 })
 
-const LinksContainer = styled.div(({ theme }) => ({
-  width: "100%",
-  display: "flex",
-  flexDirection: "column",
-  flexWrap: "wrap",
-  justifyContent: "space-between",
-  [theme.breakpoints.down("sm")]: {
-    flexDirection: "column",
-  },
-}))
-
 const StyledChipLink = styled(ChipLink)(({ theme }) => ({
   borderColor: theme.custom.colors.lightGray2,
   color: theme.custom.colors.silverGrayDark,
@@ -201,7 +190,7 @@ const HeroSearch: React.FC = () => {
             onClear={onSearchClear}
             onSubmit={onSearchSubmit}
           />
-          <LinksContainer>
+          <>
             <BrowseByTopicContainer>
               <BrowseByTopicText>
                 or browse by{" "}
@@ -233,7 +222,7 @@ const HeroSearch: React.FC = () => {
                 ),
               )}
             </TrendingContainer>
-          </LinksContainer>
+          </>
         </ControlsContainer>
       </TitleAndControls>
       <ImageContainer>

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -5,34 +5,58 @@ import type { ChipLinkProps } from "ol-components"
 import { SearchInput, SearchInputProps } from "./SearchInput"
 import { ABOUT } from "@/common/urls"
 import { NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER } from "../AboutPage/AboutPage"
+import {
+  RiAddBoxLine,
+  RiAwardLine,
+  RiSearch2Line,
+  RiThumbUpLine,
+  RiTimeLine,
+  RiVerifiedBadgeLine,
+} from "@remixicon/react"
 
 type SearchChip = {
   label: string
   href: string
   variant?: ChipLinkProps["variant"]
+  icon?: React.ReactElement
 }
 
 const SEARCH_CHIPS: SearchChip[] = [
   {
-    label: "New",
+    label: "Recently Added",
     href: "/search?sortby=new",
-    variant: "outlined",
+    variant: "outlinedWhite",
+    icon: <RiTimeLine />,
   },
   {
     label: "Popular",
     href: "/search?sortby=-views",
+    variant: "outlinedWhite",
+    icon: <RiThumbUpLine />,
   },
   {
     label: "Upcoming",
     href: "/search?sortby=upcoming",
+    variant: "outlinedWhite",
+    icon: <RiAddBoxLine />,
   },
   {
     label: "Free",
     href: "/search?free=true",
+    variant: "outlinedWhite",
+    icon: <RiVerifiedBadgeLine />,
   },
   {
     label: "With Certificate",
     href: "/search?certification=true",
+    variant: "outlinedWhite",
+    icon: <RiAwardLine />,
+  },
+  {
+    label: "Explore All",
+    href: "/search/",
+    variant: "gray",
+    icon: <RiSearch2Line />,
   },
 ]
 
@@ -70,29 +94,6 @@ const ImageContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const SquaredChip = styled(ChipLink, {
-  shouldForwardProp: (propName) => !["noBorder", "grow"].includes(propName),
-})<{ noBorder?: boolean; grow?: boolean }>(({ noBorder, theme, grow }) => [
-  {
-    borderRadius: "4px",
-    [theme.breakpoints.down("sm")]: {
-      ...theme.typography.body4,
-      padding: "4px 0px",
-    },
-  },
-  grow && {
-    [theme.breakpoints.down("sm")]: {
-      flex: 1,
-      height: "32px",
-    },
-  },
-  noBorder && {
-    "&:not(:hover)": {
-      borderColor: "white",
-    },
-  },
-])
-
 const ControlsContainer = styled.div(({ theme }) => ({
   marginTop: "24px",
   display: "flex",
@@ -100,12 +101,6 @@ const ControlsContainer = styled.div(({ theme }) => ({
   flexDirection: "column",
   alignItems: "flex-start",
   justifyContent: "center",
-  gap: "20px",
-  padding: "24px",
-  backgroundColor: theme.custom.colors.white,
-  borderRadius: "8px",
-  boxShadow:
-    "0px 2px 4px 0px rgba(37, 38, 43, 0.10), 0px 2px 4px 0px rgba(37, 38, 43, 0.10)",
   [theme.breakpoints.down("sm")]: {
     padding: "12px",
     gap: "16px",
@@ -116,35 +111,35 @@ const ControlsContainer = styled.div(({ theme }) => ({
     },
   },
 }))
+
+const BrowseByTopicContainer = styled.div({
+  marginTop: "16px",
+  marginBottom: "24px",
+})
+
+const BrowseByTopicText = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.body2,
+}))
+
 const LinksContainer = styled.div(({ theme }) => ({
   width: "100%",
   display: "flex",
-  flexDirection: "row",
+  flexDirection: "column",
   flexWrap: "wrap",
-  gap: "12px",
   justifyContent: "space-between",
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
   },
 }))
-const TrenderingContainer = styled.div(({ theme }) => ({
+
+const TrendingContainer = styled.div({
   display: "flex",
   flexDirection: "row",
   alignItems: "center",
   flexWrap: "wrap",
-  [theme.breakpoints.down("sm")]: {
-    gap: "8px",
-  },
-}))
-const BrowseContainer = styled.div(({ theme }) => ({
-  display: "flex",
-  flexDirection: "row",
   gap: "8px",
-
-  [theme.breakpoints.down("sm")]: {
-    flex: 1,
-  },
-}))
+})
 
 const BoldLink = styled(Link)(({ theme }) => ({
   ...theme.typography.subtitle1,
@@ -194,40 +189,26 @@ const HeroSearch: React.FC = () => {
             onSubmit={onSearchSubmit}
           />
           <LinksContainer>
-            <TrenderingContainer>
-              <Typography
-                sx={{ marginRight: "8px" }}
-                typography={{ xs: "subtitle4", md: "subtitle3" }}
-              >
-                Trending
-              </Typography>
+            <BrowseByTopicContainer>
+              <BrowseByTopicText>
+                or browse by{" "}
+                <Link href="/topics/" color="red">
+                  Topic
+                </Link>
+              </BrowseByTopicText>
+            </BrowseByTopicContainer>
+            <TrendingContainer>
               {SEARCH_CHIPS.map((chip) => (
-                <SquaredChip
-                  noBorder
+                <ChipLink
                   key={chip.label}
                   variant={chip.variant}
                   size="medium"
                   label={chip.label}
                   href={chip.href}
+                  {...(chip.icon && { icon: chip.icon })}
                 />
               ))}
-            </TrenderingContainer>
-            <BrowseContainer>
-              <SquaredChip
-                grow
-                variant="outlined"
-                size="medium"
-                label="Browse by Topic"
-                href="/topics/"
-              />
-              <SquaredChip
-                grow
-                variant="filled"
-                size="medium"
-                label="Explore All"
-                href="/search/"
-              />
-            </BrowseContainer>
+            </TrendingContainer>
           </LinksContainer>
         </ControlsContainer>
       </TitleAndControls>

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -122,6 +122,10 @@ const BrowseByTopicText = styled(Typography)(({ theme }) => ({
   ...theme.typography.body2,
 }))
 
+const TopicLink = styled(Link)({
+  textDecoration: "underline",
+})
+
 const LinksContainer = styled.div(({ theme }) => ({
   width: "100%",
   display: "flex",
@@ -192,9 +196,9 @@ const HeroSearch: React.FC = () => {
             <BrowseByTopicContainer>
               <BrowseByTopicText>
                 or browse by{" "}
-                <Link href="/topics/" color="red">
+                <TopicLink href="/topics/" color="red">
                   Topic
-                </Link>
+                </TopicLink>
               </BrowseByTopicText>
             </BrowseByTopicContainer>
             <TrendingContainer>

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -141,6 +141,11 @@ const LinksContainer = styled.div(({ theme }) => ({
   },
 }))
 
+const StyledChipLink = styled(ChipLink)(({ theme }) => ({
+  borderColor: theme.custom.colors.lightGray2,
+  color: theme.custom.colors.silverGrayDark,
+}))
+
 const TrendingContainer = styled.div({
   display: "flex",
   flexDirection: "row",
@@ -206,16 +211,27 @@ const HeroSearch: React.FC = () => {
               </BrowseByTopicText>
             </BrowseByTopicContainer>
             <TrendingContainer>
-              {SEARCH_CHIPS.map((chip) => (
-                <ChipLink
-                  key={chip.label}
-                  variant={chip.variant}
-                  size="medium"
-                  label={chip.label}
-                  href={chip.href}
-                  {...(chip.icon && { icon: chip.icon })}
-                />
-              ))}
+              {SEARCH_CHIPS.map((chip) =>
+                chip.variant === "outlinedWhite" ? (
+                  <StyledChipLink
+                    key={chip.label}
+                    variant={chip.variant}
+                    size="medium"
+                    label={chip.label}
+                    href={chip.href}
+                    {...(chip.icon && { icon: chip.icon })}
+                  />
+                ) : (
+                  <ChipLink
+                    key={chip.label}
+                    variant={chip.variant}
+                    size="medium"
+                    label={chip.label}
+                    href={chip.href}
+                    {...(chip.icon && { icon: chip.icon })}
+                  />
+                ),
+              )}
             </TrendingContainer>
           </LinksContainer>
         </ControlsContainer>

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -124,6 +124,9 @@ const BrowseByTopicContainer = styled.div(({ theme }) => ({
 const BrowseByTopicText = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
   ...theme.typography.body2,
+  [theme.breakpoints.down("sm")]: {
+    ...theme.typography.body3,
+  },
 }))
 
 const TopicLink = styled(Link)({

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -195,7 +195,7 @@ const HeroSearch: React.FC = () => {
             onClear={onSearchClear}
             onSubmit={onSearchSubmit}
           />
-          <>
+          <div>
             <BrowseByTopicContainer>
               <BrowseByTopicText>
                 or browse by{" "}
@@ -216,7 +216,7 @@ const HeroSearch: React.FC = () => {
                 />
               ))}
             </TrendingContainer>
-          </>
+          </div>
         </ControlsContainer>
       </TitleAndControls>
       <ImageContainer>

--- a/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
@@ -116,12 +116,12 @@ describe("Home Page Hero", () => {
     setupAPIs()
     renderWithProviders(<HomePage />)
     const expected = [
-      { label: "New", href: "/search?sortby=new" },
+      { label: "Topic", href: "/topics/" },
+      { label: "Recently Added", href: "/search?sortby=new" },
       { label: "Popular", href: "/search?sortby=-views" },
       { label: "Upcoming", href: "/search?sortby=upcoming" },
       { label: "Free", href: "/search?free=true" },
       { label: "With Certificate", href: "/search?certification=true" },
-      { label: "Browse by Topic", href: "/topics/" },
       { label: "Explore All", href: "/search/" },
     ]
     expected.forEach(({ label, href }) => {

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -11,12 +11,6 @@ const StyledInput = styled(Input)(({ theme }) => ({
       paddingRight: "10px",
     },
   },
-  "&.Mui-focused": {
-    paddingLeft: "15px",
-    button: {
-      paddingRight: "7px",
-    },
-  },
   [theme.breakpoints.down("sm")]: {
     height: "56px",
     gap: "8px",
@@ -25,7 +19,6 @@ const StyledInput = styled(Input)(({ theme }) => ({
 
 const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
   ".MuiInputBase-sizeHero &": {
-    // Extra padding to make button easier to click
     width: "72px",
     height: "100%",
     flexShrink: 0,

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -5,6 +5,7 @@ import type { InputProps } from "ol-components"
 
 const StyledInput = styled(Input)(({ theme }) => ({
   height: "72px",
+  borderRadius: "6px",
   "&.MuiInputBase-adornedEnd": {
     paddingRight: "0 !important",
     button: {

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -8,9 +8,6 @@ const StyledInput = styled(Input)(({ theme }) => ({
   borderRadius: "6px",
   "&.MuiInputBase-adornedEnd": {
     paddingRight: "0 !important",
-    button: {
-      paddingRight: "10px",
-    },
   },
   [theme.breakpoints.down("sm")]: {
     height: "56px",

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -5,13 +5,17 @@ import type { InputProps } from "ol-components"
 
 const StyledInput = styled(Input)({
   height: "72px",
+  maxWidth: "calc(100% - 2px)",
   "&.MuiInputBase-adornedEnd": {
     paddingRight: "0 !important",
     button: {
       paddingRight: "10px",
-      "&.Mui-focused": {
-        paddingRight: "9px",
-      },
+    },
+  },
+  "&.Mui-focused": {
+    paddingLeft: "15px",
+    button: {
+      paddingRight: "7px",
     },
   },
 })

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -3,9 +3,8 @@ import { RiSearch2Line, RiCloseLine } from "@remixicon/react"
 import { Input, AdornmentButton, styled, pxToRem } from "ol-components"
 import type { InputProps } from "ol-components"
 
-const StyledInput = styled(Input)({
+const StyledInput = styled(Input)(({ theme }) => ({
   height: "72px",
-  maxWidth: "calc(100% - 2px)",
   "&.MuiInputBase-adornedEnd": {
     paddingRight: "0 !important",
     button: {
@@ -18,7 +17,11 @@ const StyledInput = styled(Input)({
       paddingRight: "7px",
     },
   },
-})
+  [theme.breakpoints.down("sm")]: {
+    height: "56px",
+    gap: "8px",
+  },
+}))
 
 const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
   ".MuiInputBase-sizeHero &": {

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -25,6 +25,7 @@ const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
     // Extra padding to make button easier to click
     width: "72px",
     height: "100%",
+    flexShrink: 0,
     ".MuiSvgIcon-root": {
       fontSize: pxToRem(24),
     },

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -1,7 +1,38 @@
 import React, { useCallback } from "react"
 import { RiSearch2Line, RiCloseLine } from "@remixicon/react"
-import { Input, AdornmentButton } from "ol-components"
+import { Input, AdornmentButton, styled, pxToRem } from "ol-components"
 import type { InputProps } from "ol-components"
+
+const StyledInput = styled(Input)({
+  height: "72px",
+  "&.MuiInputBase-adornedEnd": {
+    paddingRight: "0 !important",
+    button: {
+      paddingRight: "10px",
+      "&.Mui-focused": {
+        paddingRight: "9px",
+      },
+    },
+  },
+})
+
+const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
+  ".MuiInputBase-sizeHero &": {
+    // Extra padding to make button easier to click
+    width: "72px",
+    height: "100%",
+    ".MuiSvgIcon-root": {
+      fontSize: pxToRem(24),
+    },
+    [theme.breakpoints.down("sm")]: {
+      width: "37px",
+      height: "100%",
+      ".MuiSvgIcon-root": {
+        fontSize: pxToRem(16),
+      },
+    },
+  },
+}))
 
 export interface SearchSubmissionEvent {
   target: {
@@ -50,7 +81,7 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
     )
 
   return (
-    <Input
+    <StyledInput
       fullWidth={props.fullWidth}
       size={props.size}
       inputProps={muiInputProps}
@@ -62,25 +93,25 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
       value={props.value}
       onChange={props.onChange}
       onKeyDown={onInputKeyDown}
-      startAdornment={
-        <AdornmentButton
-          aria-label="Search"
-          className={props.classNameSearch}
-          onClick={handleSubmit}
-        >
-          <RiSearch2Line fontSize="inherit" />
-        </AdornmentButton>
-      }
       endAdornment={
-        props.value && (
-          <AdornmentButton
-            className={props.classNameClear}
-            aria-label="Clear search text"
-            onClick={props.onClear}
+        <>
+          {props.value && (
+            <StyledAdornmentButton
+              className={props.classNameClear}
+              aria-label="Clear search text"
+              onClick={props.onClear}
+            >
+              <RiCloseLine />
+            </StyledAdornmentButton>
+          )}
+          <StyledAdornmentButton
+            aria-label="Search"
+            className={props.classNameSearch}
+            onClick={handleSubmit}
           >
-            <RiCloseLine />
-          </AdornmentButton>
-        )
+            <RiSearch2Line fontSize="inherit" />
+          </StyledAdornmentButton>
+        </>
       }
     />
   )

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -108,7 +108,7 @@ const Input = styled(InputBase)(({
       },
       [theme.breakpoints.down("sm")]: {
         "& .MuiInputBase-input": {
-          ...theme.typography.body4,
+          ...theme.typography.body3,
         },
         "&.MuiInputBase-adornedStart": {
           paddingLeft: `${12 - buttonPadding.heroMobile}px`,

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -46,6 +46,7 @@ const baseInputStyles = (theme: Theme) => ({
   },
   "&.Mui-error": {
     borderColor: theme.custom.colors.red,
+    outlineColor: theme.custom.colors.red,
   },
   "& input::placeholder": {
     color: theme.custom.colors.silverGrayDark,

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -28,13 +28,21 @@ const baseInputStyles = (theme: Theme) => ({
   "&.Mui-disabled": {
     backgroundColor: theme.custom.colors.lightGray1,
   },
-  "&:hover:not(.Mui-disabled)": {
+  "&:hover:not(.Mui-disabled):not(.Mui-focused)": {
     borderColor: theme.custom.colors.darkGray2,
   },
   "&.Mui-focused": {
-    borderWidth: "2px",
+    /**
+     * When change border width, it affects either the elements outside of it or
+     * inside based on the border-box setting.
+     *
+     * Instead of changing the border width, we hide the border and change width
+     * using outline.
+     */
+    borderColor: "transparent",
+    outline: "2px solid currentcolor",
+    outlineOffset: "-2px",
     color: theme.custom.colors.darkGray2,
-    borderColor: "currentcolor",
   },
   "&.Mui-error": {
     borderColor: theme.custom.colors.red,
@@ -72,15 +80,9 @@ const Input = styled(InputBase)(({
       borderRadius: "4px",
       "&.MuiInputBase-adornedStart": {
         paddingLeft: `${12 - buttonPadding.medium}px`,
-        "&.Mui-focused": {
-          paddingLeft: `${11 - buttonPadding.medium}px`,
-        },
       },
       "&.MuiInputBase-adornedEnd": {
         paddingRight: `${12 - buttonPadding.medium}px`,
-        "&.Mui-focused": {
-          paddingRight: `${11 - buttonPadding.medium}px`,
-        },
       },
     },
     size === "medium" &&
@@ -96,15 +98,9 @@ const Input = styled(InputBase)(({
       borderRadius: "8px",
       "&.MuiInputBase-adornedStart": {
         paddingLeft: `${16 - buttonPadding.hero}px`,
-        "&.Mui-focused": {
-          paddingLeft: `${15 - buttonPadding.hero}px`,
-        },
       },
       "&.MuiInputBase-adornedEnd": {
         paddingRight: `${16 - buttonPadding.hero}px`,
-        "&.Mui-focused": {
-          paddingRight: `${15 - buttonPadding.hero}px`,
-        },
       },
       [theme.breakpoints.down("sm")]: {
         "& .MuiInputBase-input": {
@@ -112,15 +108,9 @@ const Input = styled(InputBase)(({
         },
         "&.MuiInputBase-adornedStart": {
           paddingLeft: `${12 - buttonPadding.heroMobile}px`,
-          "&.Mui-focused": {
-            paddingLeft: `${11 - buttonPadding.heroMobile}px`,
-          },
         },
         "&.MuiInputBase-adornedEnd": {
           paddingRight: `${12 - buttonPadding.heroMobile}px`,
-          "&.Mui-focused": {
-            paddingRight: `${11 - buttonPadding.heroMobile}px`,
-          },
         },
       },
     },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5231

### Description (What does it do?)
This PR updates the home page search box and the area surrounding it to reflect the latest designs. (mobile pending)

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7f316f2f-6928-4244-a10d-f95d8705bb1d)
![image](https://github.com/user-attachments/assets/a0ef9c2a-fbf1-4714-af17-e7e5ebe70a49)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit the home page at http://localhost:8063
 - Click into the search box and type something
 - Ensure that the close button appears on the right next to the search button, and that you can click it to clear the search input
 - Ensure that typing something and clicking search brings you to the search page with your search term entered
 - Back on the home page, ensure that the links under the search box all go to the right place
