### PR TITLE
Add user verification step to all data mgmt commands if --delete option is specified

### DIFF
--- a/learning_resources/management/commands/backpopulate_micromasters_data.py
+++ b/learning_resources/management/commands/backpopulate_micromasters_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_micromasters_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate micromasters programs and courses"""
 
     help = "Populate micromasters programs and courses"

--- a/learning_resources/management/commands/backpopulate_mit_edx_data.py
+++ b/learning_resources/management/commands/backpopulate_mit_edx_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_mit_edx_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate MIT edX courses"""
 
     help = "Populate MIT edX courses"

--- a/learning_resources/management/commands/backpopulate_mitpe_data.py
+++ b/learning_resources/management/commands/backpopulate_mitpe_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_mitpe_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate professional education  courses"""
 
     help = "Populate professional education courses"

--- a/learning_resources/management/commands/backpopulate_mitxonline_data.py
+++ b/learning_resources/management/commands/backpopulate_mitxonline_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_mitxonline_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate mitxonline courses"""
 
     help = "Populate mitxonline courses"

--- a/learning_resources/management/commands/backpopulate_ocw_data.py
+++ b/learning_resources/management/commands/backpopulate_ocw_data.py
@@ -4,7 +4,10 @@ from django.conf import settings
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_ocw_data
 from learning_resources.utils import resource_delete_actions
@@ -12,7 +15,7 @@ from main.constants import ISOFORMAT
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate OCW learning resources"""
 
     help = "Populate OCW learning resources"

--- a/learning_resources/management/commands/backpopulate_oll_data.py
+++ b/learning_resources/management/commands/backpopulate_oll_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_oll_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate oll courses"""
 
     help = "Populate oll courses"

--- a/learning_resources/management/commands/backpopulate_ovs_data.py
+++ b/learning_resources/management/commands/backpopulate_ovs_data.py
@@ -3,40 +3,42 @@
 from django.core.management import BaseCommand
 
 from learning_resources.constants import LearningResourceType, PlatformType
+from learning_resources.management.commands.mixins import ConfirmDeleteMixin
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_ovs_data, get_ovs_transcripts
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(BaseCommand):
+class Command(ConfirmDeleteMixin, BaseCommand):
     """Populate OVS videos"""
 
     help = "Populate OVS videos and transcripts"
 
     def add_arguments(self, parser):
