### PR TITLE
Cached department and topic page counts

### DIFF
--- a/frontends/mit-learn/src/common/utils.ts
+++ b/frontends/mit-learn/src/common/utils.ts
@@ -1,3 +1,4 @@
+import { ChannelCounts } from "api/v0"
 const getSearchParamMap = (urlParams: URLSearchParams) => {
   const params: Record<string, string[] | string> = {}
   for (const [key] of urlParams.entries()) {
@@ -6,4 +7,27 @@ const getSearchParamMap = (urlParams: URLSearchParams) => {
   return params
 }
 
-export { getSearchParamMap }
+const aggregateProgramCounts = (
+  groupBy: string,
+  data: Array<ChannelCounts>,
+): Record<string, number> => {
+  return Object.fromEntries(
+    Object.entries(data).map(([_key, value]) => {
+      console.log("value", value)
+      return [value[groupBy], value.counts.programs]
+    }),
+  )
+}
+
+const aggregateCourseCounts = (
+  groupBy: string,
+  data: Array<ChannelCounts>,
+): Record<string, number> => {
+  return Object.fromEntries(
+    Object.entries(data).map(([_key, value]) => {
+      return [value[groupBy], value.counts.courses]
+    }),
+  )
+}
+
+export { getSearchParamMap, aggregateProgramCounts, aggregateCourseCounts }

--- a/frontends/mit-learn/src/common/utils.ts
+++ b/frontends/mit-learn/src/common/utils.ts
@@ -13,7 +13,7 @@ const aggregateProgramCounts = (
 ): Record<string, number> => {
   return Object.fromEntries(
     Object.entries(data).map(([_key, value]) => {
-      return [value[groupBy], value.counts.programs]
+      return [value[groupBy as keyof ChannelCounts], value.counts.programs]
     }),
   )
 }
@@ -24,7 +24,7 @@ const aggregateCourseCounts = (
 ): Record<string, number> => {
   return Object.fromEntries(
     Object.entries(data).map(([_key, value]) => {
-      return [value[groupBy], value.counts.courses]
+      return [value[groupBy as keyof ChannelCounts], value.counts.courses]
     }),
   )
 }

--- a/frontends/mit-learn/src/common/utils.ts
+++ b/frontends/mit-learn/src/common/utils.ts
@@ -13,7 +13,6 @@ const aggregateProgramCounts = (
 ): Record<string, number> => {
   return Object.fromEntries(
     Object.entries(data).map(([_key, value]) => {
-      console.log("value", value)
       return [value[groupBy], value.counts.programs]
     }),
   )

--- a/frontends/mit-learn/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
+++ b/frontends/mit-learn/src/pages/DepartmentListingPage/DepartmentListingPage.test.tsx
@@ -62,6 +62,48 @@ describe("DepartmentListingPage", () => {
     }
 
     setMockResponse.get(urls.schools.list(), schools)
+    setMockResponse.get(urls.channels.counts("department"), [
+      {
+        name: department1.name,
+        title: department1.name,
+        counts: {
+          programs: 1,
+          courses: 10,
+        },
+      },
+      {
+        name: department2.name,
+        title: department2.name,
+        counts: {
+          programs: 2,
+          courses: 20,
+        },
+      },
+      {
+        name: department3.name,
+        title: department3.name,
+        counts: {
+          programs: 0,
+          courses: 1,
+        },
+      },
+      {
+        name: department4.name,
+        title: department4.name,
+        counts: {
+          programs: 4,
+          courses: 40,
+        },
+      },
+      {
+        name: department5.name,
+        title: department5.name,
+        counts: {
+          programs: 5,
+          courses: 50,
+        },
+      },
+    ])
     setMockResponse.get(
       urls.search.resources({
         resource_type: ["course"],

--- a/frontends/mit-learn/src/pages/OnboardingPage/OnboardingPage.tsx
+++ b/frontends/mit-learn/src/pages/OnboardingPage/OnboardingPage.tsx
@@ -229,7 +229,6 @@ const OnboardingPage: React.FC = () => {
         }
         values={formik.values.goals}
         onChange={(event) => {
-          console.log(event)
           formik.handleChange(event)
         }}
       />

--- a/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.test.tsx
+++ b/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.test.tsx
@@ -51,6 +51,25 @@ describe("TopicsListingPage", () => {
       [t2.name]: 20,
     }
 
+    setMockResponse.get(urls.channels.counts("topic"), [
+      {
+        name: t1.name,
+        title: t1.name,
+        counts: {
+          programs: 10,
+          courses: 100,
+        },
+      },
+      {
+        name: t2.name,
+        title: t2.name,
+        counts: {
+          programs: 20,
+          courses: 200,
+        },
+      },
+    ])
+
     setMockResponse.get(urls.topics.list(), {
       count: Object.values(topics).length,
       next: null,

--- a/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.tsx
@@ -15,10 +15,7 @@ import { Link } from "react-router-dom"
 import { propsNotNil } from "ol-utilities"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
 
-import {
-  useLearningResourceTopics,
-  useLearningResourcesSearch,
-} from "api/hooks/learningResources"
+import { useLearningResourceTopics } from "api/hooks/learningResources"
 import { LearningResourceTopic } from "api"
 import RootTopicIcon from "@/components/RootTopicIcon/RootTopicIcon"
 import { HOME } from "@/common/urls"
@@ -251,14 +248,6 @@ const RootTopicList = styled(PlainList)(({ theme }) => ({
 const ToopicsListingPage: React.FC = () => {
   const channelCountQuery = useChannelCounts("topic")
   const topicsQuery = useLearningResourceTopics()
-  const courseQuery = useLearningResourcesSearch({
-    resource_type: ["course"],
-    aggregations: ["topic"],
-  })
-  const programQuery = useLearningResourcesSearch({
-    resource_type: ["program"],
-    aggregations: ["topic"],
-  })
 
   const channelsGroups = useMemo(() => {
     const courseCounts = channelCountQuery.data
@@ -272,7 +261,7 @@ const ToopicsListingPage: React.FC = () => {
       courseCounts,
       programCounts,
     )
-  }, [topicsQuery.data?.results, courseQuery.data, programQuery.data])
+  }, [topicsQuery.data?.results, channelCountQuery.data])
 
   return (
     <Page>

--- a/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/TopicListingPage/TopicsListingPage.tsx
@@ -19,9 +19,11 @@ import {
   useLearningResourceTopics,
   useLearningResourcesSearch,
 } from "api/hooks/learningResources"
-import { LearningResourcesSearchResponse, LearningResourceTopic } from "api"
+import { LearningResourceTopic } from "api"
 import RootTopicIcon from "@/components/RootTopicIcon/RootTopicIcon"
 import { HOME } from "@/common/urls"
+import { aggregateProgramCounts, aggregateCourseCounts } from "@/common/utils"
+import { useChannelCounts } from "api/hooks/channels"
 
 const TOPICS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 
@@ -182,17 +184,6 @@ const TopicBoxLoading = () => {
 
 const Page = styled.div({})
 
-const aggregateByTopic = (
-  data: LearningResourcesSearchResponse,
-): Record<string, number> => {
-  const buckets = data.metadata.aggregations["topic"] ?? []
-  return Object.fromEntries(
-    buckets.map((bucket) => {
-      return [bucket.key, bucket.doc_count]
-    }),
-  )
-}
-
 type TopicGroup = {
   id: number
   title: string
@@ -258,6 +249,7 @@ const RootTopicList = styled(PlainList)(({ theme }) => ({
 }))
 
 const ToopicsListingPage: React.FC = () => {
+  const channelCountQuery = useChannelCounts("topic")
   const topicsQuery = useLearningResourceTopics()
   const courseQuery = useLearningResourcesSearch({
     resource_type: ["course"],
@@ -267,12 +259,13 @@ const ToopicsListingPage: React.FC = () => {
     resource_type: ["program"],
     aggregations: ["topic"],
   })
+
   const channelsGroups = useMemo(() => {
-    const courseCounts = courseQuery.data
-      ? aggregateByTopic(courseQuery.data)
+    const courseCounts = channelCountQuery.data
+      ? aggregateCourseCounts("title", channelCountQuery.data)
       : {}
-    const programCounts = programQuery.data
-      ? aggregateByTopic(programQuery.data)
+    const programCounts = channelCountQuery.data
+      ? aggregateProgramCounts("title", channelCountQuery.data)
       : {}
     return groupTopics(
       topicsQuery.data?.results ?? [],
@@ -280,6 +273,7 @@ const ToopicsListingPage: React.FC = () => {
       programCounts,
     )
   }, [topicsQuery.data?.results, courseQuery.data, programQuery.data])
+
   return (
     <Page>
       <MetaTags title="Topics" />

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -15,30 +15,11 @@ import { LearningResourceOfferorDetail } from "api"
 import { HOME } from "@/common/urls"
 import { UnitCards, UnitCardLoading } from "./UnitCard"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
-import { ChannelCounts } from "api/v0"
+
+import { aggregateProgramCounts, aggregateCourseCounts } from "@/common/utils"
 
 const UNITS_BANNER_IMAGE = "/static/images/background_steps.jpeg"
 const DESKTOP_WIDTH = "1056px"
-
-const aggregateProgramCounts = (
-  data: Array<ChannelCounts>,
-): Record<string, number> => {
-  return Object.fromEntries(
-    Object.entries(data).map(([_key, value]) => {
-      return [value.name, value.counts.programs]
-    }),
-  )
-}
-
-const aggregateCourseCounts = (
-  data: Array<ChannelCounts>,
-): Record<string, number> => {
-  return Object.fromEntries(
-    Object.entries(data).map(([_key, value]) => {
-      return [value.name, value.counts.courses]
-    }),
-  )
-}
 
 const sortUnits = (
   units: Array<LearningResourceOfferorDetail> | undefined,
@@ -46,10 +27,10 @@ const sortUnits = (
   programCounts: Record<string, number>,
 ) => {
   return units?.sort((a, b) => {
-    const courseCountA = courseCounts[a.code] || 0
-    const programCountA = programCounts[a.code] || 0
-    const courseCountB = courseCounts[b.code] || 0
-    const programCountB = programCounts[b.code] || 0
+    const courseCountA = courseCounts[a.id] || 0
+    const programCountA = programCounts[a.id] || 0
+    const courseCountB = courseCounts[b.id] || 0
+    const programCountB = programCounts[b.id] || 0
     const totalA = courseCountA + programCountA
     const totalB = courseCountB + programCountB
     return totalB - totalA
@@ -221,12 +202,11 @@ const UnitsListingPage: React.FC = () => {
   const channelCountQuery = useChannelCounts("unit")
 
   const courseCounts = channelCountQuery.data
-    ? aggregateCourseCounts(channelCountQuery.data)
+    ? aggregateCourseCounts("name", channelCountQuery.data)
     : {}
   const programCounts = channelCountQuery.data
-    ? aggregateProgramCounts(channelCountQuery.data)
+    ? aggregateProgramCounts("name", channelCountQuery.data)
     : {}
-
   const academicUnits = sortUnits(
     units?.filter((unit) => unit.professional === false),
     courseCounts,

--- a/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
+++ b/frontends/mit-learn/src/pages/UnitsListingPage/UnitsListingPage.tsx
@@ -27,10 +27,10 @@ const sortUnits = (
   programCounts: Record<string, number>,
 ) => {
   return units?.sort((a, b) => {
-    const courseCountA = courseCounts[a.id] || 0
-    const programCountA = programCounts[a.id] || 0
-    const courseCountB = courseCounts[b.id] || 0
-    const programCountB = programCounts[b.id] || 0
+    const courseCountA = courseCounts[a.code] || 0
+    const programCountA = programCounts[a.code] || 0
+    const courseCountB = courseCounts[b.code] || 0
+    const programCountB = programCounts[b.code] || 0
     const totalA = courseCountA + programCountA
     const totalB = courseCountB + programCountB
     return totalB - totalA


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5564
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR updates the /topics and /departments channel pages to use the new cached counts api endpoints to fetch program and course counts.


### How can this be tested?
1. visit the production MIT Learn topics and departments channel pages with web inspector open. note that the page makes multiple requests to fetch counts to the search endpoint (looks something like /api/v1/learning_resources_search/?aggregations=department&resource_type=course)
2. checkout this branch. make sure you have topics and departments loaded up locally.
3. visit the topics and departments channel pages and note that the requests to the search endpoint do not show up. Also verify the counts for programs and courses look accurate. note: the counts endpoint is cached so it wont update immediately after deleting something - you will need to clear the cache manually to see it update

