### PR TITLE
Security: Disable yarn postinstall scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,23 +1,16 @@
 compressionLevel: mixed
-
 enableGlobalCache: false
-
 nodeLinker: node-modules
-
 yarnPath: .yarn/releases/yarn-4.9.2.cjs
-
-# https://github.com/vitejs/vite-plugin-react-swc/issues/74#issuecomment-1520484130
-# https://github.com/swc-project/swc/issues/5616#issuecomment-1265639797
-# This setting ensures we always install the Linux binaries when running `yarn install`. This is needed for running
-# swc natively in Docker (addresses swc-loader bindings not found error).
 supportedArchitectures:
   os:
-    - current
-    - linux
+  - current
+  - linux
   cpu:
-    - current
-    - x64
-    - arm64
+  - current
+  - x64
+  - arm64
   libc:
-    - current
-    - glibc
+  - current
+  - glibc
+enableScripts: false


### PR DESCRIPTION
_This PR was generated automatically via a script._

This PR disables yarn's postinstall scripts by setting `enableScripts: false` in `.yarnrc.yml`.

## Why this change?

Disabling postinstall scripts improves security by:
- **Preventing malicious code execution**: Stops potentially harmful scripts from running during package installation
- **Supply chain security**: Reduces risk from compromised packages that could execute malicious postinstall scripts
- **Controlled execution**: Allows manual review and execution of necessary scripts only when needed

## What changed?

- Added `enableScripts: false` to `.yarnrc.yml`

## Impact

- Some packages may require manual script execution if they depend on postinstall hooks
- Improved security posture against supply chain attacks
- No functional changes to core application code

This is a security best practice recommended for production applications to prevent potential malicious code execution during package installation.