### PR TITLE
"unfollow" confirmation modal and "Unfollow All" button 

### DIFF
--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.test.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.test.tsx
@@ -87,4 +87,14 @@ describe("SettingsPage", () => {
       expect(makeRequest).toHaveBeenCalledWith("delete", unsubUrl, undefined)
     }
   })
+  test("Unsubscribe from all is hidden if there are no subscriptions", async () => {
+    setupApis({
+      isAuthenticated: true,
+      isSubscribed: false,
+      subscriptionRequest: {},
+    })
+    renderWithProviders(<SettingsPage />)
+    const unfollowButton = screen.queryByText("Unfollow All")
+    expect(unfollowButton).not.toBeInTheDocument()
+  })
 })

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.test.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.test.tsx
@@ -25,10 +25,15 @@ const setupApis = ({
     `${urls.userSubscription.check(subscriptionRequest)}`,
     subscribeResponse,
   )
-  const unsubscribeUrl = urls.userSubscription.delete(subscribeResponse[0]?.id)
-  setMockResponse.delete(unsubscribeUrl, subscribeResponse[0])
+  const unsubscribeUrls = []
+  for (const sub of subscribeResponse) {
+    const unsubscribeUrl = urls.userSubscription.delete(sub?.id)
+    unsubscribeUrls.push(unsubscribeUrl)
+    setMockResponse.delete(unsubscribeUrl, sub)
+  }
+
   return {
-    unsubscribeUrl,
+    unsubscribeUrls,
   }
 }
 
