### PR TITLE
add task decorator back to command

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -497,6 +497,7 @@ def _sentry_healthcheck_log(healthcheck, alert_type, context, message):
         sentry_sdk.capture_message(message)
 
 
+@app.task
 def sync_topics():
     """
     Sync topics to the Qdrant collection


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/9290
<!--- Fixes # --->
<!--- N/A --->

note: the openapi diff error appears to be unrelated to these changes

### Description (What does it do?)
This PR re-introduces a missing celery task decorator to the sync_topics task


### How can this be tested?
1. checkout main
2. attempt to run `python manage.py sync_topic_embeddings`
3. see that it fails with an error
4. checkout this branch
5. restart celery and re-run the command - note that it passes



