### PR TITLE
raise SystemExit as a RetryError

### DIFF
--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -283,7 +283,7 @@ def send_subscription_emails(self, subscription_type, period="daily"):
 @app.task(
     acks_late=True,
     reject_on_worker_lost=True,
-    autoretry_for=(RetryError, SystemExit),
+    autoretry_for=(RetryError,),
     retry_backoff=True,
     rate_limit="600/m",
 )
@@ -301,8 +301,10 @@ def index_learning_resources(ids, resource_type, index_types):
     try:
         with wrap_retry_exception(*SEARCH_CONN_EXCEPTIONS):
             api.index_learning_resources(ids, resource_type, index_types)
-    except (RetryError, Ignore, SystemExit):
+    except (RetryError, Ignore):
         raise
+    except SystemExit as err:
+        raise RetryError(SystemExit.__name__) from err
     except:  # noqa: E722
         error = "index_courses threw an error"
         log.exception(error)
@@ -362,7 +364,7 @@ def bulk_deindex_percolators(ids):
 @app.task(
     acks_late=True,
     reject_on_worker_lost=True,
-    autoretry_for=(RetryError, SystemExit),
+    autoretry_for=(RetryError,),
     retry_backoff=True,
     rate_limit="600/m",
 )
@@ -383,8 +385,10 @@ def bulk_index_percolate_queries(percolate_ids, index_types):
             PERCOLATE_INDEX_TYPE,
             index_types,
         )
-    except (RetryError, Ignore, SystemExit):
+    except (RetryError, Ignore):
         raise
+    except SystemExit as err:
+        raise RetryError(SystemExit.__name__) from err
     except:  # noqa: E722
         error = "bulk_index_percolate_queries threw an error"
         log.exception(error)
@@ -417,7 +421,7 @@ def index_course_content_files(course_ids, index_types):
 @app.task(
     acks_late=True,
     reject_on_worker_lost=True,
-    autoretry_for=(RetryError, SystemExit),
+    autoretry_for=(RetryError,),
     retry_backoff=True,
     rate_limit="600/m",
 )
@@ -441,8 +445,10 @@ def index_content_files(
             api.index_content_files(
                 content_file_ids, learning_resource_id, index_types=index_types
             )
-    except (RetryError, Ignore, SystemExit):
+    except (RetryError, Ignore):
         raise
+    except SystemExit as err:
+        raise RetryError(SystemExit.__name__) from err
     except:  # noqa: E722
         error = "index_content_files threw an error"
         log.exception(error)

--- a/learning_resources_search/tasks_test.py
+++ b/learning_resources_search/tasks_test.py
@@ -119,6 +119,18 @@ def test_wrap_retry_exception_matching(matching):
         raise_thing()
 
 
+def test_system_exit_retry(mocker):
+    """Task should raise a retry error on system exit"""
+    mocker.patch(
+        "learning_resources_search.tasks.wrap_retry_exception", side_effect=SystemExit
+    )
+    with pytest.raises(Retry) as exc:
+        index_learning_resources.delay(
+            [1], COURSE_TYPE, IndexestoUpdate.current_index.value
+        )
+    assert str(exc.value.args[1]) == "SystemExit"
+
+
 @pytest.mark.parametrize(
     "indexes",
     [["course"], ["program"]],


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5615

### Description (What does it do?)
Tries to avoid the following error which occurred on RC when restarting the celery dyno:

> 2024-10-01T18:11:19.451534+00:00 app[extra_worker_performance.1]: [2024-10-01 18:11:19,446: ERROR/ForkPoolWorker-144] Task learning_resources_search.tasks.index_learning_resources[f5205655-dcae-4cff-9317-51621c9ee3df] raised unexpected: EncodeError(TypeError('Object of type SystemExit is not JSON serializable'))


### How can this be tested?
Follow the same instructions as the previous PR: https://github.com/mitodl/mit-open/pull/1615


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
