### PR TITLE
display sub topics on topic channels

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -21272,7 +21272,7 @@ export const TopicsApiAxiosParamCreator = function (
      * @param {number} [limit] Number of results to return per page.
      * @param {Array<string>} [name] Multiple values may be separated by commas.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {Array<string>} [parent_topic_name] Multiple values may be separated by commas.
+     * @param {Array<number>} [parent_topic_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -21281,7 +21281,7 @@ export const TopicsApiAxiosParamCreator = function (
       limit?: number,
       name?: Array<string>,
       offset?: number,
-      parent_topic_name?: Array<string>,
+      parent_topic_id?: Array<number>,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/topics/`
@@ -21316,8 +21316,8 @@ export const TopicsApiAxiosParamCreator = function (
         localVarQueryParameter["offset"] = offset
       }
 
-      if (parent_topic_name) {
-        localVarQueryParameter["parent_topic_name"] = parent_topic_name.join(
+      if (parent_topic_id) {
+        localVarQueryParameter["parent_topic_id"] = parent_topic_id.join(
           COLLECTION_FORMATS.csv,
         )
       }
@@ -21399,7 +21399,7 @@ export const TopicsApiFp = function (configuration?: Configuration) {
      * @param {number} [limit] Number of results to return per page.
      * @param {Array<string>} [name] Multiple values may be separated by commas.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {Array<string>} [parent_topic_name] Multiple values may be separated by commas.
+     * @param {Array<number>} [parent_topic_id] Multiple values may be separated by commas.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -21408,7 +21408,7 @@ export const TopicsApiFp = function (configuration?: Configuration) {
       limit?: number,
       name?: Array<string>,
       offset?: number,
-      parent_topic_name?: Array<string>,
+      parent_topic_id?: Array<number>,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -21421,7 +21421,7 @@ export const TopicsApiFp = function (configuration?: Configuration) {
         limit,
         name,
         offset,
-        parent_topic_name,
+        parent_topic_id,
         options,
       )
       const index = configuration?.serverIndex ?? 0
@@ -21497,7 +21497,7 @@ export const TopicsApiFactory = function (
           requestParameters.limit,
           requestParameters.name,
           requestParameters.offset,
-          requestParameters.parent_topic_name,
+          requestParameters.parent_topic_id,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -21556,10 +21556,10 @@ export interface TopicsApiTopicsListRequest {
 
   /**
    * Multiple values may be separated by commas.
-   * @type {Array<string>}
+   * @type {Array<number>}
    * @memberof TopicsApiTopicsList
    */
-  readonly parent_topic_name?: Array<string>
+  readonly parent_topic_id?: Array<number>
 }
 
 /**
@@ -21601,7 +21601,7 @@ export class TopicsApi extends BaseAPI {
         requestParameters.limit,
         requestParameters.name,
         requestParameters.offset,
-        requestParameters.parent_topic_name,
+        requestParameters.parent_topic_id,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
@@ -262,41 +262,41 @@ describe.each(NON_UNIT_CHANNEL_TYPES)(
         ])
       })
     })
-
-    if (channelType === ChannelTypeEnum.Topic) {
-      test("Subtopics display", async () => {
-        const { channel, subTopics } = setupApis({
-          search_filter: "topic=Physics",
-          channel_type: channelType,
-        })
-        renderTestApp({ url: `/c/${channel.channel_type}/${channel.name}` })
-
-        await waitFor(() => {
-          if (
-            channel.channel_type === ChannelTypeEnum.Topic &&
-            channel.topic_detail.topic
-          ) {
-            expect(makeRequest).toHaveBeenCalledWith(
-              "get",
-              urls.topics.list({
-                parent_topic_id: [channel.topic_detail.topic],
-              }),
-              undefined,
-            )
-            const links = screen.getAllByRole("link")
-            if (subTopics) {
-              for (const topic of subTopics.results) {
-                const link = links.find((el) => el.textContent === topic.name)
-                expect(link).toBeInTheDocument()
-                expect(link).toHaveAttribute("href", topic.channel_url)
-              }
-            }
-          }
-        })
-      })
-    }
   },
 )
+
+describe("Channel Pages, Topic only", () => {
+  test("Subtopics display", async () => {
+    const { channel, subTopics } = setupApis({
+      search_filter: "topic=Physics",
+      channel_type: ChannelTypeEnum.Topic,
+    })
+    renderTestApp({ url: `/c/${channel.channel_type}/${channel.name}` })
+
+    await waitFor(() => {
+      if (
+        channel.channel_type === ChannelTypeEnum.Topic &&
+        channel.topic_detail.topic
+      ) {
+        expect(makeRequest).toHaveBeenCalledWith(
+          "get",
+          urls.topics.list({
+            parent_topic_id: [channel.topic_detail.topic],
+          }),
+          undefined,
+        )
+        const links = screen.getAllByRole("link")
+        if (subTopics) {
+          for (const topic of subTopics.results) {
+            const link = links.find((el) => el.textContent === topic.name)
+            expect(link).toBeInTheDocument()
+            expect(link).toHaveAttribute("href", topic.channel_url)
+          }
+        }
+      }
+    })
+  })
+})
 
 describe("Channel Pages, Unit only", () => {
   it("Sets the expected meta tags", async () => {

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
@@ -274,21 +274,19 @@ describe("Channel Pages, Topic only", () => {
     })
     renderTestApp({ url: `/c/${channel.channel_type}/${channel.name}` })
 
-    await waitFor(async () => {
-      if (
-        channel.channel_type === ChannelTypeEnum.Topic &&
-        channel.topic_detail.topic
-      ) {
-        invariant(subTopics)
-        const links = await screen.findAllByRole("link", {
-          // name arg can be string, regex, or function
-          name: (name) => subTopics?.results.map((t) => t.name).includes(name),
-        })
-        links.forEach((link, i) => {
-          expect(link).toHaveAttribute("href", subTopics.results[i].channel_url)
-        })
-      }
-    })
+    if (
+      channel.channel_type === ChannelTypeEnum.Topic &&
+      channel.topic_detail.topic
+    ) {
+      invariant(subTopics)
+      const links = await screen.findAllByRole("link", {
+        // name arg can be string, regex, or function
+        name: (name) => subTopics?.results.map((t) => t.name).includes(name),
+      })
+      links.forEach((link, i) => {
+        expect(link).toHaveAttribute("href", subTopics.results[i].channel_url)
+      })
+    }
   })
 })
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
@@ -274,19 +274,14 @@ describe("Channel Pages, Topic only", () => {
     })
     renderTestApp({ url: `/c/${channel.channel_type}/${channel.name}` })
 
-    if (
-      channel.channel_type === ChannelTypeEnum.Topic &&
-      channel.topic_detail.topic
-    ) {
-      invariant(subTopics)
-      const links = await screen.findAllByRole("link", {
-        // name arg can be string, regex, or function
-        name: (name) => subTopics?.results.map((t) => t.name).includes(name),
-      })
-      links.forEach((link, i) => {
-        expect(link).toHaveAttribute("href", subTopics.results[i].channel_url)
-      })
-    }
+    invariant(subTopics)
+    const links = await screen.findAllByRole("link", {
+      // name arg can be string, regex, or function
+      name: (name) => subTopics?.results.map((t) => t.name).includes(name),
+    })
+    links.forEach((link, i) => {
+      expect(link).toHaveAttribute("href", subTopics.results[i].channel_url)
+    })
   })
 })
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.test.tsx
@@ -104,6 +104,16 @@ const setupApis = (
     results: [],
   })
 
+  if (
+    channel.channel_type === ChannelTypeEnum.Topic &&
+    channel.topic_detail.topic
+  ) {
+    setMockResponse.get(
+      urls.topics.list({ parent_topic_id: [channel.topic_detail.topic] }),
+      factories.learningResources.topics({ count: 5 }),
+    )
+  }
+
   return {
     channel,
   }

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -86,9 +86,9 @@ const ChannelPage: React.FC = () => {
             <Typography variant="body1">{publicDescription}</Typography>
           )}
           {channelQuery.data?.channel_type === ChannelTypeEnum.Topic &&
-          channelQuery.data?.topic_detail.topic ? (
+          channelQuery.data?.topic_detail?.topic ? (
             <SubTopicsDisplay
-              parentTopicId={channelQuery.data?.topic_detail.topic}
+              parentTopicId={channelQuery.data?.topic_detail?.topic}
             />
           ) : null}
           {channelQuery.data?.search_filter && (

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -44,21 +44,24 @@ const SubTopicsDisplay: React.FC<SubTopicDisplayProps> = (props) => {
   const topicsQuery = useLearningResourceTopics({
     parent_topic_id: [parentTopicId],
   })
+  const totalSubtopics = topicsQuery.data?.results?.length ?? 0
   return (
-    <SubTopicsContainer>
-      <SubTopicsHeader>Related Topics</SubTopicsHeader>
-      <ChipsContainer>
-        {topicsQuery.data?.results.map((topic) => (
-          <ChipLink
-            size="large"
-            variant="outlinedWhite"
-            key={topic.id}
-            href={topic.channel_url ? topic.channel_url : ""}
-            label={topic.name}
-          />
-        ))}
-      </ChipsContainer>
-    </SubTopicsContainer>
+    totalSubtopics > 0 && (
+      <SubTopicsContainer>
+        <SubTopicsHeader>Related Topics</SubTopicsHeader>
+        <ChipsContainer>
+          {topicsQuery.data?.results.map((topic) => (
+            <ChipLink
+              size="large"
+              variant="outlinedWhite"
+              key={topic.id}
+              href={topic.channel_url ? topic.channel_url : ""}
+              label={topic.name}
+            />
+          ))}
+        </ChipsContainer>
+      </SubTopicsContainer>
+    )
   )
 }
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -12,12 +12,15 @@ import { ChannelTypeEnum } from "api/v0"
 import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { ChipLink, Container, styled, Typography } from "ol-components"
 
-const SubTopicsContainer = styled(Container)({
+const SubTopicsContainer = styled(Container)(({ theme }) => ({
   paddingTop: "50px",
-})
+  [theme.breakpoints.down("md")]: {
+    paddingTop: "24px",
+  },
+}))
 
 const SubTopicsHeader = styled(Typography)(({ theme }) => ({
-  marginBottom: "16px",
+  marginBottom: "10px",
   ...theme.typography.subtitle1,
 }))
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -13,7 +13,7 @@ import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { ChipLink, Container, styled, Typography } from "ol-components"
 
 const SubTopicsContainer = styled(Container)(({ theme }) => ({
-  paddingTop: "50px",
+  paddingTop: "40px",
   [theme.breakpoints.down("md")]: {
     paddingTop: "24px",
   },

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -44,13 +44,16 @@ const SubTopicsDisplay: React.FC<SubTopicDisplayProps> = (props) => {
   const topicsQuery = useLearningResourceTopics({
     parent_topic_id: [parentTopicId],
   })
-  const totalSubtopics = topicsQuery.data?.results?.length ?? 0
+  const totalSubtopics = topicsQuery.data?.results.length ?? 0
+  const subTopics = topicsQuery.data?.results.filter(
+    (topic) => topic.channel_url,
+  )
   return (
     totalSubtopics > 0 && (
       <SubTopicsContainer>
         <SubTopicsHeader>Related Topics</SubTopicsHeader>
         <ChipsContainer>
-          {topicsQuery.data?.results.map((topic) => (
+          {subTopics?.map((topic) => (
             <ChipLink
               size="large"
               variant="outlinedWhite"

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -11,6 +11,7 @@ import type {
 import { ChannelTypeEnum } from "api/v0"
 import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { ChipLink, Container, styled, Typography } from "ol-components"
+import { propsNotNil } from "ol-utilities"
 
 const SubTopicsContainer = styled(Container)(({ theme }) => ({
   marginBottom: "60px",
@@ -46,7 +47,7 @@ const SubTopicsDisplay: React.FC<SubTopicDisplayProps> = (props) => {
   })
   const totalSubtopics = topicsQuery.data?.results.length ?? 0
   const subTopics = topicsQuery.data?.results.filter(
-    (topic) => topic.channel_url,
+    propsNotNil(["channel_url"]),
   )
   return (
     totalSubtopics > 0 && (
@@ -58,7 +59,7 @@ const SubTopicsDisplay: React.FC<SubTopicDisplayProps> = (props) => {
               size="large"
               variant="outlinedWhite"
               key={topic.id}
-              href={topic.channel_url ? topic.channel_url : ""}
+              href={topic.channel_url}
               label={topic.name}
             />
           ))}

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -88,7 +88,7 @@ const ChannelPage: React.FC = () => {
           {channelQuery.data?.channel_type === ChannelTypeEnum.Topic &&
           channelQuery.data?.topic_detail.topic ? (
             <SubTopicsDisplay
-              parent_topic_id={channelQuery.data?.topic_detail.topic}
+              parentTopicId={channelQuery.data?.topic_detail.topic}
             />
           ) : null}
           {channelQuery.data?.search_filter && (

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelPage.tsx
@@ -13,9 +13,9 @@ import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { ChipLink, Container, styled, Typography } from "ol-components"
 
 const SubTopicsContainer = styled(Container)(({ theme }) => ({
-  paddingTop: "40px",
-  [theme.breakpoints.down("md")]: {
-    paddingTop: "24px",
+  marginBottom: "60px",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "24px",
   },
 }))
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.test.tsx
@@ -76,6 +76,16 @@ const setMockApiResponses = ({
     results: [],
   })
 
+  if (
+    channel.channel_type === ChannelTypeEnum.Topic &&
+    channel.topic_detail.topic
+  ) {
+    setMockResponse.get(
+      urls.topics.list({ parent_topic_id: [channel.topic_detail.topic] }),
+      factories.learningResources.topics({ count: 5 }),
+    )
+  }
+
   return {
     channel,
   }

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.tsx
@@ -23,11 +23,11 @@ import { styled, VisuallyHidden } from "ol-components"
 
 const SearchInputContainer = styled.div`
   padding-bottom: 40px;
-  margin-top: 80px;
+  margin-top: 64px;
 
   ${({ theme }) => theme.breakpoints.down("md")} {
     padding-bottom: 35px;
-    margin-top: 40px;
+    margin-top: 24px;
   }
 `
 

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelSearch.tsx
@@ -23,11 +23,9 @@ import { styled, VisuallyHidden } from "ol-components"
 
 const SearchInputContainer = styled.div`
   padding-bottom: 40px;
-  margin-top: 64px;
 
   ${({ theme }) => theme.breakpoints.down("md")} {
     padding-bottom: 35px;
-    margin-top: 24px;
   }
 `
 

--- a/frontends/mit-learn/src/pages/ChannelPage/DefaultChannelTemplate.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/DefaultChannelTemplate.tsx
@@ -13,7 +13,7 @@ import {
 import MetaTags from "@/page-components/MetaTags/MetaTags"
 
 const ChildrenContainer = styled.div(({ theme }) => ({
-  paddingTop: "64px",
+  paddingTop: "40px",
   [theme.breakpoints.down("sm")]: {
     paddingTop: "24px",
   },

--- a/frontends/mit-learn/src/pages/ChannelPage/DefaultChannelTemplate.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/DefaultChannelTemplate.tsx
@@ -12,6 +12,13 @@ import {
 } from "./ChannelPageTemplate"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
 
+const ChildrenContainer = styled.div(({ theme }) => ({
+  paddingTop: "64px",
+  [theme.breakpoints.down("sm")]: {
+    paddingTop: "24px",
+  },
+}))
+
 const ChannelControlsContainer = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
@@ -107,7 +114,7 @@ const DefaultChannelTemplate: React.FC<DefaultChannelTemplateProps> = ({
           </ChannelControlsContainer>
         }
       />
-      {children}
+      <ChildrenContainer>{children}</ChildrenContainer>
     </>
   )
 }

--- a/frontends/mit-learn/src/pages/ChannelPage/EditChannelAppearanceForm.test.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/EditChannelAppearanceForm.test.tsx
@@ -9,7 +9,7 @@ import { factories, urls, setMockResponse } from "api/test-utils"
 import { channels as factory } from "api/test-utils/factories"
 import { makeChannelViewPath, makeChannelEditPath } from "@/common/urls"
 import { makeWidgetListResponse } from "ol-widgets/src/factories"
-import type { Channel } from "api/v0"
+import { ChannelTypeEnum, type Channel } from "api/v0"
 
 const setupApis = (channelOverrides: Partial<Channel>) => {
   const channel = factory.channel({ is_moderator: true, ...channelOverrides })
@@ -32,6 +32,16 @@ const setupApis = (channelOverrides: Partial<Channel>) => {
   setMockResponse.get(expect.stringContaining(urls.testimonials.list({})), {
     results: [],
   })
+
+  if (
+    channel.channel_type === ChannelTypeEnum.Topic &&
+    channel.topic_detail.topic
+  ) {
+    setMockResponse.get(
+      urls.topics.list({ parent_topic_id: [channel.topic_detail.topic] }),
+      factories.learningResources.topics({ count: 5 }),
+    )
+  }
 
   return channel
 }

--- a/learning_resources/filters.py
+++ b/learning_resources/filters.py
@@ -264,9 +264,9 @@ class TopicFilter(FilterSet):
         label="Topic name",
         method="filter_name",
     )
-    parent_topic_name = CharInFilter(
-        label="Parent topic name",
-        method="filter_parent_topic_name",
+    parent_topic_id = NumberInFilter(
+        label="Parent topic ID",
+        method="filter_parent_topic_id",
     )
     is_toplevel = BooleanFilter(
         label="Filter top-level topics",
@@ -281,18 +281,6 @@ class TopicFilter(FilterSet):
         """Filter by top-level (parent == null)"""
         return queryset.filter(parent__isnull=value)
 
-    def filter_parent_topic_name(self, queryset, _, values):
-        """Filter by parent topic name (up to 2 levels deep)"""
-
-        nested_topic_filter = Q()
-
-        for topic in values:
-            nested_topic_filter |= Q(
-                parent__isnull=False, parent__name__iexact=topic
-            ) | Q(
-                parent__isnull=False,
-                parent__parent__isnull=False,
-                parent__parent__name__iexact=topic,
-            )
-
-        return queryset.filter(nested_topic_filter)
+    def filter_parent_topic_id(self, queryset, _, values):
+        """Get direct children of a topic"""
+        return queryset.filter(parent_id__in=values)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -6308,11 +6308,11 @@ paths:
         schema:
           type: integer
       - in: query
-        name: parent_topic_name
+        name: parent_topic_id
         schema:
           type: array
           items:
-            type: string
+            type: number
         description: Multiple values may be separated by commas.
         explode: false
         style: form


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5295

### Description (What does it do?)
This PR adds link chips for sub topics to the top of topic channel pages. The topics API endpoint was modified to accept a new `parent_topic_id` parameter. This allows you to pass the ID of a topic and get the direct child topics in return.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/033b456e-19f9-4de1-b60e-553b49b8b82a)
![image](https://github.com/user-attachments/assets/c792f1eb-27b8-4b58-b9a5-cae757db1731)

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Visit the topics listing page at http://localhost:8062/topics
 - Click on the header for any of the topics
 - Ensure that the subtopic chips are properly displayed beneath the banner
 - Click the subtopic chips and ensure you are brought to the proper topic page

### Additional Context
The spacing below the topics and above the search input may look incorrect, but it will be adjusted as part of some coming changes to the channel page search box.