### PR TITLE
Article Editor: Fix tooltip zindex

### DIFF
--- a/frontends/ol-components/src/components/TiptapEditor/TipTapEditor.styles.scss
+++ b/frontends/ol-components/src/components/TiptapEditor/TipTapEditor.styles.scss
@@ -1,10 +1,10 @@
-/*
-Avoid using this file. It defines GLOBAL styles; these
-might be applied to the entire Learn site.
+/**
+NOTE: These styles will be applied to entire Learn site.
+Do not target raw HTML elements!
 */
 
-// Ensure tooltips appear above other UI elements like the sticky site header
-// NOTE: This must be global because tooltips are appended to document body.
+// Note: This cannot be handled via styled-components, since tooltips
+// are appended to the document body and not scoped with the styled element.
 .tiptap-tooltip {
   z-index: 2000;
 }


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/9558

### Description (What does it do?)
Fixes tooltip zindex.

### Screenshots (if appropriate):
<img width="705" height="225" alt="Screenshot 2025-12-16 at 11 56 02 AM" src="https://github.com/user-attachments/assets/650bc9ea-0111-4a94-beda-44b8ada095f4" />


### How can this be tested?
1. Navigate to http://open.odl.local:8062/articles/new
2. Hover on one of the buttons
