### PR TITLE
Avoid double slashes in paths

### DIFF
--- a/video_shorts/factories.py
+++ b/video_shorts/factories.py
@@ -20,12 +20,12 @@ class VideoShortFactory(DjangoModelFactory):
         datetime.now(tz=UTC),
     )
     thumbnail_url = factory.LazyAttribute(
-        lambda obj: f"https://example.com/thumbnails/{obj.youtube_id}.jpg"
+        lambda obj: f"shorts/{obj.youtube_id}/{obj.youtube_id}.jpg"
     )
     thumbnail_height = FuzzyInteger(360, 720)
     thumbnail_width = FuzzyInteger(480, 1280)
     video_url = factory.LazyAttribute(
-        lambda obj: f"https://example.com/videos/{obj.youtube_id}.mp4"
+        lambda obj: f"shorts/{obj.youtube_id}/{obj.youtube_id}.mp4"
     )
 
     class Meta:

--- a/video_shorts/serializers.py
+++ b/video_shorts/serializers.py
@@ -1,5 +1,7 @@
 """Serializers for video shorts"""
 
+from urllib.parse import urljoin
+
 from django.conf import settings
 from rest_framework import serializers
 
@@ -46,7 +48,7 @@ class YouTubeMetadataSerializer(VideoShortSerializer):
         )
 
         # Use relative URLs so they work regardless of domain
-        base_path = f"/{settings.VIDEO_SHORTS_S3_PREFIX}/{youtube_id}/"
+        base_path = urljoin(f"/{settings.VIDEO_SHORTS_S3_PREFIX}/", f"{youtube_id}/")
         transformed_data = {
             "youtube_id": youtube_id,
             "title": snippet.get("title"),

--- a/video_shorts/serializers_test.py
+++ b/video_shorts/serializers_test.py
@@ -22,10 +22,10 @@ def test_video_short_serializer_read():
         title="Test Video",
         description="Test description",
         published_at=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
-        thumbnail_url="https://example.com/thumb.jpg",
+        thumbnail_url="/shorts/test_123/test_123.jpg",
         thumbnail_height=360,
         thumbnail_width=480,
-        video_url="https://example.com/video.mp4",
+        video_url="/shorts/test_123/test_123.mp4",
     )
 
     serializer = VideoShortSerializer(video_short)
@@ -41,10 +41,10 @@ def test_video_short_serializer_read():
             "title": "Test Video",
             "description": "Test description",
             "published_at": "2024-01-15T12:00:00Z",
-            "thumbnail_url": "https://example.com/thumb.jpg",
+            "thumbnail_url": "/shorts/test_123/test_123.jpg",
             "thumbnail_height": 360,
             "thumbnail_width": 480,
-            "video_url": "https://example.com/video.mp4",
+            "video_url": "/shorts/test_123/test_123.mp4",
         },
     )
 
@@ -56,10 +56,10 @@ def test_video_short_serializer_create():
         "title": "Created Video",
         "description": "Created description",
         "published_at": "2024-01-15T12:00:00Z",
-        "thumbnail_url": "https://example.com/created_thumb.jpg",
+        "thumbnail_url": "/shorts/create_test/create_test.jpg",
         "thumbnail_height": 720,
         "thumbnail_width": 1280,
-        "video_url": "https://example.com/created_video.mp4",
+        "video_url": "/shorts/create_test/create_test.mp4",
     }
 
     serializer = VideoShortSerializer(data=data)
@@ -120,9 +120,12 @@ def test_video_short_serializer_update():
     assert_json_equal(result_data, data)
 
 
-def test_youtube_metadata_serializer(settings, sample_youtube_metadata):
+@pytest.mark.parametrize(
+    "prefix", ["youtube_shorts/", "youtube_shorts", "youtube_shorts//"]
+)
+def test_youtube_metadata_serializer(settings, sample_youtube_metadata, prefix):
     """Test YouTubeMetadataSerializer transforms YouTube API data correctly"""
-    settings.VIDEO_SHORTS_S3_PREFIX = "youtube_shorts"
+    settings.VIDEO_SHORTS_S3_PREFIX = prefix
 
     serializer = YouTubeMetadataSerializer(data=sample_youtube_metadata)
     assert serializer.is_valid()


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/2631

### Description (What does it do?)
Avoids double slashes in video short url paths

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Run `./manage.py backpopulate_video_shorts`
- Go to http://open.odl.local:8063/api/v0/video_shorts/, check that there are not double slashes in the url paths
