### PR TITLE
removing check for custom api base in content summarizer

### DIFF
--- a/learning_resources/content_summarizer.py
+++ b/learning_resources/content_summarizer.py
@@ -215,9 +215,6 @@ class ContentSummarizer:
         if not settings.LITELLM_CUSTOM_PROVIDER:
             raise ValueError("The 'LITELLM_CUSTOM_PROVIDER' setting must be set.")  # noqa: EM101, TRY003
 
-        if not settings.LITELLM_API_BASE:
-            raise ValueError("The 'LITELLM_API_BASE' setting must be set.")  # noqa: EM101, TRY003
-
         return ChatLiteLLM(
             model=model,
             temperature=temperature,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8186


### Description (What does it do?)
Very small change that removes the check for the LITELLM_API_BASE setting


### How can this be tested?
Tests should pass locally. We will have to deploy this and confirm that we can now generate summaries.


