### PR TITLE
Fix search page history stack

### DIFF
--- a/frontends/jest-shared-setup.ts
+++ b/frontends/jest-shared-setup.ts
@@ -4,6 +4,7 @@ import "cross-fetch/polyfill"
 import { configure } from "@testing-library/react"
 import { resetAllWhenMocks } from "jest-when"
 import * as matchers from "jest-extended"
+import { mockRouter } from "ol-test-utilities/mocks/nextNavigation"
 
 expect.extend(matchers)
 
@@ -92,4 +93,6 @@ afterEach(() => {
    */
   jest.clearAllMocks()
   resetAllWhenMocks()
+  mockRouter.setCurrentUrl("/")
+  window.history.replaceState({}, "", "/")
 })

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1",
     "@remixicon/react": "^4.2.0",
     "@tanstack/react-query": "^4.36.1",
     "api": "workspace:*",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1",
+    "@mitodl/course-search-utils": "3.2.4",
     "@remixicon/react": "^4.2.0",
     "@tanstack/react-query": "^4.36.1",
     "api": "workspace:*",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",
     "@emotion/cache": "^11.13.1",
-    "@mitodl/course-search-utils": "^3.2.3",
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57",
     "@remixicon/react": "^4.2.0",
     "@tanstack/react-query": "^4.36.1",
     "api": "workspace:*",

