### PR TITLE
learning resource drawer list buttons

### DIFF
--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -40,6 +40,7 @@ describe("LearningResourceDrawer", () => {
   ])(
     "Renders drawer content when resource=id is in the URL and captures the view if PostHog $descriptor",
     async ({ enablePostHog }) => {
+      setMockResponse.get(urls.userMe.get(), {})
       APP_SETTINGS.POSTHOG = {
         api_key: enablePostHog ? "test1234" : "", // pragma: allowlist secret
       }

--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -14,6 +14,7 @@ import { urls, factories, setMockResponse } from "api/test-utils"
 import { LearningResourceExpanded } from "ol-components"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 import { ResourceTypeEnum } from "api"
+import invariant from "tiny-invariant"
 
 jest.mock("ol-components", () => {
   const actual = jest.requireActual("ol-components")
@@ -160,8 +161,9 @@ describe("LearningResourceDrawer", () => {
       })
 
       const section = screen
-        .getByRole("heading", { name: "Info" })!
-        .closest("section")!
+        .getByRole("heading", { name: "Info" })
+        .closest("section")
+      invariant(section)
 
       if (!isAuthenticated) {
         const buttons = within(section).queryAllByRole("button")
@@ -172,16 +174,14 @@ describe("LearningResourceDrawer", () => {
         const expectedButtons =
           expectAddToLearningPathButton && expectAddToUserListButton ? 2 : 1
         expect(buttons).toHaveLength(expectedButtons)
-        if (expectAddToLearningPathButton) {
-          expect(
-            within(section).getByLabelText("Add to Learning Path"),
-          ).toBeInTheDocument()
-        }
-        if (expectAddToUserListButton) {
-          expect(
-            within(section).getByLabelText("Add to User List"),
-          ).toBeInTheDocument()
-        }
+        expect(
+          !!within(section).queryByRole("button", {
+            name: "Add to Learning Path",
+          }),
+        ).toBe(expectAddToLearningPathButton)
+        expect(
+          !!within(section).queryByRole("button", { name: "Add to User List" }),
+        ).toBe(expectAddToUserListButton)
       }
     },
   )

--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -114,12 +114,6 @@ describe("LearningResourceDrawer", () => {
       expectAddToUserListButton: true,
     },
     {
-      isLearningPathEditor: true,
-      isAuthenticated: false,
-      expectAddToLearningPathButton: false,
-      expectAddToUserListButton: false,
-    },
-    {
       isLearningPathEditor: false,
       isAuthenticated: false,
       expectAddToLearningPathButton: false,

--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -68,7 +68,7 @@ const DrawerContent: React.FC<{
   const { data: user } = useUserMe()
   const handleAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"] =
     useMemo(() => {
-      if (user?.is_authenticated && user?.is_learning_path_editor) {
+      if (user?.is_learning_path_editor) {
         return (event, resourceId: number) => {
           NiceModal.show(AddToLearningPathDialog, { resourceId })
         }

--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -77,11 +77,7 @@ const DrawerContent: React.FC<{
     }, [user])
   const handleAddToUserListClick: LearningResourceCardProps["onAddToUserListClick"] =
     useMemo(() => {
-      if (!user) {
-        // user info is still loading
-        return null
-      }
-      if (user.is_authenticated) {
+      if (user?.is_authenticated) {
         return (event, resourceId: number) => {
           NiceModal.show(AddToUserListDialog, { resourceId })
         }

--- a/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/mit-learn/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -10,6 +10,7 @@ import { useSearchParams, useLocation } from "react-router-dom"
 import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 import { usePostHog } from "posthog-js/react"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
+import { useUserMe } from "api/hooks/user"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
@@ -56,6 +57,7 @@ const DrawerContent: React.FC<{
   resourceId: number
 }> = ({ resourceId }) => {
   const resource = useLearningResourcesDetail(Number(resourceId))
+  const { data: user } = useUserMe()
   useCapturePageView(Number(resourceId))
 
   return (
@@ -70,6 +72,7 @@ const DrawerContent: React.FC<{
       <LearningResourceExpanded
         imgConfig={imgConfigs.large}
         resource={resource.data}
+        user={user}
       />
     </>
   )

--- a/frontends/ol-ckeditor/src/types/settings.d.ts
+++ b/frontends/ol-ckeditor/src/types/settings.d.ts
@@ -8,5 +8,6 @@ export declare global {
     MITOL_API_BASE_URL: string
     PUBLIC_URL: string
     SITE_NAME: string
+    CSRF_COOKIE_NAME: string
   }
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -23,7 +23,7 @@ import {
 } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Typography from "@mui/material/Typography"
-import { User } from "api/hooks/user"
+import type { User } from "api/hooks/user"
 import { CardActionButton } from "../LearningResourceCard/LearningResourceListCard"
 import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -13,6 +13,8 @@ import {
   RiTranslate2,
   RiAwardLine,
   RiPresentationLine,
+  RiMenuAddLine,
+  RiBookmarkLine,
 } from "@remixicon/react"
 import { LearningResource, LearningResourceRun, ResourceTypeEnum } from "api"
 import {
@@ -21,11 +23,24 @@ import {
 } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Typography from "@mui/material/Typography"
+import { User } from "api/hooks/user"
+import { CardActionButton } from "ol-components"
 
 const InfoItems = styled.section`
   display: flex;
   flex-direction: column;
   gap: 16px;
+`
+
+const InfoHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
+
+const ListButtonContainer = styled.div`
+  display: flex;
+  gap: 8px;
 `
 
 const InfoItemContainer = styled.div`
@@ -223,13 +238,18 @@ const InfoItem = ({ label, Icon, value }: InfoItemProps) => {
 const InfoSection = ({
   resource,
   run,
+  user,
 }: {
   resource?: LearningResource
   run?: LearningResourceRun
+  user?: User
 }) => {
   if (!resource) {
     return null
   }
+
+  const inUserList = !!resource?.user_list_parents?.length
+  const inLearningPath = !!resource?.learning_path_parents?.length
 
   const infoItems = INFO_ITEMS.map(({ label, Icon, selector }) => ({
     label,
@@ -243,9 +263,26 @@ const InfoSection = ({
 
   return (
     <InfoItems>
-      <Typography variant="subtitle2" component="h3">
-        Info
-      </Typography>
+      <InfoHeader>
+        <Typography variant="subtitle2" component="h3">
+          Info
+        </Typography>
+        <ListButtonContainer>
+          {user?.is_authenticated && user?.is_learning_path_editor && (
+            <CardActionButton
+              filled={inLearningPath}
+              aria-label="Add to Learning Path"
+            >
+              <RiMenuAddLine aria-hidden />
+            </CardActionButton>
+          )}
+          {user?.is_authenticated && (
+            <CardActionButton filled={inUserList} aria-label="Add to User List">
+              <RiBookmarkLine aria-hidden />
+            </CardActionButton>
+          )}
+        </ListButtonContainer>
+      </InfoHeader>
       {infoItems.map((props, index) => (
         <InfoItem key={index} {...props} />
       ))}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -24,7 +24,8 @@ import {
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Typography from "@mui/material/Typography"
 import { User } from "api/hooks/user"
-import { CardActionButton, LearningResourceCardProps } from "ol-components"
+import { CardActionButton } from "../LearningResourceCard/LearningResourceListCard"
+import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
 
 const InfoItems = styled.section`
   display: flex;

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -273,7 +273,7 @@ const InfoSection = ({
           Info
         </Typography>
         <ListButtonContainer>
-          {user?.is_authenticated && user?.is_learning_path_editor && (
+          {user?.is_learning_path_editor && (
             <CardActionButton
               filled={inLearningPath}
               aria-label="Add to Learning Path"

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -24,7 +24,7 @@ import {
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Typography from "@mui/material/Typography"
 import { User } from "api/hooks/user"
-import { CardActionButton } from "ol-components"
+import { CardActionButton, LearningResourceCardProps } from "ol-components"
 
 const InfoItems = styled.section`
   display: flex;
@@ -239,10 +239,14 @@ const InfoSection = ({
   resource,
   run,
   user,
+  onAddToLearningPathClick,
+  onAddToUserListClick,
 }: {
   resource?: LearningResource
   run?: LearningResourceRun
   user?: User
+  onAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"]
+  onAddToUserListClick: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
   if (!resource) {
     return null
@@ -272,12 +276,25 @@ const InfoSection = ({
             <CardActionButton
               filled={inLearningPath}
               aria-label="Add to Learning Path"
+              onClick={(event) =>
+                onAddToLearningPathClick
+                  ? onAddToLearningPathClick(event, resource.id)
+                  : null
+              }
             >
               <RiMenuAddLine aria-hidden />
             </CardActionButton>
           )}
           {user?.is_authenticated && (
-            <CardActionButton filled={inUserList} aria-label="Add to User List">
+            <CardActionButton
+              filled={inUserList}
+              aria-label="Add to User List"
+              onClick={(event) =>
+                onAddToUserListClick
+                  ? onAddToUserListClick(event, resource.id)
+                  : null
+              }
+            >
               <RiBookmarkLine aria-hidden />
             </CardActionButton>
           )}

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -246,8 +246,8 @@ const InfoSection = ({
   resource?: LearningResource
   run?: LearningResourceRun
   user?: User
-  onAddToLearningPathClick: LearningResourceCardProps["onAddToLearningPathClick"]
-  onAddToUserListClick: LearningResourceCardProps["onAddToUserListClick"]
+  onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
+  onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }) => {
   if (!resource) {
     return null

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -21,7 +21,7 @@ import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import InfoSection from "./InfoSection"
 import { User } from "api/hooks/user"
-import { LearningResourceCardProps } from "ol-components"
+import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
 
 const Container = styled.div<{ padTop?: boolean }>`
   display: flex;

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -20,6 +20,7 @@ import type { SimpleSelectProps } from "../SimpleSelect/SimpleSelect"
 import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import InfoSection from "./InfoSection"
+import { User } from "api/hooks/user"
 
 const Container = styled.div<{ padTop?: boolean }>`
   display: flex;
@@ -138,6 +139,7 @@ const OnPlatform = styled.span`
 
 type LearningResourceExpandedProps = {
   resource?: LearningResource
+  user?: User
   imgConfig: EmbedlyConfig
 }
 
@@ -314,6 +316,7 @@ const formatRunDate = (
 
 const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
   resource,
+  user,
   imgConfig,
 }) => {
   const [selectedRun, setSelectedRun] = useState(resource?.runs?.[0])
@@ -411,7 +414,7 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       <ImageSection resource={resource} config={imgConfig} />
       <CallToActionSection resource={resource} hide={isVideo} />
       <DetailSection resource={resource} />
-      <InfoSection resource={resource} run={selectedRun} />
+      <InfoSection resource={resource} run={selectedRun} user={user} />
     </Container>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -21,6 +21,7 @@ import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import InfoSection from "./InfoSection"
 import { User } from "api/hooks/user"
+import { LearningResourceCardProps } from "ol-components"
 
 const Container = styled.div<{ padTop?: boolean }>`
   display: flex;
@@ -141,6 +142,8 @@ type LearningResourceExpandedProps = {
   resource?: LearningResource
   user?: User
   imgConfig: EmbedlyConfig
+  onAddToLearningPathClick?: LearningResourceCardProps["onAddToLearningPathClick"]
+  onAddToUserListClick?: LearningResourceCardProps["onAddToUserListClick"]
 }
 
 const ImageSection: React.FC<{
@@ -318,6 +321,8 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
   resource,
   user,
   imgConfig,
+  onAddToLearningPathClick,
+  onAddToUserListClick,
 }) => {
   const [selectedRun, setSelectedRun] = useState(resource?.runs?.[0])
 
@@ -414,7 +419,13 @@ const LearningResourceExpanded: React.FC<LearningResourceExpandedProps> = ({
       <ImageSection resource={resource} config={imgConfig} />
       <CallToActionSection resource={resource} hide={isVideo} />
       <DetailSection resource={resource} />
-      <InfoSection resource={resource} run={selectedRun} user={user} />
+      <InfoSection
+        resource={resource}
+        run={selectedRun}
+        user={user}
+        onAddToLearningPathClick={onAddToLearningPathClick}
+        onAddToUserListClick={onAddToUserListClick}
+      />
     </Container>
   )
 }

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -20,7 +20,7 @@ import type { SimpleSelectProps } from "../SimpleSelect/SimpleSelect"
 import { EmbedlyCard } from "../EmbedlyCard/EmbedlyCard"
 import { PlatformLogo, PLATFORMS } from "../Logo/Logo"
 import InfoSection from "./InfoSection"
-import { User } from "api/hooks/user"
+import type { User } from "api/hooks/user"
 import { LearningResourceCardProps } from "../LearningResourceCard/LearningResourceCard"
 
 const Container = styled.div<{ padTop?: boolean }>`


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5297

### Description (What does it do?)
This PR adds "add to list" buttons to the learning resource drawer. When you bring up the drawer, if you are a learning path editor you will see both the add to learning path and user list buttons. If you are a normal user, you will only see the add to userlist button, just like how it works on cards.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/68413c1f-3b74-4476-b582-185ca95496eb)
![image](https://github.com/user-attachments/assets/ccfe1a88-cb05-4cbb-b5ac-4be22b0e3bbf)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Make sure you have some data populated into your database and have generated a search index
 - Log in as a superuser
 - Visit the search page at http://localhost:8062/search
 - Click on any search result to display the learning resource drawer
 - In the drawer, you should see both the add to learning path and add to user list buttons
 - Test out both buttons, adding the resource to both a learning path and user list
 - Log out of your superuser and log in as a normal user
 - Repeat the process, but ensure that only the "add to user list" bookmark button shows up
