### PR TITLE
removing invalid flag from clear cache command

### DIFF
--- a/scripts/heroku-release-phase.sh
+++ b/scripts/heroku-release-phase.sh
@@ -24,4 +24,4 @@ echo "-----> Generating cache tables"
 python $MANAGE_FILE createcachetable 2>&1 | indent
 
 # clear cache entries
-python $MANAGE_FILE clear_cache --noinput 2>&1 | indent
+python $MANAGE_FILE clear_cache 2>&1 | indent


### PR DESCRIPTION
### Description
This pr removes the invalid --no-input flag from the clear_cache django command in the heroku release script.
