### PR TITLE
add is_incomplete_or_stale to the search index

### DIFF
--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -213,6 +213,7 @@ class LearningResourceFactory(DjangoModelFactory):
     departments = factory.PostGeneration(_post_gen_departments)
     topics = factory.PostGeneration(_post_gen_topics)
     content_tags = factory.PostGeneration(_post_gen_tags)
+    completeness = 1
     published = True
     delivery = factory.List(random.choices(LearningResourceDelivery.names()))  # noqa: S311
     professional = factory.LazyAttribute(

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -1445,6 +1445,7 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                 "is_learning_material",
                 "resource_age_date",
                 "featured_rank",
+                "is_incomplete_or_stale",
             ]
         },
     }
@@ -1921,6 +1922,7 @@ def test_execute_learn_search_with_script_score(
                 "is_learning_material",
                 "resource_age_date",
                 "featured_rank",
+                "is_incomplete_or_stale",
             ]
         },
     }
@@ -2349,6 +2351,7 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                 "is_learning_material",
                 "resource_age_date",
                 "featured_rank",
+                "is_incomplete_or_stale",
             ]
         },
     }
@@ -2559,6 +2562,7 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                 "is_learning_material",
                 "resource_age_date",
                 "featured_rank",
+                "is_incomplete_or_stale",
             ]
         },
     }

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -115,6 +115,7 @@ LEARNING_RESOURCE_MAP = {
     },
     "free": {"type": "boolean"},
     "is_learning_material": {"type": "boolean"},
+    "is_incomplete_or_stale": {"type": "boolean"},
     "delivery": {
         "type": "nested",
         "properties": {
@@ -416,6 +417,7 @@ SOURCE_EXCLUDED_FIELDS = [
     "is_learning_material",
     "resource_age_date",
     "featured_rank",
+    "is_incomplete_or_stale",
 ]
 
 LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS = {

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -125,6 +125,9 @@ def serialize_learning_resource_for_update(
         dict: The serialized and transformed resource data
 
     """
+    STALENESS_CUTOFF = 2010
+    COMPLETENESS_CUTOFF = 0.5
+
     serialized_data = LearningResourceSerializer(instance=learning_resource_obj).data
 
     if learning_resource_obj.resource_type == LearningResourceType.course.name:
@@ -146,15 +149,22 @@ def serialize_learning_resource_for_update(
     else:
         featured_rank = None
 
+    resource_age_date = get_resource_age_date(
+        learning_resource_obj, serialized_data["resource_category"]
+    )
+
+    is_incomplete_or_stale = (
+        resource_age_date and resource_age_date.year <= STALENESS_CUTOFF
+    ) or (learning_resource_obj.completeness < COMPLETENESS_CUTOFF)
+
     return {
         "resource_relations": {"name": "resource"},
         "created_on": learning_resource_obj.created_on,
         "is_learning_material": serialized_data["resource_category"]
         == LEARNING_MATERIAL_RESOURCE_CATEGORY,
-        "resource_age_date": get_resource_age_date(
-            learning_resource_obj, serialized_data["resource_category"]
-        ),
+        "resource_age_date": resource_age_date,
         "featured_rank": featured_rank,
+        "is_incomplete_or_stale": is_incomplete_or_stale,
         **serialized_data,
     }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5658

### Description (What does it do?)
This adds is_incomplete_or_stale as a field to the search. It will be used as a sort term in the default sort so that stale or incomplete resources are not shown at the top of the results when there is no search term. For now this only adds the field, the sort will be updated in a followup pr after we reindex rc and prod

### How can this be tested?
run  ./manage.py recreate_index --all
Comment out line 420 in learning_resources_search/constants.py so is_incomplete_or_stale is shown in the results

run ./manage.py backpopulate_ocw_data --course-name sp-248-neet-ways-of-thinking-fall-2023
go to http://api.open.odl.local:8063/api/v1/learning_resources_search/?q=%22NEET%20ways%20of%20thinking%22
The is_incomplete_or_stale should be true for the resource

run ./manage.py backpopulate_ocw_data --course-name 21m-302-harmony-and-counterpoint-ii-spring-2005
go to http://localhost:8063/api/v1/learning_resources_search/?q=%22Harmony%20and%20Counterpoint%20II%22
The is_incomplete_or_stale should be true for the resource

run ./manage.py backpopulate_ocw_data 6-100l-introduction-to-cs-and-programming-using-python-fall-2022
got to http://api.open.odl.local:8063/api/v1/learning_resources_search/?q=%22Introduction%20to%20CS%20and%20Programming%20using%20Python%22
The is_incomplete_or_stale should be false for the resource
