### PR TITLE
remove elasticsearch from ci build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,6 @@ jobs:
         ports:
           - 6379:6379
 
-      elastic:
-        image: docker.elastic.co/elasticsearch/elasticsearch:8.15.1
-        env:
-          network.host: "0.0.0.0"
-          http.cors.enabled: "true"
-          http.cors.allow-origin: "*"
-          http.max_content_length: "10mb"
-          rest.action.multi.allow_explicit_index: "false"
-          ES_JAVA_OPTS: "-Xms1024m -Xmx1024m"
-          discovery.type: "single-node"
-        ports:
-          - 9200:9200
-
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Renovate wants to update the docker elasticsearch tag because the CI build still references elasticsearch rather then open search. I just removed it since clearly it's not used. 

### How can this be tested?
The tests should pass