### PR TITLE
Flaky test vector_search/tasks_test.py::test_embeddings_healthcheck_missing_both

### DIFF
--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -412,7 +412,7 @@ def test_embeddings_healthcheck_missing_both(mocker):
     """
     Test embeddings_healthcheck when there are missing content files and learning resources
     """
-    lr = LearningResourceFactory.create(published=True)
+    lr = LearningResourceFactory.create(published=True, create_runs=False)
     LearningResourceRunFactory.create(published=True, learning_resource=lr)
     cf = ContentFileFactory.create(run=lr.runs.first(), content="test", published=True)
     mocker.patch(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/9340
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes a flaky test that fails due to unexpected runs created within the factory.

This PR also includes a change to add pytest-repeat which  allows us to run tests x amount of times via `pytest --count n`

### How can this be tested?
1. checkout main
2. manually install pytest-repeat `poetry add pytest-repeat`
3. run ` pytest --count 100 vector_search/tasks_test.py::test_embeddings_healthcheck_missing_both --pdb -x -s` and see it fail
4. checkout this branch and re-run. tests should always pass

