### PR TITLE
filter articles from news_events unless flagged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Tests
         run: |
           poetry run ./manage.py collectstatic --noinput --clear
+          poetry run ./manage.py createcachetable
           export MEDIA_ROOT="$(mktemp -d)"
           ./scripts/test/python_tests.sh
         env:

--- a/frontends/api/src/hooks/newsEvents/index.ts
+++ b/frontends/api/src/hooks/newsEvents/index.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import { newsEventsQueries } from "./queries"
+import { newsEventsKeys, newsEventsQueries } from "./queries"
 import {
   NewsEventsApiNewsEventsListRequest,
   NewsEventsListFeedTypeEnum,
@@ -20,4 +20,5 @@ export {
   useNewsEventsDetail,
   NewsEventsListFeedTypeEnum,
   newsEventsQueries,
+  newsEventsKeys,
 }

--- a/frontends/main/src/app-pages/Articles/ArticleDetailPage.tsx
+++ b/frontends/main/src/app-pages/Articles/ArticleDetailPage.tsx
@@ -32,9 +32,7 @@ export const ArticleDetailPage = ({
 }) => {
   const { data: article, isLoading } = useArticleDetailRetrieve(articleId)
 
-  const showArticleDetail = useFeatureFlagEnabled(
-    FeatureFlags.ArticleEditorView,
-  )
+  const showArticleDetail = useFeatureFlagEnabled(FeatureFlags.ArticleViewer)
   const flagsLoaded = useFeatureFlagsLoaded()
 
   /* Ensure queries are accessed during loading/flag check.

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -10,7 +10,7 @@ export enum FeatureFlags {
   EnrollmentDashboard = "enrollment-dashboard",
   VideoShorts = "video-shorts",
   MitxOnlineProductPages = "mitxonline-product-pages",
-  ArticleEditorView = "article-editor-view",
+  ArticleViewer = "article-viewer",
 }
 
 /**

--- a/main/features.py
+++ b/main/features.py
@@ -19,6 +19,8 @@ durable_cache = caches["durable"]
 class Features(StrEnum):
     """Enum for feature flags"""
 
+    article_viewer = "article-viewer"
+
 
 def configure():
     """

--- a/news_events/etl/articles_news.py
+++ b/news_events/etl/articles_news.py
@@ -8,6 +8,8 @@ from news_events.etl import loaders
 
 log = logging.getLogger(__name__)
 
+LEARN_ARTICLES_URL = "/articles"
+
 
 def extract_single_article(article: Article) -> dict:
     """
@@ -51,7 +53,7 @@ def sync_single_article_to_news(article: Article):
     source, _ = FeedSource.objects.get_or_create(
         title="MIT Learn Articles",
         defaults={
-            "url": "/articles",
+            "url": LEARN_ARTICLES_URL,
             "feed_type": FeedType.news.name,
             "description": "Articles created by MIT Learn staff",
         },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9932

### Description (What does it do?)
If `article-viewer` flag is on, articles will be included in `news_events` results.

If the flag is off, they will NOT be incliuded.

### How can this be tested?
1. Set `MITOL_FEATURES_DEFAULT=False` in backend.local.env
2. In posthog, create a flag called `article-viewer` and enable it for one user. (You'll need their numeric user id, which we use in posthog for their distinct_id)
    - **NB:** We'll want to check that this flag works per-user
3. Ensure you have at least one published article in your database and run `./manage.py backpopulate_news_events -p articles_news_etl`
    - You can create an article via the UI at open.odl.local:8065/articles/new IF your user has the article editing permission.
5. As the enabled viewer, view http://api.open.odl.local:8065/api/v0/news_events/?feed_type=news ... the article should show up
6. As a non-enabled, authenticated user, view http://api.open.odl.local:8065/api/v0/news_events/?feed_type=news ... the article should NOT show up
    - **Note:** When you change the flag value for a user, you will need to clear the cached values via 
        ```sh
        python manage.py shell -c "from django.core.cache import caches; caches['durable'].clear()"
        ```
        (This clears all the cached flags, which isn't ideal, but is how this is currently set up in the backend.)
7. As an anonymous user, check that the article does NOT show up in http://api.open.odl.local:8065/api/v0/news_events/?feed_type=news

