### PR TITLE
Make metadataBase apply to all pages, not just homepage

### DIFF
--- a/frontends/main/src/app/c/[channelType]/[name]/page.tsx
+++ b/frontends/main/src/app/c/[channelType]/[name]/page.tsx
@@ -25,7 +25,6 @@ export async function generateMetadata({
     searchParams,
     title: `${channelDetails.title}`,
     description: channelDetails.public_description,
-    image: channelDetails.configuration.logo,
   })
 }
 

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import React from "react"
 import Header from "@/page-components/Header/Header"
 import Footer from "@/page-components/Footer/Footer"
@@ -10,6 +8,15 @@ import Script from "next/script"
 import ErrorBoundary from "@/components/ErrorBoundary/ErrorBoundary"
 
 import "./GlobalStyles"
+
+const { NEXT_PUBLIC_ORIGIN } = process.env
+
+/**
+ * As part of the root layout, this metadata object is site-wide defaults
+ */
+export const metadata = {
+  metadataBase: NEXT_PUBLIC_ORIGIN ? new URL(NEXT_PUBLIC_ORIGIN) : null,
+}
 
 export default function RootLayout({
   children,

--- a/frontends/main/src/app/page.tsx
+++ b/frontends/main/src/app/page.tsx
@@ -3,15 +3,12 @@ import type { Metadata } from "next"
 import HomePage from "@/app-pages/HomePage/HomePage"
 import { getMetadataAsync } from "@/common/metadata"
 
-const { NEXT_PUBLIC_ORIGIN } = process.env
-
 export async function generateMetadata({
   searchParams,
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }): Promise<Metadata> {
   return await getMetadataAsync({
-    metadataBase: NEXT_PUBLIC_ORIGIN ? new URL(NEXT_PUBLIC_ORIGIN) : null,
     title: "Learn with MIT",
     searchParams,
   })

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -1,3 +1,4 @@
+"use client"
 /// <reference types="./types/theme.d.ts" />
 /// <reference types="./types/typography.d.ts" />
 


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #1671 

### Description (What does it do?)
This PR moves `metadadataBase` from root page to root layout.

Child pages load all their parent layouts (but not parent pages!) so the earlier positioning of metadataBase was only affecting the home page.

### How can this be tested?
1. Despite what the docs say [here](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value), it seems like metadataBase does not work in local dev mode. So set `NODE_ENV=production` and `NEXT_PUBLIC_ORIGIN=https://learn.mit.edu`, then run `yarn workspace main build` `yarn workspace main start`
    - you should NOT see any warnings like 
     
    > ⚠ metadataBase property in metadata export is not set for resolving social open graph or twitter images, using "http://localhost:8062". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase 
2. Visit your local production server and run `$$('meta').forEach(e => console.log(e.outerHTML))` in the dev console
    - all pages, including homepage, should have `og:image` urls beginning with learn.mit.edu

