### PR TITLE
remove border and shadow

### DIFF
--- a/frontends/mit-learn/src/page-components/Header/Header.tsx
+++ b/frontends/mit-learn/src/page-components/Header/Header.tsx
@@ -44,20 +44,17 @@ import MITLogoLink from "../MITLogoLink/MITLogoLink"
 
 const Bar = styled(AppBar)(({ theme }) => ({
   padding: "16px 8px",
-  borderBottom: `4px solid ${theme.custom.colors.darkGray2}`,
   backgroundColor: theme.custom.colors.navGray,
+  boxShadow: "none",
   display: "flex",
   justifyContent: "space-between",
   flexDirection: "column",
-  boxShadow: "0px 3px 35px 0px rgba(23, 30, 42, 0.50)",
   ".MuiToolbar-root": {
     minHeight: "auto",
   },
   [theme.breakpoints.down("sm")]: {
     height: "60px",
     padding: "0",
-    borderBottom: `1px solid ${theme.custom.colors.darkGray2}`,
-    boxShadow: "0px -2px 20px 0px rgba(0, 0, 0, 0.05)",
   },
 }))
 

--- a/frontends/mit-learn/src/page-components/Header/MenuButton.tsx
+++ b/frontends/mit-learn/src/page-components/Header/MenuButton.tsx
@@ -40,16 +40,11 @@ const StyledMenuButton = styled.button(({ theme }) => ({
   transition: `background ${theme.transitions.duration.short}ms`,
   cursor: "pointer",
   borderStyle: "none",
-  opacity: 0.5,
   svg: {
     color: theme.custom.colors.white,
   },
   [theme.breakpoints.down("sm")]: {
     padding: "4px 0",
-    opacity: 1,
-  },
-  "&:hover": {
-    opacity: 1,
   },
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5683

### Description (What does it do?)
This PR makes some small tweaks to the recent dark header implementation. The bottom border and drop shadow were removed, along with the hover state on the "Explore MIT" nav menu button.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/30b5c64a-6be3-423f-b998-cc554f7681e6)
![image](https://github.com/user-attachments/assets/3902003e-d168-41a1-971c-ae66d0552e87)

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Visit the home page at http://localhost:8062
 - Verify that:
   - The header has no bottom border
   - The header has no drop shadow
   - The "Explore MIT" nav menu button is white and does not change color on hover
