### PR TITLE
[NextJS] fix initial carousel position

### DIFF
--- a/frontends/ol-components/src/components/Carousel/Carousel.tsx
+++ b/frontends/ol-components/src/components/Carousel/Carousel.tsx
@@ -31,14 +31,31 @@ type CarouselProps = {
   nextLabel?: string
 }
 
-const SlickStyled = styled(Slick)({
-  /**
-   * This is a fallback. The carousel's width should be constrained by it's
-   * parent. But if it's not, this will at least prevent it from resizing itself
-   * beyond the viewport width.
-   */
-  maxWidth: "100vw",
-})
+const SlickStyled = styled(Slick)<{ rendered: boolean }>(({ rendered }) => [
+  {
+    /**
+     * This is a fallback. The carousel's width should be constrained by it's
+     * parent. But if it's not, this will at least prevent it from resizing itself
+     * beyond the viewport width.
+     */
+    maxWidth: "100vw",
+    ".slick-track::before": {
+      // By default slick has empty string content on the ::before pseudo
+      // element, which interferes with spacing on initial render.
+      content: "none",
+    },
+  },
+  !rendered && {
+    ".slick-track": {
+      /**
+       * When react-slick renders on the server, it sets `style="width: 0px;"`
+       * on the `.slick-track` element. This, combined with auto margoins,
+       * causes the carousel to render with strange positioning initially.
+       */
+      width: "unset !important",
+    },
+  },
+])
 
 /**
  * Return the current slide and the sliders per paged, based on current element
@@ -125,7 +142,7 @@ const Carousel: React.FC<CarouselProps> = ({
   nextLabel = "Show next slides",
 }) => {
   const [slick, setSlick] = React.useState<Slick | null>(null)
-  const [slidesPerPage, setSlidesPerPage] = React.useState<number>(1)
+  const [slidesPerPage, setSlidesPerPage] = React.useState<number>(4)
   /**
    * The index of the first visible slide.
    * slick-carousel marks this slide with slick-current.
@@ -154,6 +171,11 @@ const Carousel: React.FC<CarouselProps> = ({
     if (!slick) return
     slick.slickPrev()
   }, [slick])
+
+  const [rendered, setRendered] = React.useState(false)
+  React.useEffect(() => {
+    setRendered(true)
+  }, [])
 
   const arrows = (
     <>
@@ -184,6 +206,7 @@ const Carousel: React.FC<CarouselProps> = ({
     <>
       <SlickStyled
         className={className}
+        rendered={rendered}
         ref={setSlick}
         variableWidth
         initialSlide={initialSlide}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5415

### Description (What does it do?)
Fixes carousel initial render

### Screenshots (if appropriate):
With JS disabled:
![Screenshot 2024-09-11 at 2 20 22 PM](https://github.com/user-attachments/assets/dcca853e-2067-48e7-8923-9a1abbc1e43e)

and enabled:

![Screenshot 2024-09-11 at 2 20 56 PM](https://github.com/user-attachments/assets/0c86b15b-bf6b-4326-a6ed-313ab4f848fe)

### How can this be tested?
Visit homepage. Carousel should not shift position as homepage loads.

You can also see this affect by disabling javascript:

1. Visit the homepage. Disable JS via dev console (cmd+shift+p, then search for "disable javascript")
2. reload page
3. Page should look good (though incomplete)

