### PR TITLE
NextJS - re-enable program letter tests

### DIFF
--- a/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetter.test.tsx
+++ b/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetter.test.tsx
@@ -19,7 +19,7 @@ const setup = ({ programLetter }: { programLetter: ProgramLetter }) => {
 
 describe("ProgramLetterDisplayPage", () => {
   // See https://github.com/mitodl/hq/issues/5694
-  it.skip("Renders a program letter from api", async () => {
+  it("Renders a program letter from api", async () => {
     const programLetter = factory.programLetter()
     setup({ programLetter })
     await waitFor(() => {

--- a/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetterPage.tsx
+++ b/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetterPage.tsx
@@ -5,7 +5,6 @@ import { styled } from "ol-components"
 import { useProgramLettersDetail } from "api/hooks/programLetters"
 import { useParams } from "next/navigation"
 import { CkeditorDisplay } from "ol-ckeditor"
-import Image from "next/image"
 
 type RouteParams = {
   id: string
@@ -106,12 +105,28 @@ const ProgramLetterFooter = styled.div`
   }
 `
 
+const ImageContainer = styled.img(({ theme }) => ({
+  display: "flex",
+  alignItems: "end",
+  minWidth: "0px",
+  maxWidth: "646px",
+  [theme.breakpoints.up("sm")]: {
+    /**
+     * Flex 1, combined with the maxWidth, was causing the image to be stretched
+     * on Safari. We don't need flex 1 on the mobile layout, so omit it there.
+     */
+    flex: 1,
+  },
+  [theme.breakpoints.down("sm")]: {
+    maxWidth: "100%",
+  },
+}))
+
 const ProgramLetterPage: React.FC = () => {
   const { id } = useParams<RouteParams>()
   const programLetter = useProgramLettersDetail(id)
   const templateFields = programLetter.data?.template_fields
   const certificateInfo = programLetter.data?.certificate
-
   return (
     <ProgramLetterPageContainer className="letter">
       <ProgramLetterHeader>
@@ -123,10 +138,9 @@ const ProgramLetterPage: React.FC = () => {
           />
         </div>
         <div className="letter-logo">
-          <Image
+          <ImageContainer
             src={templateFields?.program_letter_logo?.meta?.download_url}
-            alt=""
-            fill
+            alt="letter-logo"
           />
         </div>
       </ProgramLetterHeader>
@@ -141,10 +155,9 @@ const ProgramLetterPage: React.FC = () => {
           {templateFields?.program_letter_signatories?.map((signatory) => (
             <div key={signatory.id} className="signatory">
               <div className="sig-image">
-                <Image
+                <ImageContainer
                   src={signatory.signature_image?.meta?.download_url}
                   alt="Signature"
-                  fill
                 />
               </div>
               <div className="name">
@@ -162,10 +175,9 @@ const ProgramLetterPage: React.FC = () => {
       <ProgramLetterFooter>
         <div className="program-footer">
           {templateFields?.program_letter_footer ? (
-            <Image
+            <ImageContainer
               src={templateFields.program_letter_footer?.meta?.download_url}
               alt=""
-              fill
             />
           ) : (
             <p>MITx MicroMasters program in {templateFields?.title}</p>

--- a/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetterPage.tsx
+++ b/frontends/main/src/app-pages/ProgramLetterPage/[id]/view/ProgramLetterPage.tsx
@@ -161,7 +161,7 @@ const ProgramLetterPage: React.FC = () => {
                 />
               </div>
               <div className="name">
-                {signatory.name},{signatory.title_line_1}
+                {signatory.name}, {signatory.title_line_1}
                 {signatory.title_line_2 ? (
                   <p>, {signatory.title_line_2}</p>
                 ) : (


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5694

### Description (What does it do?)
This PR re-enabled the program letter test that was skipped in addition to fixing the program letter template (its broken in the nextjs branch).

### Screenshots (if appropriate):
<img width="624" alt="Screenshot 2024-10-16 at 11 13 20 AM" src="https://github.com/user-attachments/assets/4bdd6a40-4fc5-4845-a356-674c93748590">


### How can this be tested?
1. tests should pass including the re-enabled program letter test
2. to visually test the actual program letter template please refer to instructions [here](https://github.com/mitodl/mit-open/issues/913)

