### PR TITLE
Clear Cache on Deploy

### DIFF
--- a/main/management/commands/clear_cache.py
+++ b/main/management/commands/clear_cache.py
@@ -1,0 +1,15 @@
+"""Command to generate the channel avatar SVGs"""
+
+from django.core.management.base import BaseCommand
+
+from main.utils import clear_search_cache
+
+
+class Command(BaseCommand):
+    """Command to generate the channel avatar SVGs"""
+
+    help = "Command to clear the cache"
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        cache_items = clear_search_cache()
+        self.stdout.write(f"cleared {cache_items} items from cache")

--- a/main/utils.py
+++ b/main/utils.py
@@ -357,8 +357,10 @@ def clean_data(data: str) -> str:
 
 def clear_search_cache():
     cache = caches["redis"]
+    cleared = 0
     if hasattr(cache, "keys"):
         search_keys = cache.keys("views.decorators.cache.cache_page.search.*")
-        cache.delete_many(search_keys)
+        cleared += cache.delete_many(search_keys) or 0
         search_keys = cache.keys("views.decorators.cache.cache_header.search.*")
-        cache.delete_many(search_keys)
+        cleared += cache.delete_many(search_keys) or 0
+    return cleared

--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -22,3 +22,6 @@ python $MANAGE_FILE prune_subscription_queries 2>&1 | indent
 
 echo "-----> Generating cache tables"
 python $MANAGE_FILE createcachetable 2>&1 | indent
+
+# clear cache entries
+python $MANAGE_FILE clear_cache --noinput 2>&1 | indent


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5743

### Description (What does it do?)
This pr adds a django command that is run on each deploy to clear the cache.

The site-wide page cache gets invalidated when etl pipelines run and when search indexing operations complete however - we recently ran into an issue where an api endpoint added a new attribute and due to caching, the api responded with a cached response and a frontend feature that relied on this broke. 

### How can this be tested?
To test locally:
1. checkout this branch
2. browse around some pages in order to have some items in the cache
3. run the cache clear management command `python manage.py clear_cache` - you should see some output indicating the number of items cleared.

