### PR TITLE
Add additional event capturing for some interactions

### DIFF
--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.tsx
@@ -20,6 +20,7 @@ import type { LearningResourceOfferor } from "api"
 import { useOfferorsList } from "api/hooks/learningResources"
 import { capitalize } from "ol-utilities"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
+import { usePostHog } from "posthog-js/react"
 
 const cssGradient = `
   linear-gradient(
@@ -175,6 +176,8 @@ const useFacetManifest = (resourceCategory: string | null) => {
 const SearchPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const facetManifest = useFacetManifest(searchParams.get("resource_category"))
+  const posthog = usePostHog()
+  const { POSTHOG } = APP_SETTINGS
 
   const setPage = useCallback(
     (newPage: number) => {
@@ -191,8 +194,11 @@ const SearchPage: React.FC = () => {
     [setSearchParams],
   )
   const onFacetsChange = useCallback(() => {
+    if (!(!POSTHOG?.api_key || POSTHOG.api_key.length < 1)) {
+      posthog.capture("search_update")
+    }
     setPage(1)
-  }, [setPage])
+  }, [setPage, posthog, POSTHOG])
 
   const {
     params,

--- a/frontends/ol-ckeditor/src/types/settings.d.ts
+++ b/frontends/ol-ckeditor/src/types/settings.d.ts
@@ -1,5 +1,11 @@
 /* eslint-disable no-var */
 
+export type PostHogSettings = {
+  api_key: string
+  timeout?: int
+  bootstrap_flags?: Record<string, string | boolean>
+}
+
 export declare global {
   const APP_SETTINGS: {
     EMBEDLY_KEY: string
@@ -9,5 +15,6 @@ export declare global {
     PUBLIC_URL: string
     SITE_NAME: string
     CSRF_COOKIE_NAME: string
+    POSTHOG?: PostHogSettings
   }
 }

--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -26,6 +26,7 @@
     "material-ui-popup-state": "^5.1.0",
     "ol-test-utilities": "0.0.0",
     "ol-utilities": "0.0.0",
+    "posthog-js": "^1.165.0",
     "react": "18.3.1",
     "react-router": "^6.22.2",
     "react-router-dom": "^6.22.2",

--- a/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
+++ b/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
@@ -58,7 +58,12 @@ const SearchInput: React.FC<SearchInputProps> = (props) => {
   const { POSTHOG } = APP_SETTINGS
 
   const handleSubmit = useCallback(
-    (ev: React.SyntheticEvent<HTMLInputElement>, isEnter: boolean = false) => {
+    (
+      ev:
+        | React.SyntheticEvent<HTMLInputElement>
+        | React.SyntheticEvent<HTMLButtonElement, MouseEvent>,
+      isEnter: boolean = false,
+    ) => {
       const event = {
         target: { value },
         preventDefault: () => null,

--- a/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
+++ b/frontends/ol-components/src/components/SearchInput/SearchInput.tsx
@@ -3,6 +3,7 @@ import { RiSearch2Line, RiCloseLine } from "@remixicon/react"
 import { Input, AdornmentButton } from "../Input/Input"
 import type { InputProps } from "../Input/Input"
 import styled from "@emotion/styled"
+import { usePostHog } from "posthog-js/react"
 
 const StyledInput = styled(Input)(({ theme }) => ({
   boxShadow: "0px 8px 20px 0px rgba(120, 147, 172, 0.10)",
@@ -53,18 +54,27 @@ const muiInputProps = { "aria-label": "Search for" }
 
 const SearchInput: React.FC<SearchInputProps> = (props) => {
   const { onSubmit, value } = props
-  const handleSubmit = useCallback(() => {
-    const event = {
-      target: { value },
-      preventDefault: () => null,
-    }
-    onSubmit(event)
-  }, [onSubmit, value])
+  const posthog = usePostHog()
+  const { POSTHOG } = APP_SETTINGS
+
+  const handleSubmit = useCallback(
+    (ev: React.SyntheticEvent<HTMLInputElement>, isEnter: boolean = false) => {
+      const event = {
+        target: { value },
+        preventDefault: () => null,
+      }
+      if (!(!POSTHOG?.api_key || POSTHOG.api_key.length < 1)) {
+        posthog.capture("search_update", { isEnter: isEnter })
+      }
+      onSubmit(event)
+    },
+    [onSubmit, value, posthog, POSTHOG],
+  )
   const onInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> =
     useCallback(
       (e) => {
         if (e.key !== "Enter") return
-        handleSubmit()
+        handleSubmit(e, true)
       },
       [handleSubmit],
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -15408,6 +15408,7 @@ __metadata:
     material-ui-popup-state: "npm:^5.1.0"
     ol-test-utilities: "npm:0.0.0"
     ol-utilities: "npm:0.0.0"
+    posthog-js: "npm:^1.165.0"
     prop-types: "npm:^15.8.1"
     react: "npm:18.3.1"
     react-router: "npm:^6.22.2"
@@ -16574,6 +16575,17 @@ __metadata:
     preact: "npm:^10.19.3"
     web-vitals: "npm:^4.0.1"
   checksum: 10/5c3ad201fea4fcace4e3359cc36c4e938600400b38207a701869ef6067ae3d06a47cb89001300573f5a948be59f8b0811cb664bf1bf715eb1cbb9f9a14df0ca6
+  languageName: node
+  linkType: hard
+
+"posthog-js@npm:^1.165.0":
+  version: 1.165.0
+  resolution: "posthog-js@npm:1.165.0"
+  dependencies:
+    fflate: "npm:^0.4.8"
+    preact: "npm:^10.19.3"
+    web-vitals: "npm:^4.0.1"
+  checksum: 10/4a640b90af24ffb173b4d20f27aab572437c8641b1ff48ad23e98d593fa7e94e63e660a4ce967a18eaabaf5102ecaff8a258315b47d1916e79a7f1ec7ad3bc7d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5520
Closes https://github.com/mitodl/hq/issues/5283
https://github.com/mitodl/hq/issues/5254

### Description (What does it do?)

We need some events to fire when certain events happen in the frontend. These include:
- When a learner adds a course to a list (bookmarks it)
- When a learner adjusts their search parameters, including term

These aren't necessarily captured in an intuitive way automatically by PostHog, so this adds explicit events to capture these interactions. 

- For list adds, this will capture a `lr_add_to_list` event. This contains the same data as `lrd_view` (so, basic resource info) plus the type of list the resource was added to (either a user list or a learning path).
- For search query changes, this captures a `search_updated` event. This captures:
   - No extra data for facet changes.
   - An `isEnter` flag if the learner has adjusted their search term - this is True if they have submitted via Enter key, or False if they clicked the submit button/icon.

### How can this be tested?

If you don't have your own PostHog account set up, you can either set one up for this or use the MIT Learn Test project in the OL PostHog account.

> [!NOTE]
> If you're rolling your own, it is imperative that you also set up [this transformation](https://github.com/PostHog/posthog-app-url-parameters-to-event-properties) in Data Pipelines - it should exist in the list if you hit Add Transformation in PostHog. 
>
> The URL parameters to convert should be set to `q,resource_type,certification_type,delivery,department,topic,offered_by,free,professional` and the Prefix should be set to `search_param_`. I also turn on Ignore case and Add to user properties but these aren't strictly required. 

Test `lr_add_to_list` by adding a course to a list. You should see the event pop up in the Activity view (note that it may take a bit of time for it to show up). 

Test `search_update` by making changes to your search - select some facets, update your term. This should result in some events being captured in PostHog.

### Additional Context

`search_update` will fire once for _each_ facet that is chosen. So, if you select multiple items in a row, you will end up with events for all of those individual selections. This is _by design_ at this point - we will revisit later if we need to but we're explicitly not debouncing it now.

In testing, I noticed that there's a bug in https://github.com/PostHog/posthog-app-url-parameters-to-event-properties with regard to query parameter arrays: it does not handle them properly, so you only see whatever the first one is from the param. The facets code appends to the list rather than prepends so this means if you choose more than one of a given type of facet you'll only ever see the first one you chose. (This is especially noticeable for Topics.) This should really be fixed upstream so will work that out separately.