### PR TITLE
fixing cache clear method

### DIFF
--- a/learning_resources/management/commands/populate_featured_lists.py
+++ b/learning_resources/management/commands/populate_featured_lists.py
@@ -16,7 +16,7 @@ from learning_resources.models import (
     LearningResource,
     LearningResourceOfferor,
 )
-from main.utils import clear_cache, now_in_utc
+from main.utils import clear_search_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -90,4 +90,4 @@ class Command(BaseCommand):
             "Population of unit channel featured lists finished, "
             f"took {total_seconds} seconds"
         )
-        clear_cache()
+        clear_search_cache()

--- a/learning_resources/management/commands/update_departments_schools.py
+++ b/learning_resources/management/commands/update_departments_schools.py
@@ -6,7 +6,7 @@ from learning_resources.utils import (
     upsert_department_data,
     upsert_school_data,
 )
-from main.utils import clear_cache, now_in_utc
+from main.utils import clear_search_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -26,4 +26,4 @@ class Command(BaseCommand):
             f"Update of {len(schools)} schools & {len(departments)} "
             f"departments finished, took {total_seconds} seconds"
         )
-        clear_cache()
+        clear_search_cache()

--- a/learning_resources/management/commands/update_offered_by.py
+++ b/learning_resources/management/commands/update_offered_by.py
@@ -3,7 +3,7 @@
 from django.core.management import BaseCommand
 
 from learning_resources.utils import upsert_offered_by_data
-from main.utils import clear_cache, now_in_utc
+from main.utils import clear_search_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -21,4 +21,4 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Update of {len(offerors)} offerors finished, took {total_seconds} seconds"
         )
-        clear_cache()
+        clear_search_cache()

--- a/learning_resources/management/commands/update_platforms.py
+++ b/learning_resources/management/commands/update_platforms.py
@@ -3,7 +3,7 @@
 from django.core.management import BaseCommand
 
 from learning_resources.utils import upsert_platform_data
-from main.utils import clear_cache, now_in_utc
+from main.utils import clear_search_cache, now_in_utc
 
 
 class Command(BaseCommand):
@@ -21,4 +21,4 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Upserted {len(platform_codes)} platforms, took {total_seconds} seconds"
         )
-        clear_cache()
+        clear_search_cache()


### PR DESCRIPTION
### Description (What does it do?)
Resolves an issue with mis-named cache clear method. `from main.utils import clear_cache` should be `from main.utils import clear_search_cache` 

### How can this be tested?
checkout this branch and run the affected commands:
```
python manage.py update_platforms
python manage.py update_offered_by
python manage.py update_departments_schools
python manage.py populate_featured_lists
```
They should succeed

