### PR TITLE
allow no model for gensim_encoder

### DIFF
--- a/vector_search/encoders/gensim.py
+++ b/vector_search/encoders/gensim.py
@@ -9,7 +9,7 @@ class GensimEncoder(BaseEncoder):
     Lightweight local embedding encoder backed by gensim pretrained vectors.
     """
 
-    def __init__(self, model_name):
+    def __init__(self, model_name=None):
         if not model_name:
             model_name = "glove/glove-wiki-gigaword-50"
         self.model_name = model_name


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes `./manage.py generate_embeddings --courses --recreate-collections --skip-contentfiles` so it runs when default settings are used.

### How can this be tested?
1. Run above command with default settings. Ensure `QDRANT_ENCODER` and `QDRANT_DENSE_MODEL` are not set in your env files.

