### PR TITLE
Revert "No more contentfile scheduled tasks (#2872)"

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -44,6 +44,12 @@ CELERY_BEAT_SCHEDULE = (
             "task": "learning_resources.tasks.get_mit_edx_data",
             "schedule": crontab(minute=0, hour=5),  # 1:00am EST
         },
+        "update-edx-files-every-1-weeks": {
+            "task": "learning_resources.tasks.import_all_mit_edx_files",
+            "schedule": crontab(
+                minute=0, hour=5, day_of_week=1
+            ),  # 12:00 PM EST on Mondays
+        },
         "update-micromasters-programs-every-1-days": {
             "task": "learning_resources.tasks.get_micromasters_data",
             "schedule": crontab(minute=0, hour=5),  # 1:00am EST
@@ -56,6 +62,12 @@ CELERY_BEAT_SCHEDULE = (
             "task": "learning_resources.tasks.get_mitxonline_data",
             "schedule": crontab(minute=0, hour=5),  # 1:00am EST
         },
+        "update-mitxonline-files-every-1-weeks": {
+            "task": "learning_resources.tasks.import_all_mitxonline_files",
+            "schedule": crontab(
+                minute=0, hour=5, day_of_week=3
+            ),  # 12:00 PM EST on Wednesdays
+        },
         "update-podcasts": {
             "task": "learning_resources.tasks.get_podcast_data",
             "schedule": crontab(minute=0, hour="6,23"),  # 2am and 7pm EST
@@ -67,6 +79,12 @@ CELERY_BEAT_SCHEDULE = (
         "update-xpro-courses-every-1-days": {
             "task": "learning_resources.tasks.get_xpro_data",
             "schedule": crontab(minute=0, hour=5),  # 1:00am EST
+        },
+        "update-xpro-files-every-1-weeks": {
+            "task": "learning_resources.tasks.import_all_xpro_files",
+            "schedule": crontab(
+                minute=0, hour=5, day_of_week=2
+            ),  # 12:00 PM EST on Tuesdays
         },
         "update-youtube-videos": {
             "task": "learning_resources.tasks.get_youtube_data",


### PR DESCRIPTION
This reverts commit 27afba99966ee92ce502493d58d3394b23781233.

### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/9949

### Description (What does it do?)
Brings back weekly schedule contentfile ingestion tasks

### How can this be tested?
Celerybeat should pick up the scheduled tasks

