### PR TITLE
Search response time indicator for admin users

### DIFF
--- a/frontends/api/src/hooks/learningResources/queries.ts
+++ b/frontends/api/src/hooks/learningResources/queries.ts
@@ -187,6 +187,7 @@ const learningResourceQueries = {
             .learningResourcesSearchRetrieve(params)
             .then((res) => res.data),
         ),
+      select: (data) => data.result,
     }),
   vectorSearch: (params: VectorLearningResourcesSearchRetrieveRequest) =>
     queryOptions({
@@ -197,6 +198,7 @@ const learningResourceQueries = {
             .vectorLearningResourcesSearchRetrieve(params)
             .then((res) => res.data),
         ),
+      select: (data) => data.result,
     }),
 }
 

--- a/frontends/api/src/hooks/learningResources/queries.ts
+++ b/frontends/api/src/hooks/learningResources/queries.ts
@@ -23,6 +23,15 @@ import type { VectorLearningResourcesSearchApiVectorLearningResourcesSearchRetri
 import { queryOptions } from "@tanstack/react-query"
 import { hasPosition, randomizeGroups } from "./util"
 
+const timedPromise = async <T>(
+  promise: Promise<T>,
+): Promise<{ result: T; time: number }> => {
+  const start = performance.now()
+  const result = await promise
+  const end = performance.now()
+  return { result, time: end - start }
+}
+
 const learningResourceKeys = {
   root: ["learning_resources"],
   // list
@@ -173,17 +182,21 @@ const learningResourceQueries = {
     queryOptions({
       queryKey: learningResourceKeys.search(params),
       queryFn: () =>
-        learningResourcesSearchApi
-          .learningResourcesSearchRetrieve(params)
-          .then((res) => res.data),
+        timedPromise(
+          learningResourcesSearchApi
+            .learningResourcesSearchRetrieve(params)
+            .then((res) => res.data),
+        ),
     }),
   vectorSearch: (params: VectorLearningResourcesSearchRetrieveRequest) =>
     queryOptions({
       queryKey: learningResourceKeys.vectorSearch(params),
       queryFn: () =>
-        vectorLearningResourcesSearchApi
-          .vectorLearningResourcesSearchRetrieve(params)
-          .then((res) => res.data),
+        timedPromise(
+          vectorLearningResourcesSearchApi
+            .vectorLearningResourcesSearchRetrieve(params)
+            .then((res) => res.data),
+        ),
     }),
 }
 

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -410,6 +410,42 @@ describe("SearchPage", () => {
       screen.getByTestId("max_incompleteness_penalty-slider")
     })
   })
