### PR TITLE
Fix type error on main

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/DashboardLayout.test.tsx
@@ -10,6 +10,7 @@ import DashboardLayout from "./DashboardLayout"
 import React from "react"
 import { DASHBOARD_HOME, MY_LISTS, PROFILE, SETTINGS } from "@/common/urls"
 import { faker } from "@faker-js/faker/locale/en"
+import invariant from "tiny-invariant"
 
 jest.mock("posthog-js/react")
 
@@ -34,7 +35,7 @@ describe("DashboardLayout", () => {
 
   test("Renders user info", async () => {
     const { user } = setup()
-
+    invariant(user.profile)
     await screen.findByText(user.profile.name)
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
@@ -17,6 +17,7 @@ import React from "react"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import HomeContent from "./HomeContent"
+import invariant from "tiny-invariant"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
@@ -73,6 +74,7 @@ describe("HomeContent", () => {
         },
       },
     })
+    invariant(user.profile)
 
     const courses = factories.learningResources.courses
     const resources = {


### PR DESCRIPTION
### What are the relevant tickets?
Non

### Description (What does it do?)
There is currently a typescript error on `main` (see, e.g., https://github.com/mitodl/mit-learn/actions/runs/14247995768/job/39933709546?pr=2177)

- Starting in https://github.com/mitodl/mit-learn/pull/2156/files?show-viewed-files=true&file-filters%5B%5D=#diff-83282fef07409ca22ec9db563d88e9059520e6da5071c3c54411042687adbe29, `user.profile` is no longer a required property on `User` object.
- prior to merging ☝️ some code was added that assumed `user.profile` was non-null.
- I **think** we merged the above PR without rebasing, which is why the type error wasn't picked up until merges to main.

### How can this be tested?
Tests should pass. There are no changes here except to two test files. No runtime behavior change.