### PR TITLE
update opensearch

### DIFF
--- a/docker-compose.opensearch.base.yml
+++ b/docker-compose.opensearch.base.yml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: opensearchproject/opensearch:3.1.0
+    image: opensearchproject/opensearch:3.3.0
     environment:
       - "cluster.name=opensearch-cluster"
       - "bootstrap.memory_lock=true" # along with the memlock settings below, disables swapping


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Since opensearch 3.3 is available now on amazon we should update to it. Opensearch has already been updated to 3.3 on RC this updates the local docker version

### How can this be tested?
Go to the search page. It should work normally
