### PR TITLE
fix units page cards in Safari

### DIFF
--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -110,6 +110,9 @@ const UnitContainer = styled.section(({ theme }) => ({
   alignItems: "center",
   maxWidth: DESKTOP_WIDTH,
   gap: "32px",
+  ".MitCard-root": {
+    height: "auto",
+  },
   [theme.breakpoints.down("md")]: {
     width: "auto",
     padding: "0 16px",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5684

### Description (What does it do?)
This PR fixes an issue with the height of the cards on the units listing page. MUI Cards by default have a `height: 100%` rule on them. This conflicts with the `flex-grow: 1` setting used by the cards on the units page. Since the cards have dynamic content that can be edited, two cards with different implicit heights could end up next to each other. The `flex-grow` rule ensures that the shorter card grows to match the height of the tallest card, and the course / program counts stay pinned to the bottom of the card.

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Visit http://localhost:8062/units
 - Verify that the cards display properly in Safari
