### PR TITLE
update the zendesk domain

### DIFF
--- a/frontends/main/src/common/constants.ts
+++ b/frontends/main/src/common/constants.ts
@@ -28,4 +28,4 @@ export const PostHogEvents = {
 } as const
 
 export const DigitalCredentialsFAQLink =
-  "https://mitlearn.zendesk.com/hc/en-us/sections/45261233162267-About-Digital-Credentials"
+  "https://support.learn.mit.edu/hc/en-us/sections/45261233162267-About-Digital-Credentials"


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-learn/pull/2873

### Description (What does it do?)
This PR simply updates the domain in the Zendesk link for Digital Credentials.

### How can this be tested?
- Follow the instructions in https://github.com/mitodl/mit-learn/pull/2873
- Verify that the link you are sent to is on the `support.learn.mit.edu` domain