### PR TITLE
Add favorites list plugin to application defaults

### DIFF
--- a/main/settings_pluggy.py
+++ b/main/settings_pluggy.py
@@ -2,7 +2,7 @@ from main.envs import get_string
 
 MITOL_AUTHENTICATION_PLUGINS = get_string(
     "MITOL_AUTHENTICATION_PLUGINS",
-    "learning_resources.plugins.FavoritesListPlugin,profiles.plugins.CreateProfilePlugin",
+    "learning_resources.plugins.FavoritesListPlugin,profiles.plugins.CreateProfilePlugin,learning_resources.plugins.FavoritesListPlugin",
 )
 MITOL_LEARNING_RESOURCES_PLUGINS = get_string(
     "MITOL_LEARNING_RESOURCES_PLUGINS",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7544

### Description (What does it do?)
This PR adds the FavoritesListPlugin plugin to application defaults. FavoritesListPlugin is responsible for automatically creating a placeholder favorites list for users upon signup.


### How can this be tested?
#### NOTE: this already works locally. this fix is intended for deployed environments

1. checkout this branch
2. create a new user or login as existing
3. post-auth check to see that they have at least one favorites list via:
```python
from django.contrib.auth import get_user_model
User = get_user_model()
user = User.objects.get(id=<your user id>)
assert user.user_lists.count() >= 1
```

