### PR TITLE
Fix program dashboard "completed x of y" counts

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -1784,27 +1784,22 @@ describe("EnrollmentDisplay", () => {
         results: [
           mitxonline.factories.courses.course({
             id: 1,
-            title: "Required 1",
             courseruns: [run1],
           }),
           mitxonline.factories.courses.course({
             id: 2,
-            title: "Required 2",
             courseruns: [mitxonline.factories.courses.courseRun({ id: 102 })],
           }),
           mitxonline.factories.courses.course({
             id: 3,
-            title: "Elective 1",
             courseruns: [run3],
           }),
           mitxonline.factories.courses.course({
             id: 4,
-            title: "Elective 2",
             courseruns: [run4],
           }),
           mitxonline.factories.courses.course({
             id: 5,
-            title: "Elective 3",
             courseruns: [mitxonline.factories.courses.courseRun({ id: 105 })],
           }),
         ],
@@ -1900,17 +1895,14 @@ describe("EnrollmentDisplay", () => {
         results: [
           mitxonline.factories.courses.course({
             id: 1,
-            title: "Elective A",
             courseruns: [run1],
           }),
           mitxonline.factories.courses.course({
             id: 2,
-            title: "Elective B",
             courseruns: [run2],
           }),
           mitxonline.factories.courses.course({
             id: 3,
-            title: "Elective C",
             courseruns: [run3],
           }),
         ],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -1739,6 +1739,241 @@ describe("EnrollmentDisplay", () => {
       },
     )
 
+    test("Overall completion count caps elective completions at min_number_of value", async () => {
+      /**
+       * Program has 2 required courses (all_of) and 3 electives (min_number_of=1).
+       * User completes 1 required course + 2 electives.
+       * Bug: counts all 3 completions → "3 of 3 courses" (wrong).
+       * Fix: caps elective contribution at 1 → "2 of 3 courses" (correct).
+       */
+      const mitxOnlineUser = mitxonline.factories.user.user()
+      setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+      const reqTree =
+        new mitxonline.factories.requirements.RequirementTreeBuilder()
+      const required = reqTree.addOperator({
+        operator: "all_of",
+        title: "Required Courses",
+      })
+      required.addCourse({ course: 1 })
+      required.addCourse({ course: 2 })
+
+      const electives = reqTree.addOperator({
+        operator: "min_number_of",
+        operator_value: "1",
+        title: "Electives",
+      })
+      electives.addCourse({ course: 3 })
+      electives.addCourse({ course: 4 })
+      electives.addCourse({ course: 5 })
+
+      const program = mitxonline.factories.programs.program({
+        id: 5555,
+        courses: [1, 2, 3, 4, 5],
+        req_tree: reqTree.serialize(),
+      })
+
+      const run1 = mitxonline.factories.courses.courseRun({ id: 101 })
+      const run3 = mitxonline.factories.courses.courseRun({ id: 103 })
+      const run4 = mitxonline.factories.courses.courseRun({ id: 104 })
+
+      const courses = {
+        count: 5,
+        next: null,
+        previous: null,
+        results: [
+          mitxonline.factories.courses.course({
+            id: 1,
+            title: "Required 1",
+            courseruns: [run1],
+          }),
+          mitxonline.factories.courses.course({
+            id: 2,
+            title: "Required 2",
+            courseruns: [mitxonline.factories.courses.courseRun({ id: 102 })],
+          }),
+          mitxonline.factories.courses.course({
+            id: 3,
+            title: "Elective 1",
+            courseruns: [run3],
+          }),
+          mitxonline.factories.courses.course({
+            id: 4,
+            title: "Elective 2",
+            courseruns: [run4],
+          }),
+          mitxonline.factories.courses.course({
+            id: 5,
+            title: "Elective 3",
+            courseruns: [mitxonline.factories.courses.courseRun({ id: 105 })],
+          }),
+        ],
+      }
+
+      // Course 1 (required) completed, courses 3 and 4 (electives) completed
+      const completedGrade = mitxonline.factories.enrollment.grade({
+        passed: true,
+      })
+      const enrollments = [
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run1, course: courses.results[0] },
+          grades: [completedGrade],
+        }),
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run3, course: courses.results[2] },
+          grades: [completedGrade],
+        }),
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run4, course: courses.results[3] },
+          grades: [completedGrade],
+        }),
+      ]
+
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+      setMockResponse.get(
+        mitxonline.urls.enrollment.enrollmentsListV3(),
+        enrollments,
+      )
+      setMockResponse.get(
+        mitxonline.urls.programEnrollments.enrollmentsListV3(),
+        [
+          mitxonline.factories.enrollment.programEnrollmentV3({
+            program: {
+              id: program.id,
+              title: program.title,
+              live: program.live,
+              program_type: program.program_type,
+              readable_id: program.readable_id,
+            },
+          }),
+        ],
+      )
+      setMockResponse.get(mitxonline.urls.programs.programDetail(5555), program)
+      setMockResponse.get(
+        mitxonline.urls.courses.coursesList({
+          id: program.courses,
+          page_size: program.courses.length,
+        }),
+        courses,
+      )
+
+      renderWithProviders(<EnrollmentDisplay programId={5555} />)
+
+      // 1 required completed + min(2 electives completed, 1 required) = 2 total completed
+      // total = 2 required + 1 elective min = 3
+      await screen.findByText(/2 of 3 courses/)
+    })
+
+    test("Section header caps displayed count at operator_value for min_number_of sections", async () => {
+      /**
+       * Electives section with min_number_of=1 and 3 completed courses.
+       * The section header should show "Completed 1 of 1", not "Completed 3 of 1".
+       */
+      const mitxOnlineUser = mitxonline.factories.user.user()
+      setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+      const reqTree =
+        new mitxonline.factories.requirements.RequirementTreeBuilder()
+      const electives = reqTree.addOperator({
+        operator: "min_number_of",
+        operator_value: "1",
+        title: "Electives",
+      })
+      electives.addCourse({ course: 1 })
+      electives.addCourse({ course: 2 })
+      electives.addCourse({ course: 3 })
+
+      const program = mitxonline.factories.programs.program({
+        id: 6666,
+        courses: [1, 2, 3],
+        req_tree: reqTree.serialize(),
+      })
+
+      const run1 = mitxonline.factories.courses.courseRun({ id: 201 })
+      const run2 = mitxonline.factories.courses.courseRun({ id: 202 })
+      const run3 = mitxonline.factories.courses.courseRun({ id: 203 })
+
+      const courses = {
+        count: 3,
+        next: null,
+        previous: null,
+        results: [
+          mitxonline.factories.courses.course({
+            id: 1,
+            title: "Elective A",
+            courseruns: [run1],
+          }),
+          mitxonline.factories.courses.course({
+            id: 2,
+            title: "Elective B",
+            courseruns: [run2],
+          }),
+          mitxonline.factories.courses.course({
+            id: 3,
+            title: "Elective C",
+            courseruns: [run3],
+          }),
+        ],
+      }
+
+      // All 3 electives completed
+      const completedGrade = mitxonline.factories.enrollment.grade({
+        passed: true,
+      })
+      const enrollments = [
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run1, course: courses.results[0] },
+          grades: [completedGrade],
+        }),
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run2, course: courses.results[1] },
+          grades: [completedGrade],
+        }),
+        mitxonline.factories.enrollment.courseEnrollment({
+          run: { ...run3, course: courses.results[2] },
+          grades: [completedGrade],
+        }),
+      ]
+
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+      setMockResponse.get(
+        mitxonline.urls.enrollment.enrollmentsListV3(),
+        enrollments,
+      )
+      setMockResponse.get(
+        mitxonline.urls.programEnrollments.enrollmentsListV3(),
+        [
+          mitxonline.factories.enrollment.programEnrollmentV3({
+            program: {
+              id: program.id,
+              title: program.title,
+              live: program.live,
+              program_type: program.program_type,
+              readable_id: program.readable_id,
+            },
+          }),
+        ],
+      )
+      setMockResponse.get(mitxonline.urls.programs.programDetail(6666), program)
+      setMockResponse.get(
+        mitxonline.urls.courses.coursesList({
+          id: program.courses,
+          page_size: program.courses.length,
+        }),
+        courses,
+      )
+
+      renderWithProviders(<EnrollmentDisplay programId={6666} />)
+
+      await screen.findByText("Electives")
+
+      // Section header should show "Completed 1 of 1", capped at operator_value
+      const sectionCount = screen.getByTestId("section-completion-count")
+      expect(sectionCount).toHaveTextContent("Completed 1 of 1")
+      // Overall header should also show 1 of 1 (only electives section)
+      expect(screen.getByText(/1 of 1 courses/)).toBeInTheDocument()
+    })
+
     test("Returns 404 page when user is not enrolled in the program", async () => {
       const mitxOnlineUser = mitxonline.factories.user.user()
       setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -18,10 +18,8 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import {
   EnrollmentStatus,
   getEnrollmentStatus,
-  getProgramCounts,
+  getRequirementsProgress,
   getKey,
-  isRequirementSectionItemCompleted,
-  RequirementSection,
   ResourceType,
   selectBestEnrollment,
 } from "./helpers"
@@ -310,6 +308,35 @@ interface ResourceItem {
   type: "course" | "program"
 }
 
+type CourseRequirementItem = {
+  resourceType: "course"
+  course: CourseWithCourseRunsSerializerV2
+}
+
+type ProgramAsCourseRequirementItem = {
+  resourceType: "program-as-course"
+  courseProgramId: number
+  courseProgram: V2ProgramDetail
+  courseProgramEnrollment: V3UserProgramEnrollment | undefined
+}
+
+type ProgramEnrollmentRequirementItem = {
+  resourceType: "program-enrollment"
+  enrollment: V3UserProgramEnrollment
+}
+
+type RequirementSectionItem =
+  | CourseRequirementItem
+  | ProgramAsCourseRequirementItem
+  | ProgramEnrollmentRequirementItem
+
+type RequirementSection = {
+  key: string | number | null | undefined
+  title: string
+  items: RequirementSectionItem[]
+  node: V2ProgramRequirement
+}
+
 const extractResourcesFromNode = (
   node: V2ProgramRequirement,
 ): ResourceItem[] => {
@@ -438,6 +465,14 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     {} as Record<number, CourseRunEnrollmentV3[]>,
   )
 
+  const programEnrollmentsById = (programEnrollments ?? []).reduce(
+    (acc, enrollment) => {
+      acc[enrollment.program.id] = enrollment
+      return acc
+    },
+    {} as Record<number, V3UserProgramEnrollment>,
+  )
+
   const requirementSections: RequirementSection[] =
     program?.req_tree
       .filter((node) => node.data.node_type === "operator")
@@ -446,12 +481,6 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
           (programCourses?.results ?? []).map((c) => [c.id, c]),
         )
         const programsById = new Map(requiredProgramList.map((p) => [p.id, p]))
-        const programEnrollmentsById = new Map(
-          (programEnrollments ?? []).map((enrollment) => [
-            enrollment.program.id,
-            enrollment,
-          ]),
-        )
 
         const sectionItems = extractResourcesFromNode(node)
           .map((resource) => {
@@ -475,13 +504,12 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                 resourceType: "program-as-course" as const,
                 courseProgramId: requiredProgram.id,
                 courseProgram: requiredProgram,
-                courseProgramEnrollment: programEnrollmentsById.get(
-                  requiredProgram.id,
-                ),
+                courseProgramEnrollment:
+                  programEnrollmentsById[requiredProgram.id],
               }
             }
 
-            const enrollment = programEnrollmentsById.get(requiredProgram.id)
+            const enrollment = programEnrollmentsById[requiredProgram.id]
             if (!enrollment) return null
 
             return {
@@ -515,10 +543,12 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     )
   }, [requiredProgramList, requiredProgramCourses?.results])
 
