### PR TITLE
search environment vars

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,26 @@
       "description": "The domain to set the CSRF cookie on",
       "required": false
     },
+    "DEFAULT_SEARCH_MODE": {
+      "description": "Default search mode for the search API and frontend",
+      "required": false
+    },
+    "DEFAULT_SEARCH_SLOP": {
+      "description": "Default slop value for the search API and frontend. Only used for phrase queries.",
+      "required": false
+    },
+    "DEFAULT_SEARCH_STALENESS_PENALTY": {
+      "description": "Default staleness penalty value for the search API and frontend",
+      "required": false
+    },
+    "DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF": {
+      "description": "Default minimum score cutoff value for the search API and frontend",
+      "required": false
+    },
+    "DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY": {
+      "description": "Default max incompleteness penalty value for the search API and frontend",
+      "required": false
+    },
     "EDX_API_ACCESS_TOKEN_URL": {
       "description": "URL to retrieve a MITx access token",
       "required": false

--- a/frontends/mit-learn/jest.config.ts
+++ b/frontends/mit-learn/jest.config.ts
@@ -19,6 +19,11 @@ const config: Config.InitialOptions = {
       MITOL_API_BASE_URL: "https://api.test.learn.mit.edu",
       PUBLIC_URL: "",
       SITE_NAME: "MIT Learn",
+      DEFAULT_SEARCH_MODE: "phrase",
+      DEFAULT_SEARCH_SLOP: 6,
+      DEFAULT_SEARCH_STALENESS_PENALTY: 2.5,
+      DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF: 0,
+      DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY: 90,
     },
   },
 }

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -172,6 +172,11 @@ const FacetStyles = styled.div`
 
     &.facets-expanded {
       max-height: 600px;
+
+      &.admin-facet {
+        max-height: fit-content;
+      }
+
       transition: max-height 0.4s ease-in;
     }
 
@@ -515,6 +520,14 @@ interface SearchDisplayProps {
   filterHeadingEl: React.ElementType
 }
 
+const {
+  DEFAULT_SEARCH_MODE,
+  DEFAULT_SEARCH_SLOP,
+  DEFAULT_SEARCH_STALENESS_PENALTY,
+  DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF,
+  DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY,
+} = APP_SETTINGS
+
 const SearchDisplay: React.FC<SearchDisplayProps> = ({
   page,
   setPage,
@@ -585,7 +598,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   const searchModeDropdown = (
     <StyledSelect
       size="small"
-      value={searchParams.get("search_mode") || "best_fields"}
+      value={searchParams.get("search_mode") || DEFAULT_SEARCH_MODE}
       onChange={(e) =>
         setSearchParams((prev) => {
           const next = new URLSearchParams(prev)
@@ -623,7 +636,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
     return (
       <div
-        className={`facets base-facet${expandAdminOptions ? " facets-expanded" : ""}`}
+        className={`facets admin-facet base-facet${expandAdminOptions ? " facets-expanded" : ""}`}
       >
         <button
           className="filter-section-button"
@@ -645,7 +658,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               currentValue={
                 searchParams.get("yearly_decay_percent")
                   ? Number(searchParams.get("yearly_decay_percent"))
-                  : 2.5
+                  : DEFAULT_SEARCH_STALENESS_PENALTY
               }
               setSearchParams={setSearchParams}
               urlParam="yearly_decay_percent"
@@ -666,7 +679,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                 OpenSearch search multi-match query type.
               </ExplanationContainer>
             </div>
-            {searchParams.get("search_mode") === "phrase" ? (
+            {(!searchParams.get("search_mode") &&
+              DEFAULT_SEARCH_MODE === "phrase") ||
+            searchParams.get("search_mode") === "phrase" ? (
               <div>
                 <AdminTitleContainer>Slop</AdminTitleContainer>
 
@@ -674,7 +689,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
                   currentValue={
                     searchParams.get("slop")
                       ? Number(searchParams.get("slop"))
-                      : 0
+                      : DEFAULT_SEARCH_SLOP
                   }
                   setSearchParams={setSearchParams}
                   urlParam="slop"
@@ -694,7 +709,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               currentValue={
                 searchParams.get("min_score")
                   ? Number(searchParams.get("min_score"))
-                  : 0
+                  : DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF
               }
               setSearchParams={setSearchParams}
               urlParam="min_score"
@@ -713,7 +728,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               currentValue={
                 searchParams.get("max_incompleteness_penalty")
                   ? Number(searchParams.get("max_incompleteness_penalty"))
-                  : 0
+                  : DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY
               }
               setSearchParams={setSearchParams}
               urlParam="max_incompleteness_penalty"

--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.test.tsx
@@ -306,6 +306,11 @@ describe("SearchPage", () => {
     setMockResponse.get(urls.userMe.get(), {
       is_learning_path_editor: true,
     })
+    APP_SETTINGS.DEFAULT_SEARCH_MODE = "phrase"
+    APP_SETTINGS.DEFAULT_SEARCH_SLOP = 6
+    APP_SETTINGS.DEFAULT_SEARCH_STALENESS_PENALTY = 2.5
+    APP_SETTINGS.DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF = 0
+    APP_SETTINGS.DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY = 90
     renderWithProviders(<SearchPage />)
     await waitFor(() => {
       const adminFacetContainer = screen.getByText("Admin Options")
@@ -321,6 +326,11 @@ describe("SearchPage", () => {
 })
 
 test("admin users can set the search mode and slop", async () => {
+  APP_SETTINGS.DEFAULT_SEARCH_MODE = "phrase"
+  APP_SETTINGS.DEFAULT_SEARCH_SLOP = 6
+  APP_SETTINGS.DEFAULT_SEARCH_STALENESS_PENALTY = 2.5
+  APP_SETTINGS.DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF = 0
+  APP_SETTINGS.DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY = 90
   setMockApiResponses({
     search: {
       count: 700,
@@ -349,11 +359,21 @@ test("admin users can set the search mode and slop", async () => {
     user.click(adminFacetContainer)
   })
 
-  let slopSlider = screen.queryByText("Slop")
-  expect(slopSlider).toBeNull()
-
-  const searchModeDropdowns = await screen.findAllByText("best_fields")
+  const searchModeDropdowns = await screen.findAllByText("phrase")
   const searchModeDropdown = searchModeDropdowns[0]
+
+  await user.click(searchModeDropdown)
+
+  const mostFieldsSelect = await screen.findByRole("option", {
+    name: "most_fields",
+  })
+
+  await user.click(mostFieldsSelect)
+
+  expect(location.current.search).toBe("?search_mode=most_fields")
+
+  const slopSlider = screen.queryByText("Slop")
+  expect(slopSlider).toBeNull()
 
   await user.click(searchModeDropdown)
 
@@ -370,17 +390,6 @@ test("admin users can set the search mode and slop", async () => {
   })
 
   await user.click(searchModeDropdown)
-
-  const mostFieldsSelect = await screen.findByRole("option", {
-    name: "most_fields",
-  })
-
-  await user.click(mostFieldsSelect)
-
-  expect(location.current.search).toBe("?search_mode=most_fields")
-
-  slopSlider = screen.queryByText("Slop")
-  expect(slopSlider).toBeNull()
 })
 
 describe("Search Page Tabs", () => {

--- a/frontends/mit-learn/webpack.config.js
+++ b/frontends/mit-learn/webpack.config.js
@@ -45,6 +45,11 @@ const {
   CSRF_COOKIE_NAME,
   APPZI_URL,
   MITOL_NOINDEX,
+  DEFAULT_SEARCH_MODE,
+  DEFAULT_SEARCH_SLOP,
+  DEFAULT_SEARCH_STALENESS_PENALTY,
+  DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF,
+  DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY,
 } = cleanEnv(process.env, {
   NODE_ENV: str({
     choices: ["development", "production", "test"],
@@ -123,6 +128,26 @@ const {
   MITOL_NOINDEX: bool({
     desc: "Whether to include a noindex meta tag",
     default: true,
+  }),
+  DEFAULT_SEARCH_SLOP: num({
+    desc: "The default search slop",
+    default: 6,
+  }),
+  DEFAULT_SEARCH_STALENESS_PENALTY: num({
+    desc: "The default search staleness penalty",
+    default: 2.5,
+  }),
+  DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF: num({
+    desc: "The default search minimum score cutoff",
+    default: 0,
+  }),
+  DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY: num({
+    desc: "The default search max incompleteness penalty",
+    default: 90,
+  }),
+  DEFAULT_SEARCH_MODE: str({
+    desc: "The default search mode",
+    default: "phrase",
   }),
 })
 
@@ -265,6 +290,11 @@ module.exports = (env, argv) => {
           MITOL_SUPPORT_EMAIL: JSON.stringify(MITOL_SUPPORT_EMAIL),
           PUBLIC_URL: JSON.stringify(PUBLIC_URL),
           CSRF_COOKIE_NAME: JSON.stringify(CSRF_COOKIE_NAME),
+          DEFAULT_SEARCH_MODE: JSON.stringify(DEFAULT_SEARCH_MODE),
+          DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY,
+          DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF,
+          DEFAULT_SEARCH_SLOP,
+          DEFAULT_SEARCH_STALENESS_PENALTY,
         },
       }),
     ]

--- a/frontends/ol-utilities/src/types/settings.d.ts
+++ b/frontends/ol-utilities/src/types/settings.d.ts
@@ -22,5 +22,10 @@ export declare global {
     SITE_NAME: string
     MITOL_SUPPORT_EMAIL: string
     PUBLIC_URL: string
+    DEFAULT_SEARCH_MODE: string
+    DEFAULT_SEARCH_SLOP: number
+    DEFAULT_SEARCH_STALENESS_PENALTY: number
+    DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF: number
+    DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY: number
   }
 }

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1051,6 +1051,10 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
         "offset": 1,
         "sortby": "-readable_id",
         "endpoint": LEARNING_RESOURCE,
+        "yearly_decay_percent": 0,
+        "max_incompleteness_penalty": 0,
+        "min_score": 0,
+        "search_mode": "best_fields",
     }
 
     query = {
@@ -1079,6 +1083,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                     "course_feature",
                                                                     "video.transcript.english",
                                                                 ],
+                                                                "type": "best_fields",
                                                             }
                                                         },
                                                         {
@@ -1090,6 +1095,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                         "fields": [
                                                                             "topics.name"
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                             }
@@ -1104,6 +1110,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                             "departments.department_id",
                                                                             "departments.name",
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                             }
@@ -1117,6 +1124,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                         "fields": [
                                                                             "course.course_numbers.value"
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                             }
@@ -1132,6 +1140,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                             "runs.semester",
                                                                             "runs.level",
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                             }
@@ -1150,6 +1159,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                                     "runs.instructors.last_name^5",
                                                                                     "runs.instructors.full_name^5",
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                     }
@@ -1168,6 +1178,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                             "short_description.english^2",
                                                                             "content_feature_type",
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                                 "score_mode": "avg",
@@ -1194,6 +1205,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                             "course_feature",
                                             "video.transcript.english",
                                         ],
+                                        "type": "best_fields",
                                     }
                                 },
                                 {
@@ -1203,6 +1215,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                             "multi_match": {
                                                 "query": "math",
                                                 "fields": ["topics.name"],
+                                                "type": "best_fields",
                                             }
                                         },
                                     }
@@ -1217,6 +1230,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                     "departments.department_id",
                                                     "departments.name",
                                                 ],
+                                                "type": "best_fields",
                                             }
                                         },
                                     }
@@ -1230,6 +1244,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                 "fields": [
                                                     "course.course_numbers.value"
                                                 ],
+                                                "type": "best_fields",
                                             }
                                         },
                                     }
@@ -1245,6 +1260,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                     "runs.semester",
                                                     "runs.level",
                                                 ],
+                                                "type": "best_fields",
                                             }
                                         },
                                     }
@@ -1263,6 +1279,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                             "runs.instructors.last_name^5",
                                                             "runs.instructors.full_name^5",
                                                         ],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                             }
@@ -1281,6 +1298,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                     "short_description.english^2",
                                                     "content_feature_type",
                                                 ],
+                                                "type": "best_fields",
                                             }
                                         },
                                         "score_mode": "avg",
@@ -1450,8 +1468,12 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
     ],
 )
 def test_execute_learn_search_with_script_score(
-    mocker, opensearch, yearly_decay_percent, max_incompleteness_penalty
+    mocker, settings, opensearch, yearly_decay_percent, max_incompleteness_penalty
 ):
+    settings.DEFAULT_SEARCH_MODE = "phrase"
+    settings.DEFAULT_SEARCH_SLOP = 0
+    settings.DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF = 0
+
     opensearch.conn.search.return_value = {
         "hits": {"total": {"value": 10, "relation": "eq"}}
     }
@@ -1531,6 +1553,7 @@ def test_execute_learn_search_with_script_score(
                                                                             "course_feature",
                                                                             "video.transcript.english",
                                                                         ],
+                                                                        "type": "phrase",
                                                                     }
                                                                 },
                                                                 {
@@ -1542,6 +1565,7 @@ def test_execute_learn_search_with_script_score(
                                                                                 "fields": [
                                                                                     "topics.name"
                                                                                 ],
+                                                                                "type": "phrase",
                                                                             }
                                                                         },
                                                                     }
@@ -1556,6 +1580,7 @@ def test_execute_learn_search_with_script_score(
                                                                                     "departments.department_id",
                                                                                     "departments.name",
                                                                                 ],
+                                                                                "type": "phrase",
                                                                             }
                                                                         },
                                                                     }
@@ -1569,6 +1594,7 @@ def test_execute_learn_search_with_script_score(
                                                                                 "fields": [
                                                                                     "course.course_numbers.value"
                                                                                 ],
+                                                                                "type": "phrase",
                                                                             }
                                                                         },
                                                                     }
@@ -1584,6 +1610,7 @@ def test_execute_learn_search_with_script_score(
                                                                                     "runs.semester",
                                                                                     "runs.level",
                                                                                 ],
+                                                                                "type": "phrase",
                                                                             }
                                                                         },
                                                                     }
@@ -1602,6 +1629,7 @@ def test_execute_learn_search_with_script_score(
                                                                                             "runs.instructors.last_name^5",
                                                                                             "runs.instructors.full_name^5",
                                                                                         ],
+                                                                                        "type": "phrase",
                                                                                     }
                                                                                 },
                                                                             }
@@ -1620,6 +1648,7 @@ def test_execute_learn_search_with_script_score(
                                                                                     "short_description.english^2",
                                                                                     "content_feature_type",
                                                                                 ],
+                                                                                "type": "phrase",
                                                                             }
                                                                         },
                                                                         "score_mode": "avg",
@@ -1646,6 +1675,7 @@ def test_execute_learn_search_with_script_score(
                                                     "course_feature",
                                                     "video.transcript.english",
                                                 ],
+                                                "type": "phrase",
                                             }
                                         },
                                         {
@@ -1655,6 +1685,7 @@ def test_execute_learn_search_with_script_score(
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": ["topics.name"],
+                                                        "type": "phrase",
                                                     }
                                                 },
                                             }
@@ -1669,6 +1700,7 @@ def test_execute_learn_search_with_script_score(
                                                             "departments.department_id",
                                                             "departments.name",
                                                         ],
+                                                        "type": "phrase",
                                                     }
                                                 },
                                             }
@@ -1682,6 +1714,7 @@ def test_execute_learn_search_with_script_score(
                                                         "fields": [
                                                             "course.course_numbers.value"
                                                         ],
+                                                        "type": "phrase",
                                                     }
                                                 },
                                             }
@@ -1697,6 +1730,7 @@ def test_execute_learn_search_with_script_score(
                                                             "runs.semester",
                                                             "runs.level",
                                                         ],
+                                                        "type": "phrase",
                                                     }
                                                 },
                                             }
@@ -1715,6 +1749,7 @@ def test_execute_learn_search_with_script_score(
                                                                     "runs.instructors.last_name^5",
                                                                     "runs.instructors.full_name^5",
                                                                 ],
+                                                                "type": "phrase",
                                                             }
                                                         },
                                                     }
@@ -1733,6 +1768,7 @@ def test_execute_learn_search_with_script_score(
                                                             "short_description.english^2",
                                                             "content_feature_type",
                                                         ],
+                                                        "type": "phrase",
                                                     }
                                                 },
                                                 "score_mode": "avg",
@@ -1898,10 +1934,14 @@ def test_execute_learn_search_with_script_score(
     )
 
 
-def test_execute_learn_search_with_min_score(mocker, opensearch):
+def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
     opensearch.conn.search.return_value = {
         "hits": {"total": {"value": 10, "relation": "eq"}}
     }
+
+    settings.DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY = 0
+    settings.DEFAULT_SEARCH_STALENESS_PENALTY = 0
+    settings.DEFAULT_SEARCH_MODE = "best_fields"
 
     search_params = {
         "aggregations": ["offered_by"],
@@ -1943,6 +1983,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                             "course_feature",
                                                                             "video.transcript.english",
                                                                         ],
+                                                                        "type": "best_fields",
                                                                     }
                                                                 },
                                                                 {
@@ -1954,6 +1995,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                 "fields": [
                                                                                     "topics.name"
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                     }
@@ -1968,6 +2010,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                     "departments.department_id",
                                                                                     "departments.name",
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                     }
@@ -1981,6 +2024,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                 "fields": [
                                                                                     "course.course_numbers.value"
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                     }
@@ -1996,6 +2040,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                     "runs.semester",
                                                                                     "runs.level",
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                     }
@@ -2014,6 +2059,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                             "runs.instructors.last_name^5",
                                                                                             "runs.instructors.full_name^5",
                                                                                         ],
+                                                                                        "type": "best_fields",
                                                                                     }
                                                                                 },
                                                                             }
@@ -2032,6 +2078,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                                     "short_description.english^2",
                                                                                     "content_feature_type",
                                                                                 ],
+                                                                                "type": "best_fields",
                                                                             }
                                                                         },
                                                                         "score_mode": "avg",
@@ -2058,6 +2105,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                     "course_feature",
                                                     "video.transcript.english",
                                                 ],
+                                                "type": "best_fields",
                                             }
                                         },
                                         {
@@ -2067,6 +2115,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": ["topics.name"],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                             }
@@ -2081,6 +2130,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                             "departments.department_id",
                                                             "departments.name",
                                                         ],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                             }
@@ -2094,6 +2144,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                         "fields": [
                                                             "course.course_numbers.value"
                                                         ],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                             }
@@ -2109,6 +2160,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                             "runs.semester",
                                                             "runs.level",
                                                         ],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                             }
@@ -2127,6 +2179,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                                     "runs.instructors.last_name^5",
                                                                     "runs.instructors.full_name^5",
                                                                 ],
+                                                                "type": "best_fields",
                                                             }
                                                         },
                                                     }
@@ -2145,6 +2198,7 @@ def test_execute_learn_search_with_min_score(mocker, opensearch):
                                                             "short_description.english^2",
                                                             "content_feature_type",
                                                         ],
+                                                        "type": "best_fields",
                                                     }
                                                 },
                                                 "score_mode": "avg",

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -331,7 +331,6 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         min_value=0,
         required=False,
         allow_null=True,
-        default=2.5,
         help_text=(
             "Relevance score penalty percent per year for for resources without "
             "upcoming runs. Only affects results if there is a search term."
@@ -425,7 +424,6 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         min_value=0,
         required=False,
         allow_null=True,
-        default=0,
         help_text=(
             "Minimum score value a text query result needs to have to be displayed"
         ),
@@ -435,7 +433,6 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
         min_value=0,
         required=False,
         allow_null=True,
-        default=0,
         help_text=(
             "Maximum score penalty for incomplete OCW courses in percent. "
             "An OCW course with completeness = 0 will have this score penalty. "

--- a/main/settings.py
+++ b/main/settings.py
@@ -766,3 +766,16 @@ POSTHOG_PROJECT_ID = get_int(
 
 # Enable or disable search engine indexing
 MITOL_NOINDEX = get_bool("MITOL_NOINDEX", True)  # noqa: FBT003
+
+# Search defaults settings - adjustable throught the admin ui
+DEFAULT_SEARCH_MODE = get_string(name="DEFAULT_SEARCH_MODE", default="phrase")
+DEFAULT_SEARCH_SLOP = get_int(name="DEFAULT_SEARCH_SLOP", default=6)
+DEFAULT_SEARCH_STALENESS_PENALTY = get_float(
+    name="DEFAULT_SEARCH_STALENESS_PENALTY", default=2.5
+)
+DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF = get_float(
+    name="DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF", default=0
+)
+DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY = get_float(
+    name="DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY", default=90
+)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2493,7 +2493,6 @@ paths:
           maximum: 100
           minimum: 0
           nullable: true
-          default: 0.0
         description: Maximum score penalty for incomplete OCW courses in percent.
           An OCW course with completeness = 0 will have this score penalty. Partially
           complete courses have a linear penalty proportional to the degree of incompleteness.
@@ -2506,7 +2505,6 @@ paths:
           maximum: 50
           minimum: 0
           nullable: true
-          default: 0.0
         description: Minimum score value a text query result needs to have to be displayed
       - in: query
         name: offered_by
@@ -2717,7 +2715,6 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
-          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -2976,7 +2973,6 @@ paths:
           maximum: 100
           minimum: 0
           nullable: true
-          default: 0.0
         description: Maximum score penalty for incomplete OCW courses in percent.
           An OCW course with completeness = 0 will have this score penalty. Partially
           complete courses have a linear penalty proportional to the degree of incompleteness.
@@ -2989,7 +2985,6 @@ paths:
           maximum: 50
           minimum: 0
           nullable: true
-          default: 0.0
         description: Minimum score value a text query result needs to have to be displayed
       - in: query
         name: offered_by
@@ -3200,7 +3195,6 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
-          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -3484,7 +3478,6 @@ paths:
           maximum: 100
           minimum: 0
           nullable: true
-          default: 0.0
         description: Maximum score penalty for incomplete OCW courses in percent.
           An OCW course with completeness = 0 will have this score penalty. Partially
           complete courses have a linear penalty proportional to the degree of incompleteness.
@@ -3497,7 +3490,6 @@ paths:
           maximum: 50
           minimum: 0
           nullable: true
-          default: 0.0
         description: Minimum score value a text query result needs to have to be displayed
       - in: query
         name: offered_by
@@ -3722,7 +3714,6 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
-          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -3983,7 +3974,6 @@ paths:
           maximum: 100
           minimum: 0
           nullable: true
-          default: 0.0
         description: Maximum score penalty for incomplete OCW courses in percent.
           An OCW course with completeness = 0 will have this score penalty. Partially
           complete courses have a linear penalty proportional to the degree of incompleteness.
@@ -3996,7 +3986,6 @@ paths:
           maximum: 50
           minimum: 0
           nullable: true
-          default: 0.0
         description: Minimum score value a text query result needs to have to be displayed
       - in: query
         name: offered_by
@@ -4221,7 +4210,6 @@ paths:
           maximum: 10
           minimum: 0
           nullable: true
-          default: 2.5
         description: Relevance score penalty percent per year for for resources without
           upcoming runs. Only affects results if there is a search term.
       tags:
@@ -10055,7 +10043,6 @@ components:
           maximum: 10
           minimum: 0
           nullable: true
-          default: 2.5
           description: Relevance score penalty percent per year for for resources
             without upcoming runs. Only affects results if there is a search term.
         certification:
@@ -10136,7 +10123,6 @@ components:
           maximum: 50
           minimum: 0
           nullable: true
-          default: 0.0
           description: Minimum score value a text query result needs to have to be
             displayed
         max_incompleteness_penalty:
@@ -10145,7 +10131,6 @@ components:
           maximum: 100
           minimum: 0
           nullable: true
-          default: 0.0
           description: Maximum score penalty for incomplete OCW courses in percent.
             An OCW course with completeness = 0 will have this score penalty. Partially
             complete courses have a linear penalty proportional to the degree of incompleteness.


### PR DESCRIPTION
### What are the relevant tickets?
- closes https://github.com/mitodl/hq/issues/5527 

### Description (What does it do?)
This PR makes default admin search setting settable as environment variables. I also sets search_mode= phrase slop=6 max_incompleteness_penalty=90 as the default


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Verify that the search page works
- Verify that as a logged in user, you can manipulate the admin settings
- Verify that when you set   DEFAULT_SEARCH_MODE, DEFAULT_SEARCH_SLOP, DEFAULT_SEARCH_STALENESS_PENALTY, DEFAULT_SEARCH_MINIMUM_SCORE_CUTOFF or DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY, the default is changed in the ui for admin users