### PR TITLE
[NextJS] Make noindex tag opt-out (like main) rather than opt-in

### DIFF
--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -13,12 +13,9 @@ export async function generateMetadata({
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
-  const robots =
-    process.env.MITOL_NOINDEX === "false" ? undefined : "noindex, nofollow"
   return await getMetadataAsync({
     title: "Learn with MIT",
     searchParams,
-    robots,
   })
 }
 

--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -13,11 +13,12 @@ export async function generateMetadata({
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
+  const robots =
+    process.env.MITOL_NOINDEX === "false" ? undefined : "noindex, nofollow"
   return await getMetadataAsync({
     title: "Learn with MIT",
     searchParams,
-    robots:
-      process.env.MITOL_NOINDEX === "true" ? "noindex, nofollow" : undefined,
+    robots,
   })
 }
 

--- a/frontends/main/src/common/metadata.ts
+++ b/frontends/main/src/common/metadata.ts
@@ -102,6 +102,8 @@ export const standardizeMetadata = ({
     title,
     description,
     ...socialMetadata,
+    robots:
+      process.env.MITOL_NOINDEX === "false" ? undefined : "noindex, nofollow",
     ...otherMeta,
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes  https://github.com/mitodl/hq/issues/5565

### Description (What does it do?)
This PR makes the `<meta name="robots" content="noindex">` the default. I.e., indexing is opt-in instead of opt-out. This is the same as what we currently do on `main`. Note that currently all releases of Learn should have noindex, per our "soft launch" status.

### How can this be tested?
1. With MITOL_NOINDEX undefined, check that you **do** get a noindex tag.
2. With `MITOL_NOINDEX=false`, check that you **do not** get a noindex tag.