### PR TITLE
fix homepage topics icon alignment

### DIFF
--- a/frontends/mit-learn/src/pages/HomePage/BrowseTopicsSection.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/BrowseTopicsSection.tsx
@@ -77,7 +77,7 @@ const TopicBox = styled(Link)`
 const TopicBoxContent = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: start;
+  align-items: center;
   gap: 10px;
   width: 100%;
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5359

### Description (What does it do?)
This PR simply changes the style on the wrappers of items in the "Browse by Topic" section of the homepage to use `align-items: center` instead of `align-items: start`, centering the icons vertically next to the text as desired.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/5eea2b41-b097-4eb9-ae13-1869462d549d)
![image](https://github.com/user-attachments/assets/8195a1e6-ef9a-429b-b231-fffcbb6690d9)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit the home page at http://localhost:8062/
 - Verify that the Browse by Topic sections renders as expected