### PR TITLE
Remove Pathways (Coming Soon)

### DIFF
--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -13,7 +13,6 @@ import {
   RiSearch2Line,
   RiPencilRulerLine,
   RiStackLine,
-  RiSignpostLine,
   RiBookMarkedLine,
   RiPresentationLine,
   RiNodeTree,
@@ -188,12 +187,6 @@ const navData: NavData = {
           description:
             "A series of courses for in-depth learning across a range of topics",
           href: SEARCH_PROGRAM,
-        },
-        {
-          title: "Pathways",
-          icon: <RiSignpostLine />,
-          description:
-            "Achieve your learning goals with a curated collection of courses",
         },
         {
           title: "Learning Materials",

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.stories.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.stories.tsx
@@ -24,13 +24,6 @@ const NavDrawerDemo = () => {
             title: "Link but no description",
             href: "https://ocw.mit.edu",
           },
-          {
-            title: "Description, but no link",
-            description: "This item has a description, but no link",
-          },
-          {
-            title: "Title only",
-          },
         ],
       },
     ],

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.test.tsx
@@ -25,13 +25,6 @@ describe("NavDrawer", () => {
               title: "Link but no description",
               href: "https://ocw.mit.edu",
             },
-            {
-              title: "Description, but no link",
-              description: "This item has a description, but no link",
-            },
-            {
-              title: "Title only",
-            },
           ],
         },
       ],
@@ -45,14 +38,7 @@ describe("NavDrawer", () => {
     const descriptions = screen.getAllByTestId("nav-link-description")
     expect(links).toHaveLength(3)
     expect(icons).toHaveLength(1)
-    expect(titles).toHaveLength(5)
-    expect(descriptions).toHaveLength(3)
-    let linksComingSoon = 0
-    Array.prototype.forEach.call(titles, (title) => {
-      if (title.textContent?.includes("(Coming Soon)")) {
-        linksComingSoon++
-      }
-    })
-    expect(linksComingSoon === 2).toBeTruthy()
+    expect(titles).toHaveLength(3)
+    expect(descriptions).toHaveLength(2)
   })
 })

--- a/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
+++ b/frontends/ol-components/src/components/NavDrawer/NavDrawer.tsx
@@ -108,7 +108,7 @@ export interface NavItem {
   title: string
   icon?: string | ReactElement
   description?: string
-  href?: string
+  href: string
 }
 
 const NavItem: React.FC<NavItem> = (props) => {
@@ -127,7 +127,7 @@ const NavItem: React.FC<NavItem> = (props) => {
       </NavIconContainer>
       <NavTextContainer>
         <NavLinkText className="nav-link-text" data-testid="nav-link-text">
-          {title} {href ? "" : "(Coming Soon)"}
+          {title}
         </NavLinkText>
         {description ? (
           <NavLinkDescription data-testid="nav-link-description">
@@ -137,12 +137,10 @@ const NavItem: React.FC<NavItem> = (props) => {
       </NavTextContainer>
     </NavItemContainer>
   )
-  return href ? (
+  return (
     <NavItemLink href={href} data-testid="nav-link">
       {navItem}
     </NavItemLink>
-  ) : (
-    navItem
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Request https://mitodl.slack.com/archives/C03K5HYGPT9/p1724946425030809

### Description (What does it do?)
Removes the Pathways (Coming Soon) nav item.

### Screenshots (if appropriate):
<img width="1442" alt="Screenshot 2024-08-29 at 11 56 30 AM" src="https://github.com/user-attachments/assets/c5865d95-bf7d-4213-acba-e01244be8f37">


### How can this be tested?
Nav drawer should function and look same as RC / Prod except for the removed item.