### PR TITLE
add caching to remaining views

### DIFF
--- a/articles/views.py
+++ b/articles/views.py
@@ -8,7 +8,7 @@ from rest_framework.permissions import IsAdminUser
 from articles.models import Article
 from articles.serializers import ArticleSerializer
 from main.constants import VALID_HTTP_METHODS
-from main.utils import cache_page_for_all_users
+from main.utils import cache_page_for_all_users, clear_search_cache
 
 # Create your views here.
 
@@ -48,3 +48,11 @@ class ArticleViewSet(viewsets.ModelViewSet):
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    def create(self, request, *args, **kwargs):
+        clear_search_cache()
+        return super().create(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        clear_search_cache()
+        return super().destroy(request, *args, **kwargs)

--- a/articles/views.py
+++ b/articles/views.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import viewsets
 from rest_framework.pagination import LimitOffsetPagination
@@ -6,6 +8,7 @@ from rest_framework.permissions import IsAdminUser
 from articles.models import Article
 from articles.serializers import ArticleSerializer
 from main.constants import VALID_HTTP_METHODS
+from main.utils import cache_page_for_all_users
 
 # Create your views here.
 
@@ -37,3 +40,11 @@ class ArticleViewSet(viewsets.ModelViewSet):
 
     permission_classes = [IsAdminUser]
     http_method_names = VALID_HTTP_METHODS
+
+    @method_decorator(
+        cache_page_for_all_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/channels/views.py
+++ b/channels/views.py
@@ -28,7 +28,7 @@ from channels.serializers import (
 from learning_resources.views import DefaultPagination
 from main.constants import VALID_HTTP_METHODS
 from main.permissions import AnonymousAccessReadonlyPermission
-from main.utils import cache_page_for_all_users
+from main.utils import cache_page_for_anonymous_users
 
 log = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ class ChannelCountsView(mixins.ListModelMixin, viewsets.GenericViewSet):
         )
 
     @method_decorator(
-        cache_page_for_all_users(
+        cache_page_for_anonymous_users(
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
         )
     )

--- a/channels/views.py
+++ b/channels/views.py
@@ -28,7 +28,7 @@ from channels.serializers import (
 from learning_resources.views import DefaultPagination
 from main.constants import VALID_HTTP_METHODS
 from main.permissions import AnonymousAccessReadonlyPermission
-from main.utils import cache_page_for_anonymous_users
+from main.utils import cache_page_for_all_users
 
 log = logging.getLogger(__name__)
 
@@ -218,7 +218,7 @@ class ChannelCountsView(mixins.ListModelMixin, viewsets.GenericViewSet):
         )
 
     @method_decorator(
-        cache_page_for_anonymous_users(
+        cache_page_for_all_users(
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
         )
     )

--- a/channels/views_test.py
+++ b/channels/views_test.py
@@ -483,8 +483,14 @@ def test_channel_counts_view(client):
             )
 
 
-def test_channel_counts_view_is_cached_for_anonymous_users(client):
+def test_channel_counts_view_is_cached_for_anonymous_users(client, settings):
     """Test the channel counts view is cached for anonymous users"""
+    settings.CACHES["redis"] = {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": settings.CELERY_BROKER_URL,
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    }
+
     channel_count = 5
     channels = ChannelFactory.create_batch(channel_count, channel_type="unit")
     url = reverse(
@@ -499,8 +505,13 @@ def test_channel_counts_view_is_cached_for_anonymous_users(client):
     assert len(response) == channel_count
 
 
-def test_channel_counts_view_is_cached_for_authenticated_users(client):
+def test_channel_counts_view_is_cached_for_authenticated_users(client, settings):
     """Test the channel counts view is cached for authenticated users"""
+    settings.CACHES["redis"] = {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": settings.CELERY_BROKER_URL,
+        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+    }
     channel_count = 5
     channel_user = UserFactory.create()
     client.force_login(channel_user)

--- a/conftest.py
+++ b/conftest.py
@@ -20,3 +20,12 @@ def prevent_requests(mocker, request):  # noqa: PT004
         autospec=True,
         side_effect=DoNotUseRequestException,
     )
+
+
+@pytest.fixture(autouse=True)
+def _use_dummy_redis_cache_backend(settings):
+    new_cache_settings = settings.CACHES.copy()
+    new_cache_settings["redis"] = {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+    settings.CACHES = new_cache_settings

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16195,8 +16195,7 @@ export const LearningpathsApiAxiosParamCreator = function (
       }
     },
     /**
-     * Get a list of related learning resources for a learning resource.
-     * @summary Nested Learning Resource List
+     * Viewset for LearningPath related resources
      * @param {number} learning_resource_id The learning resource id of the learning path
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
@@ -16779,8 +16778,7 @@ export const LearningpathsApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
-     * Get a list of related learning resources for a learning resource.
-     * @summary Nested Learning Resource List
+     * Viewset for LearningPath related resources
      * @param {number} learning_resource_id The learning resource id of the learning path
      * @param {number} [limit] Number of results to return per page.
      * @param {number} [offset] The initial index from which to return the results.
@@ -17133,8 +17131,7 @@ export const LearningpathsApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Get a list of related learning resources for a learning resource.
-     * @summary Nested Learning Resource List
+     * Viewset for LearningPath related resources
      * @param {LearningpathsApiLearningpathsItemsListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -17673,8 +17670,7 @@ export class LearningpathsApi extends BaseAPI {
   }
 
   /**
-   * Get a list of related learning resources for a learning resource.
-   * @summary Nested Learning Resource List
+   * Viewset for LearningPath related resources
    * @param {LearningpathsApiLearningpathsItemsListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}

--- a/learning_resources/management/commands/populate_featured_lists.py
+++ b/learning_resources/management/commands/populate_featured_lists.py
@@ -16,7 +16,7 @@ from learning_resources.models import (
     LearningResource,
     LearningResourceOfferor,
 )
-from main.utils import now_in_utc
+from main.utils import clear_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -90,3 +90,4 @@ class Command(BaseCommand):
             "Population of unit channel featured lists finished, "
             f"took {total_seconds} seconds"
         )
+        clear_cache()

--- a/learning_resources/management/commands/update_departments_schools.py
+++ b/learning_resources/management/commands/update_departments_schools.py
@@ -6,7 +6,7 @@ from learning_resources.utils import (
     upsert_department_data,
     upsert_school_data,
 )
-from main.utils import now_in_utc
+from main.utils import clear_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -26,3 +26,4 @@ class Command(BaseCommand):
             f"Update of {len(schools)} schools & {len(departments)} "
             f"departments finished, took {total_seconds} seconds"
         )
+        clear_cache()

--- a/learning_resources/management/commands/update_offered_by.py
+++ b/learning_resources/management/commands/update_offered_by.py
@@ -3,7 +3,7 @@
 from django.core.management import BaseCommand
 
 from learning_resources.utils import upsert_offered_by_data
-from main.utils import now_in_utc
+from main.utils import clear_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -21,3 +21,4 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Update of {len(offerors)} offerors finished, took {total_seconds} seconds"
         )
+        clear_cache()

--- a/learning_resources/management/commands/update_platforms.py
+++ b/learning_resources/management/commands/update_platforms.py
@@ -3,7 +3,7 @@
 from django.core.management import BaseCommand
 
 from learning_resources.utils import upsert_platform_data
-from main.utils import now_in_utc
+from main.utils import clear_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -21,3 +21,4 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Upserted {len(platform_codes)} platforms, took {total_seconds} seconds"
         )
+        clear_cache()

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -91,7 +91,7 @@ from main.permissions import (
     AnonymousAccessReadonlyPermission,
     is_admin_user,
 )
-from main.utils import chunks
+from main.utils import cache_page_for_anonymous_users, chunks
 
 log = logging.getLogger(__name__)
 
@@ -158,6 +158,14 @@ class BaseLearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
             QuerySet of LearningResource objects
         """
         return self._get_base_queryset().filter(published=True)
+
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def dispatch(self, request, *args, **kwargs):
+        return super().dispatch(request, *args, **kwargs)
 
 
 @extend_schema_view(

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -593,7 +593,7 @@ class TopicViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = TopicFilter
 
     @method_decorator(
-        cache_page_for_anonymous_users(
+        cache_page_for_all_users(
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
         )
     )

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -386,14 +386,6 @@ class ResourceListItemsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet
     filter_backends = [OrderingFilter]
     ordering = ["position", "-child__last_modified"]
 
-    @method_decorator(
-        cache_page_for_anonymous_users(
-            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
-        )
-    )
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
-
 
 @extend_schema(
     parameters=[

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -91,7 +91,7 @@ from main.permissions import (
     AnonymousAccessReadonlyPermission,
     is_admin_user,
 )
-from main.utils import cache_page_for_anonymous_users, chunks
+from main.utils import cache_page_for_all_users, cache_page_for_anonymous_users, chunks
 
 log = logging.getLogger(__name__)
 
@@ -164,8 +164,8 @@ class BaseLearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
         )
     )
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 @extend_schema_view(
@@ -386,6 +386,14 @@ class ResourceListItemsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet
     filter_backends = [OrderingFilter]
     ordering = ["position", "-child__last_modified"]
 
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
 
 @extend_schema(
     parameters=[
@@ -516,6 +524,14 @@ class LearningResourceListRelationshipViewSet(viewsets.GenericViewSet):
         serializer = SerializerClass(current_relationships, many=True)
         return Response(serializer.data)
 
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
 
 @extend_schema_view(
     create=extend_schema(summary="Learning Path Resource Relationship Add"),
@@ -540,6 +556,14 @@ class LearningPathItemsViewSet(ResourceListItemsViewSet, viewsets.ModelViewSet):
     serializer_class = LearningPathRelationshipSerializer
     permission_classes = (permissions.HasLearningPathItemPermissions,)
     http_method_names = VALID_HTTP_METHODS
+
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):
         request.data["parent"] = request.data.get("parent_id")
@@ -575,6 +599,14 @@ class TopicViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = (AnonymousAccessReadonlyPermission,)
     filter_backends = [DjangoFilterBackend]
     filterset_class = TopicFilter
+
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 @extend_schema_view(
@@ -827,6 +859,14 @@ class ContentTagViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = LargePagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
 
+    @method_decorator(
+        cache_page_for_all_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, *args, **kwargs):
+        return super().list(*args, **kwargs)
+
 
 @extend_schema_view(
     list=extend_schema(summary="List"),
@@ -846,6 +886,14 @@ class DepartmentViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_url_kwarg = "department_id"
     lookup_field = "department_id__iexact"
 
+    @method_decorator(
+        cache_page_for_all_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, *args, **kwargs):
+        return super().list(*args, **kwargs)
+
 
 @extend_schema_view(
     list=extend_schema(summary="List"),
@@ -860,6 +908,14 @@ class SchoolViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = LearningResourceSchoolSerializer
     pagination_class = LargePagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
+
+    @method_decorator(
+        cache_page_for_all_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, *args, **kwargs):
+        return super().list(*args, **kwargs)
 
 
 @extend_schema_view(
@@ -876,6 +932,14 @@ class PlatformViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = LargePagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
 
+    @method_decorator(
+        cache_page_for_all_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, *args, **kwargs):
+        return super().list(*args, **kwargs)
+
 
 @extend_schema_view(
     list=extend_schema(summary="List"),
@@ -891,6 +955,14 @@ class OfferedByViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = LargePagination
     permission_classes = (AnonymousAccessReadonlyPermission,)
     lookup_field = "code"
+
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 @extend_schema_view(
@@ -1002,6 +1074,11 @@ class FeaturedViewSet(
             .distinct()
         )
 
+    @method_decorator(
+        cache_page_for_anonymous_users(
+            settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"
+        )
+    )
     @extend_schema(
         summary="List",
         description="Get a paginated list of featured resources",

--- a/main/utils.py
+++ b/main/utils.py
@@ -357,7 +357,8 @@ def clean_data(data: str) -> str:
 
 def clear_search_cache():
     cache = caches["redis"]
-    search_keys = cache.keys("views.decorators.cache.cache_page.search.*")
-    cache.delete_many(search_keys)
-    search_keys = cache.keys("views.decorators.cache.cache_header.search.*")
-    cache.delete_many(search_keys)
+    if hasattr(cache, "keys"):
+        search_keys = cache.keys("views.decorators.cache.cache_page.search.*")
+        cache.delete_many(search_keys)
+        search_keys = cache.keys("views.decorators.cache.cache_header.search.*")
+        cache.delete_many(search_keys)

--- a/news_events/management/commands/backpopulate_news_events.py
+++ b/news_events/management/commands/backpopulate_news_events.py
@@ -4,7 +4,7 @@ from itertools import chain
 
 from django.core.management import BaseCommand
 
-from main.utils import clear_cache
+from main.utils import clear_search_cache
 from news_events.etl import pipelines
 from news_events.models import FeedImage, FeedSource
 
@@ -56,4 +56,4 @@ class Command(BaseCommand):
                     f"Processed {etl_func} pipeline with {item_count} items"
                 )
         self.stdout.write("Finished running news/events ETL pipelines")
-        clear_cache()
+        clear_search_cache()

--- a/news_events/management/commands/backpopulate_news_events.py
+++ b/news_events/management/commands/backpopulate_news_events.py
@@ -4,6 +4,7 @@ from itertools import chain
 
 from django.core.management import BaseCommand
 
+from main.utils import clear_cache
 from news_events.etl import pipelines
 from news_events.models import FeedImage, FeedSource
 
@@ -55,3 +56,4 @@ class Command(BaseCommand):
                     f"Processed {etl_func} pipeline with {item_count} items"
                 )
         self.stdout.write("Finished running news/events ETL pipelines")
+        clear_cache()

--- a/news_events/tasks.py
+++ b/news_events/tasks.py
@@ -1,7 +1,7 @@
 """Tasks for news_events"""
 
 from main.celery import app
-from main.utils import clear_cache
+from main.utils import clear_search_cache
 from news_events.etl import pipelines
 
 
@@ -9,39 +9,39 @@ from news_events.etl import pipelines
 def get_medium_mit_news():
     """Run the Medium MIT News ETL pipeline"""
     pipelines.medium_mit_news_etl()
-    clear_cache()
+    clear_search_cache()
 
 
 @app.task
 def get_ol_events():
     """Run the Open Learning Events ETL pipeline"""
     pipelines.ol_events_etl()
-    clear_cache()
+    clear_search_cache()
 
 
 @app.task
 def get_sloan_exec_news():
     """Run the Sloan executive education news ETL pipeline"""
     pipelines.sloan_exec_news_etl()
-    clear_cache()
+    clear_search_cache()
 
 
 @app.task
 def get_sloan_exec_webinars():
     """Run the Sloan webinars ETL pipeline"""
     pipelines.sloan_webinars_etl()
-    clear_cache()
+    clear_search_cache()
 
 
 @app.task
 def get_mitpe_news():
     """Run the MIT Professional Education news ETL pipeline"""
     pipelines.mitpe_news_etl()
-    clear_cache()
+    clear_search_cache()
 
 
 @app.task
 def get_mitpe_events():
     """Run the MIT Professional Education events ETL pipeline"""
     pipelines.mitpe_events_etl()
-    clear_cache()
+    clear_search_cache()

--- a/news_events/tasks.py
+++ b/news_events/tasks.py
@@ -1,6 +1,7 @@
 """Tasks for news_events"""
 
 from main.celery import app
+from main.utils import clear_cache
 from news_events.etl import pipelines
 
 
@@ -8,33 +9,39 @@ from news_events.etl import pipelines
 def get_medium_mit_news():
     """Run the Medium MIT News ETL pipeline"""
     pipelines.medium_mit_news_etl()
+    clear_cache()
 
 
 @app.task
 def get_ol_events():
     """Run the Open Learning Events ETL pipeline"""
     pipelines.ol_events_etl()
+    clear_cache()
 
 
 @app.task
 def get_sloan_exec_news():
     """Run the Sloan executive education news ETL pipeline"""
     pipelines.sloan_exec_news_etl()
+    clear_cache()
 
 
 @app.task
 def get_sloan_exec_webinars():
     """Run the Sloan webinars ETL pipeline"""
     pipelines.sloan_webinars_etl()
+    clear_cache()
 
 
 @app.task
 def get_mitpe_news():
     """Run the MIT Professional Education news ETL pipeline"""
     pipelines.mitpe_news_etl()
+    clear_cache()
 
 
 @app.task
 def get_mitpe_events():
     """Run the MIT Professional Education events ETL pipeline"""
     pipelines.mitpe_events_etl()
+    clear_cache()

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -4923,8 +4923,7 @@ paths:
   /api/v1/learningpaths/{learning_resource_id}/items/:
     get:
       operationId: learningpaths_items_list
-      description: Get a list of related learning resources for a learning resource.
-      summary: Nested Learning Resource List
+      description: Viewset for LearningPath related resources
       parameters:
       - in: path
         name: learning_resource_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5450

### Description (What does it do?)
This PR adds caching to the remaining server side views. We cache for all users on views that don't have any user specific info using "cache_page_for_all_users" decorator otherwise we use "cache_page_for_anonymous_users" to only cache for anonymous users


### How can this be tested?
1. checkout this branch. have data loaded
2. as you browse around the first page view will cache api calls (most of them for anonymous users only but some for all users)
3. make note of performance differences between main and the cached version
4. to clear all the caches we can manually run 
```
from main.utils import clear_search_cache
clear_search_cache()
```

there are some further instructions (specific to search cache but can now be applied to remaining api views) [here](https://github.com/mitodl/mit-open/pull/1392)

### Additional Context
Some key things in this PR for reviewer to double check:
1. The cache mechanism used for each view is appropriate (to cache for all users vs just anonymous)
2. Are the resources in the cached view refreshed appropriately (every 24 hours on loading new resources). Are there any views we should remove this caching from or tweak when it is cleared.


The cache is by default now set to the "DummyCache" - we can explicitly enable and disable on a per test basis if the point of the test is to test something with caching enabled as done [here](https://github.com/mitodl/mit-open/pull/1555/files#diff-53d113070f251b6fa10ae4a451b0c5ef650923e54ebe3c5fd4157961c1b2f2cfR488)
