### PR TITLE
Append UTM query params to drawer CTA

### DIFF
--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -10,6 +10,7 @@ import { PLATFORM_LOGOS } from "ol-components"
 import user from "@testing-library/user-event"
 import { renderWithProviders } from "@/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
+import { kebabCase } from "lodash"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
@@ -95,7 +96,9 @@ describe("Learning Resource Expanded", () => {
           name: linkName,
         }) as HTMLAnchorElement
         expect(link.target).toBe("_blank")
-        expect(link.href).toMatch(new RegExp(`^${resource.url}/?$`))
+        expect(link.href).toBe(
+          `${resource.url?.replace(/\/$/, "")}/?utm_source=mit-learn&utm_medium=referral&utm_content=${kebabCase(resource.title)}`,
+        )
       }
     },
   )
@@ -134,9 +137,10 @@ describe("Learning Resource Expanded", () => {
   })
 
   test.each([ResourceTypeEnum.Program, ResourceTypeEnum.LearningPath])(
-    'Renders CTA button for resource type "%s"',
+    'Renders CTA button for resource type "%s" with UTM params',
     (resourceType) => {
       const resource = factories.learningResources.resource({
+        title: "Test Resource",
         resource_type: resourceType,
       })
 
@@ -148,7 +152,9 @@ describe("Learning Resource Expanded", () => {
           name: linkName,
         }) as HTMLAnchorElement
 
-        expect(link.href).toMatch(new RegExp(`^${resource.url}/?$`))
+        expect(link.href).toBe(
+          `${resource.url?.replace(/\/$/, "")}/?utm_source=mit-learn&utm_medium=referral&utm_content=test-resource`,
+        )
         expect(link.getAttribute("data-ph-action")).toBe("click-cta")
       }
     },


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Closes https://github.com/mitodl/hq/issues/8040

### Description (What does it do?)
<!--- Describe your changes in detail -->

Appends UTM parameters to the drawer CTA button more ("Learn More" / "Access Course Materials"):

- `utm_source` = "mit-learn"
- `utm_medium` = "referal"
- `utm_content` = The resource title in kebab case



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Open a resource drawer and confirm the parameters are set on the CTA button link.