### PR TITLE
Codespace opensearch service fix

### DIFF
--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -19,3 +19,20 @@ services:
       file: docker-compose.apps.yml
       service: celery
     env_file: env/codespaces.env
+
+  opensearch-node-mitopen-1:
+    extends:
+      file: docker-compose.opensearch.base.yml
+      service: opensearch
+    hostname: opensearch-node-mitopen-1
+    environment:
+      - "node.name=opensearch-node-mitopen-1"
+      - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data
+    ports:
+      - 9100:9200 # REST API
+      - 9500:9600 # Performance Analyzer
+
+volumes:
+  opensearch-data1:

--- a/docker-compose.codespaces.yml
+++ b/docker-compose.codespaces.yml
@@ -7,6 +7,8 @@ services:
       file: docker-compose.apps.yml
       service: web
     env_file: env/codespaces.env
+    depends_on:
+      - opensearch-node-mitopen-1
 
   watch:
     extends:
@@ -19,20 +21,3 @@ services:
       file: docker-compose.apps.yml
       service: celery
     env_file: env/codespaces.env
-
-  opensearch-node-mitopen-1:
-    extends:
-      file: docker-compose.opensearch.base.yml
-      service: opensearch
-    hostname: opensearch-node-mitopen-1
-    environment:
-      - "node.name=opensearch-node-mitopen-1"
-      - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
-    volumes:
-      - opensearch-data1:/usr/share/opensearch/data
-    ports:
-      - 9100:9200 # REST API
-      - 9500:9600 # Performance Analyzer
-
-volumes:
-  opensearch-data1:


### PR DESCRIPTION
### Description (What does it do?)
Fixes an issue where the opensearch service is not started when creating a codespace due to a descrepency with copose versions and how we now inherit compose configurations

### How can this be tested?
1. No need to check out any code! create a codespace directly off of this PR - You can click this in the bottom right to follow the build progress:
<img width="467" alt="Screenshot 2024-09-18 at 2 59 34 PM" src="https://github.com/user-attachments/assets/bbbef0b4-b163-46bb-8ffb-0d54a828577a">

2. Let it finish initializing (A few minutes after you see 3 ports show up in the ports tab - you will want the initialization script to complete as well - a blue "Finished configuring codespace." should show up at the bottom of the terminal tab)
3. In the ports tab - set port 8063 to "public"
4. Visit the running frontend at the 8062 address - You should be able to go to the search page and see some results display

