### PR TITLE
Canvas ingestion bug fix

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -85,7 +85,7 @@ def run_for_canvas_archive(course_archive_path, course_folder, overwrite):
     """
     checksum = calc_checksum(course_archive_path)
     course_info = parse_canvas_settings(course_archive_path)
-    course_title = course_info.get("title")
+    course_title = course_info.get("title", f"canvas course {course_folder}")
     url = canvas_course_url(course_archive_path)
     start_at = course_info.get("start_at")
     end_at = course_info.get("conclude_at")

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -114,7 +114,10 @@ def parse_module_meta(course_archive_path: str) -> dict:
     """
     Parse module_meta.xml and return publish/active status of resources.
     """
+
     with zipfile.ZipFile(course_archive_path, "r") as course_archive:
+        if "course_settings/module_meta.xml" not in course_archive.namelist():
+            return {"active": [], "unpublished": []}
         module_xml = course_archive.read("course_settings/module_meta.xml")
         manifest_xml = course_archive.read("imsmanifest.xml")
     resource_map = extract_resources_by_identifierref(manifest_xml)
@@ -412,6 +415,8 @@ def parse_context_xml(course_archive_path: str) -> dict:
     Parse course_settings/context.xml and return context info
     """
     with zipfile.ZipFile(course_archive_path, "r") as course_archive:
+        if "course_settings/context.xml" not in course_archive.namelist():
+            return {}
         context = course_archive.read("course_settings/context.xml")
     root = ElementTree.fromstring(context)
     context_info = {}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/9269
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resoolves an issue where if a canvas course does not have any modules. The ingestion process silently fails even if there are tutor problems and/or files to process as contentfiles.

### How can this be tested?
1. checkout main
2. download the [example canvas archive](https://drive.google.com/file/d/1pTVUL1AXnY8UBwmfv9Rj64klU-VRNXsa/view?usp=drive_link) which is missing modules_meta.xml
3. place the archive relative to your learn repo
4. open a django shell and attempt to process it with the following script and see it fail:
```python
from learning_resources.etl.canvas import run_for_canvas_archive,transform_canvas_content_files
from pathlib import Path
zipfile = Path("broken-canvas.zip")
_, run = run_for_canvas_archive(zipfile, "tmp", True)
list(transform_canvas_content_files(zipfile, run,{}, overwrite=True))
```
5. checkout this branch and do the same and note that it succeeds
