### PR TITLE
fix testimonial color title attribute

### DIFF
--- a/frontends/mit-learn/src/page-components/TestimonialDisplay/AttestantBlock.tsx
+++ b/frontends/mit-learn/src/page-components/TestimonialDisplay/AttestantBlock.tsx
@@ -152,7 +152,7 @@ const AttestantBlock: React.FC<AttestantBlockProps> = ({
         >
           {attestation?.attestant_name}
         </AttestantName>
-        <AttestantTitle variant={variant}>
+        <AttestantTitle variant={variant} color={color}>
           <TruncateText lineClamp={2}>{attestation.title}</TruncateText>
         </AttestantTitle>
       </AttestantNameBlock>


### PR DESCRIPTION
### What are the relevant tickets?
followup to https://github.com/mitodl/mit-open/issues/1568

### Description (What does it do?)
fixes a color issue on the attestant title

### Screenshots (if appropriate):
Now (and `release`):

<img width="241" alt="Screenshot 2024-09-18 at 12 37 27 PM" src="https://github.com/user-attachments/assets/d6bbb724-38ac-4c1e-b3d1-1472b37f872d">

Before (`main`)
<img width="246" alt="Screenshot 2024-09-18 at 12 27 02 PM" src="https://github.com/user-attachments/assets/2c9ce30b-6806-4c3b-87fd-cc3befd384a7">


### How can this be tested?
1. Check testimonials on homepage AND unit pages. Homepage should be dark text on white background, unit pages should be light text on dark background
