### PR TITLE
Carousel accessibility improvements

### DIFF
--- a/frontends/mit-learn/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/mit-learn/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -205,16 +205,27 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
   if (!isLoading && allChildrenLoaded && allChildrenEmpty) {
     return null
   }
+  const buttonsContainerElement = (
+    <ButtonsContainer role="group" aria-label="Slide navigation" ref={setRef} />
+  )
 
   return (
-    <MobileOverflow className={className} data-testid={dataTestId}>
+    <MobileOverflow
+      as="section"
+      aria-label={`Carousel of ${title}`}
+      className={className}
+      data-testid={dataTestId}
+    >
       <TabContext value={tab}>
         <HeaderRow>
           <HeaderText variant="h4">{title}</HeaderText>
-          {config.length === 1 ? <ButtonsContainer ref={setRef} /> : null}
+          {config.length === 1 ? buttonsContainerElement : null}
           {config.length > 1 ? (
             <ControlsContainer>
-              <TabsList onChange={(e, newValue) => setTab(newValue)}>
+              <TabsList
+                aria-label="Carousel Filters"
+                onChange={(e, newValue) => setTab(newValue)}
+              >
                 {config.map((tabConfig, index) => {
                   if (
                     !isLoading &&
@@ -232,7 +243,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                   )
                 })}
               </TabsList>
-              <ButtonsContainer ref={setRef} />
+              {buttonsContainerElement}
             </ControlsContainer>
           ) : null}
         </HeaderRow>

--- a/frontends/mit-learn/src/page-components/TestimonialDisplay/AttestantBlock.tsx
+++ b/frontends/mit-learn/src/page-components/TestimonialDisplay/AttestantBlock.tsx
@@ -24,7 +24,7 @@ const StyledRiAccountCircleFill = styled(RiAccountCircleFill)({
   height: "40px",
 })
 
-const AttestantBlockContainer = styled.div<AttestantBlockChildProps>(
+const AttestantBlockContainer = styled.cite<AttestantBlockChildProps>(
   (props) => {
     const flexDir = props.variant === "end" ? "row-reverse" : "row"
 

--- a/frontends/mit-learn/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
@@ -2,7 +2,13 @@ import React from "react"
 
 import { RiArrowRightLine, RiArrowLeftLine } from "@remixicon/react"
 import Slider from "react-slick"
-import { ActionButton, TruncateText, styled, theme } from "ol-components"
+import {
+  ActionButton,
+  TruncateText,
+  onReInitSlickA11y,
+  styled,
+  theme,
+} from "ol-components"
 import AttestantBlock from "./AttestantBlock"
 import { useTestimonialList } from "api/hooks/testimonials"
 import type { Attestation } from "api/v0"
@@ -147,6 +153,7 @@ const TestimonialDisplay: React.FC<TestimonialDisplayProps> = ({
           <>
             <Slider
               ref={setSlick}
+              onReInit={() => onReInitSlickA11y(slick)}
               infinite={true}
               slidesToShow={1}
               arrows={false}

--- a/frontends/mit-learn/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/TestimonialDisplay/TestimonialDisplay.tsx
@@ -81,7 +81,8 @@ const QuoteBody = styled.div(({ theme }) => ({
   },
 }))
 
-const AttestationBlock = styled.div(({ theme }) => ({
+const AttestationBlock = styled.blockquote(({ theme }) => ({
+  margin: "0px",
   width: "auto",
   flexGrow: "5",
   ...theme.typography.h5,
@@ -148,7 +149,7 @@ const TestimonialDisplay: React.FC<TestimonialDisplayProps> = ({
   return (
     <QuoteContainer>
       <QuoteBlock>
-        <QuoteLeader>“</QuoteLeader>
+        <QuoteLeader aria-hidden>“</QuoteLeader>
         {data.count > 1 ? (
           <>
             <Slider

--- a/frontends/mit-learn/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/TestimonialsSection.tsx
@@ -185,6 +185,7 @@ const ButtonsContainer = styled.div({
 })
 
 const TestimonialTruncateText = styled(TruncateText)({
+  margin: "0px",
   textOverflow: "none",
   ...theme.typography.h4,
   fontSize: pxToRem(20), // This is a unicorn font size per the Figma design - it's not used anywhere else.
@@ -252,8 +253,10 @@ const SlickCarousel = () => {
                 />
               </TestimonialCardImage>
               <TestimonialCardQuote>
-                <div className="testimonial-quote-opener">&ldquo;</div>
-                <TestimonialTruncateText lineClamp={7}>
+                <div className="testimonial-quote-opener" aria-hidden>
+                  &ldquo;
+                </div>
+                <TestimonialTruncateText as="blockquote" lineClamp={7}>
                   {resource.quote.slice(0, 350)}
                   {resource.quote.length >= 350 ? "..." : ""}
                 </TestimonialTruncateText>

--- a/frontends/mit-learn/src/pages/HomePage/TestimonialsSection.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/TestimonialsSection.tsx
@@ -8,6 +8,7 @@ import {
   pxToRem,
   ActionButton,
   TruncateText,
+  onReInitSlickA11y,
 } from "ol-components"
 import { useTestimonialList } from "api/hooks/testimonials"
 import { RiArrowRightLine, RiArrowLeftLine } from "@remixicon/react"
@@ -215,6 +216,7 @@ const SlickCarousel = () => {
 
   const settings = {
     ref: setSlick,
+    onReInit: () => onReInitSlickA11y(slick),
     infinite: true,
     slidesToShow: 1,
     centerPadding: "15%",
@@ -231,7 +233,7 @@ const SlickCarousel = () => {
   }
 
   return (
-    <OverlayContainer>
+    <OverlayContainer as="section" aria-label="Carousel of learner experiences">
       <Slider {...settings}>
         {_.shuffle(data?.results).map((resource, idx) => (
           <TestimonialCardContainer
@@ -274,14 +276,14 @@ const SlickCarousel = () => {
           variant="inverted"
           onClick={slick?.slickPrev}
         >
-          <RiArrowLeftLineStyled />
+          <RiArrowLeftLineStyled aria-hidden />
         </ActionButton>
         <ActionButton
           aria-label="Show next"
           variant="inverted"
           onClick={slick?.slickNext}
         >
-          <RiArrowRightLineStyled />
+          <RiArrowRightLineStyled aria-hidden />
         </ActionButton>
       </ButtonsContainer>
     </OverlayContainer>

--- a/frontends/ol-components/src/components/Carousel/Carousel.tsx
+++ b/frontends/ol-components/src/components/Carousel/Carousel.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react"
 import { createPortal } from "react-dom"
 import Slick from "react-slick"
+import { onReInitSlickA11y } from "./util"
 import { ActionButton } from "../Button/Button"
 import { RiArrowRightLine, RiArrowLeftLine } from "@remixicon/react"
 import styled from "@emotion/styled"
@@ -14,6 +15,20 @@ type CarouselProps = {
    */
   animationDuration?: number
   arrowsContainer?: HTMLElement | null
+  /**
+   * aria-label for the prev/next buttons container.
+   * Not used if `arrowsContainer` supplied.
+   * Defaults to "Slide navigation".
+   */
+  arrowGroupLabel?: string
+  /**
+   * aria-label for the previous button; defaults to "Show previous slides".
+   */
+  prevLabel?: string
+  /**
+   * aria-label for the next button; defaults to "Show next slides".
+   */
+  nextLabel?: string
 }
 
 const SlickStyled = styled(Slick)({
@@ -105,6 +120,9 @@ const Carousel: React.FC<CarouselProps> = ({
   className,
   initialSlide = 0,
   arrowsContainer,
+  arrowGroupLabel = "Slide navigation",
+  prevLabel = "Show previous slides",
+  nextLabel = "Show next slides",
 }) => {
   const [slick, setSlick] = React.useState<Slick | null>(null)
   const [slidesPerPage, setSlidesPerPage] = React.useState<number>(1)
@@ -126,6 +144,7 @@ const Carousel: React.FC<CarouselProps> = ({
     if (slideInfo.currentIndex !== undefined) {
       setCurrentIndex(slideInfo.currentIndex)
     }
+    onReInitSlickA11y(slick)
   }, [slick])
   const nextPage = React.useCallback(() => {
     if (!slick) return
@@ -144,9 +163,9 @@ const Carousel: React.FC<CarouselProps> = ({
         variant="tertiary"
         onClick={prevPage}
         disabled={!canPrev}
-        aria-label="Previous"
+        aria-label={prevLabel}
       >
-        <RiArrowLeftLine />
+        <RiArrowLeftLine aria-hidden />
       </ActionButton>
       <ActionButton
         size="small"
@@ -154,9 +173,9 @@ const Carousel: React.FC<CarouselProps> = ({
         variant="tertiary"
         onClick={nextPage}
         disabled={!canNext}
-        aria-label="Next"
+        aria-label={nextLabel}
       >
-        <RiArrowRightLine />
+        <RiArrowRightLine aria-hidden />
       </ActionButton>
     </>
   )
@@ -177,11 +196,15 @@ const Carousel: React.FC<CarouselProps> = ({
       >
         {children}
       </SlickStyled>
-      {arrowsContainer === undefined ? arrows : null}
+      {arrowsContainer === undefined ? (
+        <div role="group" aria-label={arrowGroupLabel}>
+          {arrows}
+        </div>
+      ) : null}
       {arrowsContainer ? createPortal(arrows, arrowsContainer) : null}
     </>
   )
 }
 
-export { Carousel }
+export { Carousel, onReInitSlickA11y }
 export type { CarouselProps }

--- a/frontends/ol-components/src/components/Carousel/util.ts
+++ b/frontends/ol-components/src/components/Carousel/util.ts
@@ -1,0 +1,49 @@
+import type Slick from "react-slick"
+
+const DEFAULT_INTERACTIVE_CHILD_SELECTOR =
+  "a, button, input, select, textarea, [tabindex], iframe, [contenteditable=true]"
+
+/**
+ * This enhances slick carousel accessibility in a few ways:
+ * - Adds `role="group"`
+ *  - Adds `aria-label` to each slide indicating slide count
+ * - sets tabindex to -1 on interactive elements in aria hidden states
+ */
+const onReInitSlickA11y = (
+  slick: Slick | null,
+  interactiveChildSelector: string = DEFAULT_INTERACTIVE_CHILD_SELECTOR,
+) => {
+  const container = slick?.innerSlider?.list
+  if (!container) return
+
+  // These have aria-hidden via slick, but are not fully hidden yet.
+  const hidden = container.querySelectorAll('.slick-slide[aria-hidden="true"]')
+
+  // Note: .slick-cloned is used on ifinite carousels. We can ignore those
+  // slides, and including them would skew our slide count
+  const slides = container.querySelectorAll(".slick-slide:not(.slick-cloned)")
+
+  // Reset tabindex for all card contents so they are reachable for keyboard users
+  slides.forEach(function (slide, index) {
+    slide.setAttribute("role", "group")
+    slide.setAttribute("aria-label", `${index + 1} of ${slides.length}`)
+    slide.querySelectorAll(interactiveChildSelector).forEach(function (el) {
+      el.removeAttribute("tabindex")
+    })
+  })
+
+  // Make hidden slides impossible to reach via keyboard, as well as interactive
+  // elements within them
+  hidden.forEach(function (slide) {
+    // Note: Interactive children are removed from tab focus via tabindex
+    // rather than using `inert` on the parent slide. This is because `inert`
+    // on the parent slide will also disable some CSS effects on the slide.
+    // Since our slides have aria-hidden when partially visible, removing css
+    // effects is a bit weird without other intentional styling changes
+    slide.querySelectorAll(interactiveChildSelector).forEach(function (el) {
+      el.setAttribute("tabindex", "-1")
+    })
+  })
+}
+
+export { onReInitSlickA11y }

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -266,7 +266,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
-            <RiMenuAddLine />
+            <RiMenuAddLine aria-hidden />
           </CardActionButton>
         )}
         {onAddToUserListClick && (
@@ -275,7 +275,11 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
-            {inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+            {inUserList ? (
+              <RiBookmarkFill aria-hidden />
+            ) : (
+              <RiBookmarkLine aria-hidden />
+            )}
           </CardActionButton>
         )}
       </Card.Actions>

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -317,7 +317,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
-            <RiMenuAddLine />
+            <RiMenuAddLine aria-hidden />
           </CardActionButton>
         )}
         {onAddToUserListClick && (
@@ -326,7 +326,11 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
-            {inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+            {inUserList ? (
+              <RiBookmarkFill aria-hidden />
+            ) : (
+              <RiBookmarkLine aria-hidden />
+            )}
           </CardActionButton>
         )}
         {editMenu}

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -130,7 +130,7 @@ const LearningResourceListCardCondensed: React.FC<
             aria-label="Add to Learning Path"
             onClick={(event) => onAddToLearningPathClick(event, resource.id)}
           >
-            <RiMenuAddLine />
+            <RiMenuAddLine aria-hidden />
           </CardActionButton>
         )}
         {onAddToUserListClick && (
@@ -139,7 +139,11 @@ const LearningResourceListCardCondensed: React.FC<
             aria-label="Add to User List"
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
-            {inUserList ? <RiBookmarkFill /> : <RiBookmarkLine />}
+            {inUserList ? (
+              <RiBookmarkFill aria-hidden />
+            ) : (
+              <RiBookmarkLine aria-hidden />
+            )}
           </CardActionButton>
         )}
         {editMenu}

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -166,6 +166,8 @@ export * from "./components/Breadcrumbs/Breadcrumbs"
 export * from "./components/Card/Card"
 export * from "./components/Card/ListCardCondensed"
 export * from "./components/Carousel/Carousel"
+export { onReInitSlickA11y } from "./components/Carousel/util"
+
 export * from "./components/Checkbox/Checkbox"
 export * from "./components/Checkbox/CheckboxChoiceField"
 export * from "./components/Chips/ChipLink"


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/5144


### Description (What does it do?)
This PR aims to improve screenreader experience for our carousels.

*There should be no visual changes to the site.*

### How can this be tested?
Ideally, you should test this in two ways:
- via tab navigation
- via screenreader navigation
    - With a screenreader, you _can_ tab between interactive elements. But screenreaders also support navigation via arrow keys to a wider variety of content. Additionally, if an HTML element has special behavior associated with arrow keys (e.g., via keydown listeners) that generally won't work on a screenreader.
    - If you use Mac, you could test this with Voiceover. 

#### Expected Carousel Behavior:
- Carousel slides themselves are not focusable, but might be in the browser tab order if they contain focusable content.
- Any slides that are offscreen or partially offscreen have `aria-hidden="true"`
    - Additionally, these slides should not be tab accessible. If they contain interactive elements, those elements should have `tabindex=-1`. 
- Carousel slides should have `role="group"` and and `aria-label` indicating how many slides there are.
- Carousel buttons should have reasonable `aria-label`s.

#### Test the resource carousels
These are on homepage and dashboard.
1. Without a screenreader, keyboard only. *Reminder: shift+tab = focus previous item*
    - Try tabbing through the carousel. You should be able to tab to all fully visible slides.
    - You can change pages via the carousel buttons.
        - This is currently kind of annoying to do because you need to tab backwards to before the carousel.
    - You can change pages via left/right arrow keys
        - NB: This will not work on a screenreader.
2. With a screenreader, keyboard-only:
    - Try navigating through the carousel. Listen for the things noted above (role "group", slide labels)
    - Try turning carousel pages via carousel buttons

#### Testimonial carousels
This is on the homepage and on channel pages.
1. Without a screenreader, keyboard-only:
    - You visually see the testimonial content
    - You can change pages via carousel buttons
    - NB: You **cannot** use the left/right arrow key shortcuts in this case, because the carousel has no interactive content.
2. With a screenreader, keyboard-only:
    - Screenreader should read the carousel slides... Note role "group" and aria-label indicating slide number and how many slides there are.
        - Depending on the mode your screenreader is in, this may require you to navigate through each slide. 
    - You should be able to navigate the screenreader slides with the arrow buttons, which should have reasonable labels.


### Additional Context
- This is a very good article on carousel accessibility https://dev.to/jasonwebb/how-to-build-a-more-accessible-carousel-or-slider-35lp, with an associated github repo https://github.com/Accessible360/accessible-carousel-boilerplates. Some of the bheavior / implementation here was based off of that. 