### PR TITLE
always use dfs_query_then_fetch

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3623,12 +3623,6 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   dev_mode?: boolean | null
   /**
-   * If true sets search_type=dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof PercolateQuerySubscriptionRequestRequest
-   */
-  use_dfs_query_then_fetch?: boolean | null
-  /**
    * The id value for the learning resource
    * @type {Array<number>}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -7144,7 +7138,6 @@ export const ContentFileSearchApiAxiosParamCreator = function (
      * @param {Array<number>} [run_id] The id value of the run that the content file belongs to
      * @param {ContentFileSearchRetrieveSortbyEnum} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7162,7 +7155,6 @@ export const ContentFileSearchApiAxiosParamCreator = function (
       run_id?: Array<number>,
       sortby?: ContentFileSearchRetrieveSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       const localVarPath = `/api/v1/content_file_search/`
@@ -7233,11 +7225,6 @@ export const ContentFileSearchApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
-      if (use_dfs_query_then_fetch !== undefined) {
-        localVarQueryParameter["use_dfs_query_then_fetch"] =
-          use_dfs_query_then_fetch
-      }
-
       setSearchParams(localVarUrlObj, localVarQueryParameter)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -7279,7 +7266,6 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
      * @param {Array<number>} [run_id] The id value of the run that the content file belongs to
      * @param {ContentFileSearchRetrieveSortbyEnum} [sortby] if the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;id&#x60; - id * &#x60;-id&#x60; - -id * &#x60;resource_readable_id&#x60; - resource_readable_id * &#x60;-resource_readable_id&#x60; - -resource_readable_id
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -7297,7 +7283,6 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
       run_id?: Array<number>,
       sortby?: ContentFileSearchRetrieveSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -7320,7 +7305,6 @@ export const ContentFileSearchApiFp = function (configuration?: Configuration) {
           run_id,
           sortby,
           topic,
-          use_dfs_query_then_fetch,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -7376,7 +7360,6 @@ export const ContentFileSearchApiFactory = function (
           requestParameters.run_id,
           requestParameters.sortby,
           requestParameters.topic,
-          requestParameters.use_dfs_query_then_fetch,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -7480,13 +7463,6 @@ export interface ContentFileSearchApiContentFileSearchRetrieveRequest {
    * @memberof ContentFileSearchApiContentFileSearchRetrieve
    */
   readonly topic?: Array<string>
-
-  /**
-   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof ContentFileSearchApiContentFileSearchRetrieve
-   */
-  readonly use_dfs_query_then_fetch?: boolean | null
 }
 
 /**
@@ -7523,7 +7499,6 @@ export class ContentFileSearchApi extends BaseAPI {
         requestParameters.run_id,
         requestParameters.sortby,
         requestParameters.topic,
-        requestParameters.use_dfs_query_then_fetch,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -12650,7 +12625,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12681,7 +12655,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       slop?: number | null,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -12802,11 +12775,6 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
-      if (use_dfs_query_then_fetch !== undefined) {
-        localVarQueryParameter["use_dfs_query_then_fetch"] =
-          use_dfs_query_then_fetch
-      }
-
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -12866,7 +12834,6 @@ export const LearningResourcesSearchApiFp = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesSearchRetrieveSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -12897,7 +12864,6 @@ export const LearningResourcesSearchApiFp = function (
       slop?: number | null,
       sortby?: LearningResourcesSearchRetrieveSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -12933,7 +12899,6 @@ export const LearningResourcesSearchApiFp = function (
           slop,
           sortby,
           topic,
-          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -13002,7 +12967,6 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.slop,
           requestParameters.sortby,
           requestParameters.topic,
-          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -13193,13 +13157,6 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
   readonly topic?: Array<string>
 
   /**
-   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
-   */
-  readonly use_dfs_query_then_fetch?: boolean | null
-
-  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
@@ -13253,7 +13210,6 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.slop,
         requestParameters.sortby,
         requestParameters.topic,
-        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -13504,7 +13460,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13536,7 +13491,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -13661,11 +13615,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
-      if (use_dfs_query_then_fetch !== undefined) {
-        localVarQueryParameter["use_dfs_query_then_fetch"] =
-          use_dfs_query_then_fetch
-      }
-
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -13712,7 +13661,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -13743,7 +13691,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       slop?: number | null,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
@@ -13864,11 +13811,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
-      if (use_dfs_query_then_fetch !== undefined) {
-        localVarQueryParameter["use_dfs_query_then_fetch"] =
-          use_dfs_query_then_fetch
-      }
-
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -13916,7 +13858,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
@@ -13949,7 +13890,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options: RawAxiosRequestConfig = {},
@@ -14075,11 +14015,6 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
         localVarQueryParameter["topic"] = topic
       }
 
