### PR TITLE
MITx Online courses with enrollment_end/end_date in the past should not offer certifications

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -194,7 +194,7 @@ def parse_departments(departments_data: list[dict or str]) -> list[str]:
 def is_fully_enrollable(run_data: dict) -> bool:
     """
     Determine if the run is really enrollable.
-    Some runs aren't really enrollable even though they have is_enrollable=True.
+    Some runs aren't enrollable even though they have is_enrollable=True.
     These should be published but not shown as offering certificates (free only).
 
     Args:

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -605,8 +605,8 @@ def test_fetch_data(mock_responses, expected_results, mocker, settings):
             {
                 "published": True,
                 "is_enrollable": True,
-                "end_date": "2024-01-01T00:00:00Z",
-                "enrollment_end": "2024-01-01T00:00:00Z",
+                "end_date": "2124-01-01T00:00:00Z",
+                "enrollment_end": "2124-01-01T00:00:00Z",
             },
             True,
         ),
@@ -625,8 +625,8 @@ def test_fetch_data(mock_responses, expected_results, mocker, settings):
             {
                 "published": True,
                 "is_enrollable": False,
-                "end_date": "2024-01-01T00:00:00Z",
-                "enrollment_end": "2024-01-01T00:00:00Z",
+                "end_date": "2124-01-01T00:00:00Z",
+                "enrollment_end": "2124-01-01T00:00:00Z",
             },
             False,
         ),
@@ -681,7 +681,7 @@ def test_fetch_data(mock_responses, expected_results, mocker, settings):
     ],
 )
 def test_is_fully_enrollable(mocker, run_data, expected):
-    """Test that is_fully_enrollable correctly determines if a run is fully enrollable"""
+    """Test that is_fully_enrollable returns the correct boolean value based on run data"""
     mock_now = datetime(2023, 6, 1, tzinfo=UTC)
     mocker.patch("learning_resources.etl.mitxonline.now_in_utc", return_value=mock_now)
     assert is_fully_enrollable(run_data) == expected


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/8791

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Sets a run `status` to `"archived"` and `prices` to `[]` if the run's `enrollment_end` (or `end_date` if `enrollment_end` is `None`) is in the past
- The above consequently sets course `certification` to False


### How can this be tested?
- Run `./manage.py backpopulate_mitxonline_data`
- Search for the following 2 courses, they should both be shown as not offering certificates, free only, no prices:
  - http://open.odl.local:8062/search?q=%22NxN+Systems%22
  - http://open.odl.local:8062/search?q=%22Computational+Data+Science+in+Physics+II%22
- Search for the following courses, they should offer certificates and show prices:
  - http://open.odl.local:8062/search?q=%22Electronic%2C+Optical+and+Magnetic+Properties+of+Materials%22
  - http://open.odl.local:8062/search?q=%22Cellular+Solids%22
