### PR TITLE
Shanbady/fix multiple instances of subscriptions

### DIFF
--- a/learning_resources_search/management/commands/align_subscription_queries.py
+++ b/learning_resources_search/management/commands/align_subscription_queries.py
@@ -1,0 +1,10 @@
+"""Management command to update learning resource content"""
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Indexes opensearch content"""
+
+    def handle(self, **options):
+        """Index the comments and posts for the channels the user is subscribed to"""

--- a/learning_resources_search/management/commands/align_subscription_queries.py
+++ b/learning_resources_search/management/commands/align_subscription_queries.py
@@ -2,9 +2,14 @@
 
 from django.core.management.base import BaseCommand
 
+from learning_resources_search.utils import realign_channel_subscriptions
+
 
 class Command(BaseCommand):
-    """Indexes opensearch content"""
+    """
+    Removes duplicate Percolate Queries and consolidates users
+    to the real instance when search parameters change
+    """
 
-    def handle(self, **options):
-        """Index the comments and posts for the channels the user is subscribed to"""
+    def handle(self, **options):  # noqa: ARG002
+        realign_channel_subscriptions()

--- a/learning_resources_search/management/commands/prune_subscription_queries.py
+++ b/learning_resources_search/management/commands/prune_subscription_queries.py
@@ -2,7 +2,7 @@
 
 from django.core.management.base import BaseCommand
 
-from learning_resources_search.utils import realign_channel_subscriptions
+from learning_resources_search.utils import prune_channel_subscriptions
 
 
 class Command(BaseCommand):
@@ -12,4 +12,4 @@ class Command(BaseCommand):
     """
 
     def handle(self, **options):  # noqa: ARG002
-        realign_channel_subscriptions()
+        prune_channel_subscriptions()

--- a/learning_resources_search/utils.py
+++ b/learning_resources_search/utils.py
@@ -42,6 +42,11 @@ def realign_channel_subscriptions():
                 for user in q.users.all():
                     actual_query.users.add(user)
                 q.delete()
+                msg = (
+                    f"removing duplicate percolate query ({q.id}) "
+                    "for channel {channel.title}"
+                )
+                log.info(msg)
 
 
 def remove_child_queries(query):

--- a/learning_resources_search/utils.py
+++ b/learning_resources_search/utils.py
@@ -51,13 +51,13 @@ def realign_channel_subscriptions():
                         dup.users.remove(user)
                         dup.save()
                         actual_query.users.add(user)
+                    msg = (
+                        f"removing duplicate percolate query ({dup.id}) "
+                        f"for channel {channel.title}"
+                    )
+                    log.info(msg)
                     dup.delete()
                 actual_query.save()
-                msg = (
-                    f"removing duplicate percolate query ({q.id}) "
-                    f"for channel {channel.title}"
-                )
-                log.info(msg)
 
 
 def remove_child_queries(query):

--- a/learning_resources_search/utils.py
+++ b/learning_resources_search/utils.py
@@ -22,7 +22,8 @@ def prune_channel_subscriptions():
 
     for channel in Channel.objects.all():
         query_string = channel.search_filter
-
+        if not query_string:
+            continue
         percolate_serializer = PercolateQuerySubscriptionRequestSerializer(
             data=urllib.parse.parse_qs(query_string)
         )
@@ -46,6 +47,7 @@ def prune_channel_subscriptions():
             for dup in duplicates:
                 if (
                     dup.source_type == actual_query.source_type
+                    and dup.source_channel() == channel
                     and dup.original_query != actual_query.original_query
                 ):
                     for user in dup.users.all():

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -13,14 +13,14 @@ from learning_resources_search.utils import prune_channel_subscriptions
 from main.factories import UserFactory
 
 
-@pytest.fixture
+@pytest.fixture()
 def mocked_api(mocker):
     """Mock object that patches the channels API"""
     return mocker.patch("learning_resources_search.tasks.api")
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db
+@pytest.mark.django_db()
 def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated
