### PR TITLE
Cache unit page counts

### DIFF
--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -175,14 +175,23 @@ class ChannelCountsSerializer(serializers.ModelSerializer):
             resources = instance.department_detail.department.learningresource_set.all()
         elif instance.channel_type == "topic":
             resources = instance.topic_detail.topic.learningresource_set.all()
-
         course_count = resources.filter(course__isnull=False, published=True).count()
         program_count = resources.filter(program__isnull=False, published=True).count()
         return {"courses": course_count, "programs": program_count}
 
     class Meta:
         model = Channel
-        exclude = ["published"]
+        exclude = [
+            "avatar",
+            "published",
+            "banner",
+            "about",
+            "configuration",
+            "public_description",
+            "ga_tracking_id",
+            "featured_list",
+            "widget_list",
+        ]
 
 
 class ChannelTopicDetailSerializer(serializers.ModelSerializer):

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -161,6 +161,10 @@ class ChannelBaseSerializer(ChannelAppearanceMixin, serializers.ModelSerializer)
 
 
 class ChannelCountsSerializer(serializers.ModelSerializer):
+    """
+    Serializer for resource counts associated with Channel
+    """
+
     counts = serializers.SerializerMethodField(read_only=True)
     channel_url = serializers.SerializerMethodField(read_only=True)
 

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -5,7 +5,7 @@ import logging
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
-from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.utils import extend_schema_field, inline_serializer
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -168,6 +168,15 @@ class ChannelCountsSerializer(serializers.ModelSerializer):
         """Get the URL for the channel"""
         return instance.channel_url
 
+    @extend_schema_field(
+        inline_serializer(
+            name="Counts",
+            fields={
+                "courses": serializers.IntegerField(),
+                "programs": serializers.IntegerField(),
+            },
+        )
+    )
     def get_counts(self, instance):
         if instance.channel_type == "unit":
             resources = instance.unit_detail.unit.learningresource_set.all()

--- a/channels/serializers.py
+++ b/channels/serializers.py
@@ -161,24 +161,8 @@ class ChannelBaseSerializer(ChannelAppearanceMixin, serializers.ModelSerializer)
 
 
 class ChannelCountsSerializer(serializers.ModelSerializer):
-    lists = serializers.SerializerMethodField()
     counts = serializers.SerializerMethodField(read_only=True)
     channel_url = serializers.SerializerMethodField(read_only=True)
-    featured_list = LearningPathPreviewSerializer(
-        allow_null=True,
-        many=False,
-        read_only=True,
-        help_text="Learning path featured in this channel.",
-    )
-    sub_channels = SubChannelSerializer(many=True, read_only=True)
-
-    @extend_schema_field(LearningPathPreviewSerializer(many=True))
-    def get_lists(self, instance):
-        """Return the channel's list of LearningPaths"""
-        return [
-            LearningPathPreviewSerializer(channel_list.channel_list).data
-            for channel_list in instance.lists.all()
-        ]
 
     def get_channel_url(self, instance) -> str:
         """Get the URL for the channel"""

