### PR TITLE
change hero text

### DIFF
--- a/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
+++ b/frontends/main/src/page-components/HeroSearch/HeroSearch.tsx
@@ -15,13 +15,11 @@ import {
 } from "ol-components"
 import type { ChipLinkProps } from "ol-components"
 import {
-  ABOUT,
   SEARCH_CERTIFICATE,
   SEARCH_FREE,
   SEARCH_NEW,
   SEARCH_POPULAR,
   SEARCH_UPCOMING,
-  ABOUT_NON_DEGREE_LEARNING_FRAGMENT,
 } from "@/common/urls"
 import {
   RiAwardLine,
@@ -233,17 +231,7 @@ const HeroSearch: React.FC<{ imageIndex: number }> = ({ imageIndex }) => {
         >
           Learn with MIT
         </Typography>
-        <Typography>
-          Explore MIT's{" "}
-          <Link
-            color="black"
-            size="large"
-            href={`${ABOUT}#${ABOUT_NON_DEGREE_LEARNING_FRAGMENT}`}
-            prefetch={false}
-          >
-            Non-Degree Learning
-          </Link>
-        </Typography>
+        <Typography>Lifelong Learning. The MIT way.</Typography>
         <ControlsContainer>
           <SearchField
             size="hero"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7437

### Description (What does it do?)
This pr updates the hero text for the front page

### Screenshots (if appropriate):
<img width="385" alt="Screenshot 2025-05-30 at 12 01 32 PM" src="https://github.com/user-attachments/assets/26fc8e40-7061-414e-911b-bd030fe968b6" />
<img width="1679" alt="Screenshot 2025-05-30 at 12 01 19 PM" src="https://github.com/user-attachments/assets/549d8164-47f8-47d0-94d2-2a84536d28a1" />


### How can this be tested?
Go to the front page. Verify that the hero text looks good