### PR TITLE
new -> recently added

### DIFF
--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -219,7 +219,7 @@ const navData: NavData = {
       title: "DISCOVER LEARNING RESOURCES",
       items: [
         {
-          title: "New",
+          title: "Recently Added",
           icon: <RiFileAddLine />,
           href: SEARCH_NEW,
         },

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -52,10 +52,6 @@ import { ResourceCard } from "../ResourceCard/ResourceCard"
 import { useSearchParams } from "@mitodl/course-search-utils/react-router"
 import { useUserMe } from "api/hooks/user"
 
-export const StyledSelect = styled(SimpleSelect)`
-  min-width: 160px;
-`
-
 const StyledResourceTabs = styled(ResourceCategoryTabs.TabList)`
   margin-top: 0 px;
 `
@@ -470,7 +466,7 @@ const SORT_OPTIONS = [
     value: "",
   },
   {
-    label: "New",
+    label: "Recently Added",
     value: "new",
   },
   {
@@ -596,7 +592,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   }
 
   const searchModeDropdown = (
-    <StyledSelect
+    <SimpleSelect
       size="small"
       value={searchParams.get("search_mode") || DEFAULT_SEARCH_MODE}
       onChange={(e) =>
@@ -615,7 +611,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   )
 
   const sortDropdown = (
-    <StyledSelect
+    <SimpleSelect
       size="small"
       value={requestParams.sortby || ""}
       onChange={(e) => setParamValue("sortby", e.target.value)}

--- a/frontends/mit-learn/src/pages/ChannelPage/ChannelSearchFacetDisplay.tsx
+++ b/frontends/mit-learn/src/pages/ChannelPage/ChannelSearchFacetDisplay.tsx
@@ -8,9 +8,8 @@ import type {
   BooleanFacetKey,
 } from "@mitodl/course-search-utils"
 import { BOOLEAN_FACET_NAMES } from "@mitodl/course-search-utils"
-import { Skeleton, styled } from "ol-components"
+import { Skeleton, styled, SimpleSelect } from "ol-components"
 import type { SimpleSelectOption } from "ol-components"
-import { StyledSelect } from "@/page-components/SearchDisplay/SearchDisplay"
 
 const StyledSkeleton = styled(Skeleton)`
   display: inline-flex;
@@ -117,7 +116,7 @@ const AvailableFacetsDropdowns: React.FC<
 
         return (
           facetItems.length && (
-            <StyledSelect
+            <SimpleSelect
               key={facetSetting.name}
               value={displayValue}
               multiple={isMultiple}


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5302

### Description (What does it do?)
Changes "New" to recently added in the sort dropdown and navigation. Removes the width from the sort dropdown

### Screenshots (if appropriate):
<img width="1726" alt="Screenshot 2024-09-23 at 12 10 43 PM" src="https://github.com/user-attachments/assets/1ada569d-2e91-4c15-becb-4bfd25d2d2f6">
<img width="328" alt="Screenshot 2024-09-23 at 12 11 24 PM" src="https://github.com/user-attachments/assets/d7c66079-ce26-442d-8ea6-ffa55415d59b">
<img width="1189" alt="Screenshot 2024-09-23 at 12 11 12 PM" src="https://github.com/user-attachments/assets/7639cb7a-351f-4255-b0a4-4d96ccb90957">
<img width="328" alt="Screenshot 2024-09-23 at 12 10 58 PM" src="https://github.com/user-attachments/assets/bf4ad1e5-23a4-4bde-9b6e-760a7680cca3">


### How can this be tested?
Go to the search page. Verify that "New" is change to "Recently Added" in the navigation and sort dropdown. Verify that navigation and sorting still works as expected