### PR TITLE
Increase cache stale time to match CDN TTL setting

### DIFF
--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -103,6 +103,8 @@ const makeBrowserQueryClient = (
         /**
          * Public API content is server-rendered to the base page and cached by the CDN.
          * Keep staleTime >= CDN TTL so hydrated queries are not immediately refetched.
+         * The CDN TTL is specified by the s-max-age value in the Cache-Control header
+         * in next.config.js.
          *
          * Most content is stable for ~24 hours (ETL cadence), but if staleTime is shorter
          * than the CDN TTL, React Query will refetch on hydration once the cached HTML


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

- Closes https://github.com/mitodl/hq/issues/8058

### Description (What does it do?)

This sets the global React Query staleTime to match the CDN cache TTL of 30 mins.

Public API content is server-rendered and cached at the CDN layer. Previously, the frontend staleTime was shorter than the CDN TTL, which caused hydrated queries to be marked stale and immediately refetched on the client. For unstable endpoints (notably the featured learning resources, which are intentionally randomized), this resulted in content flicker and unnecessary client-side refetches.

Aligning staleTime with CDN caching ensures SSR-rendered content remains fresh through hydration and avoids surprise refetches.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

This will need to checked with thought experiment until it reaches RC where we have CDN frontage. 

To verify on RC:

- Load the homepage and watch the "Featured Courses" carousel to ensure there is no flicker.

- You will need to be in a 15 minute window where the CDN-cached based HTML is fresh and the React Query cache was previously stale to conform the fix.
  - Check the response headers on the base HTML response. You will need an X-Cache HIT and and Age of more than 900.

  - Refresh the page multiple times and observe:

  - No client-side refetch of the featured content on hydration (GET /api/v1/featured/?limit=12).

  - No visible content flicker on the carousel, or reshuffling on initial load.

  - Also inspect network requests to confirm that no public APIs are called on initial page load. You should not see any of these:

    <img width="632" height="234" alt="image" src="https://github.com/user-attachments/assets/b3969e08-d305-46ab-88ac-071be6ec39a6" />


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

This change intentionally affects all queries, but most API content is stable over ~24 hours (ETL cadence), so the longer staleTime aligns with existing data freshness expectations.

The previous staleTime value was arbitrary and did not account for SSR + CDN caching behavior.

Authenticated API content is also impacted by this change (increase cache stale time from 15 to 30 minutes). This includes profile and user lists. We considered reducing their stale time and setting `refetchOnWindowFocus` to "always" [^1]. The cache is invalidated when we mutate data, so this only covers the case that a user has a second window open showing stale data. Weighing up the increased complexity, the thinking is that a user would reasonably expect to refresh the page when returning to previous windows if they don't see an expected change. The request for the user auth session (`userQueries.me()`) already has a 3 second stale time and `refetchOnWindowFocus: "always"`.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

[^1]: https://tanstack.com/query/v4/docs/framework/react/reference/useQuery