### PR TITLE
fix Safari MIT logo bug

### DIFF
--- a/frontends/mit-learn/src/GlobalStyles.tsx
+++ b/frontends/mit-learn/src/GlobalStyles.tsx
@@ -20,8 +20,12 @@ const pageCss = css`
   }
 
   #app-container {
-    height: calc(100vh - 60px);
-    margin-top: 60px;
+    height: calc(100vh - 72px);
+    margin-top: 72px;
+    ${theme.breakpoints.down("sm")} {
+      margin-top: 60px;
+      height: calc(100vh - 60px);
+    }
   }
 
   a {

--- a/frontends/mit-learn/src/page-components/Header/UserMenu.tsx
+++ b/frontends/mit-learn/src/page-components/Header/UserMenu.tsx
@@ -108,13 +108,15 @@ const UserMenuChevron: React.FC<{ open: boolean }> = ({ open }) => {
 }
 
 const StyledMITLogoLink = styled(MITLogoLink)(({ theme }) => ({
-  width: "64px",
-  height: "32px",
-  marginLeft: "16px",
-  [theme.breakpoints.down("sm")]: {
-    width: "48px",
-    height: "24px",
-    marginLeft: "0",
+  img: {
+    width: "64px",
+    height: "32px",
+    marginLeft: "16px",
+    [theme.breakpoints.down("sm")]: {
+      width: "48px",
+      height: "24px",
+      marginLeft: "0",
+    },
   },
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-open/pull/1622

### Description (What does it do?)
This PR fixes a bug with Safari where the MIT logo in the header was not being scaled properly due to the width / height only being applied to the parent and not directly to the `img` element

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0f51646b-f163-44ce-a91e-9f26f11382b9)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Visit the home page at http://localhost:8062 in Safari
 - Ensure that the header MIT logo looks correct