### PR TITLE
content file weight

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3863,6 +3863,12 @@ export interface PercolateQuerySubscriptionRequestRequest {
    */
   max_incompleteness_penalty?: number | null
   /**
+   * Score weight for content file data.  1 is the default. 0 means content files are ignored
+   * @type {number}
+   * @memberof PercolateQuerySubscriptionRequestRequest
+   */
+  content_file_score_weight?: number | null
+  /**
    *
    * @type {SourceTypeEnum}
    * @memberof PercolateQuerySubscriptionRequestRequest
@@ -12873,6 +12879,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSearchRetrieveAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesSearchRetrieveCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesSearchRetrieveDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -12903,6 +12910,7 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
       aggregations?: Array<LearningResourcesSearchRetrieveAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesSearchRetrieveCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesSearchRetrieveDeliveryEnum>,
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
@@ -12954,6 +12962,11 @@ export const LearningResourcesSearchApiAxiosParamCreator = function (
 
       if (certification_type) {
         localVarQueryParameter["certification_type"] = certification_type
+      }
+
+      if (content_file_score_weight !== undefined) {
+        localVarQueryParameter["content_file_score_weight"] =
+          content_file_score_weight
       }
 
       if (course_feature) {
@@ -13082,6 +13095,7 @@ export const LearningResourcesSearchApiFp = function (
      * @param {Array<LearningResourcesSearchRetrieveAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesSearchRetrieveCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesSearchRetrieveDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesSearchRetrieveDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -13112,6 +13126,7 @@ export const LearningResourcesSearchApiFp = function (
       aggregations?: Array<LearningResourcesSearchRetrieveAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesSearchRetrieveCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesSearchRetrieveDeliveryEnum>,
       department?: Array<LearningResourcesSearchRetrieveDepartmentEnum>,
@@ -13147,6 +13162,7 @@ export const LearningResourcesSearchApiFp = function (
           aggregations,
           certification,
           certification_type,
+          content_file_score_weight,
           course_feature,
           delivery,
           department,
@@ -13215,6 +13231,7 @@ export const LearningResourcesSearchApiFactory = function (
           requestParameters.aggregations,
           requestParameters.certification,
           requestParameters.certification_type,
+          requestParameters.content_file_score_weight,
           requestParameters.course_feature,
           requestParameters.delivery,
           requestParameters.department,
@@ -13271,6 +13288,13 @@ export interface LearningResourcesSearchApiLearningResourcesSearchRetrieveReques
    * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
    */
   readonly certification_type?: Array<LearningResourcesSearchRetrieveCertificationTypeEnum>
+
+  /**
+   * Score weight for content file data.  1 is the default. 0 means content files are ignored
+   * @type {number}
+   * @memberof LearningResourcesSearchApiLearningResourcesSearchRetrieve
+   */
+  readonly content_file_score_weight?: number | null
 
   /**
    * The course feature. Possible options are at api/v1/course_features/
@@ -13458,6 +13482,7 @@ export class LearningResourcesSearchApi extends BaseAPI {
         requestParameters.aggregations,
         requestParameters.certification,
         requestParameters.certification_type,
+        requestParameters.content_file_score_weight,
         requestParameters.course_feature,
         requestParameters.delivery,
         requestParameters.department,
@@ -13696,6 +13721,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionCheckListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -13727,6 +13753,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       aggregations?: Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionCheckListDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
@@ -13779,6 +13806,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (certification_type) {
         localVarQueryParameter["certification_type"] = certification_type
+      }
+
+      if (content_file_score_weight !== undefined) {
+        localVarQueryParameter["content_file_score_weight"] =
+          content_file_score_weight
       }
 
       if (course_feature) {
@@ -13898,6 +13930,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionListAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -13928,6 +13961,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       aggregations?: Array<LearningResourcesUserSubscriptionListAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionListDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
@@ -13979,6 +14013,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (certification_type) {
         localVarQueryParameter["certification_type"] = certification_type
+      }
+
+      if (content_file_score_weight !== undefined) {
+        localVarQueryParameter["content_file_score_weight"] =
+          content_file_score_weight
       }
 
       if (course_feature) {
@@ -14094,6 +14133,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -14126,6 +14166,7 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
       aggregations?: Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionSubscribeCreateDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
@@ -14179,6 +14220,11 @@ export const LearningResourcesUserSubscriptionApiAxiosParamCreator = function (
 
       if (certification_type) {
         localVarQueryParameter["certification_type"] = certification_type
+      }
+
+      if (content_file_score_weight !== undefined) {
+        localVarQueryParameter["content_file_score_weight"] =
+          content_file_score_weight
       }
 
       if (course_feature) {
@@ -14369,6 +14415,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionCheckListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -14400,6 +14447,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       aggregations?: Array<LearningResourcesUserSubscriptionCheckListAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionCheckListDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionCheckListDepartmentEnum>,
@@ -14436,6 +14484,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           aggregations,
           certification,
           certification_type,
+          content_file_score_weight,
           course_feature,
           delivery,
           department,
@@ -14481,6 +14530,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionListAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -14511,6 +14561,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       aggregations?: Array<LearningResourcesUserSubscriptionListAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionListDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionListDepartmentEnum>,
@@ -14546,6 +14597,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           aggregations,
           certification,
           certification_type,
+          content_file_score_weight,
           course_feature,
           delivery,
           department,
@@ -14590,6 +14642,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>} [aggregations] Show resource counts by category
      * @param {boolean | null} [certification] True if the learning resource offers a certificate
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - Micromasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {number | null} [content_file_score_weight] Score weight for content file data.  1 is the default. 0 means content files are ignored
      * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
      * @param {Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
@@ -14622,6 +14675,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
       aggregations?: Array<LearningResourcesUserSubscriptionSubscribeCreateAggregationsEnum>,
       certification?: boolean | null,
       certification_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>,
+      content_file_score_weight?: number | null,
       course_feature?: Array<string>,
       delivery?: Array<LearningResourcesUserSubscriptionSubscribeCreateDeliveryEnum>,
       department?: Array<LearningResourcesUserSubscriptionSubscribeCreateDepartmentEnum>,
@@ -14656,6 +14710,7 @@ export const LearningResourcesUserSubscriptionApiFp = function (
           aggregations,
           certification,
           certification_type,
+          content_file_score_weight,
           course_feature,
           delivery,
           department,
@@ -14757,6 +14812,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.aggregations,
           requestParameters.certification,
           requestParameters.certification_type,
+          requestParameters.content_file_score_weight,
           requestParameters.course_feature,
           requestParameters.delivery,
           requestParameters.department,
@@ -14801,6 +14857,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.aggregations,
           requestParameters.certification,
           requestParameters.certification_type,
+          requestParameters.content_file_score_weight,
           requestParameters.course_feature,
           requestParameters.delivery,
           requestParameters.department,
@@ -14844,6 +14901,7 @@ export const LearningResourcesUserSubscriptionApiFactory = function (
           requestParameters.aggregations,
           requestParameters.certification,
           requestParameters.certification_type,
+          requestParameters.content_file_score_weight,
           requestParameters.course_feature,
           requestParameters.delivery,
           requestParameters.department,
@@ -14920,6 +14978,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
    */
   readonly certification_type?: Array<LearningResourcesUserSubscriptionCheckListCertificationTypeEnum>
+
+  /**
+   * Score weight for content file data.  1 is the default. 0 means content files are ignored
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionCheckList
+   */
+  readonly content_file_score_weight?: number | null
 
   /**
    * The course feature. Possible options are at api/v1/course_features/
@@ -15118,6 +15183,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
   readonly certification_type?: Array<LearningResourcesUserSubscriptionListCertificationTypeEnum>
 
   /**
+   * Score weight for content file data.  1 is the default. 0 means content files are ignored
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
+   */
+  readonly content_file_score_weight?: number | null
+
+  /**
    * The course feature. Possible options are at api/v1/course_features/
    * @type {Array<string>}
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionList
@@ -15305,6 +15377,13 @@ export interface LearningResourcesUserSubscriptionApiLearningResourcesUserSubscr
    * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
    */
   readonly certification_type?: Array<LearningResourcesUserSubscriptionSubscribeCreateCertificationTypeEnum>
+
+  /**
+   * Score weight for content file data.  1 is the default. 0 means content files are ignored
+   * @type {number}
+   * @memberof LearningResourcesUserSubscriptionApiLearningResourcesUserSubscriptionSubscribeCreate
+   */
+  readonly content_file_score_weight?: number | null
 
   /**
    * The course feature. Possible options are at api/v1/course_features/
@@ -15520,6 +15599,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.aggregations,
         requestParameters.certification,
         requestParameters.certification_type,
+        requestParameters.content_file_score_weight,
         requestParameters.course_feature,
         requestParameters.delivery,
         requestParameters.department,
@@ -15566,6 +15646,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.aggregations,
         requestParameters.certification,
         requestParameters.certification_type,
+        requestParameters.content_file_score_weight,
         requestParameters.course_feature,
         requestParameters.delivery,
         requestParameters.department,
@@ -15611,6 +15692,7 @@ export class LearningResourcesUserSubscriptionApi extends BaseAPI {
         requestParameters.aggregations,
         requestParameters.certification,
         requestParameters.certification_type,
+        requestParameters.content_file_score_weight,
         requestParameters.course_feature,
         requestParameters.delivery,
         requestParameters.department,

--- a/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/mit-learn/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -562,6 +562,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       max_incompleteness_penalty: searchParams.get(
         "max_incompleteness_penalty",
       ),
+      content_file_score_weight: searchParams.get("content_file_score_weight"),
       ...requestParams,
       aggregations: (facetNames || []).concat([
         "resource_category",
@@ -738,6 +739,26 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
               Partially complete courses have a linear penalty proportional to
               the degree of incompleteness. Only affects results if there is a
               search term.
+            </ExplanationContainer>
+            <AdminTitleContainer>
+              Content File Score Weight Adjustment
+            </AdminTitleContainer>
+            <SliderInput
+              currentValue={
+                searchParams.get("content_file_score_weight")
+                  ? Number(searchParams.get("content_file_score_weight"))
+                  : 1
+              }
+              setSearchParams={setSearchParams}
+              urlParam="content_file_score_weight"
+              min={0}
+              max={1}
+              step={0.1}
+            />
+            <ExplanationContainer>
+              Score weight adjustment for content file matches. 1 means no
+              adjustment. 0 means content file matches are not counted in the
+              score. Only affects the results if there is a search term.
             </ExplanationContainer>
           </div>
         ) : null}

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -199,7 +199,9 @@ def generate_content_file_text_clause(text):
     return wrap_text_clause(text_query)
 
 
-def generate_learning_resources_text_clause(text, search_mode, slop):
+def generate_learning_resources_text_clause(
+    text, search_mode, slop, content_file_score_weight
+):
     """
     Return text clause for the query
 
@@ -220,6 +222,14 @@ def generate_learning_resources_text_clause(text, search_mode, slop):
 
         if search_mode == "phrase" and slop:
             extra_params["slop"] = slop
+
+    if content_file_score_weight is not None:
+        resourcefile_fields = [
+            f"{field}^{content_file_score_weight}"
+            for field in RESOURCEFILE_QUERY_FIELDS
+        ]
+    else:
+        resourcefile_fields = RESOURCEFILE_QUERY_FIELDS
 
     if text:
         text_query = {
@@ -302,7 +312,7 @@ def generate_learning_resources_text_clause(text, search_mode, slop):
                         "query": {
                             query_type: {
                                 "query": text,
-                                "fields": RESOURCEFILE_QUERY_FIELDS,
+                                "fields": resourcefile_fields,
                                 **extra_params,
                             }
                         },
@@ -557,7 +567,10 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
         text_query = generate_content_file_text_clause(text)
     else:
         text_query = generate_learning_resources_text_clause(
-            text, search_params.get("search_mode"), search_params.get("slop")
+            text,
+            search_params.get("search_mode"),
+            search_params.get("slop"),
+            search_params.get("content_file_score_weight"),
         )
 
     yearly_decay_percent = search_params.get("yearly_decay_percent")

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -135,7 +135,10 @@ def test_generate_sort_clause(sort_param, departments, result):
 
 @pytest.mark.parametrize("search_mode", ["best_fields", "most_fields", "phrase", None])
 @pytest.mark.parametrize("slop", [None, 2])
-def test_generate_learning_resources_text_clause(search_mode, slop):
+@pytest.mark.parametrize("content_file_score_weight", [None, 0, 0.5, 1])
+def test_generate_learning_resources_text_clause(
+    search_mode, slop, content_file_score_weight
+):
     extra_params = {}
 
     if search_mode:
@@ -143,6 +146,23 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
 
     if search_mode == "phrase" and slop:
         extra_params["slop"] = slop
+
+    if content_file_score_weight is None:
+        content_file_fields = [
+            "content.english",
+            "title.english",
+            "content_title.english",
+            "description.english",
+            "content_feature_type",
+        ]
+    else:
+        content_file_fields = [
+            f"content.english^{content_file_score_weight}",
+            f"title.english^{content_file_score_weight}",
+            f"content_title.english^{content_file_score_weight}",
+            f"description.english^{content_file_score_weight}",
+            f"content_feature_type^{content_file_score_weight}",
+        ]
 
     result1 = {
         "bool": {
@@ -251,12 +271,7 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                             "query": {
                                                 "multi_match": {
                                                     "query": "math",
-                                                    "fields": [
-                                                        "content",
-                                                        "title.english^3",
-                                                        "short_description.english^2",
-                                                        "content_feature_type",
-                                                    ],
+                                                    "fields": content_file_fields,
                                                     **extra_params,
                                                 }
                                             },
@@ -365,12 +380,7 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                         "query": {
                             "multi_match": {
                                 "query": "math",
-                                "fields": [
-                                    "content",
-                                    "title.english^3",
-                                    "short_description.english^2",
-                                    "content_feature_type",
-                                ],
+                                "fields": content_file_fields,
                                 **extra_params,
                             }
                         },
@@ -482,12 +492,7 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                                             "query": {
                                                 "query_string": {
                                                     "query": '"math"',
-                                                    "fields": [
-                                                        "content",
-                                                        "title.english^3",
-                                                        "short_description.english^2",
-                                                        "content_feature_type",
-                                                    ],
+                                                    "fields": content_file_fields,
                                                 }
                                             },
                                             "score_mode": "avg",
@@ -590,12 +595,7 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
                         "query": {
                             "query_string": {
                                 "query": '"math"',
-                                "fields": [
-                                    "content",
-                                    "title.english^3",
-                                    "short_description.english^2",
-                                    "content_feature_type",
-                                ],
+                                "fields": content_file_fields,
                             }
                         },
                         "score_mode": "avg",
@@ -604,9 +604,17 @@ def test_generate_learning_resources_text_clause(search_mode, slop):
             ],
         }
     }
-    assert generate_learning_resources_text_clause("math", search_mode, slop) == result1
     assert (
-        generate_learning_resources_text_clause('"math"', search_mode, slop) == result2
+        generate_learning_resources_text_clause(
+            "math", search_mode, slop, content_file_score_weight
+        )
+        == result1
+    )
+    assert (
+        generate_learning_resources_text_clause(
+            '"math"', search_mode, slop, content_file_score_weight
+        )
+        == result2
     )
 
 
@@ -623,9 +631,10 @@ def test_generate_content_file_text_clause():
                                         "multi_match": {
                                             "query": "math",
                                             "fields": [
-                                                "content",
-                                                "title.english^3",
-                                                "short_description.english^2",
+                                                "content.english",
+                                                "title.english",
+                                                "content_title.english",
+                                                "description.english",
                                                 "content_feature_type",
                                             ],
                                         }
@@ -655,9 +664,10 @@ def test_generate_content_file_text_clause():
                     "multi_match": {
                         "query": "math",
                         "fields": [
-                            "content",
-                            "title.english^3",
-                            "short_description.english^2",
+                            "content.english",
+                            "title.english",
+                            "content_title.english",
+                            "description.english",
                             "content_feature_type",
                         ],
                     }
@@ -691,9 +701,10 @@ def test_generate_content_file_text_clause():
                                         "query_string": {
                                             "query": '"math"',
                                             "fields": [
-                                                "content",
-                                                "title.english^3",
-                                                "short_description.english^2",
+                                                "content.english",
+                                                "title.english",
+                                                "content_title.english",
+                                                "description.english",
                                                 "content_feature_type",
                                             ],
                                         }
@@ -723,9 +734,10 @@ def test_generate_content_file_text_clause():
                     "query_string": {
                         "query": '"math"',
                         "fields": [
-                            "content",
-                            "title.english^3",
-                            "short_description.english^2",
+                            "content.english",
+                            "title.english",
+                            "content_title.english",
+                            "description.english",
                             "content_feature_type",
                         ],
                     }
@@ -1170,9 +1182,10 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                                                     "multi_match": {
                                                                         "query": "math",
                                                                         "fields": [
-                                                                            "content",
-                                                                            "title.english^3",
-                                                                            "short_description.english^2",
+                                                                            "content.english",
+                                                                            "title.english",
+                                                                            "content_title.english",
+                                                                            "description.english",
                                                                             "content_feature_type",
                                                                         ],
                                                                         "type": "best_fields",
@@ -1289,9 +1302,10 @@ def test_execute_learn_search_for_learning_resource_query(opensearch):
                                             "multi_match": {
                                                 "query": "math",
                                                 "fields": [
-                                                    "content",
-                                                    "title.english^3",
-                                                    "short_description.english^2",
+                                                    "content.english",
+                                                    "title.english",
+                                                    "content_title.english",
+                                                    "description.english",
                                                     "content_feature_type",
                                                 ],
                                                 "type": "best_fields",
@@ -1639,9 +1653,10 @@ def test_execute_learn_search_with_script_score(
                                                                             "multi_match": {
                                                                                 "query": "math",
                                                                                 "fields": [
-                                                                                    "content",
-                                                                                    "title.english^3",
-                                                                                    "short_description.english^2",
+                                                                                    "content.english",
+                                                                                    "title.english",
+                                                                                    "content_title.english",
+                                                                                    "description.english",
                                                                                     "content_feature_type",
                                                                                 ],
                                                                                 "type": "phrase",
@@ -1758,9 +1773,10 @@ def test_execute_learn_search_with_script_score(
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": [
-                                                            "content",
-                                                            "title.english^3",
-                                                            "short_description.english^2",
+                                                            "content.english",
+                                                            "title.english",
+                                                            "content_title.english",
+                                                            "description.english",
                                                             "content_feature_type",
                                                         ],
                                                         "type": "phrase",
@@ -2068,9 +2084,10 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                                             "multi_match": {
                                                                                 "query": "math",
                                                                                 "fields": [
-                                                                                    "content",
-                                                                                    "title.english^3",
-                                                                                    "short_description.english^2",
+                                                                                    "content.english",
+                                                                                    "title.english",
+                                                                                    "content_title.english",
+                                                                                    "description.english",
                                                                                     "content_feature_type",
                                                                                 ],
                                                                                 "type": "best_fields",
@@ -2187,9 +2204,10 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                                                     "multi_match": {
                                                         "query": "math",
                                                         "fields": [
-                                                            "content",
-                                                            "title.english^3",
-                                                            "short_description.english^2",
+                                                            "content.english",
+                                                            "title.english",
+                                                            "content_title.english",
+                                                            "description.english",
                                                             "content_feature_type",
                                                         ],
                                                         "type": "best_fields",
@@ -2388,9 +2406,10 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                                                             "multi_match": {
                                                                 "query": "math",
                                                                 "fields": [
-                                                                    "content",
-                                                                    "title.english^3",
-                                                                    "short_description.english^2",
+                                                                    "content.english",
+                                                                    "title.english",
+                                                                    "content_title.english",
+                                                                    "description.english",
                                                                     "content_feature_type",
                                                                 ],
                                                             }
@@ -2421,9 +2440,10 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                                     "multi_match": {
                                         "query": "math",
                                         "fields": [
-                                            "content",
-                                            "title.english^3",
-                                            "short_description.english^2",
+                                            "content.english",
+                                            "title.english",
+                                            "content_title.english",
+                                            "description.english",
                                             "content_feature_type",
                                         ],
                                     }

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -387,9 +387,10 @@ RUN_INSTRUCTORS_QUERY_FIELDS = [
 ]
 
 RESOURCEFILE_QUERY_FIELDS = [
-    "content",
-    "title.english^3",
-    "short_description.english^2",
+    "content.english",
+    "title.english",
+    "content_title.english",
+    "description.english",
     "content_feature_type",
 ]
 

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -456,6 +456,16 @@ class LearningResourcesSearchRequestSerializer(SearchRequestSerializer):
             "search term."
         ),
     )
+    content_file_score_weight = serializers.FloatField(
+        max_value=1,
+        min_value=0,
+        required=False,
+        allow_null=True,
+        help_text=(
+            "Score weight for content file data.  1 is the default."
+            " 0 means content files are ignored"
+        ),
+    )
 
 
 class ContentFileSearchRequestSerializer(SearchRequestSerializer):

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -929,6 +929,7 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
+        "content_file_score_weight": 0,
     }
 
     cleaned = {
@@ -955,6 +956,7 @@ def test_learning_resources_search_request_serializer():
         "slop": 2,
         "min_score": 0,
         "max_incompleteness_penalty": 25,
+        "content_file_score_weight": 0,
     }
 
     serialized = LearningResourcesSearchRequestSerializer(data=data)

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2321,6 +2321,16 @@ paths:
           \ Credential\n* `professional` - Professional Certificate\n* `completion`\
           \ - Certificate of Completion\n* `none` - No Certificate"
       - in: query
+        name: content_file_score_weight
+        schema:
+          type: number
+          format: double
+          maximum: 1
+          minimum: 0
+          nullable: true
+        description: Score weight for content file data.  1 is the default. 0 means
+          content files are ignored
+      - in: query
         name: course_feature
         schema:
           type: array
@@ -2808,6 +2818,16 @@ paths:
         description: "The type of certificate             \n\n* `micromasters` - Micromasters\
           \ Credential\n* `professional` - Professional Certificate\n* `completion`\
           \ - Certificate of Completion\n* `none` - No Certificate"
+      - in: query
+        name: content_file_score_weight
+        schema:
+          type: number
+          format: double
+          maximum: 1
+          minimum: 0
+          nullable: true
+        description: Score weight for content file data.  1 is the default. 0 means
+          content files are ignored
       - in: query
         name: course_feature
         schema:
@@ -3322,6 +3342,16 @@ paths:
           \ Credential\n* `professional` - Professional Certificate\n* `completion`\
           \ - Certificate of Completion\n* `none` - No Certificate"
       - in: query
+        name: content_file_score_weight
+        schema:
+          type: number
+          format: double
+          maximum: 1
+          minimum: 0
+          nullable: true
+        description: Score weight for content file data.  1 is the default. 0 means
+          content files are ignored
+      - in: query
         name: course_feature
         schema:
           type: array
@@ -3825,6 +3855,16 @@ paths:
         description: "The type of certificate             \n\n* `micromasters` - Micromasters\
           \ Credential\n* `professional` - Professional Certificate\n* `completion`\
           \ - Certificate of Completion\n* `none` - No Certificate"
+      - in: query
+        name: content_file_score_weight
+        schema:
+          type: number
+          format: double
+          maximum: 1
+          minimum: 0
+          nullable: true
+        description: Score weight for content file data.  1 is the default. 0 means
+          content files are ignored
       - in: query
         name: course_feature
         schema:
@@ -10340,6 +10380,14 @@ components:
             An OCW course with completeness = 0 will have this score penalty. Partially
             complete courses have a linear penalty proportional to the degree of incompleteness.
             Only affects results if there is a search term.
+        content_file_score_weight:
+          type: number
+          format: double
+          maximum: 1
+          minimum: 0
+          nullable: true
+          description: Score weight for content file data.  1 is the default. 0 means
+            content files are ignored
         source_type:
           allOf:
           - $ref: '#/components/schemas/SourceTypeEnum'


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5721

### Description (What does it do?)
This adds a slider to the the admin search section to control whether to include content file data in the search results for searches with a text query

### How can this be tested?
run ./manage.py backpopulate_ocw_data --course-name 6-006-introduction-to-algorithms-spring-2020

http://open.odl.local:8062/search/?q=dirt should return that course 

http://open.odl.local:8062/search/?q=dirt&content_file_score_weight=0  should not return it

Verify that as an admin you see "Content File Score Weight Adjustment" in the admin facet sidebar and can set it

Verify that search works normally otherwise
