### PR TITLE
Filtering for similarity endpoints

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16799,48 +16799,54 @@ export const LearningResourcesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by Qdrant filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources using vector embeddings
      * @param {number} id
-     * @param {boolean} [certification]
-     * @param {Array<LearningResourcesVectorSimilarListCertificationTypeEnum>} [certification_type] The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-     * @param {Array<string>} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {Array<Array<LearningResourcesVectorSimilarListDeliveryEnum>>} [delivery] The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-     * @param {Array<LearningResourcesVectorSimilarListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {boolean} [free] The course/program is offered for free
-     * @param {Array<LearningResourcesVectorSimilarListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {boolean | null} [certification] True if the learning resource offers a certificate
+     * @param {Array<LearningResourcesVectorSimilarListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
+     * @param {Array<LearningResourcesVectorSimilarListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+     * @param {Array<LearningResourcesVectorSimilarListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [free]
+     * @param {Array<LearningResourcesVectorSimilarListLevelEnum>} [level]
      * @param {number} [limit]
-     * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-     * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-     * @param {boolean} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
+     * @param {Array<string>} [ocw_topic] The ocw topic name.
+     * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+     * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+     * @param {boolean | null} [professional]
+     * @param {string} [readable_id] The readable id of the resource
      * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
-     * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-     * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+     * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+     * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {LearningResourcesVectorSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-     * @param {Array<string>} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
+     * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesVectorSimilarList: async (
       id: number,
-      certification?: boolean,
+      certification?: boolean | null,
       certification_type?: Array<LearningResourcesVectorSimilarListCertificationTypeEnum>,
       course_feature?: Array<string>,
-      delivery?: Array<Array<LearningResourcesVectorSimilarListDeliveryEnum>>,
+      delivery?: Array<LearningResourcesVectorSimilarListDeliveryEnum>,
       department?: Array<LearningResourcesVectorSimilarListDepartmentEnum>,
-      free?: boolean,
+      free?: boolean | null,
       level?: Array<LearningResourcesVectorSimilarListLevelEnum>,
       limit?: number,
+      ocw_topic?: Array<string>,
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
-      professional?: boolean,
-      readable_id?: Array<string>,
+      professional?: boolean | null,
+      readable_id?: string,
       resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
       sortby?: LearningResourcesVectorSimilarListSortbyEnum,
+      title__isnull?: boolean | null,
       topic?: Array<string>,
+      url__isnull?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'id' is not null or undefined
@@ -16897,6 +16903,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
+      if (ocw_topic) {
+        localVarQueryParameter["ocw_topic"] = ocw_topic
+      }
+
       if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
@@ -16909,7 +16919,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (readable_id) {
+      if (readable_id !== undefined) {
         localVarQueryParameter["readable_id"] = readable_id
       }
 
@@ -16929,8 +16939,16 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["sortby"] = sortby
       }
 
+      if (title__isnull !== undefined) {
+        localVarQueryParameter["title__isnull"] = title__isnull
+      }
+
       if (topic) {
         localVarQueryParameter["topic"] = topic
+      }
+
+      if (url__isnull !== undefined) {
+        localVarQueryParameter["url__isnull"] = url__isnull
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -17497,48 +17515,54 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by Qdrant filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources using vector embeddings
      * @param {number} id
-     * @param {boolean} [certification]
-     * @param {Array<LearningResourcesVectorSimilarListCertificationTypeEnum>} [certification_type] The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-     * @param {Array<string>} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {Array<Array<LearningResourcesVectorSimilarListDeliveryEnum>>} [delivery] The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-     * @param {Array<LearningResourcesVectorSimilarListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {boolean} [free] The course/program is offered for free
-     * @param {Array<LearningResourcesVectorSimilarListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {boolean | null} [certification] True if the learning resource offers a certificate
+     * @param {Array<LearningResourcesVectorSimilarListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
+     * @param {Array<LearningResourcesVectorSimilarListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+     * @param {Array<LearningResourcesVectorSimilarListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [free]
+     * @param {Array<LearningResourcesVectorSimilarListLevelEnum>} [level]
      * @param {number} [limit]
-     * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-     * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-     * @param {boolean} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
+     * @param {Array<string>} [ocw_topic] The ocw topic name.
+     * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+     * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+     * @param {boolean | null} [professional]
+     * @param {string} [readable_id] The readable id of the resource
      * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
-     * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-     * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+     * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+     * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {LearningResourcesVectorSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-     * @param {Array<string>} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
+     * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesVectorSimilarList(
       id: number,
-      certification?: boolean,
+      certification?: boolean | null,
       certification_type?: Array<LearningResourcesVectorSimilarListCertificationTypeEnum>,
       course_feature?: Array<string>,
-      delivery?: Array<Array<LearningResourcesVectorSimilarListDeliveryEnum>>,
+      delivery?: Array<LearningResourcesVectorSimilarListDeliveryEnum>,
       department?: Array<LearningResourcesVectorSimilarListDepartmentEnum>,
-      free?: boolean,
+      free?: boolean | null,
       level?: Array<LearningResourcesVectorSimilarListLevelEnum>,
       limit?: number,
+      ocw_topic?: Array<string>,
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
-      professional?: boolean,
-      readable_id?: Array<string>,
+      professional?: boolean | null,
+      readable_id?: string,
       resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
       sortby?: LearningResourcesVectorSimilarListSortbyEnum,
+      title__isnull?: boolean | null,
       topic?: Array<string>,
+      url__isnull?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -17557,6 +17581,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           free,
           level,
           limit,
+          ocw_topic,
           offered_by,
           platform,
           professional,
@@ -17565,7 +17590,9 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           resource_type,
           resource_type_group,
           sortby,
+          title__isnull,
           topic,
+          url__isnull,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -17841,7 +17868,7 @@ export const LearningResourcesApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by Qdrant filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources using vector embeddings
      * @param {LearningResourcesApiLearningResourcesVectorSimilarListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -17862,6 +17889,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.free,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.ocw_topic,
           requestParameters.offered_by,
           requestParameters.platform,
           requestParameters.professional,
@@ -17870,7 +17898,9 @@ export const LearningResourcesApiFactory = function (
           requestParameters.resource_type,
           requestParameters.resource_type_group,
           requestParameters.sortby,
+          requestParameters.title__isnull,
           requestParameters.topic,
+          requestParameters.url__isnull,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -18508,52 +18538,50 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly id: number
 
   /**
-   *
+   * True if the learning resource offers a certificate
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly certification?: boolean
+  readonly certification?: boolean | null
 
   /**
-   * The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-   * @type {Array<'completion' | 'micromasters' | 'none' | 'professional'>}
+   * The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+   * @type {Array<'micromasters' | 'professional' | 'completion' | 'none'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly certification_type?: Array<LearningResourcesVectorSimilarListCertificationTypeEnum>
 
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
+   * The course feature. Possible options are at api/v1/course_features/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly course_feature?: Array<string>
 
   /**
-   * The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-   * @type {Array<Array<'online' | 'hybrid' | 'in_person' | 'offline'>>}
+   * The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+   * @type {Array<'online' | 'hybrid' | 'in_person' | 'offline'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly delivery?: Array<
-    Array<LearningResourcesVectorSimilarListDeliveryEnum>
-  >
+  readonly delivery?: Array<LearningResourcesVectorSimilarListDeliveryEnum>
 
   /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'SP' | 'STS' | 'WGS'>}
+   * The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+   * @type {Array<'1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'SP' | 'STS' | 'WGS'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly department?: Array<LearningResourcesVectorSimilarListDepartmentEnum>
 
   /**
-   * The course/program is offered for free
+   *
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly free?: boolean
+  readonly free?: boolean | null
 
   /**
-   * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
+   *
+   * @type {Array<'undergraduate' | 'graduate' | 'high_school' | 'noncredit' | 'advanced' | 'intermediate' | 'introductory'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly level?: Array<LearningResourcesVectorSimilarListLevelEnum>
@@ -18566,15 +18594,22 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly limit?: number
 
   /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-   * @type {Array<'bootcamps' | 'climate' | 'mitpe' | 'mitx' | 'ocw' | 'see' | 'xpro'>}
+   * The ocw topic name.
+   * @type {Array<string>}
+   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
+   */
+  readonly ocw_topic?: Array<string>
+
+  /**
+   * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+   * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see' | 'climate'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>
 
   /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-   * @type {Array<'bootcamps' | 'canvas' | 'climate' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'ovs' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro' | 'youtube'>}
+   * The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+   * @type {Array<'edx' | 'ocw' | 'oll' | 'mitxonline' | 'bootcamps' | 'xpro' | 'csail' | 'mitpe' | 'see' | 'scc' | 'ctl' | 'whu' | 'susskind' | 'globalalumni' | 'simplilearn' | 'emeritus' | 'podcast' | 'youtube' | 'canvas' | 'climate' | 'ovs'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>
@@ -18584,14 +18619,14 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly professional?: boolean
+  readonly professional?: boolean | null
 
   /**
-   * A unique text identifier for the resources
-   * @type {Array<string>}
+   * The readable id of the resource
+   * @type {string}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly readable_id?: Array<string>
+  readonly readable_id?: string
 
   /**
    * Comma-separated list of learning resource IDs
@@ -18601,15 +18636,15 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly resource_id?: Array<number>
 
   /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-   * @type {Array<'course' | 'document' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
+   * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+   * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>
 
   /**
-   * The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>
@@ -18622,11 +18657,25 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly sortby?: LearningResourcesVectorSimilarListSortbyEnum
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+   * Filter to learning resources where title is null/not null
+   * @type {boolean}
+   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
+   */
+  readonly title__isnull?: boolean | null
+
+  /**
+   * The topic name. To see a list of options go to api/v1/topics/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly topic?: Array<string>
+
+  /**
+   * Filter to learning resources where url is null/not null
+   * @type {boolean}
+   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
+   */
+  readonly url__isnull?: boolean | null
 }
 
 /**
@@ -18902,7 +18951,7 @@ export class LearningResourcesApi extends BaseAPI {
   }
 
   /**
-   * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+   * Fetch similar learning resources, optionally narrowed by Qdrant filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
    * @summary Get similar resources using vector embeddings
    * @param {LearningResourcesApiLearningResourcesVectorSimilarListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -18924,6 +18973,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.free,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.ocw_topic,
         requestParameters.offered_by,
         requestParameters.platform,
         requestParameters.professional,
@@ -18932,7 +18982,9 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.resource_type,
         requestParameters.resource_type_group,
         requestParameters.sortby,
+        requestParameters.title__isnull,
         requestParameters.topic,
+        requestParameters.url__isnull,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -19489,10 +19541,10 @@ export type LearningResourcesSummaryListSortbyEnum =
  * @export
  */
 export const LearningResourcesVectorSimilarListCertificationTypeEnum = {
-  Completion: "completion",
   Micromasters: "micromasters",
-  None: "none",
   Professional: "professional",
+  Completion: "completion",
+  None: "none",
 } as const
 export type LearningResourcesVectorSimilarListCertificationTypeEnum =
   (typeof LearningResourcesVectorSimilarListCertificationTypeEnum)[keyof typeof LearningResourcesVectorSimilarListCertificationTypeEnum]
@@ -19512,6 +19564,14 @@ export type LearningResourcesVectorSimilarListDeliveryEnum =
  */
 export const LearningResourcesVectorSimilarListDepartmentEnum = {
   _1: "1",
+  _2: "2",
+  _3: "3",
+  _4: "4",
+  _5: "5",
+  _6: "6",
+  _7: "7",
+  _8: "8",
+  _9: "9",
   _10: "10",
   _11: "11",
   _12: "12",
@@ -19520,7 +19580,6 @@ export const LearningResourcesVectorSimilarListDepartmentEnum = {
   _16: "16",
   _17: "17",
   _18: "18",
-  _2: "2",
   _20: "20",
   _21A: "21A",
   _21G: "21G",
@@ -19529,13 +19588,6 @@ export const LearningResourcesVectorSimilarListDepartmentEnum = {
   _21M: "21M",
   _22: "22",
   _24: "24",
-  _3: "3",
-  _4: "4",
-  _5: "5",
-  _6: "6",
-  _7: "7",
-  _8: "8",
-  _9: "9",
   Cc: "CC",
   CmsW: "CMS-W",
   Ec: "EC",
@@ -19555,13 +19607,13 @@ export type LearningResourcesVectorSimilarListDepartmentEnum =
  * @export
  */
 export const LearningResourcesVectorSimilarListLevelEnum = {
-  Advanced: "advanced",
+  Undergraduate: "undergraduate",
   Graduate: "graduate",
   HighSchool: "high_school",
+  Noncredit: "noncredit",
+  Advanced: "advanced",
   Intermediate: "intermediate",
   Introductory: "introductory",
-  Noncredit: "noncredit",
-  Undergraduate: "undergraduate",
 } as const
 export type LearningResourcesVectorSimilarListLevelEnum =
   (typeof LearningResourcesVectorSimilarListLevelEnum)[keyof typeof LearningResourcesVectorSimilarListLevelEnum]
@@ -19569,13 +19621,13 @@ export type LearningResourcesVectorSimilarListLevelEnum =
  * @export
  */
 export const LearningResourcesVectorSimilarListOfferedByEnum = {
-  Bootcamps: "bootcamps",
-  Climate: "climate",
-  Mitpe: "mitpe",
   Mitx: "mitx",
   Ocw: "ocw",
-  See: "see",
+  Bootcamps: "bootcamps",
   Xpro: "xpro",
+  Mitpe: "mitpe",
+  See: "see",
+  Climate: "climate",
 } as const
 export type LearningResourcesVectorSimilarListOfferedByEnum =
   (typeof LearningResourcesVectorSimilarListOfferedByEnum)[keyof typeof LearningResourcesVectorSimilarListOfferedByEnum]
@@ -19583,27 +19635,27 @@ export type LearningResourcesVectorSimilarListOfferedByEnum =
  * @export
  */
 export const LearningResourcesVectorSimilarListPlatformEnum = {
-  Bootcamps: "bootcamps",
-  Canvas: "canvas",
-  Climate: "climate",
-  Csail: "csail",
-  Ctl: "ctl",
   Edx: "edx",
-  Emeritus: "emeritus",
-  Globalalumni: "globalalumni",
-  Mitpe: "mitpe",
-  Mitxonline: "mitxonline",
   Ocw: "ocw",
   Oll: "oll",
-  Ovs: "ovs",
-  Podcast: "podcast",
-  Scc: "scc",
-  See: "see",
-  Simplilearn: "simplilearn",
-  Susskind: "susskind",
-  Whu: "whu",
+  Mitxonline: "mitxonline",
+  Bootcamps: "bootcamps",
   Xpro: "xpro",
+  Csail: "csail",
+  Mitpe: "mitpe",
+  See: "see",
+  Scc: "scc",
+  Ctl: "ctl",
+  Whu: "whu",
+  Susskind: "susskind",
+  Globalalumni: "globalalumni",
+  Simplilearn: "simplilearn",
+  Emeritus: "emeritus",
+  Podcast: "podcast",
   Youtube: "youtube",
+  Canvas: "canvas",
+  Climate: "climate",
+  Ovs: "ovs",
 } as const
 export type LearningResourcesVectorSimilarListPlatformEnum =
   (typeof LearningResourcesVectorSimilarListPlatformEnum)[keyof typeof LearningResourcesVectorSimilarListPlatformEnum]
@@ -19612,13 +19664,13 @@ export type LearningResourcesVectorSimilarListPlatformEnum =
  */
 export const LearningResourcesVectorSimilarListResourceTypeEnum = {
   Course: "course",
-  Document: "document",
+  Program: "program",
   LearningPath: "learning_path",
   Podcast: "podcast",
   PodcastEpisode: "podcast_episode",
-  Program: "program",
   Video: "video",
   VideoPlaylist: "video_playlist",
+  Document: "document",
 } as const
 export type LearningResourcesVectorSimilarListResourceTypeEnum =
   (typeof LearningResourcesVectorSimilarListResourceTypeEnum)[keyof typeof LearningResourcesVectorSimilarListResourceTypeEnum]
@@ -19627,8 +19679,8 @@ export type LearningResourcesVectorSimilarListResourceTypeEnum =
  */
 export const LearningResourcesVectorSimilarListResourceTypeGroupEnum = {
   Course: "course",
-  LearningMaterial: "learning_material",
   Program: "program",
+  LearningMaterial: "learning_material",
 } as const
 export type LearningResourcesVectorSimilarListResourceTypeGroupEnum =
   (typeof LearningResourcesVectorSimilarListResourceTypeGroupEnum)[keyof typeof LearningResourcesVectorSimilarListResourceTypeGroupEnum]

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16460,9 +16460,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {boolean | null} [professional]
      * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16482,9 +16480,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       professional?: boolean | null,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
-      title__isnull?: boolean | null,
       topic?: Array<string>,
-      url__isnull?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'id' is not null or undefined
@@ -16564,16 +16560,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["resource_type_group"] = resource_type_group
       }
 
-      if (title__isnull !== undefined) {
-        localVarQueryParameter["title__isnull"] = title__isnull
-      }
-
       if (topic) {
         localVarQueryParameter["topic"] = topic
-      }
-
-      if (url__isnull !== undefined) {
-        localVarQueryParameter["url__isnull"] = url__isnull
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -16816,9 +16804,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {boolean | null} [professional]
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -16838,9 +16824,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       professional?: boolean | null,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
-      title__isnull?: boolean | null,
       topic?: Array<string>,
-      url__isnull?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'id' is not null or undefined
@@ -16921,16 +16905,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["resource_type_group"] = resource_type_group
       }
 
-      if (title__isnull !== undefined) {
-        localVarQueryParameter["title__isnull"] = title__isnull
-      }
-
       if (topic) {
         localVarQueryParameter["topic"] = topic
-      }
-
-      if (url__isnull !== undefined) {
-        localVarQueryParameter["url__isnull"] = url__isnull
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -17304,9 +17280,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {boolean | null} [professional]
      * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17326,9 +17300,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       professional?: boolean | null,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
-      title__isnull?: boolean | null,
       topic?: Array<string>,
-      url__isnull?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -17353,9 +17325,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           professional,
           resource_type,
           resource_type_group,
-          title__isnull,
           topic,
-          url__isnull,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -17514,9 +17484,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {boolean | null} [professional]
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
-     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -17536,9 +17504,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       professional?: boolean | null,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
-      title__isnull?: boolean | null,
       topic?: Array<string>,
-      url__isnull?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -17563,9 +17529,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           professional,
           resource_type,
           resource_type_group,
-          title__isnull,
           topic,
-          url__isnull,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -17778,9 +17742,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.professional,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
-          requestParameters.title__isnull,
           requestParameters.topic,
-          requestParameters.url__isnull,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -17868,9 +17830,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.professional,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
-          requestParameters.title__isnull,
           requestParameters.topic,
-          requestParameters.url__isnull,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -18312,25 +18272,11 @@ export interface LearningResourcesApiLearningResourcesSimilarListRequest {
   readonly resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>
 
   /**
-   * Filter to learning resources where title is null/not null
-   * @type {boolean}
-   * @memberof LearningResourcesApiLearningResourcesSimilarList
-   */
-  readonly title__isnull?: boolean | null
-
-  /**
    * The topic name. To see a list of options go to api/v1/topics/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly topic?: Array<string>
-
-  /**
-   * Filter to learning resources where url is null/not null
-   * @type {boolean}
-   * @memberof LearningResourcesApiLearningResourcesSimilarList
-   */
-  readonly url__isnull?: boolean | null
 }
 
 /**
@@ -18606,25 +18552,11 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>
 
   /**
-   * Filter to learning resources where title is null/not null
-   * @type {boolean}
-   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
-   */
-  readonly title__isnull?: boolean | null
-
-  /**
    * The topic name. To see a list of options go to api/v1/topics/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly topic?: Array<string>
-
-  /**
-   * Filter to learning resources where url is null/not null
-   * @type {boolean}
-   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
-   */
-  readonly url__isnull?: boolean | null
 }
 
 /**
@@ -18832,9 +18764,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.professional,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
-        requestParameters.title__isnull,
         requestParameters.topic,
-        requestParameters.url__isnull,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -18928,9 +18858,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.professional,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
-        requestParameters.title__isnull,
         requestParameters.topic,
-        requestParameters.url__isnull,
         options,
       )
       .then((request) => request(this.axios, this.basePath))

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16443,48 +16443,48 @@ export const LearningResourcesApiAxiosParamCreator = function (
       }
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources
      * @param {number} id
-     * @param {boolean} [certification]
-     * @param {Array<LearningResourcesSimilarListCertificationTypeEnum>} [certification_type] The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-     * @param {Array<string>} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {Array<Array<LearningResourcesSimilarListDeliveryEnum>>} [delivery] The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-     * @param {Array<LearningResourcesSimilarListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {boolean} [free] The course/program is offered for free
-     * @param {Array<LearningResourcesSimilarListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {boolean | null} [certification] True if the learning resource offers a certificate
+     * @param {Array<LearningResourcesSimilarListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
+     * @param {Array<LearningResourcesSimilarListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+     * @param {Array<LearningResourcesSimilarListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [free]
+     * @param {Array<LearningResourcesSimilarListLevelEnum>} [level]
      * @param {number} [limit]
-     * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-     * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-     * @param {boolean} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
-     * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
-     * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-     * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {LearningResourcesSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-     * @param {Array<string>} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [ocw_topic] The ocw topic name.
+     * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+     * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+     * @param {boolean | null} [professional]
+     * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+     * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
+     * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     learningResourcesSimilarList: async (
       id: number,
-      certification?: boolean,
+      certification?: boolean | null,
       certification_type?: Array<LearningResourcesSimilarListCertificationTypeEnum>,
       course_feature?: Array<string>,
-      delivery?: Array<Array<LearningResourcesSimilarListDeliveryEnum>>,
+      delivery?: Array<LearningResourcesSimilarListDeliveryEnum>,
       department?: Array<LearningResourcesSimilarListDepartmentEnum>,
-      free?: boolean,
+      free?: boolean | null,
       level?: Array<LearningResourcesSimilarListLevelEnum>,
       limit?: number,
+      ocw_topic?: Array<string>,
       offered_by?: Array<LearningResourcesSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesSimilarListPlatformEnum>,
-      professional?: boolean,
-      readable_id?: Array<string>,
-      resource_id?: Array<number>,
+      professional?: boolean | null,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
-      sortby?: LearningResourcesSimilarListSortbyEnum,
+      title__isnull?: boolean | null,
       topic?: Array<string>,
+      url__isnull?: boolean | null,
       options: RawAxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'id' is not null or undefined
@@ -16540,6 +16540,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["limit"] = limit
       }
 
+      if (ocw_topic) {
+        localVarQueryParameter["ocw_topic"] = ocw_topic
+      }
+
       if (offered_by) {
         localVarQueryParameter["offered_by"] = offered_by
       }
@@ -16552,14 +16556,6 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (readable_id) {
-        localVarQueryParameter["readable_id"] = readable_id
-      }
-
-      if (resource_id) {
-        localVarQueryParameter["resource_id"] = resource_id
-      }
-
       if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
@@ -16568,12 +16564,16 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["resource_type_group"] = resource_type_group
       }
 
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
+      if (title__isnull !== undefined) {
+        localVarQueryParameter["title__isnull"] = title__isnull
       }
 
       if (topic) {
         localVarQueryParameter["topic"] = topic
+      }
+
+      if (url__isnull !== undefined) {
+        localVarQueryParameter["url__isnull"] = url__isnull
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter)
@@ -17287,48 +17287,48 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
         )(axios, operationBasePath || basePath)
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources
      * @param {number} id
-     * @param {boolean} [certification]
-     * @param {Array<LearningResourcesSimilarListCertificationTypeEnum>} [certification_type] The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-     * @param {Array<string>} [course_feature] Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
-     * @param {Array<Array<LearningResourcesSimilarListDeliveryEnum>>} [delivery] The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-     * @param {Array<LearningResourcesSimilarListDepartmentEnum>} [department] The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-     * @param {boolean} [free] The course/program is offered for free
-     * @param {Array<LearningResourcesSimilarListLevelEnum>} [level] The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
+     * @param {boolean | null} [certification] True if the learning resource offers a certificate
+     * @param {Array<LearningResourcesSimilarListCertificationTypeEnum>} [certification_type] The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+     * @param {Array<string>} [course_feature] The course feature. Possible options are at api/v1/course_features/
+     * @param {Array<LearningResourcesSimilarListDeliveryEnum>} [delivery] The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+     * @param {Array<LearningResourcesSimilarListDepartmentEnum>} [department] The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+     * @param {boolean | null} [free]
+     * @param {Array<LearningResourcesSimilarListLevelEnum>} [level]
      * @param {number} [limit]
-     * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-     * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-     * @param {boolean} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
-     * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
-     * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-     * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {LearningResourcesSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-     * @param {Array<string>} [topic] Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+     * @param {Array<string>} [ocw_topic] The ocw topic name.
+     * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+     * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+     * @param {boolean | null} [professional]
+     * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+     * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+     * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
+     * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
+     * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async learningResourcesSimilarList(
       id: number,
-      certification?: boolean,
+      certification?: boolean | null,
       certification_type?: Array<LearningResourcesSimilarListCertificationTypeEnum>,
       course_feature?: Array<string>,
-      delivery?: Array<Array<LearningResourcesSimilarListDeliveryEnum>>,
+      delivery?: Array<LearningResourcesSimilarListDeliveryEnum>,
       department?: Array<LearningResourcesSimilarListDepartmentEnum>,
-      free?: boolean,
+      free?: boolean | null,
       level?: Array<LearningResourcesSimilarListLevelEnum>,
       limit?: number,
+      ocw_topic?: Array<string>,
       offered_by?: Array<LearningResourcesSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesSimilarListPlatformEnum>,
-      professional?: boolean,
-      readable_id?: Array<string>,
-      resource_id?: Array<number>,
+      professional?: boolean | null,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
-      sortby?: LearningResourcesSimilarListSortbyEnum,
+      title__isnull?: boolean | null,
       topic?: Array<string>,
+      url__isnull?: boolean | null,
       options?: RawAxiosRequestConfig,
     ): Promise<
       (
@@ -17347,15 +17347,15 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           free,
           level,
           limit,
+          ocw_topic,
           offered_by,
           platform,
           professional,
-          readable_id,
-          resource_id,
           resource_type,
           resource_type_group,
-          sortby,
+          title__isnull,
           topic,
+          url__isnull,
           options,
         )
       const index = configuration?.serverIndex ?? 0
@@ -17751,7 +17751,7 @@ export const LearningResourcesApiFactory = function (
         .then((request) => request(axios, basePath))
     },
     /**
-     * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+     * Fetch similar learning resources, optionally narrowed by filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
      * @summary Get similar resources
      * @param {LearningResourcesApiLearningResourcesSimilarListRequest} requestParameters Request parameters.
      * @param {*} [options] Override http request option.
@@ -17772,15 +17772,15 @@ export const LearningResourcesApiFactory = function (
           requestParameters.free,
           requestParameters.level,
           requestParameters.limit,
+          requestParameters.ocw_topic,
           requestParameters.offered_by,
           requestParameters.platform,
           requestParameters.professional,
-          requestParameters.readable_id,
-          requestParameters.resource_id,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
-          requestParameters.sortby,
+          requestParameters.title__isnull,
           requestParameters.topic,
+          requestParameters.url__isnull,
           options,
         )
         .then((request) => request(axios, basePath))
@@ -18214,50 +18214,50 @@ export interface LearningResourcesApiLearningResourcesSimilarListRequest {
   readonly id: number
 
   /**
-   *
+   * True if the learning resource offers a certificate
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
-  readonly certification?: boolean
+  readonly certification?: boolean | null
 
   /**
-   * The type of certification offered  * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
-   * @type {Array<'completion' | 'micromasters' | 'none' | 'professional'>}
+   * The type of certificate               * &#x60;micromasters&#x60; - MicroMasters Credential * &#x60;professional&#x60; - Professional Certificate * &#x60;completion&#x60; - Certificate of Completion * &#x60;none&#x60; - No Certificate
+   * @type {Array<'micromasters' | 'professional' | 'completion' | 'none'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly certification_type?: Array<LearningResourcesSimilarListCertificationTypeEnum>
 
   /**
-   * Content feature for the resources. Load the \&#39;api/v1/course_features\&#39; endpoint for a list of course features
+   * The course feature. Possible options are at api/v1/course_features/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly course_feature?: Array<string>
 
   /**
-   * The delivery of course/program resources  * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
-   * @type {Array<Array<'online' | 'hybrid' | 'in_person' | 'offline'>>}
+   * The delivery options in which the learning resource is offered               * &#x60;online&#x60; - Online * &#x60;hybrid&#x60; - Hybrid * &#x60;in_person&#x60; - In person * &#x60;offline&#x60; - Offline
+   * @type {Array<'online' | 'hybrid' | 'in_person' | 'offline'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
-  readonly delivery?: Array<Array<LearningResourcesSimilarListDeliveryEnum>>
+  readonly delivery?: Array<LearningResourcesSimilarListDeliveryEnum>
 
   /**
-   * The department that offers learning resources  * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
-   * @type {Array<'1' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '2' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'SP' | 'STS' | 'WGS'>}
+   * The department that offers the learning resource               * &#x60;1&#x60; - Civil and Environmental Engineering * &#x60;2&#x60; - Mechanical Engineering * &#x60;3&#x60; - Materials Science and Engineering * &#x60;4&#x60; - Architecture * &#x60;5&#x60; - Chemistry * &#x60;6&#x60; - Electrical Engineering and Computer Science * &#x60;7&#x60; - Biology * &#x60;8&#x60; - Physics * &#x60;9&#x60; - Brain and Cognitive Sciences * &#x60;10&#x60; - Chemical Engineering * &#x60;11&#x60; - Urban Studies and Planning * &#x60;12&#x60; - Earth, Atmospheric, and Planetary Sciences * &#x60;14&#x60; - Economics * &#x60;15&#x60; - Management * &#x60;16&#x60; - Aeronautics and Astronautics * &#x60;17&#x60; - Political Science * &#x60;18&#x60; - Mathematics * &#x60;20&#x60; - Biological Engineering * &#x60;21A&#x60; - Anthropology * &#x60;21G&#x60; - Global Languages * &#x60;21H&#x60; - History * &#x60;21L&#x60; - Literature * &#x60;21M&#x60; - Music and Theater Arts * &#x60;22&#x60; - Nuclear Science and Engineering * &#x60;24&#x60; - Linguistics and Philosophy * &#x60;CC&#x60; - Concourse * &#x60;CMS-W&#x60; - Comparative Media Studies/Writing * &#x60;EC&#x60; - Edgerton Center * &#x60;ES&#x60; - Experimental Study Group * &#x60;ESD&#x60; - Engineering Systems Division * &#x60;HST&#x60; - Medical Engineering and Science * &#x60;IDS&#x60; - Data, Systems, and Society * &#x60;MAS&#x60; - Media Arts and Sciences * &#x60;PE&#x60; - Athletics, Physical Education and Recreation * &#x60;SP&#x60; - Special Programs * &#x60;STS&#x60; - Science, Technology, and Society * &#x60;WGS&#x60; - Women\&#39;s and Gender Studies
+   * @type {Array<'1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '14' | '15' | '16' | '17' | '18' | '20' | '21A' | '21G' | '21H' | '21L' | '21M' | '22' | '24' | 'CC' | 'CMS-W' | 'EC' | 'ES' | 'ESD' | 'HST' | 'IDS' | 'MAS' | 'PE' | 'SP' | 'STS' | 'WGS'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly department?: Array<LearningResourcesSimilarListDepartmentEnum>
 
   /**
-   * The course/program is offered for free
+   *
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
-  readonly free?: boolean
+  readonly free?: boolean | null
 
   /**
-   * The academic level of the resources  * &#x60;undergraduate&#x60; - Undergraduate * &#x60;graduate&#x60; - Graduate * &#x60;high_school&#x60; - High School * &#x60;noncredit&#x60; - Non-Credit * &#x60;advanced&#x60; - Advanced * &#x60;intermediate&#x60; - Intermediate * &#x60;introductory&#x60; - Introductory
-   * @type {Array<'advanced' | 'graduate' | 'high_school' | 'intermediate' | 'introductory' | 'noncredit' | 'undergraduate'>}
+   *
+   * @type {Array<'undergraduate' | 'graduate' | 'high_school' | 'noncredit' | 'advanced' | 'intermediate' | 'introductory'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly level?: Array<LearningResourcesSimilarListLevelEnum>
@@ -18270,15 +18270,22 @@ export interface LearningResourcesApiLearningResourcesSimilarListRequest {
   readonly limit?: number
 
   /**
-   * The organization that offers a learning resource  * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
-   * @type {Array<'bootcamps' | 'climate' | 'mitpe' | 'mitx' | 'ocw' | 'see' | 'xpro'>}
+   * The ocw topic name.
+   * @type {Array<string>}
+   * @memberof LearningResourcesApiLearningResourcesSimilarList
+   */
+  readonly ocw_topic?: Array<string>
+
+  /**
+   * The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
+   * @type {Array<'mitx' | 'ocw' | 'bootcamps' | 'xpro' | 'mitpe' | 'see' | 'climate'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly offered_by?: Array<LearningResourcesSimilarListOfferedByEnum>
 
   /**
-   * The platform on which learning resources are offered  * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
-   * @type {Array<'bootcamps' | 'canvas' | 'climate' | 'csail' | 'ctl' | 'edx' | 'emeritus' | 'globalalumni' | 'mitpe' | 'mitxonline' | 'ocw' | 'oll' | 'ovs' | 'podcast' | 'scc' | 'see' | 'simplilearn' | 'susskind' | 'whu' | 'xpro' | 'youtube'>}
+   * The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
+   * @type {Array<'edx' | 'ocw' | 'oll' | 'mitxonline' | 'bootcamps' | 'xpro' | 'csail' | 'mitpe' | 'see' | 'scc' | 'ctl' | 'whu' | 'susskind' | 'globalalumni' | 'simplilearn' | 'emeritus' | 'podcast' | 'youtube' | 'canvas' | 'climate' | 'ovs'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly platform?: Array<LearningResourcesSimilarListPlatformEnum>
@@ -18288,49 +18295,42 @@ export interface LearningResourcesApiLearningResourcesSimilarListRequest {
    * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
-  readonly professional?: boolean
+  readonly professional?: boolean | null
 
   /**
-   * A unique text identifier for the resources
-   * @type {Array<string>}
-   * @memberof LearningResourcesApiLearningResourcesSimilarList
-   */
-  readonly readable_id?: Array<string>
-
-  /**
-   * Comma-separated list of learning resource IDs
-   * @type {Array<number>}
-   * @memberof LearningResourcesApiLearningResourcesSimilarList
-   */
-  readonly resource_id?: Array<number>
-
-  /**
-   * The type of learning resource  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_path&#x60; - Learning Path * &#x60;podcast&#x60; - Podcast * &#x60;podcast_episode&#x60; - Podcast Episode * &#x60;video&#x60; - Video * &#x60;video_playlist&#x60; - Video Playlist * &#x60;document&#x60; - Document
-   * @type {Array<'course' | 'document' | 'learning_path' | 'podcast' | 'podcast_episode' | 'program' | 'video' | 'video_playlist'>}
+   * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
+   * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>
 
   /**
-   * The resource type group of the learning resources  * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-   * @type {Array<'course' | 'learning_material' | 'program'>}
+   * The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
+   * @type {Array<'course' | 'program' | 'learning_material'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>
 
   /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-   * @type {'-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | '-views' | 'id' | 'last_modified' | 'mitcoursenumber' | 'new' | 'readable_id' | 'start_date' | 'upcoming' | 'views'}
+   * Filter to learning resources where title is null/not null
+   * @type {boolean}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
-  readonly sortby?: LearningResourcesSimilarListSortbyEnum
+  readonly title__isnull?: boolean | null
 
   /**
-   * Topics covered by the resources. Load the \&#39;/api/v1/topics\&#39; endpoint for a list of topics
+   * The topic name. To see a list of options go to api/v1/topics/
    * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
    */
   readonly topic?: Array<string>
+
+  /**
+   * Filter to learning resources where url is null/not null
+   * @type {boolean}
+   * @memberof LearningResourcesApiLearningResourcesSimilarList
+   */
+  readonly url__isnull?: boolean | null
 }
 
 /**
@@ -18804,7 +18804,7 @@ export class LearningResourcesApi extends BaseAPI {
   }
 
   /**
-   * Fetch similar learning resources  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
+   * Fetch similar learning resources, optionally narrowed by filters.  Args: id (integer): The id of the learning resource  Returns: QuerySet of similar LearningResource for the resource matching the id parameter
    * @summary Get similar resources
    * @param {LearningResourcesApiLearningResourcesSimilarListRequest} requestParameters Request parameters.
    * @param {*} [options] Override http request option.
@@ -18826,15 +18826,15 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.free,
         requestParameters.level,
         requestParameters.limit,
+        requestParameters.ocw_topic,
         requestParameters.offered_by,
         requestParameters.platform,
         requestParameters.professional,
-        requestParameters.readable_id,
-        requestParameters.resource_id,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
-        requestParameters.sortby,
+        requestParameters.title__isnull,
         requestParameters.topic,
+        requestParameters.url__isnull,
         options,
       )
       .then((request) => request(this.axios, this.basePath))
@@ -19151,10 +19151,10 @@ export type LearningResourcesListSortbyEnum =
  * @export
  */
 export const LearningResourcesSimilarListCertificationTypeEnum = {
-  Completion: "completion",
   Micromasters: "micromasters",
-  None: "none",
   Professional: "professional",
+  Completion: "completion",
+  None: "none",
 } as const
 export type LearningResourcesSimilarListCertificationTypeEnum =
   (typeof LearningResourcesSimilarListCertificationTypeEnum)[keyof typeof LearningResourcesSimilarListCertificationTypeEnum]
@@ -19174,6 +19174,14 @@ export type LearningResourcesSimilarListDeliveryEnum =
  */
 export const LearningResourcesSimilarListDepartmentEnum = {
   _1: "1",
+  _2: "2",
+  _3: "3",
+  _4: "4",
+  _5: "5",
+  _6: "6",
+  _7: "7",
+  _8: "8",
+  _9: "9",
   _10: "10",
   _11: "11",
   _12: "12",
@@ -19182,7 +19190,6 @@ export const LearningResourcesSimilarListDepartmentEnum = {
   _16: "16",
   _17: "17",
   _18: "18",
-  _2: "2",
   _20: "20",
   _21A: "21A",
   _21G: "21G",
@@ -19191,13 +19198,6 @@ export const LearningResourcesSimilarListDepartmentEnum = {
   _21M: "21M",
   _22: "22",
   _24: "24",
-  _3: "3",
-  _4: "4",
-  _5: "5",
-  _6: "6",
-  _7: "7",
-  _8: "8",
-  _9: "9",
   Cc: "CC",
   CmsW: "CMS-W",
   Ec: "EC",
@@ -19217,13 +19217,13 @@ export type LearningResourcesSimilarListDepartmentEnum =
  * @export
  */
 export const LearningResourcesSimilarListLevelEnum = {
-  Advanced: "advanced",
+  Undergraduate: "undergraduate",
   Graduate: "graduate",
   HighSchool: "high_school",
+  Noncredit: "noncredit",
+  Advanced: "advanced",
   Intermediate: "intermediate",
   Introductory: "introductory",
-  Noncredit: "noncredit",
-  Undergraduate: "undergraduate",
 } as const
 export type LearningResourcesSimilarListLevelEnum =
   (typeof LearningResourcesSimilarListLevelEnum)[keyof typeof LearningResourcesSimilarListLevelEnum]
@@ -19231,13 +19231,13 @@ export type LearningResourcesSimilarListLevelEnum =
  * @export
  */
 export const LearningResourcesSimilarListOfferedByEnum = {
-  Bootcamps: "bootcamps",
-  Climate: "climate",
-  Mitpe: "mitpe",
   Mitx: "mitx",
   Ocw: "ocw",
-  See: "see",
+  Bootcamps: "bootcamps",
   Xpro: "xpro",
+  Mitpe: "mitpe",
+  See: "see",
+  Climate: "climate",
 } as const
 export type LearningResourcesSimilarListOfferedByEnum =
   (typeof LearningResourcesSimilarListOfferedByEnum)[keyof typeof LearningResourcesSimilarListOfferedByEnum]
@@ -19245,27 +19245,27 @@ export type LearningResourcesSimilarListOfferedByEnum =
  * @export
  */
 export const LearningResourcesSimilarListPlatformEnum = {
-  Bootcamps: "bootcamps",
-  Canvas: "canvas",
-  Climate: "climate",
-  Csail: "csail",
-  Ctl: "ctl",
   Edx: "edx",
-  Emeritus: "emeritus",
-  Globalalumni: "globalalumni",
-  Mitpe: "mitpe",
-  Mitxonline: "mitxonline",
   Ocw: "ocw",
   Oll: "oll",
-  Ovs: "ovs",
-  Podcast: "podcast",
-  Scc: "scc",
-  See: "see",
-  Simplilearn: "simplilearn",
-  Susskind: "susskind",
-  Whu: "whu",
+  Mitxonline: "mitxonline",
+  Bootcamps: "bootcamps",
   Xpro: "xpro",
+  Csail: "csail",
+  Mitpe: "mitpe",
+  See: "see",
+  Scc: "scc",
+  Ctl: "ctl",
+  Whu: "whu",
+  Susskind: "susskind",
+  Globalalumni: "globalalumni",
+  Simplilearn: "simplilearn",
+  Emeritus: "emeritus",
+  Podcast: "podcast",
   Youtube: "youtube",
+  Canvas: "canvas",
+  Climate: "climate",
+  Ovs: "ovs",
 } as const
 export type LearningResourcesSimilarListPlatformEnum =
   (typeof LearningResourcesSimilarListPlatformEnum)[keyof typeof LearningResourcesSimilarListPlatformEnum]
@@ -19274,13 +19274,13 @@ export type LearningResourcesSimilarListPlatformEnum =
  */
 export const LearningResourcesSimilarListResourceTypeEnum = {
   Course: "course",
-  Document: "document",
+  Program: "program",
   LearningPath: "learning_path",
   Podcast: "podcast",
   PodcastEpisode: "podcast_episode",
-  Program: "program",
   Video: "video",
   VideoPlaylist: "video_playlist",
+  Document: "document",
 } as const
 export type LearningResourcesSimilarListResourceTypeEnum =
   (typeof LearningResourcesSimilarListResourceTypeEnum)[keyof typeof LearningResourcesSimilarListResourceTypeEnum]
@@ -19289,32 +19289,11 @@ export type LearningResourcesSimilarListResourceTypeEnum =
  */
 export const LearningResourcesSimilarListResourceTypeGroupEnum = {
   Course: "course",
-  LearningMaterial: "learning_material",
   Program: "program",
+  LearningMaterial: "learning_material",
 } as const
 export type LearningResourcesSimilarListResourceTypeGroupEnum =
   (typeof LearningResourcesSimilarListResourceTypeGroupEnum)[keyof typeof LearningResourcesSimilarListResourceTypeGroupEnum]
-/**
- * @export
- */
-export const LearningResourcesSimilarListSortbyEnum = {
-  Id: "-id",
-  LastModified: "-last_modified",
-  Mitcoursenumber: "-mitcoursenumber",
-  ReadableId: "-readable_id",
-  StartDate: "-start_date",
-  Views: "-views",
-  Id2: "id",
-  LastModified2: "last_modified",
-  Mitcoursenumber2: "mitcoursenumber",
-  New: "new",
-  ReadableId2: "readable_id",
-  StartDate2: "start_date",
-  Upcoming: "upcoming",
-  Views2: "views",
-} as const
-export type LearningResourcesSimilarListSortbyEnum =
-  (typeof LearningResourcesSimilarListSortbyEnum)[keyof typeof LearningResourcesSimilarListSortbyEnum]
 /**
  * @export
  */

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16814,11 +16814,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
-     * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {LearningResourcesVectorSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
      * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
@@ -16839,11 +16836,8 @@ export const LearningResourcesApiAxiosParamCreator = function (
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
-      readable_id?: Array<string>,
-      resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
-      sortby?: LearningResourcesVectorSimilarListSortbyEnum,
       title__isnull?: boolean | null,
       topic?: Array<string>,
       url__isnull?: boolean | null,
@@ -16919,24 +16913,12 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (readable_id) {
-        localVarQueryParameter["readable_id"] = readable_id
-      }
-
-      if (resource_id) {
-        localVarQueryParameter["resource_id"] = resource_id
-      }
-
       if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
 
       if (resource_type_group) {
         localVarQueryParameter["resource_type_group"] = resource_type_group
-      }
-
-      if (sortby !== undefined) {
-        localVarQueryParameter["sortby"] = sortby
       }
 
       if (title__isnull !== undefined) {
@@ -17530,11 +17512,8 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
-     * @param {Array<string>} [readable_id] A unique text identifier for the resources
-     * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
-     * @param {LearningResourcesVectorSimilarListSortbyEnum} [sortby] Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
      * @param {boolean | null} [title__isnull] Filter to learning resources where title is null/not null
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
      * @param {boolean | null} [url__isnull] Filter to learning resources where url is null/not null
@@ -17555,11 +17534,8 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
-      readable_id?: Array<string>,
-      resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
-      sortby?: LearningResourcesVectorSimilarListSortbyEnum,
       title__isnull?: boolean | null,
       topic?: Array<string>,
       url__isnull?: boolean | null,
@@ -17585,11 +17561,8 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           offered_by,
           platform,
           professional,
-          readable_id,
-          resource_id,
           resource_type,
           resource_type_group,
-          sortby,
           title__isnull,
           topic,
           url__isnull,
@@ -17893,11 +17866,8 @@ export const LearningResourcesApiFactory = function (
           requestParameters.offered_by,
           requestParameters.platform,
           requestParameters.professional,
-          requestParameters.readable_id,
-          requestParameters.resource_id,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
-          requestParameters.sortby,
           requestParameters.title__isnull,
           requestParameters.topic,
           requestParameters.url__isnull,
@@ -18622,20 +18592,6 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly professional?: boolean | null
 
   /**
-   * A unique text identifier for the resources
-   * @type {Array<string>}
-   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
-   */
-  readonly readable_id?: Array<string>
-
-  /**
-   * Comma-separated list of learning resource IDs
-   * @type {Array<number>}
-   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
-   */
-  readonly resource_id?: Array<number>
-
-  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
@@ -18648,13 +18604,6 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
   readonly resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>
-
-  /**
-   * Sort By  * &#x60;id&#x60; - Object ID ascending * &#x60;-id&#x60; - Object ID descending * &#x60;readable_id&#x60; - Readable ID ascending * &#x60;-readable_id&#x60; - Readable ID descending * &#x60;last_modified&#x60; - Last Modified Date ascending * &#x60;-last_modified&#x60; - Last Modified Date descending * &#x60;new&#x60; - Newest resources first * &#x60;start_date&#x60; - Start Date ascending * &#x60;-start_date&#x60; - Start Date descending * &#x60;mitcoursenumber&#x60; - MIT course number ascending * &#x60;-mitcoursenumber&#x60; - MIT course number descending * &#x60;views&#x60; - Popularity ascending * &#x60;-views&#x60; - Popularity descending * &#x60;upcoming&#x60; - Next start date ascending
-   * @type {'-id' | '-last_modified' | '-mitcoursenumber' | '-readable_id' | '-start_date' | '-views' | 'id' | 'last_modified' | 'mitcoursenumber' | 'new' | 'readable_id' | 'start_date' | 'upcoming' | 'views'}
-   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
-   */
-  readonly sortby?: LearningResourcesVectorSimilarListSortbyEnum
 
   /**
    * Filter to learning resources where title is null/not null
@@ -18977,11 +18926,8 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.offered_by,
         requestParameters.platform,
         requestParameters.professional,
-        requestParameters.readable_id,
-        requestParameters.resource_id,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
-        requestParameters.sortby,
         requestParameters.title__isnull,
         requestParameters.topic,
         requestParameters.url__isnull,
@@ -19684,27 +19630,6 @@ export const LearningResourcesVectorSimilarListResourceTypeGroupEnum = {
 } as const
 export type LearningResourcesVectorSimilarListResourceTypeGroupEnum =
   (typeof LearningResourcesVectorSimilarListResourceTypeGroupEnum)[keyof typeof LearningResourcesVectorSimilarListResourceTypeGroupEnum]
-/**
- * @export
- */
-export const LearningResourcesVectorSimilarListSortbyEnum = {
-  Id: "-id",
-  LastModified: "-last_modified",
-  Mitcoursenumber: "-mitcoursenumber",
-  ReadableId: "-readable_id",
-  StartDate: "-start_date",
-  Views: "-views",
-  Id2: "id",
-  LastModified2: "last_modified",
-  Mitcoursenumber2: "mitcoursenumber",
-  New: "new",
-  ReadableId2: "readable_id",
-  StartDate2: "start_date",
-  Upcoming: "upcoming",
-  Views2: "views",
-} as const
-export type LearningResourcesVectorSimilarListSortbyEnum =
-  (typeof LearningResourcesVectorSimilarListSortbyEnum)[keyof typeof LearningResourcesVectorSimilarListSortbyEnum]
 
 /**
  * LearningResourcesSearchApi - axios parameter creator

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16814,7 +16814,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
-     * @param {string} [readable_id] The readable id of the resource
+     * @param {Array<string>} [readable_id] A unique text identifier for the resources
      * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
@@ -16839,7 +16839,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
-      readable_id?: string,
+      readable_id?: Array<string>,
       resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
@@ -16919,7 +16919,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
         localVarQueryParameter["professional"] = professional
       }
 
-      if (readable_id !== undefined) {
+      if (readable_id) {
         localVarQueryParameter["readable_id"] = readable_id
       }
 
@@ -17530,7 +17530,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
-     * @param {string} [readable_id] The readable id of the resource
+     * @param {Array<string>} [readable_id] A unique text identifier for the resources
      * @param {Array<number>} [resource_id] Comma-separated list of learning resource IDs
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
@@ -17555,7 +17555,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
-      readable_id?: string,
+      readable_id?: Array<string>,
       resource_id?: Array<number>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
@@ -18622,11 +18622,11 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly professional?: boolean | null
 
   /**
-   * The readable id of the resource
-   * @type {string}
+   * A unique text identifier for the resources
+   * @type {Array<string>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
    */
-  readonly readable_id?: string
+  readonly readable_id?: Array<string>
 
   /**
    * Comma-separated list of learning resource IDs

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -110,7 +110,6 @@ from main.permissions import (
 )
 from main.utils import cache_page_for_all_users, cache_page_for_anonymous_users, chunks
 from vector_search.serializers import LearningResourcesSearchFiltersSerializer
-from vector_search.utils import qdrant_query_conditions
 
 
 def show_content_file_content(user):
@@ -208,7 +207,7 @@ class LearningResourceViewSet(
 
     @property
     def filter_backends(self):
-        if self.action == "vector_similar":
+        if self.action in ("similar", "vector_similar"):
             return []
         return super().filter_backends
 
@@ -217,6 +216,7 @@ class LearningResourceViewSet(
         parameters=[
             OpenApiParameter(name="id", type=int, location=OpenApiParameter.PATH),
             OpenApiParameter(name="limit", type=int, location=OpenApiParameter.QUERY),
+            LearningResourcesSearchFiltersSerializer,
         ],
         responses=LearningResourceSerializer(many=True),
     )
@@ -233,7 +233,7 @@ class LearningResourceViewSet(
     )
     def similar(self, request, *_, **kwargs):
         """
-        Fetch similar learning resources
+        Fetch similar learning resources, optionally narrowed by filters.
 
         Args:
         id (integer): The id of the learning resource
@@ -243,13 +243,25 @@ class LearningResourceViewSet(
         """
         limit = int(request.GET.get("limit", 12))
         pk = int(kwargs.get("id"))
+        filter_serializer = LearningResourcesSearchFiltersSerializer(data=request.GET)
+        filter_serializer.is_valid(raise_exception=True)
+        filter_params = {
+            k: v
+            for k, v in filter_serializer.validated_data.items()
+            if v not in (None, [], "")
+        }
         learning_resource = get_object_or_404(LearningResource, id=pk)
         learning_resource = LearningResource.objects.for_search_serialization().get(
             id=pk
         )
         resource_data = serialize_learning_resource_for_update(learning_resource)
         similar = get_similar_resources(
-            resource_data, limit, 2, 3, use_embeddings=False
+            resource_data,
+            limit,
+            2,
+            3,
+            use_embeddings=False,
+            filter_params=filter_params,
         )
         return Response(LearningResourceSerializer(list(similar), many=True).data)
 
@@ -295,7 +307,6 @@ class LearningResourceViewSet(
             for k, v in filter_serializer.validated_data.items()
             if v not in (None, [], "")
         }
-        query_filter = qdrant_query_conditions(filter_params) if filter_params else None
 
         try:
             learning_resource = LearningResource.objects.for_search_serialization().get(
@@ -312,7 +323,7 @@ class LearningResourceViewSet(
                 2,
                 3,
                 use_embeddings=True,
-                query_filter=query_filter,
+                filter_params=filter_params,
             )
             return Response(LearningResourceSerializer(list(similar), many=True).data)
         except _InactiveRpcError as ircp:

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -131,6 +131,10 @@ def show_content_file_content(user):
 log = logging.getLogger(__name__)
 
 
+def _clean_filter_params(params: dict) -> dict:
+    return {k: v for k, v in params.items() if v not in (None, [], "")}
+
+
 @extend_schema_view(
     list=extend_schema(
         summary="List",
@@ -245,11 +249,7 @@ class LearningResourceViewSet(
         pk = int(kwargs.get("id"))
         filter_serializer = LearningResourcesSearchFiltersSerializer(data=request.GET)
         filter_serializer.is_valid(raise_exception=True)
-        filter_params = {
-            k: v
-            for k, v in filter_serializer.validated_data.items()
-            if v not in (None, [], "")
-        }
+        filter_params = _clean_filter_params(filter_serializer.validated_data)
         learning_resource = get_object_or_404(LearningResource, id=pk)
         learning_resource = LearningResource.objects.for_search_serialization().get(
             id=pk
@@ -302,11 +302,7 @@ class LearningResourceViewSet(
 
         filter_serializer = LearningResourcesSearchFiltersSerializer(data=request.GET)
         filter_serializer.is_valid(raise_exception=True)
-        filter_params = {
-            k: v
-            for k, v in filter_serializer.validated_data.items()
-            if v not in (None, [], "")
-        }
+        filter_params = _clean_filter_params(filter_serializer.validated_data)
 
         try:
             learning_resource = LearningResource.objects.for_search_serialization().get(

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -206,6 +206,12 @@ class LearningResourceViewSet(
     resource_type_name_plural = "Learning Resources"
     serializer_class = LearningResourceSerializer
 
+    @property
+    def filter_backends(self):
+        if self.action == "vector_similar":
+            return []
+        return super().filter_backends
+
     @extend_schema(
         summary="Get similar resources",
         parameters=[

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -109,6 +109,8 @@ from main.permissions import (
     is_admin_user,
 )
 from main.utils import cache_page_for_all_users, cache_page_for_anonymous_users, chunks
+from vector_search.serializers import LearningResourcesSearchFiltersSerializer
+from vector_search.utils import qdrant_query_conditions
 
 
 def show_content_file_content(user):
@@ -250,6 +252,7 @@ class LearningResourceViewSet(
         parameters=[
             OpenApiParameter(name="id", type=int, location=OpenApiParameter.PATH),
             OpenApiParameter(name="limit", type=int, location=OpenApiParameter.QUERY),
+            LearningResourcesSearchFiltersSerializer,
         ],
         responses=LearningResourceSerializer(many=True),
     )
@@ -268,7 +271,7 @@ class LearningResourceViewSet(
     )
     def vector_similar(self, request, *_, **kwargs):
         """
-        Fetch similar learning resources
+        Fetch similar learning resources, optionally narrowed by Qdrant filters.
 
         Args:
         id (integer): The id of the learning resource
@@ -278,6 +281,15 @@ class LearningResourceViewSet(
         """
         limit = int(request.GET.get("limit", 12))
         pk = int(kwargs.get("id"))
+
+        filter_serializer = LearningResourcesSearchFiltersSerializer(data=request.GET)
+        filter_serializer.is_valid(raise_exception=True)
+        filter_params = {
+            k: v
+            for k, v in filter_serializer.validated_data.items()
+            if v not in (None, [], "")
+        }
+        query_filter = qdrant_query_conditions(filter_params) if filter_params else None
 
         try:
             learning_resource = LearningResource.objects.for_search_serialization().get(
@@ -289,7 +301,12 @@ class LearningResourceViewSet(
         resource_data = serialize_learning_resource_for_update(learning_resource)
         try:
             similar = get_similar_resources(
-                resource_data, limit, 2, 3, use_embeddings=True
+                resource_data,
+                limit,
+                2,
+                3,
+                use_embeddings=True,
+                query_filter=query_filter,
             )
             return Response(LearningResourceSerializer(list(similar), many=True).data)
         except _InactiveRpcError as ircp:

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -250,9 +250,9 @@ class LearningResourceViewSet(
         filter_serializer = LearningResourcesSearchFiltersSerializer(data=request.GET)
         filter_serializer.is_valid(raise_exception=True)
         filter_params = _clean_filter_params(filter_serializer.validated_data)
-        learning_resource = get_object_or_404(LearningResource, id=pk)
-        learning_resource = LearningResource.objects.for_search_serialization().get(
-            id=pk
+        learning_resource = get_object_or_404(
+            LearningResource.objects.for_search_serialization(),
+            id=pk,
         )
         resource_data = serialize_learning_resource_for_update(learning_resource)
         similar = get_similar_resources(

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1405,6 +1405,34 @@ def test_vector_similar_no_filter_passes_none(mocker, client):
 
 
 @pytest.mark.skip_nplusone_check
+def test_similar_passes_filter_params_to_opensearch(mocker, client):
+    """resource_type query param is forwarded as filter_params to the OpenSearch path"""
+    resource = LearningResourceFactory.create()
+    mock_similar = mocker.patch(
+        "learning_resources_search.api.get_similar_resources_opensearch",
+        return_value=[],
+    )
+    client.get(
+        reverse("lr:v1:learning_resources_api-similar", args=[resource.id]),
+        {"resource_type": "video_playlist"},
+    )
+    assert mock_similar.call_args.kwargs["filter_params"] == {
+        "resource_type": ["video_playlist"]
+    }
+
+
+@pytest.mark.skip_nplusone_check
+def test_similar_rejects_invalid_resource_type(client):
+    """Unknown resource_type value returns 400 on the OpenSearch similarity endpoint"""
+    resource = LearningResourceFactory.create()
+    resp = client.get(
+        reverse("lr:v1:learning_resources_api-similar", args=[resource.id]),
+        {"resource_type": "not_a_real_type"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.skip_nplusone_check
 def test_learning_resources_display_info_list_view(mocker, client):
     """Test learning_resources_display_info_list_view returns expected results"""
     from learning_resources.models import LearningResource

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1319,6 +1319,92 @@ def test_vector_similar_resources_endpoint_only_returns_published(mocker, client
 
 
 @pytest.mark.skip_nplusone_check
+def test_vector_similar_passes_resource_type_filter_to_qdrant(mocker, client):
+    """resource_type query param is translated to a Qdrant filter"""
+    from qdrant_client import models as qdrant_models
+
+    from learning_resources.models import LearningResource
+
+    resources = LearningResourceFactory.create_batch(3)
+    similar_for = resources[0].id
+    mocker.patch(
+        "vector_search.utils.qdrant_client",
+        return_value=QdrantClient(
+            host="hidden_port_addr.com",
+            port=None,
+            prefix="custom",
+            check_compatibility=False,
+        ),
+    )
+    mock_similar = mocker.patch(
+        "learning_resources_search.api._qdrant_similar_results",
+        return_value=[
+            serialize_learning_resource_for_update(lr)
+            for lr in LearningResource.objects.for_search_serialization().filter(
+                id__in=[r.id for r in resources[1:]]
+            )
+        ],
+    )
+
+    client.get(
+        reverse("lr:v1:learning_resources_api-vector-similar", args=[similar_for]),
+        {"resource_type": "video_playlist"},
+    )
+
+    query_filter = mock_similar.call_args.kwargs["query_filter"]
+    assert query_filter is not None
+    assert any(
+        isinstance(c, qdrant_models.FieldCondition)
+        and c.key == "resource_type"
+        and c.match.any == ["video_playlist"]
+        for c in query_filter.must
+    )
+
+
+@pytest.mark.skip_nplusone_check
+def test_vector_similar_rejects_invalid_resource_type(mocker, client):
+    """Unknown resource_type value returns 400"""
+    resource = LearningResourceFactory.create()
+    mocker.patch(
+        "vector_search.utils.qdrant_client",
+        return_value=QdrantClient(
+            host="hidden_port_addr.com",
+            port=None,
+            prefix="custom",
+            check_compatibility=False,
+        ),
+    )
+    resp = client.get(
+        reverse("lr:v1:learning_resources_api-vector-similar", args=[resource.id]),
+        {"resource_type": "not_a_real_type"},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.skip_nplusone_check
+def test_vector_similar_no_filter_passes_none(mocker, client):
+    """Absence of filter params yields query_filter=None"""
+    resource = LearningResourceFactory.create()
+    mocker.patch(
+        "vector_search.utils.qdrant_client",
+        return_value=QdrantClient(
+            host="hidden_port_addr.com",
+            port=None,
+            prefix="custom",
+            check_compatibility=False,
+        ),
+    )
+    mock_similar = mocker.patch(
+        "learning_resources_search.api._qdrant_similar_results",
+        return_value=[],
+    )
+    client.get(
+        reverse("lr:v1:learning_resources_api-vector-similar", args=[resource.id])
+    )
+    assert mock_similar.call_args.kwargs["query_filter"] is None
+
+
+@pytest.mark.skip_nplusone_check
 def test_learning_resources_display_info_list_view(mocker, client):
     """Test learning_resources_display_info_list_view returns expected results"""
     from learning_resources.models import LearningResource

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1432,6 +1432,22 @@ def test_similar_rejects_invalid_resource_type(client):
     assert resp.status_code == 400
 
 
+@pytest.mark.parametrize(("free_value", "expected"), [("true", True), ("false", False)])
+@pytest.mark.skip_nplusone_check
+def test_similar_boolean_filter_forwarded(mocker, client, free_value, expected):
+    """Boolean filter params (free=true/false) are forwarded correctly to the OpenSearch path"""
+    resource = LearningResourceFactory.create()
+    mock_similar = mocker.patch(
+        "learning_resources_search.api.get_similar_resources_opensearch",
+        return_value=[],
+    )
+    client.get(
+        reverse("lr:v1:learning_resources_api-similar", args=[resource.id]),
+        {"free": free_value},
+    )
+    assert mock_similar.call_args.kwargs["filter_params"] == {"free": expected}
+
+
 @pytest.mark.skip_nplusone_check
 def test_learning_resources_display_info_list_view(mocker, client):
     """Test learning_resources_display_info_list_view returns expected results"""

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1318,7 +1318,6 @@ def test_vector_similar_resources_endpoint_only_returns_published(mocker, client
     assert len(response_ids) == 1
 
 
-@pytest.mark.skip_nplusone_check
 def test_vector_similar_passes_resource_type_filter_to_qdrant(mocker, client):
     """resource_type query param is translated to a Qdrant filter"""
     from qdrant_client import models as qdrant_models
@@ -1361,7 +1360,6 @@ def test_vector_similar_passes_resource_type_filter_to_qdrant(mocker, client):
     )
 
 
-@pytest.mark.skip_nplusone_check
 def test_vector_similar_rejects_invalid_resource_type(mocker, client):
     """Unknown resource_type value returns 400"""
     resource = LearningResourceFactory.create()
@@ -1381,7 +1379,6 @@ def test_vector_similar_rejects_invalid_resource_type(mocker, client):
     assert resp.status_code == 400
 
 
-@pytest.mark.skip_nplusone_check
 def test_vector_similar_no_filter_passes_none(mocker, client):
     """Absence of filter params yields query_filter=None"""
     resource = LearningResourceFactory.create()
@@ -1404,7 +1401,6 @@ def test_vector_similar_no_filter_passes_none(mocker, client):
     assert mock_similar.call_args.kwargs["query_filter"] is None
 
 
-@pytest.mark.skip_nplusone_check
 def test_similar_passes_filter_params_to_opensearch(mocker, client):
     """resource_type query param is forwarded as filter_params to the OpenSearch path"""
     resource = LearningResourceFactory.create()
@@ -1421,7 +1417,6 @@ def test_similar_passes_filter_params_to_opensearch(mocker, client):
     }
 
 
-@pytest.mark.skip_nplusone_check
 def test_similar_rejects_invalid_resource_type(client):
     """Unknown resource_type value returns 400 on the OpenSearch similarity endpoint"""
     resource = LearningResourceFactory.create()
@@ -1433,7 +1428,6 @@ def test_similar_rejects_invalid_resource_type(client):
 
 
 @pytest.mark.parametrize(("free_value", "expected"), [("true", True), ("false", False)])
-@pytest.mark.skip_nplusone_check
 def test_similar_boolean_filter_forwarded(mocker, client, free_value, expected):
     """Boolean filter params (free=true/false) are forwarded correctly to the OpenSearch path"""
     resource = LearningResourceFactory.create()

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1079,12 +1079,13 @@ def get_similar_topics(
     return list(dict(counter.most_common(num_topics)).keys())
 
 
-def get_similar_resources(
+def get_similar_resources(  # noqa: PLR0913
     value_doc: dict,
     num_resources: int,
     min_term_freq: int,
     min_doc_freq: int,
     use_embeddings,
+    query_filter=None,
 ) -> list[str]:
     """
     Get a list of similar resources based on another resource
@@ -1100,13 +1101,17 @@ def get_similar_resources(
             minimum times a term needs to show up in docs
         use_embeddings (bool):
             use vector embeddings to retrieve results
+        query_filter:
+            optional Qdrant filter (qdrant path only); ignored for opensearch
 
     Returns:
         list of str:
             list of topic values
     """
     if use_embeddings:
-        return get_similar_resources_qdrant(value_doc, num_resources)
+        return get_similar_resources_qdrant(
+            value_doc, num_resources, query_filter=query_filter
+        )
     return get_similar_resources_opensearch(
         value_doc, num_resources, min_term_freq, min_doc_freq
     )
@@ -1117,15 +1122,22 @@ def _qdrant_similar_results(
     num_resources=6,
     collection_name=RESOURCES_COLLECTION_NAME,
     score_threshold=0,
+    query_filter=None,
 ):
     """
     Get similar resources from qdrant
 
     Args:
-        doc (dict):
-            a document representing the data fields we want to search with
+        input_query:
+            point id to query with
         num_resources (int):
             number of resources to return
+        collection_name (str):
+            qdrant collection name
+        score_threshold (float):
+            minimum similarity score
+        query_filter:
+            optional Qdrant filter to apply alongside the similarity search
 
     Returns:
         list of dict:
@@ -1145,11 +1157,14 @@ def _qdrant_similar_results(
             limit=num_resources,
             using=encoder.model_short_name(),
             score_threshold=score_threshold,
+            query_filter=query_filter,
         ).points
     ]
 
 
-def get_similar_resources_qdrant(value_doc: dict, num_resources: int):
+def get_similar_resources_qdrant(
+    value_doc: dict, num_resources: int, query_filter=None
+):
     """
     Get a list of similar resources from qdrant
 
@@ -1158,6 +1173,8 @@ def get_similar_resources_qdrant(value_doc: dict, num_resources: int):
             a document representing the data fields we want to search with
         num_resources (int):
             number of resources to return
+        query_filter:
+            optional Qdrant filter to narrow the similarity search
 
     Returns:
         list of str:
@@ -1168,6 +1185,7 @@ def get_similar_resources_qdrant(value_doc: dict, num_resources: int):
     hits = _qdrant_similar_results(
         input_query=vector_point_id(vector_point_key(value_doc)),
         num_resources=num_resources,
+        query_filter=query_filter,
     )
     return (
         LearningResource.objects.for_search_serialization()

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1258,9 +1258,15 @@ def get_similar_resources_opensearch(
         k: [v] if isinstance(v, bool) else v for k, v in (filter_params or {}).items()
     }
     filter_clauses = generate_filter_clauses(normalized_params)
-    filters = [{"exists": {"field": "resource_type"}}, *filter_clauses.values()]
+    # Wrap all filters in a bool/must so opensearch-dsl serializes them as a
+    # single AND'd filter dict rather than a bare list (which it may not handle).
+    combined_filter = {
+        "bool": {
+            "must": [{"exists": {"field": "resource_type"}}, *filter_clauses.values()]
+        }
+    }
     # return only learning_resources
-    search = search.query("bool", must=[mlt_query], filter=filters)
+    search = search.query("bool", must=[mlt_query], filter=combined_filter)
     response = search.execute()
     return LearningResource.objects.for_search_serialization().filter(
         id__in=[

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1252,7 +1252,12 @@ def get_similar_resources_opensearch(
         min_term_freq=min_term_freq,
         min_doc_freq=min_doc_freq,
     )
-    filter_clauses = generate_filter_clauses(filter_params or {})
+    # generate_filter_clauses expects list values; scalar booleans (from
+    # ArrayWrappedBoolean validated_data) must be wrapped before iterating.
+    normalized_params = {
+        k: [v] if isinstance(v, bool) else v for k, v in (filter_params or {}).items()
+    }
+    filter_clauses = generate_filter_clauses(normalized_params)
     filters = [{"exists": {"field": "resource_type"}}, *filter_clauses.values()]
     # return only learning_resources
     search = search.query("bool", must=[mlt_query], filter=filters)

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -6,6 +6,7 @@ from collections import Counter
 from datetime import UTC, datetime
 
 from django.conf import settings
+from django.db.models import QuerySet
 from opensearch_dsl import Search
 from opensearch_dsl.query import MoreLikeThis, Percolate
 from opensearchpy.exceptions import NotFoundError
@@ -1086,7 +1087,7 @@ def get_similar_resources(  # noqa: PLR0913
     min_doc_freq: int,
     use_embeddings,
     filter_params=None,
-) -> list[str]:
+) -> QuerySet[LearningResource]:
     """
     Get a list of similar resources based on another resource
 
@@ -1106,8 +1107,8 @@ def get_similar_resources(  # noqa: PLR0913
             backend translates these to its own filter format
 
     Returns:
-        list of str:
-            list of learning resources
+        QuerySet[LearningResource]:
+            queryset of learning resources
     """
     if use_embeddings:
         return get_similar_resources_qdrant(
@@ -1134,7 +1135,8 @@ def _qdrant_similar_results(
 
     Args:
         input_query:
-            point id to query with
+            query input for Qdrant similarity search; may be either a point id
+            or a raw embedding vector, depending on the caller
         num_resources (int):
             number of resources to return
         collection_name (str):
@@ -1169,7 +1171,7 @@ def _qdrant_similar_results(
 
 def get_similar_resources_qdrant(
     value_doc: dict, num_resources: int, filter_params=None
-):
+) -> QuerySet[LearningResource]:
     """
     Get a list of similar resources from qdrant
 
@@ -1214,7 +1216,7 @@ def get_similar_resources_opensearch(
     min_term_freq: int,
     min_doc_freq: int,
     filter_params=None,
-) -> list[str]:
+) -> QuerySet[LearningResource]:
     """
     Get a list of similar resources from opensearch
 

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -1085,7 +1085,7 @@ def get_similar_resources(  # noqa: PLR0913
     min_term_freq: int,
     min_doc_freq: int,
     use_embeddings,
-    query_filter=None,
+    filter_params=None,
 ) -> list[str]:
     """
     Get a list of similar resources based on another resource
@@ -1093,7 +1093,7 @@ def get_similar_resources(  # noqa: PLR0913
     Args:
         value_doc (dict):
             a document representing the data fields we want to search with
-        num_topics (int):
+        num_resources (int):
             number of resources to return
         min_term_freq (int):
             minimum times a term needs to show up in input
@@ -1101,19 +1101,24 @@ def get_similar_resources(  # noqa: PLR0913
             minimum times a term needs to show up in docs
         use_embeddings (bool):
             use vector embeddings to retrieve results
-        query_filter:
-            optional Qdrant filter (qdrant path only); ignored for opensearch
+        filter_params (dict):
+            optional filter parameters (validated serializer data); each
+            backend translates these to its own filter format
 
     Returns:
         list of str:
-            list of topic values
+            list of learning resources
     """
     if use_embeddings:
         return get_similar_resources_qdrant(
-            value_doc, num_resources, query_filter=query_filter
+            value_doc, num_resources, filter_params=filter_params
         )
     return get_similar_resources_opensearch(
-        value_doc, num_resources, min_term_freq, min_doc_freq
+        value_doc,
+        num_resources,
+        min_term_freq,
+        min_doc_freq,
+        filter_params=filter_params,
     )
 
 
@@ -1163,7 +1168,7 @@ def _qdrant_similar_results(
 
 
 def get_similar_resources_qdrant(
-    value_doc: dict, num_resources: int, query_filter=None
+    value_doc: dict, num_resources: int, filter_params=None
 ):
     """
     Get a list of similar resources from qdrant
@@ -1173,15 +1178,20 @@ def get_similar_resources_qdrant(
             a document representing the data fields we want to search with
         num_resources (int):
             number of resources to return
-        query_filter:
-            optional Qdrant filter to narrow the similarity search
+        filter_params (dict):
+            optional filter parameters (validated serializer data) to narrow
+            the similarity search
 
     Returns:
-        list of str:
-            list of learning resources
+        list of learning resources
     """
-    from vector_search.utils import vector_point_id, vector_point_key
+    from vector_search.utils import (
+        qdrant_query_conditions,
+        vector_point_id,
+        vector_point_key,
+    )
 
+    query_filter = qdrant_query_conditions(filter_params) if filter_params else None
     hits = _qdrant_similar_results(
         input_query=vector_point_id(vector_point_key(value_doc)),
         num_resources=num_resources,
@@ -1199,7 +1209,11 @@ def get_similar_resources_qdrant(
 
 
 def get_similar_resources_opensearch(
-    value_doc: dict, num_resources: int, min_term_freq: int, min_doc_freq: int
+    value_doc: dict,
+    num_resources: int,
+    min_term_freq: int,
+    min_doc_freq: int,
+    filter_params=None,
 ) -> list[str]:
     """
     Get a list of similar resources from opensearch
@@ -1207,16 +1221,18 @@ def get_similar_resources_opensearch(
     Args:
         value_doc (dict):
             a document representing the data fields we want to search with
-        num_topics (int):
+        num_resources (int):
             number of resources to return
         min_term_freq (int):
             minimum times a term needs to show up in input
         min_doc_freq (int):
             minimum times a term needs to show up in docs
+        filter_params (dict):
+            optional filter parameters (validated serializer data) to narrow
+            the similarity search
 
     Returns:
-        list of str:
-            list of learning resources
+        list of learning resources
     """
     indexes = relevant_indexes(
         LEARNING_RESOURCE_TYPES, [], endpoint=LEARNING_RESOURCE, use_hybrid_search=False
@@ -1236,10 +1252,10 @@ def get_similar_resources_opensearch(
         min_term_freq=min_term_freq,
         min_doc_freq=min_doc_freq,
     )
+    filter_clauses = generate_filter_clauses(filter_params or {})
+    filters = [{"exists": {"field": "resource_type"}}, *filter_clauses.values()]
     # return only learning_resources
-    search = search.query(
-        "bool", must=[mlt_query], filter={"exists": {"field": "resource_type"}}
-    )
+    search = search.query("bool", must=[mlt_query], filter=filters)
     response = search.execute()
     return LearningResource.objects.for_search_serialization().filter(
         id__in=[

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -4524,3 +4524,42 @@ def test_get_similar_resources_opensearch_passes_filter_params(mocker):
         }
         for f in filters
     )
+
+
+@pytest.mark.parametrize("free_value", [True, False])
+def test_get_similar_resources_opensearch_boolean_filter(mocker, free_value):
+    """Scalar boolean filter_params are normalized to lists before generate_filter_clauses"""
+    from learning_resources_search.api import get_similar_resources_opensearch
+
+    mock_search = mocker.MagicMock()
+    mock_search.extra.return_value = mock_search
+    mock_search.query.return_value = mock_search
+    mock_search.execute.return_value = mocker.MagicMock(hits=[])
+    mocker.patch("learning_resources_search.api.Search", return_value=mock_search)
+    mocker.patch(
+        "learning_resources_search.api.relevant_indexes", return_value=["index"]
+    )
+
+    # Should not raise TypeError from iterating a scalar bool,
+    # and False must not be skipped by the truthiness check.
+    get_similar_resources_opensearch(
+        value_doc={"id": 1, "readable_id": "abc"},
+        num_resources=5,
+        min_term_freq=2,
+        min_doc_freq=3,
+        filter_params={"free": free_value},
+    )
+
+    _, kwargs = mock_search.query.call_args
+    filters = kwargs["filter"]
+    assert any(
+        f
+        == {
+            "bool": {
+                "should": [
+                    {"term": {"free": {"value": free_value, "case_insensitive": True}}}
+                ]
+            }
+        }
+        for f in filters
+    )

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -4505,7 +4505,7 @@ def test_get_similar_resources_opensearch_passes_filter_params(mocker):
     )
 
     _, kwargs = mock_search.query.call_args
-    filters = kwargs["filter"]
+    must_clauses = kwargs["filter"]["bool"]["must"]
     assert any(
         f
         == {
@@ -4522,7 +4522,7 @@ def test_get_similar_resources_opensearch_passes_filter_params(mocker):
                 ]
             }
         }
-        for f in filters
+        for f in must_clauses
     )
 
 
@@ -4551,7 +4551,7 @@ def test_get_similar_resources_opensearch_boolean_filter(mocker, free_value):
     )
 
     _, kwargs = mock_search.query.call_args
-    filters = kwargs["filter"]
+    must_clauses = kwargs["filter"]["bool"]["must"]
     assert any(
         f
         == {
@@ -4561,5 +4561,5 @@ def test_get_similar_resources_opensearch_boolean_filter(mocker, free_value):
                 ]
             }
         }
-        for f in filters
+        for f in must_clauses
     )

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -4460,3 +4460,20 @@ def test_get_similar_topics_qdrant_uses_cached_embedding(mocker):
     encoder_instance.embed.assert_not_called()
     # Assert that the result is as expected
     assert result == ["topic1", "topic2"]
+
+
+def test_get_similar_resources_qdrant_passes_query_filter(mocker):
+    """query_filter argument is forwarded to _qdrant_similar_results"""
+    from learning_resources_search.api import get_similar_resources_qdrant
+
+    mock_similar = mocker.patch(
+        "learning_resources_search.api._qdrant_similar_results",
+        return_value=[],
+    )
+    sentinel_filter = object()
+    get_similar_resources_qdrant(
+        value_doc={"id": 1, "readable_id": "abc", "platform": {"code": "ocw"}},
+        num_resources=5,
+        query_filter=sentinel_filter,
+    )
+    assert mock_similar.call_args.kwargs["query_filter"] is sentinel_filter

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -4462,8 +4462,8 @@ def test_get_similar_topics_qdrant_uses_cached_embedding(mocker):
     assert result == ["topic1", "topic2"]
 
 
-def test_get_similar_resources_qdrant_passes_query_filter(mocker):
-    """query_filter argument is forwarded to _qdrant_similar_results"""
+def test_get_similar_resources_qdrant_passes_filter_params(mocker):
+    """filter_params are translated to a Qdrant filter and forwarded to _qdrant_similar_results"""
     from learning_resources_search.api import get_similar_resources_qdrant
 
     mock_similar = mocker.patch(
@@ -4471,9 +4471,56 @@ def test_get_similar_resources_qdrant_passes_query_filter(mocker):
         return_value=[],
     )
     sentinel_filter = object()
+    mocker.patch(
+        "vector_search.utils.qdrant_query_conditions",
+        return_value=sentinel_filter,
+    )
     get_similar_resources_qdrant(
         value_doc={"id": 1, "readable_id": "abc", "platform": {"code": "ocw"}},
         num_resources=5,
-        query_filter=sentinel_filter,
+        filter_params={"resource_type": ["video_playlist"]},
     )
     assert mock_similar.call_args.kwargs["query_filter"] is sentinel_filter
+
+
+def test_get_similar_resources_opensearch_passes_filter_params(mocker):
+    """filter_params are translated to OpenSearch clauses via generate_filter_clauses"""
+    from learning_resources_search.api import get_similar_resources_opensearch
+
+    mock_search = mocker.MagicMock()
+    mock_search.extra.return_value = mock_search
+    mock_search.query.return_value = mock_search
+    mock_search.execute.return_value = mocker.MagicMock(hits=[])
+    mocker.patch("learning_resources_search.api.Search", return_value=mock_search)
+    mocker.patch(
+        "learning_resources_search.api.relevant_indexes", return_value=["index"]
+    )
+
+    get_similar_resources_opensearch(
+        value_doc={"id": 1, "readable_id": "abc"},
+        num_resources=5,
+        min_term_freq=2,
+        min_doc_freq=3,
+        filter_params={"resource_type": ["video_playlist"]},
+    )
+
+    _, kwargs = mock_search.query.call_args
+    filters = kwargs["filter"]
+    assert any(
+        f
+        == {
+            "bool": {
+                "should": [
+                    {
+                        "term": {
+                            "resource_type": {
+                                "value": "video_playlist",
+                                "case_insensitive": True,
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        for f in filters
+    )

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2692,7 +2692,7 @@ paths:
     get:
       operationId: learning_resources_similar_list
       description: |-
-        Fetch similar learning resources
+        Fetch similar learning resources, optionally narrowed by filters.
 
         Args:
         id (integer): The id of the learning resource
@@ -2705,76 +2705,69 @@ paths:
         name: certification
         schema:
           type: boolean
+          nullable: true
+        description: True if the learning resource offers a certificate
       - in: query
         name: certification_type
         schema:
           type: array
           items:
-            type: string
             enum:
-            - completion
             - micromasters
-            - none
             - professional
-        description: |-
-          The type of certification offered
-
-          * `micromasters` - MicroMasters Credential
-          * `professional` - Professional Certificate
-          * `completion` - Certificate of Completion
-          * `none` - No Certificate
-        explode: true
-        style: form
+            - completion
+            - none
+            type: string
+            description: |-
+              * `micromasters` - MicroMasters Credential
+              * `professional` - Professional Certificate
+              * `completion` - Certificate of Completion
+              * `none` - No Certificate
+        description: "The type of certificate             \n\n* `micromasters` - MicroMasters\
+          \ Credential\n* `professional` - Professional Certificate\n* `completion`\
+          \ - Certificate of Completion\n* `none` - No Certificate"
       - in: query
         name: course_feature
         schema:
           type: array
           items:
             type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
-        explode: true
-        style: form
+            minLength: 1
+        description: The course feature. Possible options are at api/v1/course_features/
       - in: query
         name: delivery
         schema:
           type: array
           items:
-            type: array
-            items:
-              enum:
-              - online
-              - hybrid
-              - in_person
-              - offline
-              type: string
-              description: |-
-                * `online` - Online
-                * `hybrid` - Hybrid
-                * `in_person` - In person
-                * `offline` - Offline
             enum:
+            - online
             - hybrid
             - in_person
             - offline
-            - online
-        description: |-
-          The delivery of course/program resources
-
-          * `online` - Online
-          * `hybrid` - Hybrid
-          * `in_person` - In person
-          * `offline` - Offline
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `online` - Online
+              * `hybrid` - Hybrid
+              * `in_person` - In person
+              * `offline` - Offline
+        description: "The delivery options in which the learning resource is offered\
+          \             \n\n* `online` - Online\n* `hybrid` - Hybrid\n* `in_person`\
+          \ - In person\n* `offline` - Offline"
       - in: query
         name: department
         schema:
           type: array
           items:
-            type: string
             enum:
             - '1'
+            - '2'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
             - '10'
             - '11'
             - '12'
@@ -2783,7 +2776,6 @@ paths:
             - '16'
             - '17'
             - '18'
-            - '2'
             - '20'
             - 21A
             - 21G
@@ -2792,13 +2784,6 @@ paths:
             - 21M
             - '22'
             - '24'
-            - '3'
-            - '4'
-            - '5'
-            - '6'
-            - '7'
-            - '8'
-            - '9'
             - CC
             - CMS-W
             - EC
@@ -2811,53 +2796,68 @@ paths:
             - SP
             - STS
             - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Medical Engineering and Science
-          * `IDS` - Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `SP` - Special Programs
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `1` - Civil and Environmental Engineering
+              * `2` - Mechanical Engineering
+              * `3` - Materials Science and Engineering
+              * `4` - Architecture
+              * `5` - Chemistry
+              * `6` - Electrical Engineering and Computer Science
+              * `7` - Biology
+              * `8` - Physics
+              * `9` - Brain and Cognitive Sciences
+              * `10` - Chemical Engineering
+              * `11` - Urban Studies and Planning
+              * `12` - Earth, Atmospheric, and Planetary Sciences
+              * `14` - Economics
+              * `15` - Management
+              * `16` - Aeronautics and Astronautics
+              * `17` - Political Science
+              * `18` - Mathematics
+              * `20` - Biological Engineering
+              * `21A` - Anthropology
+              * `21G` - Global Languages
+              * `21H` - History
+              * `21L` - Literature
+              * `21M` - Music and Theater Arts
+              * `22` - Nuclear Science and Engineering
+              * `24` - Linguistics and Philosophy
+              * `CC` - Concourse
+              * `CMS-W` - Comparative Media Studies/Writing
+              * `EC` - Edgerton Center
+              * `ES` - Experimental Study Group
+              * `ESD` - Engineering Systems Division
+              * `HST` - Medical Engineering and Science
+              * `IDS` - Data, Systems, and Society
+              * `MAS` - Media Arts and Sciences
+              * `PE` - Athletics, Physical Education and Recreation
+              * `SP` - Special Programs
+              * `STS` - Science, Technology, and Society
+              * `WGS` - Women's and Gender Studies
+        description: "The department that offers the learning resource           \
+          \  \n\n* `1` - Civil and Environmental Engineering\n* `2` - Mechanical Engineering\n\
+          * `3` - Materials Science and Engineering\n* `4` - Architecture\n* `5` -\
+          \ Chemistry\n* `6` - Electrical Engineering and Computer Science\n* `7`\
+          \ - Biology\n* `8` - Physics\n* `9` - Brain and Cognitive Sciences\n* `10`\
+          \ - Chemical Engineering\n* `11` - Urban Studies and Planning\n* `12` -\
+          \ Earth, Atmospheric, and Planetary Sciences\n* `14` - Economics\n* `15`\
+          \ - Management\n* `16` - Aeronautics and Astronautics\n* `17` - Political\
+          \ Science\n* `18` - Mathematics\n* `20` - Biological Engineering\n* `21A`\
+          \ - Anthropology\n* `21G` - Global Languages\n* `21H` - History\n* `21L`\
+          \ - Literature\n* `21M` - Music and Theater Arts\n* `22` - Nuclear Science\
+          \ and Engineering\n* `24` - Linguistics and Philosophy\n* `CC` - Concourse\n\
+          * `CMS-W` - Comparative Media Studies/Writing\n* `EC` - Edgerton Center\n\
+          * `ES` - Experimental Study Group\n* `ESD` - Engineering Systems Division\n\
+          * `HST` - Medical Engineering and Science\n* `IDS` - Data, Systems, and\
+          \ Society\n* `MAS` - Media Arts and Sciences\n* `PE` - Athletics, Physical\
+          \ Education and Recreation\n* `SP` - Special Programs\n* `STS` - Science,\
+          \ Technology, and Society\n* `WGS` - Women's and Gender Studies"
       - in: query
         name: free
         schema:
           type: boolean
-        description: The course/program is offered for free
+          nullable: true
       - in: path
         name: id
         schema:
@@ -2868,225 +2868,190 @@ paths:
         schema:
           type: array
           items:
-            type: string
             enum:
-            - advanced
+            - undergraduate
             - graduate
             - high_school
+            - noncredit
+            - advanced
             - intermediate
             - introductory
-            - noncredit
-            - undergraduate
-        description: |-
-          The academic level of the resources
-
-          * `undergraduate` - Undergraduate
-          * `graduate` - Graduate
-          * `high_school` - High School
-          * `noncredit` - Non-Credit
-          * `advanced` - Advanced
-          * `intermediate` - Intermediate
-          * `introductory` - Introductory
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `undergraduate` - Undergraduate
+              * `graduate` - Graduate
+              * `high_school` - High School
+              * `noncredit` - Non-Credit
+              * `advanced` - Advanced
+              * `intermediate` - Intermediate
+              * `introductory` - Introductory
       - in: query
         name: limit
         schema:
           type: integer
       - in: query
-        name: offered_by
+        name: ocw_topic
         schema:
           type: array
           items:
             type: string
+            minLength: 1
+        description: The ocw topic name.
+      - in: query
+        name: offered_by
+        schema:
+          type: array
+          items:
             enum:
-            - bootcamps
-            - climate
-            - mitpe
             - mitx
             - ocw
-            - see
+            - bootcamps
             - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - MIT OpenCourseWare
-          * `bootcamps` - Bootcamps
-          * `xpro` - MIT xPRO
-          * `mitpe` - MIT Professional Education
-          * `see` - MIT Sloan Executive Education
-          * `climate` - MIT Climate
-        explode: true
-        style: form
+            - mitpe
+            - see
+            - climate
+            type: string
+            description: |-
+              * `mitx` - MITx
+              * `ocw` - MIT OpenCourseWare
+              * `bootcamps` - Bootcamps
+              * `xpro` - MIT xPRO
+              * `mitpe` - MIT Professional Education
+              * `see` - MIT Sloan Executive Education
+              * `climate` - MIT Climate
+        description: "The organization that offers the learning resource         \
+          \    \n\n* `mitx` - MITx\n* `ocw` - MIT OpenCourseWare\n* `bootcamps` -\
+          \ Bootcamps\n* `xpro` - MIT xPRO\n* `mitpe` - MIT Professional Education\n\
+          * `see` - MIT Sloan Executive Education\n* `climate` - MIT Climate"
       - in: query
         name: platform
         schema:
           type: array
           items:
-            type: string
             enum:
-            - bootcamps
-            - canvas
-            - climate
-            - csail
-            - ctl
             - edx
-            - emeritus
-            - globalalumni
-            - mitpe
-            - mitxonline
             - ocw
             - oll
-            - ovs
-            - podcast
-            - scc
-            - see
-            - simplilearn
-            - susskind
-            - whu
+            - mitxonline
+            - bootcamps
             - xpro
+            - csail
+            - mitpe
+            - see
+            - scc
+            - ctl
+            - whu
+            - susskind
+            - globalalumni
+            - simplilearn
+            - emeritus
+            - podcast
             - youtube
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - MIT OpenCourseWare
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - MIT xPRO
-          * `csail` - CSAIL
-          * `mitpe` - MIT Professional Education
-          * `see` - MIT Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-          * `youtube` - YouTube
-          * `canvas` - Canvas
-          * `climate` - MIT Climate
-          * `ovs` - ODL Video Service
-        explode: true
-        style: form
+            - canvas
+            - climate
+            - ovs
+            type: string
+            description: |-
+              * `edx` - edX
+              * `ocw` - MIT OpenCourseWare
+              * `oll` - Open Learning Library
+              * `mitxonline` - MITx Online
+              * `bootcamps` - Bootcamps
+              * `xpro` - MIT xPRO
+              * `csail` - CSAIL
+              * `mitpe` - MIT Professional Education
+              * `see` - MIT Sloan Executive Education
+              * `scc` - Schwarzman College of Computing
+              * `ctl` - Center for Transportation & Logistics
+              * `whu` - WHU
+              * `susskind` - Susskind
+              * `globalalumni` - Global Alumni
+              * `simplilearn` - Simplilearn
+              * `emeritus` - Emeritus
+              * `podcast` - Podcast
+              * `youtube` - YouTube
+              * `canvas` - Canvas
+              * `climate` - MIT Climate
+              * `ovs` - ODL Video Service
+        description: "The platform on which the learning resource is offered     \
+          \        \n\n* `edx` - edX\n* `ocw` - MIT OpenCourseWare\n* `oll` - Open\
+          \ Learning Library\n* `mitxonline` - MITx Online\n* `bootcamps` - Bootcamps\n\
+          * `xpro` - MIT xPRO\n* `csail` - CSAIL\n* `mitpe` - MIT Professional Education\n\
+          * `see` - MIT Sloan Executive Education\n* `scc` - Schwarzman College of\
+          \ Computing\n* `ctl` - Center for Transportation & Logistics\n* `whu` -\
+          \ WHU\n* `susskind` - Susskind\n* `globalalumni` - Global Alumni\n* `simplilearn`\
+          \ - Simplilearn\n* `emeritus` - Emeritus\n* `podcast` - Podcast\n* `youtube`\
+          \ - YouTube\n* `canvas` - Canvas\n* `climate` - MIT Climate\n* `ovs` - ODL\
+          \ Video Service"
       - in: query
         name: professional
         schema:
           type: boolean
-      - in: query
-        name: readable_id
-        schema:
-          type: array
-          items:
-            type: string
-        description: A unique text identifier for the resources
-        explode: true
-        style: form
-      - in: query
-        name: resource_id
-        schema:
-          type: array
-          items:
-            type: integer
-        description: Comma-separated list of learning resource IDs
-        explode: true
-        style: form
+          nullable: true
       - in: query
         name: resource_type
         schema:
           type: array
           items:
-            type: string
             enum:
             - course
-            - document
+            - program
             - learning_path
             - podcast
             - podcast_episode
-            - program
             - video
             - video_playlist
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-          * `video` - Video
-          * `video_playlist` - Video Playlist
-          * `document` - Document
-        explode: true
-        style: form
+            - document
+            type: string
+            description: |-
+              * `course` - course
+              * `program` - program
+              * `learning_path` - learning path
+              * `podcast` - podcast
+              * `podcast_episode` - podcast episode
+              * `video` - video
+              * `video_playlist` - video playlist
+              * `document` - document
+        description: "The type of learning resource             \n\n* `course` - course\n\
+          * `program` - program\n* `learning_path` - learning path\n* `podcast` -\
+          \ podcast\n* `podcast_episode` - podcast episode\n* `video` - video\n* `video_playlist`\
+          \ - video playlist\n* `document` - document"
       - in: query
         name: resource_type_group
         schema:
           type: array
           items:
-            type: string
             enum:
             - course
-            - learning_material
             - program
-        description: |-
-          The resource type group of the learning resources
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_material` - Learning Material
-        explode: true
-        style: form
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
-        name: sortby
+        name: title__isnull
         schema:
-          type: string
-          enum:
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - -views
-          - id
-          - last_modified
-          - mitcoursenumber
-          - new
-          - readable_id
-          - start_date
-          - upcoming
-          - views
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `new` - Newest resources first
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-          * `views` - Popularity ascending
-          * `-views` - Popularity descending
-          * `upcoming` - Next start date ascending
+          type: boolean
+          nullable: true
+        description: Filter to learning resources where title is null/not null
       - in: query
         name: topic
         schema:
           type: array
           items:
             type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
-        explode: true
-        style: form
+            minLength: 1
+        description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: url__isnull
+        schema:
+          type: boolean
+          nullable: true
+        description: Filter to learning resources where url is null/not null
       tags:
       - learning_resources
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3033,12 +3033,6 @@ paths:
         description: "The category of learning resource             \n\n* `course`\
           \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
-        name: title__isnull
-        schema:
-          type: boolean
-          nullable: true
-        description: Filter to learning resources where title is null/not null
-      - in: query
         name: topic
         schema:
           type: array
@@ -3046,12 +3040,6 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
-      - in: query
-        name: url__isnull
-        schema:
-          type: boolean
-          nullable: true
-        description: Filter to learning resources where url is null/not null
       tags:
       - learning_resources
       responses:
@@ -3408,12 +3396,6 @@ paths:
         description: "The category of learning resource             \n\n* `course`\
           \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
-        name: title__isnull
-        schema:
-          type: boolean
-          nullable: true
-        description: Filter to learning resources where title is null/not null
-      - in: query
         name: topic
         schema:
           type: array
@@ -3421,12 +3403,6 @@ paths:
             type: string
             minLength: 1
         description: The topic name. To see a list of options go to api/v1/topics/
-      - in: query
-        name: url__isnull
-        schema:
-          type: boolean
-          nullable: true
-        description: Filter to learning resources where url is null/not null
       tags:
       - learning_resources
       responses:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3399,24 +3399,6 @@ paths:
           type: boolean
           nullable: true
       - in: query
-        name: readable_id
-        schema:
-          type: array
-          items:
-            type: string
-        description: A unique text identifier for the resources
-        explode: true
-        style: form
-      - in: query
-        name: resource_id
-        schema:
-          type: array
-          items:
-            type: integer
-        description: Comma-separated list of learning resource IDs
-        explode: true
-        style: form
-      - in: query
         name: resource_type
         schema:
           type: array
@@ -3460,42 +3442,6 @@ paths:
               * `learning_material` - Learning Material
         description: "The category of learning resource             \n\n* `course`\
           \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
-      - in: query
-        name: sortby
-        schema:
-          type: string
-          enum:
-          - -id
-          - -last_modified
-          - -mitcoursenumber
-          - -readable_id
-          - -start_date
-          - -views
-          - id
-          - last_modified
-          - mitcoursenumber
-          - new
-          - readable_id
-          - start_date
-          - upcoming
-          - views
-        description: |-
-          Sort By
-
-          * `id` - Object ID ascending
-          * `-id` - Object ID descending
-          * `readable_id` - Readable ID ascending
-          * `-readable_id` - Readable ID descending
-          * `last_modified` - Last Modified Date ascending
-          * `-last_modified` - Last Modified Date descending
-          * `new` - Newest resources first
-          * `start_date` - Start Date ascending
-          * `-start_date` - Start Date descending
-          * `mitcoursenumber` - MIT course number ascending
-          * `-mitcoursenumber` - MIT course number descending
-          * `views` - Popularity ascending
-          * `-views` - Popularity descending
-          * `upcoming` - Next start date ascending
       - in: query
         name: title__isnull
         schema:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3401,9 +3401,12 @@ paths:
       - in: query
         name: readable_id
         schema:
-          type: string
-          minLength: 1
-        description: The readable id of the resource
+          type: array
+          items:
+            type: string
+        description: A unique text identifier for the resources
+        explode: true
+        style: form
       - in: query
         name: resource_id
         schema:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -3102,7 +3102,7 @@ paths:
     get:
       operationId: learning_resources_vector_similar_list
       description: |-
-        Fetch similar learning resources
+        Fetch similar learning resources, optionally narrowed by Qdrant filters.
 
         Args:
         id (integer): The id of the learning resource
@@ -3115,76 +3115,69 @@ paths:
         name: certification
         schema:
           type: boolean
+          nullable: true
+        description: True if the learning resource offers a certificate
       - in: query
         name: certification_type
         schema:
           type: array
           items:
-            type: string
             enum:
-            - completion
             - micromasters
-            - none
             - professional
-        description: |-
-          The type of certification offered
-
-          * `micromasters` - MicroMasters Credential
-          * `professional` - Professional Certificate
-          * `completion` - Certificate of Completion
-          * `none` - No Certificate
-        explode: true
-        style: form
+            - completion
+            - none
+            type: string
+            description: |-
+              * `micromasters` - MicroMasters Credential
+              * `professional` - Professional Certificate
+              * `completion` - Certificate of Completion
+              * `none` - No Certificate
+        description: "The type of certificate             \n\n* `micromasters` - MicroMasters\
+          \ Credential\n* `professional` - Professional Certificate\n* `completion`\
+          \ - Certificate of Completion\n* `none` - No Certificate"
       - in: query
         name: course_feature
         schema:
           type: array
           items:
             type: string
-        description: Content feature for the resources. Load the 'api/v1/course_features'
-          endpoint for a list of course features
-        explode: true
-        style: form
+            minLength: 1
+        description: The course feature. Possible options are at api/v1/course_features/
       - in: query
         name: delivery
         schema:
           type: array
           items:
-            type: array
-            items:
-              enum:
-              - online
-              - hybrid
-              - in_person
-              - offline
-              type: string
-              description: |-
-                * `online` - Online
-                * `hybrid` - Hybrid
-                * `in_person` - In person
-                * `offline` - Offline
             enum:
+            - online
             - hybrid
             - in_person
             - offline
-            - online
-        description: |-
-          The delivery of course/program resources
-
-          * `online` - Online
-          * `hybrid` - Hybrid
-          * `in_person` - In person
-          * `offline` - Offline
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `online` - Online
+              * `hybrid` - Hybrid
+              * `in_person` - In person
+              * `offline` - Offline
+        description: "The delivery options in which the learning resource is offered\
+          \             \n\n* `online` - Online\n* `hybrid` - Hybrid\n* `in_person`\
+          \ - In person\n* `offline` - Offline"
       - in: query
         name: department
         schema:
           type: array
           items:
-            type: string
             enum:
             - '1'
+            - '2'
+            - '3'
+            - '4'
+            - '5'
+            - '6'
+            - '7'
+            - '8'
+            - '9'
             - '10'
             - '11'
             - '12'
@@ -3193,7 +3186,6 @@ paths:
             - '16'
             - '17'
             - '18'
-            - '2'
             - '20'
             - 21A
             - 21G
@@ -3202,13 +3194,6 @@ paths:
             - 21M
             - '22'
             - '24'
-            - '3'
-            - '4'
-            - '5'
-            - '6'
-            - '7'
-            - '8'
-            - '9'
             - CC
             - CMS-W
             - EC
@@ -3221,53 +3206,68 @@ paths:
             - SP
             - STS
             - WGS
-        description: |-
-          The department that offers learning resources
-
-          * `1` - Civil and Environmental Engineering
-          * `2` - Mechanical Engineering
-          * `3` - Materials Science and Engineering
-          * `4` - Architecture
-          * `5` - Chemistry
-          * `6` - Electrical Engineering and Computer Science
-          * `7` - Biology
-          * `8` - Physics
-          * `9` - Brain and Cognitive Sciences
-          * `10` - Chemical Engineering
-          * `11` - Urban Studies and Planning
-          * `12` - Earth, Atmospheric, and Planetary Sciences
-          * `14` - Economics
-          * `15` - Management
-          * `16` - Aeronautics and Astronautics
-          * `17` - Political Science
-          * `18` - Mathematics
-          * `20` - Biological Engineering
-          * `21A` - Anthropology
-          * `21G` - Global Languages
-          * `21H` - History
-          * `21L` - Literature
-          * `21M` - Music and Theater Arts
-          * `22` - Nuclear Science and Engineering
-          * `24` - Linguistics and Philosophy
-          * `CC` - Concourse
-          * `CMS-W` - Comparative Media Studies/Writing
-          * `EC` - Edgerton Center
-          * `ES` - Experimental Study Group
-          * `ESD` - Engineering Systems Division
-          * `HST` - Medical Engineering and Science
-          * `IDS` - Data, Systems, and Society
-          * `MAS` - Media Arts and Sciences
-          * `PE` - Athletics, Physical Education and Recreation
-          * `SP` - Special Programs
-          * `STS` - Science, Technology, and Society
-          * `WGS` - Women's and Gender Studies
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `1` - Civil and Environmental Engineering
+              * `2` - Mechanical Engineering
+              * `3` - Materials Science and Engineering
+              * `4` - Architecture
+              * `5` - Chemistry
+              * `6` - Electrical Engineering and Computer Science
+              * `7` - Biology
+              * `8` - Physics
+              * `9` - Brain and Cognitive Sciences
+              * `10` - Chemical Engineering
+              * `11` - Urban Studies and Planning
+              * `12` - Earth, Atmospheric, and Planetary Sciences
+              * `14` - Economics
+              * `15` - Management
+              * `16` - Aeronautics and Astronautics
+              * `17` - Political Science
+              * `18` - Mathematics
+              * `20` - Biological Engineering
+              * `21A` - Anthropology
+              * `21G` - Global Languages
+              * `21H` - History
+              * `21L` - Literature
+              * `21M` - Music and Theater Arts
+              * `22` - Nuclear Science and Engineering
+              * `24` - Linguistics and Philosophy
+              * `CC` - Concourse
+              * `CMS-W` - Comparative Media Studies/Writing
+              * `EC` - Edgerton Center
+              * `ES` - Experimental Study Group
+              * `ESD` - Engineering Systems Division
+              * `HST` - Medical Engineering and Science
+              * `IDS` - Data, Systems, and Society
+              * `MAS` - Media Arts and Sciences
+              * `PE` - Athletics, Physical Education and Recreation
+              * `SP` - Special Programs
+              * `STS` - Science, Technology, and Society
+              * `WGS` - Women's and Gender Studies
+        description: "The department that offers the learning resource           \
+          \  \n\n* `1` - Civil and Environmental Engineering\n* `2` - Mechanical Engineering\n\
+          * `3` - Materials Science and Engineering\n* `4` - Architecture\n* `5` -\
+          \ Chemistry\n* `6` - Electrical Engineering and Computer Science\n* `7`\
+          \ - Biology\n* `8` - Physics\n* `9` - Brain and Cognitive Sciences\n* `10`\
+          \ - Chemical Engineering\n* `11` - Urban Studies and Planning\n* `12` -\
+          \ Earth, Atmospheric, and Planetary Sciences\n* `14` - Economics\n* `15`\
+          \ - Management\n* `16` - Aeronautics and Astronautics\n* `17` - Political\
+          \ Science\n* `18` - Mathematics\n* `20` - Biological Engineering\n* `21A`\
+          \ - Anthropology\n* `21G` - Global Languages\n* `21H` - History\n* `21L`\
+          \ - Literature\n* `21M` - Music and Theater Arts\n* `22` - Nuclear Science\
+          \ and Engineering\n* `24` - Linguistics and Philosophy\n* `CC` - Concourse\n\
+          * `CMS-W` - Comparative Media Studies/Writing\n* `EC` - Edgerton Center\n\
+          * `ES` - Experimental Study Group\n* `ESD` - Engineering Systems Division\n\
+          * `HST` - Medical Engineering and Science\n* `IDS` - Data, Systems, and\
+          \ Society\n* `MAS` - Media Arts and Sciences\n* `PE` - Athletics, Physical\
+          \ Education and Recreation\n* `SP` - Special Programs\n* `STS` - Science,\
+          \ Technology, and Society\n* `WGS` - Women's and Gender Studies"
       - in: query
         name: free
         schema:
           type: boolean
-        description: The course/program is offered for free
+          nullable: true
       - in: path
         name: id
         schema:
@@ -3278,124 +3278,132 @@ paths:
         schema:
           type: array
           items:
-            type: string
             enum:
-            - advanced
+            - undergraduate
             - graduate
             - high_school
+            - noncredit
+            - advanced
             - intermediate
             - introductory
-            - noncredit
-            - undergraduate
-        description: |-
-          The academic level of the resources
-
-          * `undergraduate` - Undergraduate
-          * `graduate` - Graduate
-          * `high_school` - High School
-          * `noncredit` - Non-Credit
-          * `advanced` - Advanced
-          * `intermediate` - Intermediate
-          * `introductory` - Introductory
-        explode: true
-        style: form
+            type: string
+            description: |-
+              * `undergraduate` - Undergraduate
+              * `graduate` - Graduate
+              * `high_school` - High School
+              * `noncredit` - Non-Credit
+              * `advanced` - Advanced
+              * `intermediate` - Intermediate
+              * `introductory` - Introductory
       - in: query
         name: limit
         schema:
           type: integer
       - in: query
-        name: offered_by
+        name: ocw_topic
         schema:
           type: array
           items:
             type: string
+            minLength: 1
+        description: The ocw topic name.
+      - in: query
+        name: offered_by
+        schema:
+          type: array
+          items:
             enum:
-            - bootcamps
-            - climate
-            - mitpe
             - mitx
             - ocw
-            - see
+            - bootcamps
             - xpro
-        description: |-
-          The organization that offers a learning resource
-
-          * `mitx` - MITx
-          * `ocw` - MIT OpenCourseWare
-          * `bootcamps` - Bootcamps
-          * `xpro` - MIT xPRO
-          * `mitpe` - MIT Professional Education
-          * `see` - MIT Sloan Executive Education
-          * `climate` - MIT Climate
-        explode: true
-        style: form
+            - mitpe
+            - see
+            - climate
+            type: string
+            description: |-
+              * `mitx` - MITx
+              * `ocw` - MIT OpenCourseWare
+              * `bootcamps` - Bootcamps
+              * `xpro` - MIT xPRO
+              * `mitpe` - MIT Professional Education
+              * `see` - MIT Sloan Executive Education
+              * `climate` - MIT Climate
+        description: "The organization that offers the learning resource         \
+          \    \n\n* `mitx` - MITx\n* `ocw` - MIT OpenCourseWare\n* `bootcamps` -\
+          \ Bootcamps\n* `xpro` - MIT xPRO\n* `mitpe` - MIT Professional Education\n\
+          * `see` - MIT Sloan Executive Education\n* `climate` - MIT Climate"
       - in: query
         name: platform
         schema:
           type: array
           items:
-            type: string
             enum:
-            - bootcamps
-            - canvas
-            - climate
-            - csail
-            - ctl
             - edx
-            - emeritus
-            - globalalumni
-            - mitpe
-            - mitxonline
             - ocw
             - oll
-            - ovs
-            - podcast
-            - scc
-            - see
-            - simplilearn
-            - susskind
-            - whu
+            - mitxonline
+            - bootcamps
             - xpro
+            - csail
+            - mitpe
+            - see
+            - scc
+            - ctl
+            - whu
+            - susskind
+            - globalalumni
+            - simplilearn
+            - emeritus
+            - podcast
             - youtube
-        description: |-
-          The platform on which learning resources are offered
-
-          * `edx` - edX
-          * `ocw` - MIT OpenCourseWare
-          * `oll` - Open Learning Library
-          * `mitxonline` - MITx Online
-          * `bootcamps` - Bootcamps
-          * `xpro` - MIT xPRO
-          * `csail` - CSAIL
-          * `mitpe` - MIT Professional Education
-          * `see` - MIT Sloan Executive Education
-          * `scc` - Schwarzman College of Computing
-          * `ctl` - Center for Transportation & Logistics
-          * `whu` - WHU
-          * `susskind` - Susskind
-          * `globalalumni` - Global Alumni
-          * `simplilearn` - Simplilearn
-          * `emeritus` - Emeritus
-          * `podcast` - Podcast
-          * `youtube` - YouTube
-          * `canvas` - Canvas
-          * `climate` - MIT Climate
-          * `ovs` - ODL Video Service
-        explode: true
-        style: form
+            - canvas
+            - climate
+            - ovs
+            type: string
+            description: |-
+              * `edx` - edX
+              * `ocw` - MIT OpenCourseWare
+              * `oll` - Open Learning Library
+              * `mitxonline` - MITx Online
+              * `bootcamps` - Bootcamps
+              * `xpro` - MIT xPRO
+              * `csail` - CSAIL
+              * `mitpe` - MIT Professional Education
+              * `see` - MIT Sloan Executive Education
+              * `scc` - Schwarzman College of Computing
+              * `ctl` - Center for Transportation & Logistics
+              * `whu` - WHU
+              * `susskind` - Susskind
+              * `globalalumni` - Global Alumni
+              * `simplilearn` - Simplilearn
+              * `emeritus` - Emeritus
+              * `podcast` - Podcast
+              * `youtube` - YouTube
+              * `canvas` - Canvas
+              * `climate` - MIT Climate
+              * `ovs` - ODL Video Service
+        description: "The platform on which the learning resource is offered     \
+          \        \n\n* `edx` - edX\n* `ocw` - MIT OpenCourseWare\n* `oll` - Open\
+          \ Learning Library\n* `mitxonline` - MITx Online\n* `bootcamps` - Bootcamps\n\
+          * `xpro` - MIT xPRO\n* `csail` - CSAIL\n* `mitpe` - MIT Professional Education\n\
+          * `see` - MIT Sloan Executive Education\n* `scc` - Schwarzman College of\
+          \ Computing\n* `ctl` - Center for Transportation & Logistics\n* `whu` -\
+          \ WHU\n* `susskind` - Susskind\n* `globalalumni` - Global Alumni\n* `simplilearn`\
+          \ - Simplilearn\n* `emeritus` - Emeritus\n* `podcast` - Podcast\n* `youtube`\
+          \ - YouTube\n* `canvas` - Canvas\n* `climate` - MIT Climate\n* `ovs` - ODL\
+          \ Video Service"
       - in: query
         name: professional
         schema:
           type: boolean
+          nullable: true
       - in: query
         name: readable_id
         schema:
-          type: array
-          items:
-            type: string
-        description: A unique text identifier for the resources
-        explode: true
-        style: form
+          type: string
+          minLength: 1
+        description: The readable id of the resource
       - in: query
         name: resource_id
         schema:
@@ -3410,47 +3418,45 @@ paths:
         schema:
           type: array
           items:
-            type: string
             enum:
             - course
-            - document
+            - program
             - learning_path
             - podcast
             - podcast_episode
-            - program
             - video
             - video_playlist
-        description: |-
-          The type of learning resource
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_path` - Learning Path
-          * `podcast` - Podcast
-          * `podcast_episode` - Podcast Episode
-          * `video` - Video
-          * `video_playlist` - Video Playlist
-          * `document` - Document
-        explode: true
-        style: form
+            - document
+            type: string
+            description: |-
+              * `course` - course
+              * `program` - program
+              * `learning_path` - learning path
+              * `podcast` - podcast
+              * `podcast_episode` - podcast episode
+              * `video` - video
+              * `video_playlist` - video playlist
+              * `document` - document
+        description: "The type of learning resource             \n\n* `course` - course\n\
+          * `program` - program\n* `learning_path` - learning path\n* `podcast` -\
+          \ podcast\n* `podcast_episode` - podcast episode\n* `video` - video\n* `video_playlist`\
+          \ - video playlist\n* `document` - document"
       - in: query
         name: resource_type_group
         schema:
           type: array
           items:
-            type: string
             enum:
             - course
-            - learning_material
             - program
-        description: |-
-          The resource type group of the learning resources
-
-          * `course` - Course
-          * `program` - Program
-          * `learning_material` - Learning Material
-        explode: true
-        style: form
+            - learning_material
+            type: string
+            description: |-
+              * `course` - Course
+              * `program` - Program
+              * `learning_material` - Learning Material
+        description: "The category of learning resource             \n\n* `course`\
+          \ - Course\n* `program` - Program\n* `learning_material` - Learning Material"
       - in: query
         name: sortby
         schema:
@@ -3488,15 +3494,25 @@ paths:
           * `-views` - Popularity descending
           * `upcoming` - Next start date ascending
       - in: query
+        name: title__isnull
+        schema:
+          type: boolean
+          nullable: true
+        description: Filter to learning resources where title is null/not null
+      - in: query
         name: topic
         schema:
           type: array
           items:
             type: string
-        description: Topics covered by the resources. Load the '/api/v1/topics' endpoint
-          for a list of topics
-        explode: true
-        style: form
+            minLength: 1
+        description: The topic name. To see a list of options go to api/v1/topics/
+      - in: query
+        name: url__isnull
+        schema:
+          type: boolean
+          nullable: true
+        description: Filter to learning resources where url is null/not null
       tags:
       - learning_resources
       responses:

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -141,18 +141,6 @@ class LearningResourcesSearchFiltersSerializer(serializers.Serializer):
             \n\n{build_choice_description_list(resource_type_group_choices)}"
         ),
     )
-    url__isnull = serializers.BooleanField(
-        required=False,
-        default=None,
-        allow_null=True,
-        help_text="Filter to learning resources where url is null/not null",
-    )
-    title__isnull = serializers.BooleanField(
-        required=False,
-        default=None,
-        allow_null=True,
-        help_text="Filter to learning resources where title is null/not null",
-    )
 
 
 class LearningResourcesVectorSearchRequestSerializer(
@@ -165,6 +153,18 @@ class LearningResourcesVectorSearchRequestSerializer(
 
     readable_id = serializers.CharField(
         required=False, help_text="The readable id of the resource"
+    )
+    url__isnull = serializers.BooleanField(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Filter to learning resources where url is null/not null",
+    )
+    title__isnull = serializers.BooleanField(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Filter to learning resources where title is null/not null",
     )
     q = serializers.CharField(required=False, help_text="The search text")
     offset = serializers.IntegerField(

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -22,19 +22,15 @@ from learning_resources_search.serializers import (
 )
 
 
-class LearningResourcesVectorSearchRequestSerializer(serializers.Serializer):
+class LearningResourcesSearchFiltersSerializer(serializers.Serializer):
     """
-    Request serializer for vector based search
-    instead of id we use readable_id in case we upload qdrant snapshots
+    Shared filter fields for Qdrant-backed learning resource queries.
+
+    Every field here must have a corresponding entry in
+    vector_search.constants.QDRANT_RESOURCE_PARAM_MAP so it can be translated
+    to a Qdrant filter by qdrant_query_conditions().
     """
 
-    q = serializers.CharField(required=False, help_text="The search text")
-    offset = serializers.IntegerField(
-        required=False, help_text="The initial index from which to return the results"
-    )
-    limit = serializers.IntegerField(
-        required=False, help_text="Number of results to return per page"
-    )
     readable_id = serializers.CharField(
         required=False, help_text="The readable id of the resource"
     )
@@ -159,6 +155,23 @@ class LearningResourcesVectorSearchRequestSerializer(serializers.Serializer):
         default=None,
         allow_null=True,
         help_text="Filter to learning resources where title is null/not null",
+    )
+
+
+class LearningResourcesVectorSearchRequestSerializer(
+    LearningResourcesSearchFiltersSerializer
+):
+    """
+    Request serializer for vector based search
+    instead of id we use readable_id in case we upload qdrant snapshots
+    """
+
+    q = serializers.CharField(required=False, help_text="The search text")
+    offset = serializers.IntegerField(
+        required=False, help_text="The initial index from which to return the results"
+    )
+    limit = serializers.IntegerField(
+        required=False, help_text="Number of results to return per page"
     )
     hybrid_search = serializers.BooleanField(
         required=False,

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -31,9 +31,6 @@ class LearningResourcesSearchFiltersSerializer(serializers.Serializer):
     to a Qdrant filter by qdrant_query_conditions().
     """
 
-    readable_id = serializers.CharField(
-        required=False, help_text="The readable id of the resource"
-    )
     offered_by_choices = [(e.name.lower(), e.value) for e in OfferedBy]
     offered_by = serializers.ListField(
         required=False,
@@ -166,6 +163,9 @@ class LearningResourcesVectorSearchRequestSerializer(
     instead of id we use readable_id in case we upload qdrant snapshots
     """
 
+    readable_id = serializers.CharField(
+        required=False, help_text="The readable id of the resource"
+    )
     q = serializers.CharField(required=False, help_text="The search text")
     offset = serializers.IntegerField(
         required=False, help_text="The initial index from which to return the results"

--- a/vector_search/serializers_test.py
+++ b/vector_search/serializers_test.py
@@ -1,3 +1,38 @@
 import pytest
 
+from vector_search.serializers import (
+    LearningResourcesSearchFiltersSerializer,
+    LearningResourcesVectorSearchRequestSerializer,
+)
+
 pytestmark = pytest.mark.django_db
+
+
+def test_filter_serializer_accepts_resource_type():
+    s = LearningResourcesSearchFiltersSerializer(
+        data={"resource_type": ["video_playlist"]}
+    )
+    assert s.is_valid(), s.errors
+    assert s.validated_data["resource_type"] == ["video_playlist"]
+
+
+def test_filter_serializer_rejects_invalid_resource_type():
+    s = LearningResourcesSearchFiltersSerializer(data={"resource_type": ["not_a_type"]})
+    assert not s.is_valid()
+    assert "resource_type" in s.errors
+
+
+def test_filter_serializer_has_no_search_fields():
+    fields = LearningResourcesSearchFiltersSerializer().fields
+    assert "q" not in fields
+    assert "offset" not in fields
+    assert "limit" not in fields
+    assert "hybrid_search" not in fields
+
+
+def test_vector_search_request_serializer_inherits_filter_fields():
+    fields = LearningResourcesVectorSearchRequestSerializer().fields
+    assert "resource_type" in fields
+    assert "platform" in fields
+    assert "q" in fields
+    assert "hybrid_search" in fields

--- a/vector_search/serializers_test.py
+++ b/vector_search/serializers_test.py
@@ -29,6 +29,10 @@ def test_filter_serializer_has_no_search_fields():
     assert "limit" not in fields
     assert "hybrid_search" not in fields
     assert "readable_id" not in fields
+    # isnull filters are Qdrant-only and must not be in the shared base,
+    # since generate_filter_clauses (OpenSearch) doesn't support them
+    assert "url__isnull" not in fields
+    assert "title__isnull" not in fields
 
 
 def test_vector_search_request_serializer_inherits_filter_fields():

--- a/vector_search/serializers_test.py
+++ b/vector_search/serializers_test.py
@@ -1,11 +1,7 @@
-import pytest
-
 from vector_search.serializers import (
     LearningResourcesSearchFiltersSerializer,
     LearningResourcesVectorSearchRequestSerializer,
 )
-
-pytestmark = pytest.mark.django_db
 
 
 def test_filter_serializer_accepts_resource_type():

--- a/vector_search/serializers_test.py
+++ b/vector_search/serializers_test.py
@@ -28,6 +28,7 @@ def test_filter_serializer_has_no_search_fields():
     assert "offset" not in fields
     assert "limit" not in fields
     assert "hybrid_search" not in fields
+    assert "readable_id" not in fields
 
 
 def test_vector_search_request_serializer_inherits_filter_fields():


### PR DESCRIPTION
### What are the relevant tickets?
Closes
- https://github.com/mitodl/hq/issues/10896

### Description (What does it do?)
Adds filtering for the similar and vector_similar endpoints + Makes OpenAPI spec reflect the available filters.


### How can this be tested?
1. If you haven't populate qdrant with `./manage.py generate_embeddings --courses --skip-contentfiles`, `./manage.py generate_embeddings --programs --skip-contentfiles`; this can take a while depending on how many resources you have.
2. Try both endpoints with various filters:
    - For example:
        - http://api.open.odl.local:8065/api/v1/learning_resources/14/vector_similar/?resource_type=course&resource_type=program&platform=mitxonline
        - http://api.open.odl.local:8065/api/v1/learning_resources/14/similar/?resource_type=course&resource_type=program&platform=mitxonline
    - OpenAPI:
        - http://api.open.odl.local:8065/api/v1/schema/swagger-ui/#/learning_resources/learning_resources_similar_list
        - http://api.open.odl.local:8065/api/v1/schema/swagger-ui/#/learning_resources/learning_resources_vector_similar_list

Note: You may need to clear your redis cache when you switch to this branch:
```python
 from django.core.cache import caches
 
 cache = caches["redis"]
 
 deleted_similar = cache.delete_pattern(
     "views.decorators.cache.cache_page.similar.GET.*"
 )
 deleted_vector_similar = cache.delete_pattern(
     "views.decorators.cache.cache_page.vector_similar.GET.*"
 )
 
 print(f"Deleted similar keys: {deleted_similar}")
 print(f"Deleted vector_similar keys: {deleted_vector_similar}")
```