-  const { completed: completedCount, total: totalCount } = getProgramCounts(
-    requirementSections,
-    enrollmentsByCourseId,
-  )
+  const { completed: completedCount, total: totalCount } =
+    getRequirementsProgress(
+      requirementSections.map((s) => s.node),
+      enrollmentsByCourseId,
+      programEnrollmentsById,
+    )
 
   if (isLoading) {
     return (
@@ -558,20 +588,12 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
         </Typography>
       </Stack>
       {requirementSections.map((section, index) => {
-        const sectionCompletedCount = section.items.filter((item) =>
-          isRequirementSectionItemCompleted(item, enrollmentsByCourseId),
-        ).length
-
-        const sectionRequiredCount =
-          section.node.data.operator === "min_number_of" &&
-          section.node.data.operator_value
-            ? parseInt(section.node.data.operator_value, 10)
-            : section.items.filter((item) => {
-                return (
-                  item.resourceType === "course" ||
-                  item.resourceType === "program-as-course"
-                )
-              }).length
+        const { completed: sectionCompleted, total: sectionTotal } =
+          getRequirementsProgress(
+            [section.node],
+            enrollmentsByCourseId,
+            programEnrollmentsById,
+          )
 
         return (
           <React.Fragment key={section.key}>
@@ -588,15 +610,13 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
               >
                 {section.title}
               </Typography>
-              {sectionRequiredCount > 0 ? (
+              {sectionTotal > 0 ? (
                 <Typography
                   data-testid="section-completion-count"
                   variant="body2"
                   color={theme.custom.colors.silverGrayDark}
                 >
-                  Completed{" "}
-                  {Math.min(sectionCompletedCount, sectionRequiredCount)} of{" "}
-                  {sectionRequiredCount}
+                  Completed {sectionCompleted} of {sectionTotal}
                 </Typography>
               ) : null}
             </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -18,8 +18,10 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import {
   EnrollmentStatus,
   getEnrollmentStatus,
-  getProgramEnrollmentStatus,
+  getProgramCounts,
   getKey,
+  isRequirementSectionItemCompleted,
+  RequirementSection,
   ResourceType,
   selectBestEnrollment,
 } from "./helpers"
@@ -436,7 +438,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     {} as Record<number, CourseRunEnrollmentV3[]>,
   )
 
-  const requirementSections =
+  const requirementSections: RequirementSection[] =
     program?.req_tree
       .filter((node) => node.data.node_type === "operator")
       .map((node) => {
@@ -513,44 +515,10 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     )
   }, [requiredProgramList, requiredProgramCourses?.results])
 
-  const completedCount = requirementSections
-    .flatMap((section) => section.items)
-    .filter((item) => {
-      if (item.resourceType === "course") {
-        const bestEnrollment = selectBestEnrollment(
-          item.course,
-          enrollmentsByCourseId[item.course.id] || [],
-        )
-        return (
-          getEnrollmentStatus(bestEnrollment) === EnrollmentStatus.Completed
-        )
-      }
-      if (item.resourceType === "program-as-course") {
-        return (
-          getProgramEnrollmentStatus(item.courseProgramEnrollment, 0, 0) ===
-          EnrollmentStatus.Completed
-        )
-      }
-      return false
-    }).length
-
-  const totalCount = requirementSections.reduce((sum, section) => {
-    if (
-      section.node.data.operator === "min_number_of" &&
-      section.node.data.operator_value
-    ) {
-      return sum + parseInt(section.node.data.operator_value, 10)
-    }
-    return (
-      sum +
-      section.items.filter((item) => {
-        return (
-          item.resourceType === "course" ||
-          item.resourceType === "program-as-course"
-        )
-      }).length
-    )
-  }, 0)
+  const { completed: completedCount, total: totalCount } = getProgramCounts(
+    requirementSections,
+    enrollmentsByCourseId,
+  )
 
   if (isLoading) {
     return (
@@ -590,24 +558,9 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
         </Typography>
       </Stack>
       {requirementSections.map((section, index) => {
-        const sectionCompletedCount = section.items.filter((item) => {
-          if (item.resourceType === "course") {
-            const bestEnrollment = selectBestEnrollment(
-              item.course,
-              enrollmentsByCourseId[item.course.id] || [],
-            )
-            return (
-              getEnrollmentStatus(bestEnrollment) === EnrollmentStatus.Completed
-            )
-          }
-          if (item.resourceType === "program-as-course") {
-            return (
-              getProgramEnrollmentStatus(item.courseProgramEnrollment, 0, 0) ===
-              EnrollmentStatus.Completed
-            )
-          }
-          return false
-        }).length
+        const sectionCompletedCount = section.items.filter((item) =>
+          isRequirementSectionItemCompleted(item, enrollmentsByCourseId),
+        ).length
 
         const sectionRequiredCount =
           section.node.data.operator === "min_number_of" &&
@@ -641,7 +594,9 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                   variant="body2"
                   color={theme.custom.colors.silverGrayDark}
                 >
-                  Completed {sectionCompletedCount} of {sectionRequiredCount}
+                  Completed{" "}
+                  {Math.min(sectionCompletedCount, sectionRequiredCount)} of{" "}
+                  {sectionRequiredCount}
                 </Typography>
               ) : null}
             </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -15,6 +15,7 @@ import {
   getEnrollmentStatus,
   ResourceType,
 } from "./helpers"
+import { allowConsoleErrors } from "ol-test-utilities"
 
 describe("helpers", () => {
   describe("getKey", () => {
@@ -567,9 +568,11 @@ describe("helpers", () => {
       const nested = operator("all_of", [courseLeaf(99)])
       const nodes = [operator("all_of", [courseLeaf(1), nested])]
 
+      const { consoleWarn } = allowConsoleErrors()
       expect(
         getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
       ).toEqual({ completed: 1, total: 1 })
+      expect(consoleWarn).toHaveBeenCalled()
     })
 
     test("min_number_of with operator_value=0 contributes nothing", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -1,12 +1,19 @@
 import { factories } from "api/mitxonline-test-utils"
 import {
+  CourseRunEnrollmentV3,
+  V2ProgramRequirement,
+} from "@mitodl/mitxonline-api-axios/v2"
+import {
   EnrollmentStatus,
   filterEnrollmentsByOrganization,
   getBestRun,
-  selectBestEnrollment,
-  getEnrollmentStatus,
+  getProgramCounts,
   getProgramEnrollmentStatus,
   getKey,
+  isRequirementSectionItemCompleted,
+  RequirementSection,
+  selectBestEnrollment,
+  getEnrollmentStatus,
   ResourceType,
 } from "./helpers"
 
@@ -448,6 +455,353 @@ describe("helpers", () => {
       expect(getProgramEnrollmentStatus(programEnrollment, 0, 2)).toBe(
         EnrollmentStatus.Enrolled,
       )
+    })
+  })
+
+  describe("getProgramCounts", () => {
+    const makeNode = (
+      operator: string,
+      operatorValue: string | null = null,
+    ): V2ProgramRequirement => ({
+      data: {
+        node_type: "operator",
+        operator,
+        operator_value: operatorValue, // eslint-disable-line camelcase
+      },
+    })
+
+    const passedGrade = factories.enrollment.grade({ passed: true })
+    const failedGrade = factories.enrollment.grade({ passed: false })
+
+    test("all_of section: counts all completed and total items", () => {
+      const run1 = factories.courses.courseRun({ id: 1 })
+      const run2 = factories.courses.courseRun({ id: 2 })
+      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
+      const course2 = factories.courses.course({ id: 2, courseruns: [run2] })
+
+      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
+        1: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run1, course: course1 },
+            grades: [passedGrade],
+          }),
+        ],
+        2: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run2, course: course2 },
+            grades: [failedGrade],
+          }),
+        ],
+      }
+
+      const sections: RequirementSection[] = [
+        {
+          key: "s1",
+          title: "Required",
+          node: makeNode("all_of"),
+          items: [
+            { resourceType: "course", course: course1 },
+            { resourceType: "course", course: course2 },
+          ],
+        },
+      ]
+
+      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+        completed: 1,
+        total: 2,
+      })
+    })
+
+    test("min_number_of section: caps completions at operator_value", () => {
+      const run3 = factories.courses.courseRun({ id: 3 })
+      const run4 = factories.courses.courseRun({ id: 4 })
+      const run5 = factories.courses.courseRun({ id: 5 })
+      const course3 = factories.courses.course({ id: 3, courseruns: [run3] })
+      const course4 = factories.courses.course({ id: 4, courseruns: [run4] })
+      const course5 = factories.courses.course({ id: 5, courseruns: [run5] })
+
+      // All 3 electives completed, but only 1 is required
+      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
+        3: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run3, course: course3 },
+            grades: [passedGrade],
+          }),
+        ],
+        4: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run4, course: course4 },
+            grades: [passedGrade],
+          }),
+        ],
+        5: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run5, course: course5 },
+            grades: [passedGrade],
+          }),
+        ],
+      }
+
+      const sections: RequirementSection[] = [
+        {
+          key: "s1",
+          title: "Electives",
+          node: makeNode("min_number_of", "1"),
+          items: [
+            { resourceType: "course", course: course3 },
+            { resourceType: "course", course: course4 },
+            { resourceType: "course", course: course5 },
+          ],
+        },
+      ]
+
+      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+        completed: 1, // capped at operator_value=1, not 3
+        total: 1,
+      })
+    })
+
+    test("mixed sections: required all_of + optional min_number_of", () => {
+      const run1 = factories.courses.courseRun({ id: 1 })
+      const run2 = factories.courses.courseRun({ id: 2 })
+      const run3 = factories.courses.courseRun({ id: 3 })
+      const run4 = factories.courses.courseRun({ id: 4 })
+      const run5 = factories.courses.courseRun({ id: 5 })
+      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
+      const course2 = factories.courses.course({ id: 2, courseruns: [run2] })
+      const course3 = factories.courses.course({ id: 3, courseruns: [run3] })
+      const course4 = factories.courses.course({ id: 4, courseruns: [run4] })
+      const course5 = factories.courses.course({ id: 5, courseruns: [run5] })
+
+      // Course 1 (required) completed + courses 3, 4 (electives) completed
+      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
+        1: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run1, course: course1 },
+            grades: [passedGrade],
+          }),
+        ],
+        3: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run3, course: course3 },
+            grades: [passedGrade],
+          }),
+        ],
+        4: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run4, course: course4 },
+            grades: [passedGrade],
+          }),
+        ],
+      }
+
+      const sections: RequirementSection[] = [
+        {
+          key: "required",
+          title: "Required Courses",
+          node: makeNode("all_of"),
+          items: [
+            { resourceType: "course", course: course1 },
+            { resourceType: "course", course: course2 },
+          ],
+        },
+        {
+          key: "electives",
+          title: "Electives",
+          node: makeNode("min_number_of", "1"),
+          items: [
+            { resourceType: "course", course: course3 },
+            { resourceType: "course", course: course4 },
+            { resourceType: "course", course: course5 },
+          ],
+        },
+      ]
+
+      // completed: 1 required + min(2 electives, 1 required) = 2
+      // total: 2 required + 1 elective min = 3
+      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+        completed: 2,
+        total: 3,
+      })
+    })
+
+    test("min_number_of with operator_value=0 contributes nothing to total or completed", () => {
+      const run1 = factories.courses.courseRun({ id: 1 })
+      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
+
+      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
+        1: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run1, course: course1 },
+            grades: [passedGrade],
+          }),
+        ],
+      }
+
+      const sections: RequirementSection[] = [
+        {
+          key: "s1",
+          title: "Bonus",
+          node: makeNode("min_number_of", "0"),
+          items: [{ resourceType: "course", course: course1 }],
+        },
+      ]
+
+      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+        completed: 0,
+        total: 0,
+      })
+    })
+
+    test("program-enrollment items are excluded from both counts", () => {
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        certificate: null,
+      })
+
+      const sections: RequirementSection[] = [
+        {
+          key: "s1",
+          title: "Sub-programs",
+          node: makeNode("all_of"),
+          items: [
+            {
+              resourceType: "program-enrollment",
+              enrollment: programEnrollment,
+            },
+          ],
+        },
+      ]
+
+      expect(getProgramCounts(sections, {})).toEqual({
+        completed: 0,
+        total: 0,
+      })
+    })
+
+    test("empty sections returns zeroes", () => {
+      expect(getProgramCounts([], {})).toEqual({ completed: 0, total: 0 })
+    })
+
+    test("malformed operator_value falls back to counting all items", () => {
+      const run1 = factories.courses.courseRun({ id: 1 })
+      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
+      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
+        1: [
+          factories.enrollment.courseEnrollment({
+            run: { ...run1, course: course1 },
+            grades: [factories.enrollment.grade({ passed: true })],
+          }),
+        ],
+      }
+
+      const sections: RequirementSection[] = [
+        {
+          key: "s1",
+          title: "Electives",
+          node: makeNode("min_number_of", "not-a-number"),
+          items: [{ resourceType: "course", course: course1 }],
+        },
+      ]
+
+      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+        completed: 1,
+        total: 1,
+      })
+    })
+  })
+
+  describe("isRequirementSectionItemCompleted", () => {
+    test("course item is completed when best enrollment has passing grade", () => {
+      const run = factories.courses.courseRun({ id: 1 })
+      const course = factories.courses.course({ id: 1, courseruns: [run] })
+      const enrollment = factories.enrollment.courseEnrollment({
+        run: { ...run, course },
+        grades: [factories.enrollment.grade({ passed: true })],
+      })
+
+      const result = isRequirementSectionItemCompleted(
+        { resourceType: "course", course },
+        { 1: [enrollment] },
+      )
+      expect(result).toBe(true)
+    })
+
+    test("course item is not completed when no passing grade", () => {
+      const run = factories.courses.courseRun({ id: 1 })
+      const course = factories.courses.course({ id: 1, courseruns: [run] })
+      const enrollment = factories.enrollment.courseEnrollment({
+        run: { ...run, course },
+        grades: [factories.enrollment.grade({ passed: false })],
+      })
+
+      const result = isRequirementSectionItemCompleted(
+        { resourceType: "course", course },
+        { 1: [enrollment] },
+      )
+      expect(result).toBe(false)
+    })
+
+    test("program-as-course item is completed when it has a certificate", () => {
+      const program = factories.programs.program()
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        certificate: { uuid: "cert-uuid" },
+      })
+
+      const result = isRequirementSectionItemCompleted(
+        {
+          resourceType: "program-as-course",
+          courseProgramId: program.id,
+          courseProgram: program,
+          courseProgramEnrollment: programEnrollment,
+        },
+        {},
+      )
+      expect(result).toBe(true)
+    })
+
+    test("program-as-course item is not completed when enrollment has no certificate", () => {
+      const program = factories.programs.program()
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        certificate: null,
+      })
+
+      const result = isRequirementSectionItemCompleted(
+        {
+          resourceType: "program-as-course",
+          courseProgramId: program.id,
+          courseProgram: program,
+          courseProgramEnrollment: programEnrollment,
+        },
+        {},
+      )
+      expect(result).toBe(false)
+    })
+
+    test("program-as-course item is not completed when enrollment is undefined", () => {
+      const program = factories.programs.program()
+
+      const result = isRequirementSectionItemCompleted(
+        {
+          resourceType: "program-as-course",
+          courseProgramId: program.id,
+          courseProgram: program,
+          courseProgramEnrollment: undefined,
+        },
+        {},
+      )
+      expect(result).toBe(false)
+    })
+
+    test("program-enrollment item is never completed", () => {
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        certificate: { uuid: "cert-uuid" },
+      })
+
+      const result = isRequirementSectionItemCompleted(
+        { resourceType: "program-enrollment", enrollment: programEnrollment },
+        {},
+      )
+      expect(result).toBe(false)
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -2,16 +2,15 @@ import { factories } from "api/mitxonline-test-utils"
 import {
   CourseRunEnrollmentV3,
   V2ProgramRequirement,
+  V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   EnrollmentStatus,
   filterEnrollmentsByOrganization,
   getBestRun,
-  getProgramCounts,
+  getRequirementsProgress,
   getProgramEnrollmentStatus,
   getKey,
-  isRequirementSectionItemCompleted,
-  RequirementSection,
   selectBestEnrollment,
   getEnrollmentStatus,
   ResourceType,
@@ -458,350 +457,142 @@ describe("helpers", () => {
     })
   })
 
