### PR TITLE
fix certification search url

### DIFF
--- a/frontends/mit-learn/src/common/urls.ts
+++ b/frontends/mit-learn/src/common/urls.ts
@@ -101,3 +101,29 @@ export const querifiedSearchUrl = (
     | Record<string, string>
     | undefined,
 ) => `${SEARCH}?${new URLSearchParams(params).toString()}`
+
+export const SEARCH_NEW = querifiedSearchUrl({ sortby: "new" })
+
+export const SEARCH_UPCOMING = querifiedSearchUrl({ sortby: "upcoming" })
+
+export const SEARCH_POPULAR = querifiedSearchUrl({ sortby: "-views" })
+
+export const SEARCH_FREE = querifiedSearchUrl({ free: "true" })
+
+const CERTIFICATION_SEARCH_PARAMS = new URLSearchParams()
+CERTIFICATION_SEARCH_PARAMS.append("certification_type", "professional")
+CERTIFICATION_SEARCH_PARAMS.append("certification_type", "completion")
+CERTIFICATION_SEARCH_PARAMS.append("certification_type", "micromasters")
+export const SEARCH_CERTIFICATE = querifiedSearchUrl(
+  CERTIFICATION_SEARCH_PARAMS,
+)
+
+export const SEARCH_COURSE = querifiedSearchUrl({ resource_category: "course" })
+
+export const SEARCH_PROGRAM = querifiedSearchUrl({
+  resource_category: "program",
+})
+
+export const SEARCH_LEARNING_MATERIAL = querifiedSearchUrl({
+  resource_category: "learning_material",
+})

--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -33,7 +33,14 @@ import {
   RESOURCE_DRAWER_QUERY_PARAM,
   SEARCH,
   UNITS,
-  querifiedSearchUrl,
+  SEARCH_NEW,
+  SEARCH_UPCOMING,
+  SEARCH_POPULAR,
+  SEARCH_FREE,
+  SEARCH_CERTIFICATE,
+  SEARCH_COURSE,
+  SEARCH_PROGRAM,
+  SEARCH_LEARNING_MATERIAL,
 } from "@/common/urls"
 import { useSearchParams } from "react-router-dom"
 import { useUserMe } from "api/hooks/user"
@@ -173,14 +180,14 @@ const navData: NavData = {
           icon: <RiPencilRulerLine />,
           description:
             "Single courses on a specific subject, taught by MIT instructors",
-          href: querifiedSearchUrl({ resource_category: "course" }),
+          href: SEARCH_COURSE,
         },
         {
           title: "Programs",
           icon: <RiStackLine />,
           description:
             "A series of courses for in-depth learning across a range of topics",
-          href: querifiedSearchUrl({ resource_category: "program" }),
+          href: SEARCH_PROGRAM,
         },
         {
           title: "Pathways",
@@ -193,7 +200,7 @@ const navData: NavData = {
           icon: <RiBookMarkedLine />,
           description:
             "Free learning and teaching materials, including videos, podcasts, lecture notes, and more",
-          href: querifiedSearchUrl({ resource_category: "learning_material" }),
+          href: SEARCH_LEARNING_MATERIAL,
         },
       ],
     },
@@ -223,27 +230,27 @@ const navData: NavData = {
         {
           title: "New",
           icon: <RiFileAddLine />,
-          href: querifiedSearchUrl({ sortby: "new" }),
+          href: SEARCH_NEW,
         },
         {
           title: "Upcoming",
           icon: <RiTimeLine />,
-          href: querifiedSearchUrl({ sortby: "upcoming" }),
+          href: SEARCH_UPCOMING,
         },
         {
           title: "Popular",
-          href: querifiedSearchUrl({ sortby: "-views" }),
+          href: SEARCH_POPULAR,
           icon: <RiHeartLine />,
         },
         {
           title: "Free",
           icon: <RiPriceTag3Line />,
-          href: querifiedSearchUrl({ free: "true" }),
+          href: SEARCH_FREE,
         },
         {
           title: "With Certificate",
           icon: <RiAwardLine />,
-          href: querifiedSearchUrl({ certification: "true" }),
+          href: SEARCH_CERTIFICATE,
         },
       ],
     },

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -3,7 +3,14 @@ import { useNavigate } from "react-router"
 import { Typography, styled, ChipLink, Link } from "ol-components"
 import type { ChipLinkProps } from "ol-components"
 import { SearchInput, SearchInputProps } from "./SearchInput"
-import { ABOUT } from "@/common/urls"
+import {
+  ABOUT,
+  SEARCH_CERTIFICATE,
+  SEARCH_FREE,
+  SEARCH_NEW,
+  SEARCH_POPULAR,
+  SEARCH_UPCOMING,
+} from "@/common/urls"
 import { NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER } from "../AboutPage/AboutPage"
 import {
   RiAddBoxLine,
@@ -24,31 +31,31 @@ type SearchChip = {
 const SEARCH_CHIPS: SearchChip[] = [
   {
     label: "Recently Added",
-    href: "/search?sortby=new",
+    href: SEARCH_NEW,
     variant: "outlinedWhite",
     icon: <RiTimeLine />,
   },
   {
     label: "Popular",
-    href: "/search?sortby=-views",
+    href: SEARCH_POPULAR,
     variant: "outlinedWhite",
     icon: <RiThumbUpLine />,
   },
   {
     label: "Upcoming",
-    href: "/search?sortby=upcoming",
+    href: SEARCH_UPCOMING,
     variant: "outlinedWhite",
     icon: <RiAddBoxLine />,
   },
   {
     label: "Free",
-    href: "/search?free=true",
+    href: SEARCH_FREE,
     variant: "outlinedWhite",
     icon: <RiVerifiedBadgeLine />,
   },
   {
     label: "With Certificate",
-    href: "/search?certification=true",
+    href: SEARCH_CERTIFICATE,
     variant: "outlinedWhite",
     icon: <RiAwardLine />,
   },

--- a/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
@@ -117,11 +117,14 @@ describe("Home Page Hero", () => {
     renderWithProviders(<HomePage />)
     const expected = [
       { label: "Topic", href: "/topics/" },
-      { label: "Recently Added", href: "/search?sortby=new" },
-      { label: "Popular", href: "/search?sortby=-views" },
-      { label: "Upcoming", href: "/search?sortby=upcoming" },
-      { label: "Free", href: "/search?free=true" },
-      { label: "With Certificate", href: "/search?certification=true" },
+      { label: "Recently Added", href: "/search/?sortby=new" },
+      { label: "Popular", href: "/search/?sortby=-views" },
+      { label: "Upcoming", href: "/search/?sortby=upcoming" },
+      { label: "Free", href: "/search/?free=true" },
+      {
+        label: "With Certificate",
+        href: "/search/?certification_type=professional&certification_type=completion&certification_type=micromasters",
+      },
       { label: "Explore All", href: "/search/" },
     ]
     expected.forEach(({ label, href }) => {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5171

### Description (What does it do?)
This PR fixes the URL on "With Certification" search links throughout the site. All reused search URLs have been consolidated in `urls.ts`.

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Test out the search links in the nav drawer and the chips under the home page search box:
   - Courses (nav drawer only)
   - Programs (nav drawer only)
   - Learning Materials (nav drawer only)
   - Recently Added / New
   - Popular
   - Upcoming
   - Free
   - With Certificate
 - When testing "With Certificate" pay special attention to the search facets that appear on the left hand side, making sure you can uncheck them after landing on the page