### PR TITLE
Add support for dynamically displaying the How You'll Learn cards

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -29,7 +29,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "^2026.3.26",
+    "@mitodl/mitxonline-api-axios": "^2026.4.23",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
@@ -88,7 +88,11 @@ const programEnrollmentV3: PartialFactory<V3UserProgramEnrollment> = (
           link: `/certificate/program/${faker.string.uuid()}/`,
         }
       : null,
-    enrollment_mode: faker.helpers.arrayElement(["audit", "verified", undefined]),
+    enrollment_mode: faker.helpers.arrayElement([
+      "audit",
+      "verified",
+      undefined,
+    ]),
     program: program,
   }
   return mergeOverrides<V3UserProgramEnrollment>(defaults, overrides)

--- a/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/enrollment.ts
@@ -88,7 +88,7 @@ const programEnrollmentV3: PartialFactory<V3UserProgramEnrollment> = (
           link: `/certificate/program/${faker.string.uuid()}/`,
         }
       : null,
-    enrollment_mode: faker.helpers.arrayElement(["audit", "verified", null]),
+    enrollment_mode: faker.helpers.arrayElement(["audit", "verified", undefined]),
     program: program,
   }
   return mergeOverrides<V3UserProgramEnrollment>(defaults, overrides)

--- a/frontends/api/src/mitxonline/test-utils/factories/orders.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/orders.ts
@@ -13,6 +13,7 @@ const transactionLine = (
   total_paid: faker.commerce.price({ min: 50, max: 500 }),
   discount: "0.00",
   price: faker.commerce.price({ min: 50, max: 500 }),
+  content_type: "",
   ...overrides,
 })
 

--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -164,6 +164,12 @@ const coursePageItem: PartialFactory<CoursePageItem> = (override) => {
     ],
     video_url: faker.internet.url(),
     what_you_learn: makeHTMLList(5),
+    hyl_choice_realworld_learning: true,
+    hyl_choice_learn_by_doing: true,
+    hyl_choice_learn_from_others: false,
+    hyl_choice_learn_on_demand: false,
+    hyl_choice_ai_enabled_support: true,
+    hyl_choice_stackable_credentials: true,
   }
   return mergeOverrides<CoursePageItem>(defaults, override)
 }
@@ -215,6 +221,12 @@ const programPageItem: PartialFactory<ProgramPageItem> = (override) => {
     faq_url: faker.internet.url(),
     about: makeHTMLParagraph(3),
     what_you_learn: makeHTMLList(5),
+    hyl_choice_realworld_learning: true,
+    hyl_choice_learn_by_doing: true,
+    hyl_choice_learn_from_others: false,
+    hyl_choice_learn_on_demand: false,
+    hyl_choice_ai_enabled_support: true,
+    hyl_choice_stackable_credentials: true,
     feature_image: featureImage(),
     video_url: faker.datatype.boolean() ? faker.internet.url() : null,
     faculty_section_title: "Meet your instructors",

--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -164,12 +164,32 @@ const coursePageItem: PartialFactory<CoursePageItem> = (override) => {
     ],
     video_url: faker.internet.url(),
     what_you_learn: makeHTMLList(5),
-    hyl_choice_realworld_learning: true,
-    hyl_choice_learn_by_doing: true,
-    hyl_choice_learn_from_others: false,
-    hyl_choice_learn_on_demand: false,
-    hyl_choice_ai_enabled_support: true,
-    hyl_choice_stackable_credentials: true,
+    how_youll_learn: [
+      {
+        key: "learn_by_doing",
+        icon: "IconComputerBulb",
+        title: "Learn by doing",
+        text: "Apply what you learn with interactive exercises, projects, and real-world case studies.",
+      },
+      {
+        key: "realworld_learning",
+        icon: "IconConnectedPeople",
+        title: "Real-world learning",
+        text: "Engage with real-world scenarios and examples to understand how concepts apply in practice.",
+      },
+      {
+        key: "learn_from_others",
+        icon: "IconConnectedPeople",
+        title: "Learn from others",
+        text: "Collaborate with peers and learn from their perspectives through group projects and discussions.",
+      },
+      {
+        key: "learn_on_demand",
+        icon: "IconComputerBulb",
+        title: "Learn on demand",
+        text: "Access course materials anytime, anywhere, and learn at your own pace.",
+      },
+    ],
   }
   return mergeOverrides<CoursePageItem>(defaults, override)
 }
