### PR TITLE
update the footer logo

### DIFF
--- a/frontends/mit-learn/public/images/mit_logo_std_cmyk_black.svg
+++ b/frontends/mit-learn/public/images/mit_logo_std_cmyk_black.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1360 720">
+  <!-- Generator: Adobe Illustrator 28.6.0, SVG Export Plug-In . SVG Version: 1.2.0 Build 709)  -->
+  <g>
+    <g id="Layer_1">
+      <g id="Layer_1-2" data-name="Layer_1">
+        <path d="M720,720h160V240h-160v480ZM960,160h400V0h-400v160ZM720,0h160v160h-160V0ZM480,720h160V0h-160v720ZM240,560h160V0h-160v560ZM0,720h160V0H0v720ZM960,720h160V240h-160v480Z"/>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/frontends/mit-learn/src/page-components/Footer/Footer.tsx
+++ b/frontends/mit-learn/src/page-components/Footer/Footer.tsx
@@ -48,11 +48,11 @@ const FooterLeftContainer = styled.div(({ theme }) => ({
 }))
 
 const FooterLogo = styled(MITLogoLink)(({ theme }) => ({
-  width: "95.405px",
-  height: "47px",
-  [theme.breakpoints.down("md")]: {
-    width: "80px",
-    height: "39.411px",
+  img: {
+    height: "48px",
+    [theme.breakpoints.down("md")]: {
+      height: "40px",
+    },
   },
 }))
 
@@ -149,7 +149,7 @@ const Footer: FunctionComponent = () => {
             <FooterLeftContainer>
               <FooterLogo
                 href="https://mit.edu/"
-                src="/static/images/mit-logo-transparent5.svg"
+                src="/static/images/mit_logo_std_cmyk_black.svg"
               />
               <FooterAddress data-testid="footer-address">
                 Massachusetts Institute of Technology


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5279

### Description (What does it do?)
This PR updates the image used for the SVG logo in the footer of the site. The styling has also been updated for proper scaling.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/8ce091bd-5d0e-40a5-9b68-c15c545c0362)
![image](https://github.com/user-attachments/assets/a9adea09-a798-4f53-a39e-938e22e9307e)

### How can this be tested?
 - Spin up the site on this branch
 - Verify that the footer displays the MIT logo properly at both desktop and mobile and that the dimensions match what's specified in the issue