### PR TITLE
1454 follow-up: fix mobile adornment button width

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -24,7 +24,7 @@ const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
       fontSize: pxToRem(24),
     },
     [theme.breakpoints.down("sm")]: {
-      width: "37px",
+      width: "56px",
       height: "100%",
       ".MuiSvgIcon-root": {
         fontSize: pxToRem(16),


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-open/pull/1454

### Description (What does it do?)
This PR fixes something that was missed in the mobile implementation in the above PR, setting the proper width of the adornment buttons.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/07e960ee-6b0d-4610-afab-446293c2e9a9)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit the home page
 - Use the mobile inspector to ensure that the adornment buttons are the proper width