### PR TITLE
align LearningResourceListCard with figma

### DIFF
--- a/frontends/ol-components/src/components/Card/ListCard.tsx
+++ b/frontends/ol-components/src/components/Card/ListCard.tsx
@@ -62,7 +62,7 @@ const Image = styled(NextImage)`
   object-fit: cover;
   ${theme.breakpoints.down("md")} {
     width: 111px;
-    height: 104px;
+    height: 106px;
     margin: 0;
     border-radius: 0;
   }
@@ -115,8 +115,11 @@ export const Bottom = styled.div`
   justify-content: space-between;
   align-items: flex-end;
   height: ${theme.typography.pxToRem(32)};
+  margin-top: 2px;
   ${theme.breakpoints.down("md")} {
-    height: ${theme.typography.pxToRem(18)};
+    height: ${theme.typography.pxToRem(16)};
+    margin-top: 8px;
+    align-items: center;
   }
 `
 

--- a/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
+++ b/frontends/ol-components/src/components/Card/ListCardCondensed.tsx
@@ -18,7 +18,6 @@ import {
   Info as BaseInfo,
   Title as BaseTitle,
   Footer,
-  Bottom as BaseBottom,
 } from "./ListCard"
 import type { Card as BaseCard, TitleProps } from "./ListCard"
 
@@ -61,12 +60,11 @@ const Title = styled(BaseTitle)`
   }
 `
 
-const Bottom = styled(BaseBottom)`
-  height: auto;
+const Bottom = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
   min-height: 16px;
-  ${theme.breakpoints.down("md")} {
-    height: auto;
-  }
 `
 const Actions = styled.div`
   display: flex;

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -22,7 +22,7 @@ import type { ActionButtonProps } from "@mitodl/smoot-design"
 import { theme } from "../ThemeProvider/ThemeProvider"
 
 const IMAGE_SIZES = {
-  mobile: { width: 116, height: 104 },
+  mobile: { width: 116, height: 106 },
   desktop: { width: 236, height: 122 },
 }
 
@@ -53,6 +53,7 @@ export const Certificate = styled.div`
 
   ${theme.breakpoints.down("md")} {
     ${{ ...theme.typography.body4 }}
+    padding: 2px 4px;
     color: ${theme.custom.colors.darkGray2};
     gap: 2px;
 


### PR DESCRIPTION
### What are the relevant tickets?
Potential followup to https://github.com/mitodl/mit-learn/pull/2308

### Description (What does it do?)
<!--- Describe your changes in detail -->

Aligns mobile version of the search page resource card with Figma. Changes are:
- minor changes to spacing between header row, title, footer
- alignment of button icons... now centered on mobile relative to format, start-date

### Screenshots (if appropriate):

**Branch Mobile** vs **RC Mobile**
<img width="300" alt="Screenshot 2025-06-20 at 3 55 51 PM" src="https://github.com/user-attachments/assets/8d42477c-9280-427f-bb8e-c2311535a045" /> / <img width="300" alt="Screenshot 2025-06-20 at 3 54 14 PM" src="https://github.com/user-attachments/assets/0a21a407-c923-413f-8abd-c938ed7bbb93" />

**Branch Desktop** vs **RC Desktop** (No change)
<img width="600" alt="Screenshot 2025-06-20 at 3 43 21 PM" src="https://github.com/user-attachments/assets/4ca45d09-933b-41dc-9b27-9938bd407160" /> vs <img width="600" alt="Screenshot 2025-06-20 at 3 43 26 PM" src="https://github.com/user-attachments/assets/7dad427f-cb5e-492a-badc-05749b6c4801" />



### How can this be tested?
1. Check that search page desktop cards are unchanged, search page mobile cards look like screenshot above.
2. The userlist cards in pages like `/dashboard/my-lists/123` are unchanged.
