### PR TITLE
Remove the in-memory cache for imagekit

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -537,14 +537,8 @@ CACHES = {
     "imagekit": {
         "BACKEND": "main.cache.backends.FallbackCache",
         "LOCATION": [
-            "imagekit_in_memory",
             "imagekit_db",
         ],
-    },
-    "imagekit_in_memory": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "imagekit_in_memory_cache",
-        "TIMEOUT": None,
     },
     "imagekit_db": {
         "BACKEND": "django.core.cache.backends.db.DatabaseCache",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This removes the in-memory cache for imagekit, which is causing some performance issues. I will be following this up with another PR to add in redis caching, but this is currently holding up releases so this PR simply removes the troublesome caching.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to hit the testimonials API without issue: api.open.odl.local:8063/api/v0/testimonials/?format=json