### PR TITLE
Sort runs by start_date

### DIFF
--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -512,10 +512,12 @@ class LearningResourceRunFactory(DjangoModelFactory):
         )
     )
     start_date = factory.LazyAttribute(
-        lambda obj: obj.enrollment_start + timedelta(days=15)
+        lambda obj: obj.enrollment_start + timedelta(days=random.randint(15, 20))  # noqa: S311
     )
     end_date = factory.LazyAttribute(
-        lambda obj: obj.start_date + timedelta(days=90) if obj.start_date else None
+        lambda obj: obj.start_date + timedelta(days=random.randint(90, 100))  # noqa: S311
+        if obj.start_date
+        else None
     )
     prices = sorted(
         [

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -362,9 +362,9 @@ class LearningResourceQuerySet(TimestampedModelQuerySet):
             "content_tags",
             Prefetch(
                 "runs",
-                queryset=LearningResourceRun.objects.filter(
-                    published=True
-                ).for_serialization(),
+                queryset=LearningResourceRun.objects.filter(published=True)
+                .order_by("start_date", "enrollment_start", "id")
+                .for_serialization(),
             ),
             Prefetch(
                 "parents",

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -561,9 +561,9 @@ class ResourceListItemsViewSet(NestedViewSetMixin, viewsets.ReadOnlyModelViewSet
             ),
             Prefetch(
                 "child__runs",
-                queryset=LearningResourceRun.objects.filter(
-                    published=True
-                ).for_serialization(),
+                queryset=LearningResourceRun.objects.filter(published=True)
+                .order_by("start_date", "enrollment_start", "id")
+                .for_serialization(),
             ),
             "child__runs__instructors",
             "child__runs__resource_prices",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6074

### Description (What does it do?)
Sorts runs by `start_date` (and then `enrollment_start`, `id` if prior attribute is null or the same) across several API's (`LearningResourceViewSet`, `ResourceListItemsViewSet`)


### How can this be tested?
- On the main branch, run `./manage.py backpopulate_mitxonline_data` if you haven't already, and wait for the search upsert tasks to finish.
- Switch to this branch.
- Find the id of the resource with `readable_id=course-v1:MITxT+8.01.4x`
- Go to `http://open.odl.local:8063/api/v1/learning_resources/<course_id>/` - the course should have multiple published runs, check that they are in order by `start_date`
- Find the id of the program with `readable_id=program-v1:MITxT+8.01x`
- Go to `http://open.odl.local:8063/api/v1/learning_resources/<program_id>/items/` - search for the runs of `course-v1:MITxT+8.01.4x` and verify they are still sorted by `start_date`

- Go to `http://open.odl.local:8063/api/v1/learning_resources_search/?id=<course_id>` - the runs probably won't be in the correct order.
- Run `./manage.py backpopulate_mitxonline_data` again.   After search updates are done, check the url above again, this time the runs should be in the correct order. 


