### PR TITLE
stay updated dialog style follow-up

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.tsx
+++ b/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.tsx
@@ -36,6 +36,7 @@ const StayUpdatedDialogContainer = styled.div(({ theme }) => ({
 
 const DialogSuccessCheck = styled(Image)({
   alignSelf: "center",
+  marginBottom: "24px",
 })
 
 const mapValuesToFields = (


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-learn/pull/3170

### Description (What does it do?)
Adds some padding between the check mark and message on the success page of the stay updated dialog

### Screenshots (if appropriate):
<img width="799" height="499" alt="image" src="https://github.com/user-attachments/assets/e5496972-56ac-4d49-87dc-ec62d42fa14b" />

### How can this be tested?
- Ensure that you have access to HubSpot configured and you have set the following variables in your env:
  - `MITOL_HUBSPOT_API_PRIVATE_TOKEN` in `backend.local.env` (get from RC if you need it)
  - `NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID` in `frontend.local.env` (use `fb022df4-2509-4109-8d44-7d2a68314161` if you're using RC credentials)
  - `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` in `shared.local.env` (example defaults in backend.local.example.env, or create your own at https://www.google.com/recaptcha/admin/create)
- Ensure that you have MITx Online set up and configured to connect with MIT Learn as described in the README and have the Posthog feature flag `mitxonline-product-pages` enabled
- Make sure you have a program / courses set up in MITx Online with `include_in_learn_catalog` enabled and that you have run `backpopulate_mitxonline_courses` at least once
- Visit the program page at `/programs/program-readable-id`
- Ensure that the Stay Updated button is displaying properly in the banner
- Click the button and you should be presented with the dialog
- Fill out the details and click "Inform Me"
- Verify that you see the success message and can click "Done" to dismiss the dialog
- If you have access, log into the HubSpot dashboard and view your submission to ensure it came in correctly
