### PR TITLE
Shanbady/fix course panel start date

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -315,7 +315,8 @@ describe("Learning Resource Expanded", () => {
     expect(options[3]).toHaveTextContent(
       formatDate(farFutureDate, "MMMM DD, YYYY"),
     )
-    const selected = options.find((option) => option.selected === true)
+
+    const selected = screen.getByRole("option", { selected: true })
     expect(selected).toHaveTextContent(
       formatDate(nextFutureDate, "MMMM DD, YYYY"),
     )

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -327,7 +327,8 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       const closest = resource?.runs?.reduce(function (prev, current) {
         const now = Date.now()
         return prev.start_date &&
-          Date.parse(prev.start_date) - now > current.start_date - now
+          Date.parse(prev.start_date) - now <
+            Date.parse(current.start_date) - now
           ? prev
           : current
       })

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -60,7 +60,7 @@ const DateContainer = styled.div`
   }
 `
 
-const DateSingle = styled(Date)`
+const DateSingle = styled(DateContainer)`
   margin-top: 10px;
 `
 
@@ -331,7 +331,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
             Date.parse(current.start_date) - now
           ? prev
           : current
-      })
+      }, resource!.runs![0])
       setSelectedRun(closest)
     }
   }, [resource])

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -351,13 +351,16 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     if (!resource) {
       return <Skeleton height={40} style={{ marginTop: 0, width: "60%" }} />
     }
+
     const dateOptions: SimpleSelectProps["options"] =
-      resource.runs?.map((run) => {
-        return {
-          value: run.id.toString(),
-          label: formatRunDate(run, asTaughtIn),
-        }
-      }) ?? []
+      resource.runs
+        ?.sort((a, b) => Date.parse(a.start_date) - Date.parse(b.start_date))
+        .map((run) => {
+          return {
+            value: run.id.toString(),
+            label: formatRunDate(run, asTaughtIn),
+          }
+        }) ?? []
 
     if (
       [ResourceTypeEnum.Course, ResourceTypeEnum.Program].includes(

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -328,6 +328,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
         const now = Date.now()
         return prev.start_date &&
           current.start_date &&
+          Date.parse(prev.start_date) > now &&
           Date.parse(prev.start_date) - now <
             Date.parse(current.start_date) - now
           ? prev

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -355,7 +355,12 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
 
     const dateOptions: SimpleSelectProps["options"] =
       resource.runs
-        ?.sort((a, b) => Date.parse(a.start_date) - Date.parse(b.start_date))
+        ?.sort((a, b) => {
+          if (a?.start_date && b?.start_date) {
+            return Date.parse(a.start_date) - Date.parse(b.start_date)
+          }
+          return 0
+        })
         .map((run) => {
           return {
             value: run.id.toString(),
@@ -383,15 +388,11 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
 
     if (!selectedRun) return <NoDateSpacer />
 
-    const formatted = formatRunDate(selectedRun, asTaughtIn)
-    if (!formatted) {
-      return <NoDateSpacer />
-    }
-
+    const formatted = formatRunDate(selectedRun, asTaughtIn) ?? ""
     return (
       <DateSingle>
         <DateLabel>{label}</DateLabel>
-        {formatted}
+        {formatted ?? ""}
       </DateSingle>
     )
   }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -392,7 +392,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
     return (
       <DateSingle>
         <DateLabel>{label}</DateLabel>
-        {formatted ?? ""}
+        {formatted ?? <NoDateSpacer />}
       </DateSingle>
     )
   }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -388,11 +388,14 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
 
     if (!selectedRun) return <NoDateSpacer />
 
-    const formatted = formatRunDate(selectedRun, asTaughtIn) ?? ""
+    const formatted = formatRunDate(selectedRun, asTaughtIn)
+    if (!formatted) {
+      return <NoDateSpacer />
+    }
     return (
       <DateSingle>
         <DateLabel>{label}</DateLabel>
-        {formatted ?? <NoDateSpacer />}
+        {formatted ?? ""}
       </DateSingle>
     )
   }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -33,7 +33,7 @@ const Container = styled.div<{ padTop?: boolean }>`
   }
 `
 
-const Date = styled.div`
+const DateContainer = styled.div`
   display: flex;
   justify-content: start;
   align-self: stretch;
@@ -324,7 +324,14 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
 
   useEffect(() => {
     if (resource) {
-      setSelectedRun(resource!.runs![0])
+      const closest = resource?.runs?.reduce(function (prev, current) {
+        const now = Date.now()
+        return prev.start_date &&
+          Date.parse(prev.start_date) - now > current.start_date - now
+          ? prev
+          : current
+      })
+      setSelectedRun(closest)
     }
   }, [resource])
 
@@ -357,14 +364,14 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       multipleRuns
     ) {
       return (
-        <Date>
+        <DateContainer>
           <DateLabel>{label}</DateLabel>
           <SimpleSelect
             value={selectedRun?.id.toString() ?? ""}
             onChange={onDateChange}
             options={dateOptions}
           />
-        </Date>
+        </DateContainer>
       )
     }
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -327,6 +327,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       const closest = resource?.runs?.reduce(function (prev, current) {
         const now = Date.now()
         return prev.start_date &&
+          current.start_date &&
           Date.parse(prev.start_date) - now <
             Date.parse(current.start_date) - now
           ? prev


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5256


### Description (What does it do?)
This PR sorts the date dropdown and ensures that the closest upcoming date is pre-selected in the learning resource expanded drawer

### Screenshots (if appropriate):
<img width="419" alt="Screenshot 2024-09-05 at 2 10 16 PM" src="https://github.com/user-attachments/assets/c640a9f3-a6f8-487c-82d0-4cec34daff69">
<img width="396" alt="Screenshot 2024-09-05 at 2 10 31 PM" src="https://github.com/user-attachments/assets/40b23e6a-fa50-45ac-aa0d-33617e7e7e4e">

### How can this be tested?
1. checkout this branch. make sure you have data/learning resources loaded (in particular ones with multiple runs/dates)
2. find a resource with multiple upcoming runs and open the resource drawer
3. see that the dates are chronologically sorted and that the next upcoming date is preselected

