### PR TITLE
Copy yarn releases to the Docker container (fixes build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
           file: coverage/lcov.info
 
   build-deploy-frontend:
-    if: github.ref == 'refs/heads/nextjs'
     needs: javascript-tests
     runs-on: ubuntu-latest
     steps:
@@ -186,6 +185,7 @@ jobs:
           --context-path .
 
       - name: Release on Heroku
+        if: github.ref == 'refs/heads/nextjs'
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: heroku container:release --app mitopen-rc-nextjs web

--- a/frontends/main/Dockerfile.web
+++ b/frontends/main/Dockerfile.web
@@ -42,7 +42,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY .yarnrc.yml /app
-COPY .yarn/releases/yarn-4.4.1.cjs /app/.yarn/releases/yarn-4.4.1.cjs
+COPY .yarn/releases /app/.yarn/releases
 COPY yarn.lock /app
 COPY package.json /app
 COPY frontends /app/frontends


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Quick fix.

### Description (What does it do?)
<!--- Describe your changes in detail -->

The build is failing due to the versioned yarn release file not being available after upgrade https://github.com/mitodl/mit-open/actions/runs/11383821684/job/31670434697.

This copies the contents of .yarn/releases into the container, not just the file.

Also builds the Docker image on all push so we can see errors before we merge.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

CI passes and can build the frontend locally with Docker: 

```
docker build \
  -f frontends/main/Dockerfile.web \
  --build-arg NEXT_PUBLIC_ORIGIN=http://api.open.odl.local:8062 \
  --build-arg NEXT_PUBLIC_MITOL_API_BASE_URL=http://open.odl.local:8063 \
  --build-arg NEXT_PUBLIC_SITE_NAME="MIT Learn" \
  --build-arg NEXT_PUBLIC_MITOL_SUPPORT_EMAIL=mitlearn-support@mit.edu \
  --build-arg NEXT_PUBLIC_EMBEDLY_KEY= \
  --build-arg NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS=true \
  --build-arg NEXT_PUBLIC_CSRF_COOKIE_NAME=csrftoken-local \
  -t mitodl/mit-learn-frontend:latest .
```