-  describe("getProgramCounts", () => {
-    const makeNode = (
-      operator: string,
+  describe("getRequirementsProgress", () => {
+    const courseLeaf = (id: number): V2ProgramRequirement => ({
+      data: { node_type: "course", course: id }, // eslint-disable-line camelcase
+    })
+
+    const programLeaf = (id: number): V2ProgramRequirement => ({
+      data: { node_type: "program", required_program: id }, // eslint-disable-line camelcase
+    })
+
+    const operator = (
+      op: string,
+      children: V2ProgramRequirement[],
       operatorValue: string | null = null,
     ): V2ProgramRequirement => ({
       data: {
         node_type: "operator",
-        operator,
+        operator: op,
         operator_value: operatorValue, // eslint-disable-line camelcase
       },
+      children,
     })
 
-    const passedGrade = factories.enrollment.grade({ passed: true })
-    const failedGrade = factories.enrollment.grade({ passed: false })
+    const courseEnrollment = (
+      courseId: number,
+      passed: boolean,
+    ): CourseRunEnrollmentV3 => {
+      const run = factories.courses.courseRun({ id: courseId })
+      const course = factories.courses.course({
+        id: courseId,
+        courseruns: [run],
+      })
+      return factories.enrollment.courseEnrollment({
+        run: { ...run, course },
+        grades: [factories.enrollment.grade({ passed })],
+      })
+    }
 
-    test("all_of section: counts all completed and total items", () => {
-      const run1 = factories.courses.courseRun({ id: 1 })
-      const run2 = factories.courses.courseRun({ id: 2 })
-      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
-      const course2 = factories.courses.course({ id: 2, courseruns: [run2] })
-
-      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
-        1: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run1, course: course1 },
-            grades: [passedGrade],
-          }),
-        ],
-        2: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run2, course: course2 },
-            grades: [failedGrade],
-          }),
-        ],
+    test("all_of counts completed courses against total children", () => {
+      const nodes = [operator("all_of", [courseLeaf(1), courseLeaf(2)])]
+      const courseEnrollments = {
+        1: [courseEnrollment(1, true)],
+        2: [courseEnrollment(2, false)],
       }
 
-      const sections: RequirementSection[] = [
-        {
-          key: "s1",
-          title: "Required",
-          node: makeNode("all_of"),
-          items: [
-            { resourceType: "course", course: course1 },
-            { resourceType: "course", course: course2 },
-          ],
-        },
-      ]
-
-      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+      expect(getRequirementsProgress(nodes, courseEnrollments, {})).toEqual({
         completed: 1,
         total: 2,
       })
     })
 
