### PR TITLE
Fix bad urls for edx video contentfiles

### DIFF
--- a/data_fixtures/migrations/0017_update_edx_content_urls.py
+++ b/data_fixtures/migrations/0017_update_edx_content_urls.py
@@ -1,0 +1,44 @@
+# Generated manually
+
+
+from django.db import migrations
+from django.db.models import Value
+from django.db.models.functions import Replace
+
+from learning_resources.utils import content_files_loaded_actions
+
+
+def update_contentfile_urls(apps, schema_editor):
+    """
+    Update incorrect ContentFile URLs that use the "/jump_to/" format
+    """
+
+    ContentFile = apps.get_model("learning_resources", "ContentFile")
+    LearningResourceRun = apps.get_model("learning_resources", "LearningResourceRun")
+    content_files = ContentFile.objects.filter(url__contains="/jump_to/").only(
+        "id", "url", "run__id"
+    )
+    # Get unique run IDs before updating
+    run_ids = set(content_files.values_list("run__id", flat=True).distinct())
+
+    # Update all ContentFile URLs in a single database query
+    content_files.update(url=Replace("url", Value("/jump_to/"), Value("/jump_to_id/")))
+
+    # Process the runs
+    for run in LearningResourceRun.objects.filter(id__in=run_ids):
+        content_files_loaded_actions(run)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "data_fixtures",
+            "0016_add_canvas_platform",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_contentfile_urls, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -463,14 +463,15 @@ def get_url_from_module_id(
         if run.learning_resource.etl_source == ETLSource.oll.value
         else run.run_id
     )
+    base_jump_url = f"{root_url}/courses/{run_id}/jump_to_id/"
     if module_id.startswith("asset"):
         video_meta = video_srt_metadata.get(module_id, {}) if video_srt_metadata else {}
         if video_meta:
             # Link to the parent video
-            return f"{root_url}/courses/{run_id}/jump_to/{video_meta.split('@')[-1]}"
+            return f"{base_jump_url}{video_meta.split('@')[-1]}"
         return f"{root_url}/{module_id}"
     elif module_id.startswith("block") and is_valid_uuid(module_id.split("@")[-1]):
-        return f"{root_url}/courses/{run_id}/jump_to_id/{module_id.split('@')[-1]}"
+        return f"{base_jump_url}{module_id.split('@')[-1]}"
     else:
         return None
 

--- a/learning_resources/etl/utils_test.py
+++ b/learning_resources/etl/utils_test.py
@@ -715,7 +715,7 @@ def test_get_video_metadata(mocker, tmp_path, video_dir_exists):
             "mit_edx",
             "asset-v1:test+type@asset+block@transcript.srt",
             True,
-            "https://edx.org/courses/course-v1:test_run/jump_to/test_video",
+            "https://edx.org/courses/course-v1:test_run/jump_to_id/test_video",
         ),
         (
             "mit_edx",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7989 and https://github.com/mitodl/mit-learn/pull/2420

### Description (What does it do?)
Some contentfiles (transcripts related to videos) were being assigned incorrect urls.  This PR fixes those urls.


### How can this be tested?
On the main branch, run `docker compose run --rm web ./manage.py backpopulate_mitxonline_files --resource_ids <id of learning resource with readable_id of MITx+15.S05x> --overwrite`
You should end up with some contentfiles having a broken url (404) of https://courses.edx.org/courses/course-v1:MITx+15.S05x+2T2025/jump_to/2d7571d0d9354d33837c29d843a36f9c:

```python
from learning_resources.models import *
ContentFile.objects.filter(
    url="https://courses.edx.org/courses/course-v1:MITx+15.S05x+2T2025/jump_to/2d7571d0d9354d33837c29d843a36f9c"
).count()
```

On this branch, run the command again.
The contentfiles above should not have a working url of https://courses.edx.org/courses/course-v1:MITx+15.S05x+2T2025/jump_to_id/2d7571d0d9354d33837c29d843a36f9c though you will not be able to access it unless you're enrolled.

```python
from learning_resources.models import *
ContentFile.objects.filter(
    url="https://courses.edx.org/courses/course-v1:MITx+15.S05x+2T2025/jump_to_id/2d7571d0d9354d33837c29d843a36f9c"
).count()
```


