### PR TITLE
missing chevrons for admin facets

### DIFF
--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -22,6 +22,8 @@ import {
   RiArrowLeftLine,
   RiArrowRightLine,
   RiEqualizerLine,
+  RiArrowUpSLine,
+  RiArrowDownSLine,
 } from "@remixicon/react"
 
 import {
@@ -690,8 +692,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     expandAdminOptions,
     setExpandAdminOptions,
   ) => {
-    const titleLineIcon = expandAdminOptions ? "expand_less" : "expand_more"
-
     return (
       <div
         className={`facets admin-facet base-facet${expandAdminOptions ? " facets-expanded" : ""}`}
@@ -703,8 +703,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
           onClick={() => setExpandAdminOptions(!expandAdminOptions)}
         >
           Admin Options
-          <i className={`material-icons ${titleLineIcon}`} aria-hidden="true">
-            {titleLineIcon}
+          <i aria-hidden="true">
+            {expandAdminOptions ? <RiArrowUpSLine /> : <RiArrowDownSLine />}
           </i>
         </button>
         {expandAdminOptions ? (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5797


### Description (What does it do?)
This PR restores the chevron from the admin options on the search page


**Before:**
![Image](https://github.com/user-attachments/assets/f7bb44ba-5d9e-4c00-9b70-7dce045f2fa7)

**After:**
<img width="339" alt="Screenshot 2024-10-15 at 11 57 01 AM" src="https://github.com/user-attachments/assets/a75fd58c-aa95-496a-9099-fa3a127cd1df">


### How can this be tested?
1. checkout this branch
2. login as an admin user and go to search page. see that the arrow to expand and collapse displays in the admin options section
