### PR TITLE
log error if a shard has a failure

### DIFF
--- a/docker-compose.opensearch.base.yml
+++ b/docker-compose.opensearch.base.yml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:2.19.3
+    image: opensearchproject/opensearch:3.1.0
     environment:
       - "cluster.name=opensearch-cluster"
       - "bootstrap.memory_lock=true" # along with the memlock settings below, disables swapping

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -739,7 +739,13 @@ def execute_learn_search(search_params):
                 settings.DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY
             )
     search = construct_search(search_params)
-    return search.execute().to_dict()
+    results = search.execute().to_dict()
+    if results.get("_shards", {}).get("failures"):
+        log.error(
+            "Search encountered shard failures: %s",
+            results.get("_shards").get("failures"),
+        )
+    return results
 
 
 def subscribe_user_to_search_query(


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/9243

### Description (What does it do?)
When troubleshooting the error with search last week it was hard to pinpoint when we started to see errors because when search fails on only one index it returns a failure in the results but does not throw an error. The output looks like this
```
{
    "took": 43,
    "timed_out": false,
    "_shards": {
        "total": 14,
        "successful": 13,
        "skipped": 0,
        "failed": 1,
        "failures": [
            {
                "shard": 0,
                "index": "discussions_local_course_a95041c10a534ff4b6c10205cfc37a23",
                "node": "-OmsQRjERXCphsBXJT9LDg",
                "reason": {
                    "type": "null_pointer_exception",
                    "reason": null
                }
            }
        ]
    },
    "hits": {
        "total": {
            "value": 1,
            "relation": "eq"
        },
        "max_score": 3.6244159,
        "hits": [
.....
```

And we get hits from the 13 good shards .This means we don't have any record in sentry for the error. This creates an error log if there is something in results["_shards"]["failures"]

### How can this be tested?
For me locally i see the failure in the results for http://api.open.odl.local:8063/api/v1/learning_resources_search/?q=math&dev_mode=True&yearly_decay_percent=2&max_incompleteness_penalty=2 and no course results if opensearch version is 3.1.0 and the fix in https://github.com/mitodl/mit-learn/pull/2688 is not merged. I did not see that error right away though and rc works correctly. I'm not sure how to cause an error on only one shard if the above works for you locally like it does on rc.   It should be fine to test that this update does not cause problems in the success case then.


If you get an error/no courses with http://api.open.odl.local:8063/api/v1/learning_resources_search/?q=math&yearly_decay_percent=2&max_incompleteness_penalty=2  then you should see

web-1                        | [2025-11-10 18:35:54] ERROR 906 [learning_resources_search.api] api.py:744 - [900b20aea938] - Search encountered shard failures: [{'shard': 0, 'index': 'discussions_local_course_a95041c10a534ff4b6c10205cfc37a23', 'node': '-OmsQRjERXCphsBXJT9LDg', 'reason': {'type': 'null_pointer_exception', 'reason': None}}]
in the logs

The search with 
&yearly_decay_percent=0&max_incompleteness_penalty=0

in the params should work correctly and not log anything
