### PR TITLE
Program Unenrollment

### DIFF
--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -79,6 +79,12 @@ const useDestroyProgramEnrollment = () => {
       programEnrollmentsApi.v3ProgramEnrollmentsDestroy({
         program_id: programId,
       }),
+    onSuccess: (_data, vars) => {
+      queryClient.setQueryData(
+        enrollmentQueries.programEnrollmentsList().queryKey,
+        (data) => data?.filter((enrollment) => enrollment.program.id !== vars),
+      )
+    },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.programEnrollmentsList(),

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -72,6 +72,21 @@ const useDestroyEnrollment = () => {
   })
 }
 
+const useDestroyProgramEnrollment = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (programId: number) =>
+      programEnrollmentsApi.v3ProgramEnrollmentsDestroy({
+        program_id: programId,
+      }),
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: enrollmentKeys.programEnrollmentsList(),
+      })
+    },
+  })
+}
+
 const useCreateProgramEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
@@ -110,6 +125,7 @@ export {
   useCreateEnrollment,
   useUpdateEnrollment,
   useDestroyEnrollment,
+  useDestroyProgramEnrollment,
   useCreateProgramEnrollment,
   useCreateVerifiedProgramEnrollment,
 }

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -27,6 +27,8 @@ const enrollment = {
 
 const programEnrollments = {
   enrollmentsListV3: () => `${API_BASE_URL}/api/v3/program_enrollments/`,
+  programEnrollment: (programId: number) =>
+    `${API_BASE_URL}/api/v3/program_enrollments/${programId}/`,
 }
 
 const b2b = {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -25,6 +25,7 @@ import {
   EmailSettingsDialog,
   JustInTimeDialog,
   UnenrollDialog,
+  UnenrollProgramDialog,
 } from "./DashboardDialogs"
 import NiceModal from "@ebay/nice-modal-react"
 import {
@@ -47,6 +48,7 @@ import {
   CourseRunEnrollmentV3,
   V3UserProgramEnrollment,
   CourseRunV2,
+  DisplayModeEnum,
 } from "@mitodl/mitxonline-api-axios/v2"
 import CourseEnrollmentDialog from "@/page-components/EnrollmentDialogs/CourseEnrollmentDialog"
 
@@ -194,6 +196,23 @@ const getContextMenuItems = (
         key: "view-program-details",
         label: "View Program Details",
         href: detailsUrl,
+      })
+    }
+
+    if (
+      program.display_mode !== DisplayModeEnum.Course &&
+      !isVerifiedEnrollmentMode(resource.data.enrollment_mode)
+    ) {
+      menuItems.push({
+        className: "dashboard-card-menu-item",
+        key: "unenroll-program",
+        label: "Unenroll",
+        onClick: () => {
+          NiceModal.show(UnenrollProgramDialog, {
+            title,
+            programId: program.id,
+          })
+        },
       })
     }
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -147,6 +147,140 @@ describe("DashboardDialogs", () => {
   })
 })
 
