### PR TITLE
fix: env based _JAVA_OPTIONS for opensearch container

### DIFF
--- a/env/backend.env
+++ b/env/backend.env
@@ -33,7 +33,3 @@ UWSGI_THREADS=35
 
 TIKA_SERVER_ENDPOINT=http://tika:9998/
 TIKA_CLIENT_ONLY=True
-
-# _JAVA_OPTIONS for Opensearch container are not consistent between different CPU architectures e.g ARM and x86.
-# Here, anyone can set options like -XX:UseSVE=0 based on their CPU.
-JAVA_OPTIONS=

--- a/env/backend.local.example.env
+++ b/env/backend.local.example.env
@@ -43,3 +43,7 @@ SOCIAL_AUTH_OL_OIDC_KEY=apisix
 # This is not a secret. This is for the Keycloak container, only for local use.
 SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
 USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
+
+# _JAVA_OPTIONS for Opensearch container are not consistent between different CPU architectures e.g ARM and x86.
+# Here, anyone can set options like -XX:UseSVE=0 based on their CPU.
+JAVA_OPTIONS=


### PR DESCRIPTION
### What are the relevant tickets?
None, More flexible fix for https://github.com/mitodl/mit-learn/pull/2069
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Makes the `_JAVA_OPTIONS` setting in opensearch container configurable through env vars. Earlier, this was hardcoded to `-XX:UseSVE=0` but the x86 systems pick it and don't understand it hence stopping the container right after starting it. 

- Anyone needing `-XX:UseSVE=0` would now set it in their `backend.local.env` file

<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
We might want multiple people to test it by having different machines based on x86, ARM architecture.

- Switch to this branch and try to start your OpenSearch container 
- Ideal, Only, if you could destroy your existing Opensearch container and rebuild and start it
- Make sure that your container starts normally.

<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
