### PR TITLE
pre-filter neural query

### DIFF
--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2731,6 +2731,40 @@ def test_execute_learn_search_with_hybrid_search(mocker, settings, opensearch):
                                 "query_text": "math",
                                 "model_id": "vector_model_id",
                                 "k": 5,
+                                "filter": {
+                                    "bool": {
+                                        "should": [
+                                            {
+                                                "bool": {
+                                                    "should": [
+                                                        {
+                                                            "term": {
+                                                                "resource_type": {
+                                                                    "value": "course",
+                                                                    "case_insensitive": True,
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "bool": {
+                                                    "should": [
+                                                        {
+                                                            "term": {
+                                                                "free": {
+                                                                    "value": True,
+                                                                    "case_insensitive": True,
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                        ]
+                                    }
+                                },
                             }
                         }
                     },


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9375

### Description (What does it do?)
This pr speeds up opensearch hybrid search by moving the search filter into the the neural query. This speeds up the search by reducing the number of records that need to be considered by the neural query

### How can this be tested?
follow the instructions in https://github.com/mitodl/mit-learn/pull/2808 if you don't have the hybrid search index set up yet

verify that both the regular search and hybrid search (search_mode=hybrid added to the url or selected from the admin searchoptions) works