### PR TITLE
fix adornment color

### DIFF
--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -200,6 +200,16 @@ const AdornmentButtonStyled = styled("button")(({ theme }) => ({
   ":hover": {
     background: "rgba(0, 0, 0, 0.06)",
   },
+  color: theme.custom.colors.silverGray,
+  ".MuiInputBase-root:hover &": {
+    color: "inherit",
+  },
+  ".MuiInputBase-root.Mui-focused &": {
+    color: "inherit",
+  },
+  ".MuiInputBase-root.Mui-disabled &": {
+    color: "inherit",
+  },
   height: "100%",
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
A followup to https://github.com/mitodl/mit-open/pull/1545 to fix color bug on RC

### Description (What does it do?)
Restores some styles that were accidentally deleted 

### Screenshots (if appropriate):

**Codespace preview:** https://fictional-space-bassoon-447r595prwfq5r-8062.app.github.dev/ *Doesn't seem to have data, though*

normal:
<img width="718" alt="Screenshot 2024-09-18 at 11 37 35 AM" src="https://github.com/user-attachments/assets/74695d88-5c14-4764-90dc-92594e8550c3">

hovered:
<img width="679" alt="Screenshot 2024-09-18 at 11 37 39 AM" src="https://github.com/user-attachments/assets/2c6beae0-2b07-4e1d-8bfd-8d01ff1ecbc7">

focused:
<img width="692" alt="Screenshot 2024-09-18 at 11 37 43 AM" src="https://github.com/user-attachments/assets/4182775f-0321-4941-95d4-d499284c01bf">


### How can this be tested?
Check that the homepage input looks like it does on production.
