### PR TITLE
Make add to list dialog scrollable

### DIFF
--- a/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.test.tsx
+++ b/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.test.tsx
@@ -64,7 +64,10 @@ const setupLearningPaths = ({
     urls.learningResources.details({ id: resource.id }),
     resource,
   )
-  setMockResponse.get(urls.learningPaths.list(), paginatedLearningPaths)
+  setMockResponse.get(
+    urls.learningPaths.list({ limit: 100 }),
+    paginatedLearningPaths,
+  )
   const view = renderWithProviders(null)
   if (dialogOpen) {
     act(() => {
@@ -100,7 +103,7 @@ const setupUserLists = ({
     urls.learningResources.details({ id: resource.id }),
     resource,
   )
-  setMockResponse.get(urls.userLists.list(), paginatedUserLists)
+  setMockResponse.get(urls.userLists.list({ limit: 100 }), paginatedUserLists)
   const view = renderWithProviders(null)
   if (dialogOpen) {
     act(() => {

--- a/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.tsx
+++ b/frontends/mit-learn/src/page-components/Dialogs/AddToListDialog.tsx
@@ -14,11 +14,7 @@ import { usePostHog } from "posthog-js/react"
 
 import * as NiceModal from "@ebay/nice-modal-react"
 
-import {
-  type LearningPathResource,
-  type LearningResource,
-  type UserList,
-} from "api"
+import type { LearningPathResource, LearningResource, UserList } from "api"
 
 import {
   useLearningResourceSetUserListRelationships,
@@ -30,6 +26,8 @@ import {
 import { manageListDialogs } from "@/page-components/ManageListDialogs/ManageListDialogs"
 import { ListType } from "api/constants"
 import { useFormik } from "formik"
+
+const LIST_LIMIT = 100
 
 const ResourceTitle = styled.span({
   fontStyle: "italic",
@@ -202,7 +200,7 @@ const AddToLearningPathDialogInner: React.FC<AddToListDialogProps> = ({
 }) => {
   const resourceQuery = useLearningResourcesDetail(resourceId)
   const resource = resourceQuery.data
-  const listsQuery = useLearningPathsList()
+  const listsQuery = useLearningPathsList({ limit: LIST_LIMIT })
 
   const isReady = !!(resource && listsQuery.isSuccess)
   const lists = listsQuery.data?.results ?? []
@@ -221,7 +219,7 @@ const AddToUserListDialogInner: React.FC<AddToListDialogProps> = ({
 }) => {
   const resourceQuery = useLearningResourcesDetail(resourceId)
   const resource = resourceQuery.data
-  const listsQuery = useUserListList()
+  const listsQuery = useUserListList({ limit: LIST_LIMIT })
 
   const isReady = !!(resource && listsQuery.isSuccess)
   const lists = listsQuery.data?.results ?? []

--- a/frontends/ol-components/src/components/Dialog/Dialog.tsx
+++ b/frontends/ol-components/src/components/Dialog/Dialog.tsx
@@ -23,7 +23,9 @@ const Header = styled.div`
 `
 
 const Content = styled.div`
-  margin: 28px 28px 40px;
+  margin: 28px;
+  min-height: 0;
+  overflow: auto;
 `
 
 const DialogActions = styled(MuiDialogActions)`

--- a/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
+++ b/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
@@ -8,7 +8,6 @@ const FormContent = styled.div`
   flex-direction: column;
   gap: 20px;
   width: 100%;
-  margin-bottom: -12px;
 `
 interface FormDialogProps {
   /**

--- a/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/frontends/ol-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -77,7 +77,13 @@ const themeOptions: ThemeOptions = {
       styleOverrides: { paper: { borderRadius: "4px" } },
     },
     MuiAutocomplete: {
-      styleOverrides: { paper: { borderRadius: "4px" } },
+      styleOverrides: {
+        paper: { borderRadius: "4px" },
+        // Mui puts paddingRight: 2px, marginRight: -2px on the popupIndicator,
+        // which causes the browser to show a horizontal scrollbar on overflow
+        // containers when a scrollbar isn't really necessary.
+        popupIndicator: { paddingRight: 0, marginRight: 0 },
+      },
     },
     MuiChip: chips.chipComponent,
   },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5774

### Description (What does it do?)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):

**Change:** The AddToListDialog shows more lists and is scrollable (if necessary):

<img width="984" alt="Screenshot 2024-10-15 at 11 06 53 AM" src="https://github.com/user-attachments/assets/add4a082-7823-4b08-8aca-d92d80d4b657">

**Unchanged:** Most other dialogs

<img width="1023" alt="Screenshot 2024-10-15 at 11 07 03 AM" src="https://github.com/user-attachments/assets/0c664813-617c-4bab-b3ec-efc7833a6b2f">
<img width="998" alt="Screenshot 2024-10-15 at 11 07 15 AM" src="https://github.com/user-attachments/assets/90c791c4-07f9-4052-b2f7-e7bab496d98d">
<img width="1060" alt="Screenshot 2024-10-15 at 11 07 26 AM" src="https://github.com/user-attachments/assets/2d67fb69-f769-473e-9a6a-d4cdc3f98f1f">
<img width="1150" alt="Screenshot 2024-10-15 at 11 07 40 AM" src="https://github.com/user-attachments/assets/0dbc0c12-b22c-4ace-a332-5b1949e51b62">

### How can this be tested?
1. Create a bunch of learning paths (or userlists) and check that the AddToList dialog content scrolls. (You can open the AddToListDialog via list/bookmark button on learning resources).
2. Check that other dialogs, like the list creation (in dashboard -> my lists) is unchanged

