### PR TITLE
Fix data migration erroring if a record exists

### DIFF
--- a/data_fixtures/migrations/0014_add_department_SP.py
+++ b/data_fixtures/migrations/0014_add_department_SP.py
@@ -30,7 +30,7 @@ def add_sp(apps, schema_editor):
     Channel = apps.get_model("channels", "Channel")
     ChannelDepartmentDetail = apps.get_model("channels", "ChannelDepartmentDetail")
 
-    department = LearningResourceDepartment.objects.create(
+    department, _ = LearningResourceDepartment.objects.get_or_create(
         department_id="SP",
         name="Special Programs",
     )
@@ -42,7 +42,9 @@ def add_sp(apps, schema_editor):
         name=slugify(department.name),
         title=department.name,
     )
-    ChannelDepartmentDetail.objects.create(channel=channel, department=department)
+    ChannelDepartmentDetail.objects.get_or_create(
+        channel=channel, department=department
+    )
 
 
 class Migration(migrations.Migration):

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -5,7 +5,7 @@
 python3 manage.py collectstatic --noinput --clear
 python3 manage.py migrate --noinput
 python3 manage.py createcachetable
-RUN_DATA_MIGRATIONS=true python3 manage.py migrate --noinput
+python3 manage.py migrate --noinput
 
 # load required fixtures on development by default
 echo "Loading fixtures!"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes an insert error if you already have a record that exists that this migration is trying to add.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I'm not quite sure how I got in this state, but the migration was conflicting trying to insert this record:

```
  Apply all migrations: admin, articles, auth, authentication, channels, contenttypes, data_fixtures, guardian, learning_resources, learning_resources_search, news_events, oauth2_provider, profiles, sessions, sites, social_django, testimonials, widgets
Running migrations:
  Applying data_fixtures.0001_add_testimonial_data... OK
  Applying data_fixtures.0002_unit_page_copy_updates... OK
  Applying data_fixtures.0003_unit_page_copy_updates... OK
  Applying data_fixtures.0004_upsert_initial_topic_data... OK
  Applying data_fixtures.0005_unit_page_copy_updates... OK
  Applying data_fixtures.0006_update_parent_topic_channel_descriptions... OK
  Applying data_fixtures.0007_topic_mappings_edx_add_programming_coding_to_computer_science... OK
  Applying data_fixtures.0008_unpublish_empty_topic_channels... OK
  Applying data_fixtures.0009_topics_update_engineering_add_manufacturing... OK
  Applying data_fixtures.0010_topics_update_icons_for_innovation_data_science... OK
  Applying data_fixtures.0011_unit_page_copy_updates... OK
  Applying data_fixtures.0012_topic_mappings_adjust_sustainable_business_finance_accounting... OK
  Applying data_fixtures.0013_remove_department_RES... OK
  Applying data_fixtures.0014_add_department_SP...Traceback (most recent call last):
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "learning_resources_learningresourcedepartmentnew_pkey"
DETAIL:  Key (department_id)=(SP) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/src/./manage.py", line 29, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/base.py", line 106, in wrapper
    res = handle_func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/core/management/commands/migrate.py", line 356, in handle
    post_migrate_state = executor.migrate(
                         ^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 135, in migrate
    state = self._migrate_all_forwards(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 167, in _migrate_all_forwards
    state = self.apply_migration(
            ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/migrations/executor.py", line 252, in apply_migration
    state = migration.apply(state, schema_editor)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/migrations/migration.py", line 132, in apply
    operation.database_forwards(
  File "/opt/venv/lib/python3.12/site-packages/django/db/migrations/operations/special.py", line 193, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/src/data_fixtures/migrations/0014_add_department_SP.py", line 33, in add_sp
    department = LearningResourceDepartment.objects.create(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/query.py", line 658, in create
    obj.save(force_insert=True, using=self.db)
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/query.py", line 1805, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1822, in execute_sql
    cursor.execute(sql, params)
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/utils.py", line 1730, in runner
    return sentry_patched_function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/sentry_sdk/integrations/django/__init__.py", line 651, in execute
    result = real_execute(self, sql, params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/opt/venv/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/opt/venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.IntegrityError: duplicate key value violates unique constraint "learning_resources_learningresourcedepartmentnew_pkey"
DETAIL:  Key (department_id)=(SP) already exists.
```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
