### PR TITLE
Add caching for imagekit

### DIFF
--- a/main/cache/backends.py
+++ b/main/cache/backends.py
@@ -1,0 +1,46 @@
+from django.core.cache import caches
+from django.core.cache.backends.base import BaseCache
+
+
+class FallbackCache(BaseCache):
+    """
+    Cache backend that supports a list of fallback caches
+
+    This cache backend sets the value in all caches and reads from caches in order
+    until it gets a hit. You'll typically want to configure this with a list of
+    caches with increasing durability.
+
+    For example in settings.py:
+
+    CACHES = {
+        "fallback": {
+            "BACKEND": "main.cache.backends.FallbackCache",
+            "LOCATION": ["in-memory", "redis", "database"],
+        },
+        ...
+    }
+    """
+
+    def __init__(self, cache_names, params):
+        super().__init__(params)
+        self._cache_names = cache_names
+
+    def get(self, key, default=None, version=None):
+        """Get the value from the caches in order"""
+        for cache_name in self._cache_names:
+            cache = caches[cache_name]
+            result = cache.get(key, default=default, version=version)
+            if result:
+                return result
+        return None
+
+    def set(self, key, value, timeout=None, version=None):
+        """Set a value in the caches"""
+        for cache_name in self._cache_names:
+            cache = caches[cache_name]
+            cache.set(
+                key,
+                value,
+                timeout=timeout,
+                version=version,
+            )

--- a/main/cache/backends_test.py
+++ b/main/cache/backends_test.py
@@ -1,0 +1,44 @@
+from django.core.cache.backends.base import BaseCache
+
+from main.cache.backends import FallbackCache
+
+
+def test_fallback_cache_get(mocker, settings):
+    """Test that get() on the fallback cache works correctly"""
+    mock_cache_1 = mocker.Mock(spec=BaseCache)
+    mock_cache_1.get.return_value = 12345
+    mock_cache_2 = mocker.Mock(spec=BaseCache)
+    mock_cache_2.get.return_value = 67890
+
+    mocker.patch.dict(
+        "main.cache.backends.caches", {"dummy1": mock_cache_1, "dummy2": mock_cache_2}
+    )
+
+    cache = FallbackCache(["dummy1", "dummy2"], {})
+
+    assert cache.get("key", default="default", version=1) == 12345
+
+    mock_cache_1.get.return_value = None
+
+    assert cache.get("key", default="default", version=1) == 67890
+
+    mock_cache_2.get.return_value = None
+
+    assert cache.get("key", default="default", version=1) is None
+
+
+def test_fallback_cache_set(mocker, settings):
+    """Test that set() on the fallback cache works correctly"""
+    mock_cache_1 = mocker.Mock(spec=BaseCache)
+    mock_cache_2 = mocker.Mock(spec=BaseCache)
+
+    mocker.patch.dict(
+        "main.cache.backends.caches", {"dummy1": mock_cache_1, "dummy2": mock_cache_2}
+    )
+
+    cache = FallbackCache(["dummy1", "dummy2"], {})
+
+    cache.set("key", "value", timeout=600, version=1)
+
+    mock_cache_1.set.assert_called_once_with("key", "value", timeout=600, version=1)
+    mock_cache_2.set.assert_called_once_with("key", "value", timeout=600, version=1)

--- a/main/settings.py
+++ b/main/settings.py
@@ -509,6 +509,7 @@ if MITOL_USE_S3:
 
 IMAGEKIT_SPEC_CACHEFILE_NAMER = "imagekit.cachefiles.namers.source_name_dot_hash"
 IMAGEKIT_CACHEFILE_DIR = get_string("IMAGEKIT_CACHEFILE_DIR", "")
+IMAGEKIT_CACHE_BACKEND = "imagekit"
 
 
 # django cache back-ends
@@ -531,6 +532,24 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": CELERY_BROKER_URL,  # noqa: F405
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    },
+    # imagekit caching
+    "imagekit": {
+        "BACKEND": "main.cache.backends.FallbackCache",
+        "LOCATION": [
+            "imagekit_in_memory",
+            "imagekit_db",
+        ],
+    },
+    "imagekit_in_memory": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "imagekit_in_memory_cache",
+        "TIMEOUT": None,
+    },
+    "imagekit_db": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "imagekit_cache",
+        "TIMEOUT": None,
     },
 }
 

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -4,6 +4,7 @@
 
 python3 manage.py collectstatic --noinput --clear
 python3 manage.py migrate --noinput
+python3 manage.py createcachetable
 RUN_DATA_MIGRATIONS=true python3 manage.py migrate --noinput
 
 # load required fixtures on development by default


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes  https://github.com/mitodl/hq/issues/4885

### Description (What does it do?)
<!--- Describe your changes in detail -->
This PR adds caching for imagekit. This should make it so we aren't making a ton of requests out to S3 just to render a URL. See my comment [here](https://github.com/mitodl/hq/issues/4885#issuecomment-2313336304) for specifics on why this approach is being used.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- You don't need to have S3 configured to test this as we're testing the caching itself.
- Run `docker compose up` and hit the testimonials API at http://api.open.odl.local:8063/api/v0/testimonials/. This might be slow the first time. 
- Run `docker compose run --rm web bash`, then `./manage.py dbshell`.
- In the sql prompt, enter the query `SELECT * FROM imagekit_cache;` and you should see a bunch of records related to testimonials images.
- If you don't have S3 configured for your images then you won't see a performance difference, but that's ok.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
I added an implementation for a `FallbackCache`, this is in support of having both an in-memory cache and a database cache for imagekit data. The in-memory cache isn't perfect and we may investigate  a better implementation of in-memory caching if needed, but it's good enough for now.