-        subparsers = parser.add_subparsers(dest="command")
-
-        subparsers.add_parser("delete", help="Delete all existing OVS video records")
-
-        subparsers.add_parser("fetch", help="Fetch OVS video data")
-
-        transcripts_parser = subparsers.add_parser(
-            "transcripts", help="Fetch transcripts for OVS videos"
+        parser.add_argument(
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete all existing OVS video records",
         )
-        transcripts_parser.add_argument(
+        parser.add_argument(
+            "--transcripts",
+            dest="transcripts",
+            action="store_true",
+            help="Fetch transcripts for OVS videos",
+        )
+        parser.add_argument(
             "--overwrite",
             dest="overwrite",
             action="store_true",
             help="Overwrite any existing transcript records",
         )
-
         super().add_arguments(parser)
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Run Populate OVS video data"""
-        command = options["command"]
-        if command == "delete":
+        if options["delete"]:
             self.stdout.write("Deleting all existing OVS videos from database")
             for video in LearningResource.objects.filter(
                 resource_type=LearningResourceType.video.name,
@@ -44,7 +46,14 @@ class Command(BaseCommand):
             ).iterator():
                 resource_delete_actions(video)
             self.stdout.write("Complete")
-        elif command == "fetch":
+        elif options["transcripts"]:
+            task = get_ovs_transcripts.delay(overwrite=options["overwrite"])
+            self.stdout.write("Waiting on task...")
+            start = now_in_utc()
+            task.get()
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(f"Completed in {total_seconds} seconds")
+        else:
             task = get_ovs_data.delay()
             self.stdout.write(f"Started task {task} to get OVS video data")
             self.stdout.write("Waiting on task...")
@@ -54,13 +63,3 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"Population of OVS video data finished, took {total_seconds} seconds"
             )
-        elif command == "transcripts":
-            overwrite = options["overwrite"]
-            task = get_ovs_transcripts.delay(overwrite=overwrite)
-            self.stdout.write("Waiting on task...")
-            start = now_in_utc()
-            task.get()
-            total_seconds = (now_in_utc() - start).total_seconds()
-            self.stdout.write(f"Completed in {total_seconds} seconds")
-        else:
-            self.print_help("manage.py", "backpopulate_ovs_data")

--- a/learning_resources/management/commands/backpopulate_ovs_data.py
+++ b/learning_resources/management/commands/backpopulate_ovs_data.py
@@ -16,13 +16,14 @@ class Command(ConfirmDeleteMixin, BaseCommand):
     help = "Populate OVS videos and transcripts"
 
     def add_arguments(self, parser):
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--delete",
             dest="delete",
             action="store_true",
             help="Delete all existing OVS video records",
         )
-        parser.add_argument(
+        mode_group.add_argument(
             "--transcripts",
             dest="transcripts",
             action="store_true",

--- a/learning_resources/management/commands/backpopulate_podcast_data.py
+++ b/learning_resources/management/commands/backpopulate_podcast_data.py
@@ -3,13 +3,14 @@
 from django.core.management import BaseCommand
 
 from learning_resources.constants import LearningResourceType
+from learning_resources.management.commands.mixins import ConfirmDeleteMixin
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_podcast_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(BaseCommand):
+class Command(ConfirmDeleteMixin, BaseCommand):
     """Populate podcasts"""
 
     help = "Populate podcasts"

--- a/learning_resources/management/commands/backpopulate_sloan_data.py
+++ b/learning_resources/management/commands/backpopulate_sloan_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_sloan_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate professional education  courses"""
 
     help = "Populate Sloan Executive Education courses"

--- a/learning_resources/management/commands/backpopulate_xpro_data.py
+++ b/learning_resources/management/commands/backpopulate_xpro_data.py
@@ -3,14 +3,17 @@
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
-from learning_resources.management.commands.mixins import TestResourceConfigurationMixin
+from learning_resources.management.commands.mixins import (
+    ConfirmDeleteMixin,
+    TestResourceConfigurationMixin,
+)
 from learning_resources.models import LearningResource
 from learning_resources.tasks import get_xpro_data
 from learning_resources.utils import resource_delete_actions
 from main.utils import now_in_utc
 
 
-class Command(TestResourceConfigurationMixin, BaseCommand):
+class Command(ConfirmDeleteMixin, TestResourceConfigurationMixin, BaseCommand):
     """Populate xpro courses"""
 
     help = "Populate xpro courses"

--- a/learning_resources/management/commands/backpopulate_youtube_data.py
+++ b/learning_resources/management/commands/backpopulate_youtube_data.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from django.core.management import BaseCommand
 
 from learning_resources.etl.constants import ETLSource
+from learning_resources.management.commands.mixins import ConfirmDeleteMixin
 from learning_resources.models import LearningResource, VideoChannel
 from learning_resources.tasks import get_youtube_data, get_youtube_transcripts
 from learning_resources.utils import resource_delete_actions
@@ -12,23 +13,26 @@ from main.constants import ISOFORMAT
 from main.utils import now_in_utc
 
 
-class Command(BaseCommand):
+class Command(ConfirmDeleteMixin, BaseCommand):
     """Populate youtube videos"""
 
     help = """Populates youtube videos"""
 
     def add_arguments(self, parser):
         """Configure arguments for this command"""
-        subparsers = parser.add_subparsers(dest="command")
-
-        # delete subcommand
-        subparsers.add_parser("delete", help="Delete all existing records first")
-
-        # fetch subcommand
-        fetch_parser = subparsers.add_parser(
-            "fetch", help="Fetches video data, defaulting to recently published ones"
+        parser.add_argument(
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete all existing records first",
         )
-        fetch_parser.add_argument(
+        parser.add_argument(
+            "--transcripts",
+            dest="transcripts",
+            action="store_true",
+            help="Fetch video transcript data",
+        )
+        parser.add_argument(
             "-c",
             "--channel-id",
             dest="channel_ids",
@@ -36,36 +40,29 @@ class Command(BaseCommand):
             default=None,
             help="Only fetch channels specified by channel id",
         )
-
-        # transcripts subcommand
-        transcripts_parser = subparsers.add_parser(
-            "transcripts", help="Fetches video transcript data"
-        )
-        transcripts_parser.add_argument(
+        parser.add_argument(
             "--created-after",
             dest="created_after",
             default=None,
             help="Only fetch transcripts for videos indexed after timestamp (yyyy-mm-ddThh:mm:ssZ)",  # noqa: E501
         )
-        transcripts_parser.add_argument(
+        parser.add_argument(
             "--created-minutes",
             dest="created_minutes",
             default=None,
             help="Only fetch transcripts for videos indexed this number of minutes ago and later",  # noqa: E501
         )
-        transcripts_parser.add_argument(
+        parser.add_argument(
             "--overwrite",
             dest="overwrite",
             action="store_true",
             help="Overwrite any existing transcript records",
         )
-
         super().add_arguments(parser)
 
     def handle(self, *args, **options):  # noqa: ARG002
         """Run Populate youtube videos"""
-        command = options["command"]
-        if command == "delete":
+        if options["delete"]:
             videos_playlists = LearningResource.objects.filter(
                 etl_source=ETLSource.youtube.name
             )
@@ -76,18 +73,7 @@ class Command(BaseCommand):
                 resource_delete_actions(resource)
             VideoChannel.objects.all().delete()
             self.stdout.write("Complete")
-        elif command == "fetch":
-            channel_ids = options["channel_ids"]
-            task = get_youtube_data.delay(channel_ids=channel_ids)
-            self.stdout.write(f"Started task {task} to get YouTube video data")
-            self.stdout.write("Waiting on task...")
-            start = now_in_utc()
-            result = task.get()
-            total_seconds = (now_in_utc() - start).total_seconds()
-            self.stdout.write(
-                f"Fetched {result} YouTube channel in {total_seconds} seconds"
-            )
-        elif command == "transcripts":
+        elif options["transcripts"]:
             created_after = options["created_after"]
             created_minutes = options["created_minutes"]
             overwrite = options["overwrite"]
@@ -118,3 +104,14 @@ class Command(BaseCommand):
             task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(f"Completed in {total_seconds} seconds")
+        else:
+            channel_ids = options["channel_ids"]
+            task = get_youtube_data.delay(channel_ids=channel_ids)
+            self.stdout.write(f"Started task {task} to get YouTube video data")
+            self.stdout.write("Waiting on task...")
+            start = now_in_utc()
+            result = task.get()
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(
+                f"Fetched {result} YouTube channel in {total_seconds} seconds"
+            )

--- a/learning_resources/management/commands/backpopulate_youtube_data.py
+++ b/learning_resources/management/commands/backpopulate_youtube_data.py
@@ -20,13 +20,14 @@ class Command(ConfirmDeleteMixin, BaseCommand):
 
     def add_arguments(self, parser):
         """Configure arguments for this command"""
-        parser.add_argument(
+        mode_group = parser.add_mutually_exclusive_group()
+        mode_group.add_argument(
             "--delete",
             dest="delete",
             action="store_true",
             help="Delete all existing records first",
         )
-        parser.add_argument(
+        mode_group.add_argument(
             "--transcripts",
             dest="transcripts",
             action="store_true",

--- a/learning_resources/management/commands/mixins.py
+++ b/learning_resources/management/commands/mixins.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+from django.core.management.base import CommandError
+
 from learning_resources.models import LearningResource, LearningResourceRun
 
 
@@ -19,6 +22,24 @@ class TestResourceConfigurationMixin:
             LearningResource.objects.filter(id__in=test_ids).update(
                 test_mode=True, published=False
             )
+
+
+class ConfirmDeleteMixin:
+    """
+    Mixin that prompts the user to confirm deletion when --delete is passed
+    to a management command. The command class must define a --delete option.
+    """
+
+    def execute(self, *args, **options):
+        if options.get("delete"):
+            answer = input(
+                f"Are you sure you want to use the --delete option in "
+                f"{settings.ENVIRONMENT}? [y/N]: "
+            )
+            if answer.strip().lower() not in ("y", "yes"):
+                msg = "Aborted."
+                raise CommandError(msg)
+        return super().execute(*args, **options)
 
 
 class TestResourceIdMixin(TestResourceConfigurationMixin):


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/10847

### Description (What does it do?)
- Adds a verification step to all `backpopulate_<source>_data` commands, requesting the user to confirm that the deletion should proceed in the specified environment (dev, qa, production).
- Makes the ovs and youtube commands more consistent with others (`--delete`, `--transcripts`, no option leads to former `fetch` behavior)

### How can this be tested?
- `python manage.py backpopulate_mitpe_data` - should proceed normally
- `python manage.py backpopulate_mitpe_data --delete` - you should be asked to confirm.  Enter anything except `y` (upper/lower) and the command should be aborted
- Repeat the above step but enter `y` or `Y`, the deletion should proceed

### Additional Context
This is just in case someone uses the `--delete` option on RC/production when they think they're in their local docker container

