### PR TITLE
remove the home item from the usermenu

### DIFF
--- a/frontends/main/src/page-components/Header/UserMenu.tsx
+++ b/frontends/main/src/page-components/Header/UserMenu.tsx
@@ -134,12 +134,6 @@ const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
 
   const items: UserMenuItem[] = [
     {
-      label: "Home",
-      key: "home",
-      allow: true,
-      href: urls.HOME,
-    },
-    {
       label: "Dashboard",
       key: "dashboard",
       allow: !!user?.is_authenticated,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8912

### Description (What does it do?)
This PR simply removes the "Home" entry from the user menu.

### Screenshots (if appropriate):
<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/046ddcb6-4378-434a-9bf0-cf842d39c595" />
<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/f1585fd3-4cd0-44fb-be1c-bc0e5dafb87b" />

### How can this be tested?
- Start up Learn
- Log in and click the user menu in the upper right
- Verify that the "Home" link is gone