--- a/frontends/ol-test-utilities/src/mocks/nextNavigation.test.ts
+++ b/frontends/ol-test-utilities/src/mocks/nextNavigation.test.ts
@@ -36,13 +36,13 @@ describe("Mock Navigation", () => {
   test("useSearchParams returns the current search params", () => {
     mockRouter.setCurrentUrl("/dynamic/bar?a=1&b=2")
     const { result } = renderHook(() => useSearchParams())
-    expect(result.current.toString()).toEqual("a=1&b=2&id=bar")
+    expect(result.current.toString()).toEqual("a=1&b=2")
   })
 
   test("useSearchParams repeats duplicate keys on the querystring", () => {
     mockRouter.setCurrentUrl("/dynamic/bar?a=1&b=2&b=3")
     const { result } = renderHook(() => useSearchParams())
-    expect(result.current.toString()).toEqual("a=1&b=2&b=3&id=bar")
+    expect(result.current.toString()).toEqual("a=1&b=2&b=3")
   })
 
   test("useParams returns the current params", () => {
@@ -58,13 +58,17 @@ describe("Mock Navigation", () => {
     const { result } = renderHook(() => nextNavigationMocks.useRouter())
     act(() => {
       result.current.push(
-        "/dynamic/foo",
+        "/dynamic/foo?c=3",
         // @ts-expect-error The type signature of mockRouter.push is for old pages router.
         // The 2nd arg here is for what our application uses, the app router
         { scroll: false },
       )
     })
-    expect(mockRouter.asPath).toBe("/dynamic/foo")
+    expect(mockRouter.asPath).toBe("/dynamic/foo?c=3")
+    act(() => {
+      result.current.push("?d=4")
+    })
+    expect(mockRouter.asPath).toBe("/dynamic/foo?d=4")
   })
 
   test("router.replace", () => {
@@ -73,12 +77,38 @@ describe("Mock Navigation", () => {
     const { result } = renderHook(() => nextNavigationMocks.useRouter())
     act(() => {
       result.current.replace(
-        "/dynamic/foo",
+        "/dynamic/foo?c=3",
         // @ts-expect-error The type signature of mockRouter.replace is for old pages router.
         // The 2nd arg here is for what our application uses, the app router
         { scroll: false },
       )
     })
-    expect(mockRouter.asPath).toBe("/dynamic/foo")
+    expect(mockRouter.asPath).toBe("/dynamic/foo?c=3")
+    act(() => {
+      result.current.push("?d=4")
+    })
+    expect(mockRouter.asPath).toBe("/dynamic/foo?d=4")
+  })
+
+  test("useSearchParams reacts to history.pushState", () => {
+    const { result } = renderHook(() => nextNavigationMocks.useSearchParams())
+    expect(result.current.toString()).toBe("")
+    const push = jest.spyOn(mockRouter, "push")
+    act(() => {
+      window.history.pushState({}, "", "/dynamic/foo?a=1&b=2")
+    })
+    expect(push).toHaveBeenCalled()
+    expect(result.current.toString()).toBe("a=1&b=2")
+  })
+
+  test("useSearchParams reacts to history.replaceState", () => {
+    const { result } = renderHook(() => nextNavigationMocks.useSearchParams())
+    expect(result.current.toString()).toBe("")
+    const replace = jest.spyOn(mockRouter, "replace")
+    act(() => {
+      window.history.replaceState({}, "", "/dynamic/foo?a=1&b=2")
+    })
+    expect(replace).toHaveBeenCalled()
+    expect(result.current.toString()).toBe("a=1&b=2")
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,9 +3527,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@npm:^3.2.3":
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57":
   version: 3.2.3
-  resolution: "@mitodl/course-search-utils@npm:3.2.3"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=506ee47d6145837b8f2d3a2add9258c86b390f57"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3549,7 +3549,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/57484acd65d63289f9c539f687af738a079b233848b0c4b25855691491c3a15ff8f98e06d3065519aaee980f10a9d351507fd05abeb95cd667f0b9358d3d8521
+  checksum: 10/1d94934efb27d99540c1428f1056017d8447f05ad2f0cc4ebb4bf13075a74371f3cbd09b1a17b5e14bf489265244015b6483c94db9ecaba001eeef228d657f91
   languageName: node
   linkType: hard
 
@@ -13669,7 +13669,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "npm:^3.2.3"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57"
     "@remixicon/react": "npm:^4.2.0"
     "@tanstack/react-query": "npm:^4.36.1"
     "@testing-library/jest-dom": "npm:^6.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,9 +3527,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57":
+"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1":
   version: 3.2.3
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=506ee47d6145837b8f2d3a2add9258c86b390f57"
+  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=2be637effa7e3bdaf9adcbf98a04724cba2753b1"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3549,7 +3549,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/1d94934efb27d99540c1428f1056017d8447f05ad2f0cc4ebb4bf13075a74371f3cbd09b1a17b5e14bf489265244015b6483c94db9ecaba001eeef228d657f91
+  checksum: 10/c1e802e77d0580b5e04748386bc361779ec250f8093613c72615b53a096928e8021cfdcae2488edeb1eaabfc8114c8f8c9dd73b651ffd248432c91cb6a925e30
   languageName: node
   linkType: hard
 
@@ -13669,7 +13669,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#506ee47d6145837b8f2d3a2add9258c86b390f57"
+    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1"
     "@remixicon/react": "npm:^4.2.0"
     "@tanstack/react-query": "npm:^4.36.1"
     "@testing-library/jest-dom": "npm:^6.4.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3527,9 +3527,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1":
-  version: 3.2.3
-  resolution: "@mitodl/course-search-utils@https://github.com/mitodl/course-search-utils.git#commit=2be637effa7e3bdaf9adcbf98a04724cba2753b1"
+"@mitodl/course-search-utils@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@mitodl/course-search-utils@npm:3.2.4"
   dependencies:
     "@mitodl/open-api-axios": "npm:2024.9.16"
     "@remixicon/react": "npm:^4.2.0"
@@ -3549,7 +3549,7 @@ __metadata:
       optional: true
     react-router:
       optional: true
-  checksum: 10/c1e802e77d0580b5e04748386bc361779ec250f8093613c72615b53a096928e8021cfdcae2488edeb1eaabfc8114c8f8c9dd73b651ffd248432c91cb6a925e30
+  checksum: 10/482ceacb80b281fcb687a700431185dc36615048429ece0391ae0a317cd7aca79544e5970b98dd4da87441178ef187575ffa3df8141745394b412de63f2500c6
   languageName: node
   linkType: hard
 
@@ -13669,7 +13669,7 @@ __metadata:
     "@ebay/nice-modal-react": "npm:^1.2.13"
     "@emotion/cache": "npm:^11.13.1"
     "@faker-js/faker": "npm:^8.4.1"
-    "@mitodl/course-search-utils": "https://github.com/mitodl/course-search-utils.git#2be637effa7e3bdaf9adcbf98a04724cba2753b1"
+    "@mitodl/course-search-utils": "npm:3.2.4"
     "@remixicon/react": "npm:^4.2.0"
     "@tanstack/react-query": "npm:^4.36.1"
     "@testing-library/jest-dom": "npm:^6.4.8"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5735

### Description (What does it do?)
This PR changes `setSearchParams` to:
- add to the history stack correctly
- be purely client side

See associated `@mitodl/course-search-utils` PR for more.


### How can this be tested?
1. On this branch, `yarn install` and restart the frontend
2. Visit the search interfaces, both /search and channel search /c/unit/ocw (etc). Things to check:
    1. Clicking facets adds to the history stack (press browser back/forward button)
    2. Appropriate API calls are made to server
    3. No `text/x-component` requests to the NextJS server (except maybe on initial load, but definitely not when clicking facets or submitting search text)

### Checklist:
- [ ] First merge THIS_PR_RIGHT_HERE and use a published version