-      if (use_dfs_query_then_fetch !== undefined) {
-        localVarQueryParameter["use_dfs_query_then_fetch"] =
-          use_dfs_query_then_fetch
-      }
-
       if (yearly_decay_percent !== undefined) {
         localVarQueryParameter["yearly_decay_percent"] = yearly_decay_percent
       }
@@ -14198,7 +14133,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionCheckListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionCheckListSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -14230,7 +14164,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionCheckListSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionCheckListSourceTypeEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -14267,7 +14200,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
-          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -14312,7 +14244,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {number | null} [slop] Allowed distance for phrase search
      * @param {LearningResourcesUserSubscriptionListSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -14343,7 +14274,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       slop?: number | null,
       sortby?: LearningResourcesUserSubscriptionListSortbyEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
@@ -14379,7 +14309,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           slop,
           sortby,
           topic,
-          use_dfs_query_then_fetch,
           yearly_decay_percent,
           options,
         )
@@ -14425,7 +14354,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum} [sortby] If the parameter starts with \&#39;-\&#39; the sort is in descending order  * &#x60;featured&#x60; - Featured * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum} [source_type] The subscription type  * &#x60;search_subscription_type&#x60; - search_subscription_type * &#x60;channel_subscription_type&#x60; - channel_subscription_type
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [use_dfs_query_then_fetch] If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
      * @param {number | null} [yearly_decay_percent] Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
      * @param {PercolateQuerySubscriptionRequestRequest} [PercolateQuerySubscriptionRequestRequest]
      * @param {*} [options] Override http request option.
@@ -14458,7 +14386,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       sortby?: LearningResourcesUserSubscriptionSubscribeCreateSortbyEnum,
       source_type?: LearningResourcesUserSubscriptionSubscribeCreateSourceTypeEnum,
       topic?: Array<string>,
-      use_dfs_query_then_fetch?: boolean | null,
       yearly_decay_percent?: number | null,
       PercolateQuerySubscriptionRequestRequest?: PercolateQuerySubscriptionRequestRequest,
       options?: RawAxiosRequestConfig,
@@ -14493,7 +14420,6 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           sortby,
           source_type,
           topic,
-          use_dfs_query_then_fetch,
           yearly_decay_percent,
           PercolateQuerySubscriptionRequestRequest,
           options,
@@ -14595,7 +14521,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
-          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -14639,7 +14564,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.slop,
           requestParameters.sortby,
           requestParameters.topic,
-          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           options,
         )
@@ -14684,7 +14608,6 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.sortby,
           requestParameters.source_type,
           requestParameters.topic,
-          requestParameters.use_dfs_query_then_fetch,
           requestParameters.yearly_decay_percent,
           requestParameters.PercolateQuerySubscriptionRequestRequest,
           options,
@@ -14901,13 +14824,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly topic?: Array<string>
 
   /**
-   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
-   */
-  readonly use_dfs_query_then_fetch?: boolean | null
-
-  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
@@ -15095,13 +15011,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
    */
   readonly topic?: Array<string>
-
-  /**
-   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
-   */
-  readonly use_dfs_query_then_fetch?: boolean | null
 
   /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
