### PR TITLE
Adds PostHog back into the NextJS build

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -16,7 +16,7 @@ const processFeatureFlags = () => {
     }
   }
 
-  return { FEATURE_FLAGS: JSON.stringify(bootstrapFeatureFlags) }
+  return bootstrapFeatureFlags
 }
 
 /** @type {import('next').NextConfig} */
@@ -29,7 +29,6 @@ const nextConfig = {
       new webpack.IgnorePlugin({
         resourceRegExp: /mockAxios\.ts/,
       }),
-      new webpack.EnvironmentPlugin(processFeatureFlags()),
     )
 
     // Do not do this. Added to fix "import type", but causes a strage issue where
@@ -73,6 +72,10 @@ const nextConfig = {
         pathname: "**",
       },
     ],
+  },
+
+  env: {
+    FEATURE_FLAGS: JSON.stringify(processFeatureFlags()),
   },
 }
 

--- a/frontends/main/src/app/providers.tsx
+++ b/frontends/main/src/app/providers.tsx
@@ -5,38 +5,20 @@ import { getQueryClient } from "./getQueryClient"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider, NextJsAppRouterCacheProvider } from "ol-components"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
-import { PostHogProvider } from "posthog-js/react"
+import ConfiguredPostHogProvider from "@/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()
 
-  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY || ""
-  const apiHost =
-    process.env.NEXT_PUBLIC_POSTHOG_API_HOST || "https://us.i.posthog.com"
-  const featureFlags = JSON.parse(process.env.FEATURE_FLAGS || "")
-
-  const postHogOptions = {
-    api_host: apiHost,
-    bootstrap: {
-      featureFlags: featureFlags,
-    },
-  }
-
-  const interiorElements = (
-    <QueryClientProvider client={queryClient}>
-      <NextJsAppRouterCacheProvider>
-        <ThemeProvider>
-          <NiceModalProvider>{children}</NiceModalProvider>
-        </ThemeProvider>
-      </NextJsAppRouterCacheProvider>
-    </QueryClientProvider>
-  )
-
-  return apiKey.length > 0 ? (
-    <PostHogProvider apiKey={apiKey} options={postHogOptions}>
-      {interiorElements}
-    </PostHogProvider>
-  ) : (
-    interiorElements
+  return (
+    <ConfiguredPostHogProvider>
+      <QueryClientProvider client={queryClient}>
+        <NextJsAppRouterCacheProvider>
+          <ThemeProvider>
+            <NiceModalProvider>{children}</NiceModalProvider>
+          </ThemeProvider>
+        </NextJsAppRouterCacheProvider>
+      </QueryClientProvider>
+    </ConfiguredPostHogProvider>
   )
 }

--- a/frontends/main/src/app/providers.tsx
+++ b/frontends/main/src/app/providers.tsx
@@ -5,11 +5,24 @@ import { getQueryClient } from "./getQueryClient"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { ThemeProvider, NextJsAppRouterCacheProvider } from "ol-components"
 import { Provider as NiceModalProvider } from "@ebay/nice-modal-react"
+import { PostHogProvider } from "posthog-js/react"
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient()
 
-  return (
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY || ""
+  const apiHost =
+    process.env.NEXT_PUBLIC_POSTHOG_API_HOST || "https://us.i.posthog.com"
+  const featureFlags = JSON.parse(process.env.FEATURE_FLAGS || "")
+
+  const postHogOptions = {
+    api_host: apiHost,
+    bootstrap: {
+      featureFlags: featureFlags,
+    },
+  }
+
+  const interiorElements = (
     <QueryClientProvider client={queryClient}>
       <NextJsAppRouterCacheProvider>
         <ThemeProvider>
@@ -17,5 +30,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         </ThemeProvider>
       </NextJsAppRouterCacheProvider>
     </QueryClientProvider>
+  )
+
+  return apiKey.length > 0 ? (
+    <PostHogProvider apiKey={apiKey} options={postHogOptions}>
+      {interiorElements}
+    </PostHogProvider>
+  ) : (
+    interiorElements
   )
 }

