### PR TITLE
Adjust org dashboard loading skeletons

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/OrganizationContent.tsx
@@ -462,13 +462,8 @@ const OrganizationContentInternal: React.FC<
     </Stack>
   )
 
-  // Wait for all top-level queries to complete before rendering content
-  if (
-    programs.isLoading ||
-    programCollections.isLoading ||
-    courseRunEnrollments.isLoading ||
-    programEnrollments.isLoading
-  ) {
+  // Wait for all program and collection data to load
+  if (programs.isLoading || programCollections.isLoading) {
     return (
       <>
         <Stack>


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-learn/pull/2792

### Description (What does it do?)
After we merged the above PR and got it into RC for testing, an issue was noticed where because of the significant volume of data in RC the initial loading skeleton was displayed for longer than when testing locally. The enrollments and program enrollments endpoints were to blame, and because the above PR shows an initial loading skeleton until all of that information is available, it seems to be extra slow. This PR removes enrollments from that check, allowing loading of the downstream components to continue while waiting for enrollments data to come in.

### How can this be tested?
- Follow the instructions in the above PR to set up some test data
- Load the org dashboard with throttling turned on in your browser and watch the network tab
- You should see an initial loading skeleton while programs and program collections are being fetched, then the program titles should be displayed with loading skeletons under them while it loads the course data for each course in the program / collection