@@ -15300,13 +15209,6 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly topic?: Array<string>
 
   /**
-   * If true sets search_type&#x3D;dfs_query_then_fetch which makes Opensearchmake an extra pre-query to calculate term frequencies accross indexes
-   * @type {boolean}
-   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
-   */
-  readonly use_dfs_query_then_fetch?: boolean | null
-
-  /**
    * Relevance score penalty percent per year for for resources without upcoming runs. Only affects results if there is a search term.
    * @type {number}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
@@ -15382,7 +15284,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
-        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -15428,7 +15329,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.slop,
         requestParameters.sortby,
         requestParameters.topic,
-        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         options,
       )
@@ -15475,7 +15375,6 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.sortby,
         requestParameters.source_type,
         requestParameters.topic,
-        requestParameters.use_dfs_query_then_fetch,
         requestParameters.yearly_decay_percent,
         requestParameters.PercolateQuerySubscriptionRequestRequest,
         options,

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -553,7 +553,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       max_incompleteness_penalty: searchParams.get(
         "max_incompleteness_penalty",
       ),
-      use_dfs_query_then_fetch: searchParams.get("use_dfs_query_then_fetch"),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -595,7 +595,7 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
     return search
 
 
-def construct_search(search_params):  # noqa: C901
+def construct_search(search_params):
     """
     Construct a learning resources search based on the query
 
@@ -623,7 +623,7 @@ def construct_search(search_params):  # noqa: C901
     search = Search(index=",".join(indexes))
 
     search = search.source(fields={"excludes": SOURCE_EXCLUDED_FIELDS})
-
+    search = search.params(search_type="dfs_query_then_fetch")
     if search_params.get("offset"):
         search = search.extra(from_=search_params.get("offset"))
 
@@ -668,9 +668,6 @@ def construct_search(search_params):  # noqa: C901
 
     if search_params.get("dev_mode"):
         search = search.extra(explain=True)
-
-    if search_params.get("use_dfs_query_then_fetch"):
-        search = search.params(search_type="dfs_query_then_fetch")
 
     return search
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1436,6 +1436,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
     opensearch.conn.search.assert_called_once_with(
         body=query,
         index=["testindex_course_default"],
+        search_type="dfs_query_then_fetch",
     )
 
 
@@ -1893,6 +1894,7 @@ def test_execute_learn_search_with_script_score(
     opensearch.conn.search.assert_called_once_with(
         body=query,
         index=["testindex_course_default"],
+        search_type="dfs_query_then_fetch",
     )
 
 
@@ -2302,6 +2304,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
     opensearch.conn.search.assert_called_once_with(
         body=query,
         index=["testindex_course_default"],
+        search_type="dfs_query_then_fetch",
     )
 
 
@@ -2511,6 +2514,7 @@ def test_execute_learn_search_for_content_file_query(opensearch):
     opensearch.conn.search.assert_called_once_with(
         body=query,
         index=["testindex_course_default"],
+        search_type="dfs_query_then_fetch",
     )
 
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -284,15 +284,6 @@ class SearchRequestSerializer(serializers.Serializer):
         default=False,
         help_text="If true return raw open search results with score explanations",
     )
-    use_dfs_query_then_fetch = serializers.BooleanField(
-        required=False,
-        allow_null=True,
-        default=False,
-        help_text=(
-            "If true sets search_type=dfs_query_then_fetch which makes Opensearch"
-            "make an extra pre-query to calculate term frequencies accross indexes"
-        ),
-    )
 
     def validate(self, attrs):
         unknown = set(self.initial_data) - set(self.fields)

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -942,7 +942,6 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
-        "use_dfs_query_then_fetch": False,
     }
 
     cleaned = {
@@ -969,7 +968,6 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
-        "use_dfs_query_then_fetch": False,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)
@@ -1007,7 +1005,6 @@ def test_content_file_search_request_serializer():
         "offered_by": ["xpro", "ocw"],
         "platform": ["xpro", "edx", "ocw"],
         "dev_mode": False,
-        "use_dfs_query_then_fetch": False,
     }
 
     serialized = ContentFileSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -303,14 +303,6 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
-      - in: query
-        name: use_dfs_query_then_fetch
-        schema:
-          type: boolean
-          nullable: true
-          default: false
-        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-          an extra pre-query to calculate term frequencies accross indexes
       tags:
       - content_file_search
       responses:
@@ -2800,14 +2792,6 @@ paths:
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
       - in: query
-        name: use_dfs_query_then_fetch
-        schema:
-          type: boolean
-          nullable: true
-          default: false
-        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-          an extra pre-query to calculate term frequencies accross indexes
-      - in: query
         name: yearly_decay_percent
         schema:
           type: number
@@ -3309,14 +3293,6 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
-      - in: query
-        name: use_dfs_query_then_fetch
-        schema:
-          type: boolean
-          nullable: true
-          default: false
-        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-          an extra pre-query to calculate term frequencies accross indexes
       - in: query
         name: yearly_decay_percent
         schema:
@@ -3859,14 +3835,6 @@ paths:
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
       - in: query
-        name: use_dfs_query_then_fetch
-        schema:
-          type: boolean
-          nullable: true
-          default: false
-        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-          an extra pre-query to calculate term frequencies accross indexes
-      - in: query
         name: yearly_decay_percent
         schema:
           type: number
@@ -4384,14 +4352,6 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
-      - in: query
-        name: use_dfs_query_then_fetch
-        schema:
-          type: boolean
-          nullable: true
-          default: false
-        description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-          an extra pre-query to calculate term frequencies accross indexes
       - in: query
         name: yearly_decay_percent
         schema:
@@ -10338,12 +10298,6 @@ components:
           nullable: true
           default: false
           description: If true return raw open search results with score explanations
-        use_dfs_query_then_fetch:
-          type: boolean
-          nullable: true
-          default: false
-          description: If true sets search_type=dfs_query_then_fetch which makes Opensearchmake
-            an extra pre-query to calculate term frequencies accross indexes
         id:
           type: array
           items:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5351

### Description (What does it do?)
Programs are consistently not shown in search results with a text search because scores are calculated separately on each index and not consistent  between indexes. Setting search_type="dfs_query_then_fetch' fixes the issue. In https://github.com/mitodl/mit-open/pull/1518 i added a search parameter to use that search type because I was worried that we would get worse search performance. I tested search on rc and search_type="dfs_query_then_fetch' does not seem to affect performance, so we can just use it for all searches.


### How can this be tested?
verify that search works as expected 
verify that http://open.odl.local:8062/search/?q=Machine+Learning returns a program on the first or second page