@@ -46,7 +51,7 @@ describe("SettingsPage", () => {
   })
 
   test("Clicking 'Unfollow' removes the subscription", async () => {
-    const { unsubscribeUrl } = setupApis({
+    const { unsubscribeUrls } = setupApis({
       isAuthenticated: true,
       isSubscribed: true,
       subscriptionRequest: {},
@@ -54,13 +59,32 @@ describe("SettingsPage", () => {
     renderWithProviders(<SettingsPage />)
 
     const followList = await screen.findByTestId("follow-list")
-    const unsubscribeButton = within(followList).getAllByText("Unfollow")[0]
-    await user.click(unsubscribeButton)
+    const unsubscribeLink = within(followList).getAllByText("Unfollow")[0]
+    await user.click(unsubscribeLink)
 
+    const unsubscribeButton = await screen.findByTestId("dialog-unfollow")
+    await user.click(unsubscribeButton)
     expect(makeRequest).toHaveBeenCalledWith(
       "delete",
-      unsubscribeUrl,
+      unsubscribeUrls[0],
       undefined,
     )
+  })
+
+  test("Clicking 'Unfollow All' removes all subscriptions", async () => {
+    const { unsubscribeUrls } = setupApis({
+      isAuthenticated: true,
+      isSubscribed: true,
+      subscriptionRequest: {},
+    })
+    renderWithProviders(<SettingsPage />)
+    const unsubscribeLink = await screen.findByTestId("unfollow-all")
+    await user.click(unsubscribeLink)
+
+    const unsubscribeButton = await screen.findByTestId("dialog-unfollow")
+    await user.click(unsubscribeButton)
+    for (const unsubUrl of unsubscribeUrls) {
+      expect(makeRequest).toHaveBeenCalledWith("delete", unsubUrl, undefined)
+    }
   })
 })

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -138,6 +138,7 @@ const UnfollowDialog = NiceModal.create(
             </Button>
 
             <Button
+              data-testid="dialog-unfollow"
               onClick={async () =>
                 subscriptionIds?.map((subscriptionId) =>
                   unsubscribe(subscriptionId, {
@@ -192,6 +193,7 @@ const SettingsPage: React.FC = () => {
         {subscriptionList?.data.length > 1 ? (
           <SettingsHeaderRight>
             <Button
+              data-testid="unfollow-all"
               variant="tertiary"
               onClick={() =>
                 NiceModal.show(UnfollowDialog, {

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -113,7 +113,7 @@ const ListItemBody: React.FC<ListItemBodyProps> = ({
   )
 }
 
-interface UnfollowDialogProps {
+type UnfollowDialogProps = {
   subscriptionIds?: number[]
   subscriptionName?: string
 }
@@ -125,15 +125,15 @@ const UnfollowDialog = NiceModal.create(
     return (
       <Dialog
         {...NiceModal.muiDialogV5(modal)}
-        onConfirm={() =>
-          subscriptionIds.map((subscriptionId) => unsubscribe(subscriptionId))
-        }
+        onConfirm={async () => {
+          subscriptionIds?.map((subscriptionId) => unsubscribe(subscriptionId))
+        }}
         title="Unfollow"
         confirmText={
-          subscriptionIds.length === 1 ? "Yes, Unfollow" : "Yes, Unfollow All"
+          subscriptionIds?.length === 1 ? "Yes, Unfollow" : "Yes, Unfollow All"
         }
       >
-        {subscriptionIds.length === 1 ? (
+        {subscriptionIds?.length === 1 ? (
           <>
             Are you sure you want to unfollow <b>{subscriptionName}</b>?
           </>
@@ -158,10 +158,6 @@ const SettingsPage: React.FC = () => {
 
   if (!user || subscriptionList.isLoading) return null
 
-  const showDialog = (subscriptionIds, subscriptionName) => {
-    return NiceModal.show(UnfollowDialog, { subscriptionIds, subscriptionName })
-  }
-
   return (
     <>
       <SettingsHeader>
@@ -175,12 +171,13 @@ const SettingsPage: React.FC = () => {
           <Button
             variant="tertiary"
             onClick={() =>
-              showDialog(
-                subscriptionList?.data?.map(
+              NiceModal.show(UnfollowDialog, {
+                subscriptionIds: subscriptionList?.data?.map(
                   (subscriptionItem) => subscriptionItem.id,
                 ),
-                "All",
-              )
+                subscriptionName: "All",
+                id: "all",
+              })
             }
           >
             Unfollow All
@@ -200,10 +197,11 @@ const SettingsPage: React.FC = () => {
             />
             <StyledLink
               onClick={() =>
-                showDialog(
-                  [subscriptionItem.id],
-                  subscriptionItem.source_description,
-                )
+                NiceModal.show(UnfollowDialog, {
+                  subscriptionIds: [subscriptionItem.id],
+                  subscriptionName: subscriptionItem.source_description,
+                  id: subscriptionItem.id.toString(),
+                })
               }
             >
               Unfollow

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -164,7 +164,7 @@ const UnfollowDialog = NiceModal.create(
           <>
             Are you sure you want to <b>Unfollow All</b>? You will stop getting
             emails for all topics, academic departments, and MIT units you are
-            following.?
+            following.
           </>
         )}
       </Dialog>

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -190,7 +190,7 @@ const SettingsPage: React.FC = () => {
             All topics, academic departments, and MIT units you are following.
           </SubTitleText>
         </SettingsHeaderLeft>
-        {subscriptionList?.data.length > 1 ? (
+        {subscriptionList?.data?.length > 1 ? (
           <SettingsHeaderRight>
             <Button
               data-testid="unfollow-all"

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -130,7 +130,7 @@ const UnfollowDialog = NiceModal.create(
     return (
       <Dialog
         {...NiceModal.muiDialogV5(modal)}
-        title="Unfollow"
+        title={subscriptionIds?.length === 1 ? "Unfollow" : "Unfollow All"}
         actions={
           <Actions>
             <Button variant="secondary" onClick={() => modal.remove()}>

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { PlainList, Typography, Link, styled } from "ol-components"
+import { PlainList, Typography, Link, styled, Button } from "ol-components"
 import { useUserMe } from "api/hooks/user"
 import {
   useSearchSubscriptionDelete,
@@ -35,6 +35,29 @@ const SubTitleText = styled(Typography)(({ theme }) => ({
   marginBottom: "16px",
   color: theme.custom.colors.darkGray2,
   ...theme.typography.body2,
+}))
+
+const SettingsHeader = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  alignSelf: "stretch",
+  [theme.breakpoints.down("md")]: {
+    paddingBottom: "8px",
+  },
+}))
+
+const SettingsHeaderLeft = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  flex: "1 0 0",
+})
+
+const SettingsHeaderRight = styled.div(({ theme }) => ({
+  display: "flex",
+  [theme.breakpoints.down("md")]: {
+    display: "none",
+  },
 }))
 
 const ListItem = styled.li(({ theme }) => [
@@ -95,10 +118,17 @@ const SettingsPage: React.FC = () => {
 
   return (
     <>
-      <TitleText>Following</TitleText>
-      <SubTitleText>
-        All topics, academic departments, and MIT units you are following.
-      </SubTitleText>
+      <SettingsHeader>
+        <SettingsHeaderLeft>
+          <TitleText>Following</TitleText>
+          <SubTitleText>
+            All topics, academic departments, and MIT units you are following.
+          </SubTitleText>
+        </SettingsHeaderLeft>
+        <SettingsHeaderRight>
+          <Button variant="tertiary">Unfollow All</Button>
+        </SettingsHeaderRight>
+      </SettingsHeader>
       <FollowList data-testid="follow-list">
         {subscriptionList?.data?.map((subscriptionItem) => (
           <ListItem key={subscriptionItem.id}>

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   styled,
   Button,
   Dialog,
+  DialogActions,
 } from "ol-components"
 import { useUserMe } from "api/hooks/user"
 import {
@@ -20,6 +21,10 @@ const SOURCE_LABEL_DISPLAY = {
   saved_search: "Saved Search",
 }
 
+const Actions = styled(DialogActions)({
+  display: "flex",
+  "> *": { flex: 1 },
+})
 const FollowList = styled(PlainList)(({ theme }) => ({
   borderRadius: "8px",
   background: theme.custom.colors.white,
@@ -125,12 +130,29 @@ const UnfollowDialog = NiceModal.create(
     return (
       <Dialog
         {...NiceModal.muiDialogV5(modal)}
-        onConfirm={async () => {
-          subscriptionIds?.map((subscriptionId) => unsubscribe(subscriptionId))
-        }}
         title="Unfollow"
-        confirmText={
-          subscriptionIds?.length === 1 ? "Yes, Unfollow" : "Yes, Unfollow All"
+        actions={
+          <Actions>
+            <Button variant="secondary" onClick={() => modal.remove()}>
+              Cancel
+            </Button>
+
+            <Button
+              onClick={async () =>
+                subscriptionIds?.map((subscriptionId) =>
+                  unsubscribe(subscriptionId, {
+                    onSuccess: () => {
+                      modal.remove()
+                    },
+                  }),
+                )
+              }
+            >
+              {subscriptionIds?.length === 1
+                ? "Yes, Unfollow"
+                : "Yes, Unfollow All"}
+            </Button>
+          </Actions>
         }
       >
         {subscriptionIds?.length === 1 ? (
@@ -141,7 +163,7 @@ const UnfollowDialog = NiceModal.create(
           <>
             Are you sure you want to <b>Unfollow All</b>? You will stop getting
             emails for all topics, academic departments, and MIT units you are
-            following.{" "}
+            following.?
           </>
         )}
       </Dialog>
@@ -167,22 +189,26 @@ const SettingsPage: React.FC = () => {
             All topics, academic departments, and MIT units you are following.
           </SubTitleText>
         </SettingsHeaderLeft>
-        <SettingsHeaderRight>
-          <Button
-            variant="tertiary"
-            onClick={() =>
-              NiceModal.show(UnfollowDialog, {
-                subscriptionIds: subscriptionList?.data?.map(
-                  (subscriptionItem) => subscriptionItem.id,
-                ),
-                subscriptionName: "All",
-                id: "all",
-              })
-            }
-          >
-            Unfollow All
-          </Button>
-        </SettingsHeaderRight>
+        {subscriptionList?.data.length > 1 ? (
+          <SettingsHeaderRight>
+            <Button
+              variant="tertiary"
+              onClick={() =>
+                NiceModal.show(UnfollowDialog, {
+                  subscriptionIds: subscriptionList?.data?.map(
+                    (subscriptionItem) => subscriptionItem.id,
+                  ),
+                  subscriptionName: "All",
+                  id: "all",
+                })
+              }
+            >
+              Unfollow All
+            </Button>
+          </SettingsHeaderRight>
+        ) : (
+          <></>
+        )}
       </SettingsHeader>
       <FollowList data-testid="follow-list">
         {subscriptionList?.data?.map((subscriptionItem) => (

--- a/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
+++ b/frontends/mit-learn/src/pages/DashboardPage/SettingsPage.tsx
@@ -190,7 +190,7 @@ const SettingsPage: React.FC = () => {
             All topics, academic departments, and MIT units you are following.
           </SubTitleText>
         </SettingsHeaderLeft>
-        {subscriptionList?.data?.length > 1 ? (
+        {subscriptionList?.data && subscriptionList?.data?.length > 1 ? (
           <SettingsHeaderRight>
             <Button
               data-testid="unfollow-all"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5636

### Description (What does it do?)
This PR adds the following to the settings page in the user dashboard:
- a confirmation dialog when trying to unfollow something
- An "unfollow all" button that will unsubscribe a user from everything they follow

### Screenshots (if appropriate):
<img width="458" alt="Screenshot 2024-10-01 at 10 32 31 AM" src="https://github.com/user-attachments/assets/7e058f92-af0d-4b88-87ba-60d5fa519036">
<img width="630" alt="Screenshot 2024-10-01 at 3 14 42 PM" src="https://github.com/user-attachments/assets/83b0c95a-72a2-47b0-a471-be9567442c97">


### How can this be tested?
1. Checkout this branch
2. follow a handful of topics, departments etc
3. visit the settings page in the user dashboard
4. view the confirmation modal that appears when trying to unfollow.
5. click the "unfollow all" button and confirm. it should leave you will an empty list of follows

