### PR TITLE
properly add Mit-AdornmentButton class

### DIFF
--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -20,6 +20,7 @@
     "@types/react-dom": "^18.3.0",
     "@types/tinycolor2": "^1.4.6",
     "api": "workspace:*",
+    "classnames": "^2.5.1",
     "iso-639-1": "^3.1.2",
     "lodash": "^4.17.21",
     "material-ui-popup-state": "^5.1.0",

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled"
 import InputBase from "@mui/material/InputBase"
 import type { InputBaseProps } from "@mui/material/InputBase"
 import type { Theme } from "@mui/material/styles"
+import ClassNames from "classnames"
 
 type Size = NonNullable<InputBaseProps["size"]>
 
@@ -218,7 +219,10 @@ type AdornmentButtonProps = React.ComponentProps<typeof AdornmentButtonStyled>
  *    click. The button is still focusable via keyboard events. You can override
  *    this behavior by passing your own `onMouseDown` handler.
  */
-const AdornmentButton: React.FC<AdornmentButtonProps> = (props) => {
+const AdornmentButton: React.FC<AdornmentButtonProps> = ({
+  className,
+  ...others
+}) => {
   return (
     <AdornmentButtonStyled
       /**
@@ -226,7 +230,8 @@ const AdornmentButton: React.FC<AdornmentButtonProps> = (props) => {
        * want to steal focus from the input.
        */
       onMouseDown={noFocus}
-      {...props}
+      className={ClassNames("Mit-AdornmentButton", className)}
+      {...others}
     />
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7565,7 +7565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.2":
+"classnames@npm:^2.2.5, classnames@npm:^2.2.6, classnames@npm:^2.3.2, classnames@npm:^2.5.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10/58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
@@ -15402,6 +15402,7 @@ __metadata:
     "@types/react-slick": "npm:^0"
     "@types/tinycolor2": "npm:^1.4.6"
     api: "workspace:*"
+    classnames: "npm:^2.5.1"
     iso-639-1: "npm:^3.1.2"
     lodash: "npm:^4.17.21"
     material-ui-popup-state: "npm:^5.1.0"


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up for https://github.com/mitodl/hq/issues/5386

### Description (What does it do?)
This PR addresses an issue with https://github.com/mitodl/mit-open/pull/1545 where a class was used that was not properly defined addressing adornment buttons.

### Screenshots (if appropriate):
Good:
![Screenshot 2024-09-17 at 4 36 07 PM](https://github.com/user-attachments/assets/6011b609-196d-4f2b-a08b-a75819f63e84)
Bad:
![Screenshot 2024-09-17 at 4 36 56 PM](https://github.com/user-attachments/assets/2e4e31c3-bdd1-4af3-b45e-9594ec1c3e0d)

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Visit the home page at http://localhost:8062/
 - Ensure that the search button is the proper width
 - Visit the search page at http://localhost:8062/search and verify the same thing
 - Visit the unit search page at http://localhost:8062/c/unit/ocw/ and verify the same thing