-    test("min_number_of section: caps completions at operator_value", () => {
-      const run3 = factories.courses.courseRun({ id: 3 })
-      const run4 = factories.courses.courseRun({ id: 4 })
-      const run5 = factories.courses.courseRun({ id: 5 })
-      const course3 = factories.courses.course({ id: 3, courseruns: [run3] })
-      const course4 = factories.courses.course({ id: 4, courseruns: [run4] })
-      const course5 = factories.courses.course({ id: 5, courseruns: [run5] })
-
-      // All 3 electives completed, but only 1 is required
-      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
-        3: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run3, course: course3 },
-            grades: [passedGrade],
-          }),
-        ],
-        4: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run4, course: course4 },
-            grades: [passedGrade],
-          }),
-        ],
-        5: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run5, course: course5 },
-            grades: [passedGrade],
-          }),
-        ],
+    test("min_number_of caps completed and total at operator_value", () => {
+      const nodes = [
+        operator(
+          "min_number_of",
+          [courseLeaf(1), courseLeaf(2), courseLeaf(3)],
+          "1",
+        ),
+      ]
+      const courseEnrollments = {
+        1: [courseEnrollment(1, true)],
+        2: [courseEnrollment(2, true)],
+        3: [courseEnrollment(3, true)],
       }
 
-      const sections: RequirementSection[] = [
-        {
-          key: "s1",
-          title: "Electives",
-          node: makeNode("min_number_of", "1"),
-          items: [
-            { resourceType: "course", course: course3 },
-            { resourceType: "course", course: course4 },
-            { resourceType: "course", course: course5 },
-          ],
-        },
-      ]
-
-      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
-        completed: 1, // capped at operator_value=1, not 3
+      expect(getRequirementsProgress(nodes, courseEnrollments, {})).toEqual({
+        completed: 1,
         total: 1,
       })
     })
 
