### PR TITLE
feat: implement PostHog event tracking for user interactions

### DIFF
--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -17,7 +17,7 @@ import {
 import invariant from "tiny-invariant"
 import * as routes from "@/common/urls"
 import { FeatureFlags } from "@/common/feature_flags"
-import { assertHeadings } from "ol-test-utilities"
+import { assertHeadings, allowConsoleErrors } from "ol-test-utilities"
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
 
@@ -131,6 +131,7 @@ describe("UAI Announcement Card", () => {
   })
 
   test("CTA click fires cta_clicked with label and readableId", async () => {
+    allowConsoleErrors()
     setupAPIs()
     mockedUseFeatureFlagEnabled.mockImplementation(
       (flag) => flag === FeatureFlags.UniversalAI,

--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -19,6 +19,7 @@ import * as routes from "@/common/urls"
 import { FeatureFlags } from "@/common/feature_flags"
 import { assertHeadings } from "ol-test-utilities"
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
@@ -127,6 +128,27 @@ describe("UAI Announcement Card", () => {
       name: "Learn about Universal AI",
     })
     assertLinksTo(cta, { pathname: "/programs/program-v1:UAI+B2C" })
+  })
+
+  test("CTA click fires cta_clicked with label and readableId", async () => {
+    setupAPIs()
+    mockedUseFeatureFlagEnabled.mockImplementation(
+      (flag) => flag === FeatureFlags.UniversalAI,
+    )
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    renderWithProviders(<HomePage heroImageIndex={1} />)
+    const cta = await screen.findByRole("link", {
+      name: "Learn about Universal AI",
+    })
+    await user.click(cta)
+    expect(mockedPostHogCapture).toHaveBeenCalledWith(
+      PostHogEvents.CallToActionClicked,
+      expect.objectContaining({
+        label: "Learn about Universal AI",
+        readableId: "program-v1:UAI+B2C",
+      }),
+    )
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 })
 

--- a/frontends/main/src/app-pages/HomePage/UAIAnnouncementCard.tsx
+++ b/frontends/main/src/app-pages/HomePage/UAIAnnouncementCard.tsx
@@ -257,7 +257,6 @@ const UAIAnnouncementCard: React.FC = () => {
       posthog.capture(PostHogEvents.CallToActionClicked, {
         label: "Learn about Universal AI",
         readableId: UAI_PROGRAM_READABLE_ID,
-        resourceType: "program",
       })
     }
   }

--- a/frontends/main/src/app-pages/HomePage/UAIAnnouncementCard.tsx
+++ b/frontends/main/src/app-pages/HomePage/UAIAnnouncementCard.tsx
@@ -1,10 +1,12 @@
+"use client"
 import React from "react"
 import { Typography, styled } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import { RiArrowRightLine } from "@remixicon/react"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 import { programPageView } from "@/common/urls"
+import { PostHogEvents } from "@/common/constants"
 
 const UAI_PROGRAM_READABLE_ID = "program-v1:UAI+B2C"
 
@@ -243,14 +245,26 @@ const CTAButton = styled(ButtonLink)(({ theme }) => ({
 
 const UAIAnnouncementCard: React.FC = () => {
   const showUAICard = useFeatureFlagEnabled(FeatureFlags.UniversalAI)
-  if (!showUAICard) {
-    return null
-  }
+  const posthog = usePostHog()
 
   const ctaHref = programPageView({
     readable_id: UAI_PROGRAM_READABLE_ID,
     display_mode: null,
   })
+
+  const handleCTAClick = () => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture(PostHogEvents.CallToActionClicked, {
+        label: "Learn about Universal AI",
+        readableId: UAI_PROGRAM_READABLE_ID,
+        resourceType: "program",
+      })
+    }
+  }
+
+  if (!showUAICard) {
+    return null
+  }
 
   return (
     <Card>
@@ -275,6 +289,7 @@ const UAIAnnouncementCard: React.FC = () => {
               variant="primary"
               href={ctaHref}
               endIcon={<RiArrowRightLine />}
+              onClick={handleCTAClick}
             >
               Learn about Universal AI
             </CTAButton>
@@ -294,6 +309,7 @@ const UAIAnnouncementCard: React.FC = () => {
           variant="primary"
           href={ctaHref}
           endIcon={<RiArrowRightLine />}
+          onClick={handleCTAClick}
         >
           Learn about Universal AI
         </CTAButton>

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
@@ -15,6 +15,18 @@ import {
 } from "api/mitxonline-test-utils"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 import * as routes from "@/common/urls"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  usePostHog: jest.fn(),
+}))
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 const makeCourse = mitxFactories.courses.course
 const makeRun = mitxFactories.courses.courseRun
@@ -504,5 +516,69 @@ describe("CourseEnrollmentButton", () => {
     })
     expect(button).toBeInTheDocument()
     expect(button).toBeDisabled()
+  })
+
+  describe("PostHog tracking", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+      mockCapture.mockClear()
+    })
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+    })
+
+    test("fires cta_clicked when authenticated user clicks enroll", async () => {
+      const run = makeRun({
+        is_archived: false,
+        is_enrollable: true,
+        enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
+      })
+      const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
+      setMockResponse.get(
+        urls.userMe.get(),
+        makeUser({ is_authenticated: true }),
+      )
+
+      renderWithProviders(<CourseEnrollmentButton course={course} />)
+      await user.click(
+        await screen.findByRole("button", { name: "Enroll for Free" }),
+      )
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        PostHogEvents.CallToActionClicked,
+        expect.objectContaining({
+          resourceId: course.id,
+          readableId: course.readable_id,
+          resourceType: "course",
+        }),
+      )
+    })
+
+    test("fires cta_clicked when unauthenticated user clicks enroll", async () => {
+      const run = makeRun({
+        is_archived: false,
+        is_enrollable: true,
+        enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
+      })
+      const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
+      setMockResponse.get(
+        urls.userMe.get(),
+        makeUser({ is_authenticated: false }),
+      )
+
+      renderWithProviders(<CourseEnrollmentButton course={course} />)
+      await user.click(
+        await screen.findByRole("button", { name: "Enroll for Free" }),
+      )
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        PostHogEvents.CallToActionClicked,
+        expect.objectContaining({
+          resourceId: course.id,
+          readableId: course.readable_id,
+          resourceType: "course",
+        }),
+      )
+    })
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
@@ -538,6 +538,8 @@ describe("CourseEnrollmentButton", () => {
         urls.userMe.get(),
         makeUser({ is_authenticated: true }),
       )
+      // Clicking enroll triggers the enrollment API call; mock it to avoid failing on console.error.
+      setMockResponse.post(mitxUrls.enrollment.enrollmentsListV1(), {})
 
       renderWithProviders(<CourseEnrollmentButton course={course} />)
       await user.click(

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -99,7 +99,7 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
           resourceId: course.id,
           readableId: course.readable_id,
           resourceType: "course",
-          label: getButtonText(nextRun, price?.displayPrice),
+          label: getButtonText(nextRun, price?.finalPrice),
         })
       }
       if (enrollmentDecision.type === "dialog") {

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -93,15 +93,16 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     if (me.isLoading) {
       return
-    } else if (me.data?.is_authenticated) {
-      if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-        posthog.capture(PostHogEvents.CallToActionClicked, {
-          resourceId: course.id,
-          readableId: course.readable_id,
-          resourceType: "course",
-          label: getButtonText(nextRun, price?.finalPrice),
-        })
-      }
+    }
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture(PostHogEvents.CallToActionClicked, {
+        resourceId: course.id,
+        readableId: course.readable_id,
+        resourceType: "course",
+        label: getButtonText(nextRun, price?.finalPrice),
+      })
+    }
+    if (me.data?.is_authenticated) {
       if (enrollmentDecision.type === "dialog") {
         NiceModal.show(CourseEnrollmentDialog, { course })
       } else if (enrollmentDecision.type === "checkout") {

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -96,8 +96,10 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
     } else if (me.data?.is_authenticated) {
       if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
         posthog.capture(PostHogEvents.CallToActionClicked, {
-          course,
-          label: course.title,
+          resourceId: course.id,
+          readableId: course.readable_id,
+          resourceType: "course",
+          label: getButtonText(nextRun, price?.displayPrice),
         })
       }
       if (enrollmentDecision.type === "dialog") {

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -21,6 +21,8 @@ import { productQueries } from "api/mitxonline-hooks/products"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
 import { useCreateEnrollment } from "api/mitxonline-hooks/enrollment"
 import { useRouter } from "next-nprogress-bar"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 const DiscountedPriceContent = styled.span({
   display: "inline-flex",
@@ -60,6 +62,7 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
   const replaceBasketItem = useReplaceBasketItem()
   const createEnrollment = useCreateEnrollment()
   const router = useRouter()
+  const posthog = usePostHog()
   const nextRunId = course.next_run_id
   const nextRun = course.courseruns.find((run) => run.id === nextRunId)
   const enrollmentDecision = getCourseEnrollmentAction(course)
@@ -91,6 +94,12 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
     if (me.isLoading) {
       return
     } else if (me.data?.is_authenticated) {
+      if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+        posthog.capture(PostHogEvents.CallToActionClicked, {
+            course,
+            label: course.title,
+          })
+      }
       if (enrollmentDecision.type === "dialog") {
         NiceModal.show(CourseEnrollmentDialog, { course })
       } else if (enrollmentDecision.type === "checkout") {

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -96,9 +96,9 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
     } else if (me.data?.is_authenticated) {
       if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
         posthog.capture(PostHogEvents.CallToActionClicked, {
-            course,
-            label: course.title,
-          })
+          course,
+          label: course.title,
+        })
       }
       if (enrollmentDecision.type === "dialog") {
         NiceModal.show(CourseEnrollmentDialog, { course })

--- a/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
+++ b/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import React from "react"
+import { usePostHog } from "posthog-js/react"
 import { BaseLearningResourceCard } from "ol-components"
+import { PostHogEvents } from "@/common/constants"
 import type {
   CourseWithCourseRunsSerializerV2,
   V2ProgramDetail,
@@ -17,6 +19,7 @@ type CommonCardProps = {
   headingLevel?: number
   className?: string
   list?: boolean
+  label?: string
 }
 
 type MitxOnlineCourseCardProps = CommonCardProps & {
@@ -156,6 +159,7 @@ const extractCardData = (
 const MitxOnlineResourceCard: React.FC<MitxOnlineResourceCardProps> = (
   props,
 ) => {
+  const posthog = usePostHog()
   const {
     href,
     size = "small",
@@ -163,6 +167,7 @@ const MitxOnlineResourceCard: React.FC<MitxOnlineResourceCardProps> = (
     headingLevel = 6,
     className,
     list,
+    label,
   } = props
 
   if (isLoading) {
@@ -198,6 +203,14 @@ const MitxOnlineResourceCard: React.FC<MitxOnlineResourceCardProps> = (
       startDate={data.startDate}
       ariaLabel={`${data.displayType}: ${data.title}`}
       list={list}
+      onClick={() =>
+        posthog.capture(PostHogEvents.CourseCardClicked, {
+          label,
+          resourceId: props.resource?.id,
+          readableId: props.resource?.readable_id,
+          resourceType: props.resourceType,
+        })
+      }
     />
   )
 }

--- a/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
+++ b/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
@@ -203,14 +203,16 @@ const MitxOnlineResourceCard: React.FC<MitxOnlineResourceCardProps> = (
       startDate={data.startDate}
       ariaLabel={`${data.displayType}: ${data.title}`}
       list={list}
-      onClick={() =>
-        posthog.capture(PostHogEvents.CourseCardClicked, {
-          label,
-          resourceId: props.resource?.id,
-          readableId: props.resource?.readable_id,
-          resourceType: props.resourceType,
-        })
-      }
+      onClick={() => {
+        if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+          posthog.capture(PostHogEvents.CourseCardClicked, {
+            label,
+            resourceId: props.resource?.id,
+            readableId: props.resource?.readable_id,
+            resourceType: props.resourceType,
+          })
+        }
+      }}
     />
   )
 }

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -13,15 +13,21 @@ import {
   urls as mitxUrls,
   factories as mitxFactories,
 } from "api/mitxonline-test-utils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { programView } from "@/common/urls"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 import * as routes from "@/common/urls"
+import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
   .mocked(useFeatureFlagEnabled)
   .mockImplementation(() => false)
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 const makeProgram = mitxFactories.programs.program
 const makeProgramEnrollment = mitxFactories.enrollment.programEnrollmentV3
@@ -398,5 +404,71 @@ describe("ProgramEnrollmentButton", () => {
     await user.click(enrollButton)
 
     screen.getByTestId("signup-popover")
+  })
+
+  describe("PostHog tracking", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+      mockCapture.mockClear()
+    })
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+    })
+
+    test("fires cta_clicked when authenticated user clicks enroll", async () => {
+      const program = makeProgram({
+        enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
+      })
+      setMockResponse.get(mitxUrls.programEnrollments.enrollmentsListV3(), [])
+      setMockResponse.get(
+        urls.userMe.get(),
+        makeUser({ is_authenticated: true }),
+      )
+
+      renderWithProviders(
+        <ProgramEnrollmentButton program={program} variant="primary" />,
+      )
+      await user.click(
+        await screen.findByRole("button", { name: "Enroll for Free" }),
+      )
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        PostHogEvents.CallToActionClicked,
+        expect.objectContaining({
+          resourceId: program.id,
+          readableId: program.readable_id,
+          resourceType: "program",
+        }),
+      )
+    })
+
+    test("fires cta_clicked when unauthenticated user clicks enroll", async () => {
+      const program = makeProgram({
+        enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
+      })
+      setMockResponse.get(mitxUrls.programEnrollments.enrollmentsListV3(), [], {
+        code: 403,
+      })
+      setMockResponse.get(
+        urls.userMe.get(),
+        makeUser({ is_authenticated: false }),
+      )
+
+      renderWithProviders(
+        <ProgramEnrollmentButton program={program} variant="primary" />,
+      )
+      await user.click(
+        await screen.findByRole("button", { name: "Enroll for Free" }),
+      )
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        PostHogEvents.CallToActionClicked,
+        expect.objectContaining({
+          resourceId: program.id,
+          readableId: program.readable_id,
+          resourceType: "program",
+        }),
+      )
+    })
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -424,6 +424,11 @@ describe("ProgramEnrollmentButton", () => {
         urls.userMe.get(),
         makeUser({ is_authenticated: true }),
       )
+      setMockResponse.post(
+        mitxUrls.programEnrollments.enrollmentsListV3(),
+        null,
+        { code: 201 },
+      )
 
       renderWithProviders(
         <ProgramEnrollmentButton program={program} variant="primary" />,

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -90,8 +90,10 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
     } else if (me.data?.is_authenticated) {
       if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
         posthog.capture(PostHogEvents.CallToActionClicked, {
-          program,
-          label: program.title,
+          resourceId: program.id,
+          readableId: program.readable_id,
+          resourceType: "program",
+          label: getEnrollButtonText(),
         })
       }
       if (enrollmentType === "paid" && program.products[0]) {

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -87,15 +87,16 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     if (enrollments.isLoading || me.isLoading) {
       return
-    } else if (me.data?.is_authenticated) {
-      if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-        posthog.capture(PostHogEvents.CallToActionClicked, {
-          resourceId: program.id,
-          readableId: program.readable_id,
-          resourceType: "program",
-          label: getEnrollButtonText(),
-        })
-      }
+    }
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture(PostHogEvents.CallToActionClicked, {
+        resourceId: program.id,
+        readableId: program.readable_id,
+        resourceType: "program",
+        label: getEnrollButtonText(),
+      })
+    }
+    if (me.data?.is_authenticated) {
       if (enrollmentType === "paid" && program.products[0]) {
         replaceBasketItem.mutate(program.products[0].id)
       } else if (enrollmentType === "free") {

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -19,7 +19,7 @@ import NiceModal from "@ebay/nice-modal-react"
 import { userQueries } from "api/hooks/user"
 import { SignupPopover } from "@/page-components/SignupPopover/SignupPopover"
 import { programView } from "@/common/urls"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 import {
   enrollmentAlertSuccessUrl,
@@ -28,6 +28,7 @@ import {
 } from "@/common/mitxonline"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
 import { useRouter } from "next-nprogress-bar"
+import { PostHogEvents } from "@/common/constants"
 
 const ButtonLinkWithDisabled = styled(ButtonLink)(({ href }) => [
   !href && {
@@ -81,11 +82,18 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
   const isPending =
     replaceBasketItem.isPending || createProgramEnrollment.isPending
   const isError = replaceBasketItem.isError || createProgramEnrollment.isError
+  const posthog = usePostHog()
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
     if (enrollments.isLoading || me.isLoading) {
       return
     } else if (me.data?.is_authenticated) {
+      if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+        posthog.capture(PostHogEvents.CallToActionClicked, {
+            program,
+            label: program.title,
+          })
+      }
       if (enrollmentType === "paid" && program.products[0]) {
         replaceBasketItem.mutate(program.products[0].id)
       } else if (enrollmentType === "free") {

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -90,9 +90,9 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
     } else if (me.data?.is_authenticated) {
       if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
         posthog.capture(PostHogEvents.CallToActionClicked, {
-            program,
-            label: program.title,
-          })
+          program,
+          label: program.title,
+        })
       }
       if (enrollmentType === "paid" && program.products[0]) {
         replaceBasketItem.mutate(program.products[0].id)

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -16,7 +16,13 @@ import type {
   CourseWithCourseRunsSerializerV2,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
-import { renderWithProviders, waitFor, screen, within } from "@/test-utils"
+import {
+  renderWithProviders,
+  waitFor,
+  screen,
+  within,
+  user,
+} from "@/test-utils"
 import ProgramPage from "./ProgramPage"
 import { assertHeadings } from "ol-test-utilities"
 import { notFound } from "next/navigation"
@@ -25,14 +31,20 @@ import {
   PROGRAM_HIDE_STAY_UPDATED_CASES,
 } from "./test-utils/stayUpdated"
 
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import invariant from "tiny-invariant"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { getIdsFromReqTree } from "@/common/mitxonline"
 import { faker } from "@faker-js/faker/locale/en"
+import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 jest.mock("@/common/useFeatureFlagsLoaded")
 const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
@@ -638,6 +650,31 @@ describe("ProgramPage", () => {
     await waitFor(() => {
       expect(notFound).toHaveBeenCalled()
     })
+  })
+
+  test("clicking a requirement card fires course_card_clicked", async () => {
+    const program = makeProgram({
+      ...makeReqs({ required: { count: 1, title: "Required" } }),
+    })
+    const page = makePage({ program_details: program })
+    const { courses } = setupApis({ program, page })
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    mockCapture.mockClear()
+
+    renderWithProviders(<ProgramPage readableId={program.readable_id} />)
+
+    const course = courses[0]
+    const card = await screen.findByRole("heading", { name: course.title })
+    await user.click(card)
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      PostHogEvents.CourseCardClicked,
+      expect.objectContaining({
+        resourceId: course.id,
+        readableId: course.readable_id,
+      }),
+    )
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 
   describe("Stay Updated button", () => {

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -24,7 +24,7 @@ import {
   user,
 } from "@/test-utils"
 import ProgramPage from "./ProgramPage"
-import { assertHeadings } from "ol-test-utilities"
+import { assertHeadings, allowConsoleErrors } from "ol-test-utilities"
 import { notFound } from "next/navigation"
 import {
   useStayUpdatedEnv,
@@ -653,6 +653,7 @@ describe("ProgramPage", () => {
   })
 
   test("clicking a requirement card fires course_card_clicked", async () => {
+    allowConsoleErrors()
     const program = makeProgram({
       ...makeReqs({ required: { count: 1, title: "Required" } }),
     })

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -179,6 +179,7 @@ const RequirementsSection: React.FC<RequirementsSectionProps> = ({
                           }
                           size="small"
                           isLoading={isLoading}
+                          label={req.title}
                           list
                         />
                       </li>
@@ -201,6 +202,7 @@ const RequirementsSection: React.FC<RequirementsSectionProps> = ({
                         }
                         size="small"
                         isLoading={isLoading}
+                        label={req.title}
                         list
                       />
                     </li>

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -14,7 +14,11 @@ import type {
 } from "api"
 import invariant from "tiny-invariant"
 import { Permission } from "api/hooks/user"
-import { assertHeadings, ControlledPromise } from "ol-test-utilities"
+import {
+  assertHeadings,
+  ControlledPromise,
+  allowConsoleErrors,
+} from "ol-test-utilities"
 import { act } from "@testing-library/react"
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
@@ -1081,6 +1085,7 @@ describe("UniversalAIBanner", () => {
   })
 
   test("clicking Learn More fires cta_clicked with label and readableId", async () => {
+    allowConsoleErrors()
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
     mockCapture.mockClear()
     process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
@@ -1093,7 +1098,7 @@ describe("UniversalAIBanner", () => {
     expect(mockCapture).toHaveBeenCalledWith(
       PostHogEvents.CallToActionClicked,
       expect.objectContaining({
-        label: "Learn More",
+        label: "Learn more about Universal AI",
         readableId: "program-v1:UAI+B2C",
       }),
     )

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -16,15 +16,21 @@ import invariant from "tiny-invariant"
 import { Permission } from "api/hooks/user"
 import { assertHeadings, ControlledPromise } from "ol-test-utilities"
 import { act } from "@testing-library/react"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react", () => ({
   ...jest.requireActual("posthog-js/react"),
   useFeatureFlagEnabled: jest.fn(),
-  usePostHog: jest.fn(() => ({ capture: jest.fn() })),
+  usePostHog: jest.fn(),
 }))
 
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 const DEFAULT_SEARCH_RESPONSE: LearningResourcesSearchResponse = {
   count: 0,
@@ -1072,5 +1078,25 @@ describe("UniversalAIBanner", () => {
         "LearningMaterials(0)",
       ])
     })
+  })
+
+  test("clicking Learn More fires cta_clicked with label and readableId", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    mockCapture.mockClear()
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    setMockApiResponses({ search: { count: 10 } })
+    renderWithProviders(<SearchPage />)
+    const link = await screen.findByRole("link", {
+      name: "Learn more about Universal AI",
+    })
+    await user.click(link)
+    expect(mockCapture).toHaveBeenCalledWith(
+      PostHogEvents.CallToActionClicked,
+      expect.objectContaining({
+        label: "Learn More",
+        readableId: "program-v1:UAI+B2C",
+      }),
+    )
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 })

--- a/frontends/main/src/common/constants.ts
+++ b/frontends/main/src/common/constants.ts
@@ -1,6 +1,8 @@
 export const PostHogEvents = {
   SearchUpdate: "search_update",
   CallToActionClicked: "cta_clicked",
+  CourseCardClicked: "course_card_clicked",
+  AskTimClicked: "asktim_clicked",
   LearningResourceDrawerOpen: "lrd_open",
   LearningResourceDrawerView: "lrd_view",
   HeroBrowseTopics: "clicked_hero_browse_topics",

--- a/frontends/main/src/page-components/AiChat/AskTimDrawerButton.test.tsx
+++ b/frontends/main/src/page-components/AiChat/AskTimDrawerButton.test.tsx
@@ -4,6 +4,7 @@ import AskTIMButton from "./AskTimDrawerButton"
 import { RECOMMENDER_QUERY_PARAM } from "@/common/urls"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
+import { allowConsoleErrors } from "ol-test-utilities"
 
 jest.mock("posthog-js/react", () => ({
   ...jest.requireActual("posthog-js/react"),
@@ -53,6 +54,7 @@ describe("AskTIMButton", () => {
   })
 
   test("clicking Ask TIM fires asktim_clicked with type recommendation_bot", async () => {
+    allowConsoleErrors()
     process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
     mockCapture.mockClear()
     renderWithProviders(<AskTIMButton />)

--- a/frontends/main/src/page-components/AiChat/AskTimDrawerButton.test.tsx
+++ b/frontends/main/src/page-components/AiChat/AskTimDrawerButton.test.tsx
@@ -2,6 +2,18 @@ import React from "react"
 import { renderWithProviders, screen, user, waitFor } from "@/test-utils"
 import AskTIMButton from "./AskTimDrawerButton"
 import { RECOMMENDER_QUERY_PARAM } from "@/common/urls"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  usePostHog: jest.fn(),
+}))
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 describe("AskTIMButton", () => {
   it.each([
@@ -38,5 +50,16 @@ describe("AskTIMButton", () => {
         false,
       )
     })
+  })
+
+  test("clicking Ask TIM fires asktim_clicked with type recommendation_bot", async () => {
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    mockCapture.mockClear()
+    renderWithProviders(<AskTIMButton />)
+    await user.click(screen.getByRole("link", { name: /ask tim/i }))
+    expect(mockCapture).toHaveBeenCalledWith(PostHogEvents.AskTimClicked, {
+      type: "recommendation_bot",
+    })
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 })

--- a/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
+++ b/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
@@ -1,8 +1,12 @@
+"use client"
+
 import React from "react"
 import { Typography, styled, LinkAdapter } from "ol-components"
 import { RiSparkling2Line } from "@remixicon/react"
+import { usePostHog } from "posthog-js/react"
 import AiRecommendationBotDrawer from "./AiRecommendationBotDrawer"
 import { RECOMMENDER_QUERY_PARAM } from "@/common/urls"
+import { PostHogEvents } from "@/common/constants"
 
 const StyledButton = styled(LinkAdapter)(({ theme }) => ({
   display: "flex",
@@ -21,9 +25,19 @@ const StyledButton = styled(LinkAdapter)(({ theme }) => ({
 }))
 
 const AskTIMButton = () => {
+  const posthog = usePostHog()
+
   return (
     <>
-      <StyledButton shallow href={`?${RECOMMENDER_QUERY_PARAM}`}>
+      <StyledButton
+        shallow
+        href={`?${RECOMMENDER_QUERY_PARAM}`}
+        onClick={() =>
+          posthog.capture(PostHogEvents.AskTimClicked, {
+            type: "recommendation_bot",
+          })
+        }
+      >
         <RiSparkling2Line />
         <Typography variant="body1">
           Ask<strong>TIM</strong>

--- a/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
+++ b/frontends/main/src/page-components/AiChat/AskTimDrawerButton.tsx
@@ -32,11 +32,13 @@ const AskTIMButton = () => {
       <StyledButton
         shallow
         href={`?${RECOMMENDER_QUERY_PARAM}`}
-        onClick={() =>
-          posthog.capture(PostHogEvents.AskTimClicked, {
-            type: "recommendation_bot",
-          })
-        }
+        onClick={() => {
+          if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+            posthog.capture(PostHogEvents.AskTimClicked, {
+              type: "recommendation_bot",
+            })
+          }
+        }}
       >
         <RiSparkling2Line />
         <Typography variant="body1">

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import AiChatSyllabusSlideDown, {
+  AiChatSyllabusOpener,
   ChatTransitionState,
   STARTERS,
 } from "./AiChatSyllabusSlideDown"
@@ -7,6 +8,18 @@ import { renderWithProviders, screen, user } from "@/test-utils"
 import { factories } from "api/test-utils"
 import { ResourceTypeEnum, ResourceTypeGroupEnum } from "api"
 import invariant from "tiny-invariant"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  usePostHog: jest.fn(),
+}))
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 const mockAiChat = jest.fn<React.JSX.Element, [Record<string, unknown>]>(() => (
   <div data-testid="mock-ai-chat" />
@@ -113,5 +126,32 @@ describe("AiChatSyllabus", () => {
     expect((requestOpts.fetchOpts as Record<string, unknown>).credentials).toBe(
       "include",
     )
+  })
+
+  test("clicking Ask TIM opener fires asktim_clicked with syllabus payload", async () => {
+    const resource = factories.learningResources.course()
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    mockCapture.mockClear()
+
+    renderWithProviders(
+      <AiChatSyllabusOpener
+        open={false}
+        resource={resource}
+        onToggleOpen={jest.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: /ask tim/i }))
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      PostHogEvents.AskTimClicked,
+      expect.objectContaining({
+        type: "syllabus_bot",
+        resourceId: resource.id,
+        readableId: resource.readable_id,
+        resourceType: resource.resource_type,
+      }),
+    )
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 })

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -5,6 +5,8 @@ import { RiSparkling2Line, RiArrowDownSLine } from "@remixicon/react"
 import type { AiChatProps } from "@mitodl/smoot-design/ai"
 import { LearningResource, ResourceTypeGroupEnum } from "api"
 import { AiChat } from "@mitodl/smoot-design/ai"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 export enum ChatTransitionState {
   Closed = "Closed",
@@ -140,6 +142,8 @@ export const AiChatSyllabusOpener = ({
   onToggleOpen: (open: boolean) => void
   resource: LearningResource
 }) => {
+  const posthog = usePostHog()
+
   return (
     <Opener className={className}>
       <StyledButton
@@ -147,7 +151,16 @@ export const AiChatSyllabusOpener = ({
         edge="rounded"
         aria-pressed={open}
         open={open}
-        onClick={() => onToggleOpen(!open)}
+        onClick={() => {
+          posthog.capture(PostHogEvents.AskTimClicked, {
+            type: "syllabus_bot",
+            resourceId: resource.id,
+            readableId: resource.readable_id,
+            resourceType: resource.resource_type,
+            platformCode: resource.platform?.code,
+          })
+          onToggleOpen(!open)
+        }}
       >
         <RiSparkling2Line />
         <Typography variant="body1">

--- a/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/AiChatSyllabusSlideDown.tsx
@@ -152,13 +152,15 @@ export const AiChatSyllabusOpener = ({
         aria-pressed={open}
         open={open}
         onClick={() => {
-          posthog.capture(PostHogEvents.AskTimClicked, {
-            type: "syllabus_bot",
-            resourceId: resource.id,
-            readableId: resource.readable_id,
-            resourceType: resource.resource_type,
-            platformCode: resource.platform?.code,
-          })
+          if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+            posthog.capture(PostHogEvents.AskTimClicked, {
+              type: "syllabus_bot",
+              resourceId: resource.id,
+              readableId: resource.readable_id,
+              resourceType: resource.resource_type,
+              platformCode: resource.platform?.code,
+            })
+          }
           onToggleOpen(!open)
         }}
       >

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
@@ -349,6 +349,7 @@ describe("CallToActionSection", () => {
 
       expect(mockCapture).toHaveBeenCalledWith("cta_clicked", {
         resource,
+        label: "Learn More",
       })
 
       // Restore original value

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -414,7 +414,10 @@ const CallToActionSection = ({
           href={url}
           onClick={() => {
             if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-              posthog.capture(PostHogEvents.CallToActionClicked, { resource })
+              posthog.capture(PostHogEvents.CallToActionClicked, {
+                resource,
+                label: cta,
+              })
             }
           }}
           data-ph-action="click-cta"

--- a/frontends/main/src/page-components/ResourceCard/ResourceCard.tsx
+++ b/frontends/main/src/page-components/ResourceCard/ResourceCard.tsx
@@ -82,6 +82,7 @@ type ResourceCardProps = Omit<
 > & {
   headingLevel?: number
   parentHeadingEl?: HeadingElement
+  onCardClick?: () => void
 }
 
 /**
@@ -94,6 +95,7 @@ type ResourceCardProps = Omit<
 const ResourceCard: React.FC<ResourceCardProps> = ({
   resource,
   parentHeadingEl,
+  onCardClick,
   ...others
 }) => {
   const {
@@ -107,11 +109,18 @@ const ResourceCard: React.FC<ResourceCardProps> = ({
     onClick,
   } = useResourceCard(resource)
 
+  const composedOnClick = onCardClick
+    ? () => {
+        onClick?.()
+        onCardClick()
+      }
+    : onClick
+
   const headingLevel = parentHeadingEl ? subheadingMap[parentHeadingEl] : 6
   return (
     <>
       <LearningResourceCard
-        onClick={onClick}
+        onClick={composedOnClick}
         resource={resource}
         href={resource ? getDrawerHref(resource.id) : undefined}
         onAddToLearningPathClick={handleAddToLearningPathClick}

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/test-utils"
 import { factories, setMockResponse, makeRequest, urls } from "api/test-utils"
 import { LearningResourceCard } from "ol-components"
-import { ControlledPromise } from "ol-test-utilities"
+import { ControlledPromise, allowConsoleErrors } from "ol-test-utilities"
 import invariant from "tiny-invariant"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
@@ -342,6 +342,7 @@ describe("ResourceCarousel", () => {
   )
 
   test("clicking a card fires course_card_clicked with key payload fields", async () => {
+    allowConsoleErrors()
     const config: ResourceCarouselProps["config"] = [
       {
         label: "Test Carousel",

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -13,6 +13,18 @@ import { factories, setMockResponse, makeRequest, urls } from "api/test-utils"
 import { LearningResourceCard } from "ol-components"
 import { ControlledPromise } from "ol-test-utilities"
 import invariant from "tiny-invariant"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  usePostHog: jest.fn(),
+}))
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 jest.mock("ol-components", () => {
   const actual = jest.requireActual("ol-components")
@@ -328,4 +340,43 @@ describe("ResourceCarousel", () => {
       )
     },
   )
+
+  test("clicking a card fires course_card_clicked with key payload fields", async () => {
+    const config: ResourceCarouselProps["config"] = [
+      {
+        label: "Test Carousel",
+        data: {
+          type: "resources",
+          params: { resource_type: ["course"] },
+        },
+      },
+    ]
+    const { resources } = setupApis({ count: 2 })
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    mockCapture.mockClear()
+
+    renderWithProviders(
+      <ResourceCarousel
+        titleComponent="h2"
+        title="Test Carousel"
+        config={config}
+      />,
+    )
+
+    const firstResource = resources.list.results[0]
+    const card = await screen.findByRole("heading", {
+      name: firstResource.title,
+    })
+    await user.click(card)
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      PostHogEvents.CourseCardClicked,
+      expect.objectContaining({
+        label: "Test Carousel",
+        resourceId: firstResource.id,
+        readableId: firstResource.readable_id,
+      }),
+    )
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+  })
 })

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -19,6 +19,8 @@ import {
   UseQueryResult,
   UseQueryOptions,
 } from "@tanstack/react-query"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 const StyledCarouselV2 = styled(CarouselV2)({
   margin: "24px 0",
@@ -224,6 +226,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
   titleVariant = "h4",
   excludeResourceId,
 }) => {
+  const posthog = usePostHog()
   const [tab, setTab] = React.useState("0")
   const [ref, setRef] = React.useState<HTMLDivElement | null>(null)
   const queries = useQueries({
@@ -316,13 +319,27 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                     ))
                   : resources
                       .filter((resource) => resource.id !== excludeResourceId)
-                      .map((resource) => (
-                        <ResourceCard
+                      .map((resource, index) => (
+                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+                        <div
                           key={resource.id}
-                          resource={resource}
-                          parentHeadingEl={titleComponent}
-                          {...tabConfig.cardProps}
-                        />
+                          onClick={() =>
+                            posthog.capture(PostHogEvents.CourseCardClicked, {
+                              label: title,
+                              resourceId: resource.id,
+                              readableId: resource.readable_id,
+                              resourceType: resource.resource_type,
+                              platformCode: resource.platform?.code,
+                              position: index,
+                            })
+                          }
+                        >
+                          <ResourceCard
+                            resource={resource}
+                            parentHeadingEl={titleComponent}
+                            {...tabConfig.cardProps}
+                          />
+                        </div>
                       ))}
               </StyledCarouselV2>
             )

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -320,26 +320,24 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                   : resources
                       .filter((resource) => resource.id !== excludeResourceId)
                       .map((resource, index) => (
-                        // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-                        <div
+                        <ResourceCard
                           key={resource.id}
-                          onClick={() =>
-                            posthog.capture(PostHogEvents.CourseCardClicked, {
-                              label: title,
-                              resourceId: resource.id,
-                              readableId: resource.readable_id,
-                              resourceType: resource.resource_type,
-                              platformCode: resource.platform?.code,
-                              position: index,
-                            })
-                          }
-                        >
-                          <ResourceCard
-                            resource={resource}
-                            parentHeadingEl={titleComponent}
-                            {...tabConfig.cardProps}
-                          />
-                        </div>
+                          resource={resource}
+                          parentHeadingEl={titleComponent}
+                          {...tabConfig.cardProps}
+                          onCardClick={() => {
+                            if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+                              posthog.capture(PostHogEvents.CourseCardClicked, {
+                                label: title,
+                                resourceId: resource.id,
+                                readableId: resource.readable_id,
+                                resourceType: resource.resource_type,
+                                platformCode: resource.platform?.code,
+                                position: index,
+                              })
+                            }
+                          }}
+                        />
                       ))}
               </StyledCarouselV2>
             )

--- a/frontends/main/src/page-components/SearchDisplay/UniversalAIBanner.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/UniversalAIBanner.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo } from "react"
 import Link from "next/link"
 import { styled, Typography } from "ol-components"
-import { useFeatureFlagEnabled } from "posthog-js/react"
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 import { programPageView } from "@/common/urls"
+import { PostHogEvents } from "@/common/constants"
 
 const BANNER_SEARCH_TERMS = [
   "artificial intelligence",
@@ -92,6 +93,7 @@ const UniversalAIBanner: React.FC<UniversalAIBannerProps> = ({
   const featureFlagEnabled = useFeatureFlagEnabled(
     FeatureFlags.UniversalAISearchBanner,
   )
+  const posthog = usePostHog()
 
   const matchesSearchTerm = useMemo(() => {
     if (!searchTerm) return true // If no search term, show the banner by default
@@ -102,13 +104,22 @@ const UniversalAIBanner: React.FC<UniversalAIBannerProps> = ({
 
   const showBanner = featureFlagEnabled && matchesSearchTerm
 
-  if (!showBanner) return null
-
   const UAI_PROGRAM_READABLE_ID = "program-v1:UAI+B2C"
   const ctaHref = programPageView({
     readable_id: UAI_PROGRAM_READABLE_ID,
     display_mode: null,
   })
+
+  const handleCTAClick = () => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      posthog.capture(PostHogEvents.CallToActionClicked, {
+        label: "Learn more about Universal AI",
+        readableId: UAI_PROGRAM_READABLE_ID,
+      })
+    }
+  }
+
+  if (!showBanner) return null
 
   return (
     <BannerContainer>
@@ -121,7 +132,11 @@ const UniversalAIBanner: React.FC<UniversalAIBannerProps> = ({
           required.
         </BannerDescription>
       </BannerContent>
-      <BannerLink href={ctaHref} aria-label="Learn more about Universal AI">
+      <BannerLink
+        href={ctaHref}
+        aria-label="Learn more about Universal AI"
+        onClick={handleCTAClick}
+      >
         Learn More
       </BannerLink>
     </BannerContainer>

--- a/frontends/ol-components/src/components/LinkAdapter/LinkAdapter.tsx
+++ b/frontends/ol-components/src/components/LinkAdapter/LinkAdapter.tsx
@@ -36,11 +36,10 @@ const LinkAdapter = ({ shallow, href = "", ...props }: LinkAdapterProps) => {
       href={href}
       {...props}
       onClick={(e) => {
+        props.onClick?.(e)
         if (shallow) {
           e.preventDefault()
           window.history.pushState({}, "", href)
-        } else {
-          props.onClick?.(e)
         }
       }}
     />


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10916

### Description (What does it do?)
<!--- Describe your changes in detail -->

  Adds PostHog analytics event tracking for user interactions:

   - course_card_clicked — fired when a user clicks a course card in:
       -  Homepage featured courses
       -  Drawer - Similar Learning Resources
      -   Program page course cards 
   - cta_clicked — fired when a user clicks a button in:
       - Resource drawer CTA button (e.g. "Access to Course Materials", "Learn More")
       - Course enrollment button on course product page
       - Program enrollment button on program product page
   - asktim_clicked — fired when a user opens the AskTIM AI chat on:
      - Homepage AskTIM drawer button 
      - Resource drawer syllabus bot toggle 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

  env/frontend.local.env: 
    
```
NEXT_PUBLIC_MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:8013
NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL=http://mitxonline.odl.local:8013
FEATURE_FLAGS={"home-page-recommendation-bot": true}

```
Ensure you have courses and programs product setup on your local mitxonline  http://mitxonline.odl.local:8013/api/v2/programs/

env/shared.local.env: 
```
POSTHOG_PROJECT_API_KEY=
POSTHOG_PROJECT_ID=

```

 **course_card_clicked**

-   Go to homepage featured courses
-   Open any resource drawer ->  click on "Similar Learning Resources"
-   Go to a program page (e.g. /programs/program-v1:MITxT+18.01) → click a course card in "Required Courses" or "Elective Courses"

<img width="1236" height="46" alt="Pasted Graphic 19" src="https://github.com/user-attachments/assets/0bbf5485-195f-47de-a5f6-48cbea8a8f65" />
<img width="1109" height="229" alt="Pasted Graphic 20" src="https://github.com/user-attachments/assets/410d5ca0-08b1-499e-a6f5-ec5eb02193e2" />


  **cta_clicked**

- Open any resource drawer → click the CTA button (e.g. "Learn More") 


<img width="1217" height="107" alt="Pasted Graphic 13" src="https://github.com/user-attachments/assets/5f2a8f04-a639-4c65-9306-47b43b952361" />
<img width="1345" height="67" alt="Pasted Graphic 14" src="https://github.com/user-attachments/assets/2f62b5e3-b9ab-424a-9172-3022a91db411" />

- Go to a course product page → click the enrollment button 
- Go to a program product page → click the enrollment button
<img width="1270" height="29" alt="image" src="https://github.com/user-attachments/assets/7a22b861-f8bc-4688-a11f-e29a3fe94fb3" />

<img width="1297" height="143" alt="image" src="https://github.com/user-attachments/assets/095e79dc-57c3-4cfd-a6ca-954cd9545dd0" />


  **asktim_clicked**

-    Go to homepage (/?recommender) → click the AskTIM button 
-    Open a resource drawer → click the "AskTIM" syllabus bot toggle 

<img width="1161" height="55" alt="Pasted Graphic 18" src="https://github.com/user-attachments/assets/05b10d34-2e65-4777-9816-4bc568f9fef9" />
<img width="1348" height="169" alt="Pasted Graphic 17" src="https://github.com/user-attachments/assets/cb26c5ac-8027-4447-a458-09308708a0a5" />



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
