### PR TITLE
fix dashboard 403 populating mitxonline enrollments

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -14,6 +14,7 @@ import { useQuery } from "@tanstack/react-query"
 import { mitxonlineEnrollments } from "./transform"
 import { DashboardCard } from "./DashboardCard"
 import { DashboardCourse, EnrollmentStatus } from "./types"
+import { MaybeHasStatusAndDetail } from "@/app/getQueryClient"
 
 const Wrapper = styled.div(({ theme }) => ({
   marginTop: "32px",
@@ -176,6 +177,19 @@ const EnrollmentDisplay = () => {
   const { data: enrolledCourses, isLoading } = useQuery({
     ...enrollmentQueries.enrollmentsList({}),
     select: mitxonlineEnrollments,
+    throwOnError: (error) => {
+      const err = error as MaybeHasStatusAndDetail
+      const status = err?.response?.status
+      if (
+        status === 403 &&
+        err.response?.data?.detail ===
+          "Authentication credentials were not provided."
+      ) {
+        // For now, we don't want to throw an error if the user is not authenticated.
+        return false
+      }
+      return true
+    },
   })
 
   const { completed, expired, started, notStarted } = sortEnrollments(

--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -2,9 +2,12 @@
 
 import { QueryClient, isServer } from "@tanstack/react-query"
 
-type MaybeHasStatus = {
+type MaybeHasStatusAndDetail = {
   response?: {
     status?: number
+    data?: {
+      detail?: string
+    }
   }
 }
 
@@ -26,12 +29,12 @@ const makeQueryClient = (): QueryClient => {
          * be handled locally by components.
          */
         throwOnError: (error) => {
-          const status = (error as MaybeHasStatus)?.response?.status
+          const status = (error as MaybeHasStatusAndDetail)?.response?.status
           return THROW_ERROR_CODES.includes(status ?? 0)
         },
 
         retry: (failureCount, error) => {
-          const status = (error as MaybeHasStatus)?.response?.status
+          const status = (error as MaybeHasStatusAndDetail)?.response?.status
           const isNetworkError = status === undefined || status === 0
 
           /**
@@ -78,3 +81,4 @@ function getQueryClient() {
 }
 
 export { makeQueryClient, getQueryClient }
+export type { MaybeHasStatusAndDetail }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7493

### Description (What does it do?)
This PR sets up the enrollments query on the dashboard home page to not throw errors on authentication based 403 errors returned in response to said query. This happens due to a CSRF error currently, which is expected if the MITx Online integration is misconfigured.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 learn.odl.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values (note that we are intentionally misconfiguring the cookie domain):
```
COMPOSE_PROFILES=apisix
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=mitxonline.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://learn.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=mitxonline.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user --promote --superuser admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create one, adding some of the test courses to it
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- In the MITx Online Dashboard, enroll the test admin user in the courses you put in your B2B org, making sure you select the course runs generated by the org
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables (note that we are intentionally misconfiguring the cookie domain):
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=learn.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- Log in with the `admin@odl.local` test user
- Navigate to the Dashboard
- There should be no error on the page and it should load normally, but if you inspect the developer console you should still see the 403 on the enrollments endpoint there.
