### PR TITLE
Display certificate type on list cards

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -154,6 +154,19 @@ describe("Learning Resource List Card", () => {
     screen.getByText("Certificate")
   })
 
+  test("Displays certificate type", () => {
+    const resource = factories.learningResources.resource({
+      certification: true,
+      certification_type: {
+        name: "Test Certificate",
+      },
+    })
+
+    setup({ resource })
+
+    screen.getByText("Test Certificate")
+  })
+
   test("Does not display certificate badge", () => {
     const resource = factories.learningResources.resource({
       certification: false,

--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.tsx
@@ -120,7 +120,7 @@ const Info = ({ resource }: { resource: LearningResource }) => {
         <Certificate>
           <RiAwardFill />
           <CertificateText>
-            Certificate
+            {resource.certification_type?.name || "Certificate"}
             <CertificatePrice>
               {prices.certificate.display ? ": " : ""}{" "}
               {prices.certificate.display}


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/hq/issues/7708

### Description (What does it do?)
<!--- Describe your changes in detail -->

Displays the type of certificate on learning resource list cards.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->


<img width="967" alt="image" src="https://github.com/user-attachments/assets/6b48594a-5904-4abb-940a-7ec169b26c3f" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Navigate to the search page and confirm the relevant certificate type is displayed. This is provided on the learning resource API at `.results[].certification_type.name`.

Use the certificate filter to confirm that filtered results match the available certificates:
- Professional Certificate
- Certificate of Completion
- MicroMasters Credential


