### PR TITLE
improve enrollment code redirect

### DIFF
--- a/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.test.tsx
+++ b/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.test.tsx
@@ -90,7 +90,14 @@ describe("EnrollmentCodePage", () => {
 
     setMockResponse.get(mitxOnlineUrls.userMe.get(), mitxOnlineUser)
 
-    setMockResponse.post(b2bUrls.b2bAttach.b2bAttachView("test-code"), [])
+    setMockResponse.post(b2bUrls.b2bAttach.b2bAttachView("test-code"), [
+      {
+        id: 1,
+        organization: 1,
+        active: true,
+        contract_end: "2024-12-31T23:59:59Z",
+      },
+    ])
 
     renderWithProviders(<EnrollmentCodePage code="test-code" />, {
       url: commonUrls.B2B_ATTACH_VIEW,

--- a/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.tsx
+++ b/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.tsx
@@ -19,14 +19,15 @@ const InterstitialMessage = styled(Typography)(({ theme }) => ({
 
 const OrgRedirect: React.FC<{ orgId: number }> = ({ orgId }) => {
   const { data: mitxOnlineUser } = useMitxOnlineUserMe()
+  const router = useRouter()
   const orgSlug = mitxOnlineUser?.b2b_organizations?.find(
     (org) => org.id === orgId,
   )?.slug
   React.useEffect(() => {
     if (orgSlug) {
-      window.location.href = urls.organizationView(orgSlug.replace("org-", ""))
+      router.push(urls.organizationView(orgSlug.replace("org-", "")))
     }
-  }, [orgSlug])
+  }, [orgSlug, router])
   if (!orgSlug) {
     return (
       <Typography color="error">
@@ -89,7 +90,7 @@ const EnrollmentCodePage: React.FC<EnrollmentCodePage> = ({ code }) => {
       {isPending && (
         <InterstitialMessage>Validating code "{code}"...</InterstitialMessage>
       )}
-      {isSuccess && contracts.data && (
+      {isSuccess && contracts?.data && contracts.data.length > 0 && (
         <OrgRedirect orgId={contracts.data[0].organization} />
       )}
     </Container>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8811

### Description (What does it do?)
This PR adjusts the code in `EnrollmentCodePage` so that it redirects to the proper org dashboard reflected by the contract they've just enrolled in via a submitted enrollment code. A contract is returned when the enrollment code is redeemed, and this contract includes the ID of the org that the contract belongs to. The MITx Online user data contains this info in `b2b_organizations`, so the ID returned on the contract is simply matched against that.

### How can this be tested?
In order to test this, you need a basic installation of `mitxonline` up and running with example data in it. You may be able to skip one or more steps if you have already done them:
- Ensure you have local `hosts` redirects for the following domains, replacing the example IP with your __local__ IP address (Google how to get this if unsure, mine is 192.168.1.50)
```
192.168.1.50 open.odl.local
192.168.1.50 api.open.odl.local
192.168.1.50 kc.ol.local
192.168.1.50 mitxonline.odl.local
```
- Clone `mitxonline`: https://github.com/mitodl/mitxonline
- Create a `.env` file with the following values:
```
CELERY_TASK_ALWAYS_EAGER=True
DJANGO_LOG_LEVEL=INFO
LOG_LEVEL=INFO
SENTRY_LOG_LEVEL=ERROR
MAILGUN_KEY=fake
MAILGUN_URL=
MAILGUN_RECIPIENT_OVERRIDE=
MAILGUN_SENDER_DOMAIN=.odl.local
SECRET_KEY=
STATUS_TOKEN=
UWSGI_THREADS=5
SENTRY_DSN=
MITX_ONLINE_BASE_URL=http://open.odl.local:8065/mitxonline
MITX_ONLINE_ADMIN_CLIENT_ID=refine-local-client-id
MITX_ONLINE_ADMIN_BASE_URL=http://mitxonline.odl.local:8016
POSTHOG_PROJECT_API_KEY=
POSTHOG_API_HOST=https://app.posthog.com/
HUBSPOT_HOME_PAGE_FORM_GUID=
HUBSPOT_PORTAL_ID=
APISIX_PORT=9080

# APISIX/Keycloak settings
APISIX_LOGOUT_URL=http://api.open.odl.local:8065/logout/
APISIX_SESSION_SECRET_KEY=supertopsecret1234
KC_SPI_THEME_WELCOME_THEME=scim
KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY=
KEYCLOAK_BASE_URL=http://kc.ol.local:8066
KEYCLOAK_CLIENT_ID=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
KEYCLOAK_CLIENT_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
KEYCLOAK_DISCOVERY_URL=http://kc.ol.local:8066/realms/ol-local/.well-known/openid-configuration
KEYCLOAK_REALM_NAME=ol-local
KEYCLOAK_SCOPES="openid profile ol-profile"
KEYCLOAK_SVC_KEYSTORE_PASSWORD=supertopsecret1234
KEYCLOAK_SVC_HOSTNAME=kc.ol.local
KEYCLOAK_SVC_ADMIN=admin
KEYCLOAK_SVC_ADMIN_PASSWORD=admin
AUTHORIZATION_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/auth
ACCESS_TOKEN_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/token
OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT=http://kc.ol.local:8066/realms/ol-local
SOCIAL_AUTH_OL_OIDC_KEY=apisix
# This is not a secret. This is for the Keycloak container, only for local use.
SOCIAL_AUTH_OL_OIDC_SECRET=HckCZXToXfaetbBx0Fo3xbjnC468oMi4 # pragma: allowlist-secret
USERINFO_URL=http://kc.ol.local:8066/realms/ol-local/protocol/openid-connect/userinfo
MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=False

FEATURE_IGNORE_EDX_FAILURES=True
OPENEDX_API_CLIENT_ID=fake
OPENEDX_API_CLIENT_SECRET=fake
OPENEDX_SERVICE_WORKER_API_TOKEN=fake

CSRF_COOKIE_DOMAIN=.odl.local
CORS_ALLOWED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
CSRF_TRUSTED_ORIGINS=http://mitxonline.odl.local:8065, http://open.odl.local:8062, http://api.open.odl.local:8065
```
- Spin up `mitxonline` with `docker compose up --build -d`
- Promote the admin user with `docker compose exec web ./manage.py promote_user promote --superuser --email admin@odl.local`
- Populate test course data with `docker compose exec web ./manage.py populate_course_data`
- Generate docs with `pants docs ::`
- In `dist/sphinx/index.html`, read the section on generating a B2B organization / contract and create two, adding some of the test courses to both, and some to only org a / only org b
- In Django admin, create a `Program` and add some courses to the program that are included in your B2B org, making sure to mark the program as "live"
- Create a few more programs with different courses in them that are not part of your B2B org
- Navigate to Wagtail at http://mitxonline.odl.local:8065/cms
- Browse to Home Page -> Program Collections
- Create a new program collection
- Add both programs to your collection, the one that's part of your org and the one that isn't
- Make sure you have a personal Posthog project configured and have the API key at the ready
- Before we spin up `mit-learn`, we need to set some env variables:
```
.env
...
MITX_ONLINE_UPSTREAM=mitxonline.odl.local:8013
MITX_ONLINE_DOMAIN=mitxonline.odl.local
MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8065
POSTHOG_ENABLED=True
CSRF_COOKIE_DOMAIN=.odl.local

shared.local.env
POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_PROJECT_ID=YOUR_PROJECT_ID_HERE
POSTHOG_TIMEOUT_MS=1500
```
- In your Posthog project, enable the `enrollment-dashboard` and `mitlearn-organization-dashboard` feature flags for all users
- Spin up `MIT Learn`
- In MITx Online, list the contracts with `docker compose exec web ./manage.py b2b_list contracts`. Once you have the ID for the contract you made, list the codes for it. For example, assuming your ID is 30: `docker compose exec web ./manage.py b2b_list contracts --codes 30`
- Also generate codes for the second org you created
- Log in as a user that is not part of any orgs (I used `student@odl.local`) in an incognito window
- Visit `/enrollmentcode/the-code`, replacing `the-code` with the code you got from the above command
- You should see a brief message, then be redirected to the org dashboard
- Verify that enrollment worked
- Repeat this process with a code from the second org with the same user and verify that you are redirected to the proper org dashboard