### PR TITLE
Increase cache duration

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -45,7 +45,7 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=120",
+            value: "s-maxage=1800",
           },
         ],
       },
@@ -58,7 +58,7 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value: "s-maxage=600",
+            value: "s-maxage=31536000",
           },
         ],
       },

--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -36,9 +36,12 @@ const nextConfig = {
 
   async headers() {
     return [
-      /* This is intended to target the base HTML responses. Some are dynamically rendered,
-       * so Next.js instructs no-cache, however we are currently serving public content that
-       * is cacheable. Excludes everything with a file extension so we're matching only on routes.
+      /* This is intended to target the base HTML responses and streamed RSC
+       * content. Some routes are dynamically rendered, so NextJS by default
+       * sets no-cache. However we are currently serving public content that is
+       * cacheable.
+       *
+       * Excludes everything with a file extension so we're matching only on routes.
        */
       {
         source: "/((?!.*\\.[a-zA-Z0-9]{2,4}$).*)",


### PR DESCRIPTION
### What are the relevant tickets?

Follow on from https://github.com/mitodl/mit-open/pull/1700

https://github.com/mitodl/hq/issues/5796

### Description (What does it do?)
<!--- Describe your changes in detail -->

The previous PR had a short cache duration for testing. This updates to 30 minutes for HTML responses (and adds a missed [suggestion](https://github.com/mitodl/mit-open/pull/1700#discussion_r1803781279) to add comment detail).


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

All HTML responses for route paths have a `Cache-Control: s-maxage=1800` header. 