### PR TITLE
Shanbady/xpro logo for all xpro offerings

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -4,7 +4,12 @@ import { render, screen, within } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import { LearningResourceExpanded } from "./LearningResourceExpanded"
 import type { LearningResourceExpandedProps } from "./LearningResourceExpanded"
-import { ResourceTypeEnum, PodcastEpisodeResource, AvailabilityEnum } from "api"
+import {
+  ResourceTypeEnum,
+  PodcastEpisodeResource,
+  AvailabilityEnum,
+  PlatformEnum,
+} from "api"
 import { factories } from "api/test-utils"
 import { formatDate } from "ol-utilities"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
@@ -129,6 +134,29 @@ describe("Learning Resource Expanded", () => {
           `^${(resource as PodcastEpisodeResource).podcast_episode?.episode_link}/?$`,
         ),
       )
+    },
+  )
+
+  test.each([ResourceTypeEnum.PodcastEpisode])(
+    "Renders xpro logo onditionally on offered_by=xpro and not platform.code",
+    (resourceType) => {
+      const resource = factories.learningResources.resource({
+        resource_type: resourceType,
+        platform: { code: "test" },
+        offered_by: { code: "xpro" },
+        podcast_episode: {
+          episode_link: "https://example.com",
+        },
+      })
+
+      setup(resource)
+      const xproImage = screen
+        .getAllByRole("img")
+        .find((img) => img.getAttribute("alt")?.includes("xPRO"))
+
+      expect(xproImage).toBeInTheDocument()
+
+      expect(xproImage).toHaveAttribute("alt", PlatformEnum.Xpro.name)
     },
   )
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -4,18 +4,14 @@ import { render, screen, within } from "@testing-library/react"
 import user from "@testing-library/user-event"
 import { LearningResourceExpanded } from "./LearningResourceExpanded"
 import type { LearningResourceExpandedProps } from "./LearningResourceExpanded"
-import {
-  ResourceTypeEnum,
-  PodcastEpisodeResource,
-  AvailabilityEnum,
-  PlatformEnum,
-} from "api"
+import { ResourceTypeEnum, PodcastEpisodeResource, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { formatDate } from "ol-utilities"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
 import invariant from "tiny-invariant"
 import type { LearningResource } from "api"
 import { faker } from "@faker-js/faker/locale/en"
+import { PLATFORMS } from "../Logo/Logo"
 
 const IMG_CONFIG: LearningResourceExpandedProps["imgConfig"] = {
   key: "fake-key",
@@ -155,8 +151,7 @@ describe("Learning Resource Expanded", () => {
         .find((img) => img.getAttribute("alt")?.includes("xPRO"))
 
       expect(xproImage).toBeInTheDocument()
-
-      expect(xproImage).toHaveAttribute("alt", PlatformEnum.Xpro.name)
+      expect(xproImage).toHaveAttribute("alt", PLATFORMS["xpro"].name)
     },
   )
 

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -134,7 +134,7 @@ describe("Learning Resource Expanded", () => {
   )
 
   test.each([ResourceTypeEnum.PodcastEpisode])(
-    "Renders xpro logo onditionally on offered_by=xpro and not platform.code",
+    "Renders xpro logo conditionally on offered_by=xpro and not platform.code",
     (resourceType) => {
       const resource = factories.learningResources.resource({
         resource_type: resourceType,

--- a/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/LearningResourceExpanded.tsx
@@ -212,11 +212,13 @@ const CallToActionSection = ({
       </CallToAction>
     )
   }
-
-  const platformImage =
-    PLATFORMS[resource?.platform?.code as PlatformEnum]?.image
-
   const { platform } = resource!
+  const offeredBy = resource?.offered_by
+  const platformCode =
+    (offeredBy?.code as PlatformEnum) === PlatformEnum.Xpro
+      ? (offeredBy?.code as PlatformEnum)
+      : (platform?.code as PlatformEnum)
+  const platformImage = PLATFORMS[platformCode]?.image
 
   const getCallToActionText = (resource: LearningResource): string => {
     if (resource?.platform?.code === PlatformEnum.Ocw) {
@@ -244,7 +246,7 @@ const CallToActionSection = ({
       {platformImage ? (
         <Platform>
           <OnPlatform>on</OnPlatform>
-          <StyledPlatformLogo platformCode={platform?.code as PlatformEnum} />
+          <StyledPlatformLogo platformCode={platformCode} />
         </Platform>
       ) : null}
     </CallToAction>


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5802
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes sure that for learning resource drawers if the offered_by is xpro we ignoring the platform.code and always show the "On <MIT xPro logo>"
<img width="482" alt="Screenshot 2024-10-16 at 9 07 32 AM" src="https://github.com/user-attachments/assets/091d01d0-5f1c-4ad2-90d3-1e20f666b824">


### How can this be tested?
1. checkout this branch
2. make sure you have resources loaded - in particular xpro courses
3. resources that are xpro should still show the xpro logo. resources that have a platform.code of something else but have an offered_by attribute of xpro should show xpro. examples of this are courses from [Emeritus](https://learn.mit.edu/search?professional=true&q=designing+AI+&resource=2705) and [Global Alumni](https://learn.mit.edu/c/unit/xpro/?resource=16055)