### PR TITLE
Hardcoded versions for apisix, keycloak, postgres

### DIFF
--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -5,7 +5,7 @@ services:
   db:
     profiles:
       - backend
-    image: postgres:12.22
+    image: postgres:16
     healthcheck:
       test: ["CMD", "pg_isready"]
       interval: 3s
@@ -91,7 +91,7 @@ services:
   keycloak:
     profiles:
       - keycloak
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:26.4
     depends_on:
       db:
         condition: service_healthy
@@ -117,7 +117,7 @@ services:
   apigateway:
     profiles:
       - apisix
-    image: apache/apisix:latest
+    image: apache/apisix:3.13.0-debian # versions above this drop the local port on redirects
     environment:
       - CSRF_COOKIE_DOMAIN=${CSRF_COOKIE_DOMAIN:-.odl.local}
       - KEYCLOAK_REALM_NAME=${KEYCLOAK_REALM_NAME:-ol-local}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds hardcoded version of postgres, keycloak, and apisix.  Postgres and keycloak versions match deployed versions. Versions of apisix above 3.13 do not include the local port when redirecting on login.


### How can this be tested?
- Back up your database if you want to keep the info there.
- Run `docker compose down`
- Run `docker compose up`
- Restore your database if you backed it up
- Try logging in and logging out