### PR TITLE
replacing underscore with dashes for bootstrap featureflags

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -15,7 +15,7 @@ const processFeatureFlags = () => {
   for (const [key, value] of Object.entries(process.env)) {
     if (key.startsWith(`NEXT_PUBLIC_${featureFlagPrefix}`)) {
       bootstrapFeatureFlags[
-        key.replace(`NEXT_PUBLIC_${featureFlagPrefix}`, "")
+        key.replace(`NEXT_PUBLIC_${featureFlagPrefix}`, "").replaceAll("_", "-")
       ] = value === "True" ? true : JSON.stringify(value)
     }
   }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/9102
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This Pr includes a small change so that we can properly pull boostrapped feature flags from environment variables. our existing feature-flags use hyphens which wont work for environment variables.

There is an associated [ol-infrastructure](https://github.com/mitodl/ol-infrastructure/pull/3822) PR to set the defaults based off of [the spreadsheet](https://docs.google.com/document/d/1jYV3nYLG4MeyYnziifhZicA2u-01Qk1z3_Ad6jPQ414/edit?tab=t.0)

### How can this be tested?
1. checkout this branch
2. Make sure you have posthog setup and enabled locally
3. go to the homepage and note that there is no "asktim" under the search bar (assuming you dont have the feature flag set in your personal/test account)
4. set NEXT_PUBLIC_FEATURE_home_page_recommendation_bot=True in your frontend.env file
5. `docker docker compose down web watch` and `docker compose up -d`
6. visit the homepage - nothing should be different ("asktim" should still be hidden)
7. turn off your wifi and reload the homepage - note that "asktim" is visible since it falls back to the bootstrapped value (the default we want from the spreadsheet)

