### PR TITLE
adding default timeout to qdrant client

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -830,6 +830,8 @@ QDRANT_BATCH_SIZE_BYTES = get_int(
     name="QDRANT_BATCH_SIZE_BYTES", default=10 * 1024 * 1024
 )  # default 10 MB limit for batch processing
 
+QDRANT_CLIENT_TIMEOUT = get_int(name="QDRANT_CLIENT_TIMEOUT", default=10)
+
 # toggle to use requests (default for local) or webdriver which renders js elements
 EMBEDDINGS_EXTERNAL_FETCH_USE_WEBDRIVER = get_bool(
     "EMBEDDINGS_EXTERNAL_FETCH_USE_WEBDRIVER", default=False

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -52,6 +52,7 @@ def qdrant_client():
         api_key=settings.QDRANT_API_KEY,
         grpc_port=6334,
         prefer_grpc=True,
+        timeout=settings.QDRANT_CLIENT_TIMEOUT,
     )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/9877
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR adds a default timeout to the qdrant client which prevents exceptions from being thrown for queries that take slightly longer than the default

### How can this be tested?
This behavior can be seen and tested manually on rc.

1. ssh into rc
2. in a django shell run the following which instantiates the qdrant client with a default timeout:
```python

from django.conf import settings
from qdrant_client import QdrantClient, models
from vector_search.constants import (
    CONTENT_FILES_COLLECTION_NAME,
   
)
from vector_search.encoders.utils import dense_encoder


client = QdrantClient(
        url=settings.QDRANT_HOST,
        api_key=settings.QDRANT_API_KEY,
        grpc_port=6334,
        prefer_grpc=True,
)

encoder = dense_encoder()


params = {
	"collection_name": CONTENT_FILES_COLLECTION_NAME,
	"using": encoder.model_short_name(),
     "query": encoder.embed_query("testing 1234"),
     "group_by": "file_extension",
     "group_size":220
}

client.query_points_groups(**params)
```
3.  note the timeout exception
4. Re-run the query using a 10 second timeout
```python

client = QdrantClient(
        url=settings.QDRANT_HOST,
        api_key=settings.QDRANT_API_KEY,
        grpc_port=6334,
        prefer_grpc=True,
        timeout=10
)

client.query_points_groups(**params)
```
5. note that it succeeds

