### PR TITLE
prevent featured course carousel from re-randomizing

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -211,7 +211,7 @@ describe("LearningPath CRUD", () => {
   }
 
   test("useLearningpathCreate calls correct API", async () => {
-    const { path, pathUrls, keys } = makeData()
+    const { path, pathUrls } = makeData()
     const url = pathUrls.list
 
     const requestData = { title: path.title }
@@ -226,9 +226,12 @@ describe("LearningPath CRUD", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
-    expect(queryClient.invalidateQueries).toHaveBeenCalledWith(
-      keys.learningResources,
-    )
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith([
+      "learningResources",
+      "learningpaths",
+      "learning_paths",
+      "list",
+    ])
   })
 
   test("useLearningpathDestroy calls correct API", async () => {

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -41,6 +41,7 @@ import learningResources, {
   invalidateResourceWithUserListQueries,
   updateListParentsOnAdd,
   updateListParentsOnDestroy,
+  updateListParents,
 } from "./keyFactory"
 import { ListType } from "../../common/constants"
 
@@ -349,6 +350,13 @@ const useLearningResourceSetUserListRelationships = () => {
         invalidateUserListQueries(queryClient, userlistId)
       })
     },
+    onSuccess: (response, vars) => {
+      queryClient.setQueriesData<PaginatedLearningResourceList>(
+        learningResources.featured({}).queryKey,
+        (featured) =>
+          updateListParents(vars.id, featured, response.data, "userlist"),
+      )
+    },
   })
 }
 
@@ -365,9 +373,16 @@ const useLearningResourceSetLearningPathRelationships = () => {
       })
       vars.learning_path_id?.forEach((learningPathId) => {
         invalidateResourceQueries(queryClient, learningPathId, {
-          skipFeatured: false,
+          skipFeatured: true,
         })
       })
+    },
+    onSuccess: (response, vars) => {
+      queryClient.setQueriesData<PaginatedLearningResourceList>(
+        learningResources.featured({}).queryKey,
+        (featured) =>
+          updateListParents(vars.id, featured, response.data, "learningpath"),
+      )
     },
   })
 }

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -343,7 +343,7 @@ const useLearningResourceSetUserListRelationships = () => {
     ) => learningResourcesApi.learningResourcesUserlistsPartialUpdate(params),
     onSettled: (_response, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.id, {
-        skipFeatured: false,
+        skipFeatured: true,
       })
       vars.userlist_id?.forEach((userlistId) => {
         invalidateUserListQueries(queryClient, userlistId)
@@ -361,7 +361,7 @@ const useLearningResourceSetLearningPathRelationships = () => {
       learningResourcesApi.learningResourcesLearningPathsPartialUpdate(params),
     onSettled: (_response, _err, vars) => {
       invalidateResourceQueries(queryClient, vars.id, {
-        skipFeatured: false,
+        skipFeatured: true,
       })
       vars.learning_path_id?.forEach((learningPathId) => {
         invalidateResourceQueries(queryClient, learningPathId, {

--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -124,9 +124,9 @@ const useLearningpathCreate = () => {
         LearningPathResourceRequest: params,
       }),
     onSettled: () => {
-      // Invalidate everything: this is over-aggressive, but the new resource
-      // could appear in most lists
-      queryClient.invalidateQueries(learningResources._def)
+      queryClient.invalidateQueries(
+        learningResources.learningpaths._ctx.list._def,
+      )
     },
   })
 }

--- a/frontends/api/src/hooks/learningResources/keyFactory.ts
+++ b/frontends/api/src/hooks/learningResources/keyFactory.ts
@@ -371,6 +371,41 @@ const updateListParentsOnDestroy = (
   }
 }
 
+/**
+ * Given
+ *  - a LearningResource ID
+ *  - a paginated list of current resources
+ *  - a list of new relationships
+ *  - the type of list
+ * Update the resources' user_list_parents field to include the new relationships
+ */
+const updateListParents = (
+  resourceId: number,
+  staleResources?: PaginatedLearningResourceList,
+  newRelationships?: MicroUserListRelationship[],
+  listType?: "userlist" | "learningpath",
+) => {
+  if (!resourceId || !staleResources || !newRelationships || !listType)
+    return staleResources
+  const matchIndex = staleResources.results.findIndex(
+    (res) => res.id === resourceId,
+  )
+  if (matchIndex === -1) return staleResources
+  const updatedResults = [...staleResources.results]
+  const newResource = { ...updatedResults[matchIndex] }
+  if (listType === "userlist") {
+    newResource.user_list_parents = newRelationships
+  }
+  if (listType === "learningpath") {
+    newResource.learning_path_parents = newRelationships
+  }
+  updatedResults[matchIndex] = newResource
+  return {
+    ...staleResources,
+    results: updatedResults,
+  }
+}
+
 export default learningResources
 export {
   invalidateResourceQueries,
@@ -378,4 +413,5 @@ export {
   invalidateResourceWithUserListQueries,
   updateListParentsOnAdd,
   updateListParentsOnDestroy,
+  updateListParents,
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5434

### Description (What does it do?)
This PR fixes an issue where the featured course carousel on the home page would re-render (and re-randomize) if you save one of the courses to a learning path / user list.

### How can this be tested?
 - Spin up this branch of `mit-learn`
 - Ensure that you have sufficient data backpopulated to have courses show up in the featured course carousel on the homepage, and that you are logged in as a staff / superuser
 - Visit the home page at http://localhost:8062/
 - Add one of the courses to a user list by clicking the bookmark icon, selecting a list and then clicking Save
 - Verify that the bookmark icon is now highlighted red and the carousel does not refresh / re-randomize
 - Repeat the above, but use the list icon to add / remove a course from a learning path
