### PR TITLE
fix hybrid search

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -665,7 +665,7 @@ def add_text_query_to_search(
             }
         }
 
-        pagination_depth = search_params.get("limit") * 3
+        pagination_depth = search_params.get("limit", 10) * 3
         search = search.extra(
             query={
                 "hybrid": {


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/2796 introduced a bug
https://api.rc.learn.mit.edu/api/v1/learning_resources_search/?q=calculus&search_mode=hybrid

returns a 500 because limit is null. 

https://rc.learn.mit.edu/search?q=calculus&search_mode=hybrid works correctly because the ui passes a limit

this fixes the issue


### How can this be tested?
http://api.open.odl.local:8063/api/v1/learning_resources_search/?search_mode=hybrid&q=calculus should load
