### PR TITLE
fix spacing issues on nextjs branch

### DIFF
--- a/frontends/main/src/app/styled.tsx
+++ b/frontends/main/src/app/styled.tsx
@@ -8,13 +8,17 @@ import { styled } from "ol-components"
  * Solution for now is to "use client", though I would expect these to be prerendered
  */
 
-export const PageWrapper = styled.div({
-  height: "calc(100vh - 80px)",
+export const PageWrapper = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
-})
+  height: "calc(100vh - 72px)",
+  marginTop: "72px",
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "60px",
+    height: "calc(100vh - 60px)",
+  },
+}))
 
 export const PageWrapperInner = styled.div({
   flex: "1",
-  paddingTop: "60px",
 })

--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -100,8 +100,8 @@ const ImageContainer = styled.div(({ theme }) => ({
   flexDirection: "row",
   alignItems: "center",
   justifyContent: "center",
-  marginTop: "22px",
-  transform: "translateX(24px)",
+  marginTop: "44px",
+  transform: "translateX(48px)",
   width: "513px",
   aspectRatio: "513 / 522",
   [theme.breakpoints.down("md")]: {

--- a/frontends/ol-components/src/components/Input/Input.tsx
+++ b/frontends/ol-components/src/components/Input/Input.tsx
@@ -99,9 +99,6 @@ const baseInputStyles = (theme: Theme) => ({
   borderWidth: "1px",
   borderStyle: "solid",
   borderRadius: "4px",
-  ".MuiInputBase-input": {
-    padding: "0",
-  },
   "&.Mui-disabled": {
     backgroundColor: theme.custom.colors.lightGray1,
   },

--- a/frontends/ol-components/src/components/ThemeProvider/MITLearnGlobalStyles.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/MITLearnGlobalStyles.tsx
@@ -38,15 +38,6 @@ const pageCss = css`
     box-sizing: border-box;
   }
 
-  #app-container {
-    height: calc(100vh - 72px);
-    margin-top: 72px;
-    ${theme.breakpoints.down("sm")} {
-      margin-top: 60px;
-      height: calc(100vh - 60px);
-    }
-  }
-
   a {
     text-decoration: none;
     color: inherit;


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5745

### Description (What does it do?)
This PR addresses some spacing issues between the `main` and `nextjs` branches:
 - `#app-container` styles moved to `PageWrapper`
 - fixed padding on the home page hero image
 - fixed search input padding issue

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/34004598-80d2-4a5d-ae95-2456aaf50e24)
![image](https://github.com/user-attachments/assets/96883df4-d375-4bc5-bc1f-c6227dad52d8)

### How can this be tested?
 - Spin up this branch of `mit-learn` (If you are coming from `main` you will need to rebuild your containers)
 - Visit the home page at http://localhost:8062/
 - Verify that the styles described above and in the issue match production (https://learn.mit.edu)
