### PR TITLE
fix random hero image

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -186,6 +186,15 @@ const getRandomHeroImage = () => {
   return `/static/images/hero/hero-${imageNumber}.png`
 }
 
+const HeroImage: React.FC = () => {
+  const [heroImage, _] = useState(getRandomHeroImage)
+  return (
+    <ImageContainer>
+      <img alt="" src={heroImage} />
+    </ImageContainer>
+  )
+}
+
 const HeroSearch: React.FC = () => {
   const [searchText, setSearchText] = useState("")
   const onSearchClear = useCallback(() => setSearchText(""), [])
@@ -255,7 +264,7 @@ const HeroSearch: React.FC = () => {
         </ControlsContainer>
       </TitleAndControls>
       <ImageContainer>
-        <img alt="" src={getRandomHeroImage()} />
+        <HeroImage />
       </ImageContainer>
     </HeroWrapper>
   )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5348

### Description (What does it do?)
This PR fixes some odd behavior where the home page hero image re-renders and chooses a new random image each time you type a character in the search box. The `src` property of the image was calling the random function directly, which causes the React re-rendering to choose a new one every time. The randomized image is now stored in a state variable so that doesn't happen.

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Go to the homepage at http://localhost:8062/
 - Click on the search box and start typing
 - Keep doing this for a while and ensure that the hero image does not change