### PR TITLE
Switched imagekit caching from in-memory to redis

### DIFF
--- a/main/cache/backends_test.py
+++ b/main/cache/backends_test.py
@@ -1,44 +1,87 @@
-from django.core.cache.backends.base import BaseCache
+from dataclasses import dataclass
+
+import pytest
+from django.core.cache.backends.base import DEFAULT_TIMEOUT, BaseCache
 
 from main.cache.backends import FallbackCache
 
 
-def test_fallback_cache_get(mocker, settings):
+@dataclass
+class MockCaches:
+    caches: list[BaseCache]
+    cache_names: list[str]
+    caches_by_name: dict[str, BaseCache]
+    cache_results: list[str]
+
+
+@pytest.fixture(autouse=True)
+def mock_caches(mocker):
+    """Define mock caches"""
+    cache_names = []
+    caches = []
+    caches_by_name = {}
+    cache_results = []
+
+    for idx in range(3):
+        name = f"dummy-{idx}"
+        result = f"result-{idx}"
+        mock_cache = mocker.Mock(spec=BaseCache)
+        mock_cache.get.return_value = result
+
+        cache_names.append(name)
+        caches.append(mock_cache)
+        caches_by_name[name] = mock_cache
+        cache_results.append(result)
+
+    mocker.patch.dict("main.cache.backends.caches", caches_by_name)
+
+    return MockCaches(caches, cache_names, caches_by_name, cache_results)
+
+
+@pytest.mark.parametrize("cache_hit_idx", range(4))
+def test_fallback_cache_get(mock_caches: MockCaches, settings, cache_hit_idx):
     """Test that get() on the fallback cache works correctly"""
-    mock_cache_1 = mocker.Mock(spec=BaseCache)
-    mock_cache_1.get.return_value = 12345
-    mock_cache_2 = mocker.Mock(spec=BaseCache)
-    mock_cache_2.get.return_value = 67890
 
-    mocker.patch.dict(
-        "main.cache.backends.caches", {"dummy1": mock_cache_1, "dummy2": mock_cache_2}
+    cache = FallbackCache(mock_caches.cache_names, {})
+
+    cold_caches = mock_caches.caches[:cache_hit_idx]
+
+    for mock_cache in cold_caches:
+        mock_cache.get.return_value = None
+
+    caches_exhausted = cache_hit_idx >= len(mock_caches.caches)
+    expected_value = (
+        "default" if caches_exhausted else mock_caches.cache_results[cache_hit_idx]
     )
 
-    cache = FallbackCache(["dummy1", "dummy2"], {})
+    assert cache.get("key", default="default", version=1) == expected_value
 
-    assert cache.get("key", default="default", version=1) == 12345
-
-    mock_cache_1.get.return_value = None
-
-    assert cache.get("key", default="default", version=1) == 67890
-
-    mock_cache_2.get.return_value = None
-
-    assert cache.get("key", default="default", version=1) is None
+    if not caches_exhausted:
+        for mock_cache in cold_caches:
+            mock_cache.set.assert_called_once_with(
+                "key", expected_value, timeout=cache.get_backend_timeout(), version=1
+            )
 
 
-def test_fallback_cache_set(mocker, settings):
+@pytest.mark.parametrize("cache_timeout", [DEFAULT_TIMEOUT, None, 0, 1000])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"timeout": 600},
+        {"version": 1},
+        {"timeout": 600, "version": 1},
+    ],
+)
+def test_fallback_cache_set(mock_caches, settings, cache_timeout, kwargs):
     """Test that set() on the fallback cache works correctly"""
-    mock_cache_1 = mocker.Mock(spec=BaseCache)
-    mock_cache_2 = mocker.Mock(spec=BaseCache)
+    cache = FallbackCache(mock_caches.cache_names, {"TIMEOUT": cache_timeout})
+    cache.set("key", "value", **kwargs)
 
-    mocker.patch.dict(
-        "main.cache.backends.caches", {"dummy1": mock_cache_1, "dummy2": mock_cache_2}
-    )
+    expected_timeout = kwargs.get("timeout", cache_timeout)
+    expected_version = kwargs.get("version", None)
 
-    cache = FallbackCache(["dummy1", "dummy2"], {})
-
-    cache.set("key", "value", timeout=600, version=1)
-
-    mock_cache_1.set.assert_called_once_with("key", "value", timeout=600, version=1)
-    mock_cache_2.set.assert_called_once_with("key", "value", timeout=600, version=1)
+    for mock_cache in mock_caches.caches:
+        mock_cache.set.assert_called_once_with(
+            "key", "value", timeout=expected_timeout, version=expected_version
+        )

--- a/main/settings.py
+++ b/main/settings.py
@@ -537,8 +537,20 @@ CACHES = {
     "imagekit": {
         "BACKEND": "main.cache.backends.FallbackCache",
         "LOCATION": [
+            "imagekit_redis",
             "imagekit_db",
         ],
+    },
+    # This uses FallbackCache but it's basically a proxy to the redis cache
+    # so that we can reuse the client and not create another pile of connections.
+    # The main purpose of this is to set TIMEOUT without specifying it on
+    # the global redis cache.
+    "imagekit_redis": {
+        "BACKEND": "main.cache.backends.FallbackCache",
+        "LOCATION": [
+            "redis",
+        ],
+        "TIMEOUT": 60 * 60,
     },
     "imagekit_db": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A, follow up to https://github.com/mitodl/mit-open/pull/1472

### Description (What does it do?)
<!--- Describe your changes in detail -->
This switches the in-memory cache for imagekit over to a redis cache since the in-memory cache seems to negatively impact performance when things expire / when the server first starts.

It also adds support for the `TIMEOUT` setting to `FallbackCache` since I needed that to have these values have a finite TTL in redis. This required a bit of a rework of how `get()` works - it calls `set()` on the caches that were missed. This seemed counterintuitive because typically in a cache you'd call `get()` and it'd have no side effects, however, we need to populate those caches when we have partial misses. If all caches miss then most likely the code calling `get()` will compute the value and then call `set()`, but if `get()` returns a value, `set()` is typically never called because we just got the value from that cache.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- Go to http://api.open.odl.local:8063/api/v0/testimonials/?format=json, verify you get a response with image urls.
- To verify the data has been cached in redis, run: 
```bash
docker compose exec redis redis-cli -n 4 KEYS ":1:imagekit:*"
```
