### PR TITLE
Fix bug for staleness and completeness opensearch

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -592,38 +592,37 @@ def add_text_query_to_search(search, text, search_params, query_type_query):
 
     if yearly_decay_percent or max_incompleteness_penalty:
         script_query = {
-            "script_score": {
+            "function_score": {
                 "query": {"bool": {"must": [text_query], "filter": query_type_query}}
             }
         }
 
-        completeness_term = (
-            "(doc['completeness'].value * params.max_incompleteness_penalty + "
-            "(1-params.max_incompleteness_penalty))"
-        )
-
-        staleness_term = (
-            "(doc['resource_age_date'].size() == 0 ? 1 : "
-            "decayDateLinear(params.origin, params.scale, params.offset, params.decay, "
-            "doc['resource_age_date'].value))"
-        )
-
-        source = "_score"
+        source = []
         params = {}
 
         if max_incompleteness_penalty:
-            source = f"{source} * {completeness_term}"
+            completeness_term = (
+                "(doc['completeness'].value * params.max_incompleteness_penalty + "
+                "(1-params.max_incompleteness_penalty))"
+            )
+            source.append(completeness_term)
             params["max_incompleteness_penalty"] = max_incompleteness_penalty
 
         if yearly_decay_percent:
-            source = f"{source} * {staleness_term}"
+            staleness_term = (
+                "(doc['resource_age_date'].size() == 0 ? 1 : "
+                "decayDateLinear(params.origin, params.scale, params.offset, "
+                "params.decay, doc['resource_age_date'].value))"
+            )
+            source.append(staleness_term)
             params["decay"] = 1 - (yearly_decay_percent / 100)
             params["offset"] = "0"
             params["scale"] = "365d"
             params["origin"] = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
-        script_query["script_score"]["script"] = {
-            "source": source,
+        script_query["function_score"]["script_score"] = {}
+        script_query["function_score"]["script_score"]["script"] = {
+            "source": "*".join(source),
             "params": params,
         }
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2000,8 +2000,8 @@ def test_execute_learn_search_with_script_score(
 
     if yearly_decay_percent > 0 and max_incompleteness_penalty > 0:
         source = (
-            "_score * (doc['completeness'].value * params.max_incompleteness_penalty + "
-            "(1-params.max_incompleteness_penalty)) * (doc['resource_age_date'].size() == 0 ? "
+            "(doc['completeness'].value * params.max_incompleteness_penalty + "
+            "(1-params.max_incompleteness_penalty))*(doc['resource_age_date'].size() == 0 ? "
             "1 : decayDateLinear(params.origin, params.scale, params.offset, params.decay, "
             "doc['resource_age_date'].value))"
         )
@@ -2014,7 +2014,7 @@ def test_execute_learn_search_with_script_score(
         }
     elif yearly_decay_percent > 0:
         source = (
-            "_score * (doc['resource_age_date'].size() == 0 ? "
+            "(doc['resource_age_date'].size() == 0 ? "
             "1 : decayDateLinear(params.origin, params.scale, params.offset, params.decay, "
             "doc['resource_age_date'].value))"
         )
@@ -2027,7 +2027,7 @@ def test_execute_learn_search_with_script_score(
         }
     else:
         source = (
-            "_score * (doc['completeness'].value * params.max_incompleteness_penalty +"
+            "(doc['completeness'].value * params.max_incompleteness_penalty +"
             " (1-params.max_incompleteness_penalty))"
         )
         params = {"max_incompleteness_penalty": 0.25}
@@ -2047,7 +2047,17 @@ def test_execute_learn_search_with_script_score(
 
     query = {
         "query": {
-            "script_score": {
+            "function_score": {
+                "functions": [
+                    {
+                        "script_score": {
+                            "script": {
+                                "params": params,
+                                "source": source,
+                            },
+                        },
+                    },
+                ],
                 "query": {
                     "bool": {
                         "must": [
@@ -2300,10 +2310,6 @@ def test_execute_learn_search_with_script_score(
                         ],
                         "filter": [{"exists": {"field": "resource_type"}}],
                     }
-                },
-                "script": {
-                    "source": source,
-                    "params": params,
                 },
             }
         },


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/9243

### Description (What does it do?)
Currently there is a bug on production causing errors if yearly_decay_percent or max_incompleteness_penalty is greater than zero. For example

https://learn.mit.edu/search?q=human+brain&yearly_decay_percent=5&resource_category=course

I was able to recreate the issue locally (but weirdly rc works correctly)

Changing the the format of the query to match the opensearch documentation fixed it for me locally https://docs.opensearch.org/latest/query-dsl/compound/function-score/

Hopefully it works on prod too and is a good idea regardless

There is also a  separate bug that is setting `next_start_date` to the latest etl run for ocw courses https://github.com/mitodl/hq/issues/9206 that will be fixed in a different pr


### How can this be tested?

Download single variable calculus from fall 2006
`
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 18-01-single-variable-calculus-fall-2006 --skip-contentfiles
`

Clear out next_start_date from ocw courses 
`
 LearningResource.objects.filter(offered_by='ocw').update(next_start_date=None)
`

Update the course index to update `next_start_date` in search
`
docker-compose run web ./manage.py update_index --courses
`
go to  http://open.odl.local:8062/search  and login

Search for "single variable calculus" 

You should be able to set "Resource Score Staleness Penalty" from the admin section to any value. 18-01-single-variable-calculus-fall-2006 should move down in the search results as "Resource Score Staleness Penalty"  increases