### PR TITLE
Fix search page hydration error

### DIFF
--- a/frontends/main/src/app/search/page.tsx
+++ b/frontends/main/src/app/search/page.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from "react"
+import React from "react"
 import { getMetadataAsync } from "@/common/metadata"
 import SearchPage from "@/app-pages/SearchPage/SearchPage"
 
@@ -13,12 +13,20 @@ export async function generateMetadata({
   })
 }
 
+/**
+ * The search page uses Next's `useSearchParams`. This requires either:
+ *  1. wrap the <SearchPage /> in Suspense
+ *  2. or force-dynamic.
+ *
+ * (1) caused a hydration error for authenticated users. We haven not found
+ * the root cause of the hydration error.
+ *
+ * (2) seems to work well.
+ */
+export const dynamic = "force-dynamic"
+
 const Page: React.FC = () => {
-  return (
-    <Suspense>
-      <SearchPage />
-    </Suspense>
-  )
+  return <SearchPage />
 }
 
 export default Page


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5465

### Description (What does it do?)
Removes `Suspense` from search page in favor of `export const dynamic = "force-dynamic"`

### How can this be tested?
1. On branch `nextjs`, as an authenticated user, load and reload the search page. You should eventually see some hydration errors.
2. Repeat on this branch. It should not happen.