### PR TITLE
Remove duplicate download credential button

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -802,13 +802,6 @@ const CertificatePage: React.FC<{
         ) : null}
         <Button
           variant="bordered"
-          startIcon={<RiDownloadLine />}
-          onClick={() => setDigitalCredentialDialogOpen(true)}
-        >
-          Download Digital Credential
-        </Button>
-        <Button
-          variant="bordered"
           startIcon={<RiShareLine />}
           onClick={() => setShareOpen(true)}
         >


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

This change inadvertently added a duplicate "Dowload Digital Credential" button on the certificate page (bad merge): https://github.com/mitodl/mit-learn/pull/2847. This PR removes it.


### Screenshots (if appropriate):
<!--- optional - delete if empty --->

Before:

<img width="1162" height="295" alt="image" src="https://github.com/user-attachments/assets/c80444f8-02aa-4631-a20c-f9ce2ac59af7" />

After:

<img width="1118" height="309" alt="image" src="https://github.com/user-attachments/assets/4b7160b1-dc68-4411-b379-a70dfe27873f" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Static review should be sufficient here.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
