### PR TITLE
Remove unnecessary webpack customizations

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -21,29 +21,6 @@ const processFeatureFlags = () => {
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  webpack: (config, { webpack }) => {
-    config.plugins.push(
-      new webpack.IgnorePlugin({
-        resourceRegExp: /\.test\.tsx$/,
-      }),
-      new webpack.IgnorePlugin({
-        resourceRegExp: /mockAxios\.ts/,
-      }),
-    )
-
-    // Do not do this. Added to fix "import type", but causes a strage issue where
-    // the root page and layout think they're Client Components and "use client"
-    // directives not properly respected.
-    // https://nextjs.org/docs/app/api-reference/next-config-js/webpack
-    //
-    // config.module.rules.push({
-    //   test: /\.tsx?$/,
-    //   use: [defaultLoaders.babel],
-    // })
-
-    return config
-  },
-
   async rewrites() {
     return [
       /* Images moved from /static, though image paths are sometimes


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR removes some unnecessary webpack customizations from our NextJS site.

### How can this be tested?
1. There should be no change to the site. Sanity check that the app works as before.
2. If you want, you can double check that running `NODE_ENV=production yarn workspace main build` produces the same file sizes on this branch vs `nextjs`. It does.

