### PR TITLE
fix: Remove pgbouncer related configuration

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -307,10 +307,6 @@ DEFAULT_DATABASE_CONFIG = dj_database_url.parse(
         "sqlite:///{}".format(os.path.join(BASE_DIR, "db.sqlite3")),  # noqa: PTH118
     )
 )
-DEFAULT_DATABASE_CONFIG["DISABLE_SERVER_SIDE_CURSORS"] = get_bool(
-    "MITOL_DB_DISABLE_SS_CURSORS",
-    True,  # noqa: FBT003
-)
 DEFAULT_DATABASE_CONFIG["CONN_MAX_AGE"] = get_int("MITOL_DB_CONN_MAX_AGE", 0)
 
 if get_bool("MITOL_DB_DISABLE_SSL", False):  # noqa: FBT003

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -164,14 +164,6 @@ class TestSettings(TestCase):
             ):
                 self.reload_settings()
 
-    def test_server_side_cursors_disabled(self):
-        """DISABLE_SERVER_SIDE_CURSORS should be true by default"""
-        with mock.patch.dict("os.environ", REQUIRED_SETTINGS):
-            settings_vars = self.reload_settings()
-            assert (
-                settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
-                is True
-            )
 
     def test_server_side_cursors_enabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be false if MITOL_DB_DISABLE_SS_CURSORS is false"""

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -164,7 +164,6 @@ class TestSettings(TestCase):
             ):
                 self.reload_settings()
 
-
     def test_server_side_cursors_enabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be false if MITOL_DB_DISABLE_SS_CURSORS is false"""
         with mock.patch.dict(


### PR DESCRIPTION


### What are the relevant tickets?
Part of mitodl/hq#9395

### Description (What does it do?)

fix: Remove pgbouncer related configuration

- Don't disable server side cursors


### How can this be tested?
Looking for feedback on how to test.