### PR TITLE
fix: opensearch container on ARM64 based architecture

### DIFF
--- a/docker-compose.opensearch.base.yml
+++ b/docker-compose.opensearch.base.yml
@@ -4,6 +4,7 @@ services:
     environment:
       - "cluster.name=opensearch-cluster"
       - "bootstrap.memory_lock=true" # along with the memlock settings below, disables swapping
+      - "_JAVA_OPTIONS=-XX:UseSVE=0" # disables SVE (Scalable Vector Extension) for ARM64
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # Set min and max JVM heap sizes to at least 50% of system RAM
       - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
       - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml


### PR DESCRIPTION
### What are the relevant tickets?
None, Noticed it while running the project containers on Apple Silicon(M4) machine.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
I couldn't run the `Opensearch` container while setting up this project on Macbook Pro m4. While running the opensearch container using the current configuration breaks with the JDK version. This seems to be an incompatible JDK version error.

This seems to be a known issue in JDK with ARM architecture reported
- https://bugs.openjdk.org/browse/JDK-8345296
- https://github.com/opensearch-project/opensearch-build/issues/5217

I've applied the suggested solution based on the above reported issues.

**The error log:**

```
2025-02-24 16:00:45 Disabling OpenSearch Security Plugin
2025-02-24 16:00:45 Enabling execution of OPENSEARCH_HOME/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli for OpenSearch Performance Analyzer Plugin
2025-02-24 16:00:45 #
2025-02-24 16:00:45 # A fatal error has been detected by the Java Runtime Environment:
2025-02-24 16:00:45 #
2025-02-24 16:00:45 #  SIGILL (0x4) at pc=0x0000ffff8fd3fc5c, pid=33, tid=34
2025-02-24 16:00:45 #
2025-02-24 16:00:45 # JRE version:  (21.0.6+7) (build )
2025-02-24 16:00:45 # Java VM: OpenJDK 64-Bit Server VM (21.0.6+7-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
2025-02-24 16:00:45 # Problematic frame:
2025-02-24 16:00:45 # j  java.lang.System.registerNatives()V+0 java.base@21.0.6
2025-02-24 16:00:45 #
2025-02-24 16:00:45 # No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
2025-02-24 16:00:45 #
2025-02-24 16:00:45 # An error report file with more information is saved as:
2025-02-24 16:00:45 # /usr/share/opensearch/hs_err_pid33.log
2025-02-24 16:00:45 [0.024s][warning][os] Loading hsdis library failed
2025-02-24 16:00:45 #
2025-02-24 16:00:45 # The crash happened outside the Java Virtual Machine in native code.
2025-02-24 16:00:45 # See problematic frame for where to report the bug.
2025-02-24 16:00:45 #
2025-02-24 16:00:45 /usr/share/opensearch/bin/opensearch-env: line 99:    33 Aborted                 "$JAVA" "$XSHARE" -cp "$OPENSEARCH_CLASSPATH" org.opensearch.tools.java_version_checker.JavaVersionChecker
```


### How can this be tested?
It would be great if you could reproduce this issue on an arm64 based machine

This is how I tested it:
- Run the containers on this branch
- Made sure that the opensearch container runs successfully
- Ran the `recreate_index` management command
- Monitored the celery tasks for any error
- Made sure that the re-index finishes successfully and no errors are reported in celery

<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
