### PR TITLE
Fixes flaky test on resource cards

### DIFF
--- a/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
+++ b/frontends/ol-components/src/components/LearningResourceCard/LearningResourceListCard.test.tsx
@@ -162,12 +162,14 @@ describe("Learning Resource List Card", () => {
 
   test("Displays certificate badge", () => {
     const resource = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
       certification: true,
     })
 
     setup({ resource })
 
-    expect(screen.getAllByText("Certificate").length).toEqual(2)
+    screen.getByText("Certificate")
+    screen.getByText(resource.certification_type.name)
   })
 
   test("Displays certificate type", () => {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

This PR added a test for the certificate text on resource cards https://github.com/mitodl/mit-learn/pull/2623 and provided test factories for the values, however only programs and courses have certification.

This introduces flake on a test that select a resource type at random. This fix sets it to always be a course to ensure values for `certification_type`.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

`yarn test LearningResourceListCard` should pass consistently.
