### PR TITLE
Revert "pre-filter neural query (#2828)"

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -364,7 +364,7 @@ def generate_filter_clause(
     path: str, value: str, *, case_sensitive: bool, _current_path_length=1
 ):
     """
-    Generate search clause for a single filter path and value.
+    Generate search clause for a single filter path abd value.
 
     Args:
         path (str): Search index on which to filter
@@ -595,29 +595,9 @@ def percolate_matches_for_document(document_id):
     return percolated_queries
 
 
-def add_text_query_to_search(  # noqa: PLR0913
-    search,
-    text,
-    search_params,
-    query_type_query,
-    use_hybrid_search,
-    filter_clauses,
+def add_text_query_to_search(
+    search, text, search_params, query_type_query, use_hybrid_search
 ):
-    """
-    Add text query to the opensearch_dsl search object
-
-    Args:
-        search: opensearch_dsl.Search object
-        text: user text query
-        search_params: full search params dict
-        query_type_query: subquery to filter by resource_type or content_type
-        use_hybrid_search: boolean whether to use hybrid search
-        filter_clauses: array of all filter clauses for the search
-
-    returns:
-        updated opensearch_dsl.Search object
-    """
-
     if search_params.get("endpoint") == CONTENT_FILE_TYPE:
         text_query = generate_content_file_text_clause(text)
     else:
@@ -692,13 +672,11 @@ def add_text_query_to_search(  # noqa: PLR0913
                     "query_text": text,
                     "model_id": model_id,
                     "k": HYBRID_SEARCH_KNN_K_VALUE,
-                    "filter": {"bool": {"should": list(filter_clauses.values())}},
                 }
             }
         }
 
         pagination_depth = search_params.get("limit", 10) * 3
-
         search = search.extra(
             query={
                 "hybrid": {
@@ -707,7 +685,6 @@ def add_text_query_to_search(  # noqa: PLR0913
                 }
             }
         )
-
     else:
         search = search.query(text_query)
 
@@ -726,14 +703,14 @@ def construct_search(search_params):  # noqa: C901
     Returns:
         opensearch_dsl.Search: an opensearch search instance
     """
-    use_hybrid_search = search_params.get("search_mode") == HYBRID_SEARCH_MODE
 
     if (
         not search_params.get("resource_type")
         and search_params.get("endpoint") != CONTENT_FILE_TYPE
-        and not use_hybrid_search
     ):
         search_params["resource_type"] = list(LEARNING_RESOURCE_TYPES)
+
+    use_hybrid_search = search_params.get("search_mode") == HYBRID_SEARCH_MODE
 
     indexes = relevant_indexes(
         search_params.get("resource_type"),
@@ -764,22 +741,17 @@ def construct_search(search_params):  # noqa: C901
     else:
         query_type_query = {"exists": {"field": "resource_type"}}
 
-    filter_clauses = generate_filter_clauses(search_params)
-
     if search_params.get("q"):
         text = re.sub("[\u201c\u201d]", '"', search_params.get("q"))
 
         search = add_text_query_to_search(
-            search,
-            text,
-            search_params,
-            query_type_query,
-            use_hybrid_search,
-            filter_clauses,
+            search, text, search_params, query_type_query, use_hybrid_search
         )
 
     else:
         search = search.query(query_type_query)
+
+    filter_clauses = generate_filter_clauses(search_params)
 
     search = search.post_filter("bool", must=list(filter_clauses.values()))
 

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2731,40 +2731,6 @@ def test_execute_learn_search_with_hybrid_search(mocker, settings, opensearch):
                                 "query_text": "math",
                                 "model_id": "vector_model_id",
                                 "k": 5,
-                                "filter": {
-                                    "bool": {
-                                        "should": [
-                                            {
-                                                "bool": {
-                                                    "should": [
-                                                        {
-                                                            "term": {
-                                                                "resource_type": {
-                                                                    "value": "course",
-                                                                    "case_insensitive": True,
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "bool": {
-                                                    "should": [
-                                                        {
-                                                            "term": {
-                                                                "free": {
-                                                                    "value": True,
-                                                                    "case_insensitive": True,
-                                                                }
-                                                            }
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                        ]
-                                    }
-                                },
                             }
                         }
                     },


### PR DESCRIPTION
This reverts [commit ec3d27d49e15c64b96242fd1b604f9359a7d6748.
](https://github.com/mitodl/mit-learn/pull/2828)

### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/9845

### Description (What does it do?)
The filter within the hybrid search subquery creates bad side effects for facets 1) it messes up the facet counts and 2) since the neural query always returns results it creates a bad user experience when a user selects a facet because the search shows resources that were not shown before the facet is selected


### How can this be tested?
follow the instructions in https://github.com/mitodl/mit-learn/pull/2808 if you don't have the hybrid search index set up yet

verify that both the regular search and hybrid search (search_mode=hybrid added to the url or selected from the admin searchoptions) works