### PR TITLE
Add Zendesk FAQ link

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/DigitalCredentialDialog.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/DigitalCredentialDialog.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import Image from "next/image"
-import { Dialog, Typography, styled } from "ol-components"
+import { Dialog, Link, Typography, styled } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import VerifyIcon from "@/public/images/icons/verify.svg"
+import { DigitalCredentialsFAQLink } from "@/common/constants"
 
 const Content = styled.div({})
 
@@ -162,9 +163,17 @@ export const DigitalCredentialDialog = ({
           and digital resumes.
         </Typography>
 
-        <Typography variant="body2">
+        <Typography variant="body2" marginTop={"24px"}>
           Learners choose this option if they need to add a verified credential
-          to a social profile like LinkedIn.
+          to a social profile like LinkedIn.{" "}
+          <Link
+            href={DigitalCredentialsFAQLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            color={"red"}
+          >
+            Learn More.
+          </Link>
         </Typography>
 
         <InfoPanel>

--- a/frontends/main/src/common/constants.ts
+++ b/frontends/main/src/common/constants.ts
@@ -26,3 +26,6 @@ export const PostHogEvents = {
   ClickedNavBrowseFree: "clicked_nav_browse_free",
   ClickedNavBrowseCertificate: "clicked_nav_browse_certificate",
 } as const
+
+export const DigitalCredentialsFAQLink =
+  "https://mitlearn.zendesk.com/hc/en-us/sections/45261233162267-About-Digital-Credentials"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9896

### Description (What does it do?)
This PR adds the Zendesk FAQ link for Digital Credentials to the dialog.

### Screenshots (if appropriate):
<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/7dba2a8c-38d6-40f9-aa88-3e5c7fc1971f" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/5904f5ad-e0f7-43be-902b-fc78a79579bc" />

### How can this be tested?
- Follow the instructions in the README to connect an instance of MITx Online to your local MIT Learn
- Follow the instructions in https://github.com/mitodl/mit-learn/pull/2830 to create a Digital Credential associated with a certificate for testing
- Open the certificate via its link from the dashboard, then click on Download Digital Credential and subsequently "Learn More" in the dialog that pops up
- Verify you are sent to https://mitlearn.zendesk.com/hc/en-us/sections/45261233162267-About-Digital-Credentials

### Additional Context
Right now this links directly to ZenDesk, but this should be updated to point at https://support.learn.mit.edu/hc/en-us/sections/45261233162267-About-Digital-Credentials once https://github.com/mitodl/hq/issues/9878 is closed.
