### PR TITLE
update canvas etl

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -9,7 +9,11 @@ from tempfile import TemporaryDirectory
 from defusedxml import ElementTree
 from django.conf import settings
 
-from learning_resources.constants import LearningResourceType, PlatformType
+from learning_resources.constants import (
+    VALID_TUTOR_PROBLEM_TYPES,
+    LearningResourceType,
+    PlatformType,
+)
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.utils import (
     _process_olx_path,
@@ -178,11 +182,13 @@ def transform_canvas_problem_files(
             }
             path = file_data["source_path"]
             path = path[len(settings.CANVAS_TUTORBOT_FOLDER) :]
-            path_parts = path.split("/")
+            path_parts = path.split("/", 1)
             problem_file_data["problem_title"] = path_parts[0]
+            for problem_type in VALID_TUTOR_PROBLEM_TYPES:
+                if problem_type in path_parts[1].lower():
+                    problem_file_data["type"] = problem_type
+                    break
 
-            if path_parts[1] in ["problem", "solution"]:
-                problem_file_data["type"] = path_parts[1]
             yield problem_file_data
 
 


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7937

### Description (What does it do?)
Updates the expected file structure of the problem file folder for canvas problems so that there is less nesting


### How can this be tested?
in your .env folder set
CANVAS_TUTORBOT_FOLDER=web_resources/ai/tutor-new-format/
run ` docker compose exec web ./manage.py backpopulate_canvas_courses --canvas-ids=14566 --overwrite`

from the shell run 

`from learning_resources.models import *`

`TutorProblemFile.objects.count()` should be 4
`TutorProblemFile.objects.last().__dict__` should have  `source_path` that includes `web_resources/ai/tutor-new-format/` and `type` should be correctly populated as `problem` or `solution` based on the file name
