### PR TITLE
Ab/update legal docs

### DIFF
--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   TypographyProps,
   styled,
+  Link,
 } from "ol-components"
 import * as urls from "@/common/urls"
 
@@ -49,7 +50,7 @@ const BodyContainer = styled.div({
   flexDirection: "column",
   alignItems: "center",
   alignSelf: "stretch",
-  gap: "20px",
+  gap: "10px",
 })
 
 const BodyText = styled(Typography)(({ theme }) => ({
@@ -59,6 +60,14 @@ const BodyText = styled(Typography)(({ theme }) => ({
 
 const OrderedList = styled.ol(({ theme }) => ({
   ...theme.typography.body1,
+  li: {
+    marginTop: "10px",
+  },
+}))
+
+const LetteredOrderedList = styled.ol(({ theme }) => ({
+  ...theme.typography.body1,
+  listStyleType: "upper-alpha",
 }))
 
 const UnorderedList = styled.ul(({ theme }) => ({
@@ -83,90 +92,114 @@ const TermsPage: React.FC = () => {
         </BannerContainer>
         <BodyContainer>
           <BodyText variant="body1">
-            Welcome to the MIT LEARN website (the “Site”). By accessing this
-            Site, users agree to be bound by the following terms and conditions
-            which MIT may revise at any time. Users are encouraged to visit this
+            Welcome to MIT Learn (the “Site”). By accessing this Site, you agree
+            to be bound by the following terms and conditions (the “Terms”),
+            which MIT may revise at any time. You are encouraged to visit this
             page periodically to review current terms and conditions, as your
-            continued use of this Site signifies your agreement to these terms
-            and conditions. If you do not understand or do not agree to be bound
-            by these terms and conditions, please exit this Site immediately.
+            continued use of this Site signifies your agreement to these term
+            and conditions.
           </BodyText>
           <OrderedList>
             <li>
-              Your use of this Site is entirely voluntary. This Site is designed
-              to assist and facilitate your access to MIT LEARN materials and
-              the MIT LEARN community. These terms and conditions govern your
-              use of this Site alone.
+              By using this Site, you confirm that you are at least 13 years old
+              or have the legal capacity to enter into a binding agreement in
+              your jurisdiction. If you do not agree with these Terms, including
+              the Terms of Service and Privacy Policy, you must not access or
+              use the Site.
             </li>
             <li>
-              MIT respects your privacy. We do not collect personally
-              identifiable information about you unless you voluntarily provide
-              it. Our primary aim in collecting personally identifiable
-              information is to provide you with the best educational experience
-              possible. By "personally identifiable information," we are
-              referring to (1) data that uniquely identifies you or permits us
-              to contact you, such as your name, email address, mailing address,
-              and phone number; and (2) other information that we collect
-              through the Site and combine and maintain in combination with that
-              personally identifiable information, such as your area of
-              interest; educational and employment background; Among other
-              things, MIT may use the personally identifiable information that
-              you provide to respond to your questions; provide you the specific
-              courses and/or services you select; send you updates about courses
-              and information, including specifically the MIT educational
-              programs and information about MIT events; send you information
-              about Site maintenance or updates; and for all appropriate MIT
-              administrative and research purposes. Except as set forth herein
-              or as specifically agreed to by you, MIT will not disclose any
-              personally identifiable information we gather from you on the Site
-              to any third parties.
+              MIT Learn respects your privacy. Please review{" "}
+              <Link href={urls.PRIVACY} color="red" size="large">
+                https://learn.mit.edu/privacy
+              </Link>{" "}
+              for more information on how this Site collects, stores, and uses
+              your personal information.
             </li>
             <li>
-              You agree to use the Site in accordance with all applicable laws.
-              You are responsible for your own communications, including the
-              upload, transmission and posting of information, and are
-              responsible for the consequences of their posting on or through
-              the Site. You further agree that you will not email or post
-              malicious or harmful content anywhere on the Site or on any other
-              MIT computing resources including without limitation the
-              following:
-              <UnorderedList>
-                <li>Content that defames or threatens others.</li>
+              Additional Terms of Service: Certain features or services offered
+              on or through the Site may be subject to additional terms and
+              conditions. Use of those services of offerings is governed by
+              their respective Terms of Service, which are made available at the
+              point of use and are incorporated into these Terms by reference.
+              <LetteredOrderedList>
                 <li>
-                  Harassing statements or content that violates federal or state
-                  law.
+                  Terms of Service
+                  <UnorderedList>
+                    <li>
+                      MITx Online:{" "}
+                      <Link
+                        href="https://mitxonline.mit.edu/terms-of-service/"
+                        color="red"
+                        size="large"
+                      >
+                        https://mitxonline.mit.edu/terms-of-service/
+                      </Link>
+                    </li>
+                  </UnorderedList>
                 </li>
                 <li>
-                  Content that discusses illegal activities with the intent to
-                  commit them.
+                  Privacy Policy
+                  <UnorderedList>
+                    <li>
+                      MITx Online:{" "}
+                      <Link
+                        href="https://mitxonline.mit.edu/privacy-policy"
+                        color="red"
+                        size="large"
+                      >
+                        https://mitxonline.mit.edu/privacy-policy/
+                      </Link>
+                    </li>
+                  </UnorderedList>
                 </li>
                 <li>
-                  Content that is not your own or infringes another's
-                  intellectual property including, but not limited to,
-                  copyrights, trademarks, or trade secrets.
+                  Honor Code
+                  <UnorderedList>
+                    <li>
+                      MITx Online:{" "}
+                      <Link
+                        href="https://mitxonline.mit.edu/honor-code/"
+                        color="red"
+                        size="large"
+                      >
+                        https://mitxonline.mit.edu/honor-code/
+                      </Link>
+                    </li>
+                  </UnorderedList>
                 </li>
-                <li>
-                  Material that contains obscene (i.e. pornographic) language or
-                  images.
-                </li>
-                <li>
-                  Advertising or any form of commercial solicitation or
-                  promotion, including links to other sites.
-                </li>
-                <li>Content that is otherwise unlawful.</li>
-                <li>
-                  Intentionally incomplete, misleading, or inaccurate content.
-                </li>
-              </UnorderedList>
+              </LetteredOrderedList>
+            </li>
+            <li>
+              MIT respects the intellectual property rights of others. If you
+              believe another user is infringing your copyright, please provide
+              written notice to MIT by emailing{" "}
+              <Link
+                href="mailto:dmca-agent@mit.edu."
+                size="large"
+                color="black"
+              >
+                dmca-agent@mit.edu.
+              </Link>{" "}
+              {""}
+              You agree that if a third party claims that any material you have
+              contributed to the Site is unlawful, you will bear the burden of
+              establishing that the material complies with all applicable laws.
+            </li>
+            <li>
+              All content, design, text, graphics, logos, images, software, and
+              other materials on the Site are the property of MIT and/or its
+              licensors and are protected by intellectual property laws. You may
+              not copy, distribute, modify, or create derivative works without
+              our express written permission.
             </li>
             <li>
               "MIT", "Massachusetts Institute of Technology", and its logos and
               seal are trademarks of the Massachusetts Institute of Technology.
-              Except for purposes of attribution, you may not use MIT's names or
+              Except for purposes of attribution, you may not use MIT’s names or
               logos, or any variations thereof, without prior written consent of
               MIT. You may not use the MIT name in any of its forms nor MIT
               seals or logos for promotional purposes, or in any way that
-              deliberately or inadvertently claims, suggests, or in MIT's sole
+              deliberately or inadvertently claims, suggests, or in MIT’s sole
               judgment gives the appearance or impression of a relationship with
               or endorsement by MIT.
             </li>
@@ -180,15 +213,15 @@ const TermsPage: React.FC = () => {
               COMPILATION.
             </li>
             <li>
-              You agree to defend, hold harmless, and indemnify MIT and its
+              You agree to defend, hold harmless and indemnify MIT, and its
               subsidiaries, affiliates, officers, agents, and employees from and
-              against any third-party claims, actions, or demands arising out
-              of, resulting from, or in any way related to your use of the Site,
+              against any third-party claims, actions or demands arising out of,
+              resulting from or in any way related to your use of the Site,
               including any liability or expense arising from any and all
               claims, losses, damages (actual and consequential), suits,
-              judgments, litigation costs and attorneys' fees, of every kind and
+              judgments, litigation costs and attorneys’ fees, of every kind and
               nature. In such a case, MIT will provide you with written notice
-              of such claim, suit, or action.
+              of such claim, suit or action.
             </li>
             <li>
               These terms and conditions constitute the entire agreement between
@@ -199,13 +232,13 @@ const TermsPage: React.FC = () => {
               waiver of such right or provision. If any provision of the terms
               and conditions is found by a court of competent jurisdiction to be
               invalid, the parties nevertheless agree that the court should
-              endeavor to give effect to the parties' intentions as reflected in
-              the provision and the other provisions of the terms and conditions
-              remain in full force and effect.
+              endeavor to give effect to the parties’ intentions as reflected in
+              the provision, and the other provisions of the terms and
+              conditions remain in full force and effect.
             </li>
             <li>
               You agree that any dispute arising out of or relating to these
-              terms and conditions or any content posted to a Site will be
+              terms and conditions or any content posted to the Site will be
               governed by the laws of the Commonwealth of Massachusetts,
               excluding its conflicts of law provisions. You further consent to
               the personal jurisdiction of and exclusive venue in the federal
@@ -213,9 +246,6 @@ const TermsPage: React.FC = () => {
               the legal forum for any such dispute.
             </li>
           </OrderedList>
-          <BodyText variant="subtitle1">
-            This policy was last updated in June 2024.
-          </BodyText>
         </BodyContainer>
       </PageContainer>
     </Container>

--- a/frontends/main/src/page-components/Footer/Footer.tsx
+++ b/frontends/main/src/page-components/Footer/Footer.tsx
@@ -165,8 +165,8 @@ const Footer: FunctionComponent = () => {
                   href={urls.ACCESSIBILITY}
                 />
                 <FooterLinkComponent
-                  text="Privacy Policy"
-                  href={urls.PRIVACY}
+                  text="Terms of Service"
+                  href={urls.TERMS}
                 />
                 <FooterLinkComponent text="Contact Us" href={urls.CONTACT} />
               </FooterLinksContainer>


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7341

### Description (What does it do?)
This pr updates the terms of service and links to it in the footer

### Screenshots (if appropriate):
<img width="1679" alt="Screenshot 2025-05-30 at 3 21 59 PM" src="https://github.com/user-attachments/assets/d4972280-12cb-44b0-9058-190077aaec1e" />
<img width="386" alt="Screenshot 2025-05-30 at 3 22 14 PM" src="https://github.com/user-attachments/assets/ce3df8f4-5447-4116-b9ee-d11fd4eb4829" />
<img width="1677" alt="Screenshot 2025-05-30 at 3 24 04 PM" src="https://github.com/user-attachments/assets/93ec5f8a-8bbe-4f32-a9a4-9f9a03487157" />
<img width="1685" alt="Screenshot 2025-05-30 at 3 24 22 PM" src="https://github.com/user-attachments/assets/53f4224a-bccf-4f15-adc9-4b0bc5ba1aa1" />
<img width="385" alt="Screenshot 2025-05-30 at 3 24 39 PM" src="https://github.com/user-attachments/assets/712aafb7-1030-428c-9668-dec6c24ed261" />

### How can this be tested?
Verify that the text in http://open.odl.local:8062/terms matches the document in the issue 
Verify that the link to "Terms of Service" in the footer works