### PR TITLE
Test fix: ensure unique instructor ids

### DIFF
--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -44,10 +44,11 @@ const priceItem: Factory<PriceItem> = (override) => {
   }
 }
 
+const uniqueFacultyId = new UniqueEnforcer()
 const faculty: Factory<Faculty> = (override) => {
   return {
     feature_image_src: faker.image.urlLoremFlickr({ width: 640, height: 480 }),
-    id: faker.number.int({ min: 1, max: 1000 }),
+    id: uniqueFacultyId.enforce(() => faker.number.int()),
     instructor_bio_long: makeHTMLParagraph(2),
     instructor_bio_short: faker.lorem.sentences(2),
     instructor_name: faker.person.fullName(),


### PR DESCRIPTION
### What are the relevant tickets?
- [Flaky JS test for MIT Learn](https://github.com/mitodl/hq/issues/8857)

### Description (What does it do?)
Ensure instructor ids are unique.

### How can this be tested
If you want, change the `describe` blocks in ProgramPage.test.tsx to `describe.each(new Array(100).fill(null))("ProgramPage..."), () => {})` They should all pass.