-    test("mixed sections: required all_of + optional min_number_of", () => {
-      const run1 = factories.courses.courseRun({ id: 1 })
-      const run2 = factories.courses.courseRun({ id: 2 })
-      const run3 = factories.courses.courseRun({ id: 3 })
-      const run4 = factories.courses.courseRun({ id: 4 })
-      const run5 = factories.courses.courseRun({ id: 5 })
-      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
-      const course2 = factories.courses.course({ id: 2, courseruns: [run2] })
-      const course3 = factories.courses.course({ id: 3, courseruns: [run3] })
-      const course4 = factories.courses.course({ id: 4, courseruns: [run4] })
-      const course5 = factories.courses.course({ id: 5, courseruns: [run5] })
-
-      // Course 1 (required) completed + courses 3, 4 (electives) completed
-      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
-        1: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run1, course: course1 },
-            grades: [passedGrade],
-          }),
-        ],
-        3: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run3, course: course3 },
-            grades: [passedGrade],
-          }),
-        ],
-        4: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run4, course: course4 },
-            grades: [passedGrade],
-          }),
-        ],
+    test("sums progress across multiple top-level operators", () => {
+      const nodes = [
+        operator("all_of", [courseLeaf(1), courseLeaf(2)]),
+        operator(
+          "min_number_of",
+          [courseLeaf(3), courseLeaf(4), courseLeaf(5)],
+          "1",
+        ),
+      ]
+      const courseEnrollments = {
+        1: [courseEnrollment(1, true)],
+        3: [courseEnrollment(3, true)],
+        4: [courseEnrollment(4, true)],
       }
 
-      const sections: RequirementSection[] = [
-        {
-          key: "required",
-          title: "Required Courses",
-          node: makeNode("all_of"),
-          items: [
-            { resourceType: "course", course: course1 },
-            { resourceType: "course", course: course2 },
-          ],
-        },
-        {
-          key: "electives",
-          title: "Electives",
-          node: makeNode("min_number_of", "1"),
-          items: [
-            { resourceType: "course", course: course3 },
-            { resourceType: "course", course: course4 },
-            { resourceType: "course", course: course5 },
-          ],
-        },
-      ]
-
-      // completed: 1 required + min(2 electives, 1 required) = 2
-      // total: 2 required + 1 elective min = 3
-      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+      expect(getRequirementsProgress(nodes, courseEnrollments, {})).toEqual({
         completed: 2,
         total: 3,
       })
     })
 
