### PR TITLE
instructor search mode

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -289,7 +289,7 @@ def generate_learning_resources_text_clause(text, search_mode, slop):
                                     query_type: {
                                         "query": text,
                                         "fields": RUN_INSTRUCTORS_QUERY_FIELDS,
-                                        **extra_params,
+                                        "type": "best_fields",
                                     }
                                 },
                             }

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -235,11 +235,10 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                                         "multi_match": {
                                                             "query": "math",
                                                             "fields": [
-                                                                "runs.instructors.first_name",
                                                                 "runs.instructors.last_name^5",
                                                                 "runs.instructors.full_name^5",
                                                             ],
-                                                            **extra_params,
+                                                            "type": "best_fields",
                                                         }
                                                     },
                                                 }
@@ -350,11 +349,10 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                     "multi_match": {
                                         "query": "math",
                                         "fields": [
-                                            "runs.instructors.first_name",
                                             "runs.instructors.last_name^5",
                                             "runs.instructors.full_name^5",
                                         ],
-                                        **extra_params,
+                                        "type": "best_fields",
                                     }
                                 },
                             }
@@ -468,10 +466,10 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                                         "query_string": {
                                                             "query": '"math"',
                                                             "fields": [
-                                                                "runs.instructors.first_name",
                                                                 "runs.instructors.last_name^5",
                                                                 "runs.instructors.full_name^5",
                                                             ],
+                                                            "type": "best_fields",
                                                         }
                                                     },
                                                 }
@@ -576,10 +574,10 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                     "query_string": {
                                         "query": '"math"',
                                         "fields": [
-                                            "runs.instructors.first_name",
                                             "runs.instructors.last_name^5",
                                             "runs.instructors.full_name^5",
                                         ],
+                                        "type": "best_fields",
                                     }
                                 },
                             }
@@ -1155,7 +1153,6 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                             "multi_match": {
                                                                                 "query": "math",
                                                                                 "fields": [
-                                                                                    "runs.instructors.first_name",
                                                                                     "runs.instructors.last_name^5",
                                                                                     "runs.instructors.full_name^5",
                                                                                 ],
@@ -1275,7 +1272,6 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": [
-                                                            "runs.instructors.first_name",
                                                             "runs.instructors.last_name^5",
                                                             "runs.instructors.full_name^5",
                                                         ],
@@ -1626,11 +1622,10 @@ def test_execute_learn_search_with_script_score(
                                                                                     "multi_match": {
                                                                                         "query": "math",
                                                                                         "fields": [
-                                                                                            "runs.instructors.first_name",
                                                                                             "runs.instructors.last_name^5",
                                                                                             "runs.instructors.full_name^5",
                                                                                         ],
-                                                                                        "type": "phrase",
+                                                                                        "type": "best_fields",
                                                                                     }
                                                                                 },
                                                                             }
@@ -1746,11 +1741,10 @@ def test_execute_learn_search_with_script_score(
                                                             "multi_match": {
                                                                 "query": "math",
                                                                 "fields": [
-                                                                    "runs.instructors.first_name",
                                                                     "runs.instructors.last_name^5",
                                                                     "runs.instructors.full_name^5",
                                                                 ],
-                                                                "type": "phrase",
+                                                                "type": "best_fields",
                                                             }
                                                         },
                                                     }
@@ -2057,7 +2051,6 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                                                     "multi_match": {
                                                                                         "query": "math",
                                                                                         "fields": [
-                                                                                            "runs.instructors.first_name",
                                                                                             "runs.instructors.last_name^5",
                                                                                             "runs.instructors.full_name^5",
                                                                                         ],
@@ -2177,7 +2170,6 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                             "multi_match": {
                                                                 "query": "math",
                                                                 "fields": [
-                                                                    "runs.instructors.first_name",
                                                                     "runs.instructors.last_name^5",
                                                                     "runs.instructors.full_name^5",
                                                                 ],

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -380,7 +380,6 @@ RUNS_QUERY_FIELDS = [
 ]
 
 RUN_INSTRUCTORS_QUERY_FIELDS = [
-    "runs.instructors.first_name",
     "runs.instructors.last_name^5",
     "runs.instructors.full_name^5",
 ]


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5696

### Description (What does it do?)
This pr updates the search so that instructor names use "best_fields" instead of "phrase" just for instructor fields. It also removes instructor.first_name as a field because it is very likely to result in incorrect matches since some first names are very common

### How can this be tested?
Run 
manage.py backpopulate_oll_data
manage.py backpopulate_mitxonline_data

Search for "Dr. Jennifer French Kamrin"

You should see the OLL version of "Introduction to Probability and Statistics" where the instructor is listed as "Jennifer French Kamrin"

You should see mitxonline "Introduction to Differential Equations" where the instructor is listed as "Jennifer French"

There are a few extra results with other Jennifers or Drs as instructors, but they are below the relevant results.

