### PR TITLE
exclude topics with no associated channel in api responses

### DIFF
--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -591,6 +591,10 @@ class TopicViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = TopicFilter
 
+    def filter_queryset(self, queryset):
+        queryset = queryset.exclude(channel_url__isnull=True)
+        return super().filter_queryset(queryset)
+
     @method_decorator(
         cache_page_for_all_users(
             settings.SEARCH_PAGE_CACHE_DURATION, cache="redis", key_prefix="search"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5775

### Description (What does it do?)
This PR configures `filter_queryset` on `TopicViewSet` to exclude topics where `channel_url` is null, meaning that the Topic has no associated channel. This has the effect of filtering out these topics from API responses, preventing errors related to accessing `channel_url` where it might not exist.

### How can this be tested?
Firstly, make sure you have data backpopulated in your database relating to courses, topics and channels. You will need both a `LearningResourceTopic` without and with an associated `Channel` object. The "AR/VR/MR/XR" topic had no channel for me, so either try and use that topic for testing or use a Django shell to ensure that you have the required data. Your user should also be a user with `is_staff` or `is_superuser` set to true.

To reproduce the issue:
 - Spin up the `main` branch of `mit-learn`
 - Go to the home page and click the list button on any of the featured courses
 - Click the "Create New List" button
 - Name and describe your list however you want, but under topics select the topic you found above with no associated `Channel`
 - Upon creating the list, you should see the error regarding `channel_url`
To see the fix in action:
 - Spin up this branch of `mit-learn`
 - Repeat the above process and ensure that the topic without a `Channel` does not even appear in the list of topics you can choose from
