### PR TITLE
Remove youtube transcript scheduled task

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -90,12 +90,6 @@ CELERY_BEAT_SCHEDULE = (
             "task": "learning_resources.tasks.get_youtube_data",
             "schedule": crontab(minute=30, hour=8),  # 4:30am EST
         },
-        "update-youtube-transcripts": {
-            "task": "learning_resources.tasks.get_youtube_transcripts",
-            "schedule": get_int(
-                "YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS", 60 * 60 * 12
-            ),  # default is 12 hours
-        },
         "update_medium_mit_news": {
             "task": "news_events.tasks.get_medium_mit_news",
             "schedule": get_int(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This ETL task is blocked by Youtube when running from QA/production, so no point in having it run right now.


### How can this be tested?
Tests should pass

### Additional Context
https://mit-office-of-digital-learning.sentry.io/issues/6610673106/events/?environment=rc&project=4506260054540288&query=is%3Aunresolved&referrer=issue-stream

https://github.com/jdepoix/youtube-transcript-api?tab=readme-ov-file#working-around-ip-bans-requestblocked-or-ipblocked-exception


