### PR TITLE
set h5 on the welcome message

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -108,7 +108,7 @@ const WelcomeMessage: React.FC<{ org?: OrganizationPage }> = ({ org }) => {
   return (
     <Stack gap="12px" paddingTop="40px" paddingBottom="24px">
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Typography variant="body1">{welcomeMessage}</Typography>
+        <Typography variant="h5">{welcomeMessage}</Typography>
         <Link
           scroll={false}
           color="red"


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-learn/pull/2677

### Description (What does it do?)
In the above PR, I missed setting an important style

### How can this be tested?
Follow the instructions in https://github.com/mitodl/mit-learn/pull/2677 and verify that the welcome message title displays as an h5 and not body text.
