### PR TITLE
Shanbady/improve bookmark button label

### DIFF
--- a/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -7,6 +7,7 @@ import {
   expectProps,
 } from "../../test-utils"
 import type { User } from "../../test-utils"
+import { getReadableResourceType } from "ol-utilities"
 import { ResourceCard } from "./ResourceCard"
 import {
   AddToLearningPathDialog,
@@ -65,11 +66,6 @@ describe.each([
     return { resource, view, location }
   }
 
-  const labels = {
-    addToLearningPaths: "Add to Learning Path",
-    addToUserList: "Add to User List",
-  }
-
   test("Applies className to the resource card", () => {
     const { view } = setup({ user: {}, props: { className: "test-class" } })
     expect(view.container.firstChild).toHaveClass("test-class")
@@ -91,12 +87,13 @@ describe.each([
   ])(
     "Always shows 'Add to User List' button, but only shows 'Add to Learning Path' button if user is a learning path editor",
     async ({ user, expectAddToLearningPathButton }) => {
-      setup({ user })
+      const { resource } = setup({ user })
       await screen.findByRole("button", {
-        name: labels.addToUserList,
+        name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
       })
+
       const addToLearningPathButton = screen.queryByRole("button", {
-        name: labels.addToLearningPaths,
+        name: "Add to Learning Path",
       })
       expect(!!addToLearningPathButton).toBe(expectAddToLearningPathButton)
     },
@@ -150,10 +147,10 @@ describe.each([
       user: { is_learning_path_editor: true, is_authenticated: true },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: labels.addToUserList,
+      name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
     })
     const addToLearningPathButton = await screen.findByRole("button", {
-      name: labels.addToLearningPaths,
+      name: "Add to Learning Path",
     })
 
     expect(showModal).not.toHaveBeenCalled()
@@ -169,11 +166,11 @@ describe.each([
   })
 
   test("Clicking 'Add to User List' opens signup popover if not authenticated", async () => {
-    setup({
+    const { resource } = setup({
       user: { is_authenticated: false },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: labels.addToUserList,
+      name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
     })
     await user.click(addToUserListButton)
     const dialog = screen.getByRole("dialog")

--- a/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -9,6 +9,7 @@ import {
 import type { User } from "../../test-utils"
 import { getReadableResourceType } from "ol-utilities"
 import { ResourceCard } from "./ResourceCard"
+import { ResourceTypeEnum } from "api"
 import {
   AddToLearningPathDialog,
   AddToUserListDialog,
@@ -89,7 +90,7 @@ describe.each([
     async ({ user, expectAddToLearningPathButton }) => {
       const { resource } = setup({ user })
       await screen.findByRole("button", {
-        name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
+        name: `Bookmark ${getReadableResourceType(resource?.resource_type as ResourceTypeEnum)}`,
       })
 
       const addToLearningPathButton = screen.queryByRole("button", {
@@ -147,7 +148,7 @@ describe.each([
       user: { is_learning_path_editor: true, is_authenticated: true },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
+      name: `Bookmark ${getReadableResourceType(resource?.resource_type as ResourceTypeEnum)}`,
     })
     const addToLearningPathButton = await screen.findByRole("button", {
       name: "Add to Learning Path",
@@ -170,7 +171,7 @@ describe.each([
       user: { is_authenticated: false },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
+      name: `Bookmark ${getReadableResourceType(resource?.resource_type as ResourceTypeEnum)}`,
     })
     await user.click(addToUserListButton)
     const dialog = screen.getByRole("dialog")

--- a/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/mit-learn/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -89,7 +89,7 @@ describe.each([
     async ({ user, expectAddToLearningPathButton }) => {
       const { resource } = setup({ user })
       await screen.findByRole("button", {
-        name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
+        name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
       })
 
       const addToLearningPathButton = screen.queryByRole("button", {
@@ -147,7 +147,7 @@ describe.each([
       user: { is_learning_path_editor: true, is_authenticated: true },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
+      name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
     })
     const addToLearningPathButton = await screen.findByRole("button", {
       name: "Add to Learning Path",
@@ -170,7 +170,7 @@ describe.each([
       user: { is_authenticated: false },
     })
     const addToUserListButton = await screen.findByRole("button", {
-      name: `Bookmark ${getReadableResourceType(resource.resource_type)}`,
+      name: `Bookmark ${getReadableResourceType(resource?.resource_type)}`,
     })
     await user.click(addToUserListButton)
     const dialog = screen.getByRole("dialog")

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.test.tsx
@@ -3,7 +3,11 @@ import { BrowserRouter } from "react-router-dom"
 import { screen, render } from "@testing-library/react"
 import { LearningResourceCard } from "./LearningResourceCard"
 import type { LearningResourceCardProps } from "./LearningResourceCard"
-import { DEFAULT_RESOURCE_IMG, embedlyCroppedImage } from "ol-utilities"
+import {
+  DEFAULT_RESOURCE_IMG,
+  embedlyCroppedImage,
+  getReadableResourceType,
+} from "ol-utilities"
 import { ResourceTypeEnum, PlatformEnum, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
@@ -131,7 +135,9 @@ describe("Learning Resource Card", () => {
 
     await addToLearningPathButton.click()
 
-    const addToUserListButton = screen.getByLabelText("Add to User List")
+    const addToUserListButton = screen.getByLabelText(
+      `Bookmark ${getReadableResourceType(resource.resource_type)}`,
+    )
 
     await addToUserListButton.click()
 

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceCard.tsx
@@ -272,7 +272,7 @@ const LearningResourceCard: React.FC<LearningResourceCardProps> = ({
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label="Add to User List"
+            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -3,7 +3,11 @@ import { BrowserRouter } from "react-router-dom"
 import { screen, render } from "@testing-library/react"
 import { LearningResourceListCard } from "./LearningResourceListCard"
 import type { LearningResourceListCardProps } from "./LearningResourceListCard"
-import { DEFAULT_RESOURCE_IMG, embedlyCroppedImage } from "ol-utilities"
+import {
+  DEFAULT_RESOURCE_IMG,
+  embedlyCroppedImage,
+  getReadableResourceType,
+} from "ol-utilities"
 import { ResourceTypeEnum, PlatformEnum, AvailabilityEnum } from "api"
 import { factories } from "api/test-utils"
 import { ThemeProvider } from "../ThemeProvider/ThemeProvider"
@@ -123,7 +127,9 @@ describe("Learning Resource List Card", () => {
     )
     await addToLearningPathButton.click()
 
-    const addToUserListButton = screen.getByLabelText("Add to User List")
+    const addToUserListButton = screen.getByLabelText(
+      `Bookmark ${getReadableResourceType(resource.resource_type)}`,
+    )
     await addToUserListButton.click()
 
     expect(onAddToLearningPathClick).toHaveBeenCalledWith(

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -295,7 +295,6 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
   if (!resource) {
     return null
   }
-
   return (
     <ListCard href={href} className={className} draggable={draggable}>
       <ListCard.Image
@@ -323,7 +322,7 @@ const LearningResourceListCard: React.FC<LearningResourceListCardProps> = ({
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label="Add to User List"
+            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCardCondensed.tsx
@@ -114,6 +114,7 @@ const LearningResourceListCardCondensed: React.FC<
       </ListCardCondensed>
     )
   }
+
   if (!resource) {
     return null
   }
@@ -136,7 +137,7 @@ const LearningResourceListCardCondensed: React.FC<
         {onAddToUserListClick && (
           <CardActionButton
             filled={inUserList}
-            aria-label="Add to User List"
+            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
             onClick={(event) => onAddToUserListClick(event, resource.id)}
           >
             {inUserList ? (

--- a/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/ol-components/src/components/LearningResourceExpanded/InfoSection.tsx
@@ -20,6 +20,7 @@ import { LearningResource, LearningResourceRun, ResourceTypeEnum } from "api"
 import {
   formatDurationClockTime,
   getLearningResourcePrices,
+  getReadableResourceType,
 } from "ol-utilities"
 import { theme } from "../ThemeProvider/ThemeProvider"
 import Typography from "@mui/material/Typography"
@@ -288,7 +289,7 @@ const InfoSection = ({
           )}
           <CardActionButton
             filled={inUserList}
-            aria-label="Add to User List"
+            aria-label={`Bookmark ${getReadableResourceType(resource.resource_type)}`}
             onClick={
               onAddToUserListClick
                 ? (event) => onAddToUserListClick?.(event, resource.id)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/5545


### Description (What does it do?)
This PR changes the aria-label for the add to user list button to "Bookmark (resource type)"


### How can this be tested?
1. checkout this branch. 
2. validate that the aria label for the add to user list (little bookmark icon) on resource cards says "Bookmark (resource type)"
  -  <img width="49" alt="Screenshot 2024-10-16 at 1 35 48 PM" src="https://github.com/user-attachments/assets/33425bed-6f8a-4d2a-9ff6-570beffdff48">
4. optionally use a screen reader and verify it captures the aria-label

