### PR TITLE
Prevent unnecessary refreshes and add sort order

### DIFF
--- a/frontends/mit-learn/src/services/react-query/react-query.ts
+++ b/frontends/mit-learn/src/services/react-query/react-query.ts
@@ -16,7 +16,8 @@ const createQueryClient = (): QueryClient => {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        staleTime: 30 * 1000,
+        refetchOnWindowFocus: false,
+        staleTime: Infinity,
         queryFn: async ({ queryKey }) => {
           const url = queryKey[0]
           if (typeof url !== "string" || queryKey.length !== 1) {

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -39,7 +39,7 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["featured_rank", "is_learning_material"]
+DEFAULT_SORT = ["featured_rank", "is_learning_material", "-created_on"]
 
 
 def gen_content_file_id(content_file_id):

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2636,7 +2636,15 @@ def test_document_percolation(opensearch, mocker):
     [
         ("-views", None, [{"views": {"order": "desc"}}]),
         ("-views", "text", [{"views": {"order": "desc"}}]),
-        (None, None, ["featured_rank", "is_learning_material"]),
+        (
+            None,
+            None,
+            [
+                "featured_rank",
+                "is_learning_material",
+                {"created_on": {"order": "desc"}},
+            ],
+        ),
         (None, "text", None),
     ],
 )


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5454

### Description (What does it do?)
This pr fixes two related bugs:

1) The search page refreshes if you go to a different tab or just leave the page open for too long
2) If there is no search term, the search results don't have a determined order after the featured resources on the first few pages so that if you refresh https://rc.learn.mit.edu/search/?page=10 a few times, for example the results change. The results are the same from each node but not the same between nodes so if the query is picked up by a different node, the results change. This means that if a user is paging through resources there will be some duplicates and some resources that aren't shown.

For a user this combination of bugs is annoying because if the user clicks through to a learning resource then comes back, they lose their search results

### How can this be tested?
- Verify that both the home page and the search page still load everything

- To test 1) Go to http://open.odl.local:8062/search/?page=10. Go to a different tab and stay there for a minute. Come back to your original tab. The page should not refresh
- Unfortunately 2) can't be tested locally, since locally there is only one opensearch node locally. It can be tested on rc