+describe("UnenrollProgramDialog", () => {
+  const setupProgramCard = (
+    enrollmentMode: string | null = "audit",
+    displayMode: string | null = null,
+  ) => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: enrollmentMode,
+        program: { display_mode: displayMode } as never,
+      })
+
+    return { programEnrollment }
+  }
+
+  test("Shows unenroll option for free (audit) program enrollments", async () => {
+    const { programEnrollment } = setupProgramCard("audit", null)
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+      />,
+    )
+
+    const desktopCard = await screen.findByTestId("enrollment-card-desktop")
+    const contextMenuButton = within(desktopCard).getByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Unenroll" }),
+    ).toBeInTheDocument()
+  })
+
+  test("Does not show unenroll option for paid (verified) program enrollments", async () => {
+    const { programEnrollment } = setupProgramCard("verified", null)
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+      />,
+    )
+
+    const desktopCard = await screen.findByTestId("enrollment-card-desktop")
+    const contextMenuButton = within(desktopCard).getByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Unenroll" }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("Does not show unenroll option for program-as-course display_mode programs", async () => {
+    const { programEnrollment } = setupProgramCard("audit", "course")
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+      />,
+    )
+
+    const desktopCard = await screen.findByTestId("enrollment-card-desktop")
+    const contextMenuButton = within(desktopCard).getByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Unenroll" }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("Confirming unenroll from a program fires the proper API call", async () => {
+    const { programEnrollment } = setupProgramCard("audit", null)
+
+    setMockResponse.delete(
+      mitxonline.urls.programEnrollments.programEnrollment(
+        programEnrollment.program.id,
+      ),
+      null,
+    )
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+      />,
+    )
+
+    const desktopCard = await screen.findByTestId("enrollment-card-desktop")
+    const contextMenuButton = within(desktopCard).getByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    const unenrollMenuItem = await screen.findByRole("menuitem", {
+      name: "Unenroll",
+    })
+    await user.click(unenrollMenuItem)
+
+    const dialog = await screen.findByRole("dialog", {
+      name: `Unenroll from ${programEnrollment.program.title}`,
+    })
+    expect(dialog).toBeInTheDocument()
+    expect(
+      within(dialog).getByText(
+        `Are you sure you want to unenroll from ${programEnrollment.program.title}?`,
+      ),
+    ).toBeInTheDocument()
+
+    const confirmButton = within(dialog).getByRole("button", {
+      name: "Unenroll",
+    })
+    await user.click(confirmButton)
+
+    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "DELETE",
+        url: mitxonline.urls.programEnrollments.programEnrollment(
+          programEnrollment.program.id,
+        ),
+      }),
+    )
+  })
+})
+
 describe("JustInTimeDialog", () => {
   const getFields = (root: HTMLElement) => {
     return {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -279,6 +279,57 @@ describe("UnenrollProgramDialog", () => {
       }),
     )
   })
+
+  test("Cancelling the dialog does not fire the API call", async () => {
+    const { programEnrollment } = setupProgramCard("audit", null)
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+      />,
+    )
+
+    const desktopCard = await screen.findByTestId("enrollment-card-desktop")
+    const contextMenuButton = within(desktopCard).getByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    await user.click(await screen.findByRole("menuitem", { name: "Unenroll" }))
+    await screen.findByRole("dialog", {
+      name: `Unenroll from ${programEnrollment.program.title}`,
+    })
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(mockAxiosInstance.request).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "DELETE" }),
+    )
+  })
+
+  test.each(["enrollment-card-desktop", "enrollment-card-mobile"] as const)(
+    "Unenroll option is accessible from the %s overflow menu",
+    async (cardTestId) => {
+      const { programEnrollment } = setupProgramCard("audit", null)
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.ProgramEnrollment,
+            data: programEnrollment,
+          }}
+        />,
+      )
+
+      const card = await screen.findByTestId(cardTestId)
+      await user.click(within(card).getByLabelText("More options"))
+
+      expect(
+        await screen.findByRole("menuitem", { name: "Unenroll" }),
+      ).toBeInTheDocument()
+    },
+  )
 })
 
 describe("JustInTimeDialog", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -337,9 +337,7 @@ const UnenrollProgramDialogInner: React.FC<UnenrollProgramDialogProps> = ({
     initialValues: {},
     onSubmit: async () => {
       await destroyProgramEnrollment.mutateAsync(programId)
-      if (!destroyProgramEnrollment.isError) {
-        modal.hide()
-      }
+      modal.hide()
     },
   })
   return (

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -17,6 +17,7 @@ import { useFormik } from "formik"
 import {
   useCreateB2bEnrollment,
   useDestroyEnrollment,
+  useDestroyProgramEnrollment,
   useUpdateEnrollment,
 } from "api/mitxonline-hooks/enrollment"
 import {
@@ -318,4 +319,79 @@ const EmailSettingsDialog = NiceModal.create(EmailSettingsDialogInner)
 const UnenrollDialog = NiceModal.create(UnenrollDialogInner)
 const JustInTimeDialog = NiceModal.create(JustInTimeDialogInner)
 
-export { EmailSettingsDialog, UnenrollDialog, JustInTimeDialog }
+type UnenrollProgramDialogProps = {
+  title: string
+  programId: number
+}
+
+const UnenrollProgramDialogInner: React.FC<UnenrollProgramDialogProps> = ({
+  title,
+  programId,
+}) => {
+  const modal = NiceModal.useModal()
+  const destroyProgramEnrollment = useDestroyProgramEnrollment()
+  const formik = useFormik({
+    enableReinitialize: true,
+    validateOnChange: false,
+    validateOnBlur: false,
+    initialValues: {},
+    onSubmit: async () => {
+      await destroyProgramEnrollment.mutateAsync(programId)
+      if (!destroyProgramEnrollment.isError) {
+        modal.hide()
+      }
+    },
+  })
+  return (
+    <FormDialog
+      title={`Unenroll from ${title}`}
+      fullWidth
+      onReset={formik.resetForm}
+      onSubmit={formik.handleSubmit}
+      {...muiDialogV5(modal)}
+      actions={
+        <DialogActions>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              modal.hide()
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={destroyProgramEnrollment.isPending}
+            endIcon={
+              destroyProgramEnrollment.isPending ? (
+                <LoadingSpinner color="inherit" loading={true} size={16} />
+              ) : undefined
+            }
+          >
+            Unenroll
+          </Button>
+        </DialogActions>
+      }
+    >
+      <Typography variant="body1">
+        Are you sure you want to unenroll from {title}?
+      </Typography>
+      {destroyProgramEnrollment.isError && (
+        <Alert severity="error">
+          There was a problem unenrolling you from this program. Please try
+          again later.
+        </Alert>
+      )}
+    </FormDialog>
+  )
+}
+
+const UnenrollProgramDialog = NiceModal.create(UnenrollProgramDialogInner)
+
+export {
+  EmailSettingsDialog,
+  UnenrollDialog,
+  UnenrollProgramDialog,
+  JustInTimeDialog,
+}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -790,6 +790,8 @@ const AllEnrollmentsDisplay: React.FC = () => {
         page_size: enrolledProgramIds.length,
       }),
       enabled: enrolledProgramIds.length > 0,
+      // If the query key changes, show the old data while loading
+      // example: Deleting a program enrollment
       placeholderData: keepPreviousData,
     })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -14,7 +14,7 @@ import {
   theme,
 } from "ol-components"
 import { Alert } from "@mitodl/smoot-design"
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import {
   EnrollmentStatus,
   getEnrollmentStatus,
@@ -790,6 +790,7 @@ const AllEnrollmentsDisplay: React.FC = () => {
         page_size: enrolledProgramIds.length,
       }),
       enabled: enrolledProgramIds.length > 0,
+      placeholderData: keepPreviousData,
     })
 
   const filteredProgramEnrollments = enrolledPrograms
@@ -820,6 +821,7 @@ const AllEnrollmentsDisplay: React.FC = () => {
       page_size: homeCourseProgramModuleIds.length || undefined,
     }),
     enabled: homeCourseProgramModuleIds.length > 0,
+    placeholderData: keepPreviousData,
   })
 
   const homeCourseProgramsById = new Map(


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/9852

### Description (What does it do?)
Adds a program unenrollmemt option to the enrollment dropdown for program cards. Only present if enrollment mode is "audit".


### How can this be tested?
1. Enroll in some programs, including one program enrollment with "verified" track". (You could just change your enrollment status in MITxOnline django admin.)
2. Try unenrolling on the Learn dashboard `...` menu.
    - verified enrollment should not present the unenroll option
    - audit enrollment should
