### PR TITLE
More efficient S3 key retrieval for edX contentfile archives

### DIFF
--- a/learning_resources/etl/edx_shared.py
+++ b/learning_resources/etl/edx_shared.py
@@ -91,7 +91,7 @@ def get_most_recent_course_archives(
             reversed(  # noqa: C413
                 sorted(
                     [
-                        obj
+                        (obj.key, obj.last_modified)
                         for obj in bucket.objects.filter(
                             # Use s3_prefix for OLL, "20" for all others
                             Prefix=s3_prefix
@@ -100,17 +100,17 @@ def get_most_recent_course_archives(
                         )
                         if re.search(course_tar_regex, obj.key)
                     ],
-                    key=lambda obj: obj.last_modified,
+                    key=lambda obj: obj[1],
                 )
             )
         )
         if override_base_prefix:
             # More hoops to get desired result from OLL compared to other sources
             most_recent_export_date = "/".join(
-                [s3_prefix, most_recent_export_file.key.lstrip(s3_prefix).split("/")[0]]
+                [s3_prefix, most_recent_export_file[0].lstrip(s3_prefix).split("/")[0]]
             )
         else:
-            most_recent_export_date = most_recent_export_file.key.split("/")[0]
+            most_recent_export_date = most_recent_export_file[0].split("/")[0]
         log.info("Most recent export date is %s", most_recent_export_date)
         return [
             obj.key


### PR DESCRIPTION
### What are the relevant tickets?
Short-term fix for https://github.com/mitodl/hq/issues/9587

### Description (What does it do?)
Refactors the code so that just the relevant attributes of each S3 object (key, last modified) are added to the list used to find the most recent archives.

### How can this be tested?
- In a shell, run the following:
  ```
  from learning_resources.etl.edx_shared import *
  get_most_recent_course_archives("mitxonline")
  ```

While that is running, use `docker stats` in separate terminal to monitor memory usage.  It might go up by ~150MB or so.

It should complete successfully and return a list of strings with a prefix close to today's date (ex: `20251212/courses/course-v1:MITx+Template.PC.Firefox+04_05_2023.tar.gz')

If you try the same thing on the main branch, the memory usage will be significantly higher.

