### PR TITLE
Deindex unpublished test_mode resources, not contentfiles

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -80,11 +80,7 @@ def update_index(learning_resource, newly_created):
         learning resource (LearningResource): a learning resource
         newly_created (bool): whether the learning resource has just been created
     """
-    if (
-        not newly_created
-        and not learning_resource.published
-        and not learning_resource.test_mode
-    ):
+    if not newly_created and not learning_resource.published:
         resource_unpublished_actions(learning_resource)
     elif learning_resource.published:
         resource_upserted_actions(

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -185,17 +185,17 @@ def test_update_index_test_mode_behavior(
     test_mode,
     newly_created,
 ):
-    """Test update_index does not remove test_mode content files from index"""
+    """Test update_index unpublishes existing unpublished resources"""
     resource_unpublished_actions = mocker.patch(
         "learning_resources.etl.loaders.resource_unpublished_actions"
     )
     lr = LearningResourceFactory.create(published=published, test_mode=test_mode)
 
     loaders.update_index(lr, newly_created)
-    if test_mode:
-        resource_unpublished_actions.assert_not_called()
-    elif not published and not newly_created:
+    if not published and not newly_created:
         resource_unpublished_actions.assert_called_once()
+    else:
+        resource_unpublished_actions.assert_not_called()
 
 
 @pytest.fixture

--- a/learning_resources_search/plugins.py
+++ b/learning_resources_search/plugins.py
@@ -104,7 +104,7 @@ class SearchIndexPlugin:
             )
         try_with_retry_as_task(chain(*unpublished_tasks))
 
-        if resource.resource_type == COURSE_TYPE:
+        if resource.resource_type == COURSE_TYPE and not resource.test_mode:
             for run in resource.runs.all():
                 self.resource_run_unpublished(run)
 

--- a/learning_resources_search/plugins.py
+++ b/learning_resources_search/plugins.py
@@ -159,6 +159,8 @@ class SearchIndexPlugin:
         """
         Remove a resource from the search index and then delete the object
         """
+        # Ensure test mode is false so the resource is removed from the search index
+        resource.test_mode = False
         self.resource_unpublished(resource)
 
     @hookimpl

--- a/learning_resources_search/plugins_test.py
+++ b/learning_resources_search/plugins_test.py
@@ -89,11 +89,14 @@ def test_search_index_plugin_resource_upserted(
 @pytest.mark.django_db
 @pytest.mark.parametrize("resource_type", [COURSE_TYPE, PROGRAM_TYPE])
 @pytest.mark.parametrize("has_content_files", [True, False])
+@pytest.mark.parametrize("test_mode", [True, False])
 def test_search_index_plugin_resource_unpublished(
-    mocker, mock_search_index_helpers, resource_type, has_content_files
+    mocker, mock_search_index_helpers, resource_type, has_content_files, test_mode
 ):
     """The plugin function should remove a resource from the search index"""
-    resource = LearningResourceFactory.create(resource_type=resource_type)
+    resource = LearningResourceFactory.create(
+        resource_type=resource_type, test_mode=test_mode
+    )
     if resource_type == COURSE_TYPE and has_content_files:
         for run in resource.runs.all():
             ContentFileFactory.create(run=run)
@@ -104,7 +107,7 @@ def test_search_index_plugin_resource_unpublished(
     mock_search_index_helpers.mock_remove_learning_resource_immutable_signature.assert_called_once_with(
         resource.id, resource.resource_type
     )
-    if resource_type == COURSE_TYPE and has_content_files:
+    if resource_type == COURSE_TYPE and has_content_files and not test_mode:
         assert unpublish_run_mock.call_count == resource.runs.count()
         for run in resource.runs.all():
             unpublish_run_mock.assert_any_call(run.id, unpublished_only=False)

--- a/learning_resources_search/plugins_test.py
+++ b/learning_resources_search/plugins_test.py
@@ -117,17 +117,39 @@ def test_search_index_plugin_resource_unpublished(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("resource_type", [COURSE_TYPE, PROGRAM_TYPE])
+@pytest.mark.parametrize("test_mode", [True, False])
 def test_search_index_plugin_resource_before_delete(
-    mock_search_index_helpers, resource_type
+    mock_search_index_helpers, resource_type, test_mode
 ):
     """The plugin function should remove a resource from the search index then delete the resource"""
-    resource = LearningResourceFactory.create(resource_type=resource_type)
+    resource = LearningResourceFactory.create(
+        resource_type=resource_type,
+        test_mode=test_mode,
+    )
+    if resource_type == COURSE_TYPE:
+        for run in resource.runs.all():
+            ContentFileFactory.create(run=run)
+
     resource_id = resource.id
     SearchIndexPlugin().resource_before_delete(resource)
 
     mock_search_index_helpers.mock_remove_learning_resource_immutable_signature.assert_called_once_with(
         resource_id, resource.resource_type
     )
+    assert resource.test_mode is False
+
+    if resource_type == COURSE_TYPE:
+        assert (
+            mock_search_index_helpers.mock_remove_contentfiles_immutable_signature.call_count
+            == resource.runs.count()
+        )
+        for run in resource.runs.all():
+            mock_search_index_helpers.mock_remove_contentfiles_immutable_signature.assert_any_call(
+                run.id,
+                unpublished_only=False,
+            )
+    else:
+        mock_search_index_helpers.mock_remove_contentfiles_immutable_signature.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/10847 and https://github.com/mitodl/mit-learn/pull/3174

### Description (What does it do?)
<!--- Describe your changes in detail -->
If a `test_mode=True` learning resource is unpublished, the resource itself should be deindexed from open/vector search, but its contentfiles should not.



### How can this be tested?
#### on the main branch
- Find a test_mode mitxonline course with contentfiles and set it to published=True:
  ```python
  from learning_resources.models import *
  from learning_resources.etl.loaders import update_index
   lr = LearningResource.objects.filter(
      etl_source="mitxonline", 
      published=False, 
      test_mode=True, 
      runs__content_files__isnull=False
  ).first()
  print(lr.id, lr.title)
  lr.published=True
  lr.save()
  update_index(lr, False)
  ```
- Wait a bit for indexing to occur, the do a search by title for that resource, it should show up.
- Verify that it has publised contentfiles:
  ```python
  ContentFile.objects.filter(run__learning_resource=lr, published=True).count()
  ```
- Unpublish the resource:
  ```python
  lr = LearningResource.objects.get(id=<resource_id>`
  lr.published=False
  lr.save()
  update_index(lr, False)
  ```
-  Wait a bit, then search by title again, it will still show up,
- It will still have published contentfiles:
  ```python
  ContentFile.objects.filter(run__learning_resource=lr, published=True).count()
  ```
  
####  This branch
- Switch to this branch and restart containers.
- Run this in a shell:
  ```python
  from learning_resources.models import *
  from learning_resources.etl.loaders import update_index
   lr = LearningResource.objects.get(id=<resource_id>)
   update_index(lr, False)    
-  Wait a bit, then search by title again, it should not show up,
- It should still have published contentfiles:
  ```python
  ContentFile.objects.filter(run__learning_resource=lr, published=True).count()
  ```  