@@ -221,12 +241,32 @@ const programPageItem: PartialFactory<ProgramPageItem> = (override) => {
     faq_url: faker.internet.url(),
     about: makeHTMLParagraph(3),
     what_you_learn: makeHTMLList(5),
-    hyl_choice_realworld_learning: true,
-    hyl_choice_learn_by_doing: true,
-    hyl_choice_learn_from_others: false,
-    hyl_choice_learn_on_demand: false,
-    hyl_choice_ai_enabled_support: true,
-    hyl_choice_stackable_credentials: true,
+    how_youll_learn: [
+      {
+        key: "learn_by_doing",
+        icon: "IconComputerBulb",
+        title: "Learn by doing",
+        text: "Apply what you learn with interactive exercises, projects, and real-world case studies.",
+      },
+      {
+        key: "realworld_learning",
+        icon: "IconConnectedPeople",
+        title: "Real-world learning",
+        text: "Engage with real-world scenarios and examples to understand how concepts apply in practice.",
+      },
+      {
+        key: "learn_from_others",
+        icon: "IconConnectedPeople",
+        title: "Learn from others",
+        text: "Collaborate with peers and learn from their perspectives through group projects and discussions.",
+      },
+      {
+        key: "learn_on_demand",
+        icon: "IconComputerBulb",
+        title: "Learn on demand",
+        text: "Access course materials anytime, anywhere, and learn at your own pace.",
+      },
+    ],
     feature_image: featureImage(),
     video_url: faker.datatype.boolean() ? faker.internet.url() : null,
     faculty_section_title: "Meet your instructors",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "^2026.3.26",
+    "@mitodl/mitxonline-api-axios": "^2026.4.23",
     "@mitodl/smoot-design": "^6.24.0",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -157,7 +157,7 @@ describe("UnenrollProgramDialog", () => {
 
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
-        enrollment_mode: enrollmentMode,
+        enrollment_mode: enrollmentMode ? enrollmentMode : undefined,
         program: { display_mode: displayMode } as never,
       })
 

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -16,7 +16,7 @@ import RawHTML from "./RawHTML"
 import AboutSection from "./AboutSection"
 import ProductPageTemplate from "./ProductPageTemplate"
 import WhatYoullLearnSection from "./WhatYoullLearnSection"
-import HowYoullLearnSection, { DEFAULT_HOW_DATA, HowYoullLearnSectionWrapper } from "./HowYoullLearnSection"
+import HowYoullLearnSection from "./HowYoullLearnSection"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
@@ -65,14 +65,6 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
 
   const imageSrc =
     page.course_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
-  const hylCards = [
-    page.hasOwnProperty("hyl_choice_realworld_learning") && page.hyl_choice_realworld_learning ? "hyl_choice_realworld_learning" : null,
-    page.hasOwnProperty("hyl_choice_learn_by_doing") && page.hyl_choice_learn_by_doing ? "hyl_choice_learn_by_doing" : null,
-    page.hasOwnProperty("hyl_choice_learn_from_others") && page.hyl_choice_learn_from_others ? "hyl_choice_learn_from_others" : null,
-    page.hasOwnProperty("hyl_choice_learn_on_demand") && page.hyl_choice_learn_on_demand ? "hyl_choice_learn_on_demand" : null,
-    page.hasOwnProperty("hyl_choice_ai_enabled_support") && page.hyl_choice_ai_enabled_support ? "hyl_choice_ai_enabled_support" : null,
-    page.hasOwnProperty("hyl_choice_stackable_credentials") && page.hyl_choice_stackable_credentials ? "hyl_choice_stackable_credentials" : null,
-  ]
 
   return (
     <ProductPageTemplate
@@ -106,7 +98,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
       {page.what_you_learn ? (
         <WhatYoullLearnSection html={page.what_you_learn} />
       ) : null}
-      <HowYoullLearnSectionWrapper data={hylCards.filter(Boolean) as string[]} />
+      <HowYoullLearnSection page={page} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>
           <Typography variant="h4" component="h2" id={HeadingIds.Prereqs}>

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -16,7 +16,7 @@ import RawHTML from "./RawHTML"
 import AboutSection from "./AboutSection"
 import ProductPageTemplate from "./ProductPageTemplate"
 import WhatYoullLearnSection from "./WhatYoullLearnSection"
-import HowYoullLearnSection, { DEFAULT_HOW_DATA } from "./HowYoullLearnSection"
+import HowYoullLearnSection, { DEFAULT_HOW_DATA, HowYoullLearnSectionWrapper } from "./HowYoullLearnSection"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
@@ -65,6 +65,14 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
 
   const imageSrc =
     page.course_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+  const hylCards = [
+    page.hasOwnProperty("hyl_choice_realworld_learning") && page.hyl_choice_realworld_learning ? "hyl_choice_realworld_learning" : null,
+    page.hasOwnProperty("hyl_choice_learn_by_doing") && page.hyl_choice_learn_by_doing ? "hyl_choice_learn_by_doing" : null,
+    page.hasOwnProperty("hyl_choice_learn_from_others") && page.hyl_choice_learn_from_others ? "hyl_choice_learn_from_others" : null,
+    page.hasOwnProperty("hyl_choice_learn_on_demand") && page.hyl_choice_learn_on_demand ? "hyl_choice_learn_on_demand" : null,
+    page.hasOwnProperty("hyl_choice_ai_enabled_support") && page.hyl_choice_ai_enabled_support ? "hyl_choice_ai_enabled_support" : null,
+    page.hasOwnProperty("hyl_choice_stackable_credentials") && page.hyl_choice_stackable_credentials ? "hyl_choice_stackable_credentials" : null,
+  ]
 
   return (
     <ProductPageTemplate
@@ -98,7 +106,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
       {page.what_you_learn ? (
         <WhatYoullLearnSection html={page.what_you_learn} />
       ) : null}
-      <HowYoullLearnSection data={DEFAULT_HOW_DATA} />
+      <HowYoullLearnSectionWrapper data={hylCards.filter(Boolean) as string[]} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>
           <Typography variant="h4" component="h2" id={HeadingIds.Prereqs}>

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -74,6 +74,10 @@ type HowYoullLearnItemData = {
   title: string
   text: string
 }
+type HowYoullLearnOption = {
+  name: string
+  data: HowYoullLearnItemData
+}
 
 // Placeholder data — will be replaced by API-driven content.
 const DEFAULT_HOW_DATA: HowYoullLearnItemData[] = [
@@ -98,6 +102,65 @@ const DEFAULT_HOW_DATA: HowYoullLearnItemData[] = [
     text: "Earn an MIT Open Learning certificate at each milestone—module, course, and program—demonstrating your AI expertise. Available in paid courses only.",
   },
 ]
+
+const HOW_YOULL_LEARN_OPTIONS: HowYoullLearnOption[] = [
+  {
+    name: "hyl_choice_realworld_learning",
+    data: {
+      icon: IconConnectedPeople,
+      title: "Real-World Learning",
+      text: "Learn from MIT faculty and experts who ground their teaching in real-world cases rather than mathematical models, making the material approachable for all.",
+    },
+  },
+  {
+    name: "hyl_choice_learn_by_doing",
+    data: {
+      icon: IconBrains,
+      title: "Practical Application",
+      text: "Apply your new knowledge with hands-on, practical exercises drawn from healthcare, sports, finance, sustainability, and more.",
+    },
+  },
+  {
+    name: "hyl_choice_learn_from_others",
+    data: {
+      icon: IconBrains,
+      title: "Learn From Others",
+      text: "Connect with an international community of professionals working on real-world projects.",
+    },
+  },
+  {
+    name: "hyl_choice_learn_on_demand",
+    data: {
+      icon: IconBrains,
+      title: "Learn On Demand",
+      text: "Access all course content online with complete flexibility to study at your own pace.",
+    },
+  },
+  {
+    name: "hyl_choice_ai_enabled_support",
+    data: {
+      icon: IconComputerBulb,
+      title: "AI-Enabled Support",
+      text: "Deepen your understanding of the course material and get help on assignments from AskTIM, the AI assistant built by MIT researchers.",
+    },
+  },
+  {
+    name: "hyl_choice_stackable_credentials",
+    data: {
+      icon: IconCertificate,
+      title: "Stackable Credentials",
+      text: "Earn an MIT Open Learning certificate at each milestone—module, course, and program—demonstrating your AI expertise. Available in paid courses only.",
+    },
+  },
+]
+
+const HowYoullLearnSectionWrapper: React.FC<{
+  data: Array<string>
+}> = ({data}) => {
+  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter((option) => data.includes(option.name))
+  const items = filteredOptions.map((option) => option.data)
+  return <HowYoullLearnSection data={items} />
+}
 
 const HowYoullLearnSection: React.FC<{
   data: HowYoullLearnItemData[]
@@ -128,5 +191,5 @@ const HowYoullLearnSection: React.FC<{
 }
 
 export default HowYoullLearnSection
-export { DEFAULT_HOW_DATA }
+export { DEFAULT_HOW_DATA, HOW_YOULL_LEARN_OPTIONS, HowYoullLearnSectionWrapper }
 export type { HowYoullLearnItemData }

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -74,13 +74,24 @@ const HowYoullLearnDescription = styled.p(({ theme }) => ({
   },
 }))
 
+// These fields come from the CMS page types. Once @mitodl/mitxonline-api-axios
+// is published with these fields, this can be replaced with:
+// Extract<keyof CoursePageItem & keyof ProgramPageItem, `hyl_choice_${string}`>
+type HylChoiceKey =
+  | "hyl_choice_realworld_learning"
+  | "hyl_choice_learn_by_doing"
+  | "hyl_choice_learn_from_others"
+  | "hyl_choice_learn_on_demand"
+  | "hyl_choice_ai_enabled_support"
+  | "hyl_choice_stackable_credentials"
+
 type HowYoullLearnItemData = {
   icon: typeof IconComputerBulb
   title: string
   text: string
 }
 type HowYoullLearnOption = {
-  name: string
+  name: HylChoiceKey
   data: HowYoullLearnItemData
 }
 
@@ -139,29 +150,28 @@ const HowYoullLearnSection: React.FC<{
   page: CoursePageItem | ProgramPageItem
 }> = ({ page }) => {
   const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter(
-    (option) =>
-      page.hasOwnProperty(option.name) &&
-      (page as unknown as Record<string, boolean>)[option.name],
+    (option) => (page as Record<HylChoiceKey, boolean>)[option.name],
   )
-  const items = filteredOptions.map((option) => option.data)
-  return items.length > 0 ? (
+  return filteredOptions.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>
       <Typography variant="h4" component="h2" id={HeadingIds.How}>
         How you'll learn
       </Typography>
       <HowYoullLearnGrid>
-        {items.map((item, index) => (
-          <HowYoullLearnItem key={index}>
+        {filteredOptions.map((option) => (
+          <HowYoullLearnItem key={option.name}>
             <HowYoullLearnHeader>
               <HowYoullLearnIcon
-                src={item.icon}
+                src={option.data.icon}
                 width={80}
                 height={50}
                 alt=""
               />
-              <HowYoullLearnTitle>{item.title}</HowYoullLearnTitle>
+              <HowYoullLearnTitle>{option.data.title}</HowYoullLearnTitle>
             </HowYoullLearnHeader>
-            <HowYoullLearnDescription>{item.text}</HowYoullLearnDescription>
+            <HowYoullLearnDescription>
+              {option.data.text}
+            </HowYoullLearnDescription>
           </HowYoullLearnItem>
         ))}
       </HowYoullLearnGrid>

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -150,7 +150,8 @@ const HowYoullLearnSection: React.FC<{
   page: CoursePageItem | ProgramPageItem
 }> = ({ page }) => {
   const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter(
-    (option) => (page as Record<HylChoiceKey, boolean>)[option.name],
+    (option) =>
+      (page as Record<HylChoiceKey, boolean | undefined>)[option.name] === true,
   )
   return filteredOptions.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -9,6 +9,8 @@ import IconCertificate from "@/public/images/product/icon_certificate.png"
 import IconComputerBulb from "@/public/images/product/icon_computer_lightbulb.png"
 import IconConnectedPeople from "@/public/images/product/icon_connected_people.png"
 
+import type { CoursePageItem, ProgramPageItem } from "@mitodl/mitxonline-api-axios/v2"
+
 const HowYoullLearnRoot = styled.section(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
@@ -79,30 +81,6 @@ type HowYoullLearnOption = {
   data: HowYoullLearnItemData
 }
 
-// Placeholder data — will be replaced by API-driven content.
-const DEFAULT_HOW_DATA: HowYoullLearnItemData[] = [
-  {
-    icon: IconConnectedPeople,
-    title: "Real-World Learning",
-    text: "Learn from MIT faculty and experts who ground their teaching in real-world cases rather than mathematical models, making the material approachable for all.",
-  },
-  {
-    icon: IconBrains,
-    title: "Practical Application",
-    text: "Apply your new knowledge with hands-on, practical exercises drawn from healthcare, sports, finance, sustainability, and more.",
-  },
-  {
-    icon: IconComputerBulb,
-    title: "AI-Enabled Support",
-    text: "Deepen your understanding of the course material and get help on assignments from AskTIM, the AI assistant built by MIT researchers.",
-  },
-  {
-    icon: IconCertificate,
-    title: "Stackable Credentials",
-    text: "Earn an MIT Open Learning certificate at each milestone—module, course, and program—demonstrating your AI expertise. Available in paid courses only.",
-  },
-]
-
 const HOW_YOULL_LEARN_OPTIONS: HowYoullLearnOption[] = [
   {
     name: "hyl_choice_realworld_learning",
@@ -154,24 +132,19 @@ const HOW_YOULL_LEARN_OPTIONS: HowYoullLearnOption[] = [
   },
 ]
 
-const HowYoullLearnSectionWrapper: React.FC<{
-  data: Array<string>
-}> = ({data}) => {
-  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter((option) => data.includes(option.name))
-  const items = filteredOptions.map((option) => option.data)
-  return <HowYoullLearnSection data={items} />
-}
 
 const HowYoullLearnSection: React.FC<{
-  data: HowYoullLearnItemData[]
-}> = ({ data }) => {
-  return (
+  page: CoursePageItem | ProgramPageItem
+}> = ({ page }) => {
+  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter((option) => page.hasOwnProperty(option.name) && (page as Record<string, boolean>)[option.name])
+  const items = filteredOptions.map((option) => option.data)
+  return items.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>
       <Typography variant="h4" component="h2" id={HeadingIds.How}>
         How you'll learn
       </Typography>
       <HowYoullLearnGrid>
-        {data.map((item, index) => (
+        {items.map((item, index) => (
           <HowYoullLearnItem key={index}>
             <HowYoullLearnHeader>
               <HowYoullLearnIcon
@@ -187,9 +160,8 @@ const HowYoullLearnSection: React.FC<{
         ))}
       </HowYoullLearnGrid>
     </HowYoullLearnRoot>
-  )
+  ) : null
 }
 
 export default HowYoullLearnSection
-export { DEFAULT_HOW_DATA, HOW_YOULL_LEARN_OPTIONS, HowYoullLearnSectionWrapper }
 export type { HowYoullLearnItemData }

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -9,7 +9,10 @@ import IconCertificate from "@/public/images/product/icon_certificate.png"
 import IconComputerBulb from "@/public/images/product/icon_computer_lightbulb.png"
 import IconConnectedPeople from "@/public/images/product/icon_connected_people.png"
 
-import type { CoursePageItem, ProgramPageItem } from "@mitodl/mitxonline-api-axios/v2"
+import type {
+  CoursePageItem,
+  ProgramPageItem,
+} from "@mitodl/mitxonline-api-axios/v2"
 
 const HowYoullLearnRoot = styled.section(({ theme }) => ({
   display: "flex",
@@ -132,11 +135,14 @@ const HOW_YOULL_LEARN_OPTIONS: HowYoullLearnOption[] = [
   },
 ]
 
-
 const HowYoullLearnSection: React.FC<{
   page: CoursePageItem | ProgramPageItem
 }> = ({ page }) => {
-  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter((option) => page.hasOwnProperty(option.name) && (page as Record<string, boolean>)[option.name])
+  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter(
+    (option) =>
+      page.hasOwnProperty(option.name) &&
+      (page as unknown as Record<string, boolean>)[option.name],
+  )
   const items = filteredOptions.map((option) => option.data)
   return items.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -54,7 +54,7 @@ const HowYoullLearnHeader = styled.div({
   alignItems: "center",
 })
 
-const HowYoullLearnIcon = styled(Image)({
+const HowYoullLearnIconImage = styled(Image)({
   width: "80px",
   height: "50px",
   flexShrink: 0,
@@ -74,85 +74,47 @@ const HowYoullLearnDescription = styled.p(({ theme }) => ({
   },
 }))
 
-// These fields come from the CMS page types. Once @mitodl/mitxonline-api-axios
-// is published with these fields, this can be replaced with:
-// Extract<keyof CoursePageItem & keyof ProgramPageItem, `hyl_choice_${string}`>
-type HylChoiceKey =
-  | "hyl_choice_realworld_learning"
-  | "hyl_choice_learn_by_doing"
-  | "hyl_choice_learn_from_others"
-  | "hyl_choice_learn_on_demand"
-  | "hyl_choice_ai_enabled_support"
-  | "hyl_choice_stackable_credentials"
+const HowYoullLearnIcon: React.FC<{
+  src: string
+  width: number
+  height: number
+  alt: string
+}> = ({ src, width, height, alt }) => {
+  let iconSrc: typeof IconBrains | null = null
+  switch (src) {
+    case "IconBrains":
+      iconSrc = IconBrains
+      break
+    case "IconCertificate":
+      iconSrc = IconCertificate
+      break
+    case "IconComputerBulb":
+      iconSrc = IconComputerBulb
+      break
+    case "IconConnectedPeople":
+      iconSrc = IconConnectedPeople
+      break
+    default:
+      console.warn(`Unknown how_youll_learn icon: ${src}`)
+  }
 
-type HowYoullLearnItemData = {
-  icon: typeof IconComputerBulb
-  title: string
-  text: string
+  return (
+    iconSrc && (
+      <HowYoullLearnIconImage
+        src={iconSrc}
+        width={width}
+        height={height}
+        alt={alt}
+      />
+    )
+  )
 }
-type HowYoullLearnOption = {
-  name: HylChoiceKey
-  data: HowYoullLearnItemData
-}
-
-const HOW_YOULL_LEARN_OPTIONS: HowYoullLearnOption[] = [
-  {
-    name: "hyl_choice_realworld_learning",
-    data: {
-      icon: IconConnectedPeople,
-      title: "Real-World Learning",
-      text: "Learn from MIT faculty and experts who ground their teaching in real-world cases rather than mathematical models, making the material approachable for all.",
-    },
-  },
-  {
-    name: "hyl_choice_learn_by_doing",
-    data: {
-      icon: IconBrains,
-      title: "Practical Application",
-      text: "Apply your new knowledge with hands-on, practical exercises drawn from healthcare, sports, finance, sustainability, and more.",
-    },
-  },
-  {
-    name: "hyl_choice_learn_from_others",
-    data: {
-      icon: IconBrains,
-      title: "Learn From Others",
-      text: "Connect with an international community of professionals working on real-world projects.",
-    },
-  },
-  {
-    name: "hyl_choice_learn_on_demand",
-    data: {
-      icon: IconBrains,
-      title: "Learn On Demand",
-      text: "Access all course content online with complete flexibility to study at your own pace.",
-    },
-  },
-  {
-    name: "hyl_choice_ai_enabled_support",
-    data: {
-      icon: IconComputerBulb,
-      title: "AI-Enabled Support",
-      text: "Deepen your understanding of the course material and get help on assignments from AskTIM, the AI assistant built by MIT researchers.",
-    },
-  },
-  {
-    name: "hyl_choice_stackable_credentials",
-    data: {
-      icon: IconCertificate,
-      title: "Stackable Credentials",
-      text: "Earn an MIT Open Learning certificate at each milestone—module, course, and program—demonstrating your AI expertise. Available in paid courses only.",
-    },
-  },
-]
 
 const HowYoullLearnSection: React.FC<{
   page: CoursePageItem | ProgramPageItem
 }> = ({ page }) => {
-  const filteredOptions = HOW_YOULL_LEARN_OPTIONS.filter(
-    (option) =>
-      (page as Record<HylChoiceKey, boolean | undefined>)[option.name] === true,
-  )
+  const filteredOptions = page.how_youll_learn ? page.how_youll_learn : []
+
   return filteredOptions.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>
       <Typography variant="h4" component="h2" id={HeadingIds.How}>
@@ -160,19 +122,17 @@ const HowYoullLearnSection: React.FC<{
       </Typography>
       <HowYoullLearnGrid>
         {filteredOptions.map((option) => (
-          <HowYoullLearnItem key={option.name}>
+          <HowYoullLearnItem key={option.key}>
             <HowYoullLearnHeader>
               <HowYoullLearnIcon
-                src={option.data.icon}
+                src={option.icon}
                 width={80}
                 height={50}
                 alt=""
               />
-              <HowYoullLearnTitle>{option.data.title}</HowYoullLearnTitle>
+              <HowYoullLearnTitle>{option.title}</HowYoullLearnTitle>
             </HowYoullLearnHeader>
-            <HowYoullLearnDescription>
-              {option.data.text}
-            </HowYoullLearnDescription>
+            <HowYoullLearnDescription>{option.text}</HowYoullLearnDescription>
           </HowYoullLearnItem>
         ))}
       </HowYoullLearnGrid>
@@ -181,4 +141,3 @@ const HowYoullLearnSection: React.FC<{
 }
 
 export default HowYoullLearnSection
-export type { HowYoullLearnItemData }

--- a/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/HowYoullLearnSection.tsx
@@ -113,7 +113,7 @@ const HowYoullLearnIcon: React.FC<{
 const HowYoullLearnSection: React.FC<{
   page: CoursePageItem | ProgramPageItem
 }> = ({ page }) => {
-  const filteredOptions = page.how_youll_learn ? page.how_youll_learn : []
+  const filteredOptions = page.how_youll_learn ?? []
 
   return filteredOptions.length > 0 ? (
     <HowYoullLearnRoot aria-labelledby={HeadingIds.How}>

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -21,7 +21,7 @@ import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 import AboutSection from "./AboutSection"
 import ProductPageTemplate from "./ProductPageTemplate"
 import WhatYoullLearnSection from "./WhatYoullLearnSection"
-import HowYoullLearnSection, { DEFAULT_HOW_DATA } from "./HowYoullLearnSection"
+import HowYoullLearnSection from "./HowYoullLearnSection"
 import { DEFAULT_RESOURCE_IMG, pluralize } from "ol-utilities"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import ProgramAsCourseInfoBox from "./InfoBoxProgramAsCourse"
@@ -312,7 +312,7 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
         childPrograms={childPrograms.data?.results}
         isLoading={dataLoading}
       />
-      <HowYoullLearnSection data={DEFAULT_HOW_DATA} />
+      <HowYoullLearnSection page={page} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>
           <Typography variant="h4" component="h2" id={HeadingIds.Prereqs}>

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -21,7 +21,7 @@ import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 import AboutSection from "./AboutSection"
 import ProductPageTemplate from "./ProductPageTemplate"
 import WhatYoullLearnSection from "./WhatYoullLearnSection"
-import HowYoullLearnSection, { DEFAULT_HOW_DATA } from "./HowYoullLearnSection"
+import HowYoullLearnSection from "./HowYoullLearnSection"
 import type {
   V2ProgramDetail,
   CourseWithCourseRunsSerializerV2,
@@ -311,7 +311,7 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
         // Use skeleton as fallback for loading OR error
         isLoading={dataLoading}
       />
-      <HowYoullLearnSection data={DEFAULT_HOW_DATA} />
+      <HowYoullLearnSection page={page} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>
           <Typography variant="h4" component="h2" id={HeadingIds.Prereqs}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3521,16 +3521,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:^2026.3.26":
-  version: 2026.3.26
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.3.26"
-  dependencies:
-    "@types/node": "npm:^20.11.19"
-    axios: "npm:^1.6.5"
-  checksum: 10/66d36280b62505ea4510db2376cf1887ade17286aa17b840d120dc88a48817097e9d194cd2a54c3479535d457031883f6b420995ee8909d9afb3debb3b520ab9
-  languageName: node
-  linkType: hard
-
 "@mitodl/mitxonline-api-axios@npm:^2026.4.23":
   version: 2026.4.23
   resolution: "@mitodl/mitxonline-api-axios@npm:2026.4.23"
@@ -16390,7 +16380,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:^2026.3.26"
+    "@mitodl/mitxonline-api-axios": "npm:^2026.4.23"
     "@mitodl/smoot-design": "npm:^6.24.0"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3531,6 +3531,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mitodl/mitxonline-api-axios@npm:^2026.4.23":
+  version: 2026.4.23
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.4.23"
+  dependencies:
+    "@types/node": "npm:^20.11.19"
+    axios: "npm:^1.6.5"
+  checksum: 10/9580cb496742649450c0567b8b4be6ad19082af9d3ea1c2cd1f9dcec1c87746c8370c8af984b5012660d6e9a52f36dded227115da635a8efb7634df952499a25
+  languageName: node
+  linkType: hard
+
 "@mitodl/smoot-design@npm:^6.24.0":
   version: 6.24.0
   resolution: "@mitodl/smoot-design@npm:6.24.0"
@@ -9141,7 +9151,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:^2026.3.26"
+    "@mitodl/mitxonline-api-axios": "npm:^2026.4.23"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#10856
Depends on https://github.com/mitodl/mitxonline/pull/3487

### Description (What does it do?)

The dependent PR adds a handful of fields to the product pages that allow the cards in the How You'll Learn section to be toggled on and off. This is the other side of that; it updates the product pages to only display the cards that are checked in the CMS page.

### Screenshots (if appropriate):

(Probably worth noting here that I didn't change any of the text on the 4 cards that exist. So, "Learn by Doing" seemed like it should match up with the "Practical Application" card, so that's what I set it to.)

<img width="2440" height="1330" alt="Screenshot 2026-04-14 at 11 57 44 AM" src="https://github.com/user-attachments/assets/eb354e07-84ec-4082-960b-7564efe05388" />

<img width="2440" height="1330" alt="Screenshot 2026-04-14 at 11 57 13 AM" src="https://github.com/user-attachments/assets/bfb67479-c8ab-46c9-a57b-f7c7c36eab98" />

### How can this be tested?

Test with both a course page and a program page. (Ideally, also test with a program-course; those don't have a separate product page necessarily but good to check anyway.)

For the given item, go into the CMS in MITx Online and check random boxes in the How You'll Learn section and publish your changes. Then, check the product page in Learn. You should only see cards for the selected items.

### Additional Context

We'll want to additionally customize this according to the kind of course or provider (or maybe some other thing). The wording and iconography may need to change for different situations - UAI versus xPRO versus MITx, etc. - which we can do in the frontend. This PR doesn't implement that, though. 

This needs some text and icons for the new cards. We had these before I started mucking with it:
* Practical Application - "Learn by Doing" 
* Real-World Learning
* AI-Enabled Support
* Stackable Credentials

The new ones are "Learn From Others" and "Learn On Demand".  They have the text from the issue but I reused the brains icon.