### PR TITLE
Async vector/qdrant search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,4 +76,4 @@ USER mitodl
 
 EXPOSE 8061
 ENV PORT 8061
-CMD ["sh", "-c", "exec granian --interface wsgi --host 0.0.0.0 --port 8061 --workers ${GRANIAN_WORKERS:-3} --blocking-threads ${GRANIAN_BLOCKING_THREADS:-2} main.wsgi:application"]
+CMD ["sh", "-c", "exec granian --interface asginl --host 0.0.0.0 --port 8061 --workers ${GRANIAN_WORKERS:-3} --blocking-threads 1 main.asgi:application"]

--- a/authentication/decorators.py
+++ b/authentication/decorators.py
@@ -1,13 +1,21 @@
 """Authentication-based decorators"""
 
+import asyncio
 from functools import wraps
 
 
 def blocked_ip_exempt(view_func):
     """Mark a view function as being exempt from blocked IP protection."""
 
-    def wrapped_view(*args, **kwargs):
-        return view_func(*args, **kwargs)
+    if asyncio.iscoroutinefunction(view_func):
+
+        async def wrapped_view(*args, **kwargs):
+            return await view_func(*args, **kwargs)
+
+    else:
+
+        def wrapped_view(*args, **kwargs):
+            return view_func(*args, **kwargs)
 
     wrapped_view.blocked_ip_exempt = True
     return wraps(view_func)(wrapped_view)

--- a/main/asgi.py
+++ b/main/asgi.py
@@ -1,0 +1,9 @@
+import os
+
+from django.core.asgi import get_asgi_application
+
+# Set the default settings module for the 'asgi' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "main.settings")
+
+# This is the ASGI application callable used by the server.
+application = get_asgi_application()

--- a/main/utils.py
+++ b/main/utils.py
@@ -36,7 +36,7 @@ def _sorted_query_string(query_dict):
     return "&".join(items)
 
 
