### PR TITLE
Switch to lightweight static embeddings model for local development

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -806,7 +806,7 @@ QDRANT_CHUNK_SIZE = get_int(
 )
 
 QDRANT_ENCODER = get_string(
-    name="QDRANT_ENCODER", default="vector_search.encoders.fastembed.FastEmbedEncoder"
+    name="QDRANT_ENCODER", default="vector_search.encoders.gensim.GensimEncoder"
 )
 
 QDRANT_POINT_UPLOAD_BATCH_SIZE = get_int(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ dependencies = [
     "django-removals>=1.1.6,<2",
     "langchain-litellm>=0.5.1",
     "scikit-learn>=1.8.0",
+    "gensim>=4.4.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1313,6 +1313,24 @@ wheels = [
 ]
 
 [[package]]
+name = "gensim"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "smart-open" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/80/fe9d2e1ace968041814dbcfce4e8499a643a36c41267fa4b6c4f54cce420/gensim-4.4.0.tar.gz", hash = "sha256:a3f5b626da5518e79a479140361c663089fe7998df8ba52d56e1ded71ac5bdf5", size = 23260095, upload-time = "2025-10-18T02:06:45.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/65/d5285865ca54b93d41ccd8683c2d79952434957c76b411283c7a6c66ca69/gensim-4.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0845b2fa039dbea5667fb278b5414e70f6d48fd208ef51f33e84a78444288d8d", size = 24467245, upload-time = "2025-10-18T01:55:09.924Z" },
+    { url = "https://files.pythonhosted.org/packages/32/59/f0ea443cbfb3b06e1d2e060217bb91f954845f6df38cbc9c5468b6c9c638/gensim-4.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1853fc5be730f692c444a826041fef9a2fc8d74c73bb59748904b2e3221daa86", size = 24455775, upload-time = "2025-10-18T01:55:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/9b0ba15756e41ccfdd852f9c65cd2b552f240c201dc3237ad8c178642e80/gensim-4.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23a2a4260f01c8f71bae5dd0e8a01bb247a2c789480c033e0eaba100b0ad4239", size = 27771345, upload-time = "2025-10-18T01:56:41.448Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2c/c29701826c963b04a43d5d7b87573a74040387ab9219e65b10f377d22b5b/gensim-4.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b73ff30af6ddd0d2ddf9473b1eb44603cd79ec14c87d93b75291802b991916c", size = 27864118, upload-time = "2025-10-18T01:57:32.428Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/f2/9ec6863143888bf390cdc5261f6d9e71d79bc95d98fb815679dba478d5f6/gensim-4.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:b3a3f9bc8d4178b01d114e1c58c5ab2333f131c7415fb3d8ec8f1ecfe4c5b544", size = 24400277, upload-time = "2025-10-18T01:58:17.629Z" },
+]
+
+[[package]]
 name = "gevent"
 version = "25.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2530,6 +2548,7 @@ dependencies = [
     { name = "drf-nested-routers" },
     { name = "drf-spectacular" },
     { name = "feedparser" },
+    { name = "gensim" },
     { name = "google-api-python-client" },
     { name = "granian", extra = ["reload"] },
     { name = "html2text" },
