### PR TITLE
S3 bucket renaming

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: ol-mitopen-app-storage-production
+          AWS_S3_BUCKET: ol-mitlearn-app-storage-production
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_PROD }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
           SOURCE_DIR: "frontends/mit-learn/build" # optional: defaults to entire repository

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           args: --acl public-read --follow-symlinks
         env:
-          AWS_S3_BUCKET: ol-mitopen-app-storage-rc
+          AWS_S3_BUCKET: ol-mitlearn-app-storage-rc
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_RC }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_RC }}
           SOURCE_DIR: "frontends/mit-learn/build" # optional: defaults to entire repository


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Renaming the s3 buckets used for storing the app.

### Screenshots (if appropriate):
N/A

### How can this be tested?
N/A

### Additional Context
Right now I'm just keeping the two buckets in sync with 

```
aws s3 sync s3://ol-mitopen-app-storage-rc/ s3://ol-mitlearn-app-storage-rc/
aws s3 sync s3://ol-mitopen-app-storage-production/ s3://ol-mitlearn-app-storage-production/
```


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
