### PR TITLE
alter org page header based on new requirements

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
@@ -26,6 +26,7 @@ const makeProgram = factories.programs.program
 const makeProgramCollection = factories.programs.programCollection
 const makeCourseEnrollment = factories.enrollment.courseEnrollment
 const makeGrade = factories.enrollment.grade
+const makeContract = factories.contracts.contract
 
 const dashboardCourse: PartialFactory<DashboardCourse> = (...overrides) => {
   return mergeOverrides<DashboardCourse>(
@@ -127,6 +128,11 @@ const setupEnrollments = (includeExpired: boolean) => {
 const setupProgramsAndCourses = () => {
   const user = u.factories.user.user()
   const orgX = factories.organizations.organization({ name: "Org X" })
+  const contract = makeContract({
+    organization: orgX.id,
+    name: "Org X Contract",
+  })
+  orgX.contracts = [contract]
   const mitxOnlineUser = factories.user.user({ b2b_organizations: [orgX] })
   setMockResponse.get(u.urls.userMe.get(), user)
   setMockResponse.get(urls.userMe.get(), mitxOnlineUser)

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.test.tsx
@@ -37,8 +37,9 @@ describe("OrganizationContent", () => {
     renderWithProviders(<OrganizationContent orgSlug={orgX.slug} />)
 
     await screen.findByRole("heading", {
-      name: `Your ${orgX.name} Home`,
+      name: orgX.name,
     })
+    await screen.findByText(orgX.contracts[0].name)
 
     const programAHeader = await screen.findByText(programA.title)
     const programBHeader = await screen.findByText(programB.title)
@@ -300,8 +301,9 @@ describe("OrganizationContent", () => {
 
     // Wait for the header to appear
     await screen.findByRole("heading", {
-      name: `Your ${orgX.name} Home`,
+      name: orgX.name,
     })
+    await screen.findByText(orgX.contracts[0].name)
 
     // Since there are no programs or collections, no program/collection components should be rendered
     const programs = screen.queryAllByTestId("org-program-root")
@@ -331,8 +333,9 @@ describe("OrganizationContent", () => {
 
     // Wait for the header to appear
     await screen.findByRole("heading", {
-      name: `Your ${orgX.name} Home`,
+      name: orgX.name,
     })
+    await screen.findByText(orgX.contracts[0].name)
 
     // Should have no collections
     const collections = screen.queryAllByTestId("org-program-collection-root")

--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -68,9 +68,10 @@ const OrganizationHeader: React.FC<{ org?: OrganizationPage }> = ({ org }) => {
       </ImageContainer>
       <Stack gap="8px">
         <Typography variant="h3" component="h1">
-          Your {org?.name} Home
+          {org?.name}
         </Typography>
-        <Typography variant="body1">MIT courses for {org?.name}</Typography>
+        {/* For now we will use the first contract name until we refactor this to be based on contracts / offerings */}
+        <Typography variant="body1">{org?.contracts[0]?.name}</Typography>
       </Stack>
     </HeaderRoot>
   )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9050

### Description (What does it do?)
This PR updates the headers on org dashboard pages to display only the org name and the contract / offering name as the subheader as detailed in the above issue. Since the org dashboards are now currently based on the organization at the top level, the first contract found is used in the subheader.

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/77cb3d3a-7ac5-4a4d-aaa3-ba3827b67410" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/81e238fe-fd0b-4e63-8852-35da08448dc8" />

### How can this be tested?
- Make sure you have an instance of MITx Online up and running
- Configure your local Learn instance to integrate with your instance of MITx Online following the directions in the README
- Make sure you have an organization set up in MITx Online and that your user is enrolled in it
- Ensure your organization has at least one contract
- Ensure that our organization has a program associated with the contract with courses in it
- Once all that is complete, visit the Learn dashboard
- Click on the org dashboard card CTA or tab to navigate to the org dashboard
- Verify that the title and subtitle reflect what is described above