### PR TITLE
Clarify MIT's trademark relationship with Axim Collaborative

### DIFF
--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -550,9 +550,9 @@ const TermsPage: React.FC = () => {
             promotional purposes, or in any way that deliberately or
             inadvertently claims, suggests or, in MIT's sole judgment, gives the
             appearance or impression of a relationship with or endorsement by
-            MIT. MIT is an authorized Licensee of the MicroMasters mark which is 
-            a registered trademark of Axim Collaborative, Inc. All rights reserved 
-            worldwide. 
+            MIT. MIT is an authorized Licensee of the MicroMasters mark which is
+            a registered trademark of Axim Collaborative, Inc. All rights reserved
+            worldwide.
           </BodyText>
           <BodyText variant="body1">
             All trademarks not owned by MIT that appear on the Site or through

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -550,7 +550,9 @@ const TermsPage: React.FC = () => {
             promotional purposes, or in any way that deliberately or
             inadvertently claims, suggests or, in MIT's sole judgment, gives the
             appearance or impression of a relationship with or endorsement by
-            MIT.
+            MIT. MIT is an authorized Licensee of the MicroMasters mark which is 
+            a registered trademark of Axim Collaborative, Inc. All rights reserved 
+            worldwide. 
           </BodyText>
           <BodyText variant="body1">
             All trademarks not owned by MIT that appear on the Site or through

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -86,8 +86,8 @@ const TermsPage: React.FC = () => {
             learning resources. Through MIT Learn, learners across the globe can
             search and browse courses, programs, and various educational
             materials from across MIT, including Universal AI, MITx, MITx
-            MicroMasters®, MIT OpenCourseWare, MIT Professional Education, MIT 
-            Sloan Executive Education, MIT xPRO, and other departments across 
+            MicroMasters®, MIT OpenCourseWare, MIT Professional Education, MIT
+            Sloan Executive Education, MIT xPRO, and other departments across
             the Institute ("Offerings").
           </BodyText>
           <BodyText variant="body1">

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -545,7 +545,9 @@ const TermsPage: React.FC = () => {
             promotional purposes, or in any way that deliberately or
             inadvertently claims, suggests or, in MIT's sole judgment, gives the
             appearance or impression of a relationship with or endorsement by
-            MIT.
+            MIT. MIT is an authorized Licensee of the MicroMasters mark which is 
+            a registered trademark of Axim Collaborative, Inc. All rights reserved 
+            worldwide. 
           </BodyText>
           <BodyText variant="body1">
             All trademarks not owned by MIT that appear on the Site or through

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -85,10 +85,10 @@ const TermsPage: React.FC = () => {
             single online platform for accessing all of MIT's non-degree
             learning resources. Through MIT Learn, learners across the globe can
             search and browse courses, programs, and various educational
-            materials from across MIT, including Universal AI, MITx, MIT
-            OpenCourseWare, MIT Professional Education, MIT Sloan Executive
-            Education, MIT xPRO, and other departments across the Institute
-            ("Offerings").
+            materials from across MIT, including Universal AI, MITx, MITx
+            MicroMasters®, MIT OpenCourseWare, MIT Professional Education, MIT 
+            Sloan Executive Education, MIT xPRO, and other departments across 
+            the Institute ("Offerings").
           </BodyText>
           <BodyText variant="body1">
             Please read these Terms of Service ("TOS") and the MIT Learn{" "}

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -545,14 +545,14 @@ const TermsPage: React.FC = () => {
             promotional purposes, or in any way that deliberately or
             inadvertently claims, suggests or, in MIT's sole judgment, gives the
             appearance or impression of a relationship with or endorsement by
-            MIT. MIT is an authorized Licensee of the MicroMasters mark which is
-            a registered trademark of Axim Collaborative, Inc. All rights reserved
-            worldwide.
+            MIT.
           </BodyText>
           <BodyText variant="body1">
             All trademarks not owned by MIT that appear on the Site or through
             the services made available on or through the Site are the property
-            of their respective owners.
+            of their respective owners. For example, MIT is an authorized
+            Licensee of the MicroMasters mark, which is a registered trademark
+            of Axim Collaborative, Inc. All rights reserved worldwide.
           </BodyText>
           <BodyText variant="body1">
             Nothing contained on the Site should be construed as granting, by

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -545,9 +545,9 @@ const TermsPage: React.FC = () => {
             promotional purposes, or in any way that deliberately or
             inadvertently claims, suggests or, in MIT's sole judgment, gives the
             appearance or impression of a relationship with or endorsement by
-            MIT. MIT is an authorized Licensee of the MicroMasters mark which is 
-            a registered trademark of Axim Collaborative, Inc. All rights reserved 
-            worldwide. 
+            MIT. MIT is an authorized Licensee of the MicroMasters mark which is
+            a registered trademark of Axim Collaborative, Inc. All rights reserved
+            worldwide.
           </BodyText>
           <BodyText variant="body1">
             All trademarks not owned by MIT that appear on the Site or through

--- a/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
+++ b/frontends/main/src/app-pages/TermsPage/TermsPage.tsx
@@ -784,7 +784,7 @@ const TermsPage: React.FC = () => {
             inconvenience of forum).
           </BodyText>
           <BodyText variant="body1">
-            These terms of service were last updated on April 14, 2026.
+            These terms of service were last updated on June 1, 2026.
           </BodyText>
         </BodyContainer>
       </PageContainer>


### PR DESCRIPTION
Added clarification regarding MIT's license of the MicroMasters trademark.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->

Part of https://github.com/mitodl/hq/issues/10501

### Description (What does it do?)
<!--- Describe your changes in detail -->

Added some text about how Axim owns MicroMasters®

