### PR TITLE
Canvas fix for "attachment" type modules

### DIFF
--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -346,6 +346,7 @@ def extract_resources_by_identifierref(manifest_xml: str) -> dict:
     # Find all item elements with identifierref attributes
     for item in root.findall(".//imscp:item[@identifierref]", NAMESPACES):
         identifierref = item.get("identifierref")
+
         title = (
             item.find("imscp:title", NAMESPACES).text
             if item.find("imscp:title", NAMESPACES) is not None
@@ -563,7 +564,6 @@ def get_published_items(zipfile_path, url_config):
         + parse_files_meta(zipfile_path)["active"]
         + parse_web_content(zipfile_path)["active"]
     )
-
     all_embedded_items = []
     for item in all_published_items:
         path = Path(item["path"]).resolve()
@@ -574,6 +574,7 @@ def get_published_items(zipfile_path, url_config):
         if item_visible and (
             str(Path(item["path"]).parent) != "web_resources"
             or files_section_is_visible
+            or item.get("module")
         ):
             published_items[path] = item
         for embedded_file in item.get("embedded_files", []):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8914
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue where if there is a module that _is also_ a file/attachment type and resides in the web_resources - we ingest it


### How can this be tested?
1. checkout main
2. restart celery
3. ingest this canvas course `python manage.py backpopulate_canvas_courses --canvas-ids 33401`
4. go into shell and see that 
```python
from learning_resources.models import *
LearningResource.objects.filter(readable_id__istartswith="33401").first().runs.first().content_files.filter(file_extension=".pdf").values_list("source_path")
```
5. see that "Lecture 9 Quesnay.pdf" does not exist in the list of files
6. re-run the above on this branch
7. see that it shows up (along with other similar attachment modules in the course)



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
