### PR TITLE
homepage search revisions

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -63,7 +63,7 @@ const SEARCH_CHIPS: SearchChip[] = [
   {
     label: "Explore All",
     href: "/search/",
-    variant: "gray",
+    variant: "outlined",
     icon: <RiSearch2Line />,
   },
 ]
@@ -141,7 +141,7 @@ const TopicLink = styled(Link)({
   textDecoration: "underline",
 })
 
-const StyledChipLink = styled(ChipLink)(({ theme, variant }) => [
+const TrendingChip = styled(ChipLink)(({ theme, variant }) => [
   {
     height: "32px",
     padding: "8px 16px",
@@ -149,9 +149,23 @@ const StyledChipLink = styled(ChipLink)(({ theme, variant }) => [
       marginRight: "4px",
     },
   },
-  variant === "outlinedWhite" ?? {
+  variant === "outlinedWhite" && {
     borderColor: theme.custom.colors.lightGray2,
     color: theme.custom.colors.silverGrayDark,
+    "&:hover": {
+      backgroundColor: `${theme.custom.colors.lightGray1} !important`,
+      borderColor: `${theme.custom.colors.silverGrayLight} !important`,
+      color: theme.custom.colors.darkGray2,
+    },
+  },
+  variant === "outlined" && {
+    backgroundColor: theme.custom.colors.lightGray2,
+    color: theme.custom.colors.darkGray2,
+    borderColor: theme.custom.colors.lightGray2,
+    "&:hover": {
+      backgroundColor: `${theme.custom.colors.lightGray2} !important`,
+      borderColor: theme.custom.colors.silverGray,
+    },
   },
 ])
 
@@ -226,7 +240,7 @@ const HeroSearch: React.FC = () => {
             </BrowseByTopicContainer>
             <TrendingContainer>
               {SEARCH_CHIPS.map((chip) => (
-                <StyledChipLink
+                <TrendingChip
                   key={chip.label}
                   variant={chip.variant}
                   size="medium"

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -13,8 +13,8 @@ import {
 } from "@/common/urls"
 import { NON_DEGREE_LEARNING_FRAGMENT_IDENTIFIER } from "../AboutPage/AboutPage"
 import {
-  RiAddBoxLine,
   RiAwardLine,
+  RiFileAddLine,
   RiSearch2Line,
   RiThumbUpLine,
   RiTimeLine,
@@ -34,7 +34,7 @@ const SEARCH_CHIPS: SearchChip[] = [
     label: "Recently Added",
     href: SEARCH_NEW,
     variant: "outlinedWhite",
-    icon: <RiTimeLine />,
+    icon: <RiFileAddLine />,
   },
   {
     label: "Popular",
@@ -46,7 +46,7 @@ const SEARCH_CHIPS: SearchChip[] = [
     label: "Upcoming",
     href: SEARCH_UPCOMING,
     variant: "outlinedWhite",
-    icon: <RiAddBoxLine />,
+    icon: <RiTimeLine />,
   },
   {
     label: "Free",

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -142,6 +142,13 @@ const TopicLink = styled(Link)({
 })
 
 const StyledChipLink = styled(ChipLink)(({ theme, variant }) => [
+  {
+    height: "32px",
+    padding: "8px 16px",
+    ".MuiChip-icon": {
+      marginRight: "4px",
+    },
+  },
   variant === "outlinedWhite" ?? {
     borderColor: theme.custom.colors.lightGray2,
     color: theme.custom.colors.silverGrayDark,

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -33,6 +33,15 @@ const StyledAdornmentButton = styled(AdornmentButton)(({ theme }) => ({
   },
 }))
 
+const StyledClearButton = styled(StyledAdornmentButton)({
+  ".MuiInputBase-sizeHero &": {
+    width: "32px",
+    ["&:hover"]: {
+      backgroundColor: "transparent",
+    },
+  },
+})
+
 export interface SearchSubmissionEvent {
   target: {
     value: string
@@ -95,13 +104,13 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
       endAdornment={
         <>
           {props.value && (
-            <StyledAdornmentButton
+            <StyledClearButton
               className={props.classNameClear}
               aria-label="Clear search text"
               onClick={props.onClear}
             >
               <RiCloseLine />
-            </StyledAdornmentButton>
+            </StyledClearButton>
           )}
           <StyledAdornmentButton
             aria-label="Search"

--- a/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/SearchInput.tsx
@@ -5,7 +5,7 @@ import type { InputProps } from "ol-components"
 
 const StyledInput = styled(Input)(({ theme }) => ({
   height: "72px",
-  borderRadius: "6px",
+  boxShadow: "0px 8px 20px 0px rgba(120, 147, 172, 0.10)",
   "&.MuiInputBase-adornedEnd": {
     paddingRight: "0 !important",
   },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5298

### Description (What does it do?)
This PR addresses some changes to the homepage hero / search area that were not addressed as part of https://github.com/mitodl/mit-open/pull/1454.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7f133347-0d3f-42c9-aa6c-05bda3d49685)
![image](https://github.com/user-attachments/assets/3750a188-2bc9-4313-8a9b-e5f23d62a82f)

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Visit the homepage at http://localhost:8062/
 - Verify that the changes from the issue have been addressed:
   - If you type something in the search box, the x button to clear your search should be narrower, but still the whole height of the text box with no hover state
   - The sizing of the search chips below the text box should be properly sized now, have the correct border / background colors and hover states and the correct icons
   - There should now be a drop shadow on the text box