### PR TITLE
clean up hardcoded labels

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -574,7 +574,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     <Stack direction="column">
       <Stack direction="column" marginBottom="24px">
         <Typography variant="h5" color={theme.custom.colors.silverGrayDark}>
-          MITx | {program?.program_type}
+          Program{program?.program_type ? `: ${program?.program_type}` : ""}
         </Typography>
         <Typography component="h1" variant="h3" paddingBottom="32px">
           {program?.title}

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -67,7 +67,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
 
   return (
     <ProductPageTemplate
-      currentBreadcrumbLabel="Learning Path"
+      currentBreadcrumbLabel="Course"
       title={page.title}
       shortDescription={page.course_details.page.description}
       imageSrc={imageSrc}

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -266,7 +266,7 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
 
   return (
     <ProductPageTemplate
-      currentBreadcrumbLabel="Learning Path"
+      currentBreadcrumbLabel="Program"
       title={page.title}
       shortDescription={
         <DescriptionHTML


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10873

### Description (What does it do?)
This PR replaces some invalid hard coded labels in the dashboard and product pages:
- "MITx |" on the program dashboard page was replaced with "Program: " followed by the program type if available. If the program type is not set, it simply says "Program."
- The "Learning Path" breadcrumb on the product pages was replaced with "Course" or "Program" depending on if it's a course or program.

### Screenshots (if appropriate):
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/8bad82af-04aa-4cee-8e76-9587c907b835" />
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/a2d76b59-cdbe-473d-b7e7-747bdb703233" />
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/89f67fc0-6687-4eee-b216-de3c81ef6aee" />

### How can this be tested?
- Ensure you have MITx Online running locally and connected to your instance of MIT Learn through the directions in the README
- Ensure you have created sufficient test data, which would be a B2C program with at least a few courses in it
- Make sure your user is enrolled in said program
- Visit the dashboard home page, and click on the "View Program" button in the My Learning section
- On the program dashboard, above the title, verify that you see "Program: Series"
- Click back, then click on the 3 dots to bring up the overflow menu on the program card, then click "View Program Details"
- On this page, verify that the breadcrumb says "Program
- Click on one of the course cards in the program
- Verify that the breadcrumb says "Course"