@@ -66,7 +66,7 @@ def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db
+@pytest.mark.django_db()
 def test_new_channel_percolate_query_is_created(mocked_api, mocker, client, user):
     """
     Test that running the prune command generates percolate current query instances for channels
@@ -100,3 +100,40 @@ def test_new_channel_percolate_query_is_created(mocked_api, mocker, client, user
         ).count()
         == 2
     )
+
+
+@factory.django.mute_signals(signals.post_delete, signals.post_save)
+@pytest.mark.django_db()
+def test_prune_subscription_on_empty_channel_search_filter(
+    mocked_api, mocker, client, user
+):
+    """
+    Test that running the prune command generates percolate current query instances for channels
+    that dont already have them or are out of date
+    """
+    assert (
+        PercolateQuery.objects.filter(
+            source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
+        ).count()
+        == 0
+    )
+    query_string = "offered_by=mitx"
+    ChannelFactory.create(search_filter="")
+    ChannelFactory.create(search_filter=query_string)
+    client.force_login(user)
+    params = urllib.parse.parse_qs(query_string)
+    params["source_type"] = PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE
+    sub_url = reverse("lr_search:v1:learning_resources_user_subscription-subscribe")
+    client.post(sub_url, json.dumps(params), content_type="application/json")
+    params = urllib.parse.parse_qs("")
+    params["source_type"] = PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE
+    sub_url = reverse("lr_search:v1:learning_resources_user_subscription-subscribe")
+    client.post(sub_url, json.dumps(params), content_type="application/json")
+    prune_channel_subscriptions()
+    assert (
+        PercolateQuery.objects.filter(
+            source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
+        ).count()
+        == 2
+    )
+    assert user.percolate_queries.count() == 2

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -13,14 +13,14 @@ from learning_resources_search.utils import prune_channel_subscriptions
 from main.factories import UserFactory
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_api(mocker):
     """Mock object that patches the channels API"""
     return mocker.patch("learning_resources_search.tasks.api")
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated
@@ -66,7 +66,7 @@ def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_new_channel_percolate_query_is_created(mocked_api, mocker, client, user):
     """
     Test that running the prune command generates percolate current query instances for channels
