### PR TITLE
add noindex setting

### DIFF
--- a/app.json
+++ b/app.json
@@ -352,6 +352,10 @@
       "description": "Shared secret for JWT auth tokens",
       "required": false
     },
+    "MITOL_NOINDEX": {
+      "description": "Prevent search engines from indexing the site",
+      "required": false
+    },
     "MITOL_SECURE_SSL_REDIRECT": {
       "description": "Application-level SSL redirect setting.",
       "value": "True",

--- a/frontends/mit-learn/public/index.html
+++ b/frontends/mit-learn/public/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <% if (MITOL_NOINDEX) { %>
+    <meta name="robots" content="noindex" />
+    <% } %>
     <!--
       Font files for Adobe Neue Haas Grotesk.
       WARNING: This is linked to chudzick@mit.edu's Adobe account.

--- a/frontends/mit-learn/webpack.config.js
+++ b/frontends/mit-learn/webpack.config.js
@@ -44,6 +44,7 @@ const {
   SENTRY_PROFILES_SAMPLE_RATE,
   CSRF_COOKIE_NAME,
   APPZI_URL,
+  MITOL_NOINDEX,
 } = cleanEnv(process.env, {
   NODE_ENV: str({
     choices: ["development", "production", "test"],
@@ -118,6 +119,10 @@ const {
     // use str() not url() to allow empty string
     desc: "URL for the Appzi feedback widget",
     default: "",
+  }),
+  MITOL_NOINDEX: bool({
+    desc: "Whether to include a noindex meta tag",
+    default: true,
   }),
 })
 
@@ -216,6 +221,7 @@ module.exports = (env, argv) => {
         template: "public/index.html",
         templateParameters: {
           APPZI_URL,
+          MITOL_NOINDEX,
         },
       }),
       new CopyPlugin({

--- a/main/settings.py
+++ b/main/settings.py
@@ -763,3 +763,6 @@ POSTHOG_PROJECT_ID = get_int(
     name="POSTHOG_PROJECT_ID",
     default=None,
 )
+
+# Enable or disable search engine indexing
+MITOL_NOINDEX = get_bool("MITOL_NOINDEX", False)  # noqa: FBT003

--- a/main/settings.py
+++ b/main/settings.py
@@ -765,4 +765,4 @@ POSTHOG_PROJECT_ID = get_int(
 )
 
 # Enable or disable search engine indexing
-MITOL_NOINDEX = get_bool("MITOL_NOINDEX", False)  # noqa: FBT003
+MITOL_NOINDEX = get_bool("MITOL_NOINDEX", True)  # noqa: FBT003


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5393

### Description (What does it do?)
This PR adds a new boolean setting to the app, `MITOL_NOINDEX`. This setting is meant to control the `noindex` meta tag in the `head` section of every page. It is `true` by default, preventing indexing of pages by search engines like Google. In production, we will set this value to `false` so that the tag is not written in and pages are indexed as expected.

### How can this be tested?
 - In your environment, set `MITOL_NOINDEX=true` (or omit the value, it defaults to `true`)
 - Spin up this branch of `mit-learn`
 - Visit the home page at http://localhost:8062/
 - Inspect the page source and ensure that you see a `<meta name="robots" content="noindex" />` had in the `head` section
 - Change the value to `false` and reload your containers
 - Visit the homepage and inspect the page source again, verifying that the tag is no longer present

### Checklist:
- [ ] Merge and deploy https://github.com/mitodl/ol-infrastructure/pull/2665