### PR TITLE
Remove usage of 'next' url cookie

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -26,7 +26,7 @@ def get_redirect_url(request, param_names):
         str: Redirect URL
     """
     for param_name in param_names:
-        next_url = request.GET.get(param_name) or request.COOKIES.get(param_name)
+        next_url = request.GET.get(param_name)
         if next_url and url_has_allowed_host_and_scheme(
             next_url, allowed_hosts=settings.ALLOWED_REDIRECT_HOSTS
         ):

--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -153,7 +153,6 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
         if settings.DISABLE_APISIX_USER_MIDDLEWARE:
             return super().process_request(request)
         apisix_user = None
-        next_param = request.GET.get("next", None) if request.GET else None
         if request.META.get(self.header):
             new_header = decode_apisix_headers(
                 request, self.header, model=settings.AUTH_USER_MODEL
@@ -192,7 +191,4 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
             log.debug("Forcing user logout because no APISIX user was found")
             logout(request)
 
-        response = self.get_response(request)
-        if next_param:
-            response.set_cookie("next", next_param, max_age=30, secure=False)
-        return response
+        return self.get_response(request)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/8977

### Description (What does it do?)
<!--- Describe your changes in detail -->
This removes the usage of the `next` parameter being stored and then being used for login and logout. This was causing issues because it was redirecting to auth-required urls on logout. The `next` param works without it anyway.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- You should be able to login and the next urls passed should still work
- You should be able to logout from a page like `/dashboard` and not be prompted to reauthenticate.