### PR TITLE
remove unnecessary padding adjustment on Input base styles

### DIFF
--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -99,9 +99,6 @@ const baseInputStyles = (theme: Theme) => ({
   borderWidth: "1px",
   borderStyle: "solid",
   borderRadius: "4px",
-  ".MuiInputBase-input": {
-    padding: "0",
-  },
   "&.Mui-disabled": {
     backgroundColor: theme.custom.colors.lightGray1,
   },

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -130,8 +130,8 @@ const baseInputStyles = (theme: Theme) => ({
     textOverflow: "ellipsis",
   },
   "& textarea": {
-    paddingTop: "6px",
-    paddingBottom: "7px",
+    paddingTop: "8px",
+    paddingBottom: "8px",
   },
   "&.MuiInputBase-adornedStart": {
     paddingLeft: "0",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5742

### Description (What does it do?)
As part of https://github.com/mitodl/mit-open/pull/1545, a `padding: "0"` rule was added to the root of our `Input` component. Padding rules were leaking through from the MUI `Input` component that is the base of our component. Later commits in that PR added responsive styles, including padding, to the component. This override was no longer necessary and should have been removed, but wasn't.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/25509a4a-cef7-44d0-a530-9ec15990ef86)
![image](https://github.com/user-attachments/assets/0ee6689b-5542-444b-a444-8a8c7b5f6dfd)

### How can this be tested?
 - Spin up `mit-learn` on this branch
 - Ensure you have some data backpopulated and a search index generated
 - Visit the search page at http://localhost:8062/
 - On one of the search results, click the add to list button on the right side of the card
 - In the modal, click the "Create New List" button
 - Ensure that there is an appropriate amount of padding on the description text input
 - Smoke test `Input` elements on the rest of the site to make sure they haven't changed, comparing to https://learn.mit.edu/:
   - Homepage search input
   - Search page search input
   - Channel page search input
   - Onboarding flow
   - Other modals