### PR TITLE
increase learning path listing limit to 100

### DIFF
--- a/frontends/mit-learn/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
+++ b/frontends/mit-learn/src/pages/LearningPathListingPage/LearningPathListingPage.test.tsx
@@ -24,7 +24,7 @@ const setup = ({
 } = {}) => {
   const paths = factories.learningResources.learningPaths({ count: listsCount })
 
-  setMockResponse.get(urls.learningPaths.list(), paths)
+  setMockResponse.get(urls.learningPaths.list({ limit: 100 }), paths)
 
   const { location } = renderWithProviders(<LearningPathListingPage />, {
     user,

--- a/frontends/mit-learn/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
+++ b/frontends/mit-learn/src/pages/LearningPathListingPage/LearningPathListingPage.tsx
@@ -70,7 +70,7 @@ const EditListMenu: React.FC<{ resource: LearningPathResource }> = ({
 }
 
 const LearningPathListingPage: React.FC = () => {
-  const listingQuery = useLearningPathsList()
+  const listingQuery = useLearningPathsList({ limit: 100 })
   const { data: user } = useUserMe()
 
   const handleCreate = useCallback(() => {


### PR DESCRIPTION

### What are the relevant tickets?
Followup to https://github.com/mitodl/hq/issues/5774 / https://github.com/mitodl/mit-open/pull/1689

### Description (What does it do?)
In https://github.com/mitodl/mit-open/pull/1689, we made the AddToListDialog scrollable to unblock DLLs editing learningpaths on production—it now shows more than 10 learning paths (max 100).

This PR does the same remediation for the listing page, `/learningpaths`—increase limit to 100.

The corresponding user-facing public UI issue is tracked via https://github.com/mitodl/hq/issues/5776


### How can this be tested?
With 10+ learning paths (but less than 100...) check that they are all visible at `/learningpaths`

