### PR TITLE
feat: use the same language as to transcript

### DIFF
--- a/learning_resources/content_summarizer_test.py
+++ b/learning_resources/content_summarizer_test.py
@@ -383,6 +383,37 @@ def test_generate_summary_flashcards_exception(
             )
 
 
+def test_generate_flashcards_uses_transcript_language_instruction(mocker, settings):
+    """Flashcard prompt should explicitly instruct same-language output."""
+    settings.OPENAI_API_KEY = "test"
+    summarizer = ContentSummarizer()
+
+    mock_chat_llm = mocker.patch(
+        "learning_resources.content_summarizer.ChatLiteLLM", autospec=True
+    )
+    mocker.patch(
+        "learning_resources.content_summarizer.get_max_tokens", return_value=10000
+    )
+    mocker.patch(
+        "learning_resources.content_summarizer.truncate_to_tokens",
+        side_effect=lambda text, *_args, **_kwargs: text,
+    )
+
+    structured_invoke = mock_chat_llm.return_value.with_structured_output.return_value
+    structured_invoke.invoke.return_value = {
+        "flashcards": [{"question": "Q", "answer": "A"}]
+    }
+
+    non_english_content = "Hola mundo. Este video explica energia y trabajo."
+    summarizer._generate_flashcards(  # noqa: SLF001
+        content=non_english_content, llm_model="test-model"
+    )
+
+    prompt_sent = structured_invoke.invoke.call_args.args[0]
+    assert "Use the same language as the transcript" in prompt_sent
+    assert non_english_content in prompt_sent
+
+
 def test_summarize_single_content_file_with_exception(
     mocker, processable_content_files, settings
 ):

--- a/main/settings.py
+++ b/main/settings.py
@@ -892,6 +892,7 @@ CONTENT_SUMMARIZER_FLASHCARD_PROMPT = get_string(
         """
         """
         Rules:
+        - Use the same language as the transcript for both questions and answers.
         - Focus ONLY on core concepts, methods, definitions,
           reasoning, and cause-effect relationships.
         - Questions must test understanding or application,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10026

### Description (What does it do?)
Updates the content summarizer’s flashcard generation prompt so LLM output matches the transcript’s language, addressing the multilingual flashcard behavior. 


### Screenshots (if appropriate):
<img width="1698" height="302" alt="Screenshot 2026-04-09 at 12 48 34 PM" src="https://github.com/user-attachments/assets/95b81c0a-bd11-4f50-b4cb-3c847f02fc9f" />


### How can this be tested?
**Prerequisites:**

**Docker stack running for mit-learn (db, redis, web available).**
**Valid OpenAI key should be available and please update that in the following script** 

This script can create missing test data if needed, then generate flashcards in the same language as the transcript content and display them in the shell.

```
docker compose run --rm \
  -e OPENAI_API_KEY="$OPENAI_API_KEY" \
  web python manage.py shell -c "
from learning_resources.models import ContentSummarizerConfiguration, LearningResourcePlatform, LearningResource, LearningResourceRun, ContentFile
from learning_resources.constants import CONTENT_TYPE_FILE
from learning_resources.content_summarizer import ContentSummarizer

platform = LearningResourcePlatform.objects.get(code='mitxonline')

# Ensure summarizer config for mitxonline allows .srt/.vtt only
ContentSummarizerConfiguration.objects.update_or_create(
    platform=platform,
    defaults={
        'allowed_content_types': [CONTENT_TYPE_FILE],
        'allowed_extensions': ['.srt', '.vtt'],
        'is_active': True,
        'llm_model': 'gpt-4o-mini',
    },
)

# Ensure at least one mitxonline resource + run exists
lr = LearningResource.objects.filter(platform=platform).first()
if lr is None:
    lr = LearningResource.objects.create(
        title='TMP mitxonline summarizer test',
        platform=platform,
        resource_type='course',
        published=True,
        require_summaries=True,
    )
else:
    lr.require_summaries = True
    lr.save(update_fields=['require_summaries'])

run = lr.runs.first()
if run is None:
    run = LearningResourceRun.objects.create(
        learning_resource=lr,
        title='TMP run',
        run_id='tmp-run-summarizer-test',
    )

# Create/update two content files:
# - .xml (should be skipped by config)
# - .srt (should be summarized + flashcards generated)
xml_cf, _ = ContentFile.objects.update_or_create(
    run=run,
    key='tmp-lang-test-xml',
    defaults={
        'title':'TMP XML test',
        'content_type': CONTENT_TYPE_FILE,
        'file_extension': '.xml',
        'content':'Hola, este contenido esta en espanol. Prueba de resumen y tarjetas.'
    }
)
srt_cf, _ = ContentFile.objects.update_or_create(
    run=run,
    key='tmp-lang-test-srt',
    defaults={
        'title':'TMP SRT test',
        'content_type': CONTENT_TYPE_FILE,
        'file_extension': '.srt',
        'content':'Hola. Este video explica la fotosintesis. La luz solar se convierte en energia quimica en las plantas.'
    }
)

summarizer = ContentSummarizer()
xml_result = summarizer.summarize_content_files_by_ids([xml_cf.id], overwrite=True)
srt_result = summarizer.summarize_content_files_by_ids([srt_cf.id], overwrite=True)

srt_cf.refresh_from_db()
print('xml_result:', xml_result)
print('srt_result:', srt_result)
print('summary preview:', (srt_cf.summary or '')[:300])
print('flashcards count:', len(srt_cf.flashcards or []))
print('flashcard sample:', (srt_cf.flashcards or [None])[0])
"
```


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
