### PR TITLE
[WIP] Fix feature flag loading issue on product pages

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -34,7 +34,7 @@
     "next-nprogress-bar": "^2.4.2",
     "ol-components": "0.0.0",
     "ol-utilities": "0.0.0",
-    "posthog-js": "^1.157.2",
+    "posthog-js": "^1.296.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-slick": "^0.30.2",

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -22,6 +22,7 @@ import ProductPageTemplate, {
 } from "./ProductPageTemplate"
 import { CoursePageItem } from "@mitodl/mitxonline-api-axios/v2"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 
 type CoursePageProps = {
   readableId: string
@@ -76,10 +77,11 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
   const page = pages.data?.items[0]
   const course = courses.data?.results?.[0]
   const enabled = useFeatureFlagEnabled(FeatureFlags.ProductPageCourse)
-  if (enabled === false) {
+  const flagsLoaded = useFeatureFlagsLoaded()
+  if (!flagsLoaded) return null
+  if (!enabled) {
     return notFound()
   }
-  if (!enabled) return
 
   const doneLoading = pages.isSuccess && courses.isSuccess
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -24,6 +24,7 @@ import { ProgramSummary } from "./ProductSummary"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { learningResourceQueries } from "api/hooks/learningResources"
 import { ResourceTypeEnum } from "api"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 
 type ProgramPageProps = {
   readableId: string
@@ -89,10 +90,11 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
   const program = programs.data?.results?.[0]
   const programResource = programResources.data?.results?.[0]
   const enabled = useFeatureFlagEnabled(FeatureFlags.ProductPageCourse)
-  if (enabled === false) {
+  const flagsLoaded = useFeatureFlagsLoaded()
+  if (!flagsLoaded) return null
+  if (!enabled) {
     return notFound()
   }
-  if (!enabled) return
 
   const isLoading =
     pages.isLoading || programs.isLoading || programResources.isLoading

--- a/frontends/main/src/common/useFeatureFlagsLoaded.test.ts
+++ b/frontends/main/src/common/useFeatureFlagsLoaded.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { act } from "react"
+import { usePostHog } from "posthog-js/react"
+import type { PostHog } from "posthog-js"
+
+// Import the real implementation, not the mock
+const { useFeatureFlagsLoaded } = jest.requireActual("./useFeatureFlagsLoaded")
+
+jest.mock("posthog-js/react", () => {
+  return {
+    __esModule: true,
+    usePostHog: jest.fn(),
+  }
+})
+
+const mockUsePostHog = jest.mocked(usePostHog)
+
+describe("useFeatureFlagsLoaded", () => {
+  let onFeatureFlagsCallback:
+    | ((flags: string[], variants: Record<string, string | boolean>) => void)
+    | null = null
+
+  const createPostHogMock = (hasLoadedFlags: boolean) => {
+    return {
+      featureFlags: {
+        hasLoadedFlags,
+      },
+      onFeatureFlags: jest.fn((callback) => {
+        onFeatureFlagsCallback = callback
+        return () => {} // Return cleanup function
+      }),
+    } as unknown as PostHog
+  }
+
+  beforeEach(() => {
+    onFeatureFlagsCallback = null
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test("Returns false when flags have not loaded yet", () => {
+    mockUsePostHog.mockReturnValue(createPostHogMock(false))
+
+    const { result } = renderHook(() => useFeatureFlagsLoaded())
+
+    expect(result.current).toBe(false)
+  })
+
+  test("Returns true when flags have already loaded", () => {
+    mockUsePostHog.mockReturnValue(createPostHogMock(true))
+
+    const { result } = renderHook(() => useFeatureFlagsLoaded())
+
+    expect(result.current).toBe(true)
+  })
+
+  test("Returned value is reactive and re-renders when onFeatureFlags callback runs", async () => {
+    mockUsePostHog.mockReturnValue(createPostHogMock(false))
+
+    const { result } = renderHook(() => useFeatureFlagsLoaded())
+
+    // Initially should be false
+    expect(result.current).toBe(false)
+
+    // Simulate flags loading by calling the callback
+    expect(onFeatureFlagsCallback).not.toBeNull()
+    act(() => {
+      onFeatureFlagsCallback!([], {})
+    })
+
+    // Wait for the state to update
+    await waitFor(() => {
+      expect(result.current).toBe(true)
+    })
+  })
+
+  test("onFeatureFlags callback is registered on mount", () => {
+    const mockPostHog = createPostHogMock(false)
+    mockUsePostHog.mockReturnValue(mockPostHog)
+
+    renderHook(() => useFeatureFlagsLoaded())
+
+    expect(mockPostHog.onFeatureFlags).toHaveBeenCalledTimes(1)
+    expect(mockPostHog.onFeatureFlags).toHaveBeenCalledWith(
+      expect.any(Function),
+    )
+  })
+})

--- a/frontends/main/src/common/useFeatureFlagsLoaded.ts
+++ b/frontends/main/src/common/useFeatureFlagsLoaded.ts
@@ -1,0 +1,17 @@
+import { usePostHog } from "posthog-js/react"
+import { useState, useEffect } from "react"
+
+const useFeatureFlagsLoaded = () => {
+  const posthog = usePostHog()
+  const [hasLoaded, setHasLoaded] = useState(
+    posthog.featureFlags.hasLoadedFlags,
+  )
+  useEffect(() => {
+    posthog.onFeatureFlags(() => {
+      setHasLoaded(true)
+    })
+  }, [posthog])
+  return hasLoaded
+}
+
+export { useFeatureFlagsLoaded }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4402,6 +4402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@posthog/core@npm:1.5.2":
+  version: 1.5.2
+  resolution: "@posthog/core@npm:1.5.2"
+  dependencies:
+    cross-spawn: "npm:^7.0.6"
+  checksum: 10/157f28357f44ab3fcd42fc1ef2b027b89c5c12dde449df98a1d6b16f9db0c3340e705827029d5cf8ba5f1193465eabe6c3ef7f2beccc25033009fa3b9cfe8416
+  languageName: node
+  linkType: hard
+
 "@prisma/instrumentation@npm:6.13.0":
   version: 6.13.0
   resolution: "@prisma/instrumentation@npm:6.13.0"
@@ -9915,6 +9924,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"core-js@npm:^3.38.1":
+  version: 3.47.0
+  resolution: "core-js@npm:3.47.0"
+  checksum: 10/c02dc6a091c7e6799e3527dc06a428c44bbcff7f8f6ee700ff818b90aa2ebaf1f17b0234146e692811da97cda5a39a6095ecadec9fd1a74b1135103eb0e96cb1
+  languageName: node
+  linkType: hard
+
 "core-util-is@npm:~1.0.0":
   version: 1.0.3
   resolution: "core-util-is@npm:1.0.3"
@@ -10029,7 +10045,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -15327,7 +15343,7 @@ __metadata:
     ol-components: "npm:0.0.0"
     ol-test-utilities: "npm:0.0.0"
     ol-utilities: "npm:0.0.0"
-    posthog-js: "npm:^1.157.2"
+    posthog-js: "npm:^1.296.1"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     react-slick: "npm:^0.30.2"
@@ -17874,14 +17890,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"posthog-js@npm:^1.157.2":
-  version: 1.167.0
-  resolution: "posthog-js@npm:1.167.0"
+"posthog-js@npm:^1.296.1":
+  version: 1.296.1
+  resolution: "posthog-js@npm:1.296.1"
   dependencies:
+    "@posthog/core": "npm:1.5.2"
+    core-js: "npm:^3.38.1"
     fflate: "npm:^0.4.8"
     preact: "npm:^10.19.3"
-    web-vitals: "npm:^4.0.1"
-  checksum: 10/7b1332cecb86094f9c08394065f459dfcb99d5de72deb79a36f1fa16be6bf88ec3524d1699b8cf1cac3d637fdf307ad95e614477cdbc3ad703d0cecfb2f3374a
+    web-vitals: "npm:^4.2.4"
+  checksum: 10/8209cb287674d9b4657f3d27488afabcbf22fc98b9b02a4bbe4652bf0d9151a71484e94cb404fa9b4469fde825f87cb0186a069257bbf725c83e160802ea7805
   languageName: node
   linkType: hard
 
@@ -22352,10 +22370,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"web-vitals@npm:^4.0.1":
-  version: 4.2.3
-  resolution: "web-vitals@npm:4.2.3"
-  checksum: 10/f4f1b0d6e0dd06b50a1d48c5cbe8a2804f26c5778d7c9bd0a8f591c147fd044f35465a3e95659b9ca801bfd85742e0ac70c3416228c4241d858fcecb8b396503
+"web-vitals@npm:^4.2.4":
+  version: 4.2.4
+  resolution: "web-vitals@npm:4.2.4"
+  checksum: 10/68cd1c2625a04b26e7eab67110623396afc6c9ef8c3a76f4e780aefe5b7d4ca1691737a0b99119e1d1ca9a463c4d468c0f0090b1875b6d784589d3a4a8503313
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9317

### Description (What does it do?)
This PR fixes an issue where the feature-flagged product pages would occasionally show 404, particularly on slow networks.


### How can this be tested?
If you really want to see (A) the issue on `main` and (B) that this PR fixes it:



1. **Prerequisites:**
    - Learn <> MITxOnline integration set up
    - Posthog setup with `product-course-page` flag enabled
    - `NODE_ENV=production` in `frontend.local.env` (I find that page loads too slowly in dev mode, meaning that posthog always loads latest; the race condition is much more reproducible in production mode.)
2. On `main`:
    1. visit `http://open.odl.local:8062/programs/<readable-id>`
    2. enable network throttling (4G should be good enough) and reload the page. If you don't get 404, keep reloading, but I've found it very reproducible on 4G throttling in production mode.
3. Repeat Step 2 on this branch. 