--- a/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { PostHogProvider } from "posthog-js/react"
+
+const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY || ""
+  const apiHost =
+    process.env.NEXT_PUBLIC_POSTHOG_API_HOST || "https://us.i.posthog.com"
+  const featureFlags = JSON.parse(process.env.FEATURE_FLAGS || "")
+
+  const postHogOptions = {
+    api_host: apiHost,
+    bootstrap: {
+      featureFlags: featureFlags,
+    },
+  }
+
+  return apiKey ? (
+    <PostHogProvider apiKey={apiKey} options={postHogOptions}>
+      {children}
+    </PostHogProvider>
+  ) : (
+    children
+  )
+}
+
+export default ConfiguredPostHogProvider

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -37,17 +37,16 @@ jest.mock("posthog-js/react", () => ({
 }))
 
 describe("LearningResourceDrawer", () => {
-  it.skip.each([
+  it.each([
     { descriptor: "is enabled", enablePostHog: true },
     { descriptor: "is not enabled", enablePostHog: false },
   ])(
     "Renders drawer content when resource=id is in the URL and captures the view if PostHog $descriptor",
     async ({ enablePostHog }) => {
       setMockResponse.get(urls.userMe.get(), {})
-      // @ts-expect-error reinstante posthog
-      APP_SETTINGS.POSTHOG = {
-        api_key: enablePostHog ? "test1234" : "", // pragma: allowlist secret
-      }
+      process.env.NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY = enablePostHog
+        ? "12345abcdef" // pragma: allowlist secret
+        : ""
       const resource = factories.learningResources.resource()
       setMockResponse.get(
         urls.learningResources.details({ id: resource.id }),

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useMemo } from "react"
+import React, { Suspense, useCallback, useEffect, useMemo } from "react"
 import {
   RoutedDrawer,
   LearningResourceExpanded,
@@ -23,38 +23,35 @@ import {
   AddToUserListDialog,
 } from "../Dialogs/AddToListDialog"
 import { SignupPopover } from "../SignupPopover/SignupPopover"
+import { usePostHog } from "posthog-js/react"
 
 const RESOURCE_DRAWER_PARAMS = [RESOURCE_DRAWER_QUERY_PARAM] as const
 
-/*
 const useCapturePageView = (resourceId: number) => {
   const { data, isSuccess } = useLearningResourcesDetail(Number(resourceId))
   const posthog = usePostHog()
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY
 
-  // TODO Provide POSTHOG env vars
-
-  // const { POSTHOG } = APP_SETTINGS
-
-  // useEffect(() => {
-  //   if (!POSTHOG?.api_key || POSTHOG.api_key.length < 1) return
-  //   if (!isSuccess) return
-  //   posthog.capture("lrd_view", {
-  //     resourceId: data?.id,
-  //     readableId: data?.readable_id,
-  //     platformCode: data?.platform?.code,
-  //     resourceType: data?.resource_type,
-  //   })
-  // }, [
-  //   isSuccess,
-  //   posthog,
-  //   data?.id,
-  //   data?.readable_id,
-  //   data?.platform?.code,
-  //   data?.resource_type,
-  //   POSTHOG?.api_key,
-  // ])
+  useEffect(() => {
+    if (!apiKey || apiKey.length < 1) return
+    if (!isSuccess) return
+    posthog.capture("lrd_view", {
+      resourceId: data?.id,
+      readableId: data?.readable_id,
+      platformCode: data?.platform?.code,
+      resourceType: data?.resource_type,
+    })
+  }, [
+    isSuccess,
+    posthog,
+    data?.id,
+    data?.readable_id,
+    data?.platform?.code,
+    data?.resource_type,
+    apiKey,
+  ])
 }
-*/
+
 /**
  * Convert HTML to plaintext, removing any HTML tags.
  * This conversion method has some issues:
@@ -93,6 +90,7 @@ const DrawerContent: React.FC<{
         NiceModal.show(AddToUserListDialog, { resourceId })
       }
     }, [user])
+  useCapturePageView(Number(resourceId))
 
   return (
     <>

--- a/frontends/main/validateEnv.js
+++ b/frontends/main/validateEnv.js
@@ -21,6 +21,11 @@ const schema = yup.object().shape({
     .string()
     .oneOf(["true", "false"]),
   NEXT_PUBLIC_CSRF_COOKIE_NAME: yup.string().required(),
+  NEXT_PUBLIC_POSTHOG_PROJECT_ID: yup.string(),
+  NEXT_PUBLIC_POSTHOG_PERSONAL_API_KEY: yup.string(),
+  NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY: yup.string(),
+  NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX: yup.string(),
+  NEXT_PUBLIC_POSTHOG_API_HOST: yup.string(),
 })
 
 const validateEnv = () => schema.validateSync(process.env)

--- a/frontends/main/validateEnv.js
+++ b/frontends/main/validateEnv.js
@@ -21,8 +21,6 @@ const schema = yup.object().shape({
     .string()
     .oneOf(["true", "false"]),
   NEXT_PUBLIC_CSRF_COOKIE_NAME: yup.string().required(),
-  NEXT_PUBLIC_POSTHOG_PROJECT_ID: yup.string(),
-  NEXT_PUBLIC_POSTHOG_PERSONAL_API_KEY: yup.string(),
   NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY: yup.string(),
   NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX: yup.string(),
   NEXT_PUBLIC_POSTHOG_API_HOST: yup.string(),


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5411

### Description (What does it do?)

The PostHog integration was not implemented in the NextJS build of Learn. This adds it back:

- Specifying the PostHog project API key and root URL (this is actually technically new)
- The root-level PostHogProvider, initialized only if there's an API key set
- Bootstrapping the provider with feature flag settings via `.env` if we want to do that, and customizing the prefix for those flags
- Capturing both automatic PostHog events and `lrd_view` events

Any future work that gets pulled in and uses the PostHog hook or components should now "just work" too. (Unless it's like the `lrd_view` code, which checks to see if PostHog is there or not.)

### Screenshots (if appropriate):

Components when not enabled:
![ph-nextjs-disabled](https://github.com/user-attachments/assets/be0195d0-73c9-462e-b6ac-4fedf93995a8)

Components and settings when enabled (this is with a test flag added too):
![ph-nextjs-enabled](https://github.com/user-attachments/assets/fe62b300-55cd-4c3f-bb55-54039df48096)

### How can this be tested?

Automated tests should pass. This includes a couple for LearningResourceDrawer that were marked as `skip` because there wasn't PostHog support yet.

Set the required environment variables:
- `NEXT_PUBLIC_POSTHOG_PROJECT_API_KEY` - the PostHog project API key

Set the optional environment variables: 
- `NEXT_PUBLIC_POSTHOG_API_HOST` - the PostHog API host; defaults to `https://us.i.posthog.com`. Don't change this unless you [have your own PostHog instance running](https://posthog.com/docs/self-host).
- `NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX` - the prefix to use for feature flags, defaults to `FEATURE_`
- `NEXT_PUBLIC_FEATURE_some_flag_name` - customize the lower case bit, and change `FEATURE_` if you set the prefix above; set this to something you'll recognize

With _at least_ the required variable set, you should see the PostHogProvider show up in the React components list as in the screenshots. Additionally, you should start to see events flowing into PostHog as you start doing things, including `lrd_view` events (which fire when you open a learning resource drawer). 

If you've bootstrapped some feature flags, you should see those get populated in the PostHogProvider options. We don't have any configured flags right now - you can manually test this by adding something that's flagged out to an existing page, but it's probably sufficient to see the options passed into the provider correctly. 

If you want to test the API host setting, you can maybe point it to something like [catch-webhooks](https://github.com/rangle/catch-webhooks) to make sure it's trying to hit the right place.
