### PR TITLE
fix: image issue related to it width

### DIFF
--- a/frontends/ol-components/src/components/TiptapEditor/extensions/node/Image/ImageWithCaption.tsx
+++ b/frontends/ol-components/src/components/TiptapEditor/extensions/node/Image/ImageWithCaption.tsx
@@ -164,11 +164,11 @@ export function ImageWithCaption({
   updateAttributes,
 }: ReactNodeViewProps) {
   const imgRef = useRef<HTMLImageElement | null>(null)
+  const [canExpand, setCanExpand] = useState(false)
 
   const [isLoading, setIsLoading] = useState(true)
 
-  const { layout, caption, src, alt, canExpand } = node.attrs
-
+  const { layout, caption, src, alt } = node.attrs
   const isEditable = node.attrs.editable
 
   useEffect(() => {
@@ -177,10 +177,7 @@ export function ImageWithCaption({
 
     const checkSize = () => {
       const imageNaturalWidth = img.naturalWidth
-      updateAttributes({
-        canExpand: (imageNaturalWidth >
-          WIDE_LAYOUT_MIN_IMG_WIDTH) as unknown as boolean,
-      })
+      setCanExpand(imageNaturalWidth > WIDE_LAYOUT_MIN_IMG_WIDTH)
     }
 
     // when image loads

--- a/frontends/ol-components/src/components/TiptapEditor/extensions/node/Image/ImageWithCaptionNode.ts
+++ b/frontends/ol-components/src/components/TiptapEditor/extensions/node/Image/ImageWithCaptionNode.ts
@@ -13,7 +13,6 @@ export const ImageWithCaptionNode = Node.create({
     return {
       src: { default: null },
       alt: { default: null },
-      canExpand: { default: true },
       title: { default: null },
       editable: { default: true },
       caption: { default: "" },


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
we have implemented the logic in which if image which is upload has it natural width less the 900 then we just have only default layout button if it is bigger than 900 then we display the all the resizable images.

### Screenshots (if appropriate):
<img width="2270" height="1258" alt="image" src="https://github.com/user-attachments/assets/2544ca20-2e9f-4de1-89d0-da74c88fbce7" />

### How can this be tested?
- For Image you just need to upload image and see if it is small is then it should not have resizable buttons except the default one if it is bigger image then all three resizable buttons should be available  on hover the image. basically we tried to restrict the image not too stretched 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
