### PR TITLE
Revert "separate login and signup redirects"

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -15,26 +15,25 @@ from main.middleware.apisix_user import ApisixUserMiddleware, decode_apisix_head
 log = logging.getLogger(__name__)
 
 
-def get_redirect_url(request, param_names):
+def get_redirect_url(request):
     """
     Get the redirect URL from the request.
 
     Args:
         request: Django request object
-        param_names: Names of the GET parameter or cookie to look for the redirect URL;
-            first match will be used.
 
     Returns:
         str: Redirect URL
     """
-    for param_name in param_names:
-        next_url = request.GET.get(param_name) or request.COOKIES.get(param_name)
-        if next_url and url_has_allowed_host_and_scheme(
+    next_url = request.GET.get("next") or request.COOKIES.get("next")
+    return (
+        next_url
+        if next_url
+        and url_has_allowed_host_and_scheme(
             next_url, allowed_hosts=settings.ALLOWED_REDIRECT_HOSTS
-        ):
-            return next_url
-
-    return "/app"
+        )
+        else "/app"
+    )
 
 
 class CustomLogoutView(View):
@@ -52,7 +51,7 @@ class CustomLogoutView(View):
         GET endpoint reached after logging a user out from Keycloak
         """
         user = getattr(request, "user", None)
-        user_redirect_url = get_redirect_url(request, ["next"])
+        user_redirect_url = get_redirect_url(request)
         if user and user.is_authenticated:
             logout(request)
         if request.META.get(ApisixUserMiddleware.header):
@@ -78,8 +77,7 @@ class CustomLoginView(View):
         """
         GET endpoint for logging a user in.
         """
-        redirect_url = get_redirect_url(request, ["next"])
-        signup_redirect_url = get_redirect_url(request, ["signup_next", "next"])
+        redirect_url = get_redirect_url(request)
         if not request.user.is_anonymous:
             profile = request.user.profile
 
@@ -106,14 +104,12 @@ class CustomLoginView(View):
                     redirect_url = urljoin(
                         settings.APP_BASE_URL, f"/dashboard/organization/{org_slug}"
                     )
-            # first-time non-org users
-            elif not profile.has_logged_in:
-                if request.GET.get("skip_onboarding", "0") == "0":
-                    params = urlencode({"next": signup_redirect_url})
-                    redirect_url = f"{settings.MITOL_NEW_USER_LOGIN_URL}?{params}"
-                    profile.save()
-                else:
-                    redirect_url = signup_redirect_url
+            elif (
+                not profile.has_logged_in
+                and request.GET.get("skip_onboarding", "0") == "0"
+            ):
+                params = urlencode({"next": redirect_url})
+                redirect_url = f"{settings.MITOL_NEW_USER_LOGIN_URL}?{params}"
 
             if not profile.has_logged_in:
                 profile.has_logged_in = True

--- a/authentication/views_test.py
+++ b/authentication/views_test.py
@@ -7,44 +7,24 @@ from urllib.parse import urljoin
 
 import pytest
 from django.test import RequestFactory
-from django.urls import reverse
-from django.utils.http import urlencode
 
 from authentication.views import CustomLoginView, get_redirect_url
 
 
 @pytest.mark.parametrize(
-    ("param_names", "expected_redirect"),
+    ("next_url", "allowed"),
     [
-        (["exists-a"], "/url-a"),
-        (["exists-b"], "/url-b"),
-        (["exists-a", "exists-b"], "/url-a"),
-        (["exists-b", "exists-a"], "/url-b"),
-        (["not-exists-x", "exists-a"], "/url-a"),
-        (["not-exists-x", "not-exists-y"], "/app"),
-        # With disallowed hosts in the params
-        (["disallowed-1"], "/app"),
-        (["not-exists-x", "disallowed-1"], "/app"),
-        (["disallowed-1", "exists-a"], "/url-a"),
-        (["allowed-2"], "https://good.com/url-2"),
+        ("/app", True),
+        ("http://open.odl.local:8062/search", True),
+        ("http://open.odl.local:8069/search", False),
+        ("https://ocw.mit.edu", True),
+        ("https://fake.fake.edu", False),
     ],
 )
-def test_get_redirect_url(mocker, param_names, expected_redirect):
+def test_custom_login(mocker, next_url, allowed):
     """Next url should be respected if host is allowed"""
-    GET = {
-        "exists-a": "/url-a",
-        "exists-b": "/url-b",
-        "exists-c": "/url-c",
-        "disallowed-a": "https://malicious.com/url-1",
-        "allowed-2": "https://good.com/url-2",
-    }
-    mocker.patch(
-        "authentication.views.settings.ALLOWED_REDIRECT_HOSTS",
-        ["good.com"],
-    )
-
-    mock_request = mocker.MagicMock(GET=GET)
-    assert get_redirect_url(mock_request, param_names) == expected_redirect
+    mock_request = mocker.MagicMock(GET={"next": next_url})
+    assert get_redirect_url(mock_request) == (next_url if allowed else "/app")
 
 
 @pytest.mark.parametrize(
@@ -140,41 +120,23 @@ def test_custom_logout_view(mocker, client, user, is_authenticated, has_next):
     assert resp.url == (next_url if has_next else "/app")
 
 
-@pytest.mark.parametrize(
-    (
-        "req_data",
-        "expected_redirect",
-    ),
-    [
-        (
-            {"next": "/irrelevant", "signup_next": "/this?after=signup"},
-            "/this?after=signup",
-        ),
-        (
-            {"next": "/redirect?here=ok"},  # falls back to next
-            "/redirect?here=ok",
-        ),
-    ],
-)
-@pytest.mark.parametrize(
-    ("skip_onboarding", "expect_onboarding"),
-    [
-        (None, True),  # default behavior is to do onboarding
-        ("0", True),  # explicit skip_onboarding=0 means do onboarding
-        ("1", False),  # explicit skip_onboarding=1 means skip onboarding
-    ],
-)
-def test_custom_login_view_authenticated_user_needs_onboarding(
-    mocker, req_data, expected_redirect, skip_onboarding, expect_onboarding
-):
-    """Test CustomLoginView for an authenticated user with incomplete onboarding"""
+def test_custom_login_view_authenticated_user_with_onboarding(mocker):
+    """Test CustomLoginView for an authenticated user who has never logged in before"""
     factory = RequestFactory()
-    if skip_onboarding is not None:
-        req_data["skip_onboarding"] = skip_onboarding
-    request = factory.get(reverse("login"), req_data)
-
+    request = factory.get("/login/", {"next": "/dashboard"})
     request.user = MagicMock(is_anonymous=False)
     request.user.profile = MagicMock(has_logged_in=False)
+
+    # Mock redirect to avoid URL resolution issues
+    mock_redirect = mocker.patch("authentication.views.redirect")
+    mock_redirect.return_value = MagicMock(
+        status_code=302, url="/onboarding?next=/search?resource=184"
+    )
+
+    mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
+    mocker.patch(
+        "authentication.views.urlencode", return_value="next=/search?resource=184"
+    )
     mocker.patch(
         "authentication.views.settings.MITOL_NEW_USER_LOGIN_URL", "/onboarding"
     )
@@ -183,41 +145,72 @@ def test_custom_login_view_authenticated_user_needs_onboarding(
     response = CustomLoginView().get(request)
 
     assert response.status_code == 302
+    assert response.url == "/onboarding?next=/search?resource=184"
 
-    if expect_onboarding:
-        assert response.url == f"/onboarding?{urlencode({'next': expected_redirect})}"
-    else:
-        assert response.url == expected_redirect
+    # Verify redirect was called with the onboarding URL
+    mock_redirect.assert_called_once_with("/onboarding?next=/search?resource=184")
+
+
+def test_custom_login_view_authenticated_user_skip_onboarding(mocker):
+    """Test skip_onboarding flag skips redirect to onboarding"""
+    factory = RequestFactory()
+    request = factory.get("/login/", {"next": "/dashboard", "skip_onboarding": "1"})
+    request.user = MagicMock(is_anonymous=False)
+    request.user.profile = MagicMock(has_logged_in=False)
+
+    # Mock redirect to avoid URL resolution issues
+    mock_redirect = mocker.patch("authentication.views.redirect")
+    mock_redirect.return_value = MagicMock(status_code=302, url="/dashboard")
+
+    mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
+    mocker.patch("authentication.views.decode_apisix_headers", return_value={})
+
+    response = CustomLoginView().get(request)
+
+    # Verify has_logged_in was set to True and profile was saved
+    assert request.user.profile.has_logged_in is True
+    request.user.profile.save.assert_called_once()
+
+    assert response.status_code == 302
+    assert response.url == "/dashboard"
 
 
 def test_custom_login_view_authenticated_user_who_has_logged_in_before(mocker):
     """Test that user who has logged in before is redirected to next url"""
     factory = RequestFactory()
-    request = factory.get(
-        reverse("login"),
-        {"next": "/should-be-redirect?foo", "signup_next": "/irrelevant"},
-    )
+    request = factory.get("/login/", {"next": "/dashboard"})
     request.user = MagicMock(is_anonymous=False)
     request.user.profile = MagicMock(has_logged_in=True)
+
+    # Mock redirect to avoid URL resolution issues
+    mock_redirect = mocker.patch("authentication.views.redirect")
+    mock_redirect.return_value = MagicMock(status_code=302, url="/dashboard")
+
+    mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
+    mocker.patch("authentication.views.decode_apisix_headers", return_value={})
 
     response = CustomLoginView().get(request)
 
     assert response.status_code == 302
-    assert response.url == "/should-be-redirect?foo"
+    assert response.url == "/dashboard"
 
 
 def test_custom_login_view_anonymous_user(mocker):
     """Test redirect for anonymous user"""
     factory = RequestFactory()
-    request = factory.get(
-        reverse("login"), {"next": "/some-url", "signup_next": "/irrelevant"}
-    )
+    request = factory.get("/login/", {"next": "/dashboard"})
     request.user = MagicMock(is_anonymous=True)
+
+    # Mock redirect to avoid URL resolution issues
+    mock_redirect = mocker.patch("authentication.views.redirect")
+    mock_redirect.return_value = MagicMock(status_code=302, url="/dashboard")
+
+    mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
 
     response = CustomLoginView().get(request)
 
     assert response.status_code == 302
-    assert response.url == "/some-url"
+    assert response.url == "/dashboard"
 
 
 def test_custom_login_view_first_time_login_sets_has_logged_in(mocker):
@@ -235,6 +228,12 @@ def test_custom_login_view_first_time_login_sets_has_logged_in(mocker):
 
     request.user = mock_user
 
+    # Mock the redirect function to avoid URL resolution
+    mock_redirect = mocker.patch("authentication.views.redirect")
+    mock_redirect.return_value = MagicMock(status_code=302, url="/dashboard")
+    mocker.patch("authentication.views.get_redirect_url", return_value="/dashboard")
+    mocker.patch("authentication.views.decode_apisix_headers", return_value={})
+
     response = CustomLoginView().get(request)
 
     # Verify the response
@@ -243,6 +242,9 @@ def test_custom_login_view_first_time_login_sets_has_logged_in(mocker):
     # Verify that has_logged_in was set to True and profile was saved
     assert mock_profile.has_logged_in is True
     mock_profile.save.assert_called_once()
+
+    # Verify redirect was called with the correct URL
+    mock_redirect.assert_called_once_with("/dashboard")
 
 
 @pytest.mark.parametrize(

--- a/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.tsx
+++ b/frontends/main/src/app-pages/B2BAttachPage/B2BAttachPage.tsx
@@ -42,11 +42,9 @@ const B2BAttachPage: React.FC<B2BAttachPageProps> = ({ code }) => {
       return
     }
     if (!user?.is_authenticated) {
-      const loginUrlString = urls.auth({
-        loginNext: {
-          pathname: urls.b2bAttachView(code),
-          searchParams: null,
-        },
+      const loginUrlString = urls.login({
+        pathname: urls.b2bAttachView(code),
+        searchParams: new URLSearchParams(),
       })
       const loginUrl = new URL(loginUrlString)
       loginUrl.searchParams.set("skip_onboarding", "1")

--- a/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.test.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { renderWithProviders, screen, waitFor } from "../../test-utils"
-import * as routes from "@/common/urls"
+import { HOME, login } from "@/common/urls"
 import ForbiddenPage from "./ForbiddenPage"
 import { setMockResponse, urls, factories } from "api/test-utils"
 import { useUserMe } from "api/hooks/user"
@@ -22,7 +22,7 @@ test("The ForbiddenPage loads with a link that directs to HomePage", async () =>
   setMockResponse.get(urls.userMe.get(), makeUser({ is_authenticated: true }))
   renderWithProviders(<ForbiddenPage />)
   const homeLink = await screen.findByRole("link", { name: "Home" })
-  expect(homeLink).toHaveAttribute("href", routes.HOME)
+  expect(homeLink).toHaveAttribute("href", HOME)
 })
 
 test("Fetches auth data afresh and redirects unauthenticated users to auth", async () => {
@@ -53,11 +53,9 @@ test("Fetches auth data afresh and redirects unauthenticated users to auth", asy
 
   await waitFor(() => {
     expect(mockedRedirect).toHaveBeenCalledWith(
-      routes.auth({
-        loginNext: {
-          pathname: "/foo",
-          searchParams: new URLSearchParams({ cat: "meow" }),
-        },
+      login({
+        pathname: "/foo",
+        searchParams: new URLSearchParams({ cat: "meow" }),
       }),
     )
   })

--- a/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.tsx
+++ b/frontends/main/src/app-pages/ErrorPage/ForbiddenPage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react"
 import ErrorPageTemplate from "./ErrorPageTemplate"
 import { userQueries } from "api/hooks/user"
 import { useQuery } from "@tanstack/react-query"
-import { redirectAuthToCurrent } from "@/common/client-utils"
+import { redirectLoginToCurrent } from "@/common/client-utils"
 
 const ForbiddenPage: React.FC = () => {
   const user = useQuery({
@@ -15,7 +15,7 @@ const ForbiddenPage: React.FC = () => {
 
   useEffect(() => {
     if (shouldRedirect) {
-      redirectAuthToCurrent()
+      redirectLoginToCurrent()
     }
   }, [shouldRedirect])
 

--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -295,11 +295,9 @@ describe("Home Page personalize section", () => {
     const link = within(personalize).getByRole("link")
     expect(link).toHaveAttribute(
       "href",
-      routes.auth({
-        loginNext: {
-          pathname: routes.DASHBOARD_HOME,
-          searchParams: null,
-        },
+      routes.login({
+        pathname: routes.DASHBOARD_HOME,
+        searchParams: null,
       }),
     )
   })

--- a/frontends/main/src/app-pages/HomePage/PersonalizeSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/PersonalizeSection.tsx
@@ -76,9 +76,7 @@ const AUTH_TEXT_DATA = {
     text: "As a member, get personalized recommendations, curate learning lists, and follow your areas of interest.",
     linkProps: {
       children: "Sign Up for Free",
-      href: urls.auth({
-        loginNext: { pathname: urls.DASHBOARD_HOME, searchParams: null },
-      }),
+      href: urls.login({ pathname: urls.DASHBOARD_HOME, searchParams: null }),
     },
   },
 }

--- a/frontends/main/src/common/client-utils.ts
+++ b/frontends/main/src/common/client-utils.ts
@@ -1,5 +1,6 @@
+"use client"
 import { ChannelCounts } from "api/v0"
-import { auth } from "./urls"
+import { login } from "./urls"
 import { redirect, usePathname, useSearchParams } from "next/navigation"
 
 const getSearchParamMap = (urlParams: URLSearchParams) => {
@@ -51,13 +52,7 @@ const getCsrfToken = () => {
   )
 }
 
-/**
- * Returns a URL to authentication that redirects to current page after auth.
- *
- * By default, new users will be redirected to default signup destination.
- * If `signup` is true, they will be redirected to the current page.
- */
-const useAuthToCurrent = ({ signup }: { signup?: boolean } = {}) => {
+const useLoginToCurrent = () => {
   /**
    * NOTES:
    *  1. This is reactive; if current URL changes, the result of this hook
@@ -69,39 +64,21 @@ const useAuthToCurrent = ({ signup }: { signup?: boolean } = {}) => {
    */
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const current = { pathname, searchParams }
-  return auth({
-    loginNext: current,
-    signupNext: signup ? current : undefined,
-  })
+  return login({ pathname, searchParams })
 }
 
 /**
- * Redirect user to auth. After auth:
- *  - existing users redirected to their current URL
- * - new users redirected to the default signup destination, unless `signup` is true.
+ * Redirect user to login route with ?next=<current-url>.
  */
-const redirectAuthToCurrent = ({
-  signup,
-}: {
-  /**
-   * Whether to redirect signup to current; by default, false. New users
-   * will be redirected to the default signup destination.
-   */
-  signup?: boolean
-} = {}): never => {
-  const current = {
-    pathname: window.location.pathname,
-    searchParams: new URLSearchParams(window.location.search),
-  }
+const redirectLoginToCurrent = (): never => {
   redirect(
     /**
      * Calculating the ?next=<current-url> via window.location is appropriate
      * here since it happens time of redirect call.
      */
-    auth({
-      loginNext: current,
-      signupNext: signup ? current : undefined,
+    login({
+      pathname: window.location.pathname,
+      searchParams: new URLSearchParams(window.location.search),
     }),
   )
 }
@@ -111,6 +88,6 @@ export {
   aggregateProgramCounts,
   aggregateCourseCounts,
   getCsrfToken,
-  useAuthToCurrent,
-  redirectAuthToCurrent,
+  useLoginToCurrent,
+  redirectLoginToCurrent,
 }

--- a/frontends/main/src/common/urls.test.ts
+++ b/frontends/main/src/common/urls.test.ts
@@ -1,35 +1,27 @@
-import { auth } from "./urls"
+import { login } from "./urls"
 
 const MITOL_API_BASE_URL = process.env.NEXT_PUBLIC_MITOL_API_BASE_URL
 
 test("login encodes the next parameter appropriately", () => {
-  expect(
-    auth({
-      loginNext: { pathname: null, searchParams: null },
-    }),
-  ).toBe(
-    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/&signup_next=http://test.learn.odl.local:8062/dashboard`,
+  expect(login({ pathname: null, searchParams: null })).toBe(
+    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/`,
   )
 
   expect(
-    auth({
-      loginNext: {
-        pathname: "/foo/bar",
-        searchParams: null,
-      },
+    login({
+      pathname: "/foo/bar",
+      searchParams: null,
     }),
   ).toBe(
-    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/foo/bar&signup_next=http://test.learn.odl.local:8062/dashboard`,
+    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/foo/bar`,
   )
 
   expect(
-    auth({
-      loginNext: {
-        pathname: "/foo/bar",
-        searchParams: new URLSearchParams("?cat=meow"),
-      },
+    login({
+      pathname: "/foo/bar",
+      searchParams: new URLSearchParams("?cat=meow"),
     }),
   ).toBe(
-    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/foo/bar%3Fcat%3Dmeow&signup_next=http://test.learn.odl.local:8062/dashboard`,
+    `${MITOL_API_BASE_URL}/login?next=http://test.learn.odl.local:8062/foo/bar%3Fcat%3Dmeow`,
   )
 })

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -55,6 +55,40 @@ if (process.env.NODE_ENV !== "production") {
 
 const MITOL_API_BASE_URL = process.env.NEXT_PUBLIC_MITOL_API_BASE_URL
 
+export const LOGIN = `${MITOL_API_BASE_URL}/login`
+export const LOGOUT = `${MITOL_API_BASE_URL}/logout/`
+
+/**
+ * Returns the URL to the login page, with a `next` parameter to redirect back
+ * to the given pathname + search parameters.
+ *
+ * NOTES:
+ *  1. useLoginToCurrent() is a convenience function that uses the current
+ *    pathname and search parameters to generate the next URL.
+ *  2. `next` is required to encourage its use. You can explicitly pass `null`
+ *    for values to skip them if desired.
+ */
+export const login = (next: {
+  pathname: string | null
+  searchParams: URLSearchParams | null
+  hash?: string | null
+}) => {
+  const pathname = next.pathname ?? "/"
+  const searchParams = next.searchParams ?? new URLSearchParams()
+  const hash = next.hash ?? ""
+  /**
+   * To include search parameters in the next URL, we need to encode them.
+   * If we pass `?next=/foo/bar?cat=meow` directly, Django receives two separate
+   * parameters: `next` and `cat`.
+   *
+   * There's no need to encode the path parameter (it might contain slashes,
+   * but those are allowed in search parameters) so let's keep it readable.
+   */
+  const search = searchParams?.toString() ? `?${searchParams.toString()}` : ""
+  const nextHref = `${ORIGIN}${pathname}${encodeURIComponent(search)}${encodeURIComponent(hash as string)}`
+  return `${LOGIN}?next=${nextHref}`
+}
+
 export const DASHBOARD_VIEW = "/dashboard/[tab]"
 const dashboardView = (tab: string) => generatePath(DASHBOARD_VIEW, { tab })
 
@@ -131,61 +165,6 @@ export const SEARCH_PROGRAM = querifiedSearchUrl({
 export const SEARCH_LEARNING_MATERIAL = querifiedSearchUrl({
   resource_category: "learning_material",
 })
-
-export const LOGIN = `${MITOL_API_BASE_URL}/login`
-export const LOGOUT = `${MITOL_API_BASE_URL}/logout/`
-
-type UrlDescriptor = {
-  pathname: string | null
-  searchParams: URLSearchParams | null
-  hash?: string | null
-}
-export type LoginUrlOpts = {
-  /**
-   * URL to redirect to after login.
-   */
-  loginNext: UrlDescriptor
-  /**
-   * URL to redirect to after signup.
-   */
-  signupNext?: UrlDescriptor
-}
-
-const DEFAULT_SIGNUP_NEXT: UrlDescriptor = {
-  pathname: DASHBOARD_HOME,
-  searchParams: null,
-}
-
-/**
- * Returns the URL to the authentication page (login and signup).
- *
- * NOTES:
- *  1. useAuthToCurrent() is a convenience function that uses the current
- *    pathname and search parameters to generate the next URL.
- *  2. `next` is required to encourage its use. You can explicitly pass `null`
- *    for values to skip them if desired.
- */
-export const auth = (opts: LoginUrlOpts) => {
-  const { loginNext, signupNext = DEFAULT_SIGNUP_NEXT } = opts
-  const encode = (value: UrlDescriptor) => {
-    const pathname = value.pathname ?? "/"
-    const searchParams = value.searchParams ?? new URLSearchParams()
-    const hash = value.hash ?? ""
-    /**
-     * To include search parameters in the next URL, we need to encode them.
-     * If we pass `?next=/foo/bar?cat=meow` directly, Django receives two separate
-     * parameters: `next` and `cat`.
-     *
-     * There's no need to encode the path parameter (it might contain slashes,
-     * but those are allowed in search parameters) so let's keep it readable.
-     */
-    const search = searchParams?.toString() ? `?${searchParams.toString()}` : ""
-    return `${ORIGIN}${pathname}${encodeURIComponent(search)}${encodeURIComponent(hash)}`
-  }
-  const loginNextHref = encode(loginNext)
-  const signupNextHref = encode(signupNext)
-  return `${LOGIN}?next=${loginNextHref}&signup_next=${signupNextHref}`
-}
 
 export const ECOMMERCE_CART = "/cart/" as const
 

--- a/frontends/main/src/components/RestrictedRoute/RestrictedRoute.tsx
+++ b/frontends/main/src/components/RestrictedRoute/RestrictedRoute.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect } from "react"
 import { ForbiddenError } from "@/common/errors"
 import { Permission, userQueries } from "api/hooks/user"
-import { redirectAuthToCurrent } from "@/common/client-utils"
+import { redirectLoginToCurrent } from "@/common/client-utils"
 import { useQuery } from "@tanstack/react-query"
 
 type RestrictedRouteProps = {
@@ -54,7 +54,7 @@ const RestrictedRoute: React.FC<RestrictedRouteProps> = ({
      * and any "secret" data is gated via API auth checks anyway.
      */
     if (shouldRedirect) {
-      redirectAuthToCurrent()
+      redirectLoginToCurrent()
     }
   }, [shouldRedirect])
   if (isLoading) return null

--- a/frontends/main/src/page-components/Header/Header.test.tsx
+++ b/frontends/main/src/page-components/Header/Header.test.tsx
@@ -60,11 +60,9 @@ describe("UserMenu", () => {
   test("Unauthenticated users see the Sign Up / Login link", async () => {
     const isAuthenticated = false
     const initialUrl = "/foo/bar?cat=meow"
-    const expectedUrl = urlConstants.auth({
-      loginNext: {
-        pathname: "/foo/bar",
-        searchParams: new URLSearchParams("?cat=meow"),
-      },
+    const expectedUrl = urlConstants.login({
+      pathname: "/foo/bar",
+      searchParams: new URLSearchParams("?cat=meow"),
     })
     setMockResponse.get(urls.userMe.get(), {
       is_authenticated: isAuthenticated,

--- a/frontends/main/src/page-components/Header/UserMenu.tsx
+++ b/frontends/main/src/page-components/Header/UserMenu.tsx
@@ -12,7 +12,7 @@ import {
 } from "@remixicon/react"
 import { useUserMe, User } from "api/hooks/user"
 import MITLogoLink from "@/components/MITLogoLink/MITLogoLink"
-import { useAuthToCurrent } from "@/common/client-utils"
+import { useLoginToCurrent } from "@/common/client-utils"
 
 const FlexContainer = styled.div({
   display: "flex",
@@ -125,7 +125,7 @@ type UserMenuProps = {
 const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
   const [visible, setVisible] = useState(false)
 
-  const loginUrl = useAuthToCurrent()
+  const loginUrl = useLoginToCurrent()
 
   const { isLoading, data: user } = useUserMe()
   if (isLoading) {

--- a/frontends/main/src/page-components/SignupPopover/SignupPopover.test.tsx
+++ b/frontends/main/src/page-components/SignupPopover/SignupPopover.test.tsx
@@ -15,15 +15,9 @@ test("SignupPopover shows link to sign up", async () => {
   const link = within(dialog).getByRole("link")
   invariant(link instanceof HTMLAnchorElement)
   expect(link.href).toMatch(
-    urls.auth({
-      loginNext: {
-        pathname: "/some-path",
-        searchParams: new URLSearchParams("dog=woof"),
-      },
-      signupNext: {
-        pathname: "/some-path",
-        searchParams: new URLSearchParams("dog=woof"),
-      },
+    urls.login({
+      pathname: "/some-path",
+      searchParams: new URLSearchParams("dog=woof"),
     }),
   )
 })

--- a/frontends/main/src/page-components/SignupPopover/SignupPopover.tsx
+++ b/frontends/main/src/page-components/SignupPopover/SignupPopover.tsx
@@ -2,8 +2,7 @@ import React from "react"
 import { Popover, Typography, styled } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import type { PopoverProps } from "ol-components"
-
-import { useAuthToCurrent } from "@/common/client-utils"
+import { useLoginToCurrent } from "@/common/client-utils"
 
 const StyledPopover = styled(Popover)({
   width: "300px",
@@ -32,7 +31,7 @@ type SignupPopoverProps = Pick<
   "anchorEl" | "onClose" | "placement"
 >
 const SignupPopover: React.FC<SignupPopoverProps> = (props) => {
-  const loginUrl = useAuthToCurrent({ signup: true })
+  const loginUrl = useLoginToCurrent()
 
   return (
     <StyledPopover {...props} open={!!props.anchorEl}>


### PR DESCRIPTION
Reverts mitodl/mit-learn#2384

This PR broke the redirect attachment for non-org signup via `learn.mit.edu/attach/{uuid}`.

The fix is easy, but testing login/signup stuff on RC is slow (especially sso), so in the interest of getting #2525 and #2531 out sooner, I'll do it separately.

