### PR TITLE
Toggle NextJS image optimization with an env var

### DIFF
--- a/env/frontend.env
+++ b/env/frontend.env
@@ -1,6 +1,7 @@
 NODE_ENV=development
 PORT=8062
 SENTRY_ENV=dev # Re-enable sentry
+OPTIMIZE_IMAGES="true"
 
 # Environment variables with `NEXT_PUBLIC_` prefix are exposed to the client side
 NEXT_PUBLIC_ORIGIN=${MITOL_APP_BASE_URL}

--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -3,7 +3,9 @@ const { validateEnv } = require("./validateEnv")
 
 validateEnv()
 
-const UNOPTIMIZED_IMAGES = Boolean(process.env.UNOPTIMIZED_IMAGES)
+const OPTIMIZE_IMAGES = Boolean(
+  (process.env.OPTIMIZE_IMAGES ?? "true") === "true",
+)
 
 const processFeatureFlags = () => {
   const featureFlagPrefix =
@@ -92,7 +94,7 @@ const nextConfig = {
   transpilePackages: ["@mitodl/smoot-design/ai"],
 
   images: {
-    unoptimized: UNOPTIMIZED_IMAGES,
+    unoptimized: !OPTIMIZE_IMAGES,
     remotePatterns: [
       {
         hostname: "**",


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This adds an env variable to toggle NextJS's image optimization

This PR was made during a production incident when images were returning 502. It turned out to be sporadic 502s not limited to images, but we made this PR to disable image optimization.

Being able to toggle image optimization via an env var seems potentially useful, so making the PR.

### How can this be tested?
1. Run locally with `OPTIMIZE_IMAGES=true`. Inspect any image on the homepage. Its src should start with `_next/`, like `http://learn.odl.local:8062/_next/image?url=https%3A%2F%2Fprofessional.mit.edu%2Fsites%2Fdefault%2Ffiles%2F2025-01%2FMPE-LNO-ENG-Course_Header-400x400.png&w=640&q=75`; note the `url=https...` part is the raw image url
2. Run locally with `OPTIMIZE_IMAGES=false` (or anything else other than `true`). Image sources should have be raw image url.s 

### Additional Context
We had some trouble on prod this morning. Turned out not to be due to image optimization.

Still might be useful to have a flag to enable/disable image optimization, so making the PR.


### Merge Checklist
- [ ] merge with https://github.com/mitodl/ol-infrastructure/pull/3403