### PR TITLE
pass in debug mode flag to docling pdf converter

### DIFF
--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -1079,7 +1079,7 @@ def _pdf_to_markdown(pdf_path):
     """
     Convert a PDF file to markdown using an llm
     """
-    converter = DoclingLLMConverter(pdf_path)
+    converter = DoclingLLMConverter(pdf_path, debug_mode=False)
     return converter.convert_to_markdown()
 
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/9524
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR passes in debug_mode to the docling converter to avoid an exception

### How can this be tested?
1. checkout main
2. set your OPENAI_API_KEY to your key and set OCR_MODEL to "gpt-5-nano-2025-08-07"
3. try backpopulating canvas courses via `python manage.py backpopulate_canvas_courses --canvas-ids 28841,28842` and note that it fails with an exception
4. checkout this branch and see that it succeeds
