### PR TITLE
Remove unnecessary searchparms check

### DIFF
--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -29,7 +29,6 @@ import { MenuButton } from "./MenuButton"
 import {
   DEPARTMENTS,
   TOPICS,
-  RESOURCE_DRAWER_QUERY_PARAM,
   SEARCH,
   UNITS,
   SEARCH_NEW,
@@ -41,7 +40,6 @@ import {
   SEARCH_PROGRAM,
   SEARCH_LEARNING_MATERIAL,
 } from "@/common/urls"
-import { useSearchParams } from "react-router-dom"
 import { useUserMe } from "api/hooks/user"
 
 const Bar = styled(AppBar)(({ theme }) => ({
@@ -252,19 +250,12 @@ const navData: NavData = {
 
 const Header: FunctionComponent = () => {
   const [drawerOpen, toggleDrawer] = useToggle(false)
-  const [searchParams] = useSearchParams()
-  const resourceDrawerOpen = searchParams.has(RESOURCE_DRAWER_QUERY_PARAM)
-
   const toggler = (event: React.MouseEvent) => {
-    if (!resourceDrawerOpen) {
-      // This is done to prevent ClickAwayHandler from closing the drawer upon open
-      event.stopPropagation()
-    }
+    event.stopPropagation()
     toggleDrawer(!drawerOpen)
   }
   const closeDrawer = (event: MouseEvent | TouchEvent) => {
-    if (drawerOpen && !resourceDrawerOpen && event.type !== "touchstart") {
-      event.preventDefault()
+    if (drawerOpen && event.type !== "touchstart") {
       toggleDrawer(false)
     }
   }

--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -251,7 +251,7 @@ const navData: NavData = {
 const Header: FunctionComponent = () => {
   const [drawerOpen, toggleDrawer] = useToggle(false)
   const toggler = (event: React.MouseEvent) => {
-    event.stopPropagation()
+    event.stopPropagation() // Prevent clicking on "Explore MIT" button from triggering the ClickAwayHandler
     toggleDrawer(!drawerOpen)
   }
   const closeDrawer = (event: MouseEvent | TouchEvent) => {


### PR DESCRIPTION
### What are the relevant tickets?
Toward fixing build on [nextjs branch](https://github.com/mitodl/mit-open/tree/nextjs)

### Description (What does it do?)
Removes unnecessary `useSearchParams` call from the nav menu trigger.

With NextJS, this usage of `useSearchParams` would be replaced by NextJS's version, which has [some rules](https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout) around it. Following the rules is easily doable, but in this case the usage of search params seems entirely unnecessary, so removing it is the simplest option.

### How can this be tested?
1. Check clicking "Explore MIT" still opens nav menu
2. With the menu open, check that:
     - clicking "Explore MIT" closes the menu
     - click outside the nav drawer closes the menu
    - Clicking a resource card closes the menu and opens the resource drawer
    - Clicking the homepage search input focus the input
3. Repeat above in mobile view.
