### PR TITLE
update smoot to proper release

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@mitodl/course-search-utils": "3.3.2",
     "@mitodl/mitxonline-api-axios": "^2025.6.3",
-    "@mitodl/smoot-design": "0.0.0-0a23f44",
+    "@mitodl/smoot-design": "^6.10.0",
     "@next/bundle-analyzer": "^14.2.15",
     "@remixicon/react": "^4.2.0",
     "@sentry/nextjs": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,9 +2732,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:0.0.0-0a23f44":
-  version: 0.0.0-0a23f44
-  resolution: "@mitodl/smoot-design@npm:0.0.0-0a23f44"
+"@mitodl/smoot-design@npm:^6.10.0":
+  version: 6.10.0
+  resolution: "@mitodl/smoot-design@npm:6.10.0"
   dependencies:
     "@ai-sdk/react": "npm:1.2.12"
     "@emotion/cache": "npm:^11.14.0"
@@ -2758,7 +2758,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/46302fdf2f064a361b4bb2e9de9ea24ffc557df41e1f52ef19da17fbb2033e94fd9da01c998c83c093295bb6b45a4f918d2d0643f4a0f223d9c78de195250baa
+  checksum: 10/d68ee7336f7102ceea562d6695ea9a2174f586d5ca36518f09bfa912c702c1493fa74146e413dedadecb8532412dfc35684b19e9143744723de8c88e90cb7ad4
   languageName: node
   linkType: hard
 
@@ -13350,7 +13350,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.0.0"
     "@mitodl/course-search-utils": "npm:3.3.2"
     "@mitodl/mitxonline-api-axios": "npm:^2025.6.3"
-    "@mitodl/smoot-design": "npm:0.0.0-0a23f44"
+    "@mitodl/smoot-design": "npm:^6.10.0"
     "@next/bundle-analyzer": "npm:^14.2.15"
     "@remixicon/react": "npm:^4.2.0"
     "@sentry/nextjs": "npm:^9.0.0"


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #2304 

### Description (What does it do?)
#2304 set mit-learn to use the pre-release version of smoot-design. This PR updates to a semver release.

It's the same code, apart from the version number—forgot to commit the change in #2304. 

### How can this be tested?

Tests should pass, site should look the same.