### PR TITLE
Ignore NotFoundErrors in switch_indices function

### DIFF
--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -560,9 +560,12 @@ def switch_indices(backing_index, object_type):
         conn.indices.delete(index)
 
     # Finally, remove the link to the reindexing alias
-    conn.indices.delete_alias(
-        name=get_reindexing_alias_name(object_type), index=backing_index
-    )
+    try:
+        conn.indices.delete_alias(
+            name=get_reindexing_alias_name(object_type), index=backing_index
+        )
+    except NotFoundError:
+        log.warning("Reindex alias not found for %s", object_type)
 
 
 def delete_orphaned_indexes(obj_types, delete_reindexing_tags):
@@ -579,20 +582,14 @@ def delete_orphaned_indexes(obj_types, delete_reindexing_tags):
             for alias in aliases:
                 if "reindexing" in alias:
                     log.info("Deleting alias %s for index %s", alias, index)
-                    try:
-                        conn.indices.delete_alias(name=alias, index=index)
-                    except NotFoundError:
-                        log.info("Alias %s not found for index %s", alias, index)
+                    conn.indices.delete_alias(name=alias, index=index)
                     keys.remove(alias)
 
         if not keys and not index.startswith("."):
             for object_type in obj_types:
                 if object_type in index:
                     log.info("Deleting orphaned index %s", index)
-                    try:
-                        conn.indices.delete(index)
-                    except NotFoundError:
-                        log.info("Index %s not found", index)
+                    conn.indices.delete(index)
                     break
 
 

--- a/learning_resources_search/indexing_api.py
+++ b/learning_resources_search/indexing_api.py
@@ -579,14 +579,20 @@ def delete_orphaned_indexes(obj_types, delete_reindexing_tags):
             for alias in aliases:
                 if "reindexing" in alias:
                     log.info("Deleting alias %s for index %s", alias, index)
-                    conn.indices.delete_alias(name=alias, index=index)
+                    try:
+                        conn.indices.delete_alias(name=alias, index=index)
+                    except NotFoundError:
+                        log.info("Alias %s not found for index %s", alias, index)
                     keys.remove(alias)
 
         if not keys and not index.startswith("."):
             for object_type in obj_types:
                 if object_type in index:
                     log.info("Deleting orphaned index %s", index)
-                    conn.indices.delete(index)
+                    try:
+                        conn.indices.delete(index)
+                    except NotFoundError:
+                        log.info("Index %s not found", index)
                     break
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5710

### Description (What does it do?)
Ignores NotFoundErrors when switching indices in the finish_recreate_index task

### How can this be tested?
- Tests should pass. 