+
+  test("Search time indicator is visible to admins and hidden from non-admins", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {},
+          suggestions: [],
+        },
+      },
+    })
+
+    // Authenticate as path editor (admin)
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: true,
+      is_authenticated: true,
+    })
+
+    const { unmount } = renderWithProviders(<SearchPage />)
+
+    await screen.findByText(/Search took/i)
+
+    unmount()
+
+    // Authenticate as non-admin
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: false,
+      is_authenticated: true,
+    })
+
+    renderWithProviders(<SearchPage />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Search took/i)).toBeNull()
+    })
+  })
 })
 
 test("admin users can set the search mode and slop", async () => {

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -428,7 +428,9 @@ describe("SearchPage", () => {
       is_authenticated: true,
     })
 
-    const { unmount } = renderWithProviders(<SearchPage />)
+    const {
+      view: { unmount },
+    } = renderWithProviders(<SearchPage />)
 
     await screen.findByText(/Search took/i)
 

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
@@ -1,18 +1,19 @@
 "use client"
-
 import { keyBy } from "lodash"
-import React, { useCallback, useMemo, useEffect } from "react"
+
+import React, { useCallback, useMemo, useEffect, useState } from "react"
 import type { FacetManifest } from "@mitodl/course-search-utils"
 import { useSearchParams } from "@mitodl/course-search-utils/next"
 import { useResourceSearchParams } from "@mitodl/course-search-utils"
 import SearchDisplay from "@/page-components/SearchDisplay/SearchDisplay"
-import { styled, Container, theme } from "ol-components"
+import { styled, Container, theme, Typography } from "ol-components"
 import { VisuallyHidden } from "@mitodl/smoot-design"
 import { SearchField } from "@/page-components/SearchField/SearchField"
 import { useOfferorsList } from "api/hooks/learningResources"
 import { facetNames } from "./searchRequests"
 import getFacetManifest from "@/page-components/SearchDisplay/getFacetManifest"
 import dynamic from "next/dynamic"
+import { useUserMe } from "api/hooks/user"
 
 const LearningResourceDrawer = dynamic(
   () =>
@@ -53,7 +54,8 @@ const SearchFieldContainer = styled(Container)({
   justifyContent: "center",
 })
 
-const StyledSearchField = styled(SearchField)(({ theme }) => ({
+const SearchFieldWrapper = styled.div(({ theme }) => ({
+  position: "relative",
   [theme.breakpoints.down("sm")]: {
     width: "100%",
   },
@@ -61,6 +63,10 @@ const StyledSearchField = styled(SearchField)(({ theme }) => ({
     width: "570px",
   },
 }))
+
+const StyledSearchField = styled(SearchField)({
+  width: "100%",
+})
 
 const constantSearchParams = {}
 
@@ -81,6 +87,15 @@ const SearchPage: React.FC = () => {
   const facetManifest = useFacetManifest(
     searchParams.get("resource_type_group"),
   )
+  const [fetchTime, setFetchTime] = useState<number | null>(null)
+  const { data: user } = useUserMe()
+
+  const formatFetchTime = (ms: number) => {
+    if (ms > 1000) {
+      return `${(ms / 1000).toFixed(2)}s`
+    }
+    return `${Math.round(ms)}ms`
+  }
 
   const setPage = useCallback(
     (newPage: number) => {
@@ -131,21 +146,40 @@ const SearchPage: React.FC = () => {
       </VisuallyHidden>
       <Header>
         <SearchFieldContainer>
-          <StyledSearchField
-            value={currentText}
-            size="large"
-            onChange={(e) => setCurrentText(e.target.value)}
-            onSubmit={(e) => {
-              setCurrentTextAndQuery(e.target.value)
-            }}
-            onClear={() => {
-              setCurrentTextAndQuery("")
-            }}
-            setPage={setPage}
-          />
+          <SearchFieldWrapper>
+            <StyledSearchField
+              value={currentText}
+              size="large"
+              onChange={(e) => setCurrentText(e.target.value)}
+              onSubmit={(e) => {
+                setCurrentTextAndQuery(e.target.value)
+              }}
+              onClear={() => {
+                setCurrentTextAndQuery("")
+              }}
+              setPage={setPage}
+            />
+            {user?.is_learning_path_editor && fetchTime !== null && (
+              <Typography
+                variant="body3"
+                color="text.secondary"
+                sx={{
+                  position: "absolute",
+                  left: "100%",
+                  top: "50%",
+                  transform: "translateY(-50%)",
+                  paddingLeft: "16px",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                Search took {formatFetchTime(fetchTime)}
+              </Typography>
+            )}
+          </SearchFieldWrapper>
         </SearchFieldContainer>
       </Header>
       <SearchDisplay
+        onFetchTimeChange={setFetchTime}
         filterHeadingEl="h2"
         resultsHeadingEl="h2"
         page={page}

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -585,9 +585,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 }) => {
   const [searchParams] = useSearchParams()
   const [expandAdminOptions, setExpandAdminOptions] = useState(false)
-  const fetchStartRef = useRef<number | null>(
-    typeof performance !== "undefined" ? performance.now() : null,
-  )
 
   const { data: adminParams, isLoading: isAdminParamsLoading } =
     useAdminSearchParams(expandAdminOptions)
@@ -634,18 +631,21 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       : learningResourceQueries.search(allParams as LRSearchRequest)),
     enabled: !wantsVectorSearch || !isUserLoading,
     placeholderData: keepPreviousData,
-    select: (
-      data:
+    select: (timedData: {
+      result:
         | LearningResourcesSearchResponse
-        | LearningResourcesVectorSearchResponse,
-    ) => {
+        | LearningResourcesVectorSearchResponse
+      time: number
+    }) => {
+      const { result: data, time } = timedData
+
       // Handle missing data gracefully
       if (
         !data?.metadata?.aggregations?.offered_by ||
         !data?.results ||
         data.results.length === 0
       ) {
-        return data
+        return { ...data, time }
       }
 
       // only show offerors with display_facet set
@@ -655,6 +655,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
       return {
         ...data,
+        time,
         metadata: {
           ...data.metadata,
           aggregations: {
@@ -668,21 +669,11 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     },
   })
 
-  const prevParamsRef = useRef(allParams)
-
   useEffect(() => {
-    if (allParams !== prevParamsRef.current) {
-      fetchStartRef.current = performance.now()
-      if (onFetchTimeChange) onFetchTimeChange(null)
-      prevParamsRef.current = allParams
+    if (onFetchTimeChange) {
+      onFetchTimeChange(data?.time ?? null)
     }
-
-    if (!isFetching && fetchStartRef.current !== null) {
-      const time = performance.now() - fetchStartRef.current
-      if (onFetchTimeChange) onFetchTimeChange(time)
-      fetchStartRef.current = null
-    }
-  }, [allParams, isFetching, onFetchTimeChange])
+  }, [data?.time, onFetchTimeChange])
 
   const [mobileDrawerOpen, setMobileDrawerOpen] = React.useState(false)
 

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import {
   styled,
   Pagination,
@@ -551,6 +551,7 @@ const toVectorSearchParams = (
 interface SearchDisplayProps {
   page: number
   setPage: (newPage: number) => void
+  onFetchTimeChange?: (time: number | null) => void
   facetManifest: FacetManifest
   facetNames: UseResourceSearchParamsProps["facets"]
   constantSearchParams: Facets & BooleanFacets
@@ -580,9 +581,11 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   setSearchParams: actuallySetSearchParams,
   resultsHeadingEl,
   filterHeadingEl,
+  onFetchTimeChange,
 }) => {
   const [searchParams] = useSearchParams()
   const [expandAdminOptions, setExpandAdminOptions] = useState(false)
+  const fetchStartRef = useRef<number | null>(null)
 
   const { data: adminParams, isLoading: isAdminParamsLoading } =
     useAdminSearchParams(expandAdminOptions)
@@ -662,6 +665,17 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
       }
     },
   })
+
+  useEffect(() => {
+    if (isFetching) {
+      fetchStartRef.current = performance.now()
+      if (onFetchTimeChange) onFetchTimeChange(null)
+    } else if (fetchStartRef.current !== null) {
+      const time = performance.now() - fetchStartRef.current
+      if (onFetchTimeChange) onFetchTimeChange(time)
+      fetchStartRef.current = null
+    }
+  }, [isFetching, onFetchTimeChange])
 
   const [mobileDrawerOpen, setMobileDrawerOpen] = React.useState(false)
 

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -585,7 +585,9 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 }) => {
   const [searchParams] = useSearchParams()
   const [expandAdminOptions, setExpandAdminOptions] = useState(false)
-  const fetchStartRef = useRef<number | null>(null)
+  const fetchStartRef = useRef<number | null>(
+    typeof performance !== "undefined" ? performance.now() : null,
+  )
 
   const { data: adminParams, isLoading: isAdminParamsLoading } =
     useAdminSearchParams(expandAdminOptions)
@@ -666,16 +668,21 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     },
   })
 
+  const prevParamsRef = useRef(allParams)
+
   useEffect(() => {
-    if (isFetching) {
+    if (allParams !== prevParamsRef.current) {
       fetchStartRef.current = performance.now()
       if (onFetchTimeChange) onFetchTimeChange(null)
-    } else if (fetchStartRef.current !== null) {
+      prevParamsRef.current = allParams
+    }
+
+    if (!isFetching && fetchStartRef.current !== null) {
       const time = performance.now() - fetchStartRef.current
       if (onFetchTimeChange) onFetchTimeChange(time)
       fetchStartRef.current = null
     }
-  }, [isFetching, onFetchTimeChange])
+  }, [allParams, isFetching, onFetchTimeChange])
 
   const [mobileDrawerOpen, setMobileDrawerOpen] = React.useState(false)
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10895
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR adds a small "response time" indicator next to the search input when logged in as an admin user so we can see performance between searches, endpoints environments etc at a glance.

### Screenshots (if appropriate):
<img width="751" height="223" alt="Screenshot 2026-04-10 at 2 55 24 PM" src="https://github.com/user-attachments/assets/c75a2b21-4888-43f9-80ff-01567c6f6cdc" />


### How can this be tested?
1. checkout this branch
2. make sure you have data locally (also embeddings if possible) and log in as an admin/superuser
3. go to the search page and try searching for different things and changing filters. you should see the response times for the search (to the right of the search input)