-def _cache_page_ignoring_cookies(
+def _cache_page_ignoring_cookies(  # noqa: C901
     timeout, cache="default", key_prefix="", *, only_anonymous=False
 ):
     """
@@ -54,7 +54,41 @@ def _cache_page_ignoring_cookies(
             users bypass the cache entirely.
     """
 
-    def inner_decorator(func):
+    def inner_decorator(func):  # noqa: C901
+        from asgiref.sync import iscoroutinefunction
+
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def inner_function(request, *args, **kwargs):
+                if timeout <= 0:
+                    return await func(request, *args, **kwargs)
+
+                if only_anonymous and request.user.is_authenticated:
+                    return await func(request, *args, **kwargs)
+
+                query_string = _sorted_query_string(request.GET)
+                raw_key = f"{key_prefix}:{request.path}:{query_string}"
+                url_hash = md5(raw_key.encode()).hexdigest()  # noqa: S324
+                cache_key = (
+                    f"views.decorators.cache.cache_page.{key_prefix}.GET.{url_hash}"
+                )
+
+                cache_backend = caches[cache]
+
+                cached_data = cache_backend.get(cache_key)
+                if cached_data is not None:
+                    return Response(cached_data)
+
+                response = await func(request, *args, **kwargs)
+
+                if response.status_code == 200:  # noqa: PLR2004
+                    cache_backend.set(cache_key, response.data, timeout)
+
+                return response
+
+            return inner_function
+
         @wraps(func)
         def inner_function(request, *args, **kwargs):
             # Skip caching entirely if timeout is 0 or negative

--- a/main/utils.py
+++ b/main/utils.py
@@ -36,7 +36,7 @@ def _sorted_query_string(query_dict):
     return "&".join(items)
 
 
-def _cache_page_ignoring_cookies(  # noqa: C901
+def _cache_page_ignoring_cookies(
     timeout, cache="default", key_prefix="", *, only_anonymous=False
 ):
     """
@@ -54,41 +54,7 @@ def _cache_page_ignoring_cookies(  # noqa: C901
             users bypass the cache entirely.
     """
 
-    def inner_decorator(func):  # noqa: C901
-        from asgiref.sync import iscoroutinefunction
-
-        if iscoroutinefunction(func):
-
-            @wraps(func)
-            async def inner_function(request, *args, **kwargs):
-                if timeout <= 0:
-                    return await func(request, *args, **kwargs)
-
-                if only_anonymous and request.user.is_authenticated:
-                    return await func(request, *args, **kwargs)
-
-                query_string = _sorted_query_string(request.GET)
-                raw_key = f"{key_prefix}:{request.path}:{query_string}"
-                url_hash = md5(raw_key.encode()).hexdigest()  # noqa: S324
-                cache_key = (
-                    f"views.decorators.cache.cache_page.{key_prefix}.GET.{url_hash}"
-                )
-
-                cache_backend = caches[cache]
-
-                cached_data = cache_backend.get(cache_key)
-                if cached_data is not None:
-                    return Response(cached_data)
-
-                response = await func(request, *args, **kwargs)
-
-                if response.status_code == 200:  # noqa: PLR2004
-                    cache_backend.set(cache_key, response.data, timeout)
-
-                return response
-
-            return inner_function
-
+    def inner_decorator(func):
         @wraps(func)
         def inner_function(request, *args, **kwargs):
             # Skip caching entirely if timeout is 0 or negative

--- a/main/utils.py
+++ b/main/utils.py
@@ -76,14 +76,14 @@ def _cache_page_ignoring_cookies(  # noqa: C901
 
                 cache_backend = caches[cache]
 
-                cached_data = cache_backend.get(cache_key)
+                cached_data = await cache_backend.aget(cache_key)
                 if cached_data is not None:
                     return Response(cached_data)
 
                 response = await func(request, *args, **kwargs)
 
                 if response.status_code == 200:  # noqa: PLR2004
-                    cache_backend.set(cache_key, response.data, timeout)
+                    await cache_backend.aset(cache_key, response.data, timeout)
 
                 return response
 

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -7,7 +7,7 @@ python3 manage.py collectstatic --noinput --clear
 # run initial django migrations
 python3 manage.py migrate --noinput
 
-granian --interface wsgi --host 0.0.0.0 --port "${PORT:-8061}" --workers "${GRANIAN_WORKERS:-3}" --blocking-threads "${GRANIAN_BLOCKING_THREADS:-2}" --reload --reload-ignore-dirs frontends --reload-ignore-dirs staticfiles --reload-ignore-dirs .git main.wsgi:application &
+granian --interface asginl --host 0.0.0.0 --port "${PORT:-8061}" --workers "${GRANIAN_WORKERS:-3}" --blocking-threads 1 --reload --reload-ignore-dirs frontends --reload-ignore-dirs staticfiles --reload-ignore-dirs .git main.asgi:application &
 GRANIAN_PID=$!
 echo "Application started with PID $GRANIAN_PID"
 

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -71,24 +71,6 @@ def qdrant_client():
     )
 
 
-def async_qdrant_client():
-    from qdrant_client import AsyncQdrantClient
-
-    enable_cloud_inference = (
-        dense_encoder().requires_cloud_inferencing
-        or sparse_encoder().requires_cloud_inferencing
-    )
-
-    return AsyncQdrantClient(
-        url=settings.QDRANT_HOST,
-        api_key=settings.QDRANT_API_KEY,
-        grpc_port=6334,
-        prefer_grpc=True,
-        cloud_inference=enable_cloud_inference,
-        timeout=settings.QDRANT_CLIENT_TIMEOUT,
-    )
-
-
 def points_generator(
     ids,
     metadata,
@@ -961,105 +943,6 @@ def vector_point_key(
     else:
         msg = "Invalid document type for vector point key"
         raise ValueError(msg)
-
-
-async def async_vector_search(  # noqa: PLR0913
-    query_string: str,
-    params: dict,
-    limit: int = 10,
-    offset: int = 10,
-    search_collection=RESOURCES_COLLECTION_NAME,
-    *,
-    hybrid_search: bool = False,
-):
-    from asgiref.sync import sync_to_async
-
-    client = async_qdrant_client()
-    encoder_dense = dense_encoder()
-    encoder_sparse = sparse_encoder()
-
-    search_filter = qdrant_query_conditions(params, collection_name=search_collection)
-    prefetch_multiplier = 20
-    prefetch_limit = (offset + limit) * prefetch_multiplier
-    if query_string:
-        search_params = {
-            "collection_name": search_collection,
-            "query_filter": search_filter,
-            "with_vectors": False,
-            "with_payload": True,
-            "search_params": models.SearchParams(indexed_only=True, exact=False),
-            "limit": limit,
-        }
-
-        if hybrid_search:
-            sparse_query = await sync_to_async(encoder_sparse.embed)(query_string)
-            dense_query = await sync_to_async(encoder_dense.embed_query)(query_string)
-            search_params["prefetch"] = [
-                models.Prefetch(
-                    query=sparse_query,
-                    using=encoder_sparse.model_short_name(),
-                    limit=prefetch_limit,
-                ),
-                models.Prefetch(
-                    query=dense_query,
-                    using=encoder_dense.model_short_name(),
-                    limit=prefetch_limit,
-                ),
-            ]
-            search_params["query"] = models.FusionQuery(fusion=models.Fusion.RRF)
-        else:
-            dense_query = await sync_to_async(encoder_dense.embed_query)(query_string)
-            search_params["using"] = encoder_dense.model_short_name()
-            search_params["query"] = dense_query
-
-        if "group_by" in params:
-            search_params.pop("search_params", None)
-            search_params["group_by"] = params.get("group_by")
-            search_params["group_size"] = params.get("group_size", 1)
-            group_result = await client.query_points_groups(**search_params)
-            search_result = []
-            for group in group_result.groups:
-                payloads = [hit.payload for hit in group.hits]
-                response_hit = _merge_dicts(payloads)
-                chunks = [payload.get("chunk_content") for payload in payloads]
-                response_hit["chunk_content"] = None
-                response_hit["chunks"] = chunks
-                response_row = {
-                    "id": response_hit[search_params["group_by"]],
-                    "payload": response_hit,
-                    "vector": [],
-                }
-                search_result.append(models.PointStruct(**response_row))
-
-        else:
-            search_params["offset"] = offset
-            result_obj = await client.query_points(**search_params)
-            search_result = result_obj.points
-    else:
-        scroll_res = await client.scroll(
-            collection_name=search_collection,
-            scroll_filter=search_filter,
-            limit=limit,
-            offset=offset,
-            with_vectors=False,
-        )
-        search_result = scroll_res[0]
-
-    if search_collection == RESOURCES_COLLECTION_NAME:
-        hits = await sync_to_async(_resource_vector_hits)(search_result)
-    else:
-        hits = await sync_to_async(_content_file_vector_hits)(search_result)
-
-    count_result = await client.count(
-        collection_name=search_collection,
-        count_filter=search_filter,
-        exact=False,
-    )
-
-    return {
-        "hits": hits,
-        "total": {"value": count_result.count},
-    }
 
 
 def vector_search(  # noqa: PLR0913

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -71,6 +71,24 @@ def qdrant_client():
     )
 
 
+def async_qdrant_client():
+    from qdrant_client import AsyncQdrantClient
+
+    enable_cloud_inference = (
+        dense_encoder().requires_cloud_inferencing
+        or sparse_encoder().requires_cloud_inferencing
+    )
+
+    return AsyncQdrantClient(
+        url=settings.QDRANT_HOST,
+        api_key=settings.QDRANT_API_KEY,
+        grpc_port=6334,
+        prefer_grpc=True,
+        cloud_inference=enable_cloud_inference,
+        timeout=settings.QDRANT_CLIENT_TIMEOUT,
+    )
+
+
 def points_generator(
     ids,
     metadata,
@@ -943,6 +961,105 @@ def vector_point_key(
     else:
         msg = "Invalid document type for vector point key"
         raise ValueError(msg)
+
+
+async def async_vector_search(  # noqa: PLR0913
+    query_string: str,
+    params: dict,
+    limit: int = 10,
+    offset: int = 10,
+    search_collection=RESOURCES_COLLECTION_NAME,
+    *,
+    hybrid_search: bool = False,
+):
+    from asgiref.sync import sync_to_async
+
+    client = async_qdrant_client()
+    encoder_dense = dense_encoder()
+    encoder_sparse = sparse_encoder()
+
+    search_filter = qdrant_query_conditions(params, collection_name=search_collection)
+    prefetch_multiplier = 20
+    prefetch_limit = (offset + limit) * prefetch_multiplier
+    if query_string:
+        search_params = {
+            "collection_name": search_collection,
+            "query_filter": search_filter,
+            "with_vectors": False,
+            "with_payload": True,
+            "search_params": models.SearchParams(indexed_only=True, exact=False),
+            "limit": limit,
+        }
+
+        if hybrid_search:
+            sparse_query = await sync_to_async(encoder_sparse.embed)(query_string)
+            dense_query = await sync_to_async(encoder_dense.embed_query)(query_string)
+            search_params["prefetch"] = [
+                models.Prefetch(
+                    query=sparse_query,
+                    using=encoder_sparse.model_short_name(),
+                    limit=prefetch_limit,
+                ),
+                models.Prefetch(
+                    query=dense_query,
+                    using=encoder_dense.model_short_name(),
+                    limit=prefetch_limit,
+                ),
+            ]
+            search_params["query"] = models.FusionQuery(fusion=models.Fusion.RRF)
+        else:
+            dense_query = await sync_to_async(encoder_dense.embed_query)(query_string)
+            search_params["using"] = encoder_dense.model_short_name()
+            search_params["query"] = dense_query
+
+        if "group_by" in params:
+            search_params.pop("search_params", None)
+            search_params["group_by"] = params.get("group_by")
+            search_params["group_size"] = params.get("group_size", 1)
+            group_result = await client.query_points_groups(**search_params)
+            search_result = []
+            for group in group_result.groups:
+                payloads = [hit.payload for hit in group.hits]
+                response_hit = _merge_dicts(payloads)
+                chunks = [payload.get("chunk_content") for payload in payloads]
+                response_hit["chunk_content"] = None
+                response_hit["chunks"] = chunks
+                response_row = {
+                    "id": response_hit[search_params["group_by"]],
+                    "payload": response_hit,
+                    "vector": [],
+                }
+                search_result.append(models.PointStruct(**response_row))
+
+        else:
+            search_params["offset"] = offset
+            result_obj = await client.query_points(**search_params)
+            search_result = result_obj.points
+    else:
+        scroll_res = await client.scroll(
+            collection_name=search_collection,
+            scroll_filter=search_filter,
+            limit=limit,
+            offset=offset,
+            with_vectors=False,
+        )
+        search_result = scroll_res[0]
+
+    if search_collection == RESOURCES_COLLECTION_NAME:
+        hits = await sync_to_async(_resource_vector_hits)(search_result)
+    else:
+        hits = await sync_to_async(_content_file_vector_hits)(search_result)
+
+    count_result = await client.count(
+        collection_name=search_collection,
+        count_filter=search_filter,
+        exact=False,
+    )
+
+    return {
+        "hits": hits,
+        "total": {"value": count_result.count},
+    }
 
 
 def vector_search(  # noqa: PLR0913

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -71,6 +71,7 @@ def qdrant_client():
     )
 
 
+@cache
 def async_qdrant_client():
     enable_cloud_inference = (
         dense_encoder().requires_cloud_inferencing

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_experimental.text_splitter import SemanticChunker
 from langchain_text_splitters import MarkdownHeaderTextSplitter
-from qdrant_client import QdrantClient, models
+from qdrant_client import AsyncQdrantClient, QdrantClient, models
 
 from learning_resources.constants import PROGRAM_COURSE_CACHE_KEY_TEST_MODE
 from learning_resources.content_summarizer import ContentSummarizer
@@ -62,6 +62,22 @@ def qdrant_client():
     )
 
     return QdrantClient(
+        url=settings.QDRANT_HOST,
+        api_key=settings.QDRANT_API_KEY,
+        grpc_port=6334,
+        prefer_grpc=True,
+        cloud_inference=enable_cloud_inference,
+        timeout=settings.QDRANT_CLIENT_TIMEOUT,
+    )
+
+
+def async_qdrant_client():
+    enable_cloud_inference = (
+        dense_encoder().requires_cloud_inferencing
+        or sparse_encoder().requires_cloud_inferencing
+    )
+
+    return AsyncQdrantClient(
         url=settings.QDRANT_HOST,
         api_key=settings.QDRANT_API_KEY,
         grpc_port=6334,
@@ -226,11 +242,9 @@ def embed_topics():
     )
 
     if indexed_count > 0:
-        existing = vector_search(
-            query_string="",
+        existing = retrieve_points_matching_params(
             params={},
-            search_collection=TOPICS_COLLECTION_NAME,
-            limit=indexed_count,
+            collection_name=TOPICS_COLLECTION_NAME,
         )
         indexed_topic_names = {hit["name"] for hit in existing["hits"]}
     else:
@@ -943,116 +957,6 @@ def vector_point_key(
     else:
         msg = "Invalid document type for vector point key"
         raise ValueError(msg)
-
-
-def vector_search(  # noqa: PLR0913
-    query_string: str,
-    params: dict,
-    limit: int = 10,
-    offset: int = 10,
-    search_collection=RESOURCES_COLLECTION_NAME,
-    *,
-    hybrid_search: bool = False,
-):
-    """
-    Perform a vector search given a query string
-
-    Args:
-        query_string (str): Query string to search
-        params (dict): Additional search filters
-        limit (int): Max number of results to return
-        offset (int): Offset to start from
-        search_collection (str): name of the collection to search
-    Returns:
-        dict:
-            Response dict containing "hits" with search results
-            and "total" with total count
-    """
-
-    client = qdrant_client()
-    encoder_dense = dense_encoder()
-    encoder_sparse = sparse_encoder()
-
-    search_filter = qdrant_query_conditions(params, collection_name=search_collection)
-
-    prefetch_multiplier = settings.VECTOR_HYBRID_SEARCH_PREFETCH_MULTIPLIER
-    prefetch_max_limit = settings.VECTOR_HYBRID_SEARCH_PREFETCH_MAX_LIMIT
-    prefetch_limit = min((offset + limit) * prefetch_multiplier, prefetch_max_limit)
-
-    if query_string:
-        search_params = {
-            "collection_name": search_collection,
-            "query_filter": search_filter,
-            "with_vectors": False,
-            "with_payload": True,
-            "search_params": models.SearchParams(indexed_only=True, exact=False),
-            "limit": limit,
-        }
-
-        if hybrid_search:
-            search_params["prefetch"] = [
-                models.Prefetch(
-                    query=encoder_sparse.embed(query_string),
-                    using=encoder_sparse.model_short_name(),
-                    limit=prefetch_limit,
-                ),
-                models.Prefetch(
-                    query=encoder_dense.embed_query(query_string),  # <-- dense vector
-                    using=encoder_dense.model_short_name(),
-                    limit=prefetch_limit,
-                ),
-            ]
-            search_params["query"] = models.FusionQuery(fusion=models.Fusion.RRF)
-        else:
-            # fallback to dense only search
-            search_params["using"] = encoder_dense.model_short_name()
-            search_params["query"] = encoder_dense.embed_query(query_string)
-
-        if "group_by" in params:
-            search_params.pop("search_params", None)
-            search_params["group_by"] = params.get("group_by")
-            search_params["group_size"] = params.get("group_size", 1)
-            group_result = client.query_points_groups(**search_params)
-            search_result = []
-            for group in group_result.groups:
-                payloads = [hit.payload for hit in group.hits]
-                response_hit = _merge_dicts(payloads)
-                chunks = [payload.get("chunk_content") for payload in payloads]
-                response_hit["chunk_content"] = None
-                response_hit["chunks"] = chunks
-                response_row = {
-                    "id": response_hit[search_params["group_by"]],
-                    "payload": response_hit,
-                    "vector": [],
-                }
-                search_result.append(models.PointStruct(**response_row))
-
-        else:
-            search_params["offset"] = offset
-            search_result = client.query_points(**search_params).points
-    else:
-        search_result = client.scroll(
-            collection_name=search_collection,
-            scroll_filter=search_filter,
-            limit=limit,
-            offset=offset,
-            with_vectors=False,
-        )[0]
-
-    if search_collection == RESOURCES_COLLECTION_NAME:
-        hits = _resource_vector_hits(search_result)
-    else:
-        hits = _content_file_vector_hits(search_result)
-    count_result = client.count(
-        collection_name=search_collection,
-        count_filter=search_filter,
-        exact=False,
-    )
-
-    return {
-        "hits": hits,
-        "total": {"value": count_result.count},
-    }
 
 
 def document_exists(document, collection_name=RESOURCES_COLLECTION_NAME):

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -242,11 +242,17 @@ def embed_topics():
     )
 
     if indexed_count > 0:
-        existing = retrieve_points_matching_params(
-            params={},
-            collection_name=TOPICS_COLLECTION_NAME,
-        )
-        indexed_topic_names = {hit["name"] for hit in existing["hits"]}
+        existing_points = []
+        next_page_offset = None
+        while True:
+            points, next_page_offset = client.scroll(
+                collection_name=TOPICS_COLLECTION_NAME,
+                offset=next_page_offset,
+            )
+            existing_points.extend(points)
+            if not next_page_offset:
+                break
+        indexed_topic_names = {point.payload["name"] for point in existing_points}
     else:
         indexed_topic_names = set()
 

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -4,9 +4,12 @@ from unittest.mock import MagicMock
 
 import pytest
 from django.conf import settings
+from django.contrib.auth.models import Group
+from django.urls import reverse
 from qdrant_client import models
 from qdrant_client.models import PointStruct
 
+from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
 from learning_resources.factories import (
     ContentFileFactory,
     LearningResourceFactory,
@@ -946,6 +949,9 @@ def test_vector_search_group_by(mocker, client, django_user_model):
         "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
+    mock_encoder = mocker.patch("vector_search.utils.dense_encoder")()
+    mock_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
+    mock_encoder.model_short_name.return_value = "test-encoder"
 
     group_by_field = "resource_readable_id"
     resource_id_1 = "resource1"
@@ -982,14 +988,10 @@ def test_vector_search_group_by(mocker, client, django_user_model):
     mock_qdrant.count.return_value = models.CountResult(count=2)
 
     mocker.patch(
-        "vector_search.views._content_file_vector_hits", side_effect=lambda x: x
+        "vector_search.utils._content_file_vector_hits", side_effect=lambda x: x
     )
 
     # Content files endpoint requires authentication
-    from django.contrib.auth.models import Group
-
-    from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
-
     user = django_user_model.objects.create()
     group, _ = Group.objects.get_or_create(name=GROUP_CONTENT_FILE_CONTENT_VIEWERS)
     group.user_set.add(user)
@@ -999,14 +1001,46 @@ def test_vector_search_group_by(mocker, client, django_user_model):
         "q": "test query",
         "group_by": group_by_field,
         "group_size": 2,
+        "offset": 0,
     }
-
-    from django.urls import reverse
 
     response = client.get(
         reverse("vector_search:v0:vector_content_files_search"), data=params
     )
+
     assert response.status_code == 200
+    response_json = response.json()
+    assert response_json["count"] == 2
+    assert len(response_json["results"]) == 2
+    grouped_results = {
+        result[group_by_field]: result for result in response_json["results"]
+    }
+    assert grouped_results[resource_id_1] == {
+        group_by_field: resource_id_1,
+        "common_field": "value1",
+        "chunks": ["First part.", "Second part."],
+        "chunk_content": None,
+    }
+    assert grouped_results[resource_id_2] == {
+        group_by_field: resource_id_2,
+        "common_field": "value2",
+        "chunks": ["Only part."],
+        "chunk_content": None,
+    }
+    hit1 = next(
+        h for h in response_json["results"] if h[group_by_field] == resource_id_1
+    )
+    hit2 = next(
+        h for h in response_json["results"] if h[group_by_field] == resource_id_2
+    )
+
+    assert hit1["chunk_content"] is None
+    assert hit1["common_field"] == "value1"
+    assert hit1["chunks"] == ["First part.", "Second part."]
+
+    assert hit2["chunk_content"] is None
+    assert hit2["common_field"] == "value2"
+    assert hit2["chunks"] == ["Only part."]
 
     mock_qdrant.query_points_groups.assert_called_once()
     call_args = mock_qdrant.query_points_groups.call_args.kwargs

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1362,6 +1362,18 @@ def test_vector_search_hybrid(mocker, client):
     mock_search_result.points = []
     mock_qdrant.query_points.return_value = mock_search_result
     mock_qdrant.count.return_value = models.CountResult(count=0)
+    mock_dense_encoder = mocker.patch("vector_search.views.dense_encoder")()
+    mock_dense_encoder.clear_cache()
+
+    mock_sparse_encoder = mocker.patch("vector_search.views.sparse_encoder")()
+    mock_sparse_encoder.clear_cache()
+
+    mock_dense_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
+    mock_dense_encoder.model_short_name.return_value = "dense-test-encoder"
+
+    # Sparse encoder expects dict like {"indices": [...], "values": [...]} for SparseVector kwargs
+    mock_sparse_encoder.embed.return_value = {"indices": [1, 2], "values": [0.5, 0.6]}
+    mock_sparse_encoder.model_short_name.return_value = "sparse-test-encoder"
 
     from django.urls import reverse
 
@@ -1386,8 +1398,13 @@ def test_vector_search_hybrid(mocker, client):
     sparse_prefetch = prefetches[0]
     dense_prefetch = prefetches[1]
 
-    assert sparse_prefetch.using is not None
-    assert dense_prefetch.using is not None
+    assert sparse_prefetch.using == "sparse-test-encoder"
+    assert isinstance(sparse_prefetch.query, models.SparseVector)
+    assert sparse_prefetch.query.indices == [1, 2]
+    assert sparse_prefetch.query.values == [0.5, 0.6]
+
+    assert dense_prefetch.using == "dense-test-encoder"
+    assert dense_prefetch.query == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.parametrize("use_group_by", [True, False])

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -51,7 +51,6 @@ from vector_search.utils import (
     update_learning_resource_payload,
     update_qdrant_indexes,
     vector_point_id,
-    vector_search,
 )
 from vector_search.utils import qdrant_client as vector_qdrant_client
 
@@ -935,15 +934,18 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
     summarize_mock.assert_called_once_with(expected_ids, True)  # noqa: FBT003
 
 
-def test_vector_search_group_by(mocker):
+def test_vector_search_group_by(mocker, client, django_user_model):
     """
-    Test that vector_search with group_by parameter returns grouped results
+    Test that async_vector_search with group_by parameter returns grouped results
     where chunks are merged on common fields
     """
-    mock_qdrant = mocker.patch("vector_search.utils.qdrant_client")()
-    mock_encoder = mocker.patch("vector_search.utils.dense_encoder")()
-    mock_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
-    mock_encoder.model_short_name.return_value = "test-encoder"
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mocker.patch(
+        "vector_search.views.async_qdrant_client",
+        return_value=mock_qdrant,
+    )
 
     group_by_field = "resource_readable_id"
     resource_id_1 = "resource1"
@@ -980,36 +982,31 @@ def test_vector_search_group_by(mocker):
     mock_qdrant.count.return_value = models.CountResult(count=2)
 
     mocker.patch(
-        "vector_search.utils._content_file_vector_hits", side_effect=lambda x: x
+        "vector_search.views._content_file_vector_hits", side_effect=lambda x: x
     )
 
+    # Content files endpoint requires authentication
+    from django.contrib.auth.models import Group
+
+    from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
+
+    user = django_user_model.objects.create()
+    group, _ = Group.objects.get_or_create(name=GROUP_CONTENT_FILE_CONTENT_VIEWERS)
+    group.user_set.add(user)
+    client.force_login(user)
+
     params = {
+        "q": "test query",
         "group_by": group_by_field,
         "group_size": 2,
     }
-    results = vector_search(
-        "test query",
-        params,
-        search_collection=CONTENT_FILES_COLLECTION_NAME,
+
+    from django.urls import reverse
+
+    response = client.get(
+        reverse("vector_search:v0:vector_content_files_search"), data=params
     )
-
-    assert len(results["hits"]) == 2
-    assert results["total"]["value"] == 2
-
-    hit1 = next(
-        h for h in results["hits"] if h.payload[group_by_field] == resource_id_1
-    )
-    hit2 = next(
-        h for h in results["hits"] if h.payload[group_by_field] == resource_id_2
-    )
-
-    assert hit1.payload["chunk_content"] is None
-    assert hit1.payload["common_field"] == "value1"
-    assert hit1.payload["chunks"] == ["First part.", "Second part."]
-
-    assert hit2.payload["chunk_content"] is None
-    assert hit2.payload["common_field"] == "value2"
-    assert hit2.payload["chunks"] == ["Only part."]
+    assert response.status_code == 200
 
     mock_qdrant.query_points_groups.assert_called_once()
     call_args = mock_qdrant.query_points_groups.call_args.kwargs
@@ -1206,6 +1203,16 @@ def test_update_qdrant_indexes_updates_mismatched_field_type(mocker):
     mock_client.create_payload_index.assert_has_calls(expected_calls, any_order=True)
 
 
+def _mock_topic_points(mocker, topic_names):
+    """Create mock Qdrant points with topic name payloads."""
+    points = []
+    for name in topic_names:
+        point = mocker.MagicMock()
+        point.payload = {"name": name}
+        points.append(point)
+    return points
+
+
 def test_embed_topics_no_new_topics(mocker):
     """
     Test embed_topics when there are no new topics to embed
@@ -1214,8 +1221,10 @@ def test_embed_topics_no_new_topics(mocker):
     mock_qdrant_client = mocker.patch("vector_search.utils.qdrant_client")
     mock_qdrant_client.return_value = mock_client
     mock_client.count.return_value.count = 1
-    mock_vector_search = mocker.patch("vector_search.utils.vector_search")
-    mock_vector_search.return_value = {"hits": [{"name": "topic1"}]}
+    mock_client.scroll.return_value = (
+        _mock_topic_points(mocker, ["topic1"]),
+        None,
+    )
     LearningResourceTopicFactory.create(name="topic1", parent=None)
     mock_remove_points_matching_params = mocker.patch(
         "vector_search.utils.remove_points_matching_params"
@@ -1233,8 +1242,10 @@ def test_embed_topics_new_topics(mocker):
     mock_qdrant_client = mocker.patch("vector_search.utils.qdrant_client")
     mock_qdrant_client.return_value = mock_client
     mock_client.count.return_value.count = 1
-    mock_vector_search = mocker.patch("vector_search.utils.vector_search")
-    mock_vector_search.return_value = {"hits": [{"name": "topic1"}]}
+    mock_client.scroll.return_value = (
+        _mock_topic_points(mocker, ["topic1"]),
+        None,
+    )
     LearningResourceTopicFactory.create(name="topic1", parent=None)
     LearningResourceTopicFactory.create(name="topic2", parent=None)
     LearningResourceTopicFactory.create(name="topic3", parent=None)
@@ -1252,8 +1263,10 @@ def test_embed_topics_remove_topics(mocker):
     mock_qdrant_client = mocker.patch("vector_search.utils.qdrant_client")
     mock_qdrant_client.return_value = mock_client
     mock_client.count.return_value.count = 1
-    mock_vector_search = mocker.patch("vector_search.utils.vector_search")
-    mock_vector_search.return_value = {"hits": [{"name": "remove-topic"}]}
+    mock_client.scroll.return_value = (
+        _mock_topic_points(mocker, ["remove-topic"]),
+        None,
+    )
 
     LearningResourceTopicFactory.create(name="topic2", parent=None)
     LearningResourceTopicFactory.create(name="topic3", parent=None)
@@ -1332,36 +1345,33 @@ def test_qdrant_cloud_inference_client(mocker, settings):
     assert second_call_kwargs.get("cloud_inference", False) is False
 
 
-def test_vector_search_hybrid(mocker):
+def test_vector_search_hybrid(mocker, client):
     """
-    Test that vector_search with hybrid_search=True searches using sparse and dense vectors
+    Test that async_vector_search with hybrid_search=True searches using
+    sparse and dense vectors
     """
-    mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant = mocker.patch("vector_search.utils.qdrant_client")()
-    mock_dense_encoder = mocker.patch("vector_search.utils.dense_encoder")()
-    mock_sparse_encoder = mocker.patch("vector_search.utils.sparse_encoder")()
-
-    mock_dense_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
-    mock_dense_encoder.model_short_name.return_value = "dense-test-encoder"
-
-    # Sparse encoder expects dict like {"indices": [...], "values": [...]} for SparseVector kwargs
-    mock_sparse_encoder.embed.return_value = {"indices": [1, 2], "values": [0.5, 0.6]}
-    mock_sparse_encoder.model_short_name.return_value = "sparse-test-encoder"
-
-    mocker.patch("vector_search.utils._resource_vector_hits", return_value=[])
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mocker.patch(
+        "vector_search.views.async_qdrant_client",
+        return_value=mock_qdrant,
+    )
 
     mock_search_result = mocker.MagicMock()
     mock_search_result.points = []
     mock_qdrant.query_points.return_value = mock_search_result
     mock_qdrant.count.return_value = models.CountResult(count=0)
 
-    from vector_search.utils import RESOURCES_COLLECTION_NAME, vector_search
+    from django.urls import reverse
 
-    vector_search(
-        "test hybrid query",
-        {},
-        search_collection=RESOURCES_COLLECTION_NAME,
-        hybrid_search=True,
+    params = {
+        "q": "test hybrid query",
+        "hybrid_search": True,
+    }
+
+    client.get(
+        reverse("vector_search:v0:vector_learning_resources_search"), data=params
     )
 
     mock_qdrant.query_points.assert_called_once()
@@ -1376,26 +1386,26 @@ def test_vector_search_hybrid(mocker):
     sparse_prefetch = prefetches[0]
     dense_prefetch = prefetches[1]
 
-    assert sparse_prefetch.using == "sparse-test-encoder"
-    assert isinstance(sparse_prefetch.query, models.SparseVector)
-    assert sparse_prefetch.query.indices == [1, 2]
-    assert sparse_prefetch.query.values == [0.5, 0.6]
-
-    assert dense_prefetch.using == "dense-test-encoder"
-    assert dense_prefetch.query == [0.1, 0.2, 0.3]
+    assert sparse_prefetch.using is not None
+    assert dense_prefetch.using is not None
 
 
 @pytest.mark.parametrize("use_group_by", [True, False])
-def test_vector_search_group_by_offset_behavior(mocker, use_group_by):
+def test_vector_search_group_by_offset_behavior(
+    mocker, client, django_user_model, use_group_by
+):
     """
-    Test that vector_search passes 'offset' to query_points when no group_by is provided,
-    and drops 'offset' and calls query_points_groups when group_by is provided.
+    Test that async_vector_search passes 'offset' to query_points when no
+    group_by is provided, and drops 'offset' and calls query_points_groups
+    when group_by is provided.
     """
-    mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant = mocker.patch("vector_search.utils.qdrant_client")()
-    mock_encoder = mocker.patch("vector_search.utils.dense_encoder")()
-    mock_encoder.embed_query.return_value = [0.1, 0.2, 0.3]
-    mock_encoder.model_short_name.return_value = "test-encoder"
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mocker.patch(
+        "vector_search.views.async_qdrant_client",
+        return_value=mock_qdrant,
+    )
 
     mock_group_result = mocker.MagicMock()
     mock_group_result.groups = []
@@ -1407,20 +1417,25 @@ def test_vector_search_group_by_offset_behavior(mocker, use_group_by):
 
     mock_qdrant.count.return_value = models.CountResult(count=0)
 
-    mocker.patch("vector_search.utils._content_file_vector_hits", return_value=[])
+    mocker.patch("vector_search.views._content_file_vector_hits", return_value=[])
 
-    from vector_search.utils import CONTENT_FILES_COLLECTION_NAME, vector_search
+    # Content files endpoint requires authentication
+    from django.contrib.auth.models import Group
 
-    params = {}
+    from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
+
+    user = django_user_model.objects.create()
+    group, _ = Group.objects.get_or_create(name=GROUP_CONTENT_FILE_CONTENT_VIEWERS)
+    group.user_set.add(user)
+    client.force_login(user)
+
+    from django.urls import reverse
+
+    params = {"q": "test query", "offset": 15}
     if use_group_by:
         params["group_by"] = "resource_readable_id"
 
-    vector_search(
-        "test query",
-        params,
-        offset=15,
-        search_collection=CONTENT_FILES_COLLECTION_NAME,
-    )
+    client.get(reverse("vector_search:v0:vector_content_files_search"), data=params)
 
     if use_group_by:
         mock_qdrant.query_points_groups.assert_called_once()

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -100,8 +100,15 @@ class QdrantView(APIView):
         search_filter = qdrant_query_conditions(
             params, collection_name=search_collection
         )
-        prefetch_multiplier = 20
+        prefetch_multiplier = getattr(
+            settings, "VECTOR_HYBRID_SEARCH_PREFETCH_MULTIPLIER", 20
+        )
         prefetch_limit = (offset + limit) * prefetch_multiplier
+        prefetch_max_limit = getattr(
+            settings, "VECTOR_HYBRID_SEARCH_PREFETCH_MAX_LIMIT", None
+        )
+        if prefetch_max_limit is not None:
+            prefetch_limit = min(prefetch_limit, prefetch_max_limit)
         if query_string:
             search_params = {
                 "collection_name": search_collection,

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -20,7 +20,7 @@ from vector_search.serializers import (
     LearningResourcesVectorSearchRequestSerializer,
     LearningResourcesVectorSearchResponseSerializer,
 )
-from vector_search.utils import vector_search
+from vector_search.utils import async_vector_search
 
 log = logging.getLogger(__name__)
 
@@ -29,6 +29,50 @@ class QdrantView(APIView):
     """
     Parent class for views that execute ES searches
     """
+
+    @classmethod
+    def as_view(cls, **initkwargs):
+        view = super().as_view(**initkwargs)
+
+        from functools import wraps
+
+        @wraps(view)
+        async def async_view(*args, **kwargs):
+            return await view(*args, **kwargs)
+
+        async_view.view_is_async = True
+        return async_view
+
+    async def dispatch(self, request, *args, **kwargs):
+        from asgiref.sync import sync_to_async
+
+        self.args = args
+        self.kwargs = kwargs
+        request = self.initialize_request(request, *args, **kwargs)
+        self.request = request
+        self.headers = self.default_response_headers
+
+        try:
+            await sync_to_async(self.initial)(request, *args, **kwargs)
+
+            if request.method.lower() in self.http_method_names:
+                handler = getattr(
+                    self, request.method.lower(), self.http_method_not_allowed
+                )
+            else:
+                handler = self.http_method_not_allowed
+
+            response = handler(request, *args, **kwargs)
+            import asyncio
+
+            if asyncio.iscoroutine(response):
+                response = await response
+
+        except Exception as exc:  # noqa: BLE001
+            response = self.handle_exception(exc)
+
+        self.response = self.finalize_response(request, response, *args, **kwargs)
+        return self.response
 
     def handle_exception(self, exc):
         if isinstance(exc, UnexpectedResponse) and (
@@ -62,7 +106,7 @@ class LearningResourcesVectorSearchView(QdrantView):
         )
     )
     @extend_schema(summary="Vector Search")
-    def get(self, request):
+    async def get(self, request):
         request_data = LearningResourcesVectorSearchRequestSerializer(data=request.GET)
 
         if request_data.is_valid():
@@ -70,7 +114,7 @@ class LearningResourcesVectorSearchView(QdrantView):
             hybrid_search = request_data.data.get("hybrid_search", False)
             limit = request_data.data.get("limit", 10)
             offset = request_data.data.get("offset", 0)
-            response = vector_search(
+            response = await async_vector_search(
                 query_text,
                 limit=limit,
                 offset=offset,
@@ -80,11 +124,16 @@ class LearningResourcesVectorSearchView(QdrantView):
             if request_data.data.get("dev_mode"):
                 return Response(response)
             else:
-                response = LearningResourcesVectorSearchResponseSerializer(
-                    response, context={"request": request}
-                ).data
-                response["results"] = list(response["results"])
-                return Response(response)
+                from asgiref.sync import sync_to_async
+
+                def serialize():
+                    return LearningResourcesVectorSearchResponseSerializer(
+                        response, context={"request": request}
+                    ).data
+
+                response_data = await sync_to_async(serialize)()
+                response_data["results"] = list(response_data["results"])
+                return Response(response_data)
         else:
             errors = {}
             for key, errors_obj in request_data.errors.items():
@@ -127,7 +176,7 @@ class ContentFilesVectorSearchView(QdrantView):
         )
     )
     @extend_schema(summary="Content File Vector Search")
-    def get(self, request):
+    async def get(self, request):
         request_data = ContentFileVectorSearchRequestSerializer(data=request.GET)
 
         if request_data.is_valid():
@@ -142,7 +191,7 @@ class ContentFilesVectorSearchView(QdrantView):
                     f"{settings.QDRANT_BASE_COLLECTION_NAME}.{collection_name_override}"
                 )
 
-            response = vector_search(
+            response = await async_vector_search(
                 query_text,
                 limit=limit,
                 offset=offset,
@@ -153,12 +202,16 @@ class ContentFilesVectorSearchView(QdrantView):
             if request_data.data.get("dev_mode"):
                 return Response(response)
             else:
-                response = ContentFileVectorSearchResponseSerializer(
-                    response, context={"request": request}
-                ).data
+                from asgiref.sync import sync_to_async
 
-                response["results"] = list(response["results"])
-                return Response(response)
+                def serialize():
+                    return ContentFileVectorSearchResponseSerializer(
+                        response, context={"request": request}
+                    ).data
+
+                response_data = await sync_to_async(serialize)()
+                response_data["results"] = list(response_data["results"])
+                return Response(response_data)
         else:
             errors = {}
             for key, errors_obj in request_data.errors.items():

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -320,8 +320,6 @@ class ContentFilesVectorSearchView(QdrantView):
             if request_data.data.get("dev_mode"):
                 return Response(response)
             else:
-                from asgiref.sync import sync_to_async
-
                 def serialize():
                     return ContentFileVectorSearchResponseSerializer(
                         response, context={"request": request}

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -1,9 +1,11 @@
 import logging
 from itertools import chain
 
+from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import extend_schema, extend_schema_view
+from qdrant_client import models
 from qdrant_client.http.exceptions import UnexpectedResponse
 from rest_framework.decorators import action
 from rest_framework.permissions import BasePermission
@@ -13,14 +15,23 @@ from rest_framework.views import APIView
 from authentication.decorators import blocked_ip_exempt
 from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
 from main.utils import cache_page_for_anonymous_users
-from vector_search.constants import CONTENT_FILES_COLLECTION_NAME
 from vector_search.serializers import (
     ContentFileVectorSearchRequestSerializer,
     ContentFileVectorSearchResponseSerializer,
     LearningResourcesVectorSearchRequestSerializer,
     LearningResourcesVectorSearchResponseSerializer,
 )
-from vector_search.utils import async_vector_search
+from vector_search.utils import (
+    CONTENT_FILES_COLLECTION_NAME,
+    RESOURCES_COLLECTION_NAME,
+    _content_file_vector_hits,
+    _merge_dicts,
+    _resource_vector_hits,
+    async_qdrant_client,
+    dense_encoder,
+    qdrant_query_conditions,
+    sparse_encoder,
+)
 
 log = logging.getLogger(__name__)
 
@@ -44,8 +55,6 @@ class QdrantView(APIView):
         return async_view
 
     async def dispatch(self, request, *args, **kwargs):
-        from asgiref.sync import sync_to_async
-
         self.args = args
         self.kwargs = kwargs
         request = self.initialize_request(request, *args, **kwargs)
@@ -73,6 +82,109 @@ class QdrantView(APIView):
 
         self.response = self.finalize_response(request, response, *args, **kwargs)
         return self.response
+
+    async def async_vector_search(  # noqa: PLR0913
+        self,
+        query_string: str,
+        params: dict,
+        limit: int = 10,
+        offset: int = 10,
+        search_collection=RESOURCES_COLLECTION_NAME,
+        *,
+        hybrid_search: bool = False,
+    ):
+        client = async_qdrant_client()
+        encoder_dense = dense_encoder()
+        encoder_sparse = sparse_encoder()
+
+        search_filter = qdrant_query_conditions(
+            params, collection_name=search_collection
+        )
+        prefetch_multiplier = 20
+        prefetch_limit = (offset + limit) * prefetch_multiplier
+        if query_string:
+            search_params = {
+                "collection_name": search_collection,
+                "query_filter": search_filter,
+                "with_vectors": False,
+                "with_payload": True,
+                "search_params": models.SearchParams(indexed_only=True, exact=False),
+                "limit": limit,
+            }
+
+            if hybrid_search:
+                sparse_query = await sync_to_async(encoder_sparse.embed)(query_string)
+                dense_query = await sync_to_async(encoder_dense.embed_query)(
+                    query_string
+                )
+                search_params["prefetch"] = [
+                    models.Prefetch(
+                        query=sparse_query,
+                        using=encoder_sparse.model_short_name(),
+                        limit=prefetch_limit,
+                    ),
+                    models.Prefetch(
+                        query=dense_query,
+                        using=encoder_dense.model_short_name(),
+                        limit=prefetch_limit,
+                    ),
+                ]
+                search_params["query"] = models.FusionQuery(fusion=models.Fusion.RRF)
+            else:
+                dense_query = await sync_to_async(encoder_dense.embed_query)(
+                    query_string
+                )
+                search_params["using"] = encoder_dense.model_short_name()
+                search_params["query"] = dense_query
+
+            if "group_by" in params:
+                search_params.pop("search_params", None)
+                search_params["group_by"] = params.get("group_by")
+                search_params["group_size"] = params.get("group_size", 1)
+                group_result = await client.query_points_groups(**search_params)
+                search_result = []
+                for group in group_result.groups:
+                    payloads = [hit.payload for hit in group.hits]
+                    response_hit = _merge_dicts(payloads)
+                    chunks = [payload.get("chunk_content") for payload in payloads]
+                    response_hit["chunk_content"] = None
+                    response_hit["chunks"] = chunks
+                    response_row = {
+                        "id": response_hit[search_params["group_by"]],
+                        "payload": response_hit,
+                        "vector": [],
+                    }
+                    search_result.append(models.PointStruct(**response_row))
+
+            else:
+                search_params["offset"] = offset
+                result_obj = await client.query_points(**search_params)
+                search_result = result_obj.points
+        else:
+            scroll_res = await client.scroll(
+                collection_name=search_collection,
+                scroll_filter=search_filter,
+                limit=limit,
+                offset=offset,
+                with_vectors=False,
+            )
+            search_result = scroll_res[0]
+
+        if search_collection == RESOURCES_COLLECTION_NAME:
+            hits = await sync_to_async(_resource_vector_hits)(search_result)
+        else:
+            hits = await sync_to_async(_content_file_vector_hits)(search_result)
+
+        count_result = await client.count(
+            collection_name=search_collection,
+            count_filter=search_filter,
+            exact=False,
+        )
+
+        return {
+            "hits": hits,
+            "total": {"value": count_result.count},
+        }
 
     def handle_exception(self, exc):
         if isinstance(exc, UnexpectedResponse) and (
@@ -114,7 +226,7 @@ class LearningResourcesVectorSearchView(QdrantView):
             hybrid_search = request_data.data.get("hybrid_search", False)
             limit = request_data.data.get("limit", 10)
             offset = request_data.data.get("offset", 0)
-            response = await async_vector_search(
+            response = await self.async_vector_search(
                 query_text,
                 limit=limit,
                 offset=offset,
@@ -124,7 +236,6 @@ class LearningResourcesVectorSearchView(QdrantView):
             if request_data.data.get("dev_mode"):
                 return Response(response)
             else:
-                from asgiref.sync import sync_to_async
 
                 def serialize():
                     return LearningResourcesVectorSearchResponseSerializer(
@@ -191,7 +302,7 @@ class ContentFilesVectorSearchView(QdrantView):
                     f"{settings.QDRANT_BASE_COLLECTION_NAME}.{collection_name_override}"
                 )
 
-            response = await async_vector_search(
+            response = await self.async_vector_search(
                 query_text,
                 limit=limit,
                 offset=offset,

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -320,6 +320,7 @@ class ContentFilesVectorSearchView(QdrantView):
             if request_data.data.get("dev_mode"):
                 return Response(response)
             else:
+
                 def serialize():
                     return ContentFileVectorSearchResponseSerializer(
                         response, context={"request": request}

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from functools import wraps
 from itertools import chain
 
 from asgiref.sync import sync_to_async
@@ -45,8 +47,6 @@ class QdrantView(APIView):
     def as_view(cls, **initkwargs):
         view = super().as_view(**initkwargs)
 
-        from functools import wraps
-
         @wraps(view)
         async def async_view(*args, **kwargs):
             return await view(*args, **kwargs)
@@ -72,7 +72,6 @@ class QdrantView(APIView):
                 handler = self.http_method_not_allowed
 
             response = handler(request, *args, **kwargs)
-            import asyncio
 
             if asyncio.iscoroutine(response):
                 response = await response
@@ -120,9 +119,13 @@ class QdrantView(APIView):
             }
 
             if hybrid_search:
-                sparse_query = await sync_to_async(encoder_sparse.embed)(query_string)
-                dense_query = await sync_to_async(encoder_dense.embed_query)(
-                    query_string
+                sparse_query, dense_query = await asyncio.gather(
+                    sync_to_async(encoder_sparse.embed, thread_sensitive=False)(
+                        query_string
+                    ),
+                    sync_to_async(encoder_dense.embed_query, thread_sensitive=False)(
+                        query_string
+                    ),
                 )
                 search_params["prefetch"] = [
                     models.Prefetch(

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -11,17 +11,13 @@ from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
 def test_vector_search_filters(mocker, client):
     """Test vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant.scroll.return_value = [[]]
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant.count.return_value = CountResult(count=10)
     params = {
         "q": "test",
         "topic": ["test"],
@@ -60,15 +56,11 @@ def test_vector_search_filters(mocker, client):
 def test_vector_search_filters_empty_query(mocker, client):
     """Test vector search filters with empty query uses scroll filters"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant.count.return_value = CountResult(count=10)
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
 
@@ -121,17 +113,13 @@ def test_content_file_vector_search_filters(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant.scroll.return_value = [[]]
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant.count.return_value = CountResult(count=10)
     params = {
         "q": "test",
         "offered_by": ["ocw"],
@@ -205,17 +193,13 @@ def test_content_file_vector_search_filters_empty_query(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant.scroll.return_value = [[]]
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant.count.return_value = CountResult(count=10)
     # omit the q param
     params = {
         "offered_by": ["ocw"],
@@ -264,18 +248,14 @@ def test_content_file_vector_search_filters_custom_collection(
 ):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
     custom_collection_name = "foo_bar_collection"
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant.scroll.return_value = [[]]
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant.count.return_value = CountResult(count=10)
 
     params = {
         "offered_by": ["ocw"],
@@ -308,19 +288,14 @@ def test_content_file_vector_search_filters_custom_collection(
 def test_content_file_vector_search_group_parameters(mocker, client, django_user_model):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch(
-        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
-    )()
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
     custom_collection_name = "foo_bar_collection"
 
-    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
-    mock_qdrant.query_points = mocker.AsyncMock()
-    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.async_qdrant_client",
+        "vector_search.utils.qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
+    mock_qdrant.count.return_value = CountResult(count=10)
     contentfile_keys = ["somefile.pdf", "trest.csv", "newfile.txt", "presentation.pptx"]
 
     mock_groups = []
@@ -347,7 +322,7 @@ def test_content_file_vector_search_group_parameters(mocker, client, django_user
         mock_groups.append(mock_group)
     mock_group_result = mocker.MagicMock()
     mock_group_result.groups = mock_groups
-    mock_qdrant.query_points_groups = mocker.AsyncMock(return_value=mock_group_result)
+    mock_qdrant.query_points_groups.return_value = mock_group_result
     params = {
         "group_by": "key",
         "resource_readable_id": ["test_resource_id_1", "test_resource_id_2"],

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -11,13 +11,17 @@ from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
 def test_vector_search_filters(mocker, client):
     """Test vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     params = {
         "q": "test",
         "topic": ["test"],
@@ -56,11 +60,15 @@ def test_vector_search_filters(mocker, client):
 def test_vector_search_filters_empty_query(mocker, client):
     """Test vector search filters with empty query uses scroll filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
 
@@ -113,13 +121,17 @@ def test_content_file_vector_search_filters(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     params = {
         "q": "test",
         "offered_by": ["ocw"],
@@ -193,13 +205,17 @@ def test_content_file_vector_search_filters_empty_query(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     # omit the q param
     params = {
         "offered_by": ["ocw"],
@@ -248,14 +264,18 @@ def test_content_file_vector_search_filters_custom_collection(
 ):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
     custom_collection_name = "foo_bar_collection"
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
 
     params = {
         "offered_by": ["ocw"],
@@ -288,14 +308,19 @@ def test_content_file_vector_search_filters_custom_collection(
 def test_content_file_vector_search_group_parameters(mocker, client, django_user_model):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
     custom_collection_name = "foo_bar_collection"
 
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.views.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     contentfile_keys = ["somefile.pdf", "trest.csv", "newfile.txt", "presentation.pptx"]
 
     mock_groups = []
@@ -322,7 +347,7 @@ def test_content_file_vector_search_group_parameters(mocker, client, django_user
         mock_groups.append(mock_group)
     mock_group_result = mocker.MagicMock()
     mock_group_result.groups = mock_groups
-    mock_qdrant.query_points_groups.return_value = mock_group_result
+    mock_qdrant.query_points_groups = mocker.AsyncMock(return_value=mock_group_result)
     params = {
         "group_by": "key",
         "resource_readable_id": ["test_resource_id_1", "test_resource_id_2"],

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -11,13 +11,17 @@ from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
 def test_vector_search_filters(mocker, client):
     """Test vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     params = {
         "q": "test",
         "topic": ["test"],
@@ -56,11 +60,15 @@ def test_vector_search_filters(mocker, client):
 def test_vector_search_filters_empty_query(mocker, client):
     """Test vector search filters with empty query uses scroll filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
 
@@ -113,13 +121,17 @@ def test_content_file_vector_search_filters(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     params = {
         "q": "test",
         "offered_by": ["ocw"],
@@ -193,13 +205,17 @@ def test_content_file_vector_search_filters_empty_query(
 ):
     """Test content file vector search with query uses query filters"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     # omit the q param
     params = {
         "offered_by": ["ocw"],
@@ -248,14 +264,18 @@ def test_content_file_vector_search_filters_custom_collection(
 ):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
     custom_collection_name = "foo_bar_collection"
-    mock_qdrant.scroll.return_value = [[]]
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
 
     params = {
         "offered_by": ["ocw"],
@@ -288,14 +308,19 @@ def test_content_file_vector_search_filters_custom_collection(
 def test_content_file_vector_search_group_parameters(mocker, client, django_user_model):
     """Test content file vector search uses custom collection if specified"""
 
-    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mock_qdrant = mocker.patch(
+        "qdrant_client.AsyncQdrantClient", return_value=mocker.AsyncMock()
+    )()
     custom_collection_name = "foo_bar_collection"
 
+    mock_qdrant.scroll = mocker.AsyncMock(return_value=[[]])
+    mock_qdrant.query_points = mocker.AsyncMock()
+    mock_qdrant.query_points_groups = mocker.AsyncMock()
     mocker.patch(
-        "vector_search.utils.qdrant_client",
+        "vector_search.utils.async_qdrant_client",
         return_value=mock_qdrant,
     )
-    mock_qdrant.count.return_value = CountResult(count=10)
+    mock_qdrant.count = mocker.AsyncMock(return_value=CountResult(count=10))
     contentfile_keys = ["somefile.pdf", "trest.csv", "newfile.txt", "presentation.pptx"]
 
     mock_groups = []
@@ -322,7 +347,7 @@ def test_content_file_vector_search_group_parameters(mocker, client, django_user
         mock_groups.append(mock_group)
     mock_group_result = mocker.MagicMock()
     mock_group_result.groups = mock_groups
-    mock_qdrant.query_points_groups.return_value = mock_group_result
+    mock_qdrant.query_points_groups = mocker.AsyncMock(return_value=mock_group_result)
     params = {
         "group_by": "key",
         "resource_readable_id": ["test_resource_id_1", "test_resource_id_2"],


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10736
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR switches use to using async views for the vector search endpoints so we can leverage qdrant's async api in order to make concurrent calls where needed.

### How can this be tested?
1. Checkout this branch
2. restart your web container
3. make sure you have some learning resources locally as well as some resources and contentfiles embedded
4. visit/browse around the vector endoints ([contentfile](http://open.odl.local:8063/api/v0/vector_content_files_search/?q=testing) and [learning resource](http://open.odl.local:8063/api/v0/vector_learning_resources_search/?q=test) ) - things should work normally (there are no functional changes here)

### Additional Context
This transition is necessary to implement faceting via https://github.com/mitodl/hq/issues/10641
