### PR TITLE
feat: track Stay Updated button click with PostHog cta_clicked event

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
@@ -549,7 +549,6 @@ describe("CourseEnrollmentButton", () => {
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,
         expect.objectContaining({
-          resourceId: course.id,
           readableId: course.readable_id,
           resourceType: "course",
         }),
@@ -576,7 +575,6 @@ describe("CourseEnrollmentButton", () => {
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,
         expect.objectContaining({
-          resourceId: course.id,
           readableId: course.readable_id,
           resourceType: "course",
         }),

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.tsx
@@ -96,7 +96,6 @@ const CourseEnrollmentButton: React.FC<CourseEnrollmentButtonProps> = ({
     }
     if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
       posthog.capture(PostHogEvents.CallToActionClicked, {
-        resourceId: course.id,
         readableId: course.readable_id,
         resourceType: "course",
         label: getButtonText(nextRun, price?.finalPrice),

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -87,6 +87,11 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
             ),
         )
       }
+      resource={{
+        id: course.id,
+        readable_id: course.readable_id,
+        resource_type: "course",
+      }}
     >
       {page.about ? (
         <AboutSection productNoun="Course" aboutHtml={page.about} />

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -88,7 +88,6 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
         )
       }
       resource={{
-        id: course.id,
         readable_id: course.readable_id,
         resource_type: "course",
       }}

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
@@ -5,6 +5,18 @@ import ProductPageTemplate from "./ProductPageTemplate"
 import { useHubspotFormDetail } from "api/hooks/hubspot"
 import NiceModal from "@ebay/nice-modal-react"
 import { STAY_UPDATED_FORM_ID } from "./test-utils/stayUpdated"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  usePostHog: jest.fn(),
+}))
+const mockCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue(
+  // @ts-expect-error Not mocking all of posthog
+  { capture: mockCapture },
+)
 
 jest.mock("api/hooks/hubspot", () => ({
   ...jest.requireActual("api/hooks/hubspot"),
@@ -24,14 +36,14 @@ jest.mock("@ebay/nice-modal-react", () => {
 })
 
 const mockedUseHubspotFormDetail = jest.mocked(useHubspotFormDetail)
-const mockedNiceModalShow = NiceModal.show as jest.MockedFunction<
-  typeof NiceModal.show
->
+const mockedNiceModalShow = jest.mocked(NiceModal.show)
 
 const renderProductPageTemplate = ({
   showStayUpdated,
+  resource,
 }: {
   showStayUpdated?: boolean
+  resource?: React.ComponentProps<typeof ProductPageTemplate>["resource"]
 } = {}) => {
   setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
   renderWithProviders(
@@ -43,6 +55,7 @@ const renderProductPageTemplate = ({
       infoBox={<div>Info box</div>}
       enrollmentAction={<button type="button">Enroll</button>}
       showStayUpdated={showStayUpdated}
+      resource={resource}
     >
       <div>Page content</div>
     </ProductPageTemplate>,
@@ -124,5 +137,53 @@ describe("ProductPageTemplate stay-updated trigger", () => {
 
     button.click()
     expect(mockedNiceModalShow).toHaveBeenCalled()
+  })
+
+  describe("PostHog tracking", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+      process.env.NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID = STAY_UPDATED_FORM_ID
+      mockedUseHubspotFormDetail.mockReturnValue({
+        data: undefined,
+        isError: false,
+      } as ReturnType<typeof useHubspotFormDetail>)
+    })
+
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+      mockCapture.mockReset()
+    })
+
+    it("fires cta_clicked with resource properties when Stay Updated is clicked", () => {
+      const resource = { id: 42, readable_id: "program-v1:test+101", resource_type: "program" as const }
+      renderProductPageTemplate({ showStayUpdated: true, resource })
+
+      screen.getByRole("button", { name: "Stay Updated" }).click()
+
+      expect(mockCapture).toHaveBeenCalledWith(PostHogEvents.CallToActionClicked, {
+        label: "Stay Updated",
+        resourceId: resource.id,
+        readableId: resource.readable_id,
+        resourceType: resource.resource_type,
+      })
+    })
+
+    it("does not fire cta_clicked when NEXT_PUBLIC_POSTHOG_API_KEY is not set", () => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+      const resource = { id: 42, readable_id: "program-v1:test+101", resource_type: "program" as const }
+      renderProductPageTemplate({ showStayUpdated: true, resource })
+
+      screen.getByRole("button", { name: "Stay Updated" }).click()
+
+      expect(mockCapture).not.toHaveBeenCalled()
+    })
+
+    it("does not fire cta_clicked when resource prop is not provided", () => {
+      renderProductPageTemplate({ showStayUpdated: true })
+
+      screen.getByRole("button", { name: "Stay Updated" }).click()
+
+      expect(mockCapture).not.toHaveBeenCalled()
+    })
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
@@ -41,7 +41,6 @@ const mockedUseHubspotFormDetail = jest.mocked(useHubspotFormDetail)
 const mockedNiceModalShow = jest.mocked(NiceModal.show)
 
 const DEFAULT_RESOURCE: ResourceInfo = {
-  id: 1,
   readable_id: "program-v1:default+test",
   resource_type: "program",
 }

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
@@ -142,7 +142,8 @@ describe("ProductPageTemplate stay-updated trigger", () => {
   describe("PostHog tracking", () => {
     beforeEach(() => {
       process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
-      process.env.NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID = STAY_UPDATED_FORM_ID
+      process.env.NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID =
+        STAY_UPDATED_FORM_ID
       mockedUseHubspotFormDetail.mockReturnValue({
         data: undefined,
         isError: false,
@@ -155,22 +156,33 @@ describe("ProductPageTemplate stay-updated trigger", () => {
     })
 
     it("fires cta_clicked with resource properties when Stay Updated is clicked", () => {
-      const resource = { id: 42, readable_id: "program-v1:test+101", resource_type: "program" as const }
+      const resource = {
+        id: 42,
+        readable_id: "program-v1:test+101",
+        resource_type: "program" as const,
+      }
       renderProductPageTemplate({ showStayUpdated: true, resource })
 
       screen.getByRole("button", { name: "Stay Updated" }).click()
 
-      expect(mockCapture).toHaveBeenCalledWith(PostHogEvents.CallToActionClicked, {
-        label: "Stay Updated",
-        resourceId: resource.id,
-        readableId: resource.readable_id,
-        resourceType: resource.resource_type,
-      })
+      expect(mockCapture).toHaveBeenCalledWith(
+        PostHogEvents.CallToActionClicked,
+        {
+          label: "Stay Updated",
+          resourceId: resource.id,
+          readableId: resource.readable_id,
+          resourceType: resource.resource_type,
+        },
+      )
     })
 
     it("does not fire cta_clicked when NEXT_PUBLIC_POSTHOG_API_KEY is not set", () => {
       delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
-      const resource = { id: 42, readable_id: "program-v1:test+101", resource_type: "program" as const }
+      const resource = {
+        id: 42,
+        readable_id: "program-v1:test+101",
+        resource_type: "program" as const,
+      }
       renderProductPageTemplate({ showStayUpdated: true, resource })
 
       screen.getByRole("button", { name: "Stay Updated" }).click()

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
@@ -8,6 +8,7 @@ import { STAY_UPDATED_FORM_ID } from "./test-utils/stayUpdated"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
 import type { ResourceInfo } from "./ProductPageTemplate"
+import { PlatformEnum } from "api"
 
 jest.mock("posthog-js/react", () => ({
   ...jest.requireActual("posthog-js/react"),
@@ -50,35 +51,20 @@ const renderProductPageTemplate = (
 ) => {
   const { showStayUpdated, resource = DEFAULT_RESOURCE } = args
   setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
-  if (showStayUpdated) {
-    renderWithProviders(
-      <ProductPageTemplate
-        currentBreadcrumbLabel="Programs"
-        title="Sample Program"
-        shortDescription={"Program description"}
-        imageSrc="/test-image.jpg"
-        infoBox={<div>Info box</div>}
-        enrollmentAction={<button type="button">Enroll</button>}
-        showStayUpdated={true}
-        resource={resource}
-      >
-        <div>Page content</div>
-      </ProductPageTemplate>,
-    )
-  } else {
-    renderWithProviders(
-      <ProductPageTemplate
-        currentBreadcrumbLabel="Programs"
-        title="Sample Program"
-        shortDescription={"Program description"}
-        imageSrc="/test-image.jpg"
-        infoBox={<div>Info box</div>}
-        enrollmentAction={<button type="button">Enroll</button>}
-      >
-        <div>Page content</div>
-      </ProductPageTemplate>,
-    )
-  }
+  renderWithProviders(
+    <ProductPageTemplate
+      currentBreadcrumbLabel="Programs"
+      title="Sample Program"
+      shortDescription={"Program description"}
+      imageSrc="/test-image.jpg"
+      infoBox={<div>Info box</div>}
+      enrollmentAction={<button type="button">Enroll</button>}
+      showStayUpdated={showStayUpdated ?? false}
+      resource={resource}
+    >
+      <div>Page content</div>
+    </ProductPageTemplate>,
+  )
 }
 
 describe("ProductPageTemplate stay-updated trigger", () => {
@@ -188,9 +174,9 @@ describe("ProductPageTemplate stay-updated trigger", () => {
         PostHogEvents.CallToActionClicked,
         {
           label: "Stay Updated",
-          resourceId: resource.id,
           readableId: resource.readable_id,
           resourceType: resource.resource_type,
+          platform: PlatformEnum.Mitxonline,
         },
       )
     })

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.test.tsx
@@ -7,6 +7,7 @@ import NiceModal from "@ebay/nice-modal-react"
 import { STAY_UPDATED_FORM_ID } from "./test-utils/stayUpdated"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
+import type { ResourceInfo } from "./ProductPageTemplate"
 
 jest.mock("posthog-js/react", () => ({
   ...jest.requireActual("posthog-js/react"),
@@ -38,28 +39,46 @@ jest.mock("@ebay/nice-modal-react", () => {
 const mockedUseHubspotFormDetail = jest.mocked(useHubspotFormDetail)
 const mockedNiceModalShow = jest.mocked(NiceModal.show)
 
-const renderProductPageTemplate = ({
-  showStayUpdated,
-  resource,
-}: {
-  showStayUpdated?: boolean
-  resource?: React.ComponentProps<typeof ProductPageTemplate>["resource"]
-} = {}) => {
+const DEFAULT_RESOURCE: ResourceInfo = {
+  id: 1,
+  readable_id: "program-v1:default+test",
+  resource_type: "program",
+}
+
+const renderProductPageTemplate = (
+  args: { showStayUpdated?: true; resource?: ResourceInfo } = {},
+) => {
+  const { showStayUpdated, resource = DEFAULT_RESOURCE } = args
   setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
-  renderWithProviders(
-    <ProductPageTemplate
-      currentBreadcrumbLabel="Programs"
-      title="Sample Program"
-      shortDescription={"Program description"}
-      imageSrc="/test-image.jpg"
-      infoBox={<div>Info box</div>}
-      enrollmentAction={<button type="button">Enroll</button>}
-      showStayUpdated={showStayUpdated}
-      resource={resource}
-    >
-      <div>Page content</div>
-    </ProductPageTemplate>,
-  )
+  if (showStayUpdated) {
+    renderWithProviders(
+      <ProductPageTemplate
+        currentBreadcrumbLabel="Programs"
+        title="Sample Program"
+        shortDescription={"Program description"}
+        imageSrc="/test-image.jpg"
+        infoBox={<div>Info box</div>}
+        enrollmentAction={<button type="button">Enroll</button>}
+        showStayUpdated={true}
+        resource={resource}
+      >
+        <div>Page content</div>
+      </ProductPageTemplate>,
+    )
+  } else {
+    renderWithProviders(
+      <ProductPageTemplate
+        currentBreadcrumbLabel="Programs"
+        title="Sample Program"
+        shortDescription={"Program description"}
+        imageSrc="/test-image.jpg"
+        infoBox={<div>Info box</div>}
+        enrollmentAction={<button type="button">Enroll</button>}
+      >
+        <div>Page content</div>
+      </ProductPageTemplate>,
+    )
+  }
 }
 
 describe("ProductPageTemplate stay-updated trigger", () => {
@@ -184,14 +203,6 @@ describe("ProductPageTemplate stay-updated trigger", () => {
         resource_type: "program" as const,
       }
       renderProductPageTemplate({ showStayUpdated: true, resource })
-
-      screen.getByRole("button", { name: "Stay Updated" }).click()
-
-      expect(mockCapture).not.toHaveBeenCalled()
-    })
-
-    it("does not fire cta_clicked when resource prop is not provided", () => {
-      renderProductPageTemplate({ showStayUpdated: true })
 
       screen.getByRole("button", { name: "Stay Updated" }).click()
 

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -256,6 +256,12 @@ const SidebarMedia: React.FC<{
   )
 }
 
+export type ResourceInfo = {
+  id: number
+  readable_id: string
+  resource_type: "course" | "program"
+}
+
 type ProductPageTemplateProps = {
   currentBreadcrumbLabel: string
   title: string
@@ -265,13 +271,10 @@ type ProductPageTemplateProps = {
   infoBox: React.ReactNode
   enrollmentAction: React.ReactNode
   children: React.ReactNode
-  showStayUpdated?: boolean
-  resource?: {
-    id: number
-    readable_id: string
-    resource_type: "course" | "program"
-  }
-}
+} & (
+  | { showStayUpdated: boolean; resource: ResourceInfo }
+  | { showStayUpdated?: false; resource?: never }
+)
 const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   currentBreadcrumbLabel,
   title,
@@ -297,12 +300,14 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   })
 
   const handleStayUpdatedClick = () => {
-    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY && resource) {
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
+      // resource is always defined when showStayUpdated=true (enforced by
+      // the discriminated union at call sites)
       posthog.capture(PostHogEvents.CallToActionClicked, {
         label: "Stay Updated",
-        resourceId: resource.id,
-        readableId: resource.readable_id,
-        resourceType: resource.resource_type,
+        resourceId: resource!.id,
+        readableId: resource!.readable_id,
+        resourceType: resource!.resource_type,
       })
     }
     NiceModal.show(StayUpdatedModal)

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -21,6 +21,7 @@ import { StayUpdatedModal } from "./StayUpdatedModal"
 import { getStayUpdatedHubspotFormId } from "@/common/config"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
+import { PlatformEnum } from "api"
 
 const GradientBanner = styled(BannerBackground)(({ theme }) => ({
   background:
@@ -300,14 +301,13 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   })
 
   const handleStayUpdatedClick = () => {
+    if (!showStayUpdated || !resource) return
     if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
-      // resource is always defined when showStayUpdated=true (enforced by
-      // the discriminated union at call sites)
       posthog.capture(PostHogEvents.CallToActionClicked, {
         label: "Stay Updated",
-        resourceId: resource!.id,
-        readableId: resource!.readable_id,
-        resourceType: resource!.resource_type,
+        readableId: resource.readable_id,
+        resourceType: resource.resource_type,
+        platform: PlatformEnum.Mitxonline,
       })
     }
     NiceModal.show(StayUpdatedModal)

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -258,7 +258,6 @@ const SidebarMedia: React.FC<{
 }
 
 export type ResourceInfo = {
-  id: number
   readable_id: string
   resource_type: "course" | "program"
 }

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -266,7 +266,7 @@ type ProductPageTemplateProps = {
   enrollmentAction: React.ReactNode
   children: React.ReactNode
   showStayUpdated?: boolean
-  resource?: { id: number; readable_id: string; resource_type: string }
+  resource?: { id: number; readable_id: string; resource_type: "course" | "program" }
 }
 const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   currentBreadcrumbLabel,

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -266,7 +266,11 @@ type ProductPageTemplateProps = {
   enrollmentAction: React.ReactNode
   children: React.ReactNode
   showStayUpdated?: boolean
-  resource?: { id: number; readable_id: string; resource_type: "course" | "program" }
+  resource?: {
+    id: number
+    readable_id: string
+    resource_type: "course" | "program"
+  }
 }
 const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   currentBreadcrumbLabel,

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -19,6 +19,8 @@ import NiceModal from "@ebay/nice-modal-react"
 import { useHubspotFormDetail } from "api/hooks/hubspot"
 import { StayUpdatedModal } from "./StayUpdatedModal"
 import { getStayUpdatedHubspotFormId } from "@/common/config"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
 
 const GradientBanner = styled(BannerBackground)(({ theme }) => ({
   background:
@@ -264,6 +266,7 @@ type ProductPageTemplateProps = {
   enrollmentAction: React.ReactNode
   children: React.ReactNode
   showStayUpdated?: boolean
+  resource?: { id: number; readable_id: string; resource_type: string }
 }
 const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   currentBreadcrumbLabel,
@@ -275,7 +278,9 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   children,
   enrollmentAction,
   showStayUpdated,
+  resource,
 }) => {
+  const posthog = usePostHog()
   const stayUpdatedFormId = getStayUpdatedHubspotFormId()
   const shouldShowStayUpdatedButton = Boolean(
     stayUpdatedFormId && showStayUpdated,
@@ -286,6 +291,18 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   const formQuery = useHubspotFormDetail(stayUpdatedParams, {
     enabled: shouldShowStayUpdatedButton,
   })
+
+  const handleStayUpdatedClick = () => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY && resource) {
+      posthog.capture(PostHogEvents.CallToActionClicked, {
+        label: "Stay Updated",
+        resourceId: resource.id,
+        readableId: resource.readable_id,
+        resourceType: resource.resource_type,
+      })
+    }
+    NiceModal.show(StayUpdatedModal)
+  }
 
   return (
     <Page>
@@ -331,7 +348,7 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
                           size="large"
                           variant="secondary"
                           disabled={formQuery.isError}
-                          onClick={() => NiceModal.show(StayUpdatedModal)}
+                          onClick={handleStayUpdatedClick}
                         >
                           Stay Updated
                         </StayUpdatedButton>

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -290,7 +290,6 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
         )
       }
       resource={{
-        id: program.id,
         readable_id: program.readable_id,
         resource_type: "program",
       }}

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -289,6 +289,11 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
           isVerifiedEnrollmentMode(mode.mode_slug),
         )
       }
+      resource={{
+        id: program.id,
+        readable_id: program.readable_id,
+        resource_type: "program",
+      }}
       infoBox={
         <ProgramAsCourseInfoBox
           program={program}

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -440,7 +440,6 @@ describe("ProgramEnrollmentButton", () => {
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,
         expect.objectContaining({
-          resourceId: program.id,
           readableId: program.readable_id,
           resourceType: "program",
         }),
@@ -469,7 +468,6 @@ describe("ProgramEnrollmentButton", () => {
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,
         expect.objectContaining({
-          resourceId: program.id,
           readableId: program.readable_id,
           resourceType: "program",
         }),

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -90,7 +90,6 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
     }
     if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {
       posthog.capture(PostHogEvents.CallToActionClicked, {
-        resourceId: program.id,
         readableId: program.readable_id,
         resourceType: "program",
         label: getEnrollButtonText(),

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -290,6 +290,11 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
           isVerifiedEnrollmentMode(mode.mode_slug),
         )
       }
+      resource={{
+        id: program.id,
+        readable_id: program.readable_id,
+        resource_type: "program",
+      }}
       infoBox={
         <ProgramInfoBox program={program} courses={courses.data?.results} />
       }

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -291,7 +291,6 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
         )
       }
       resource={{
-        id: program.id,
         readable_id: program.readable_id,
         resource_type: "program",
       }}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10916

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds PostHog cta_clicked event tracking when a user clicks the "Stay Updated" button on Course, Program product pages


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
same test as https://github.com/mitodl/mit-learn/pull/3218

To test the "Stay Updated" button on your local:

   1. Go to http://mitxonline.odl.local:8013/admin
   2. Find a program (or create one) that has a product page set up
   3. Set the enrollment modes to `verified` (no audit mode)
   4. Make sure NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID is set in `env/frontend.local.env`


```
NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=test-form-id
```

Then visit the corresponding program page on http://open.odl.local:8062 and the "Stay Updated" button should appear alongside the enrollment button.

<img width="673" height="271" alt="image" src="https://github.com/user-attachments/assets/3559572c-bd23-46d7-91b3-8fef88f03214" />

Click on "Stay Updated" and verify `cta_clicked` is captured in posthog with data attribute

<img width="1272" height="200" alt="image" src="https://github.com/user-attachments/assets/9308240e-2fe1-403f-9916-4cb5114b303f" />
<img width="982" height="144" alt="image" src="https://github.com/user-attachments/assets/be267bd0-def0-48aa-8f18-45fc6e6262db" />




### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
