### PR TITLE
feat: enable course access to staff user before the start date

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -75,7 +75,10 @@ const futureDashboardCourse: typeof mitxOnlineCourse = (...overrides) => {
 const mitxUser = mitxonline.factories.user.user
 
 const setupUserApis = (overrides?: Parameters<typeof mitxUser>[0]) => {
-  const userData = mitxonline.factories.user.user({ is_staff: false, ...overrides })
+  const userData = mitxonline.factories.user.user({
+    is_staff: false,
+    ...overrides,
+  })
   setMockResponse.get(mitxonline.urls.userMe.get(), userData)
   return userData
 }
@@ -247,8 +250,9 @@ describe.each([
     },
   )
 
-  test("Courseware CTA is enabled for staff even when course has not started", async () => {
+  test("Courseware CTA is a navigable link for staff even when course has not started", async () => {
     setupUserApis({ is_staff: true })
+    const coursewareUrl = faker.internet.url()
     const course = futureDashboardCourse()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       enrollment_mode: EnrollmentMode.Audit,
@@ -256,6 +260,7 @@ describe.each([
       run: {
         ...course.courseruns[0],
         course: course,
+        courseware_url: coursewareUrl,
       },
     })
     renderWithProviders(
@@ -267,8 +272,11 @@ describe.each([
       />,
     )
     const card = getCard()
-    const coursewareCTA = await within(card).findByTestId("courseware-button")
+    const coursewareCTA = await within(card).findByRole("link", {
+      name: "Continue",
+    })
     expect(coursewareCTA).toBeEnabled()
+    expect(coursewareCTA).toHaveAttribute("href", coursewareUrl)
   })
 
   test("Courseware CTA is disabled when no enrollable runs exist", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -257,6 +257,7 @@ describe.each([
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       enrollment_mode: EnrollmentMode.Audit,
       grades: [],
+      certificate: null,
       run: {
         ...course.courseruns[0],
         course: course,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -74,9 +74,10 @@ const futureDashboardCourse: typeof mitxOnlineCourse = (...overrides) => {
 
 const mitxUser = mitxonline.factories.user.user
 
-const setupUserApis = () => {
-  const mitxUser = mitxonline.factories.user.user()
-  setMockResponse.get(mitxonline.urls.userMe.get(), mitxUser)
+const setupUserApis = (overrides?: Parameters<typeof mitxUser>[0]) => {
+  const userData = mitxonline.factories.user.user({ is_staff: false, ...overrides })
+  setMockResponse.get(mitxonline.urls.userMe.get(), userData)
+  return userData
 }
 
 describe.each([
@@ -245,6 +246,30 @@ describe.each([
       }
     },
   )
+
+  test("Courseware CTA is enabled for staff even when course has not started", async () => {
+    setupUserApis({ is_staff: true })
+    const course = futureDashboardCourse()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      grades: [],
+      run: {
+        ...course.courseruns[0],
+        course: course,
+      },
+    })
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.CourseRunEnrollment,
+          data: enrollment,
+        }}
+      />,
+    )
+    const card = getCard()
+    const coursewareCTA = await within(card).findByTestId("courseware-button")
+    expect(coursewareCTA).toBeEnabled()
+  })
 
   test("Courseware CTA is disabled when no enrollable runs exist", () => {
     setupUserApis()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -389,6 +389,7 @@ const useEnrollmentHandler = () => {
       createEnrollment.isPending ||
       createVerifiedProgramEnrollment.isPending ||
       replaceBasketItem.isPending,
+    mitxOnlineUser: mitxOnlineUser.data,
   }
 }
 
@@ -484,6 +485,7 @@ const CoursewareButton = styled(
     const isDisabled = Boolean(
       disabled ||
         (!hasEnrolled && !onClick) || // Not enrolled and no click handler
+        (hasEnrolled && !href && !onClick) || // Enrolled but no action available
         (hasEnrolled && !!startDate && !hasStarted && !isStaff), // Enrolled but course hasn't started yet
     )
 
@@ -672,7 +674,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   onUpgradeError,
 }) => {
   const enrollment = useEnrollmentHandler()
-  const { data: mitxOnlineUser } = useQuery(mitxUserQueries.me())
+  const mitxOnlineUser = enrollment.mitxOnlineUser
   const useProductPages = useFeatureFlagEnabled(
     FeatureFlags.MitxOnlineProductPages,
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -402,6 +402,7 @@ type CoursewareButtonProps = {
   noun: string
   isProgram?: boolean
   isPending?: boolean
+  isStaff?: boolean
   "data-testid"?: string
   onClick?: React.MouseEventHandler<HTMLButtonElement>
 }
@@ -445,6 +446,7 @@ const CoursewareButton = styled(
     isProgram,
     onClick,
     isPending,
+    isStaff,
     ...others
   }: CoursewareButtonProps) => {
     const coursewareText = getCoursewareTextAndIcon({
@@ -457,7 +459,12 @@ const CoursewareButton = styled(
     const hasEnrolled = enrollmentStatus !== EnrollmentStatus.NotEnrolled
 
     // Programs or enrolled courses with started runs: show link
-    if ((isProgram || hasEnrolled) && (hasStarted || !startDate) && href) {
+    // Staff can access courseware even before the course has started
+    if (
+      (isProgram || hasEnrolled) &&
+      (hasStarted || !startDate || isStaff) &&
+      href
+    ) {
       return (
         <ButtonLink
           size="small"
@@ -473,10 +480,11 @@ const CoursewareButton = styled(
     }
 
     // Determine if button should be disabled
+    // Staff can access courseware even before the course has started
     const isDisabled = Boolean(
       disabled ||
         (!hasEnrolled && !onClick) || // Not enrolled and no click handler
-        (hasEnrolled && !!startDate && !hasStarted), // Enrolled but course hasn't started yet
+        (hasEnrolled && !!startDate && !hasStarted && !isStaff), // Enrolled but course hasn't started yet
     )
 
     return (
@@ -664,6 +672,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   onUpgradeError,
 }) => {
   const enrollment = useEnrollmentHandler()
+  const { data: mitxOnlineUser } = useQuery(mitxUserQueries.me())
   const useProductPages = useFeatureFlagEnabled(
     FeatureFlags.MitxOnlineProductPages,
   )
@@ -835,6 +844,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         isProgram={false}
         disabled={disableEnrollment}
         isPending={enrollment.isPending}
+        isStaff={mitxOnlineUser?.is_staff}
         onClick={coursewareButtonClick}
       />
     </>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -376,6 +376,7 @@ type CoursewareButtonProps = {
   href?: string | null
   disabled?: boolean
   className?: string
+  isStaff?: boolean
   "data-testid"?: string
   onClick?: React.MouseEventHandler<HTMLButtonElement>
 }
@@ -413,6 +414,7 @@ const CoursewareButton = styled(
     disabled,
     className,
     onClick,
+    isStaff,
     ...others
   }: CoursewareButtonProps) => {
     const coursewareText = getCoursewareButtonStyle({
@@ -422,7 +424,8 @@ const CoursewareButton = styled(
     const hasStarted = startDate && isInPast(startDate)
     const hasEnrolled = enrollmentStatus !== EnrollmentStatus.NotEnrolled
 
-    if (hasEnrolled && (hasStarted || !startDate) && href) {
+    // Staff can access courseware even before the course has started
+    if (hasEnrolled && (hasStarted || !startDate || isStaff) && href) {
       return (
         <StyledCoursewareButtonLink
           size="small"
@@ -437,10 +440,11 @@ const CoursewareButton = styled(
     }
 
     // Determine if button should be disabled
+    // Staff can access courseware even before the course has started
     const isDisabled = Boolean(
       disabled ||
         (!hasEnrolled && !onClick) || // Not enrolled and no click handler
-        (hasEnrolled && !!startDate && !hasStarted), // Enrolled but course hasn't started yet
+        (hasEnrolled && !!startDate && !hasStarted && !isStaff), // Enrolled but course hasn't started yet
     )
 
     return (
@@ -699,6 +703,7 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
   onUpgradeError,
 }) => {
   const enrollment = useEnrollmentHandler()
+  const { data: mitxOnlineUser } = useQuery(mitxUserQueries.me())
 
   const title = getTitle(resource)
   const enrollmentStatus = getDashboardEnrollmentStatus(resource)
@@ -838,6 +843,7 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
             href={buttonHref ?? coursewareUrl}
             endDate={courseRun?.end_date ?? enrollmentRun?.end_date}
             disabled={disableEnrollment}
+            isStaff={mitxOnlineUser?.is_staff}
             onClick={coursewareButtonClick}
           />
         </CoursewareActionColumn>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -366,6 +366,7 @@ const useEnrollmentHandler = () => {
       createEnrollment.isPending ||
       createVerifiedProgramEnrollment.isPending ||
       replaceBasketItem.isPending,
+    mitxOnlineUser: mitxOnlineUser.data,
   }
 }
 
@@ -444,6 +445,7 @@ const CoursewareButton = styled(
     const isDisabled = Boolean(
       disabled ||
         (!hasEnrolled && !onClick) || // Not enrolled and no click handler
+        (hasEnrolled && !href && !onClick) || // Enrolled but no action available
         (hasEnrolled && !!startDate && !hasStarted && !isStaff), // Enrolled but course hasn't started yet
     )
 
@@ -703,7 +705,7 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
   onUpgradeError,
 }) => {
   const enrollment = useEnrollmentHandler()
-  const { data: mitxOnlineUser } = useQuery(mitxUserQueries.me())
+  const mitxOnlineUser = enrollment.mitxOnlineUser
 
   const title = getTitle(resource)
   const enrollmentStatus = getDashboardEnrollmentStatus(resource)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10519

### Description (What does it do?)
This PR allows staff users to click into a course from the Learn enrollment dashboard before the course has started. Previously, the courseware button was disabled for all users when the course start date was in the future. With this change, users with is_staff: true on their MITx Online account bypass that restriction and see an enabled, navigable link to the courseware.

### Screenshots (if appropriate):

Staff
<img width="1512" height="876" alt="Screenshot 2026-04-10 at 2 45 11 PM" src="https://github.com/user-attachments/assets/e0f59e93-9e28-4af0-aa99-f856a739420f" />

Non staff
<img width="1512" height="876" alt="Screenshot 2026-04-10 at 3 41 14 PM" src="https://github.com/user-attachments/assets/9219eace-adaf-4118-b315-123ad892595f" />



### How can this be tested?

Manual testing (requires local MITx Online + MIT Learn setup):

- Log in as a user who has is_staff: true on their MITx Online account.
- Enroll that user in a course whose start date is in the future (e.g., 2030).
- Navigate to the Learn enrollment dashboard (/dashboard).
- Confirm the courseware button ("Continue") on the future course card is enabled and clicking it navigates to the courseware URL.
- Log out and log in as a non-staff user enrolled in the same future course.
- Confirm the courseware button is disabled for the non-staff user, as before.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
