### PR TITLE
Margin on opener to match design

### DIFF
--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -35,6 +35,10 @@ const SlideDown = styled.div<{
 
 const Opener = styled.div(({ theme }) => ({
   position: "relative",
+  margin: "0 24px",
+  [theme.breakpoints.down("md")]: {
+    margin: "0 16px",
+  },
   ":after": {
     content: "''",
     width: "100%",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

Adds a margin to the "AskTIM..." chat opener bar to match [Figma](https://www.figma.com/design/Eux3guSenAFVvNHGi1Y9Wm/MIT-Design-System?node-id=2636-61735&m=dev).



### Screenshots (if appropriate):
<!--- optional - delete if empty --->

Before:
<img width="937" height="197" alt="image" src="https://github.com/user-attachments/assets/e1eb1ba9-b79d-48a9-b3cf-435c6ac26334"  />


After:
<img width="937" height="197" alt="image" src="https://github.com/user-attachments/assets/1d4197ee-5189-482f-992f-4cc399fd1f63" />



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Open on any course resource drawer. You will need the `lr-drawer-chatbot` feature flag enabled in Posthog.

Check the horiztontal bar behind the "AskTIM about this course" button has left/right margin aligned with drawer content at all screen widths.

