### PR TITLE
wrap the credential narrative in react-markdown

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -55,6 +55,7 @@
     "posthog-js": "^1.297.2",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "react-markdown": "^10.0.0",
     "react-slick": "^0.30.2",
     "sharp": "0.34.4",
     "slick-carousel": "^1.8.1",

--- a/frontends/main/src/app-pages/CertificatePage/DigitalCredentialDialog.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/DigitalCredentialDialog.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import Image from "next/image"
 import { Dialog, Link, Typography, styled } from "ol-components"
+import ReactMarkdown from "react-markdown"
 import { ButtonLink } from "@mitodl/smoot-design"
 import VerifyIcon from "@/public/images/icons/verify.svg"
 import { DigitalCredentialsFAQLink } from "@/common/constants"
@@ -197,7 +198,9 @@ export const DigitalCredentialDialog = ({
               <InfoTerm>Description:</InfoTerm>
               <InfoDetail>{achievement.description}</InfoDetail>
               <InfoTerm>Criteria:</InfoTerm>
-              <InfoDetail>{achievement.criteria?.narrative}</InfoDetail>
+              <InfoDetail>
+                <ReactMarkdown>{achievement.criteria?.narrative}</ReactMarkdown>
+              </InfoDetail>
             </InfoColumn>
           </Info>
           <Verify>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15454,6 +15454,7 @@ __metadata:
     posthog-js: "npm:^1.297.2"
     react: "npm:^19.2.1"
     react-dom: "npm:^19.2.1"
+    react-markdown: "npm:^10.0.0"
     react-slick: "npm:^0.30.2"
     sharp: "npm:0.34.4"
     slick-carousel: "npm:^1.8.1"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9907

### Description (What does it do?)
This PR adds `react-markdown` as a dependency to the main frontend and utilizes it in the credential narrative field to render markdown as HTML.

### Screenshots (if appropriate):
<img width="1278" height="1270" alt="image" src="https://github.com/user-attachments/assets/824f0124-1511-42aa-814f-da361e2be89d" />
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/e478be6e-6a41-4412-a9c6-4374731e172b" />

### How can this be tested?
- Follow the instructions in the README to connect an instance of MITx Online to your local MIT Learn
- Follow the instructions in https://github.com/mitodl/mit-learn/pull/2830 to create a Digital Credential associated with a certificate for testing, making sure that you insert some markdown into the `credential_data` dict under `credentialSubject.achievement.criteria.narrative` property.
- Open the certificate via its link from the dashboard, then click on Download Digital Credential
