### PR TITLE
Exception in remove_duplicate_resources task

### DIFF
--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -60,10 +60,12 @@ def remove_duplicate_resources(self):
             readable_id=duplicate["readable_id"],
             published=False,
         ).values_list("id", flat=True)
-        published_resources = LearningResource.objects.filter(
-            readable_id=duplicate["readable_id"],
-            published=True,
-        ).values_list("id", flat=True)
+        published_resources = list(
+            LearningResource.objects.filter(
+                readable_id=duplicate["readable_id"],
+                published=True,
+            ).values_list("id", flat=True)
+        )
         # keep the most recently created resource, delete the rest
         LearningResource.objects.filter(id__in=unpublished_resources).delete()
         embed_tasks.append(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8451
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes a logical bug and exception thrown in the remove_duplicate_resources task

### How can this be tested?
To repro the initial error manually:
1. checkout main (or any other branch besides this)
2. run the following snippet in django shell which creates 2 resources with the same readable id except that one is published and the other unpublished:
```python
from learning_resources.models import *
LearningResource.objects.filter(readable_id="test").delete()
p1  = LearningResourcePlatform.objects.first()
p2  = LearningResourcePlatform.objects.last()
LearningResource.objects.create(readable_id="test", platform=p1, published=False)
LearningResource.objects.create(readable_id="test", platform=p2, published=True)
```
3. run the remove_duplicate_resources task manually
```python
remove_duplicate_resources.run()
from learning_resources.tasks import remove_duplicate_resources
```
4. observe that it fails with the exception in the linked ticket
5. checkout this branch and repeat the same and see it no longer fails
