### PR TITLE
dfs_query_then_fetch

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3482,6 +3482,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   dev_mode?: boolean | null
   /**
+   * If true sets search_type=dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  use_dfs_query_then_fetch?: boolean | null
+  /**
    * The id value for the learning resource
    * @type {Array<number>}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -6841,6 +6847,7 @@ export const ContentFileSearchApiAxiosParamCreator = function (
      * @param {Array<number>} [run_id] The id value of the run that the content file belongs to
      * @param {ContentFileSearchRetrieveSortbyEnum} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -6858,6 +6865,7 @@ export const ContentFileSearchApiAxiosParamCreator = function (
       run_id?: Array<number>,
       sortby?: ContentFileSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/content_file_search/`
@@ -6928,6 +6936,11 @@ export const ContentFileSearchApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (use_dfs_query_then_fetch !== undefined) {
+        localVarQueryParameter["use_dfs_query_then_fetch"] =
+          use_dfs_query_then_fetch
+      }
+
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -6969,6 +6982,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
      * @param {Array<number>} [run_id] The id value of the run that the content file belongs to
      * @param {ContentFileSearchRetrieveSortbyEnum} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -6986,6 +7000,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
       run_id?: Array<number>,
       sortby?: ContentFileSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -7008,6 +7023,7 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
           run_id,
           sortby,
           topic,
+          use_dfs_query_then_fetch,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -7063,6 +7079,7 @@ export const ContentFileSearchApiFactory = function (
           requestParameters.run_id,
           requestParameters.sortby,
           requestParameters.topic,
+          requestParameters.use_dfs_query_then_fetch,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -7166,6 +7183,13 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
   readonly topic?: Array<string>
+
+  /**
+   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof ContentFileSearchApiContentFileSearchRetrieve
+   */
+  readonly use_dfs_query_then_fetch?: boolean | null
 }
 
 /**
@@ -7202,6 +7226,7 @@ export class ContentFileSearchApi extends BaseAPI {
         requestParameters.run_id,
         requestParameters.sortby,
         requestParameters.topic,
+        requestParameters.use_dfs_query_then_fetch,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -12240,6 +12265,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12269,6 +12295,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       slop?: number | null,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -12385,6 +12412,11 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (use_dfs_query_then_fetch !== undefined) {
+        localVarQueryParameter["use_dfs_query_then_fetch"] =
+          use_dfs_query_then_fetch
+      }
+
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -12443,6 +12475,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12472,6 +12505,7 @@ export const LearningResourcesSearchApiFp = function (
       slop?: number | null,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -12506,6 +12540,7 @@ export const LearningResourcesSearchApiFp = function (
           slop,
           sortby,
           topic,
+          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -12573,6 +12608,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.slop,
           requestParameters.sortby,
           requestParameters.topic,
+          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -12756,6 +12792,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   readonly topic?: Array<string>
 
   /**
+   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly use_dfs_query_then_fetch?: boolean | null
+
+  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
@@ -12808,6 +12851,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.slop,
         requestParameters.sortby,
         requestParameters.topic,
+        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -13045,6 +13089,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13075,6 +13120,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -13195,6 +13241,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (use_dfs_query_then_fetch !== undefined) {
+        localVarQueryParameter["use_dfs_query_then_fetch"] =
+          use_dfs_query_then_fetch
+      }
+
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -13240,6 +13291,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13269,6 +13321,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       slop?: number | null,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -13385,6 +13438,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (use_dfs_query_then_fetch !== undefined) {
+        localVarQueryParameter["use_dfs_query_then_fetch"] =
+          use_dfs_query_then_fetch
+      }
+
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -13431,6 +13489,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
@@ -13462,6 +13521,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options: RawAxiosRequestConfig = {},
@@ -13583,6 +13643,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
+      if (use_dfs_query_then_fetch !== undefined) {
+        localVarQueryParameter["use_dfs_query_then_fetch"] =
+          use_dfs_query_then_fetch
+      }
+
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -13700,6 +13765,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13730,6 +13796,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -13765,6 +13832,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
+          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -13808,6 +13876,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13837,6 +13906,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       slop?: number | null,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -13871,6 +13941,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           slop,
           sortby,
           topic,
+          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -13915,6 +13986,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
@@ -13946,6 +14018,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
+      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options?: RawAxiosRequestConfig,
@@ -13979,6 +14052,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
+          use_dfs_query_then_fetch,
           yearly_decay_percent,
           PercolateQuerySubscriptionRequestRequest,
           options,
@@ -14079,6 +14153,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
+          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -14121,6 +14196,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.slop,
           requestParameters.sortby,
           requestParameters.topic,
+          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -14164,6 +14240,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
+          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           requestParameters.PercolateQuerySubscriptionRequestRequest,
           options,
@@ -14373,6 +14450,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly topic?: Array<string>
 
   /**
+   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly use_dfs_query_then_fetch?: boolean | null
+
+  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
@@ -14553,6 +14637,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly topic?: Array<string>
+
+  /**
+   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly use_dfs_query_then_fetch?: boolean | null
 
   /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
@@ -14744,6 +14835,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly topic?: Array<string>
 
   /**
+   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
+   * @type {boolean}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly use_dfs_query_then_fetch?: boolean | null
+
+  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
@@ -14818,6 +14916,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
+        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -14862,6 +14961,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.slop,
         requestParameters.sortby,
         requestParameters.topic,
+        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -14907,6 +15007,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
+        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         requestParameters.PercolateQuerySubscriptionRequestRequest,
         options,

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -553,6 +553,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       max_incompleteness_penalty: searchParams.get(
         "max_incompleteness_penalty",
       ),
+      use_dfs_query_then_fetch: searchParams.get("use_dfs_query_then_fetch"),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -595,7 +595,7 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
     return search
 
 
-def construct_search(search_params):
+def construct_search(search_params):  # noqa: C901
     """
     Construct a learning resources search based on the query
 
@@ -668,6 +668,9 @@ def construct_search(search_params):
 
     if search_params.get("dev_mode"):
         search = search.extra(explain=True)
+
+    if search_params.get("use_dfs_query_then_fetch"):
+        search = search.params(search_type="dfs_query_then_fetch")
 
     return search
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -282,6 +282,15 @@ class SearchRequestSerializer(serializers.Serializer):
         default=False,
         help_text="If true return raw open search results with score explanations",
     )
+    use_dfs_query_then_fetch = serializers.BooleanField(
+        required=False,
+        allow_null=True,
+        default=False,
+        help_text=(
+            "If true sets search_type=dfs_query_then_fetch which makes Opensearch"
+            "make an extra pre-query to calculate term frequencies accross indexes"
+        ),
+    )
 
     def validate(self, attrs):
         unknown = set(self.initial_data) - set(self.fields)

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -879,6 +879,7 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
+        "use_dfs_query_then_fetch": False,
     }
 
     cleaned = {
@@ -905,6 +906,7 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
+        "use_dfs_query_then_fetch": False,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)
@@ -942,6 +944,7 @@ def test_content_file_search_request_serializer():
         "offered_by": ["xpro", "ocw"],
         "platform": ["xpro", "edx", "ocw"],
         "dev_mode": False,
+        "use_dfs_query_then_fetch": False,
     }
 
     serialized = ContentFileSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -303,6 +303,14 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: use_dfs_query_then_fetch
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+          an extra pre-query to calculate term frequencies accross indexes
       tags:
       - content_file_search
       responses:
@@ -2675,6 +2683,14 @@ paths:
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
       - in: query
+        name: use_dfs_query_then_fetch
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+          an extra pre-query to calculate term frequencies accross indexes
+      - in: query
         name: yearly_decay_percent
         schema:
           type: number
@@ -3155,6 +3171,14 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: use_dfs_query_then_fetch
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+          an extra pre-query to calculate term frequencies accross indexes
       - in: query
         name: yearly_decay_percent
         schema:
@@ -3676,6 +3700,14 @@ paths:
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
       - in: query
+        name: use_dfs_query_then_fetch
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+          an extra pre-query to calculate term frequencies accross indexes
+      - in: query
         name: yearly_decay_percent
         schema:
           type: number
@@ -4172,6 +4204,14 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: use_dfs_query_then_fetch
+        schema:
+          type: boolean
+          nullable: true
+          default: false
+        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+          an extra pre-query to calculate term frequencies accross indexes
       - in: query
         name: yearly_decay_percent
         schema:
@@ -9835,6 +9875,12 @@ components:
           nullable: true
           default: false
           description: If true return raw open search results with score explanations
+        use_dfs_query_then_fetch:
+          type: boolean
+          nullable: true
+          default: false
+          description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
+            an extra pre-query to calculate term frequencies accross indexes
         id:
           type: array
           items:


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5351

### Description (What does it do?)
Currently opensearch calculates term frequencies on a per index level which means that scores are not consistent between learning resource types and resource types with small indexes (Programs) are penalized

Setting search_type=dfs_query_then_fetch make OpenSearch make a pre-query to get search frequencies from across all the indexes used in the query, which will make programs be given more reasonable scores. However, the documentation warns that this is turned off by default because it's slower. I am adding use_dfs_query_then_fetch as a parameter for now so we can test the performance on RC before committing to the change. I have not noticed performance issues locally.

If this doesn't work we will probably need to get rid of the resource specific open search indexes and store all learning resources in one index. We might want to do that anyway - it will make queries simpler which might also make them faster. We had separate indexes in open-discussions because different resources had different data fields. Now 
that learning resources are standardized there isn't really a good reason to have separate indexes by learning resource

### How can this be tested?
Go to http://open.odl.local:8062/search/?q=Machine+Learning&resource_category=program
And verify that you see "Professional Certificate Program in Machine Learning & Artificial Intelligence" and "Machine Learning, Modeling, and Simulation: Engineering Problem-Solving in the Age of AI". If you don't run the backpopluate commands to populate them

Go to http://open.odl.local:8062/search/?q=Machine+Learning. You will not see programs in the first few pages. For me "Professional Certificate Program in Machine Learning & Artificial Intelligence"  is on the third page and "Machine Learning, Modeling, and Simulation: Engineering Problem-Solving in the Age of AI" is not in the first 8 pages

Go to http://open.odl.local:8062/search/?q=machine+learning&use_dfs_query_then_fetch=True.  Verify that you see the programs in the results. For me "Professional Certificate Program in Machine Learning & Artificial Intelligence"  is on page one and  "Machine Learning, Modeling, and Simulation: Engineering Problem-Solving in the Age of AI" is  on page two

