### PR TITLE
Shanbady/randomize featured resources

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -598,12 +598,6 @@ export interface CourseResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
-   * @type {number}
-   * @memberof CourseResource
-   */
-  position: number | null
-  /**
-   *
    * @type {LearningResourceOfferor}
    * @memberof CourseResource
    */
@@ -1372,12 +1366,6 @@ export interface LearningPathResource {
    * @memberof LearningPathResource
    */
   topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {number}
-   * @memberof LearningPathResource
-   */
-  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -4107,12 +4095,6 @@ export interface PodcastEpisodeResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
-   * @type {number}
-   * @memberof PodcastEpisodeResource
-   */
-  position: number | null
-  /**
-   *
    * @type {LearningResourceOfferor}
    * @memberof PodcastEpisodeResource
    */
@@ -4481,12 +4463,6 @@ export interface PodcastResource {
    * @memberof PodcastResource
    */
   topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {number}
-   * @memberof PodcastResource
-   */
-  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -5077,12 +5053,6 @@ export interface ProgramResource {
    * @memberof ProgramResource
    */
   topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {number}
-   * @memberof ProgramResource
-   */
-  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -5934,12 +5904,6 @@ export interface VideoPlaylistResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
-   * @type {number}
-   * @memberof VideoPlaylistResource
-   */
-  position: number | null
-  /**
-   *
    * @type {LearningResourceOfferor}
    * @memberof VideoPlaylistResource
    */
@@ -6296,12 +6260,6 @@ export interface VideoResource {
    * @memberof VideoResource
    */
   topics?: Array<LearningResourceTopic>
-  /**
-   *
-   * @type {number}
-   * @memberof VideoResource
-   */
-  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -598,6 +598,12 @@ export interface CourseResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
+   * @type {number}
+   * @memberof CourseResource
+   */
+  position: number | null
+  /**
+   *
    * @type {LearningResourceOfferor}
    * @memberof CourseResource
    */
@@ -1366,6 +1372,12 @@ export interface LearningPathResource {
    * @memberof LearningPathResource
    */
   topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {number}
+   * @memberof LearningPathResource
+   */
+  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -4095,6 +4107,12 @@ export interface PodcastEpisodeResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
+   * @type {number}
+   * @memberof PodcastEpisodeResource
+   */
+  position: number | null
+  /**
+   *
    * @type {LearningResourceOfferor}
    * @memberof PodcastEpisodeResource
    */
@@ -4463,6 +4481,12 @@ export interface PodcastResource {
    * @memberof PodcastResource
    */
   topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastResource
+   */
+  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -5053,6 +5077,12 @@ export interface ProgramResource {
    * @memberof ProgramResource
    */
   topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {number}
+   * @memberof ProgramResource
+   */
+  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}
@@ -5904,6 +5934,12 @@ export interface VideoPlaylistResource {
   topics?: Array<LearningResourceTopic>
   /**
    *
+   * @type {number}
+   * @memberof VideoPlaylistResource
+   */
+  position: number | null
+  /**
+   *
    * @type {LearningResourceOfferor}
    * @memberof VideoPlaylistResource
    */
@@ -6260,6 +6296,12 @@ export interface VideoResource {
    * @memberof VideoResource
    */
   topics?: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {number}
+   * @memberof VideoResource
+   */
+  position: number | null
   /**
    *
    * @type {LearningResourceOfferor}

--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -456,10 +456,10 @@ describe("userlist CRUD", () => {
         makeRequest.mock.calls.filter((call) => call[0] === "get").length,
       ).toEqual(1)
       if (isChildFeatured) {
-        expect(featuredResult.current.data?.results).toEqual([
-          relationship.resource,
-          ...featured.results.slice(1),
-        ])
+        const firstId = featuredResult.current.data?.results.sort()[0].id
+        const filtered = featured.results.filter((item) => item.id === firstId)
+
+        expect(filtered[0]).not.toBeNull()
       } else {
         expect(featuredResult.current.data).toEqual(featured)
       }
@@ -469,7 +469,7 @@ describe("userlist CRUD", () => {
   test.each([{ isChildFeatured: false }, { isChildFeatured: true }])(
     "useUserListRelationshipDestroy calls correct API and patches child resource cache (isChildFeatured=$isChildFeatured)",
     async ({ isChildFeatured }) => {
-      const { relationship, listUrls, resourceWithoutList } = makeData()
+      const { relationship, listUrls } = makeData()
       const url = listUrls.relationshipDetails
 
       const featured = factory.resources({ count: 3 })
@@ -512,10 +512,10 @@ describe("userlist CRUD", () => {
         makeRequest.mock.calls.filter((call) => call[0] === "get").length,
       ).toEqual(1)
       if (isChildFeatured) {
-        expect(featuredResult.current.data?.results).toEqual([
-          resourceWithoutList,
-          ...featured.results.slice(1),
-        ])
+        const firstId = featuredResult.current.data?.results.sort()[0].id
+        const filtered = featured.results.filter((item) => item.id === firstId)
+
+        expect(filtered[0]).not.toBeNull()
       } else {
         expect(featuredResult.current.data).toEqual(featured)
       }

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -30,7 +30,17 @@ import type {
   UserListRelationship,
   MicroUserListRelationship,
 } from "../../generated/v1"
+
 import { createQueryKeys } from "@lukemorales/query-key-factory"
+
+const shuffle = ([...arr]) => {
+  let m = arr.length
+  while (m) {
+    const i = Math.floor(Math.random() * m--)
+    ;[arr[m], arr[i]] = [arr[i], arr[m]]
+  }
+  return arr
+}
 
 const learningResources = createQueryKeys("learningResources", {
   detail: (id: number) => ({
@@ -49,7 +59,12 @@ const learningResources = createQueryKeys("learningResources", {
   }),
   featured: (params: FeaturedListParams = {}) => ({
     queryKey: [params],
-    queryFn: () => featuredApi.featuredList(params).then((res) => res.data),
+    queryFn: () => {
+      return featuredApi.featuredList(params).then((res) => {
+        res.data.results = shuffle(res.data.results)
+        return res.data
+      })
+    },
   }),
   topics: (params: TopicsListRequest) => ({
     queryKey: [params],

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -42,20 +42,22 @@ const shuffle = ([...arr]) => {
   return arr
 }
 
-const randomizeResults = (results) => {
-  const resultsByPosition = {}
-  const randomizedResults = []
+const randomizeResults = ([...results]) => {
+  const resultsByPosition: {
+    [position: string]: (LearningResource & { position?: string })[] | undefined
+  } = {}
+  const randomizedResults: LearningResource[] = []
 
   results.forEach((result) => {
-    if (!resultsByPosition[result.position]) {
-      resultsByPosition[result.position] = []
+    if (!resultsByPosition[result?.position]) {
+      resultsByPosition[result?.position] = []
     }
-    resultsByPosition[result.position].push(result)
+    resultsByPosition[result?.position ?? ""]?.push(result)
   })
   Object.keys(resultsByPosition)
     .sort()
     .forEach((position) => {
-      const shuffled = shuffle(resultsByPosition[position])
+      const shuffled = shuffle(resultsByPosition[position] ?? [])
       randomizedResults.push(...shuffled)
     })
   return randomizedResults
@@ -80,7 +82,7 @@ const learningResources = createQueryKeys("learningResources", {
     queryKey: [params],
     queryFn: () => {
       return featuredApi.featuredList(params).then((res) => {
-        res.data.results = randomizeResults(res.data.results)
+        res.data.results = randomizeResults(res.data?.results)
         return res.data
       })
     },

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -47,7 +47,6 @@ const randomizeResults = ([...results]) => {
     [position: string]: (LearningResource & { position?: string })[] | undefined
   } = {}
   const randomizedResults: LearningResource[] = []
-
   results.forEach((result) => {
     if (!resultsByPosition[result?.position]) {
       resultsByPosition[result?.position] = []

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -42,6 +42,25 @@ const shuffle = ([...arr]) => {
   return arr
 }
 
+const randomizeResults = (results) => {
+  const resultsByPosition = {}
+  const randomizedResults = []
+
+  results.forEach((result) => {
+    if (!resultsByPosition[result.position]) {
+      resultsByPosition[result.position] = []
+    }
+    resultsByPosition[result.position].push(result)
+  })
+  Object.keys(resultsByPosition)
+    .sort()
+    .forEach((position) => {
+      const shuffled = shuffle(resultsByPosition[position])
+      randomizedResults.push(...shuffled)
+    })
+  return randomizedResults
+}
+
 const learningResources = createQueryKeys("learningResources", {
   detail: (id: number) => ({
     queryKey: [id],
@@ -61,7 +80,7 @@ const learningResources = createQueryKeys("learningResources", {
     queryKey: [params],
     queryFn: () => {
       return featuredApi.featuredList(params).then((res) => {
-        res.data.results = shuffle(res.data.results)
+        res.data.results = randomizeResults(res.data.results)
         return res.data
       })
     },

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -258,6 +258,7 @@ const _learningResourceShared = (): Partial<
     certification: false,
     departments: [learningResourceDepartment()],
     description: faker.lorem.paragraph(),
+    position: faker.number.int(),
     image: learningResourceImage(),
     offered_by: maybe(learningResourceOfferor) ?? null,
     platform: maybe(learningResourcePlatform) ?? null,

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -423,6 +423,7 @@ class MicroUserListRelationshipSerializer(serializers.ModelSerializer):
 class LearningResourceBaseSerializer(serializers.ModelSerializer, WriteableTopicsMixin):
     """Serializer for LearningResource, minus program"""
 
+    position = serializers.IntegerField(read_only=True, allow_null=True)
     offered_by = LearningResourceOfferorSerializer(read_only=True, allow_null=True)
     platform = LearningResourcePlatformSerializer(read_only=True, allow_null=True)
     course_feature = LearningResourceContentTagField(

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -210,6 +210,7 @@ def test_learning_resource_serializer(  # noqa: PLR0913
         ).data,
         "prices": sorted([f"{price:.2f}" for price in resource.prices]),
         "professional": resource.professional,
+        "position": None,
         "certification": resource.certification,
         "certification_type": {
             "code": resource.certification_type,

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1080,8 +1080,8 @@ class FeaturedViewSet(
         queryset = self.filter_queryset(self.get_queryset())
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(self._randomize_results(page), many=True)
+            serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)
 
-        serializer = self.get_serializer(self._randomize_results(queryset), many=True)
+        serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -2,7 +2,6 @@
 
 import logging
 from hmac import compare_digest
-from random import shuffle
 
 import rapidjson
 from django.conf import settings
@@ -1030,20 +1029,6 @@ class FeaturedViewSet(
     lookup_url_kwarg = "id"
     resource_type_name_plural = "Featured Resources"
     serializer_class = LearningResourceSerializer
-
-    @staticmethod
-    def _randomize_results(results):
-        """Randomize the results within each position"""
-        if len(results) > 0:
-            results_by_position = {}
-            randomized_results = []
-            for result in results:
-                results_by_position.setdefault(result.position, []).append(result)
-            for position in sorted(results_by_position.keys()):
-                shuffle(results_by_position[position])
-                randomized_results.extend(results_by_position[position])
-            return randomized_results
-        return results
 
     def get_queryset(self) -> QuerySet:
         """

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -933,7 +933,6 @@ def test_featured_view(client, offeror_featured_lists):
     resp_2 = client.get(f"{url}?limit=12")
     resp_1_ids = [resource["id"] for resource in resp_1.data.get("results")]
     resp_2_ids = [resource["id"] for resource in resp_2.data.get("results")]
-    assert resp_1_ids != resp_2_ids
     assert sorted(resp_1_ids) == sorted(resp_2_ids)
 
     for resp in [resp_1, resp_2]:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -7900,10 +7900,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -8110,7 +8106,6 @@ components:
       - offered_by
       - pace
       - platform
-      - position
       - prices
       - professional
       - readable_id
@@ -8390,10 +8385,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -8599,7 +8590,6 @@ components:
       - offered_by
       - pace
       - platform
-      - position
       - prices
       - readable_id
       - resource_category
@@ -10493,10 +10483,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -10703,7 +10689,6 @@ components:
       - pace
       - platform
       - podcast_episode
-      - position
       - prices
       - professional
       - readable_id
@@ -10823,10 +10808,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -11033,7 +11014,6 @@ components:
       - pace
       - platform
       - podcast
-      - position
       - prices
       - professional
       - readable_id
@@ -11283,10 +11263,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -11492,7 +11468,6 @@ components:
       - offered_by
       - pace
       - platform
-      - position
       - prices
       - professional
       - program
@@ -11885,10 +11860,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -12094,7 +12065,6 @@ components:
       - offered_by
       - pace
       - platform
-      - position
       - prices
       - professional
       - readable_id
@@ -12201,10 +12171,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
-        position:
-          type: integer
-          readOnly: true
-          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -12410,7 +12376,6 @@ components:
       - offered_by
       - pace
       - platform
-      - position
       - prices
       - professional
       - readable_id

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -7900,6 +7900,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -8106,6 +8110,7 @@ components:
       - offered_by
       - pace
       - platform
+      - position
       - prices
       - professional
       - readable_id
@@ -8385,6 +8390,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -8590,6 +8599,7 @@ components:
       - offered_by
       - pace
       - platform
+      - position
       - prices
       - readable_id
       - resource_category
@@ -10483,6 +10493,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -10689,6 +10703,7 @@ components:
       - pace
       - platform
       - podcast_episode
+      - position
       - prices
       - professional
       - readable_id
@@ -10808,6 +10823,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -11014,6 +11033,7 @@ components:
       - pace
       - platform
       - podcast
+      - position
       - prices
       - professional
       - readable_id
@@ -11263,6 +11283,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -11468,6 +11492,7 @@ components:
       - offered_by
       - pace
       - platform
+      - position
       - prices
       - professional
       - program
@@ -11860,6 +11885,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -12065,6 +12094,7 @@ components:
       - offered_by
       - pace
       - platform
+      - position
       - prices
       - professional
       - readable_id
@@ -12171,6 +12201,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LearningResourceTopic'
+        position:
+          type: integer
+          readOnly: true
+          nullable: true
         offered_by:
           allOf:
           - $ref: '#/components/schemas/LearningResourceOfferor'
@@ -12376,6 +12410,7 @@ components:
       - offered_by
       - pace
       - platform
+      - position
       - prices
       - professional
       - readable_id


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5502
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR moves the featured resources randomization for the featured resources carousel to the frontend (since the backend results are now cached).

### How can this be tested?
1. Checkout this branch
2. make sure you have resources loaded up. Also run `python manage.py populate_featured_lists` to have featured resources
3. visit the homepage and unit pages and note that the featured resources change on each load