--- a/channels/urls.py
+++ b/channels/urls.py
@@ -21,8 +21,8 @@ v0_urls = [
         name="channel_by_type_name_api-detail",
     ),
     re_path(
-        r"^channels/counts/(?P<channel_type>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9_\-]+)/$",
-        ChannelCountsView.as_view({"get": "retrieve"}),
+        r"^channels/counts/(?P<channel_type>[A-Za-z0-9_\-]+)/$",
+        ChannelCountsView.as_view({"get": "list"}),
         name="channel_counts_api-detail",
     ),
     re_path(

--- a/channels/urls.py
+++ b/channels/urls.py
@@ -5,6 +5,7 @@ from rest_framework.routers import DefaultRouter
 
 from channels.views import (
     ChannelByTypeNameDetailView,
+    ChannelCountsView,
     ChannelModeratorDetailView,
     ChannelModeratorListView,
     ChannelViewSet,
@@ -18,6 +19,11 @@ v0_urls = [
         r"^channels/type/(?P<channel_type>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9_\-]+)/$",
         ChannelByTypeNameDetailView.as_view({"get": "retrieve"}),
         name="channel_by_type_name_api-detail",
+    ),
+    re_path(
+        r"^channels/counts/(?P<channel_type>[A-Za-z0-9_\-]+)/(?P<name>[A-Za-z0-9_\-]+)/$",
+        ChannelCountsView.as_view({"get": "retrieve"}),
+        name="channel_counts_api-detail",
     ),
     re_path(
         r"^channels/(?P<id>\d+)/moderators/$",

--- a/channels/urls.py
+++ b/channels/urls.py
@@ -23,7 +23,7 @@ v0_urls = [
     re_path(
         r"^channels/counts/(?P<channel_type>[A-Za-z0-9_\-]+)/$",
         ChannelCountsView.as_view({"get": "list"}),
-        name="channel_counts_api-detail",
+        name="channel_counts_api-list",
     ),
     re_path(
         r"^channels/(?P<id>\d+)/moderators/$",

--- a/channels/views.py
+++ b/channels/views.py
@@ -28,7 +28,7 @@ from channels.serializers import (
 from learning_resources.views import DefaultPagination
 from main.constants import VALID_HTTP_METHODS
 from main.permissions import AnonymousAccessReadonlyPermission
-from main.utils import cache_page_for_anonymous_users
+from main.utils import cache_page_for_all_users
 
 log = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ class ChannelCountsView(mixins.ListModelMixin, viewsets.GenericViewSet):
         )
 
     @method_decorator(
-        cache_page_for_anonymous_users(
+        cache_page_for_all_users(
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
         )
     )

--- a/channels/views.py
+++ b/channels/views.py
@@ -17,6 +17,7 @@ from channels.constants import CHANNEL_ROLE_MODERATORS
 from channels.models import Channel, ChannelGroupRole, ChannelList
 from channels.permissions import ChannelModeratorPermissions, HasChannelPermission
 from channels.serializers import (
+    ChannelCountsSerializer,
     ChannelCreateSerializer,
     ChannelModeratorSerializer,
     ChannelSerializer,
@@ -191,3 +192,26 @@ class ChannelModeratorDetailView(APIView):
             Channel.objects.get(id=self.kwargs["id"]), CHANNEL_ROLE_MODERATORS, user
         )
         return Response(status=HTTP_204_NO_CONTENT)
+
+
+@extend_schema_view(
+    retrieve=extend_schema(summary="Channel Detail Lookup by channel type and name"),
+)
+class ChannelCountsView(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """
+    View for retrieving an individual channel by type and name
+    """
+
+    serializer_class = ChannelCountsSerializer
+    permission_classes = (AnonymousAccessReadonlyPermission,)
+
+    def get_object(self):
+        """
+        Return the channel by type and name
+        """
+        return get_object_or_404(
+            Channel,
+            channel_type=self.kwargs["channel_type"],
+            name=self.kwargs["name"],
+            published=True,
+        )

--- a/channels/views.py
+++ b/channels/views.py
@@ -197,7 +197,7 @@ class ChannelModeratorDetailView(APIView):
 @extend_schema_view(
     retrieve=extend_schema(summary="Channel Detail Lookup by channel type and name"),
 )
-class ChannelCountsView(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+class ChannelCountsView(mixins.ListModelMixin, viewsets.GenericViewSet):
     """
     View for retrieving an individual channel by type and name
     """
@@ -205,13 +205,11 @@ class ChannelCountsView(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = ChannelCountsSerializer
     permission_classes = (AnonymousAccessReadonlyPermission,)
 
-    def get_object(self):
+    def get_queryset(self):
         """
         Return the channel by type and name
         """
-        return get_object_or_404(
-            Channel,
+        return Channel.objects.filter(
             channel_type=self.kwargs["channel_type"],
-            name=self.kwargs["name"],
             published=True,
         )

--- a/channels/views.py
+++ b/channels/views.py
@@ -195,7 +195,7 @@ class ChannelModeratorDetailView(APIView):
 
 
 @extend_schema_view(
-    retrieve=extend_schema(summary="Channel Detail Lookup by channel type and name"),
+    list=extend_schema(summary="Channel Detail Lookup by channel type and name"),
 )
 class ChannelCountsView(mixins.ListModelMixin, viewsets.GenericViewSet):
     """

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -481,3 +481,37 @@ def test_channel_counts_view(client):
                 response_count_sum
                 == random_channel.unit_detail.unit.learningresource_set.count()
             )
+
+
+def test_channel_counts_view_is_cached_for_anonymous_users(client):
+    """Test the channel counts view is cached for anonymous users"""
+    channel_count = 5
+    channels = ChannelFactory.create_batch(channel_count, channel_type="unit")
+    url = reverse(
+        "channels:v0:channel_counts_api-list",
+        kwargs={"channel_type": "unit"},
+    )
+    response = client.get(url).json()
+    assert len(response) == channel_count
+    for channel in channels:
+        channel.delete()
+    response = client.get(url).json()
+    assert len(response) == channel_count
+
+
+def test_channel_counts_view_is_cached_for_authenticated_users(client):
+    """Test the channel counts view is cached for authenticated users"""
+    channel_count = 5
+    channel_user = UserFactory.create()
+    client.force_login(channel_user)
+    channels = ChannelFactory.create_batch(channel_count, channel_type="unit")
+    url = reverse(
+        "channels:v0:channel_counts_api-list",
+        kwargs={"channel_type": "unit"},
+    )
+    response = client.get(url).json()
+    assert len(response) == channel_count
+    for channel in channels:
+        channel.delete()
+    response = client.get(url).json()
+    assert len(response) == channel_count

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -1,6 +1,7 @@
 """Tests for channels.views"""
 
 import os
+import random
 from math import ceil
 
 import pytest
@@ -443,3 +444,40 @@ def test_channel_configuration_is_not_editable(client, channel):
     assert response.status_code == 200
     channel.refresh_from_db()
     assert channel.configuration == initial_config
+
+
+def test_channel_counts_view(client):
+    """Test the channel counts view returns counts for resources"""
+    url = reverse(
+        "channels:v0:channel_counts_api-list",
+        kwargs={"channel_type": "unit"},
+    )
+    total_count = 0
+    channels = ChannelFactory.create_batch(5, channel_type="unit")
+    for channel in channels:
+        resource_count = random.randint(1, 10)  # noqa: S311
+        total_count += resource_count
+        channel_unit = channel.unit_detail.unit
+        resources = LearningResourceFactory.create_batch(
+            resource_count,
+            published=True,
+            resource_type="course",
+            create_course=True,
+            create_program=False,
+        )
+        for resource in resources:
+            channel_unit.learningresource_set.add(resource)
+        channel_unit.save()
+    random_channel = random.choice(list(channels))  # noqa: S311
+
+    response = client.get(url)
+    count_response = response.json()
+    assert response.status_code == 200
+    response_count_sum = 0
+    for item in count_response:
+        if item["name"] == random_channel.name:
+            response_count_sum += sum([item["counts"][key] for key in item["counts"]])
+            assert (
+                response_count_sum
+                == random_channel.unit_detail.unit.learningresource_set.count()
+            )

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -200,7 +200,7 @@ export type Channel =
   | ({ channel_type: "unit" } & UnitChannel)
 
 /**
- *
+ * Serializer for resource counts associated with Channel
  * @export
  * @interface ChannelCounts
  */

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -213,10 +213,10 @@ export interface ChannelCounts {
   id: number
   /**
    *
-   * @type {string}
+   * @type {Counts}
    * @memberof ChannelCounts
    */
-  counts: string
+  counts: Counts
   /**
    * Get the URL for the channel
    * @type {string}
@@ -490,6 +490,25 @@ export interface ChannelUnitDetail {
    * @memberof ChannelUnitDetail
    */
   unit: LearningResourceOfferorDetail
+}
+/**
+ *
+ * @export
+ * @interface Counts
+ */
+export interface Counts {
+  /**
+   *
+   * @type {number}
+   * @memberof Counts
+   */
+  courses: number
+  /**
+   *
+   * @type {number}
+   * @memberof Counts
+   */
+  programs: number
 }
 /**
  * * `` - ---- * `Doctorate` - Doctorate * `Master\'s or professional degree` - Master\'s or professional degree * `Bachelor\'s degree` - Bachelor\'s degree * `Associate degree` - Associate degree * `Secondary/high school` - Secondary/high school * `Junior secondary/junior high/middle school` - Junior secondary/junior high/middle school * `No formal education` - No formal education * `Other education` - Other education
@@ -2952,6 +2971,7 @@ export const ChannelsApiAxiosParamCreator = function (
   return {
     /**
      * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
      * @param {string} channel_type
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -3474,6 +3494,7 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
   return {
     /**
      * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
      * @param {string} channel_type
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -3799,6 +3820,7 @@ export const ChannelsApiFactory = function (
   return {
     /**
      * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
      * @param {ChannelsApiChannelsCountsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -4161,6 +4183,7 @@ export interface ChannelsApiChannelsTypeRetrieveRequest {
 export class ChannelsApi extends BaseAPI {
   /**
    * View for retrieving an individual channel by type and name
+   * @summary Channel Detail Lookup by channel type and name
    * @param {ChannelsApiChannelsCountsListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -249,64 +249,16 @@ export interface ChannelCounts {
   title: string
   /**
    *
-   * @type {string}
-   * @memberof ChannelCounts
-   */
-  avatar?: string | null
-  /**
-   *
-   * @type {string}
-   * @memberof ChannelCounts
-   */
-  banner?: string | null
-  /**
-   *
-   * @type {any}
-   * @memberof ChannelCounts
-   */
-  about?: any | null
-  /**
-   *
    * @type {ChannelTypeEnum}
    * @memberof ChannelCounts
    */
   channel_type: ChannelTypeEnum
   /**
    *
-   * @type {any}
-   * @memberof ChannelCounts
-   */
-  configuration?: any | null
-  /**
-   *
    * @type {string}
    * @memberof ChannelCounts
    */
   search_filter?: string
-  /**
-   *
-   * @type {string}
-   * @memberof ChannelCounts
-   */
-  public_description?: string
-  /**
-   *
-   * @type {string}
-   * @memberof ChannelCounts
-   */
-  ga_tracking_id?: string
-  /**
-   *
-   * @type {number}
-   * @memberof ChannelCounts
-   */
-  featured_list?: number | null
-  /**
-   *
-   * @type {number}
-   * @memberof ChannelCounts
-   */
-  widget_list?: number | null
 }
 
 /**
@@ -3000,27 +2952,20 @@ export const ChannelsApiAxiosParamCreator = function (
   return {
     /**
      * View for retrieving an individual channel by type and name
-     * @summary Channel Detail Lookup by channel type and name
      * @param {string} channel_type
-     * @param {string} name
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    channelsCountsRetrieve: async (
+    channelsCountsList: async (
       channel_type: string,
-      name: string,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'channel_type' is not null or undefined
-      assertParamExists("channelsCountsRetrieve", "channel_type", channel_type)
-      // verify required parameter 'name' is not null or undefined
-      assertParamExists("channelsCountsRetrieve", "name", name)
-      const localVarPath = `/api/v0/channels/counts/{channel_type}/{name}/`
-        .replace(
-          `{${"channel_type"}}`,
-          encodeURIComponent(String(channel_type)),
-        )
-        .replace(`{${"name"}}`, encodeURIComponent(String(name)))
+      assertParamExists("channelsCountsList", "channel_type", channel_type)
+      const localVarPath = `/api/v0/channels/counts/{channel_type}/`.replace(
+        `{${"channel_type"}}`,
+        encodeURIComponent(String(channel_type)),
+      )
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
       let baseOptions
@@ -3529,28 +3474,27 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
   return {
     /**
      * View for retrieving an individual channel by type and name
-     * @summary Channel Detail Lookup by channel type and name
      * @param {string} channel_type
-     * @param {string} name
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    async channelsCountsRetrieve(
+    async channelsCountsList(
       channel_type: string,
-      name: string,
       options?: RawAxiosRequestConfig,
     ): Promise<
-      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ChannelCounts>
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<Array<ChannelCounts>>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.channelsCountsRetrieve(
+        await localVarAxiosParamCreator.channelsCountsList(
           channel_type,
-          name,
           options,
         )
       const index = configuration?.serverIndex ?? 0
       const operationBasePath =
-        operationServerMap["ChannelsApi.channelsCountsRetrieve"]?.[index]?.url
+        operationServerMap["ChannelsApi.channelsCountsList"]?.[index]?.url
       return (axios, basePath) =>
         createRequestFunction(
           localVarAxiosArgs,
@@ -3855,21 +3799,16 @@ export const ChannelsApiFactory = function (
   return {
     /**
      * View for retrieving an individual channel by type and name
-     * @summary Channel Detail Lookup by channel type and name
-     * @param {ChannelsApiChannelsCountsRetrieveRequest} requestParameters Request parameters.
+     * @param {ChannelsApiChannelsCountsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    channelsCountsRetrieve(
-      requestParameters: ChannelsApiChannelsCountsRetrieveRequest,
+    channelsCountsList(
+      requestParameters: ChannelsApiChannelsCountsListRequest,
       options?: RawAxiosRequestConfig,
-    ): AxiosPromise<ChannelCounts> {
+    ): AxiosPromise<Array<ChannelCounts>> {
       return localVarFp
-        .channelsCountsRetrieve(
-          requestParameters.channel_type,
-          requestParameters.name,
-          options,
-        )
+        .channelsCountsList(requestParameters.channel_type, options)
         .then((request) => request(axios, basePath))
     },
     /**
@@ -4032,24 +3971,17 @@ export const ChannelsApiFactory = function (
 }
 
 /**
- * Request parameters for channelsCountsRetrieve operation in ChannelsApi.
+ * Request parameters for channelsCountsList operation in ChannelsApi.
  * @export
- * @interface ChannelsApiChannelsCountsRetrieveRequest
+ * @interface ChannelsApiChannelsCountsListRequest
  */
-export interface ChannelsApiChannelsCountsRetrieveRequest {
+export interface ChannelsApiChannelsCountsListRequest {
   /**
    *
    * @type {string}
-   * @memberof ChannelsApiChannelsCountsRetrieve
+   * @memberof ChannelsApiChannelsCountsList
    */
   readonly channel_type: string
-
-  /**
-   *
-   * @type {string}
-   * @memberof ChannelsApiChannelsCountsRetrieve
-   */
-  readonly name: string
 }
 
 /**
@@ -4229,22 +4161,17 @@ export interface ChannelsApiChannelsTypeRetrieveRequest {
 export class ChannelsApi extends BaseAPI {
   /**
    * View for retrieving an individual channel by type and name
-   * @summary Channel Detail Lookup by channel type and name
-   * @param {ChannelsApiChannelsCountsRetrieveRequest} requestParameters Request parameters.
+   * @param {ChannelsApiChannelsCountsListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof ChannelsApi
    */
-  public channelsCountsRetrieve(
-    requestParameters: ChannelsApiChannelsCountsRetrieveRequest,
+  public channelsCountsList(
+    requestParameters: ChannelsApiChannelsCountsListRequest,
     options?: RawAxiosRequestConfig,
   ) {
     return ChannelsApiFp(this.configuration)
-      .channelsCountsRetrieve(
-        requestParameters.channel_type,
-        requestParameters.name,
-        options,
-      )
+      .channelsCountsList(requestParameters.channel_type, options)
       .then((request) => request(this.axios, this.basePath))
   }
 

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -200,6 +200,116 @@ export type Channel =
   | ({ channel_type: "unit" } & UnitChannel)
 
 /**
+ *
+ * @export
+ * @interface ChannelCounts
+ */
+export interface ChannelCounts {
+  /**
+   *
+   * @type {number}
+   * @memberof ChannelCounts
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  counts: string
+  /**
+   * Get the URL for the channel
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  channel_url: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  created_on: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  updated_on: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  name: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  avatar?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  banner?: string | null
+  /**
+   *
+   * @type {any}
+   * @memberof ChannelCounts
+   */
+  about?: any | null
+  /**
+   *
+   * @type {ChannelTypeEnum}
+   * @memberof ChannelCounts
+   */
+  channel_type: ChannelTypeEnum
+  /**
+   *
+   * @type {any}
+   * @memberof ChannelCounts
+   */
+  configuration?: any | null
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  search_filter?: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  public_description?: string
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelCounts
+   */
+  ga_tracking_id?: string
+  /**
+   *
+   * @type {number}
+   * @memberof ChannelCounts
+   */
+  featured_list?: number | null
+  /**
+   *
+   * @type {number}
+   * @memberof ChannelCounts
+   */
+  widget_list?: number | null
+}
+
+/**
  * Write serializer for Channel. Uses primary keys for referenced objects during requests, and delegates to ChannelSerializer for responses.
  * @export
  * @interface ChannelCreateRequest
@@ -2889,6 +2999,58 @@ export const ChannelsApiAxiosParamCreator = function (
 ) {
   return {
     /**
+     * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
+     * @param {string} channel_type
+     * @param {string} name
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    channelsCountsRetrieve: async (
+      channel_type: string,
+      name: string,
+      options: RawAxiosRequestConfig = {},
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'channel_type' is not null or undefined
+      assertParamExists("channelsCountsRetrieve", "channel_type", channel_type)
+      // verify required parameter 'name' is not null or undefined
+      assertParamExists("channelsCountsRetrieve", "name", name)
+      const localVarPath = `/api/v0/channels/counts/{channel_type}/{name}/`
+        .replace(
+          `{${"channel_type"}}`,
+          encodeURIComponent(String(channel_type)),
+        )
+        .replace(`{${"name"}}`, encodeURIComponent(String(name)))
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL)
+      let baseOptions
+      if (configuration) {
+        baseOptions = configuration.baseOptions
+      }
+
+      const localVarRequestOptions = {
+        method: "GET",
+        ...baseOptions,
+        ...options,
+      }
+      const localVarHeaderParameter = {} as any
+      const localVarQueryParameter = {} as any
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter)
+      let headersFromBaseOptions =
+        baseOptions && baseOptions.headers ? baseOptions.headers : {}
+      localVarRequestOptions.headers = {
+        ...localVarHeaderParameter,
+        ...headersFromBaseOptions,
+        ...options.headers,
+      }
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      }
+    },
+    /**
      * CRUD Operations related to Channels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
      * @summary Create
      * @param {ChannelCreateRequest} ChannelCreateRequest
@@ -3366,6 +3528,38 @@ export const ChannelsApiFp = function (configuration?: Configuration) {
   const localVarAxiosParamCreator = ChannelsApiAxiosParamCreator(configuration)
   return {
     /**
+     * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
+     * @param {string} channel_type
+     * @param {string} name
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async channelsCountsRetrieve(
+      channel_type: string,
+      name: string,
+      options?: RawAxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ChannelCounts>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.channelsCountsRetrieve(
+          channel_type,
+          name,
+          options,
+        )
+      const index = configuration?.serverIndex ?? 0
+      const operationBasePath =
+        operationServerMap["ChannelsApi.channelsCountsRetrieve"]?.[index]?.url
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration,
+        )(axios, operationBasePath || basePath)
+    },
+    /**
      * CRUD Operations related to Channels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
      * @summary Create
      * @param {ChannelCreateRequest} ChannelCreateRequest
@@ -3660,6 +3854,25 @@ export const ChannelsApiFactory = function (
   const localVarFp = ChannelsApiFp(configuration)
   return {
     /**
+     * View for retrieving an individual channel by type and name
+     * @summary Channel Detail Lookup by channel type and name
+     * @param {ChannelsApiChannelsCountsRetrieveRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    channelsCountsRetrieve(
+      requestParameters: ChannelsApiChannelsCountsRetrieveRequest,
+      options?: RawAxiosRequestConfig,
+    ): AxiosPromise<ChannelCounts> {
+      return localVarFp
+        .channelsCountsRetrieve(
+          requestParameters.channel_type,
+          requestParameters.name,
+          options,
+        )
+        .then((request) => request(axios, basePath))
+    },
+    /**
      * CRUD Operations related to Channels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
      * @summary Create
      * @param {ChannelsApiChannelsCreateRequest} requestParameters Request parameters.
@@ -3816,6 +4029,27 @@ export const ChannelsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
   }
+}
+
+/**
+ * Request parameters for channelsCountsRetrieve operation in ChannelsApi.
+ * @export
+ * @interface ChannelsApiChannelsCountsRetrieveRequest
+ */
+export interface ChannelsApiChannelsCountsRetrieveRequest {
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelsApiChannelsCountsRetrieve
+   */
+  readonly channel_type: string
+
+  /**
+   *
+   * @type {string}
+   * @memberof ChannelsApiChannelsCountsRetrieve
+   */
+  readonly name: string
 }
 
 /**
@@ -3993,6 +4227,27 @@ export interface ChannelsApiChannelsTypeRetrieveRequest {
  * @extends {BaseAPI}
  */
 export class ChannelsApi extends BaseAPI {
+  /**
+   * View for retrieving an individual channel by type and name
+   * @summary Channel Detail Lookup by channel type and name
+   * @param {ChannelsApiChannelsCountsRetrieveRequest} requestParameters Request parameters.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ChannelsApi
+   */
+  public channelsCountsRetrieve(
+    requestParameters: ChannelsApiChannelsCountsRetrieveRequest,
+    options?: RawAxiosRequestConfig,
+  ) {
+    return ChannelsApiFp(this.configuration)
+      .channelsCountsRetrieve(
+        requestParameters.channel_type,
+        requestParameters.name,
+        options,
+      )
+      .then((request) => request(this.axios, this.basePath))
+  }
+
   /**
    * CRUD Operations related to Channels. Channels may represent groups or organizations at MIT and are a high-level categorization of content.
    * @summary Create

--- a/frontends/api/src/hooks/channels/index.ts
+++ b/frontends/api/src/hooks/channels/index.ts
@@ -27,6 +27,11 @@ const useChannelDetail = (channelType: string, channelName: string) => {
     ...channels.detailByType(channelType, channelName),
   })
 }
+const useChannelCounts = (channelType: string) => {
+  return useQuery({
+    ...channels.countsByType(channelType),
+  })
+}
 
 const useChannelPartialUpdate = () => {
   const client = useQueryClient()
@@ -44,4 +49,9 @@ const useChannelPartialUpdate = () => {
   })
 }
 
-export { useChannelDetail, useChannelsList, useChannelPartialUpdate }
+export {
+  useChannelDetail,
+  useChannelsList,
+  useChannelPartialUpdate,
+  useChannelCounts,
+}

--- a/frontends/api/src/hooks/channels/keyFactory.ts
+++ b/frontends/api/src/hooks/channels/keyFactory.ts
@@ -11,6 +11,14 @@ const channels = createQueryKeys("channel", {
         .then((res) => res.data)
     },
   }),
+  countsByType: (channelType: string, name: string) => ({
+    queryKey: [channelType, name],
+    queryFn: () => {
+      return channelsApi
+        .channelsCountsList({ channel_type: channelType })
+        .then((res) => res.data)
+    },
+  }),
   detail: (id: number) => ({
     queryKey: [id],
     queryFn: () => {

--- a/frontends/api/src/hooks/channels/keyFactory.ts
+++ b/frontends/api/src/hooks/channels/keyFactory.ts
@@ -11,8 +11,8 @@ const channels = createQueryKeys("channel", {
         .then((res) => res.data)
     },
   }),
-  countsByType: (channelType: string, name: string) => ({
-    queryKey: [channelType, name],
+  countsByType: (channelType: string) => ({
+    queryKey: [channelType],
     queryFn: () => {
       return channelsApi
         .channelsCountsList({ channel_type: channelType })

--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -169,6 +169,8 @@ const userSubscription = {
 }
 
 const channels = {
+  counts: (channelType: string) =>
+    `${API_BASE_URL}/api/v0/channels/counts/${channelType}/`,
   details: (channelType: string, name: string) =>
     `${API_BASE_URL}/api/v0/channels/type/${channelType}/${name}/`,
   patch: (id: number) => `${API_BASE_URL}/api/v0/channels/${id}/`,

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
@@ -74,24 +74,20 @@ describe("DepartmentListingPage", () => {
       professionalUnit2,
       professionalUnit3,
     ]
-    const courseCounts = {
-      academicUnit1: 10,
-      academicUnit2: 20,
-      academicUnit3: 1,
-      professionalUnit1: 40,
-      professionalUnit2: 50,
-      professionalUnit3: 0,
-    }
-    const programCounts = {
-      academicUnit1: 1,
-      academicUnit2: 2,
-      academicUnit3: 0,
-      professionalUnit1: 4,
-      professionalUnit2: 5,
-      professionalUnit3: 6,
-    }
+    const courseCounts = 6
+    const programCounts = 5
 
+    setMockResponse.get(urls.channels.counts("unit"), [
+      {
+        name: academicUnit1,
+        counts: {
+          programs: programCounts,
+          courses: courseCounts,
+        },
+      },
+    ])
     setMockResponse.get(urls.offerors.list(), units)
+
     setMockResponse.get(
       urls.search.resources({
         resource_type: ["course"],
@@ -104,7 +100,6 @@ describe("DepartmentListingPage", () => {
         resource_type: ["program"],
         aggregations: ["offered_by"],
       }),
-      makeSearchResponse(programCounts),
     )
 
     units.forEach((unit) => {

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.test.tsx
@@ -74,15 +74,29 @@ describe("DepartmentListingPage", () => {
       professionalUnit2,
       professionalUnit3,
     ]
-    const courseCounts = 6
-    const programCounts = 5
+    const courseCounts = {
+      academicUnit1: 10,
+      academicUnit2: 20,
+      academicUnit3: 1,
+      professionalUnit1: 40,
+      professionalUnit2: 50,
+      professionalUnit3: 0,
+    }
+    const programCounts = {
+      academicUnit1: 1,
+      academicUnit2: 2,
+      academicUnit3: 0,
+      professionalUnit1: 4,
+      professionalUnit2: 5,
+      professionalUnit3: 6,
+    }
 
     setMockResponse.get(urls.channels.counts("unit"), [
       {
         name: academicUnit1,
         counts: {
-          programs: programCounts,
-          courses: courseCounts,
+          programs: 7,
+          courses: 10,
         },
       },
     ])
@@ -100,6 +114,7 @@ describe("DepartmentListingPage", () => {
         resource_type: ["program"],
         aggregations: ["offered_by"],
       }),
+      makeSearchResponse(programCounts),
     )
 
     units.forEach((unit) => {

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -10,7 +10,10 @@ import {
   theme,
 } from "ol-components"
 import { RiBookOpenLine, RiSuitcaseLine } from "@remixicon/react"
-import { LearningResourceOfferorDetail, ChannelCounts } from "api"
+import {
+  LearningResourceOfferorDetail,
+  LearningResourcesSearchResponse,
+} from "api"
 import { HOME } from "@/common/urls"
 import { UnitCards, UnitCardLoading } from "./UnitCard"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
@@ -19,7 +22,7 @@ const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
 
 const aggregateProgramCounts = (
-  data: ChannelCounts,
+  data: LearningResourcesSearchResponse,
 ): Record<string, number> => {
   return Object.fromEntries(
     data.map((item) => {
@@ -28,7 +31,9 @@ const aggregateProgramCounts = (
   )
 }
 
-const aggregateCourseCounts = (data: ChannelCounts): Record<string, number> => {
+const aggregateCourseCounts = (
+  data: LearningResourcesSearchResponse,
+): Record<string, number> => {
   return Object.fromEntries(
     data.map((item) => {
       return [item.name, item.counts.courses]

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -10,10 +10,7 @@ import {
   theme,
 } from "ol-components"
 import { RiBookOpenLine, RiSuitcaseLine } from "@remixicon/react"
-import {
-  LearningResourceOfferorDetail,
-  LearningResourcesSearchResponse,
-} from "api"
+import { LearningResourceOfferorDetail, ChannelCounts } from "api"
 import { HOME } from "@/common/urls"
 import { UnitCards, UnitCardLoading } from "./UnitCard"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
@@ -22,7 +19,7 @@ const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
 
 const aggregateProgramCounts = (
-  data: LearningResourcesSearchResponse,
+  data: ChannelCounts,
 ): Record<string, number> => {
   return Object.fromEntries(
     data.map((item) => {
@@ -31,9 +28,7 @@ const aggregateProgramCounts = (
   )
 }
 
-const aggregateCourseCounts = (
-  data: LearningResourcesSearchResponse,
-): Record<string, number> => {
+const aggregateCourseCounts = (data: ChannelCounts): Record<string, number> => {
   return Object.fromEntries(
     data.map((item) => {
       return [item.name, item.counts.courses]

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -6,37 +6,36 @@ import {
   Container,
   Typography,
   styled,
-  Breadcrumbs,
   theme,
+  Breadcrumbs,
 } from "ol-components"
+
 import { RiBookOpenLine, RiSuitcaseLine } from "@remixicon/react"
-import {
-  LearningResourceOfferorDetail,
-  LearningResourcesSearchResponse,
-} from "api"
+import { LearningResourceOfferorDetail } from "api"
 import { HOME } from "@/common/urls"
 import { UnitCards, UnitCardLoading } from "./UnitCard"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
+import { ChannelCounts } from "api/v0"
 
 const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
 
 const aggregateProgramCounts = (
-  data: LearningResourcesSearchResponse,
+  data: Array<ChannelCounts>,
 ): Record<string, number> => {
   return Object.fromEntries(
-    data.map((item) => {
-      return [item.name, item.counts.programs]
+    Object.entries(data).map(([_key, value]) => {
+      return [value.name, value.counts.programs]
     }),
   )
 }
 
 const aggregateCourseCounts = (
-  data: LearningResourcesSearchResponse,
+  data: Array<ChannelCounts>,
 ): Record<string, number> => {
   return Object.fromEntries(
-    data.map((item) => {
-      return [item.name, item.counts.courses]
+    Object.entries(data).map(([_key, value]) => {
+      return [value.name, value.counts.courses]
     }),
   )
 }

--- a/learning_resources_search/views.py
+++ b/learning_resources_search/views.py
@@ -1,12 +1,10 @@
 """View for search"""
 
 import logging
-from functools import wraps
 from itertools import chain
 
 from django.conf import settings
 from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from opensearchpy.exceptions import TransportError
 from rest_framework import mixins, viewsets
@@ -33,23 +31,9 @@ from learning_resources_search.serializers import (
     PercolateQuerySerializer,
     PercolateQuerySubscriptionRequestSerializer,
 )
+from main.utils import cache_page_for_anonymous_users
 
 log = logging.getLogger(__name__)
-
-
-def cache_page_for_anonymous_users(*cache_args, **cache_kwargs):
-    def inner_decorator(func):
-        @wraps(func)
-        def inner_function(request, *args, **kwargs):
-            if not request.user.is_authenticated:
-                return cache_page(*cache_args, **cache_kwargs)(func)(
-                    request, *args, **kwargs
-                )
-            return func(request, *args, **kwargs)
-
-        return inner_function
-
-    return inner_decorator
 
 
 class ESView(APIView):

--- a/main/utils.py
+++ b/main/utils.py
@@ -359,3 +359,5 @@ def clear_search_cache():
     cache = caches["redis"]
     search_keys = cache.keys("views.decorators.cache.cache_page.search.*")
     cache.delete_many(search_keys)
+    search_keys = cache.keys("views.decorators.cache.cache_header.search.*")
+    cache.delete_many(search_keys)

--- a/main/utils.py
+++ b/main/utils.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import os
 from enum import Flag, auto
+from functools import wraps
 from itertools import islice
 from urllib.parse import urljoin
 
@@ -11,6 +12,7 @@ import markdown2
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.cache import caches
+from django.views.decorators.cache import cache_page
 from nh3 import nh3
 
 from main.constants import ALLOWED_HTML_ATTRIBUTES, ALLOWED_HTML_TAGS
@@ -19,6 +21,21 @@ log = logging.getLogger(__name__)
 
 # This is the Django ImageField max path size
 IMAGE_PATH_MAX_LENGTH = 100
+
+
+def cache_page_for_anonymous_users(*cache_args, **cache_kwargs):
+    def inner_decorator(func):
+        @wraps(func)
+        def inner_function(request, *args, **kwargs):
+            if not request.user.is_authenticated:
+                return cache_page(*cache_args, **cache_kwargs)(func)(
+                    request, *args, **kwargs
+                )
+            return func(request, *args, **kwargs)
+
+        return inner_function
+
+    return inner_decorator
 
 
 class FeatureFlag(Flag):

--- a/main/utils.py
+++ b/main/utils.py
@@ -38,6 +38,19 @@ def cache_page_for_anonymous_users(*cache_args, **cache_kwargs):
     return inner_decorator
 
 
+def cache_page_for_all_users(*cache_args, **cache_kwargs):
+    def inner_decorator(func):
+        @wraps(func)
+        def inner_function(request, *args, **kwargs):
+            return cache_page(*cache_args, **cache_kwargs)(func)(
+                request, *args, **kwargs
+            )
+
+        return inner_function
+
+    return inner_decorator
+
+
 class FeatureFlag(Flag):
     """
     FeatureFlag enum

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -229,6 +229,7 @@ paths:
     get:
       operationId: channels_counts_list
       description: View for retrieving an individual channel by type and name
+      summary: Channel Detail Lookup by channel type and name
       parameters:
       - in: path
         name: channel_type
@@ -1011,7 +1012,8 @@ components:
           type: integer
           readOnly: true
         counts:
-          type: string
+          allOf:
+          - $ref: '#/components/schemas/Counts'
           readOnly: true
         channel_url:
           type: string
@@ -1189,6 +1191,16 @@ components:
           readOnly: true
       required:
       - unit
+    Counts:
+      type: object
+      properties:
+        courses:
+          type: integer
+        programs:
+          type: integer
+      required:
+      - courses
+      - programs
     CurrentEducationEnum:
       enum:
       - Doctorate

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -225,20 +225,13 @@ paths:
       responses:
         '204':
           description: No response body
-  /api/v0/channels/counts/{channel_type}/{name}/:
+  /api/v0/channels/counts/{channel_type}/:
     get:
-      operationId: channels_counts_retrieve
+      operationId: channels_counts_list
       description: View for retrieving an individual channel by type and name
-      summary: Channel Detail Lookup by channel type and name
       parameters:
       - in: path
         name: channel_type
-        schema:
-          type: string
-          pattern: ^[A-Za-z0-9_\-]+$
-        required: true
-      - in: path
-        name: name
         schema:
           type: string
           pattern: ^[A-Za-z0-9_\-]+$
@@ -250,7 +243,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ChannelCounts'
+                type: array
+                items:
+                  $ref: '#/components/schemas/ChannelCounts'
           description: ''
   /api/v0/channels/type/{channel_type}/{name}/:
     get:
@@ -1037,34 +1032,11 @@ components:
         title:
           type: string
           maxLength: 100
-        avatar:
-          type: string
-          format: uri
-          nullable: true
-        banner:
-          type: string
-          format: uri
-          nullable: true
-        about:
-          nullable: true
         channel_type:
           $ref: '#/components/schemas/ChannelTypeEnum'
-        configuration:
-          nullable: true
         search_filter:
           type: string
           maxLength: 2048
-        public_description:
-          type: string
-        ga_tracking_id:
-          type: string
-          maxLength: 24
-        featured_list:
-          type: integer
-          nullable: true
-        widget_list:
-          type: integer
-          nullable: true
       required:
       - channel_type
       - channel_url

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1007,6 +1007,7 @@ components:
           pathway: '#/components/schemas/PathwayChannel'
     ChannelCounts:
       type: object
+      description: Serializer for resource counts associated with Channel
       properties:
         id:
           type: integer

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -225,6 +225,33 @@ paths:
       responses:
         '204':
           description: No response body
+  /api/v0/channels/counts/{channel_type}/{name}/:
+    get:
+      operationId: channels_counts_retrieve
+      description: View for retrieving an individual channel by type and name
+      summary: Channel Detail Lookup by channel type and name
+      parameters:
+      - in: path
+        name: channel_type
+        schema:
+          type: string
+          pattern: ^[A-Za-z0-9_\-]+$
+        required: true
+      - in: path
+        name: name
+        schema:
+          type: string
+          pattern: ^[A-Za-z0-9_\-]+$
+        required: true
+      tags:
+      - channels
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChannelCounts'
+          description: ''
   /api/v0/channels/type/{channel_type}/{name}/:
     get:
       operationId: channels_type_retrieve
@@ -982,6 +1009,71 @@ components:
           department: '#/components/schemas/DepartmentChannel'
           unit: '#/components/schemas/UnitChannel'
           pathway: '#/components/schemas/PathwayChannel'
+    ChannelCounts:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        counts:
+          type: string
+          readOnly: true
+        channel_url:
+          type: string
+          description: Get the URL for the channel
+          readOnly: true
+        created_on:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_on:
+          type: string
+          format: date-time
+          readOnly: true
+        name:
+          type: string
+          pattern: ^[A-Za-z0-9_-]+$
+          maxLength: 100
+        title:
+          type: string
+          maxLength: 100
+        avatar:
+          type: string
+          format: uri
+          nullable: true
+        banner:
+          type: string
+          format: uri
+          nullable: true
+        about:
+          nullable: true
+        channel_type:
+          $ref: '#/components/schemas/ChannelTypeEnum'
+        configuration:
+          nullable: true
+        search_filter:
+          type: string
+          maxLength: 2048
+        public_description:
+          type: string
+        ga_tracking_id:
+          type: string
+          maxLength: 24
+        featured_list:
+          type: integer
+          nullable: true
+        widget_list:
+          type: integer
+          nullable: true
+      required:
+      - channel_type
+      - channel_url
+      - counts
+      - created_on
+      - id
+      - name
+      - title
+      - updated_on
     ChannelCreateRequest:
       type: object
       description: |-


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5246

### Description (What does it do?)
Currently the "programs" and "courses counts displayed on the unit page(/units/) comes from opensearch aggregations which has been determined to be expensive for just getting counts of things that change infrequently. This PR moves the counts off to their own endpoint which is then cached and invalidated along with learning resources (which get invalidated when new resources are fetched).


### How can this be tested?
1. checkout this branch and make sure you have learning resources and units loaded
2. visit /units/ and see that counts show up.
3. go into django admin and delete some resources associated with a unit
4. go back to /units/ and note that the counts do not changed (they are fetched from cache)
5. try this as a logged in and logged out user (cache behavior should be the same)

