### PR TITLE
Sort news by publish date

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -4529,7 +4529,7 @@ export const NewsEventsApiAxiosParamCreator = function (
      * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
+     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;news_date&#x60; - Creation date ascending * &#x60;-news_date&#x60; - Creation date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4647,7 +4647,7 @@ export const NewsEventsApiFp = function (configuration?: Configuration) {
      * @param {Array<NewsEventsListFeedTypeEnum>} [feed_type] The type of item  * &#x60;news&#x60; - News * &#x60;events&#x60; - Events
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
-     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
+     * @param {NewsEventsListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;news_date&#x60; - Creation date ascending * &#x60;-news_date&#x60; - Creation date descending
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -4785,8 +4785,8 @@ export interface NewsEventsApiNewsEventsListRequest {
   readonly offset?: number
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;created&#x60; - Creation date ascending * &#x60;-created&#x60; - Creation date descending
-   * @type {'-created' | '-event_date' | '-id' | 'created' | 'event_date' | 'id'}
+   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;event_date&#x60; - Event date ascending * &#x60;-event_date&#x60; - Event date  descending * &#x60;news_date&#x60; - Creation date ascending * &#x60;-news_date&#x60; - Creation date descending
+   * @type {'-event_date' | '-id' | '-news_date' | 'event_date' | 'id' | 'news_date'}
    * @memberof NewsEventsApiNewsEventsList
    */
   readonly sortby?: NewsEventsListSortbyEnum
@@ -4865,12 +4865,12 @@ export type NewsEventsListFeedTypeEnum =
  * @export
  */
 export const NewsEventsListSortbyEnum = {
-  Created: "-created",
   EventDate: "-event_date",
   Id: "-id",
-  Created2: "created",
+  NewsDate: "-news_date",
   EventDate2: "event_date",
   Id2: "id",
+  NewsDate2: "news_date",
 } as const
 export type NewsEventsListSortbyEnum =
   (typeof NewsEventsListSortbyEnum)[keyof typeof NewsEventsListSortbyEnum]

--- a/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HomePage.test.tsx
@@ -52,7 +52,11 @@ const setupAPIs = () => {
   )
 
   setMockResponse.get(
-    urls.newsEvents.list({ feed_type: ["news"], limit: 6, sortby: "-created" }),
+    urls.newsEvents.list({
+      feed_type: ["news"],
+      limit: 6,
+      sortby: "-news_date",
+    }),
     {},
   )
   setMockResponse.get(
@@ -152,7 +156,7 @@ describe("Home Page News and Events", () => {
       urls.newsEvents.list({
         feed_type: ["news"],
         limit: 6,
-        sortby: "-created",
+        sortby: "-news_date",
       }),
       news,
     )
@@ -203,7 +207,7 @@ describe("Home Page News and Events", () => {
       urls.newsEvents.list({
         feed_type: ["news"],
         limit: 6,
-        sortby: "-created",
+        sortby: "-news_date",
       }),
       news,
     )

--- a/frontends/mit-learn/src/pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/NewsEventsSection.tsx
@@ -188,7 +188,7 @@ const NewsEventsSection: React.FC = () => {
   const { data: news } = useNewsEventsList({
     feed_type: [NewsEventsListFeedTypeEnum.News],
     limit: 6,
-    sortby: "-created",
+    sortby: "-news_date",
   })
 
   const { data: events } = useNewsEventsList({

--- a/news_events/constants.py
+++ b/news_events/constants.py
@@ -29,13 +29,13 @@ NEWS_EVENTS_SORTBY_OPTIONS = {
         "title": "Event date  descending",
         "sort": "-event_details__event_datetime",
     },
-    "created": {
+    "news_date": {
         "title": "Creation date ascending",
-        "sort": "created_on",
+        "sort": "news_details__publish_date",
     },
-    "-created": {
+    "-news_date": {
         "title": "Creation date descending",
-        "sort": "-created_on",
+        "sort": "-news_details__publish_date",
     },
 }
 

--- a/news_events/filters_test.py
+++ b/news_events/filters_test.py
@@ -47,18 +47,24 @@ def test_item_filter_feed_type(client, multifilter):
     )
 
 
-@pytest.mark.parametrize("sortby", ["created", "event_date"])
+@pytest.mark.parametrize(
+    ("sortby", "feed_type"),
+    [
+        ("news_date", FeedType.news.name),
+        ("event_date", FeedType.events.name),
+    ],
+)
 @pytest.mark.parametrize("descending", [True, False])
-def test_learning_resource_sortby(client, sortby, descending):
+def test_learning_resource_sortby(client, sortby, feed_type, descending):
     """Test that the query is sorted in the correct order"""
-    source = FeedSourceFactory.create(feed_type=FeedType.events.name)
+    source = FeedSourceFactory.create(feed_type=feed_type)
     items = FeedItemFactory.create_batch(4, source=source, is_event=True)
     sortby_param = sortby
     if descending:
         sortby_param = f"-{sortby}"
 
     results = client.get(
-        f"{ITEM_API_URL}?feed_type=events&sortby={sortby_param}"
+        f"{ITEM_API_URL}?feed_type={feed_type}&sortby={sortby_param}"
     ).json()["results"]
 
     def get_sort_field(item):

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -326,12 +326,12 @@ paths:
         schema:
           type: string
           enum:
-          - -created
           - -event_date
           - -id
-          - created
+          - -news_date
           - event_date
           - id
+          - news_date
         description: |-
           Sort By
 
@@ -339,8 +339,8 @@ paths:
           * `-id` - Object ID descending
           * `event_date` - Event date ascending
           * `-event_date` - Event date  descending
-          * `created` - Creation date ascending
-          * `-created` - Creation date descending
+          * `news_date` - Creation date ascending
+          * `-news_date` - Creation date descending
       tags:
       - news_events
       responses:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5261

### Description (What does it do?)
Sorts news items by publish date instead of created date

### Screenshots (if appropriate):
![Screenshot 2024-09-05 155614](https://github.com/user-attachments/assets/ced60728-0a4b-4add-bd90-aff83ffbc687)


### How can this be tested?
-  Run `.manage.py backpopulate_news_data`
- Go to the "Stories" section of the home page.  The news items should be sorted by reverse publish date.

