### PR TITLE
Updates when search events are triggered

### DIFF
--- a/frontends/mit-learn/src/page-components/SearchField/SearchField.tsx
+++ b/frontends/mit-learn/src/page-components/SearchField/SearchField.tsx
@@ -5,7 +5,7 @@ import { usePostHog } from "posthog-js/react"
 
 type SearchFieldProps = SearchInputProps & {
   onSubmit: (event: SearchSubmissionEvent) => void
-  setPage: (page: number) => void
+  setPage?: (page: number) => void
 }
 
 const { POSTHOG } = APP_SETTINGS
@@ -26,7 +26,7 @@ const SearchField: React.FC<SearchFieldProps> = ({
     { isEnter } = {},
   ) => {
     onSubmit(event)
-    setPage(1)
+    setPage && setPage(1)
     if (POSTHOG?.api_key) {
       posthog.capture("search_update", { isEnter: isEnter })
     }

--- a/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
+++ b/frontends/mit-learn/src/pages/HomePage/HeroSearch.tsx
@@ -5,7 +5,6 @@ import {
   styled,
   ChipLink,
   Link,
-  SearchInput,
   SearchInputProps,
 } from "ol-components"
 import type { ChipLinkProps } from "ol-components"
@@ -27,6 +26,7 @@ import {
   RiVerifiedBadgeLine,
 } from "@remixicon/react"
 import _ from "lodash"
+import { SearchField } from "@/page-components/SearchField/SearchField"
 
 type SearchChip = {
   label: string
@@ -236,7 +236,7 @@ const HeroSearch: React.FC = () => {
           </BoldLink>
         </Typography>
         <ControlsContainer>
-          <SearchInput
+          <SearchField
             size="hero"
             fullWidth
             value={searchText}

--- a/frontends/mit-learn/src/pages/SearchPage/SearchPage.tsx
+++ b/frontends/mit-learn/src/pages/SearchPage/SearchPage.tsx
@@ -15,7 +15,6 @@ import type { LearningResourceOfferor } from "api"
 import { useOfferorsList } from "api/hooks/learningResources"
 import { capitalize } from "ol-utilities"
 import MetaTags from "@/page-components/MetaTags/MetaTags"
-import { usePostHog } from "posthog-js/react"
 
 const cssGradient = `
   linear-gradient(
@@ -171,8 +170,6 @@ const useFacetManifest = (resourceCategory: string | null) => {
 const SearchPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const facetManifest = useFacetManifest(searchParams.get("resource_category"))
-  const posthog = usePostHog()
-  const { POSTHOG } = APP_SETTINGS
 
   const setPage = useCallback(
     (newPage: number) => {
@@ -189,11 +186,8 @@ const SearchPage: React.FC = () => {
     [setSearchParams],
   )
   const onFacetsChange = useCallback(() => {
-    if (!(!POSTHOG?.api_key || POSTHOG.api_key.length < 1)) {
-      posthog.capture("search_update")
-    }
     setPage(1)
-  }, [setPage, posthog, POSTHOG])
+  }, [setPage])
 
   const {
     params,


### PR DESCRIPTION


### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/5763

### Description (What does it do?)

We added some triggering for search events to the app in https://github.com/mitodl/mit-open/pull/1596 . This allowed us to capture search term changes and facet selections on the search results page. However, this wasn't a complete picture of search events:
- Searches started on the homepage didn't trigger an event
- Facet changes on interior pages _besides_ the search results page (such as on a unit page) didn't trigger an event.
- Clearing selections did not trigger an event.

These changes fix that.

- Updates the homepage HeroSearch component to use the SearchField component, rather than SearchInput, so it will trigger the search_update event
- Updates the SearchInput component to not require `setPage`, so it can be used in HeroSearch.
- Adds event triggering to the relevant events in SearchDisplay (by wrapping the event handlers that are passed in for that)
- Pulls related triggering from 

### How can this be tested?

You will need a PostHog account to test manually. For best results, go to the Activity page in the sidebar and then add an event filter for `search_update`, since that's the only thing that gets triggered by this code. (Also, it helps to be patient - it can take a minute or two for PostHog to process the events and display them. But not too patient. More than a couple of minutes and it _probably_ didn't work.) 

For homepage and search results:
1. Perform a search on the homepage. You should see a `search_update`, and it should capture if the event was triggered by hitting Enter or clicking on the submit icon. 
2. On the search results page, adjust things - update the facets, change the category, update sorting, change the search term. All of these should trigger `search_update` events. 
3. On the search results page, use the Clear All button to clear facet selections. This too should trigger a `search_update` event. 

For interior pages:
1. Navigate to a unit page. This should list the resources available in the unit.
2. Change things about the results - add a term, select filters, change category, etc. You should get `search_update` events for these. 
3. Similarly, using Clear All should also trigger an event.
4. Repeat this for other pages that use the ChannelPage base - department, topics, etc. - they should all work in the same manner.

### Additional Context

The issue being tracked in https://github.com/mitodl/hq/issues/5767 is in progress still (as of writing this), so if you select >1 facet type (e.g. topic, department, etc.) you'll only ever get the first one you select. (But this should make it slightly easier to refactor our code to manually capture the data if we have to.) 