-    test("min_number_of with operator_value=0 contributes nothing to total or completed", () => {
-      const run1 = factories.courses.courseRun({ id: 1 })
-      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
-
-      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
-        1: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run1, course: course1 },
-            grades: [passedGrade],
-          }),
-        ],
+    test("program leaf is completed when enrollment has certificate", () => {
+      const enrollments: Record<number, V3UserProgramEnrollment> = {
+        10: factories.enrollment.programEnrollmentV3({
+          certificate: { uuid: "cert-uuid" },
+        }),
       }
+      const nodes = [operator("all_of", [programLeaf(10), programLeaf(11)])]
 
-      const sections: RequirementSection[] = [
-        {
-          key: "s1",
-          title: "Bonus",
-          node: makeNode("min_number_of", "0"),
-          items: [{ resourceType: "course", course: course1 }],
-        },
-      ]
-
-      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
-        completed: 0,
-        total: 0,
-      })
-    })
-
-    test("program-enrollment items are excluded from both counts", () => {
-      const programEnrollment = factories.enrollment.programEnrollmentV3({
-        certificate: null,
-      })
-
-      const sections: RequirementSection[] = [
-        {
-          key: "s1",
-          title: "Sub-programs",
-          node: makeNode("all_of"),
-          items: [
-            {
-              resourceType: "program-enrollment",
-              enrollment: programEnrollment,
-            },
-          ],
-        },
-      ]
-
-      expect(getProgramCounts(sections, {})).toEqual({
-        completed: 0,
-        total: 0,
-      })
-    })
-
-    test("empty sections returns zeroes", () => {
-      expect(getProgramCounts([], {})).toEqual({ completed: 0, total: 0 })
-    })
-
-    test("malformed operator_value falls back to counting all items", () => {
-      const run1 = factories.courses.courseRun({ id: 1 })
-      const course1 = factories.courses.course({ id: 1, courseruns: [run1] })
-      const enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]> = {
-        1: [
-          factories.enrollment.courseEnrollment({
-            run: { ...run1, course: course1 },
-            grades: [factories.enrollment.grade({ passed: true })],
-          }),
-        ],
-      }
-
-      const sections: RequirementSection[] = [
-        {
-          key: "s1",
-          title: "Electives",
-          node: makeNode("min_number_of", "not-a-number"),
-          items: [{ resourceType: "course", course: course1 }],
-        },
-      ]
-
-      expect(getProgramCounts(sections, enrollmentsByCourseId)).toEqual({
+      expect(getRequirementsProgress(nodes, {}, enrollments)).toEqual({
         completed: 1,
-        total: 1,
+        total: 2,
       })
     })
-  })
 
