### PR TITLE
Set metadataBase url

### DIFF
--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -3,12 +3,15 @@ import type { Metadata } from "next"
 import HomePage from "@/app-pages/HomePage/HomePage"
 import { getMetadataAsync } from "@/common/metadata"
 
+const { NEXT_PUBLIC_ORIGIN } = process.env
+
 export async function generateMetadata({
   searchParams,
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
   return await getMetadataAsync({
+    metadataBase: NEXT_PUBLIC_ORIGIN ? new URL(NEXT_PUBLIC_ORIGIN) : null,
     title: "Learn with MIT",
     searchParams,
   })

--- a/frontends/main/src/common/metadata.ts
+++ b/frontends/main/src/common/metadata.ts
@@ -2,7 +2,7 @@ import { RESOURCE_DRAWER_QUERY_PARAM } from "@/common/urls"
 import { learningResourcesApi } from "api/clients"
 import type { Metadata } from "next"
 
-const DEFAULT_OG_IMAGE = `${process.env.NEXT_PUBLIC_ORIGIN}/images/learn-og-image.jpg`
+const DEFAULT_OG_IMAGE = "/images/learn-og-image.jpg"
 
 type MetadataAsyncProps = {
   title?: string


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5754

### Description (What does it do?)
Sets [metadataBase](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase)

### How can this be tested?
1. On this branch, run `$$('meta').forEach(e => console.log(e.outerHTML))` in the dev console and check that `og:image` is an absolute URL
    - check og:image on homepage
    - on channel pages, where it is determined via an api call

