### PR TITLE
fix codespace backend

### DIFF
--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -10,7 +10,6 @@ services:
     extends:
       file: docker-compose.yml
       service: redis
-    env_file: env/codespaces.env
   web:
     profiles:
       - backend

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -20,6 +20,8 @@ services:
     mem_limit: 1gb
     cpus: 2
     env_file: env/codespaces.env
+    environment:
+      PORT: 8061
     command: ./scripts/run-django-dev.sh
     stdin_open: true
     tty: true

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -82,7 +82,9 @@ services:
     extends:
       file: docker-compose.yml
       service: nginx
-    env_file: env/codespaces.env
+    environment:
+      PORT: 8063
+      NGINX_UWSGI_PASS: "web:8061"
 
 volumes:
   opensearch-data1:

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -72,7 +72,6 @@ services:
     extends:
       file: docker-compose.yml
       service: tika
-    env_file: env/codespaces.env
   opensearch-node-mitopen:
     extends:
       file: docker-compose.yml
@@ -82,9 +81,6 @@ services:
     extends:
       file: docker-compose.yml
       service: nginx
-    environment:
-      PORT: 8063
-      NGINX_UWSGI_PASS: "web:8061"
 
 volumes:
   opensearch-data1:


### PR DESCRIPTION
### Description (What does it do?)
Small fix to port mapping for the codespace backend (django server)

### How can this be tested?
Detailed instructions on launching a codespace can be found in [this PR](https://github.com/mitodl/mit-open/pull/1444)
 For this PR:
1. launch a codespace on this branch
2. wait until codespace is fully initialized
3. visit "/admin/" on the service that runs on port 8063 and confirm it works