-  describe("isRequirementSectionItemCompleted", () => {
-    test("course item is completed when best enrollment has passing grade", () => {
-      const run = factories.courses.courseRun({ id: 1 })
-      const course = factories.courses.course({ id: 1, courseruns: [run] })
-      const enrollment = factories.enrollment.courseEnrollment({
-        run: { ...run, course },
-        grades: [factories.enrollment.grade({ passed: true })],
-      })
+    test("ignores non-operator and non-leaf children (nested operators)", () => {
+      // Nested operators are not counted — only direct course/program children
+      const nested = operator("all_of", [courseLeaf(99)])
+      const nodes = [operator("all_of", [courseLeaf(1), nested])]
 
-      const result = isRequirementSectionItemCompleted(
-        { resourceType: "course", course },
-        { 1: [enrollment] },
-      )
-      expect(result).toBe(true)
+      expect(
+        getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
+      ).toEqual({ completed: 1, total: 1 })
     })
 
-    test("course item is not completed when no passing grade", () => {
-      const run = factories.courses.courseRun({ id: 1 })
-      const course = factories.courses.course({ id: 1, courseruns: [run] })
-      const enrollment = factories.enrollment.courseEnrollment({
-        run: { ...run, course },
-        grades: [factories.enrollment.grade({ passed: false })],
-      })
+    test("min_number_of with operator_value=0 contributes nothing", () => {
+      const nodes = [operator("min_number_of", [courseLeaf(1)], "0")]
 
-      const result = isRequirementSectionItemCompleted(
-        { resourceType: "course", course },
-        { 1: [enrollment] },
-      )
-      expect(result).toBe(false)
+      expect(
+        getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
+      ).toEqual({ completed: 0, total: 0 })
     })
 
-    test("program-as-course item is completed when it has a certificate", () => {
-      const program = factories.programs.program()
-      const programEnrollment = factories.enrollment.programEnrollmentV3({
-        certificate: { uuid: "cert-uuid" },
-      })
+    test("malformed operator_value falls back to full count", () => {
+      const nodes = [operator("min_number_of", [courseLeaf(1)], "not-a-number")]
 
-      const result = isRequirementSectionItemCompleted(
-        {
-          resourceType: "program-as-course",
-          courseProgramId: program.id,
-          courseProgram: program,
-          courseProgramEnrollment: programEnrollment,
-        },
-        {},
-      )
-      expect(result).toBe(true)
+      expect(
+        getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
+      ).toEqual({ completed: 1, total: 1 })
     })
 
-    test("program-as-course item is not completed when enrollment has no certificate", () => {
-      const program = factories.programs.program()
-      const programEnrollment = factories.enrollment.programEnrollmentV3({
-        certificate: null,
+    test("empty nodes returns zeroes", () => {
+      expect(getRequirementsProgress([], {}, {})).toEqual({
+        completed: 0,
+        total: 0,
       })
-
-      const result = isRequirementSectionItemCompleted(
-        {
-          resourceType: "program-as-course",
-          courseProgramId: program.id,
-          courseProgram: program,
-          courseProgramEnrollment: programEnrollment,
-        },
-        {},
-      )
-      expect(result).toBe(false)
-    })
-
-    test("program-as-course item is not completed when enrollment is undefined", () => {
-      const program = factories.programs.program()
-
-      const result = isRequirementSectionItemCompleted(
-        {
-          resourceType: "program-as-course",
-          courseProgramId: program.id,
-          courseProgram: program,
-          courseProgramEnrollment: undefined,
-        },
-        {},
-      )
-      expect(result).toBe(false)
-    })
-
-    test("program-enrollment item is never completed", () => {
-      const programEnrollment = factories.enrollment.programEnrollmentV3({
-        certificate: { uuid: "cert-uuid" },
-      })
-
-      const result = isRequirementSectionItemCompleted(
-        { resourceType: "program-enrollment", enrollment: programEnrollment },
-        {},
-      )
-      expect(result).toBe(false)
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -580,12 +580,28 @@ describe("helpers", () => {
       ).toEqual({ completed: 0, total: 0 })
     })
 
-    test("malformed operator_value falls back to full count", () => {
+    test("min_number_of with malformed operator_value contributes nothing and warns", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
       const nodes = [operator("min_number_of", [courseLeaf(1)], "not-a-number")]
 
       expect(
         getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
-      ).toEqual({ completed: 1, total: 1 })
+      ).toEqual({ completed: 0, total: 0 })
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
+    })
+
+    test("unknown operator contributes nothing and warns", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+      const nodes = [
+        operator("at_least_one_of", [courseLeaf(1), courseLeaf(2)]),
+      ]
+
+      expect(
+        getRequirementsProgress(nodes, { 1: [courseEnrollment(1, true)] }, {}),
+      ).toEqual({ completed: 0, total: 0 })
+      expect(warn).toHaveBeenCalled()
+      warn.mockRestore()
     })
 
     test("empty nodes returns zeroes", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
@@ -1,7 +1,6 @@
 import {
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
-  V2ProgramDetail,
   V2ProgramRequirement,
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
@@ -113,99 +112,71 @@ export {
   getProgramEnrollmentStatus,
 }
 
-type CourseRequirementItem = {
-  resourceType: "course"
-  course: CourseWithCourseRunsSerializerV2
-}
-
-type ProgramAsCourseRequirementItem = {
-  resourceType: "program-as-course"
-  courseProgramId: number
-  courseProgram: V2ProgramDetail
-  courseProgramEnrollment: V3UserProgramEnrollment | undefined
-}
-
-type ProgramEnrollmentRequirementItem = {
-  resourceType: "program-enrollment"
-  enrollment: V3UserProgramEnrollment
-}
-
-type RequirementSectionItem =
-  | CourseRequirementItem
-  | ProgramAsCourseRequirementItem
-  | ProgramEnrollmentRequirementItem
-
-type RequirementSection = {
-  key: string | number | null | undefined
-  title: string
-  items: RequirementSectionItem[]
-  node: V2ProgramRequirement
-}
-
-const isRequirementSectionItemCompleted = (
-  item: RequirementSectionItem,
-  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>,
+const isLeafRequirementNodeCompleted = (
+  node: V2ProgramRequirement,
+  courseEnrollments: Record<number, CourseRunEnrollmentV3[]>,
+  programEnrollments: Record<number, V3UserProgramEnrollment>,
 ): boolean => {
-  if (item.resourceType === "course") {
-    const bestEnrollment = selectBestEnrollment(
-      item.course,
-      enrollmentsByCourseId[item.course.id] || [],
-    )
-    return getEnrollmentStatus(bestEnrollment) === EnrollmentStatus.Completed
+  if (
+    node.data.node_type === "course" &&
+    typeof node.data.course === "number"
+  ) {
+    const enrollments = courseEnrollments[node.data.course] ?? []
+    return enrollments.some((e) => e.grades.some((g) => g.passed))
   }
-  if (item.resourceType === "program-as-course") {
-    return (
-      getProgramEnrollmentStatus(item.courseProgramEnrollment, 0, 0) ===
-      EnrollmentStatus.Completed
-    )
+  if (node.data.node_type === "program" && node.data.required_program) {
+    return !!programEnrollments[node.data.required_program]?.certificate
   }
   return false
 }
 
 /**
- * Computes the overall completed and total course counts for a program,
- * given its requirement sections and a map of enrollments by course ID.
+ * Computes `{ completed, total }` across the given operator nodes. Each
+ * operator node's direct children are counted as its requirements — nested
+ * operators are ignored (e.g., a sub-program's internal courses don't count).
+ * For `min_number_of` operators, `completed` is capped at `operator_value`
+ * so extra electives don't inflate the overall total.
  *
- * For `min_number_of` sections (electives), completions are capped at
- * the section's `operator_value` so that completing extra electives does
- * not inflate the required-course completion count shown in the header.
+ * Pass all top-level operators for overall program progress, or a single
+ * operator node for per-section progress.
  */
-const getProgramCounts = (
-  sections: RequirementSection[],
-  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>,
+const getRequirementsProgress = (
+  nodes: V2ProgramRequirement[],
+  courseEnrollments: Record<number, CourseRunEnrollmentV3[]>,
+  programEnrollments: Record<number, V3UserProgramEnrollment>,
 ): { completed: number; total: number } => {
-  return sections.reduce(
-    (acc, section) => {
-      const countableItems = section.items.filter(
-        (item) =>
-          item.resourceType === "course" ||
-          item.resourceType === "program-as-course",
+  return nodes.reduce(
+    (acc, node) => {
+      if (node.data.node_type !== "operator") return acc
+
+      const leaves = (node.children ?? []).filter(
+        (c) => c.data.node_type === "course" || c.data.node_type === "program",
       )
-      const sectionCompleted = countableItems.filter((item) =>
-        isRequirementSectionItemCompleted(item, enrollmentsByCourseId),
+      const completed = leaves.filter((leaf) =>
+        isLeafRequirementNodeCompleted(
+          leaf,
+          courseEnrollments,
+          programEnrollments,
+        ),
       ).length
 
-      if (
-        section.node.data.operator === "min_number_of" &&
-        section.node.data.operator_value
-      ) {
-        const minRequired = parseInt(section.node.data.operator_value, 10)
+      if (node.data.operator === "min_number_of" && node.data.operator_value) {
+        const minRequired = parseInt(node.data.operator_value, 10)
         if (!isNaN(minRequired)) {
           return {
-            completed: acc.completed + Math.min(sectionCompleted, minRequired),
+            completed: acc.completed + Math.min(completed, minRequired),
             total: acc.total + minRequired,
           }
         }
       }
 
       return {
-        completed: acc.completed + sectionCompleted,
-        total: acc.total + countableItems.length,
+        completed: acc.completed + completed,
+        total: acc.total + leaves.length,
       }
     },
     { completed: 0, total: 0 },
   )
 }
 
-export type { RequirementSectionItem, RequirementSection }
-export { isRequirementSectionItemCompleted, getProgramCounts }
+export { getRequirementsProgress }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
@@ -158,8 +158,14 @@ const getRequirementsProgress = (
   return nodes.reduce(
     (acc, node) => {
       if (node.data.node_type !== "operator") return acc
+      const children = node.children ?? []
+      if (children.some((c) => c.data.node_type === "operator")) {
+        console.warn(
+          "getRequirementsProgress: nested operators are not supported and will be skipped",
+        )
+      }
 
-      const leaves = (node.children ?? []).filter(
+      const leaves = children.filter(
         (c) => c.data.node_type === "course" || c.data.node_type === "program",
       )
       const completed = leaves.filter((leaf) =>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
@@ -1,6 +1,8 @@
 import {
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
+  V2ProgramDetail,
+  V2ProgramRequirement,
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { getBestRun } from "@/common/mitxonline"
@@ -110,3 +112,100 @@ export {
   getEnrollmentStatus,
   getProgramEnrollmentStatus,
 }
+
+type CourseRequirementItem = {
+  resourceType: "course"
+  course: CourseWithCourseRunsSerializerV2
+}
+
+type ProgramAsCourseRequirementItem = {
+  resourceType: "program-as-course"
+  courseProgramId: number
+  courseProgram: V2ProgramDetail
+  courseProgramEnrollment: V3UserProgramEnrollment | undefined
+}
+
+type ProgramEnrollmentRequirementItem = {
+  resourceType: "program-enrollment"
+  enrollment: V3UserProgramEnrollment
+}
+
+type RequirementSectionItem =
+  | CourseRequirementItem
+  | ProgramAsCourseRequirementItem
+  | ProgramEnrollmentRequirementItem
+
+type RequirementSection = {
+  key: string | number | null | undefined
+  title: string
+  items: RequirementSectionItem[]
+  node: V2ProgramRequirement
+}
+
+const isRequirementSectionItemCompleted = (
+  item: RequirementSectionItem,
+  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>,
+): boolean => {
+  if (item.resourceType === "course") {
+    const bestEnrollment = selectBestEnrollment(
+      item.course,
+      enrollmentsByCourseId[item.course.id] || [],
+    )
+    return getEnrollmentStatus(bestEnrollment) === EnrollmentStatus.Completed
+  }
+  if (item.resourceType === "program-as-course") {
+    return (
+      getProgramEnrollmentStatus(item.courseProgramEnrollment, 0, 0) ===
+      EnrollmentStatus.Completed
+    )
+  }
+  return false
+}
+
+/**
+ * Computes the overall completed and total course counts for a program,
+ * given its requirement sections and a map of enrollments by course ID.
+ *
+ * For `min_number_of` sections (electives), completions are capped at
+ * the section's `operator_value` so that completing extra electives does
+ * not inflate the required-course completion count shown in the header.
+ */
+const getProgramCounts = (
+  sections: RequirementSection[],
+  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>,
+): { completed: number; total: number } => {
+  return sections.reduce(
+    (acc, section) => {
+      const countableItems = section.items.filter(
+        (item) =>
+          item.resourceType === "course" ||
+          item.resourceType === "program-as-course",
+      )
+      const sectionCompleted = countableItems.filter((item) =>
+        isRequirementSectionItemCompleted(item, enrollmentsByCourseId),
+      ).length
+
+      if (
+        section.node.data.operator === "min_number_of" &&
+        section.node.data.operator_value
+      ) {
+        const minRequired = parseInt(section.node.data.operator_value, 10)
+        if (!isNaN(minRequired)) {
+          return {
+            completed: acc.completed + Math.min(sectionCompleted, minRequired),
+            total: acc.total + minRequired,
+          }
+        }
+      }
+
+      return {
+        completed: acc.completed + sectionCompleted,
+        total: acc.total + countableItems.length,
+      }
+    },
+    { completed: 0, total: 0 },
+  )
+}
+
+export type { RequirementSectionItem, RequirementSection }
+export { isRequirementSectionItemCompleted, getProgramCounts }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
@@ -140,8 +140,9 @@ const isLeafRequirementNodeCompleted = (
  * `min_number_of=4` children, "max child progress" and "sum of all work"
  * give different answers, and picking one is a product question).
  *
- * Only `all_of` and `min_number_of` are handled explicitly; any other
- * operator is treated like `all_of` (total = leaf count).
+ * Only `all_of` and `min_number_of` (with a valid integer `operator_value`)
+ * are counted. Unknown or malformed operators contribute nothing and log
+ * a warning — we'd rather under-report than guess.
  *
  * For `min_number_of` operators, `completed` is capped at `operator_value`
  * so extra electives don't inflate the overall total.
@@ -169,8 +170,15 @@ const getRequirementsProgress = (
         ),
       ).length
 
-      if (node.data.operator === "min_number_of" && node.data.operator_value) {
-        const minRequired = parseInt(node.data.operator_value, 10)
+      if (node.data.operator === "all_of") {
+        return {
+          completed: acc.completed + completed,
+          total: acc.total + leaves.length,
+        }
+      }
+
+      if (node.data.operator === "min_number_of") {
+        const minRequired = parseInt(node.data.operator_value ?? "", 10)
         if (!isNaN(minRequired)) {
           return {
             completed: acc.completed + Math.min(completed, minRequired),
@@ -179,10 +187,10 @@ const getRequirementsProgress = (
         }
       }
 
-      return {
-        completed: acc.completed + completed,
-        total: acc.total + leaves.length,
-      }
+      console.warn(
+        `getRequirementsProgress: unsupported operator "${node.data.operator}" (operator_value=${JSON.stringify(node.data.operator_value)}); skipping.`,
+      )
+      return acc
     },
     { completed: 0, total: 0 },
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.ts
@@ -131,9 +131,18 @@ const isLeafRequirementNodeCompleted = (
 }
 
 /**
- * Computes `{ completed, total }` across the given operator nodes. Each
- * operator node's direct children are counted as its requirements — nested
- * operators are ignored (e.g., a sub-program's internal courses don't count).
+ * Computes `{ completed, total }` across the given operator nodes.
+ *
+ * Assumes a flat req_tree: each operator's direct children are leaves
+ * (`node_type: "course"` or `"program"`). Nesting operators inside
+ * operators is not supported — there is no single well-defined reduction
+ * for nested progress (e.g., with `min_number_of=1` parent over two
+ * `min_number_of=4` children, "max child progress" and "sum of all work"
+ * give different answers, and picking one is a product question).
+ *
+ * Only `all_of` and `min_number_of` are handled explicitly; any other
+ * operator is treated like `all_of` (total = leaf count).
+ *
  * For `min_number_of` operators, `completed` is capped at `operator_value`
  * so extra electives don't inflate the overall total.
  *


### PR DESCRIPTION
### What are the relevant tickets?
Fixes 
- https://github.com/mitodl/hq/issues/10784

### Description (What does it do?)

Fixes the "You have completed X of Y courses" counter on the program enrollment page incorrectly counting elective completions toward the required-course total.

**Changes at a glance:**
- For `min_number_of` (elective) sections, completions are now capped at `operator_value` — e.g., completing 3 courses in a "pick 1 of 4" section contributes 1, not 3
- Section headers ("Completed X of Y") stay consistent with the overall count
- Counting logic now lives in a single `getRequirementsProgress(nodes, courseEnrollments, programEnrollments)` helper in `helpers.ts`, used for both the overall program count and the per-section count. It operates directly on `req_tree` operator nodes rather than a UI-shaped intermediate
- Unsupported operators (unknown types, or `min_number_of` with a malformed `operator_value`) now skip + `console.warn` rather than silently falling back to `all_of`-like behavior

### Screenshots

<img width="975" height="654" alt="Screenshot 2026-04-21 at 7 50 18 PM" src="https://github.com/user-attachments/assets/6360ca6a-fbf2-4f92-b3e8-1ea7cdb33591" />


### How can this be tested?

**Prerequisite:** MITxOnline and Learn integrated, and a program with multiple requirement sections, including an elective section. For example:
```sh
Your Program # req_tree pseudocode
    Required Courses (node_type = operator, operator = all_of)
        5 courses
    Elective Courses (node_type = operator, operator = min_number_of, operator_value = 2)
        5 more courses, but you only need 2 of them.
```
For a fuller test, include some ProgramAsCourse children in your program. I.e., include some child programs with display_mode = Course.

1. Enroll in the program. View program page via its dashboard, `/dashboard/program/<program-id>` in Learn
2. Complete some of the courses in the "Required" section. The completion counts should increment:
    - the overall program count (shown in screenshot above) should increase
    - The "Required" section completion count should increase
    - **Tip:** "Completion" requires a passing grade, which you can add via MITxOnline admin
3. Now try completing some of the electives: As you complete electives, the overall completion count should increase up to some cap...
    -  for example, If an elective section requires 2 courses, that section should now contribute at most 2 courses to the program completion count
    - In particular, for UAI, this means that the "Industry specific verticals" do NOT contribute to the overall completion count.