@@ -103,7 +103,7 @@ def test_new_channel_percolate_query_is_created(mocked_api, mocker, client, user
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_prune_subscription_on_empty_channel_search_filter(
     mocked_api, mocker, client, user
 ):

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -13,14 +13,14 @@ from learning_resources_search.utils import prune_channel_subscriptions
 from main.factories import UserFactory
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_api(mocker):
     """Mock object that patches the channels API"""
     return mocker.patch("learning_resources_search.tasks.api")
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -1,0 +1,40 @@
+import urllib
+
+import pytest
+
+from channels.factories import ChannelFactory
+from learning_resources_search.api import adjust_original_query_for_percolate
+from learning_resources_search.factories import PercolateQueryFactory
+from learning_resources_search.models import PercolateQuery
+from learning_resources_search.serializers import (
+    PercolateQuerySubscriptionRequestSerializer,
+)
+
+
+@pytest.fixture()
+def mocked_api(mocker):
+    """Mock object that patches the channels API"""
+    return mocker.patch("learning_resources_search.tasks.api")
+
+
+@pytest.mark.django_db()
+def test_realign_channel_subscriptions(mocked_api, mocker):
+    channel = ChannelFactory.create(search_filter="offered_by=mitx")
+    query_string = channel.search_filter
+    percolate_serializer = PercolateQuerySubscriptionRequestSerializer(
+        data=urllib.parse.parse_qs(query_string)
+    )
+    percolate_serializer.is_valid()
+    adjusted_original_query = adjust_original_query_for_percolate(
+        percolate_serializer.get_search_request_data()
+    )
+    duplicate_query = adjusted_original_query.copy()
+    duplicate_query["yearly_decay_percent"] = None
+    PercolateQueryFactory.create(
+        source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
+        original_query=adjusted_original_query,
+    )
+    PercolateQueryFactory.create(
+        source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
+        original_query=duplicate_query,
+    )

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -13,14 +13,14 @@ from learning_resources_search.utils import prune_channel_subscriptions
 from main.factories import UserFactory
 
 
-@pytest.fixture()
+@pytest.fixture
 def mocked_api(mocker):
     """Mock object that patches the channels API"""
     return mocker.patch("learning_resources_search.tasks.api")
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated
@@ -66,7 +66,7 @@ def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
 
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_new_channel_percolate_query_is_created(mocked_api, mocker, client, user):
     """
     Test that running the prune command generates percolate current query instances for channels

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from channels.factories import ChannelFactory
 from learning_resources_search.factories import PercolateQueryFactory
 from learning_resources_search.models import PercolateQuery
-from learning_resources_search.utils import realign_channel_subscriptions
+from learning_resources_search.utils import prune_channel_subscriptions
 from main.factories import UserFactory
 
 
@@ -21,7 +21,7 @@ def mocked_api(mocker):
 
 @factory.django.mute_signals(signals.post_delete, signals.post_save)
 @pytest.mark.django_db()
-def test_realign_channel_subscriptions(mocked_api, mocker, client, user):
+def test_prune_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated
     and the users are migrated to the real instance
@@ -57,7 +57,7 @@ def test_realign_channel_subscriptions(mocked_api, mocker, client, user):
     duplicate_percolate_a.save()
     duplicate_percolate_b.save()
     duplicate_percolate_b.users.set(UserFactory.create_batch(3))
-    realign_channel_subscriptions()
+    prune_channel_subscriptions()
     channel_percolate_queries = PercolateQuery.objects.filter(
         source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
         original_query=percolate_query.original_query,

--- a/learning_resources_search/utils_test.py
+++ b/learning_resources_search/utils_test.py
@@ -1,14 +1,14 @@
+import json
 import urllib
 
+import factory
 import pytest
+from django.db.models import signals
+from django.urls import reverse
 
 from channels.factories import ChannelFactory
-from learning_resources_search.api import adjust_original_query_for_percolate
 from learning_resources_search.factories import PercolateQueryFactory
 from learning_resources_search.models import PercolateQuery
-from learning_resources_search.serializers import (
-    PercolateQuerySubscriptionRequestSerializer,
-)
 from learning_resources_search.utils import realign_channel_subscriptions
 from main.factories import UserFactory
 
@@ -19,44 +19,48 @@ def mocked_api(mocker):
     return mocker.patch("learning_resources_search.tasks.api")
 
 
+@factory.django.mute_signals(signals.post_delete, signals.post_save)
 @pytest.mark.django_db()
-def test_realign_channel_subscriptions(mocked_api, mocker):
+def test_realign_channel_subscriptions(mocked_api, mocker, client, user):
     """
     Test that duplicate percolate queries for a channel are consolidated
     and the users are migrated to the real instance
     """
     channel = ChannelFactory.create(search_filter="offered_by=mitx")
     query_string = channel.search_filter
-    percolate_serializer = PercolateQuerySubscriptionRequestSerializer(
-        data=urllib.parse.parse_qs(query_string)
-    )
-    percolate_serializer.is_valid()
-    adjusted_original_query = adjust_original_query_for_percolate(
-        percolate_serializer.get_search_request_data()
-    )
-    duplicate_query_a = adjusted_original_query.copy()
+
+    client.force_login(user)
+    params = urllib.parse.parse_qs(query_string)
+    params["source_type"] = PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE
+    sub_url = reverse("lr_search:v1:learning_resources_user_subscription-subscribe")
+    assert user.percolate_queries.count() == 0
+    client.post(sub_url, json.dumps(params), content_type="application/json")
+    assert user.percolate_queries.count() == 1
+
+    percolate_query = user.percolate_queries.first()
+
+    duplicate_query_a = percolate_query.original_query.copy()
     duplicate_query_a["yearly_decay_percent"] = None
-    duplicate_query_b = adjusted_original_query.copy()
+    duplicate_query_b = percolate_query.original_query.copy()
     duplicate_query_b["foo"] = None
-    percolate_query = PercolateQueryFactory.create(
-        source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
-        original_query=adjusted_original_query,
-    )
     duplicate_percolate_a = PercolateQueryFactory.create(
         source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
         original_query=duplicate_query_a,
     )
+
     duplicate_percolate_b = PercolateQueryFactory.create(
         source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
         original_query=duplicate_query_b,
     )
-    percolate_query.users.set(UserFactory.create_batch(2))
+
     duplicate_percolate_a.users.set(UserFactory.create_batch(7))
+    duplicate_percolate_a.save()
+    duplicate_percolate_b.save()
     duplicate_percolate_b.users.set(UserFactory.create_batch(3))
     realign_channel_subscriptions()
     channel_percolate_queries = PercolateQuery.objects.filter(
         source_type=PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE,
-        original_query=adjusted_original_query,
+        original_query=percolate_query.original_query,
     )
     assert channel_percolate_queries.count() == 1
-    assert channel_percolate_queries.first().users.count() == 12
+    assert channel_percolate_queries.first().users.count() == 11

--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -17,5 +17,8 @@ python $MANAGE_FILE showmigrations --list 2>&1 | indent
 python $MANAGE_FILE migrate --noinput 2>&1 | indent
 RUN_DATA_MIGRATIONS=true python $MANAGE_FILE migrate --noinput 2>&1 | indent
 
+# consolidate user subscriptions and remove duplicate percolate instances
+python $MANAGE_FILE align_subscription_queries 2>&1 | indent
+
 echo "-----> Generating cache tables"
 python $MANAGE_FILE createcachetable 2>&1 | indent

--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -18,7 +18,7 @@ python $MANAGE_FILE migrate --noinput 2>&1 | indent
 RUN_DATA_MIGRATIONS=true python $MANAGE_FILE migrate --noinput 2>&1 | indent
 
 # consolidate user subscriptions and remove duplicate percolate instances
-python $MANAGE_FILE align_subscription_queries 2>&1 | indent
+python $MANAGE_FILE prune_subscription_queries 2>&1 | indent
 
 echo "-----> Generating cache tables"
 python $MANAGE_FILE createcachetable 2>&1 | indent

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -11,6 +11,6 @@ echo "Loading fixtures!"
 python3 manage.py loaddata platforms schools departments offered_by
 
 # consolidate user subscriptions and remove duplicate percolate instances
-python $MANAGE_FILE align_subscription_queries 2>&1 | indent
+python $MANAGE_FILE prune_subscription_queries 2>&1 | indent
 
 uwsgi uwsgi.ini --honour-stdin

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -10,4 +10,7 @@ RUN_DATA_MIGRATIONS=true python3 manage.py migrate --noinput
 echo "Loading fixtures!"
 python3 manage.py loaddata platforms schools departments offered_by
 
+# consolidate user subscriptions and remove duplicate percolate instances
+python $MANAGE_FILE align_subscription_queries 2>&1 | indent
+
 uwsgi uwsgi.ini --honour-stdin


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/mitodl/hq/issues/5262
<!--- N/A --->

### Description (What does it do?)
This PR Introduces a management command (runs on deploy) to resolve an issue with multiple instances of a channel subscription being created whenever a a new parameter makes its way into the original subscription query. 

### How can this be tested?
To test this, we can first repro the issue locally and then run the management command and see that the duplicate queries are removed and that the users are re-assigned to the correct one.
1. checkout this branch.
2. ensure you have everything populated (channels, learning resources)
3. login and subscribe to all the unit channel pages
4. visit your dashboard and see the units show up under [settings](http://open.odl.local:8062/dashboard/settings/)
5. create some duplicate channel subscription percolate queries that resolve to the same channel (make sure the user in the script is the user you login with and ensure the "offered_by" param in the script is set to whatever channels you have subscribed to:
```
from learning_resources_search.models import PercolateQuery
from django.forms import model_to_dict
from django.contrib.auth.models import User
from learning_resources_search.api import (
    adjust_query_for_percolator,
    execute_learn_search,
    subscribe_user_to_search_query,
    unsubscribe_user_from_percolate_query,
)

me = User.objects.first()

pq = PercolateQuery.objects.filter(original_query__contains={'offered_by': ['ocw']}).first()
duplicate_dict = {
'original_query': pq.original_query,
'query':adjust_query_for_percolator( pq.original_query)
}
duplicate_dict['source_type'] = PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE
duplicate_dict['original_query']['bar'] = None
duplicate_dict['original_query']['baz'] = None
pq = PercolateQuery.objects.create(**duplicate_dict)
pq.users.add(me)
pq.save()


pq = PercolateQuery.objects.filter(original_query__contains={'offered_by': ['mitpe']}).first()
duplicate_dict = {
'original_query': pq.original_query,
'query':adjust_query_for_percolator( pq.original_query)
}
duplicate_dict['source_type'] = PercolateQuery.CHANNEL_SUBSCRIPTION_TYPE

duplicate_dict['original_query']['foo'] = None
duplicate_dict['original_query']['bar'] = None
pq = PercolateQuery.objects.create(**duplicate_dict)
pq.users.add(me)
pq.save()
```
6. visit the settings page again and note that there are multiple instances of unit subscriptions.
7. run the management command to clean them up ```python manage.py prune_subscription_queries```
8. verify that the dups have gone away
9. go back to the channel page and verify that it still shows up as following


