### PR TITLE
change search mode default

### DIFF
--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -586,7 +586,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   const searchModeDropdown = (
     <StyledSelect
       size="small"
-      value={searchParams.get("search_mode") || "best_fields"}
+      value={searchParams.get("search_mode") || "phrase"}
       onChange={(e) =>
         setSearchParams((prev) => {
           const next = new URLSearchParams(prev)
@@ -667,7 +667,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 OpenSearch search multi-match query type.
               </ExplanationContainer>
             </div>
-            {searchParams.get("search_mode") === "phrase" ? (
+            {!searchParams.get("search_mode") ||
+            searchParams.get("search_mode") === "phrase" ? (
               <div>
                 <AdminTitleContainer>Slop</AdminTitleContainer>
 
@@ -675,7 +676,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   currentValue={
                     searchParams.get("slop")
                       ? Number(searchParams.get("slop"))
-                      : 0
+                      : 6
                   }
                   setSearchParams={setSearchParams}
                   urlParam="slop"

--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
@@ -349,11 +349,21 @@ test("admin users can set the search mode and slop", async () => {
     user.click(adminFacetContainer)
   })
 
-  let slopSlider = screen.queryByText("Slop")
-  expect(slopSlider).toBeNull()
-
-  const searchModeDropdowns = await screen.findAllByText("best_fields")
+  const searchModeDropdowns = await screen.findAllByText("phrase")
   const searchModeDropdown = searchModeDropdowns[0]
+
+  await user.click(searchModeDropdown)
+
+  const mostFieldsSelect = await screen.findByRole("option", {
+    name: "most_fields",
+  })
+
+  await user.click(mostFieldsSelect)
+
+  expect(location.current.search).toBe("?search_mode=most_fields")
+
+  const slopSlider = screen.queryByText("Slop")
+  expect(slopSlider).toBeNull()
 
   await user.click(searchModeDropdown)
 
@@ -370,17 +380,6 @@ test("admin users can set the search mode and slop", async () => {
   })
 
   await user.click(searchModeDropdown)
-
-  const mostFieldsSelect = await screen.findByRole("option", {
-    name: "most_fields",
-  })
-
-  await user.click(mostFieldsSelect)
-
-  expect(location.current.search).toBe("?search_mode=most_fields")
-
-  slopSlider = screen.queryByText("Slop")
-  expect(slopSlider).toBeNull()
 })
 
 describe("Search Page Tabs", () => {

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -507,7 +507,19 @@ def adjust_original_query_for_percolate(query):
     Remove keys that are irrelevent when storing original queries
     for percolate uniqueness such as "limit" and "offset"
     """
-    for key in ["limit", "offset", "sortby", "yearly_decay_percent", "dev_mode"]:
+    for key in [
+        "limit",
+        "offset",
+        "sortby",
+        "yearly_decay_percent",
+        "dev_mode",
+        "use_dfs_query_then_fetch",
+        "max_incompleteness_penalty",
+        "min_score",
+        "search_mode",
+        "slop",
+        "use_dfs_query_then_fetch",
+    ]:
         query.pop(key, None)
     return order_params(query)
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -418,6 +418,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
     ]
     search_mode = serializers.ChoiceField(
         required=False,
+        default="phrase",
         choices=search_mode_choices,
         help_text=(
             f"The open search search type for text queries \
@@ -427,6 +428,7 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
     slop = serializers.IntegerField(
         required=False,
         allow_null=True,
+        default=6,
         help_text=("Allowed distance for phrase search"),
     )
     min_score = serializers.FloatField(

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2624,6 +2624,7 @@ paths:
           - most_fields
           - phrase
           type: string
+          default: phrase
           minLength: 1
         description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
@@ -2634,6 +2635,7 @@ paths:
         schema:
           type: integer
           nullable: true
+          default: 6
         description: Allowed distance for phrase search
       - in: query
         name: sortby
@@ -3113,6 +3115,7 @@ paths:
           - most_fields
           - phrase
           type: string
+          default: phrase
           minLength: 1
         description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
@@ -3123,6 +3126,7 @@ paths:
         schema:
           type: integer
           nullable: true
+          default: 6
         description: Allowed distance for phrase search
       - in: query
         name: sortby
@@ -3627,6 +3631,7 @@ paths:
           - most_fields
           - phrase
           type: string
+          default: phrase
           minLength: 1
         description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
@@ -3637,6 +3642,7 @@ paths:
         schema:
           type: integer
           nullable: true
+          default: 6
         description: Allowed distance for phrase search
       - in: query
         name: sortby
@@ -4132,6 +4138,7 @@ paths:
           - most_fields
           - phrase
           type: string
+          default: phrase
           minLength: 1
         description: "The open search search type for text queries             \n\n\
           * `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
@@ -4142,6 +4149,7 @@ paths:
         schema:
           type: integer
           nullable: true
+          default: 6
         description: Allowed distance for phrase search
       - in: query
         name: sortby
@@ -9994,6 +10002,7 @@ components:
         search_mode:
           allOf:
           - $ref: '#/components/schemas/SearchModeEnum'
+          default: phrase
           description: "The open search search type for text queries             \n\
             \n* `best_fields` - best_fields\n* `most_fields` - most_fields\n* `phrase`\
             \ - phrase\n\n* `best_fields` - best_fields\n* `most_fields` - most_fields\n\
@@ -10001,6 +10010,7 @@ components:
         slop:
           type: integer
           nullable: true
+          default: 6
           description: Allowed distance for phrase search
         min_score:
           type: number


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mit-open/pull/1456

### Description (What does it do?)
This pr changes the dafault search mode to "phrase search" with slop=6. This gives fewer and better results than our current search

### How can this be tested?
Go to the search. Verify that everything still works as expected.