### PR TITLE
OCW completeness penalty in search

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3584,6 +3584,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   min_score?: number | null
   /**
+   * Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness = 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  max_incompleteness_penalty?: number | null
+  /**
    *
    * @type {SourceTypeEnum}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -12221,6 +12227,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -12249,6 +12256,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesSearchRetrieveOfferedByEnum>,
       offset?: number,
@@ -12322,6 +12330,11 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (max_incompleteness_penalty !== undefined) {
+        localVarQueryParameter["max_incompleteness_penalty"] =
+          max_incompleteness_penalty
       }
 
       if (min_score !== undefined) {
@@ -12417,6 +12430,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesSearchRetrieveLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesSearchRetrieveOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -12445,6 +12459,7 @@ export const LearningResourcesSearchApiFp = function (
       learning_format?: Array<LearningResourcesSearchRetrieveLearningFormatEnum>,
       level?: Array<LearningResourcesSearchRetrieveLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesSearchRetrieveOfferedByEnum>,
       offset?: number,
@@ -12478,6 +12493,7 @@ export const LearningResourcesSearchApiFp = function (
           learning_format,
           level,
           limit,
+          max_incompleteness_penalty,
           min_score,
           offered_by,
           offset,
@@ -12544,6 +12560,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.max_incompleteness_penalty,
           requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
@@ -12646,6 +12663,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly limit?: number
+
+  /**
+   * Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly max_incompleteness_penalty?: number | null
 
   /**
    * Minimum score value a text query result needs to have to be displayed
@@ -12771,6 +12795,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.max_incompleteness_penalty,
         requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
@@ -13006,6 +13031,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13035,6 +13061,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>,
       offset?: number,
@@ -13109,6 +13136,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (max_incompleteness_penalty !== undefined) {
+        localVarQueryParameter["max_incompleteness_penalty"] =
+          max_incompleteness_penalty
       }
 
       if (min_score !== undefined) {
@@ -13195,6 +13227,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13223,6 +13256,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionListOfferedByEnum>,
       offset?: number,
@@ -13296,6 +13330,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (max_incompleteness_penalty !== undefined) {
+        localVarQueryParameter["max_incompleteness_penalty"] =
+          max_incompleteness_penalty
       }
 
       if (min_score !== undefined) {
@@ -13378,6 +13417,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13408,6 +13448,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>,
       offset?: number,
@@ -13483,6 +13524,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (limit !== undefined) {
         localVarQueryParameter["limit"] = limit
+      }
+
+      if (max_incompleteness_penalty !== undefined) {
+        localVarQueryParameter["max_incompleteness_penalty"] =
+          max_incompleteness_penalty
       }
 
       if (min_score !== undefined) {
@@ -13640,6 +13686,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionCheckListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13669,6 +13716,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionCheckListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionCheckListLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionCheckListOfferedByEnum>,
       offset?: number,
@@ -13703,6 +13751,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          max_incompleteness_penalty,
           min_score,
           offered_by,
           offset,
@@ -13746,6 +13795,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionListLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13774,6 +13824,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionListLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionListLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionListOfferedByEnum>,
       offset?: number,
@@ -13807,6 +13858,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          max_incompleteness_penalty,
           min_score,
           offered_by,
           offset,
@@ -13849,6 +13901,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>} [learning_format] The format(s) in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>} [level]
      * @param {number} [limit] Number of results to return per page
+     * @param {number | null} [max_incompleteness_penalty] Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
      * @param {number | null} [min_score] Minimum score value a text query result needs to have to be displayed
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education
      * @param {number} [offset] The initial index from which to return the results
@@ -13879,6 +13932,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       learning_format?: Array<LearningResourcesUserSubscriptionSubscribeCreateLearningFormatEnum>,
       level?: Array<LearningResourcesUserSubscriptionSubscribeCreateLevelEnum>,
       limit?: number,
+      max_incompleteness_penalty?: number | null,
       min_score?: number | null,
       offered_by?: Array<LearningResourcesUserSubscriptionSubscribeCreateOfferedByEnum>,
       offset?: number,
@@ -13911,6 +13965,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           learning_format,
           level,
           limit,
+          max_incompleteness_penalty,
           min_score,
           offered_by,
           offset,
@@ -14010,6 +14065,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.max_incompleteness_penalty,
           requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
@@ -14052,6 +14108,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.max_incompleteness_penalty,
           requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
@@ -14093,6 +14150,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.learning_format,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.max_incompleteness_penalty,
           requestParameters.min_score,
           requestParameters.offered_by,
           requestParameters.offset,
@@ -14215,6 +14273,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly limit?: number
+
+  /**
+   * Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly max_incompleteness_penalty?: number | null
 
   /**
    * Minimum score value a text query result needs to have to be displayed
@@ -14399,6 +14464,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly limit?: number
 
   /**
+   * Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly max_incompleteness_penalty?: number | null
+
+  /**
    * Minimum score value a text query result needs to have to be displayed
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
@@ -14574,6 +14646,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly limit?: number
 
   /**
+   * Maximum score penalty for incomplete OCW courses in percent. An OCW course with completeness &#x3D; 0 will have this score penalty. Partially complete courses have a linear penalty proportional to the degree of incompleteness. Only affects results if there is a search term.
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly max_incompleteness_penalty?: number | null
+
+  /**
    * Minimum score value a text query result needs to have to be displayed
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
@@ -14725,6 +14804,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.max_incompleteness_penalty,
         requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
@@ -14769,6 +14849,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.max_incompleteness_penalty,
         requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,
@@ -14812,6 +14893,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.learning_format,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.max_incompleteness_penalty,
         requestParameters.min_score,
         requestParameters.offered_by,
         requestParameters.offset,

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -550,6 +550,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       search_mode: searchParams.get("search_mode"),
       slop: searchParams.get("slop"),
       min_score: searchParams.get("min_score"),
+      max_incompleteness_penalty: searchParams.get(
+        "max_incompleteness_penalty",
+      ),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",
@@ -702,6 +705,28 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
             <ExplanationContainer>
               Minimum relevance score for a search result to be displayed. Only
               affects results if there is a search term.
+            </ExplanationContainer>
+            <AdminTitleContainer>
+              Maximum Incompleteness Penalty
+            </AdminTitleContainer>
+            <SliderInput
+              currentValue={
+                searchParams.get("max_incompleteness_penalty")
+                  ? Number(searchParams.get("max_incompleteness_penalty"))
+                  : 0
+              }
+              setSearchParams={setSearchParams}
+              urlParam="max_incompleteness_penalty"
+              min={0}
+              max={100}
+              step={1}
+            />
+            <ExplanationContainer>
+              Maximum score penalty for incomplete OCW courses in percent. An
+              OCW course with completeness = 0 will have this score penalty.
+              Partially complete courses have a linear penalty proportional to
+              the degree of incompleteness. Only affects results if there is a
+              search term.
             </ExplanationContainer>
           </div>
         ) : null}

--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
@@ -315,6 +315,7 @@ describe("SearchPage", () => {
     await waitFor(() => {
       screen.getByTestId("yearly_decay_percent-slider")
       screen.getByTestId("min_score-slider")
+      screen.getByTestId("max_incompleteness_penalty-slider")
     })
   })
 })

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -544,32 +544,48 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
 
     yearly_decay_percent = search_params.get("yearly_decay_percent")
     min_score = search_params.get("min_score")
+    max_incompleteness_penalty = (
+        search_params.get("max_incompleteness_penalty", 0) / 100
+    )
 
-    if (yearly_decay_percent and yearly_decay_percent > 0) or (
-        min_score and min_score > 0
-    ):
+    if yearly_decay_percent or min_score or max_incompleteness_penalty:
         script_query = {
             "script_score": {
                 "query": {"bool": {"must": [text_query], "filter": query_type_query}}
             }
         }
 
-        if yearly_decay_percent and yearly_decay_percent > 0:
-            script_query["script_score"]["script"] = {
-                "source": (
-                    "doc['resource_age_date'].size() == 0 ? _score : "
-                    "_score * decayDateLinear(params.origin, params.scale, "
-                    "params.offset, params.decay, doc['resource_age_date'].value)"
-                ),
-                "params": {
-                    "origin": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                    "offset": "0",
-                    "scale": "354d",
-                    "decay": 1 - (yearly_decay_percent / 100),
-                },
-            }
+        completeness_term = (
+            "(doc['completeness'].value * params.max_incompleteness_penalty + "
+            "(1-params.max_incompleteness_penalty))"
+        )
 
-        if min_score and min_score > 0:
+        staleness_term = (
+            "(doc['resource_age_date'].size() == 0 ? 1 : "
+            "decayDateLinear(params.origin, params.scale, params.offset, params.decay, "
+            "doc['resource_age_date'].value))"
+        )
+
+        source = "_score"
+        params = {}
+
+        if max_incompleteness_penalty:
+            source = f"{source} * {completeness_term}"
+            params["max_incompleteness_penalty"] = max_incompleteness_penalty
+
+        if yearly_decay_percent:
+            source = f"{source} * {staleness_term}"
+            params["decay"] = 1 - (yearly_decay_percent / 100)
+            params["offset"] = "0"
+            params["scale"] = "365d"
+            params["origin"] = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        script_query["script_score"]["script"] = {
+            "source": source,
+            "params": params,
+        }
+
+        if min_score:
             script_query["script_score"]["min_score"] = min_score
 
         search = search.query(script_query)

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -252,6 +252,7 @@ LEARNING_RESOURCE_MAP = {
     "next_start_date": {"type": "date"},
     "resource_age_date": {"type": "date"},
     "featured_rank": {"type": "float"},
+    "completeness": {"type": "float"},
 }
 
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -430,6 +430,20 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
             "Minimum score value a text query result needs to have to be displayed"
         ),
     )
+    max_incompleteness_penalty = serializers.FloatField(
+        max_value=100,
+        min_value=0,
+        required=False,
+        allow_null=True,
+        default=0,
+        help_text=(
+            "Maximum score penalty for incomplete OCW courses in percent. "
+            "An OCW course with completeness = 0 will have this score penalty. "
+            "Partially complete courses have a linear penalty proportional to "
+            "the degree of incompleteness. Only affects results if there is a "
+            "search term."
+        ),
+    )
 
 
 class ContentFileSearchRequestSerializer(SearchRequestSerializer):

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -878,6 +878,7 @@ def test_learning_resources_search_request_serializer():
         "search_mode": "phrase",
         "slop": 2,
         "min_score": 0,
+        "max_incompleteness_penalty": 25,
     }
 
     cleaned = {
@@ -903,6 +904,7 @@ def test_learning_resources_search_request_serializer():
         "search_mode": "phrase",
         "slop": 2,
         "min_score": 0,
+        "max_incompleteness_penalty": 25,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2451,6 +2451,19 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: max_incompleteness_penalty
+        schema:
+          type: number
+          format: double
+          maximum: 100
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Maximum score penalty for incomplete OCW courses in percent.
+          An OCW course with completeness = 0 will have this score penalty. Partially
+          complete courses have a linear penalty proportional to the degree of incompleteness.
+          Only affects results if there is a search term.
+      - in: query
         name: min_score
         schema:
           type: number
@@ -2918,6 +2931,19 @@ paths:
         schema:
           type: integer
         description: Number of results to return per page
+      - in: query
+        name: max_incompleteness_penalty
+        schema:
+          type: number
+          format: double
+          maximum: 100
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Maximum score penalty for incomplete OCW courses in percent.
+          An OCW course with completeness = 0 will have this score penalty. Partially
+          complete courses have a linear penalty proportional to the degree of incompleteness.
+          Only affects results if there is a search term.
       - in: query
         name: min_score
         schema:
@@ -3412,6 +3438,19 @@ paths:
           type: integer
         description: Number of results to return per page
       - in: query
+        name: max_incompleteness_penalty
+        schema:
+          type: number
+          format: double
+          maximum: 100
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Maximum score penalty for incomplete OCW courses in percent.
+          An OCW course with completeness = 0 will have this score penalty. Partially
+          complete courses have a linear penalty proportional to the degree of incompleteness.
+          Only affects results if there is a search term.
+      - in: query
         name: min_score
         schema:
           type: number
@@ -3895,6 +3934,19 @@ paths:
         schema:
           type: integer
         description: Number of results to return per page
+      - in: query
+        name: max_incompleteness_penalty
+        schema:
+          type: number
+          format: double
+          maximum: 100
+          minimum: 0
+          nullable: true
+          default: 0.0
+        description: Maximum score penalty for incomplete OCW courses in percent.
+          An OCW course with completeness = 0 will have this score penalty. Partially
+          complete courses have a linear penalty proportional to the degree of incompleteness.
+          Only affects results if there is a search term.
       - in: query
         name: min_score
         schema:
@@ -9913,6 +9965,17 @@ components:
           default: 0.0
           description: Minimum score value a text query result needs to have to be
             displayed
+        max_incompleteness_penalty:
+          type: number
+          format: double
+          maximum: 100
+          minimum: 0
+          nullable: true
+          default: 0.0
+          description: Maximum score penalty for incomplete OCW courses in percent.
+            An OCW course with completeness = 0 will have this score penalty. Partially
+            complete courses have a linear penalty proportional to the degree of incompleteness.
+            Only affects results if there is a search term.
         source_type:
           allOf:
           - $ref: '#/components/schemas/SourceTypeEnum'


### PR DESCRIPTION
### What are the relevant tickets?
closes  https://github.com/mitodl/hq/issues/5259

### Description (What does it do?)
This pr adds a slider to the admin dashboard that allows users to set the `max_incompleteness_penalty` to reduce the prominence of incomplete ocw courses in search results. Default `max_incompleteness_penalty` is set to zero for now because we need to recreate the index to add completeness and a non-zero default will break search for non-admin users while we are waiting for the reindex to finish. 

The score after the completeness adjustmet is given by
```
relevance_score * (completeness * max_incompleteness_penalty /100 + (100-max_incompleteness_penalty/100)
```
Where `completeness` is a decimal from 0 to 1
and `max_incompleteness_penalty` is a percent from 0 to 100


Completeness was added in this PR https://github.com/mitodl/mit-open/pull/1461


### How can this be tested?
Before you do anything else,  verify that search works normally for non-admins (or non logged in users) and also for admins as long as max_incompleteness_penalty is not set

Run 
./manage.py backpopulate_ocw_scores
./manage.py backpopulate_ocw_data --course-name sp-248-neet-ways-of-thinking-fall-2023
./manage.py recreate_index

Go to http://open.odl.local:8062/search/?q=ways+of+thinking
"NEET Ways of Thinking", an ocw course with low completeness will be the first result

Log in as an admin
In the admin section of the search params you should see the "Maximum Incompleteness Penalty" slider. As you increase the incompleteness penalty, "NEET Ways of Thinking" should move down in the results


