### PR TITLE
Heading elements for resource drawer

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -110,7 +110,7 @@ const DrawerContent: React.FC<{
   ) => {
     return (
       <ResourceCarousel
-        titleComponent="p"
+        titleComponent="h3"
         titleVariant="subtitle1"
         title={title}
         config={[
@@ -132,7 +132,7 @@ const DrawerContent: React.FC<{
   }
   const similarResourcesCarousel = (
     <ResourceCarousel
-      titleComponent="p"
+      titleComponent="h3"
       titleVariant="subtitle1"
       title="Similar Learning Resources"
       config={[
@@ -154,7 +154,7 @@ const DrawerContent: React.FC<{
   const topicCarousels = topics?.map((topic) => (
     <ResourceCarousel
       key={topic.id}
-      titleComponent="p"
+      titleComponent="h3"
       titleVariant="subtitle1"
       title={`Learning Resources in "${topic.name}"`}
       config={TopicCarouselConfig(topic.name)}

--- a/frontends/main/src/page-components/LearningResourceExpanded/TitleSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/TitleSection.tsx
@@ -70,20 +70,22 @@ const TitleSection: React.FC<{
 
   return (
     <TitleContainer ref={ref}>
-      <Typography
-        variant="h4"
-        id={titleId}
-        width="100%"
-        color={theme.custom.colors.darkGray2}
-      >
+      <div id={titleId}>
         <Typography
           variant="subtitle2"
           color={theme.custom.colors.silverGrayDark}
         >
           {type}
         </Typography>
-        <span lang={resource?.runs?.[0]?.languages?.[0]}>{title}</span>
-      </Typography>
+        <Typography
+          variant="h4"
+          component="h2"
+          color={theme.custom.colors.darkGray2}
+          lang={resource?.runs?.[0]?.languages?.[0]}
+        >
+          {title}
+        </Typography>
+      </div>
       <CloseButton
         variant="text"
         size="medium"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

Closes https://github.com/mitodl/hq/issues/8556

### Description (What does it do?)
<!--- Describe your changes in detail -->

Updates the learning resource drawer title to use \<h2\> and section (carousel) headings to use \<h3\>.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

<img width="523" height="162" alt="image" src="https://github.com/user-attachments/assets/dd44b602-0a27-45c2-aded-12dad472a157" />

<img width="411" height="179" alt="image" src="https://github.com/user-attachments/assets/23d9357c-077b-471d-b9ca-df3e66ef8fe3" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Open a resource drawer and confirm that the headings are indeed using heading elements and that there is no impact to styles or layout.
