### PR TITLE
add is_incomplete_or_stale to default sort

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -40,7 +40,12 @@ log = logging.getLogger(__name__)
 
 LEARN_SUGGEST_FIELDS = ["title.trigram", "description.trigram"]
 COURSENUM_SORT_FIELD = "course.course_numbers.sort_coursenum"
-DEFAULT_SORT = ["featured_rank", "is_learning_material", "-created_on"]
+DEFAULT_SORT = [
+    "featured_rank",
+    "is_learning_material",
+    "is_incomplete_or_stale",
+    "-created_on",
+]
 
 
 def gen_content_file_id(content_file_id):

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2696,6 +2696,7 @@ def test_document_percolation(opensearch, mocker):
             [
                 "featured_rank",
                 "is_learning_material",
+                "is_incomplete_or_stale",
                 {"created_on": {"order": "desc"}},
             ],
         ),


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5658

### Description (What does it do?)
https://github.com/mitodl/mit-open/pull/1627 added the is_incomplete_or_stale field to the search index
this pr updates the defualt search to use it


### How can this be tested?
run ./manage.py recreate_index --all (if you have not since https://github.com/mitodl/mit-open/pull/1627 was merged)

comment out line 420 from learning_resource_search/constants.py to remove is_incomplete_or_stale from SOURCE_EXCLUDED_FIELDS

Go to http://api.open.odl.local:8063/api/v1/learning_resources_search/?topic=Biology

The first page should be all courses/programs with is_incomplete_or_stale=false. After a few pages you should see all courses/programs with is_incomplete_or_stale=true. For me that was the fourth page. The last few pages should be all learning materials (podcasts and videos)

If you manually created/updated a featured list associated with a channel and added a stale or incomplete learning resource to it you will still see an incomplete/stale resource at the start of the results since featured resources are shown first regardless of is_incomplete_or_stale state