### PR TITLE
score cutoff

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3578,6 +3578,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   slop?: number | null
   /**
+   * Minimum score value a text query result needs to have to be displayed
+   * @type {number}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  min_score?: number | null
+  /**
    *
    * @type {SourceTypeEnum}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -12215,6 +12221,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesSearchRetrievePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -12222,7 +12229,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesSearchRetrieveResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesSearchRetrieveSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesSearchRetrieveSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -12242,6 +12249,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesSearchRetrieveOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesSearchRetrievePlatformEnum>,
@@ -12314,6 +12322,10 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (min_score !== undefined) {
+        localVarQueryParameter["min_score"] = min_score
       }
 
       if (offered_by) {
@@ -12405,6 +12417,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesSearchRetrievePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -12412,7 +12425,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesSearchRetrieveResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesSearchRetrieveSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesSearchRetrieveSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -12432,6 +12445,7 @@ export const LearningResourcesSearchApiFp = function (
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesSearchRetrieveOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesSearchRetrievePlatformEnum>,
@@ -12464,6 +12478,7 @@ export const LearningResourcesSearchApiFp = function (
           learning_format,
           level,
           limit,
+          min_score,
           offered_by,
           offset,
           platform,
@@ -12529,6 +12544,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
@@ -12632,6 +12648,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   readonly limit?: number
 
   /**
+   * Minimum score value a text query result needs to have to be displayed
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly min_score?: number | null
+
+  /**
    * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
    * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see'>}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
@@ -12681,7 +12704,7 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   readonly resource_type?: Array<LearningResourcesSearchRetrieveResourceTypeEnum>
 
   /**
-   * The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+   * The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
    * @type {'best_fields' | 'most_fields' | 'phrase'}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
@@ -12748,6 +12771,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
@@ -12982,6 +13006,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -12989,7 +13014,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionCheckListSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionCheckListSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -13010,6 +13035,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>,
@@ -13083,6 +13109,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (min_score !== undefined) {
+        localVarQueryParameter["min_score"] = min_score
       }
 
       if (offered_by) {
@@ -13165,6 +13195,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -13172,7 +13203,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionListSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionListSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -13192,6 +13223,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionListOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionListPlatformEnum>,
@@ -13264,6 +13296,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (min_score !== undefined) {
+        localVarQueryParameter["min_score"] = min_score
       }
 
       if (offered_by) {
@@ -13342,6 +13378,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -13349,7 +13386,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionSubscribeCreateSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionSubscribeCreateSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -13371,6 +13408,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>,
@@ -13445,6 +13483,10 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (min_score !== undefined) {
+        localVarQueryParameter["min_score"] = min_score
       }
 
       if (offered_by) {
@@ -13598,6 +13640,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -13605,7 +13648,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionCheckListSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionCheckListSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -13626,6 +13669,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionCheckListPlatformEnum>,
@@ -13659,6 +13703,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          min_score,
           offered_by,
           offset,
           platform,
@@ -13701,6 +13746,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -13708,7 +13754,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionListResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionListSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionListSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -13728,6 +13774,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionListOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionListPlatformEnum>,
@@ -13760,6 +13807,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          min_score,
           offered_by,
           offset,
           platform,
@@ -13801,6 +13849,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube
@@ -13808,7 +13857,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {string} [q] The search text
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceCategoryEnum>} [resource_category] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist
-     * @param {LearningResourcesUserSubscriptionSubscribeCreateSearchModeEnum} [search_mode] The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+     * @param {LearningResourcesUserSubscriptionSubscribeCreateSearchModeEnum} [search_mode] The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
@@ -13830,6 +13879,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
+      min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>,
       offset?: number,
       platform?: Array<LearningResourcesUserSubscriptionSubscribeCreatePlatformEnum>,
@@ -13861,6 +13911,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          min_score,
           offered_by,
           offset,
           platform,
@@ -13959,6 +14010,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
@@ -14000,6 +14052,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
@@ -14040,6 +14093,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
           requestParameters.platform,
@@ -14163,6 +14217,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly limit?: number
 
   /**
+   * Minimum score value a text query result needs to have to be displayed
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly min_score?: number | null
+
+  /**
    * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
    * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
@@ -14212,7 +14273,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly resource_type?: Array<LearningResourcesUserSubscriptionCheckListResourceTypeEnum>
 
   /**
-   * The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+   * The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
    * @type {'best_fields' | 'most_fields' | 'phrase'}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
@@ -14338,6 +14399,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly limit?: number
 
   /**
+   * Minimum score value a text query result needs to have to be displayed
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly min_score?: number | null
+
+  /**
    * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
    * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
@@ -14387,7 +14455,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly resource_type?: Array<LearningResourcesUserSubscriptionListResourceTypeEnum>
 
   /**
-   * The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+   * The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
    * @type {'best_fields' | 'most_fields' | 'phrase'}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
@@ -14506,6 +14574,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly limit?: number
 
   /**
+   * Minimum score value a text query result needs to have to be displayed
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly min_score?: number | null
+
+  /**
    * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
    * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see'>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
@@ -14555,7 +14630,7 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly resource_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateResourceTypeEnum>
 
   /**
-   * The open search search type               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
+   * The open search search type for text queries               * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase  * &#x60;best_fields&#x60; - best_fields * &#x60;most_fields&#x60; - most_fields * &#x60;phrase&#x60; - phrase
    * @type {'best_fields' | 'most_fields' | 'phrase'}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
@@ -14650,6 +14725,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
@@ -14693,6 +14769,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,
@@ -14735,6 +14812,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
         requestParameters.platform,

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -549,6 +549,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       yearly_decay_percent: searchParams.get("yearly_decay_percent"),
       search_mode: searchParams.get("search_mode"),
       slop: searchParams.get("slop"),
+      min_score: searchParams.get("min_score"),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",
@@ -685,6 +686,23 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 </ExplanationContainer>
               </div>
             ) : null}
+            <AdminTitleContainer>Minimum Score Cutoff</AdminTitleContainer>
+            <SliderInput
+              currentValue={
+                searchParams.get("min_score")
+                  ? Number(searchParams.get("min_score"))
+                  : 0
+              }
+              setSearchParams={setSearchParams}
+              urlParam="min_score"
+              min={0}
+              max={20}
+              step={0.5}
+            />
+            <ExplanationContainer>
+              Minimum relevance score for a search result to be displayed. Only
+              affects results if there is a search term.
+            </ExplanationContainer>
           </div>
         ) : null}
       </div>

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SliderInput.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SliderInput.tsx
@@ -9,7 +9,13 @@ const SliderInput: React.FC<{
   max: number
   step: number
 }> = ({ currentValue, setSearchParams, urlParam, min, max, step }) => {
-  const handleChange = (event: Event, newValue: number | number[]) => {
+  const [sliderDisplayValue, setSliderDisplayValue] =
+    React.useState<number>(currentValue)
+
+  const handleChange = (
+    event: Event | React.SyntheticEvent,
+    newValue: number | number[],
+  ) => {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev)
       next.set(urlParam, newValue.toString())
@@ -21,8 +27,11 @@ const SliderInput: React.FC<{
     <div>
       <Slider
         data-testid={`${urlParam}-slider`}
-        value={currentValue || 0}
-        onChange={handleChange}
+        value={sliderDisplayValue || 0}
+        onChange={(event: Event, newValue: number | number[]) => {
+          setSliderDisplayValue(newValue as number)
+        }}
+        onChangeCommitted={handleChange}
         valueLabelDisplay="auto"
         min={min}
         max={max}

--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
@@ -283,7 +283,7 @@ describe("SearchPage", () => {
     })
   })
 
-  test("admin users can set the staleness slider", async () => {
+  test("admin users can set staleness and score cutoff sliders", async () => {
     setMockApiResponses({
       search: {
         count: 700,
@@ -314,6 +314,7 @@ describe("SearchPage", () => {
 
     await waitFor(() => {
       screen.getByTestId("yearly_decay_percent-slider")
+      screen.getByTestId("min_score-slider")
     })
   })
 })

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1856,6 +1856,414 @@ def test_execute_learn_search_with_yearly_decay_percent(mocker, opensearch):
     )
 
 
+def test_execute_learn_search_with_min_score(mocker, opensearch):
+    opensearch.conn.search.return_value = {
+        "hits": {"total": {"value": 10, "relation": "eq"}}
+    }
+
+    search_params = {
+        "aggregations": ["offered_by"],
+        "q": "math",
+        "resource_type": ["course"],
+        "free": [True],
+        "limit": 1,
+        "offset": 1,
+        "sortby": "-readable_id",
+        "endpoint": LEARNING_RESOURCE,
+        "min_score": 5,
+    }
+
+    query = {
+        "query": {
+            "script_score": {
+                "query": {
+                    "bool": {
+                        "must": [
+                            {
+                                "bool": {
+                                    "filter": [
+                                        {
+                                            "bool": {
+                                                "must": [
+                                                    {
+                                                        "bool": {
+                                                            "should": [
+                                                                {
+                                                                    "multi_match": {
+                                                                        "query": "math",
+                                                                        "fields": [
+                                                                            "title.english^3",
+                                                                            "description.english^2",
+                                                                            "full_description.english",
+                                                                            "platform.name",
+                                                                            "readable_id",
+                                                                            "offered_by",
+                                                                            "course_feature",
+                                                                            "video.transcript.english",
+                                                                        ],
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "nested": {
+                                                                        "path": "topics",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "topics.name"
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "nested": {
+                                                                        "path": "departments",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "departments.department_id",
+                                                                                    "departments.name",
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "nested": {
+                                                                        "path": "course.course_numbers",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "course.course_numbers.value"
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "nested": {
+                                                                        "path": "runs",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "runs.year",
+                                                                                    "runs.semester",
+                                                                                    "runs.level",
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "nested": {
+                                                                        "path": "runs",
+                                                                        "query": {
+                                                                            "nested": {
+                                                                                "path": "runs.instructors",
+                                                                                "query": {
+                                                                                    "multi_match": {
+                                                                                        "query": "math",
+                                                                                        "fields": [
+                                                                                            "runs.instructors.first_name",
+                                                                                            "runs.instructors.last_name^5",
+                                                                                            "runs.instructors.full_name^5",
+                                                                                        ],
+                                                                                    }
+                                                                                },
+                                                                            }
+                                                                        },
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "has_child": {
+                                                                        "type": "content_file",
+                                                                        "query": {
+                                                                            "multi_match": {
+                                                                                "query": "math",
+                                                                                "fields": [
+                                                                                    "content",
+                                                                                    "title.english^3",
+                                                                                    "short_description.english^2",
+                                                                                    "content_feature_type",
+                                                                                ],
+                                                                            }
+                                                                        },
+                                                                        "score_mode": "avg",
+                                                                    }
+                                                                },
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ],
+                                    "should": [
+                                        {
+                                            "multi_match": {
+                                                "query": "math",
+                                                "fields": [
+                                                    "title.english^3",
+                                                    "description.english^2",
+                                                    "full_description.english",
+                                                    "platform.name",
+                                                    "readable_id",
+                                                    "offered_by",
+                                                    "course_feature",
+                                                    "video.transcript.english",
+                                                ],
+                                            }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "topics",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": ["topics.name"],
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "departments",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": [
+                                                            "departments.department_id",
+                                                            "departments.name",
+                                                        ],
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "course.course_numbers",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": [
+                                                            "course.course_numbers.value"
+                                                        ],
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "runs",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": [
+                                                            "runs.year",
+                                                            "runs.semester",
+                                                            "runs.level",
+                                                        ],
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        {
+                                            "nested": {
+                                                "path": "runs",
+                                                "query": {
+                                                    "nested": {
+                                                        "path": "runs.instructors",
+                                                        "query": {
+                                                            "multi_match": {
+                                                                "query": "math",
+                                                                "fields": [
+                                                                    "runs.instructors.first_name",
+                                                                    "runs.instructors.last_name^5",
+                                                                    "runs.instructors.full_name^5",
+                                                                ],
+                                                            }
+                                                        },
+                                                    }
+                                                },
+                                            }
+                                        },
+                                        {
+                                            "has_child": {
+                                                "type": "content_file",
+                                                "query": {
+                                                    "multi_match": {
+                                                        "query": "math",
+                                                        "fields": [
+                                                            "content",
+                                                            "title.english^3",
+                                                            "short_description.english^2",
+                                                            "content_feature_type",
+                                                        ],
+                                                    }
+                                                },
+                                                "score_mode": "avg",
+                                            }
+                                        },
+                                    ],
+                                }
+                            }
+                        ],
+                        "filter": [{"exists": {"field": "resource_type"}}],
+                    }
+                },
+                "min_score": 5,
+            }
+        },
+        "post_filter": {
+            "bool": {
+                "must": [
+                    {
+                        "bool": {
+                            "should": [
+                                {
+                                    "term": {
+                                        "resource_type": {
+                                            "value": "course",
+                                            "case_insensitive": True,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "bool": {
+                            "should": [
+                                {
+                                    "term": {
+                                        "free": {
+                                            "value": True,
+                                            "case_insensitive": True,
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                ]
+            }
+        },
+        "sort": [{"readable_id": {"order": "desc"}}],
+        "from": 1,
+        "size": 1,
+        "suggest": {
+            "text": "math",
+            "title.trigram": {
+                "phrase": {
+                    "field": "title.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "title.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+            "description.trigram": {
+                "phrase": {
+                    "field": "description.trigram",
+                    "size": 5,
+                    "gram_size": 1,
+                    "confidence": 0.0001,
+                    "max_errors": 3,
+                    "collate": {
+                        "query": {
+                            "source": {
+                                "match_phrase": {"{{field_name}}": "{{suggestion}}"}
+                            }
+                        },
+                        "params": {"field_name": "description.trigram"},
+                        "prune": True,
+                    },
+                }
+            },
+        },
+        "aggs": {
+            "offered_by": {
+                "aggs": {
+                    "offered_by": {
+                        "nested": {"path": "offered_by"},
+                        "aggs": {
+                            "offered_by": {
+                                "terms": {"field": "offered_by.code", "size": 10000},
+                                "aggs": {"root": {"reverse_nested": {}}},
+                            }
+                        },
+                    }
+                },
+                "filter": {
+                    "bool": {
+                        "must": [
+                            {
+                                "bool": {
+                                    "should": [
+                                        {
+                                            "term": {
+                                                "resource_type": {
+                                                    "value": "course",
+                                                    "case_insensitive": True,
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "bool": {
+                                    "should": [
+                                        {
+                                            "term": {
+                                                "free": {
+                                                    "value": True,
+                                                    "case_insensitive": True,
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                        ]
+                    }
+                },
+            }
+        },
+        "_source": {
+            "excludes": [
+                "created_on",
+                "course.course_numbers.sort_coursenum",
+                "course.course_numbers.primary",
+                "resource_relations",
+                "is_learning_material",
+                "resource_age_date",
+                "featured_rank",
+            ]
+        },
+    }
+
+    assert execute_learn_search(search_params) == opensearch.conn.search.return_value
+
+    opensearch.conn.search.assert_called_once_with(
+        body=query,
+        index=["testindex_course_default"],
+    )
+
+
 def test_execute_learn_search_for_content_file_query(opensearch):
     opensearch.conn.search.return_value = {
         "hits": {"total": {"value": 10, "relation": "eq"}}

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -411,7 +411,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         required=False,
         choices=search_mode_choices,
         help_text=(
-            f"The open search search type \
+            f"The open search search type for text queries \
             \n\n{build_choice_description_list(search_mode_choices)}"
         ),
     )
@@ -419,6 +419,16 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         required=False,
         allow_null=True,
         help_text=("Allowed distance for phrase search"),
+    )
+    min_score = serializers.FloatField(
+        max_value=50,
+        min_value=0,
+        required=False,
+        allow_null=True,
+        default=0,
+        help_text=(
+            "Minimum score value a text query result needs to have to be displayed"
+        ),
     )
 
 

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -877,6 +877,7 @@ def test_learning_resources_search_request_serializer():
         "yearly_decay_percent": "0.25",
         "search_mode": "phrase",
         "slop": 2,
+        "min_score": 0,
     }
 
     cleaned = {
@@ -901,6 +902,7 @@ def test_learning_resources_search_request_serializer():
         "dev_mode": False,
         "search_mode": "phrase",
         "slop": 2,
+        "min_score": 0,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2451,6 +2451,16 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: min_score
+        schema:
+          type: number
+          format: double
+          maximum: 50
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Minimum score value a text query result needs to have to be displayed
+      - in: query
         name: offered_by
         schema:
           type: array
@@ -2594,10 +2604,10 @@ paths:
           - phrase
           type: string
           minLength: 1
-        description: "The open search search type             \n\n* `best_fields`\
-          \ - best_fields\n* `most_fields` - most_fields\n* `phrase` - phrase\n\n\
+        description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
-          \ - phrase"
+          \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
+          * `phrase` - phrase"
       - in: query
         name: slop
         schema:
@@ -2909,6 +2919,16 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: min_score
+        schema:
+          type: number
+          format: double
+          maximum: 50
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Minimum score value a text query result needs to have to be displayed
+      - in: query
         name: offered_by
         schema:
           type: array
@@ -3052,10 +3072,10 @@ paths:
           - phrase
           type: string
           minLength: 1
-        description: "The open search search type             \n\n* `best_fields`\
-          \ - best_fields\n* `most_fields` - most_fields\n* `phrase` - phrase\n\n\
+        description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
-          \ - phrase"
+          \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
+          * `phrase` - phrase"
       - in: query
         name: slop
         schema:
@@ -3392,6 +3412,16 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: min_score
+        schema:
+          type: number
+          format: double
+          maximum: 50
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Minimum score value a text query result needs to have to be displayed
+      - in: query
         name: offered_by
         schema:
           type: array
@@ -3535,10 +3565,10 @@ paths:
           - phrase
           type: string
           minLength: 1
-        description: "The open search search type             \n\n* `best_fields`\
-          \ - best_fields\n* `most_fields` - most_fields\n* `phrase` - phrase\n\n\
+        description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
-          \ - phrase"
+          \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
+          * `phrase` - phrase"
       - in: query
         name: slop
         schema:
@@ -3866,6 +3896,16 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: min_score
+        schema:
+          type: number
+          format: double
+          maximum: 50
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Minimum score value a text query result needs to have to be displayed
+      - in: query
         name: offered_by
         schema:
           type: array
@@ -4009,10 +4049,10 @@ paths:
           - phrase
           type: string
           minLength: 1
-        description: "The open search search type             \n\n* `best_fields`\
-          \ - best_fields\n* `most_fields` - most_fields\n* `phrase` - phrase\n\n\
+        description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
-          \ - phrase"
+          \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
+          * `phrase` - phrase"
       - in: query
         name: slop
         schema:
@@ -9856,14 +9896,23 @@ components:
         search_mode:
           allOf:
           - $ref: '#/components/schemas/SearchModeEnum'
-          description: "The open search search type             \n\n* `best_fields`\
-            \ - best_fields\n* `most_fields` - most_fields\n* `phrase` - phrase\n\n\
-            * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
-            \ - phrase"
+          description: "The open search search type for text queries             \n\
+            \n* `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
+            \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
+            * `phrase` - phrase"
         slop:
           type: integer
           nullable: true
           description: Allowed distance for phrase search
+        min_score:
+          type: number
+          format: double
+          maximum: 50
+          minimum: 0
+          nullable: true
+          default: 0.0
+          description: Minimum score value a text query result needs to have to be
+            displayed
         source_type:
           allOf:
           - $ref: '#/components/schemas/SourceTypeEnum'


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4985

### Description (What does it do?)
This PR adds a slider to the admin section of the search controls to specify the minimum score needed for results to be shown

### Screenshots (if appropriate):
<img width="1724" alt="Screenshot 2024-08-26 at 3 20 04 PM" src="https://github.com/user-attachments/assets/35aeb2bd-d014-45db-92a6-27e4b8057723">
<img width="332" alt="Screenshot 2024-08-26 at 3 20 32 PM" src="https://github.com/user-attachments/assets/d7ae6c72-2d51-405e-b22b-a8674fec9e4a">


### How can this be tested?
Log in as an admin user. Go to the search page. Make a text search - verify that as you increase the Minimum Score Cutoff with the slider, the number of results goes down but the order of the top results stays the same. The score cutoff should work with all three search modes