### PR TITLE
feat: add video detail page design implementation

### DIFF
--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/RelatedPlaylist.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/RelatedPlaylist.tsx
@@ -140,7 +140,7 @@ const RelatedPlaylist: React.FC<RelatedCollectionsProps> = ({
               ))
             : collections.map((collection) => (
                 <CollectionLink
-                  href={`/video-collection/${collection.id}`}
+                  href={`/video-playlist/${collection.id}`}
                   key={collection.id}
                 >
                   <CollectionType>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
@@ -17,7 +17,15 @@ const VideoCardItem = styled(Link)({
   cursor: "pointer",
   textDecoration: "none",
 
+  "&:hover .video-card-title, &:focus-visible .video-card-title": {
+    color: theme.custom.colors.red,
+  },
+
   "&:hover .play-overlay": {
+    opacity: 1,
+  },
+
+  "&:focus-visible .play-overlay": {
     opacity: 1,
   },
 
@@ -61,6 +69,18 @@ const DurationBadge = styled.span(({ theme }) => ({
   zIndex: 1,
 }))
 
+const PlayOverlay = styled.div({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#fff",
+  opacity: 0,
+  transition: "opacity 0.2s",
+  backgroundColor: "rgba(0, 0, 0, 0.18)",
+})
+
 const CardContent = styled.div({
   flex: 1,
   display: "flex",
@@ -86,6 +106,11 @@ const CardTitle = styled(Typography)(({ theme }) => ({
     marginTop: 0,
   },
 }))
+
+const PlayIcon = styled(RiPlayCircleFill)({
+  width: 48,
+  height: 48,
+})
 
 const CardMetaRow = styled.div({
   display: "flex",
@@ -135,26 +160,14 @@ const VideoCard: React.FC<VideoCardProps> = ({ resource, href }) => {
           onError={() => setImgError(true)}
         />
         {duration && <DurationBadge>{duration}</DurationBadge>}
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            color: "#fff",
-            opacity: 0,
-            transition: "opacity 0.2s",
-          }}
-          className="play-overlay"
-        >
-          <RiPlayCircleFill style={{ width: 40, height: 40 }} />
-        </div>
+        <PlayOverlay className="play-overlay">
+          <PlayIcon />
+        </PlayOverlay>
       </ThumbnailWrapper>
 
       <CardContent>
         <CardTitleRow>
-          <CardTitle>{resource.title}</CardTitle>
+          <CardTitle className="video-card-title">{resource.title}</CardTitle>
         </CardTitleRow>
         <CardMetaRow>
           <CardMetaGroup>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
@@ -1,0 +1,695 @@
+"use client"
+
+import React, { useEffect, useRef, useState } from "react"
+import Link from "next/link"
+import dynamic from "next/dynamic"
+import Image from "next/image"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { Typography, styled, theme, Skeleton, Breadcrumbs } from "ol-components"
+import VideoContainer from "./VideoContainer"
+import { RiShareForwardFill } from "@remixicon/react"
+import { useQuery } from "@tanstack/react-query"
+import {
+  useLearningResourcesDetail,
+  learningResourceQueries,
+  videoPlaylistQueries,
+} from "api/hooks/learningResources"
+import type { VideoResource, VideoPlaylistResource } from "api/v1"
+import { VideoResourceResourceTypeEnum } from "api/v1"
+import { formatDurationClockTime } from "ol-utilities"
+import { resolveVideoSources } from "./videoSources"
+import type { VideoJsPlayerProps } from "./VideoJsPlayer"
+import { FeatureFlags } from "@/common/feature_flags"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import { notFound } from "next/navigation"
+import SharePopover from "@/components/SharePopover/SharePopover"
+
+const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
+
+// Lazy-load the video.js player only when the page mounts
+const VideoJsPlayer = dynamic<VideoJsPlayerProps>(
+  () => import("./VideoJsPlayer"),
+  { ssr: false },
+)
+
+const PageWrapper = styled.div({
+  backgroundColor: "#fff",
+  minHeight: "100vh",
+})
+
+const SkipLinksNav = styled.nav({
+  position: "absolute",
+  top: 0,
+  left: 0,
+  zIndex: 1000,
+})
+
+const SkipLink = styled.a(({ theme }) => ({
+  position: "absolute",
+  left: "-9999px",
+  top: "auto",
+  width: 1,
+  height: 1,
+  overflow: "hidden",
+  backgroundColor: theme.custom.colors.white,
+  color: theme.custom.colors.black,
+  padding: "8px 12px",
+  border: `2px solid ${theme.custom.colors.red}`,
+  textDecoration: "none",
+  "&:focus": {
+    left: "16px",
+    top: "16px",
+    width: "auto",
+    height: "auto",
+  },
+}))
+
+const BreadcrumbBar = styled.div(({ theme }) => ({
+  padding: "32px 0 16px 0",
+  borderBottom: `2px solid ${theme.custom.colors.red}`,
+  [theme.breakpoints.down("sm")]: {
+    padding: "16px 0 0 0",
+  },
+}))
+
+const StyledBreadcrumbs = styled(Breadcrumbs)(() => ({
+  "& > span > span": { paddingBottom: 0, paddingLeft: "4px" },
+}))
+
+const ContentArea = styled.div(({ theme }) => ({
+  padding: "56px 0 80px",
+  [theme.breakpoints.down("sm")]: {
+    padding: "32px 0 80px",
+  },
+}))
+
+const CategoryLabel = styled.span(({ theme }) => ({
+  display: "block",
+  ...theme.typography.body3,
+  fontWeight: theme.typography.fontWeightBold,
+  color: theme.custom.colors.red,
+  textTransform: "uppercase",
+  letterSpacing: "1.92px",
+  marginBottom: "8px",
+  fontSize: "12px",
+  fontStyle: "normal",
+  lineHeight: "150%" /* 18px */,
+}))
+
+const VideoTitle = styled.h1(({ theme }) => ({
+  ...theme.typography.h2,
+  fontWeight: theme.typography.fontWeightBold,
+  color: theme.custom.colors.black,
+  margin: "0 0 24px",
+  fontSize: "44px",
+  fontStyle: "normal",
+  lineHeight: "120%" /* 52.8px */,
+  letterSpacing: "-0.88px",
+  [theme.breakpoints.down("sm")]: {
+    ...theme.typography.h3,
+    margin: "0 0 14px",
+    letterSpacing: "inherit",
+  },
+}))
+
+const MetaRow = styled.div({
+  ...theme.typography.body2,
+  color: theme.custom.colors.darkGray1,
+  marginBottom: "24px",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "16px",
+  },
+})
+
+const PlayerWrapper = styled.div(({ theme }) => ({
+  width: "100%",
+  aspectRatio: "16/9",
+  backgroundColor: "#000",
+  overflow: "hidden",
+  position: "relative",
+  marginTop: "-10px",
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "0",
+  },
+  ".video-js, .vjs-tech": {
+    width: "100% !important",
+    height: "100% !important",
+    position: "absolute",
+    top: 0,
+    left: 0,
+  },
+  ".vjs-big-play-button": {
+    width: "64px !important",
+    height: "64px !important",
+    lineHeight: "64px !important",
+    borderRadius: "50% !important",
+  },
+}))
+
+const NoVideoMessage = styled.div({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "rgba(255,255,255,0.5)",
+  fontSize: 14,
+})
+
+const DescriptionText = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body1,
+  color: theme.custom.colors.darkGray2,
+  marginBottom: "22px",
+  fontSize: "18px",
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: "30px",
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "16px",
+    lineHeight: "28px",
+    marginBottom: "24px",
+  },
+}))
+
+const ShareRow = styled.div(({ theme }) => ({
+  display: "flex",
+  justifyContent: "flex-end",
+  width: "100%",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "32px",
+  },
+}))
+
+const ShareButton = styled.button(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  borderRadius: "4px",
+  padding: "14px 12px",
+  height: "32px",
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  background: `${theme.custom.colors.white}`,
+  cursor: "pointer",
+  ...theme.typography.body2,
+  color: theme.custom.colors.darkGray1,
+  fontWeight: theme.typography.fontWeightMedium,
+  "&:hover": {
+    color: theme.custom.colors.red,
+  },
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+    justifyContent: "center",
+  },
+}))
+
+const MoreFromTitle = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  fontWeight: theme.typography.fontWeightBold,
+  textTransform: "uppercase",
+  color: theme.custom.colors.black,
+  padding: "32px 0",
+  lineHeight: "150%",
+  letterSpacing: "1.92px",
+  [theme.breakpoints.down("sm")]: {
+    padding: "24px 0",
+  },
+}))
+
+const MoreFromList = styled.div({
+  display: "flex",
+  flexDirection: "column",
+})
+
+const BorderLine = styled.div(({ theme }) => ({
+  borderBottom: `4px solid ${theme.custom.colors.darkGray2}`,
+  marginBottom: "40px",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "24px",
+  },
+}))
+
+const MoreFromItem = styled(Link)({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "24px",
+  padding: "24px 0",
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+  textDecoration: "none",
+  "&:hover .mf-title": { color: theme.custom.colors.red },
+
+  "&:first-child": {
+    padding: "0 0 24px 0",
+  },
+
+  [theme.breakpoints.down("sm")]: {
+    flexDirection: "column",
+  },
+})
+
+const MoreFromThumbnailWrapper = styled.div(({ theme }) => ({
+  position: "relative",
+  flexShrink: 0,
+  width: 160,
+  aspectRatio: "16/9",
+  backgroundColor: theme.custom.colors.black,
+  overflow: "hidden",
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+  },
+}))
+
+const DurationBadge = styled.span(({ theme }) => ({
+  ...theme.typography.body3,
+  position: "absolute",
+  bottom: 0,
+  right: 0,
+  backgroundColor: theme.custom.colors.darkGray2,
+  color: "#fff",
+  fontWeight: theme.typography.fontWeightMedium,
+  padding: "4px 6px",
+  zIndex: 1,
+}))
+
+const MoreFromTextSide = styled.div(({ theme }) => ({
+  flex: 1,
+  minWidth: 0,
+  paddingTop: "17px",
+  [theme.breakpoints.down("sm")]: {
+    paddingTop: 0,
+  },
+}))
+
+const MoreFromItemTitle = styled(Typography)({
+  ...theme.typography.subtitle2,
+  fontWeight: theme.typography.fontWeightBold,
+  color: theme.custom.colors.black,
+  transition: "color 0.15s",
+  marginBottom: "4px",
+  fontSize: "20px",
+  lineHeight: "26px" /* 130% */,
+})
+
+const MoreFromItemMeta = styled(Typography)({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  overflow: "hidden",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  lineHeight: "22px",
+})
+
+const SeeAllLink = styled(Link)(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  marginTop: "40px",
+  ...theme.typography.body1,
+  color: theme.custom.colors.red,
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: "150%",
+  textDecoration: "none",
+  "&:hover": { textDecoration: "underline" },
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "28px",
+  },
+}))
+
+const ThumbnailWrapper = styled.div({
+  position: "relative",
+  width: "100%",
+  height: "100%",
+})
+
+const SpacerBlock = styled.div(({ theme }) => ({
+  "& .spacer-block": {
+    display: "none",
+  },
+  [theme.breakpoints.down("sm")]: {
+    height: "8px",
+    "& .spacer-block": {
+      display: "block",
+    },
+  },
+}))
+
+const TopicText = styled.span(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.body2,
+  lineHeight: "22px",
+  paddingLeft: "8px",
+}))
+
+const DurationText = styled.span(({ theme }) => ({
+  color: theme.custom.colors.black,
+  ...theme.typography.body2,
+  lineHeight: "22px",
+  fontWeight: theme.typography.fontWeightBold,
+}))
+
+const ScreenReaderOnly = styled.span({
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+})
+
+type VideoDetailPageProps = {
+  videoId: number
+  playlistId: number | null
+}
+
+const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
+  videoId,
+  playlistId,
+}) => {
+  const [shareOpen, setShareOpen] = useState(false)
+  const shareButtonRef = useRef<HTMLButtonElement>(null)
+  const titleRef = useRef<HTMLHeadingElement>(null)
+
+  const { data: resource, isLoading: videoLoading } =
+    useLearningResourcesDetail(videoId)
+
+  const { data: playlistData, isLoading: playlistLoading } = useQuery({
+    ...videoPlaylistQueries.detail(playlistId ?? 0),
+    enabled: !!playlistId,
+  })
+
+  const { data: playlistItems, isLoading: itemsLoading } = useQuery({
+    ...learningResourceQueries.items(playlistId ?? 0, {
+      learning_resource_id: playlistId ?? 0,
+    }),
+    enabled: !!playlistId,
+  })
+
+  const showVideoPlaylistPage = useFeatureFlagEnabled(
+    FeatureFlags.VideoPlaylistPage,
+  )
+  const flagsLoaded = useFeatureFlagsLoaded()
+
+  const playlist = playlistData as VideoPlaylistResource | undefined
+  const video = resource as VideoResource | undefined
+
+  const sources = video
+    ? resolveVideoSources(video.video?.streaming_url, video.url)
+    : []
+
+  const duration = video?.video?.duration
+    ? formatDurationClockTime(video.video.duration)
+    : null
+
+  const topics = video?.topics ?? []
+
+  const playlistLabel =
+    playlist?.resource_category?.trim() || playlist?.title || "Video Collection"
+
+  const otherVideos = (playlistItems ?? [])
+    .filter(
+      (item): item is VideoResource =>
+        item.resource_type === VideoResourceResourceTypeEnum.Video &&
+        item.id !== videoId,
+    )
+    .slice(0, 5)
+
+  const totalPlaylistVideos = (playlistItems ?? []).filter(
+    (item) => item.resource_type === VideoResourceResourceTypeEnum.Video,
+  ).length
+
+  const isLoading = videoLoading || (!!playlistId && playlistLoading)
+
+  const topicNames = topics
+    .map((t) => t.name)
+    .filter(Boolean)
+    .join(" · ")
+
+  const videoTitleLabel = video?.title?.trim() || "Untitled video"
+  const durationLabel = duration || "Unknown duration"
+  const topicNamesLabel = topicNames || "No topics listed"
+  const videoThumbnailAlt = `Video thumbnail for ${videoTitleLabel}. Duration: ${durationLabel}. Topics: ${topicNamesLabel}`
+  const loadingStatusMessage = isLoading
+    ? "Loading video details and player"
+    : "Video details loaded"
+
+  useEffect(() => {
+    if (!isLoading) {
+      titleRef.current?.focus()
+    }
+  }, [isLoading, videoId])
+
+  if (!showVideoPlaylistPage) {
+    return flagsLoaded ? notFound() : null
+  }
+
+  return (
+    <PageWrapper>
+      <SkipLinksNav aria-label="Skip links">
+        <SkipLink href="#video-detail-main">Skip to main content</SkipLink>
+        <SkipLink href="#video-player-region">Skip to video player</SkipLink>
+        {playlistId && (
+          <SkipLink href="#more-from-playlist">Skip to more videos</SkipLink>
+        )}
+      </SkipLinksNav>
+
+      <ScreenReaderOnly role="status" aria-live="polite" aria-atomic="true">
+        {loadingStatusMessage}
+      </ScreenReaderOnly>
+
+      <BreadcrumbBar>
+        <VideoContainer>
+          <StyledBreadcrumbs
+            variant="light"
+            separatorStyle={{ margin: "0 4px" }}
+            ancestors={[
+              { href: "/", label: "Home" },
+              ...(playlist
+                ? [
+                    {
+                      href: `/video-playlist/${playlistId}`,
+                      label: playlistLabel,
+                    },
+                  ]
+                : []),
+            ]}
+            current={video?.title}
+          />
+        </VideoContainer>
+      </BreadcrumbBar>
+
+      <ContentArea id="video-detail-main" tabIndex={-1}>
+        <VideoContainer>
+          {isLoading ? (
+            <Skeleton width={120} height={18} style={{ marginBottom: 8 }} />
+          ) : playlist ? (
+            <CategoryLabel>{playlistLabel}</CategoryLabel>
+          ) : null}
+
+          {isLoading ? (
+            <Skeleton
+              variant="text"
+              width="70%"
+              height={52}
+              style={{ marginBottom: 12 }}
+            />
+          ) : (
+            <VideoTitle ref={titleRef} tabIndex={-1}>
+              {video?.title}
+            </VideoTitle>
+          )}
+
+          {!isLoading && (duration || topicNames) && (
+            <MetaRow>
+              <DurationText>{duration && <span>{duration}</span>}</DurationText>
+              <TopicText>{topicNames}</TopicText>
+            </MetaRow>
+          )}
+
+          <PlayerWrapper
+            id="video-player-region"
+            tabIndex={-1}
+            role="region"
+            aria-label={`Video player for ${videoTitleLabel}`}
+            aria-describedby="video-description"
+          >
+            {isLoading ? (
+              <div
+                role="status"
+                aria-live="polite"
+                aria-label="Loading video player"
+              >
+                <Skeleton variant="rectangular" width="100%" height="100%" />
+              </div>
+            ) : sources.length > 0 ? (
+              <VideoJsPlayer
+                key={videoId}
+                sources={sources}
+                poster={
+                  sources[0]?.type === "video/youtube"
+                    ? undefined
+                    : (video?.video?.cover_image_url ??
+                      video?.image?.url ??
+                      undefined)
+                }
+                autoplay={false}
+                controls
+                fluid={false}
+                ariaLabel={`Video: ${videoTitleLabel}`}
+                ariaDescribedBy="video-description"
+              />
+            ) : video?.image?.url ? (
+              <ThumbnailWrapper>
+                <Image
+                  src={video.image.url}
+                  alt={videoThumbnailAlt}
+                  fill
+                  sizes="100vw"
+                  style={{ objectFit: "cover" }}
+                />
+              </ThumbnailWrapper>
+            ) : (
+              <>
+                <ScreenReaderOnly role="alert" aria-live="polite">
+                  No playable source available for this video.
+                </ScreenReaderOnly>
+                <NoVideoMessage>
+                  No playable source available for this video.
+                </NoVideoMessage>
+              </>
+            )}
+          </PlayerWrapper>
+          <BorderLine />
+
+          {!isLoading && video?.description && (
+            <DescriptionText id="video-description">
+              {video?.description}
+            </DescriptionText>
+          )}
+
+          {!isLoading && !video?.description && (
+            <ScreenReaderOnly id="video-description">
+              {videoTitleLabel}. Duration: {durationLabel}. Topics:{" "}
+              {topicNamesLabel}.
+            </ScreenReaderOnly>
+          )}
+
+          {!isLoading && video && (
+            <ShareRow>
+              <ShareButton
+                ref={shareButtonRef}
+                aria-label={`Share ${video.title ?? "video"}`}
+                onClick={() => setShareOpen(true)}
+              >
+                <RiShareForwardFill size={16} />
+                Share
+              </ShareButton>
+              <SharePopover
+                open={shareOpen}
+                title={video?.title ?? ""}
+                anchorEl={
+                  shareButtonRef.current as unknown as HTMLDivElement | null
+                }
+                onClose={() => setShareOpen(false)}
+                pageUrl={`${NEXT_PUBLIC_ORIGIN}/video-playlist/${video?.id}?playlist=${playlistId}`}
+              />
+            </ShareRow>
+          )}
+
+          {/* More from playlist */}
+          {playlistId && (
+            <section id="more-from-playlist" tabIndex={-1}>
+              {itemsLoading ? (
+                <>
+                  <Skeleton
+                    variant="text"
+                    width={220}
+                    height={24}
+                    style={{ marginBottom: 8 }}
+                  />
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <div
+                      key={i}
+                      style={{
+                        display: "flex",
+                        gap: 16,
+                        padding: "16px 0",
+                        borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+                      }}
+                    >
+                      <Skeleton variant="rectangular" width={160} height={90} />
+                      <div style={{ flex: 1 }}>
+                        <Skeleton variant="text" width="70%" height={20} />
+                        <Skeleton variant="text" width="50%" height={16} />
+                      </div>
+                    </div>
+                  ))}
+                </>
+              ) : otherVideos.length > 0 ? (
+                <>
+                  <MoreFromTitle>More from {playlistLabel}</MoreFromTitle>
+                  <MoreFromList>
+                    {otherVideos.map((item) => {
+                      const itemDuration = item.video?.duration
+                        ? formatDurationClockTime(item.video.duration)
+                        : null
+                      const imageUrl = item.image?.url ?? null
+                      const itemTopicNames = (item.topics ?? [])
+                        .map((topic) => topic.name)
+                        .filter(Boolean)
+                        .join(" · ")
+                      return (
+                        <React.Fragment key={item.id}>
+                          <MoreFromItem
+                            href={`/video-playlist/detail/${item.id}?playlist=${playlistId}`}
+                            aria-label={`Open video ${item.title}`}
+                          >
+                            <MoreFromThumbnailWrapper>
+                              {imageUrl && (
+                                <Image
+                                  src={imageUrl}
+                                  alt={`Video thumbnail for ${item.title}. Duration: ${itemDuration || "Unknown duration"}. Topics: ${itemTopicNames || "No topics listed"}`}
+                                  fill
+                                  sizes="160px"
+                                  style={{ objectFit: "cover" }}
+                                />
+                              )}
+                              {itemDuration && (
+                                <DurationBadge>{itemDuration}</DurationBadge>
+                              )}
+                            </MoreFromThumbnailWrapper>
+                            <MoreFromTextSide>
+                              <MoreFromItemTitle className="mf-title">
+                                {item.title}
+                              </MoreFromItemTitle>
+                              {item.description && (
+                                <MoreFromItemMeta>
+                                  {item.description}
+                                </MoreFromItemMeta>
+                              )}
+                            </MoreFromTextSide>
+                          </MoreFromItem>
+                          <SpacerBlock className="spacer-block"></SpacerBlock>
+                        </React.Fragment>
+                      )
+                    })}
+                  </MoreFromList>
+                  {totalPlaylistVideos > otherVideos.length + 1 && (
+                    <SeeAllLink
+                      href={`/video-playlist/${playlistId}`}
+                      aria-label={`View all videos in ${playlistLabel}`}
+                    >
+                      View all in {playlistLabel} →
+                    </SeeAllLink>
+                  )}
+                </>
+              ) : null}
+            </section>
+          )}
+        </VideoContainer>
+      </ContentArea>
+    </PageWrapper>
+  )
+}
+
+export default VideoDetailPage

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useRef, useState } from "react"
+import React, { useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
 import dynamic from "next/dynamic"
 import Image from "next/image"
@@ -101,6 +101,7 @@ const VideoTitle = styled.h1(({ theme }) => ({
   fontWeight: theme.typography.fontWeightBold,
   color: theme.custom.colors.black,
   margin: "0 0 24px",
+  "&:focus": { outline: "none" },
   fontSize: "44px",
   fontStyle: "normal",
   lineHeight: "120%" /* 52.8px */,
@@ -393,9 +394,11 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
   const playlist = playlistData as VideoPlaylistResource | undefined
   const video = resource as VideoResource | undefined
 
-  const sources = video
-    ? resolveVideoSources(video.video?.streaming_url, video.url)
-    : []
+  const sources = useMemo(
+    () =>
+      video ? resolveVideoSources(video.video?.streaming_url, video.url) : [],
+    [video],
+  )
 
   const duration = video?.video?.duration
     ? formatDurationClockTime(video.video.duration)

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer.tsx
@@ -1,0 +1,118 @@
+"use client"
+
+import React, { useEffect, useRef } from "react"
+import videojs from "video.js"
+import Player from "video.js/dist/types/player"
+import "video.js/dist/video-js.css"
+// Register YouTube tech so video.js can play youtube:// sources
+import "videojs-youtube"
+
+export type VideoJsSource = {
+  src: string
+  type: string
+}
+
+export type VideoJsPlayerProps = {
+  sources: VideoJsSource[]
+  poster?: string | null
+  autoplay?: boolean
+  controls?: boolean
+  fluid?: boolean
+  ariaLabel?: string
+  ariaDescribedBy?: string
+  onReady?: (player: Player) => void
+}
+
+/**
+ * A React wrapper around video.js.
+ * Initialises the player once on mount and disposes it on unmount.
+ */
+const VideoJsPlayer: React.FC<VideoJsPlayerProps> = ({
+  sources,
+  poster,
+  autoplay = true,
+  controls = true,
+  fluid = true,
+  ariaLabel,
+  ariaDescribedBy,
+  onReady,
+}) => {
+  const videoRef = useRef<HTMLDivElement>(null)
+  const playerRef = useRef<Player | null>(null)
+
+  useEffect(() => {
+    // Only initialise once
+    if (playerRef.current) return
+
+    const videoEl = document.createElement("video-js")
+    videoEl.classList.add("vjs-big-play-centered")
+    if (ariaLabel) {
+      videoEl.setAttribute("aria-label", ariaLabel)
+    }
+    if (ariaDescribedBy) {
+      videoEl.setAttribute("aria-describedby", ariaDescribedBy)
+    }
+    videoEl.style.width = "100%"
+    videoEl.style.height = "100%"
+    videoRef.current!.appendChild(videoEl)
+
+    const player = videojs(
+      videoEl,
+      {
+        autoplay,
+        controls,
+        fluid,
+        fill: !fluid,
+        responsive: true,
+        poster: poster ?? undefined,
+        sources,
+        techOrder: ["youtube", "html5"],
+      },
+      function (this: Player) {
+        onReady?.(this)
+      },
+    )
+
+    playerRef.current = player
+  }, [
+    ariaDescribedBy,
+    ariaLabel,
+    autoplay,
+    controls,
+    fluid,
+    onReady,
+    poster,
+    sources,
+  ])
+
+  // Update sources / poster when props change without re-creating the player
+  useEffect(() => {
+    const player = playerRef.current
+    if (!player) return
+    player.src(sources)
+    player.poster(poster ?? "")
+  }, [sources, poster])
+
+  // Dispose on unmount
+  useEffect(() => {
+    return () => {
+      const player = playerRef.current
+      if (player && !player.isDisposed()) {
+        player.dispose()
+        playerRef.current = null
+      }
+    }
+  }, [])
+
+  return (
+    <div data-vjs-player style={{ width: "100%", height: "100%" }}>
+      <div ref={videoRef} style={{ width: "100%", height: "100%" }} />
+    </div>
+  )
+}
+
+export default VideoJsPlayer
+
+// Re-export for backward compatibility — the implementation lives in
+// videoSources.ts so it can be imported without pulling in video.js.
+export { resolveVideoSources } from "./videoSources"

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.test.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.test.tsx
@@ -249,7 +249,7 @@ describe("VideoPage", () => {
       const titleEl = await screen.findByText(collection.title)
       expect(titleEl.closest("a")).toHaveAttribute(
         "href",
-        `/playlist/detail/${collection.id}?playlist=${playlist.id}`,
+        `/video-playlist/detail/${collection.id}?playlist=${playlist.id}`,
       )
     })
 
@@ -267,7 +267,7 @@ describe("VideoPage", () => {
       const titleEls = await screen.findAllByText(featured.title)
       expect(titleEls[0].closest("a")).toHaveAttribute(
         "href",
-        `/playlist/detail/${featured.id}?playlist=${playlist.id}`,
+        `/video-playlist/detail/${featured.id}?playlist=${playlist.id}`,
       )
     })
   })

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
@@ -31,7 +31,7 @@ const VideoPlaylistCollectionPage: React.FC<
   VideoPlaylistCollectionPageProps
 > = ({ playlistId }) => {
   const getVideoHref = (resource: VideoResource) =>
-    `/playlist/detail/${resource.id}?playlist=${playlistId}`
+    `/video-playlist/detail/${resource.id}?playlist=${playlistId}`
 
   const showVideoPlaylistPage = useFeatureFlagEnabled(
     FeatureFlags.VideoPlaylistPage,

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.test.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.test.ts
@@ -1,0 +1,81 @@
+import { resolveVideoSources } from "./videoSources"
+
+describe("resolveVideoSources", () => {
+  it("returns HLS source for .m3u8 streaming URL", () => {
+    const result = resolveVideoSources(
+      "https://cdn.example.com/video/index.m3u8",
+      null,
+    )
+    expect(result).toEqual([
+      {
+        src: "https://cdn.example.com/video/index.m3u8",
+        type: "application/x-mpegURL",
+      },
+    ])
+  })
+
+  it("returns DASH source for .mpd streaming URL", () => {
+    const result = resolveVideoSources(
+      "https://cdn.example.com/video/manifest.mpd",
+      null,
+    )
+    expect(result).toEqual([
+      {
+        src: "https://cdn.example.com/video/manifest.mpd",
+        type: "application/dash+xml",
+      },
+    ])
+  })
+
+  it("returns MP4 source for a generic streaming URL", () => {
+    const result = resolveVideoSources(
+      "https://cdn.example.com/video/clip.mp4",
+      null,
+    )
+    expect(result).toEqual([
+      { src: "https://cdn.example.com/video/clip.mp4", type: "video/mp4" },
+    ])
+  })
+
+  it("returns MP4 source for a streaming URL with no recognised extension", () => {
+    const result = resolveVideoSources(
+      "https://cdn.example.com/video/stream",
+      "https://www.youtube.com/watch?v=abc",
+    )
+    // streamingUrl takes precedence over pageUrl
+    expect(result).toEqual([
+      { src: "https://cdn.example.com/video/stream", type: "video/mp4" },
+    ])
+  })
+
+  it("returns YouTube source when no streaming URL and pageUrl is a youtube.com link", () => {
+    const result = resolveVideoSources(
+      null,
+      "https://www.youtube.com/watch?v=abc123",
+    )
+    expect(result).toEqual([
+      { src: "https://www.youtube.com/watch?v=abc123", type: "video/youtube" },
+    ])
+  })
+
+  it("returns YouTube source when pageUrl is a youtu.be short link", () => {
+    const result = resolveVideoSources(null, "https://youtu.be/abc123")
+    expect(result).toEqual([
+      { src: "https://youtu.be/abc123", type: "video/youtube" },
+    ])
+  })
+
+  it("returns an empty array when both arguments are null", () => {
+    expect(resolveVideoSources(null, null)).toEqual([])
+  })
+
+  it("returns an empty array when both arguments are undefined", () => {
+    expect(resolveVideoSources(undefined, undefined)).toEqual([])
+  })
+
+  it("returns an empty array when there is no streaming URL and pageUrl is not a YouTube link", () => {
+    expect(resolveVideoSources(null, "https://ocw.mit.edu/some-video")).toEqual(
+      [],
+    )
+  })
+})

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.ts
@@ -1,0 +1,31 @@
+import type { VideoJsSource } from "./VideoJsPlayer"
+
+/**
+ * Derive the correct video.js source object from a VideoResource.
+ * Prefers direct streaming_url; falls back to the YouTube page URL.
+ *
+ * Lives in its own module so it can be imported without pulling in the
+ * heavy video.js bundle that VideoJsPlayer requires.
+ */
+export function resolveVideoSources(
+  streamingUrl: string | null | undefined,
+  pageUrl: string | null | undefined,
+): VideoJsSource[] {
+  if (streamingUrl) {
+    // HLS
+    if (streamingUrl.includes(".m3u8")) {
+      return [{ src: streamingUrl, type: "application/x-mpegURL" }]
+    }
+    // DASH
+    if (streamingUrl.includes(".mpd")) {
+      return [{ src: streamingUrl, type: "application/dash+xml" }]
+    }
+    // MP4 or generic
+    return [{ src: streamingUrl, type: "video/mp4" }]
+  }
+
+  if (pageUrl && /youtube\.com|youtu\.be/.test(pageUrl)) {
+    return [{ src: pageUrl, type: "video/youtube" }]
+  }
+  return []
+}

--- a/frontends/main/src/app/video-playlist/[id]/page.tsx
+++ b/frontends/main/src/app/video-playlist/[id]/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = standardizeMetadata({
   robots: "noindex, nofollow",
 })
 
-const Page: React.FC<PageProps<"/video-collection/[id]">> = async ({
+const Page: React.FC<PageProps<"/video-playlist/[id]">> = async ({
   params,
 }) => {
   const { id } = await params

--- a/frontends/main/src/app/video-playlist/detail/[id]/page.tsx
+++ b/frontends/main/src/app/video-playlist/detail/[id]/page.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import type { Metadata } from "next"
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
+import { standardizeMetadata } from "@/common/metadata"
+import {
+  learningResourceQueries,
+  videoPlaylistQueries,
+} from "api/hooks/learningResources"
+import { getQueryClient } from "@/app/getQueryClient"
+import VideoDetailPage from "@/app-pages/VideoPlaylistCollectionPage/VideoDetailPage"
+import { notFound } from "next/navigation"
+
+export const metadata: Metadata = standardizeMetadata({
+  title: "Video Detail",
+})
+
+const Page: React.FC<PageProps<"/video-playlist/detail/[id]">> = async ({
+  params,
+  searchParams,
+}) => {
+  const { id } = await params
+  const resolvedSearchParams = await searchParams
+  const videoId = Number(id)
+  if (!Number.isInteger(videoId) || videoId <= 0) {
+    notFound()
+  }
+
+  const rawPlaylist = resolvedSearchParams?.playlist
+  let playlistId: number | null = null
+  if (rawPlaylist !== undefined) {
+    // searchParams values can be string | string[]; treat array as invalid
+    if (Array.isArray(rawPlaylist)) {
+      notFound()
+    }
+    const parsed = Number(rawPlaylist)
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      notFound()
+    }
+    playlistId = parsed
+  }
+
+  const queryClient = getQueryClient()
+
+  await queryClient.fetchQueryOr404(learningResourceQueries.detail(videoId))
+
+  const prefetches: Promise<unknown>[] = []
+
+  if (playlistId !== null) {
+    prefetches.push(
+      queryClient.fetchQueryOr404(videoPlaylistQueries.detail(playlistId)),
+      queryClient.prefetchQuery(
+        learningResourceQueries.items(playlistId, {
+          learning_resource_id: playlistId,
+        }),
+      ),
+    )
+  }
+
+  await Promise.all(prefetches)
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <VideoDetailPage videoId={videoId} playlistId={playlistId} />
+    </HydrationBoundary>
+  )
+}
+
+export default Page

--- a/frontends/ol-components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontends/ol-components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -60,10 +60,11 @@ type BreadcrumbsProps = {
   ancestors: Array<{ href: string; label: string }>
   current?: string | undefined | null
   currentHref?: string | undefined | null
+  separatorStyle?: React.CSSProperties
 }
 
 const Breadcrumbs: React.FC<BreadcrumbsProps> = (props) => {
-  const { variant, ancestors, current, currentHref } = props
+  const { variant, ancestors, current, currentHref, separatorStyle } = props
   const linkColor = variant === "light" ? "black" : "white"
   const _Separator = variant === "light" ? LightSeparator : DarkSeparator
   const _Current = variant === "light" ? LightCurrent : DarkCurrent
@@ -81,7 +82,12 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = (props) => {
             >
               <BreadcrumbText>{ancestor.label}</BreadcrumbText>
             </BreadcrumbLink>
-            {!isLast && <_Separator data-testid="breadcrumb-separator" />}
+            {!isLast && (
+              <_Separator
+                data-testid="breadcrumb-separator"
+                style={separatorStyle}
+              />
+            )}
           </Breadcrumb>
         )
       })}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10734

### Description (What does it do?)
Implement the video detail page

### Screenshots (if appropriate):
<img width="2880" height="4356" alt="image (5)" src="https://github.com/user-attachments/assets/3c721aa5-1cdb-4da0-8646-630d031354cc" />

Mobile
<img width="786" height="4572" alt="image (6)" src="https://github.com/user-attachments/assets/5772e9d8-f3a1-42a1-bf26-c7cccec0996e" />



### How can this be tested?
if you dont have playlist data locally then in frontend env file you should add the following variable `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.rc.learn.mit.edu"` it will connect with RC learn backend
then we need to enable the flag which is `video-playlist-page` and then visit the following url `http://open.odl.local:8062/video-playlist/detail/122480?playlist=122479`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