@@ -2667,6 +2686,7 @@ requires-dist = [
     { name = "drf-nested-routers", specifier = ">=0.95.0,<0.96" },
     { name = "drf-spectacular", specifier = ">=0.28.0,<0.29" },
     { name = "feedparser", specifier = ">=6.0.10,<7" },
+    { name = "gensim", specifier = ">=4.4.0" },
     { name = "google-api-python-client", specifier = ">=2.89.0,<3" },
     { name = "granian", extras = ["reload"], specifier = ">=2.5.4,<3" },
     { name = "html2text", specifier = ">=2025.0.0,<2026" },

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -24,4 +24,10 @@ class GensimEncoder(BaseEncoder):
         return np.mean(vectors, axis=0)
 
     def dim(self):
-        return self.model.vector_size
+        if hasattr(self.model, "vector_size"):
+            return self.model.vector_size
+        first_key = next(iter(self.model.index_to_key), None)
+        if first_key is not None:
+            return len(self.model[first_key])
+        msg = "Unable to determine embedding dimension for gensim model"
+        raise ValueError(msg)

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -19,4 +19,9 @@ class GensimEncoder(BaseEncoder):
     def embed(self, text):
         words = text.lower().split()
         vectors = [self.model[w] for w in words if w in self.model]
+        if not vectors:
+            return np.zeros(self.dim())
         return np.mean(vectors, axis=0)
+
+    def dim(self):
+        return self.model.vector_size

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -9,7 +9,9 @@ class GensimEncoder(BaseEncoder):
     Lightweight local embedding encoder backed by gensim pretrained vectors.
     """
 
-    def __init__(self, model_name="glove/glove-wiki-gigaword-50"):
+    def __init__(self, model_name):
+        if not model_name:
+            model_name = "glove/glove-wiki-gigaword-50"
         self.model_name = model_name
         self.model = api.load(self.model_short_name())
 

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -13,6 +13,8 @@ class GensimEncoder(BaseEncoder):
         self.model_name = model_name
         self.model = api.load(self.model_short_name())
 
+    def dim(self):
+        return self.model.vector_size
     def embed_documents(self, documents):
         return [self.embed(doc) for doc in documents]
 

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -6,7 +6,7 @@ from vector_search.encoders.base import BaseEncoder
 
 class GensimEncoder(BaseEncoder):
     """
-    Dummy Encoder
+    Lightweight local embedding encoder backed by gensim pretrained vectors.
     """
 
     def __init__(self, model_name="glove/glove-wiki-gigaword-50"):

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -15,9 +15,6 @@ class GensimEncoder(BaseEncoder):
         self.model_name = model_name
         self.model = api.load(self.model_short_name())
 
-    def dim(self):
-        return self.model.vector_size
-
     def embed_documents(self, documents):
         return [self.embed(doc) for doc in documents]
 

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -1,0 +1,22 @@
+import gensim.downloader as api
+import numpy as np
+
+from vector_search.encoders.base import BaseEncoder
+
+
+class GensimEncoder(BaseEncoder):
+    """
+    Dummy Encoder
+    """
+
+    def __init__(self, model_name="glove/glove-wiki-gigaword-50"):
+        self.model_name = model_name
+        self.model = api.load(self.model_short_name())
+
+    def embed_documents(self, documents):
+        return [self.embed(doc) for doc in documents]
+
+    def embed(self, text):
+        words = text.lower().split()
+        vectors = [self.model[w] for w in words if w in self.model]
+        return np.mean(vectors, axis=0)

--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -15,6 +15,7 @@ class GensimEncoder(BaseEncoder):
 
     def dim(self):
         return self.model.vector_size
+
     def embed_documents(self, documents):
         return [self.embed(doc) for doc in documents]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10871
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Fastembed was initially chosen as a sane default for embeddings in local environments since it is portable - however it still mostly deals with dynamic/transformer based models and can be very resource intensive.

This PR switches us to using a very lightweight static model [GloVe](https://nlp.stanford.edu/projects/glove/) - which is good enough for local testing and is not resource intensive.

### How can this be tested?
1. checkout this branch or start from fresh  mit-learn clone
2. re-build your celery and web contains via `docker compose build celery web`
3. make sure you have no local overrides for settings.QDRANT_DENSE_MODEL or settings.QDRANT_ENCODER - double check the settings via django shell. QDRANT_ENCODER should be "vector_search.encoders.gensim.GensimEncoder" and QDRANT_DENSE_MODEL should be None
4. make sure you have some learning resources populated locally or run one of the etl pipelines (```python manage.py backpopulate_mitxonline_data```
5. run the following django management commands to recreate qdrant collections and generate embeddings:
```python
./manage.py generate_embeddings --courses --recreate-collections --skip-contentfiles
```
6. You should see embedding related output in celery logs and you local [resources qdrant collection](http://localhost:6333/dashboard#/collections/resource_embeddings.resources) should have data in it.
7. as this process runs you should not see system/docker usage spike significantly (anywhere near running embeddings with fastembed)

### Additional Context
If we wanted absolutely 0 overhead locally we had the option of going with a "dummy encoder" which generates a random vector of some predefined dimension - however using glove via gensim gives us something that looks reasonable to test with vs completely random results.
