### PR TITLE
Add periodic topic collection sync task

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -181,7 +181,7 @@ CELERY_BEAT_SCHEDULE = (
             ),  # default is every 30 minutes
         },
         "daily_topic_embeddings_sync": {
-            "task": "vector_search.tasks.sync_topic_embeddings",
+            "task": "vector_search.tasks.sync_topics",
             "schedule": crontab(minute=0, hour="6,18,23"),  # 2am 2pm and 7pm EST
         },
     }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to item missed in [previous PR](https://github.com/mitodl/mit-learn/pull/2664) and https://github.com/mitodl/hq/issues/9056

### Description (What does it do?)
This PR adds the scheduled task to update the topics collection which was missed in a previous pr.


### How can this be tested?
1. checkout this branch
2. run the task manually and see that it succeeds:
```python
from vector_search.tasks import sync_topics
sync_topics()
```

