### PR TITLE
remove default slide transition from dialogs

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.test.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import * as NiceModal from "@ebay/nice-modal-react"
 import { HubspotForm, type HubspotFormProps } from "ol-components"
 import { setMockResponse, urls, factories } from "api/test-utils"
-import { renderWithProviders, screen, user, act } from "@/test-utils"
+import { renderWithProviders, screen, user, act, waitFor } from "@/test-utils"
 import { StayUpdatedModal } from "./StayUpdatedModal"
 import { STAY_UPDATED_FORM_ID } from "./test-utils/stayUpdated"
 
@@ -133,9 +133,11 @@ describe("StayUpdatedModal", () => {
     const doneButton = await screen.findByRole("button", { name: "Done" })
     await user.click(doneButton)
 
-    expect(
-      screen.queryByRole("dialog", { name: "Stay Updated" }),
-    ).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Stay Updated" }),
+      ).not.toBeInTheDocument()
+    })
   })
 
   it("closes the dialog when 'Cancel' is clicked in the form view", async () => {
@@ -148,9 +150,11 @@ describe("StayUpdatedModal", () => {
     await screen.findByRole("dialog", { name: "Stay Updated" })
     await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    expect(
-      screen.queryByRole("dialog", { name: "Stay Updated" }),
-    ).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Stay Updated" }),
+      ).not.toBeInTheDocument()
+    })
   })
 
   it("shows error message when form submission fails", async () => {

--- a/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
@@ -425,7 +425,9 @@ describe("CourseEnrollmentDialog", () => {
       )
 
       // Verify dialog has closed
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      })
     })
 
     test("Custom onCourseEnroll: calls callback instead of redirecting", async () => {
@@ -456,7 +458,9 @@ describe("CourseEnrollmentDialog", () => {
       )
 
       // Verify dialog has closed
-      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+      })
     })
 
     test("Shows error message when enrollment fails", async () => {

--- a/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.test.tsx
@@ -159,7 +159,9 @@ describe("ProgramEnrollmentDialog", () => {
     expect(location.current.searchParams.get("enrollment_title")).toBe(
       program.title,
     )
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 
   test("Custom onProgramEnroll: calls callback instead of redirecting", async () => {
@@ -190,7 +192,9 @@ describe("ProgramEnrollmentDialog", () => {
     expect(`${location.current.pathname}${location.current.search}`).toBe(
       initialLocation,
     )
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 
   test("Shows error message when enrollment fails", async () => {

--- a/frontends/main/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/main/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -106,14 +106,16 @@ describe("manageListDialogs.upsertLearningPath", () => {
     setup({
       resource: factories.learningResources.learningPath(),
     })
-    const dialog = screen.getByRole("dialog")
+    screen.getByRole("dialog")
     await user.click(inputs.cancel())
     expect(makeRequest).not.toHaveBeenCalledWith(
       "patch",
       expect.anything(),
       expect.anything(),
     )
-    expect(dialog).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 
   test("Validates required fields", async () => {
@@ -258,14 +260,16 @@ describe("manageListDialogs.upsertUserList", () => {
     setup({
       userList: factories.userLists.userList(),
     })
-    const dialog = screen.getByRole("dialog")
+    screen.getByRole("dialog")
     await user.click(inputs.cancel())
     expect(makeRequest).not.toHaveBeenCalledWith(
       "patch",
       expect.anything(),
       expect.anything(),
     )
-    expect(dialog).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 
   test("Validates required fields", async () => {
@@ -401,12 +405,13 @@ describe("manageListDialogs.destroyLearningPath", () => {
   test("Clicking cancel does not delete list", async () => {
     setup()
 
-    const dialog = screen.getByRole("dialog")
+    screen.getByRole("dialog")
     await user.click(inputs.cancel())
 
     expect(makeRequest).not.toHaveBeenCalled()
-
-    expect(dialog).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 })
 
@@ -443,10 +448,12 @@ describe("manageListDialogs.destroyUserList", () => {
   test("Clicking cancel does not delete list", async () => {
     setup()
 
-    const dialog = screen.getByRole("dialog")
+    screen.getByRole("dialog")
     await user.click(inputs.cancel())
 
     expect(makeRequest).not.toHaveBeenCalled()
-    expect(dialog).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontends/ol-components/src/components/Dialog/Dialog.tsx
+++ b/frontends/ol-components/src/components/Dialog/Dialog.tsx
@@ -127,6 +127,7 @@ const Dialog: React.FC<DialogProps> = ({
         transition: TransitionProps,
       }}
       aria-labelledby={titleId}
+      transitionDuration={process.env.NODE_ENV === "test" ? 0 : undefined}
       maxWidth={maxWidth}
       scroll={scroll}
     >

--- a/frontends/ol-components/src/components/Dialog/Dialog.tsx
+++ b/frontends/ol-components/src/components/Dialog/Dialog.tsx
@@ -8,8 +8,6 @@ import { Button, ActionButton } from "@mitodl/smoot-design"
 import MuiDialogActions from "@mui/material/DialogActions"
 import { RiCloseLine } from "@remixicon/react"
 import Typography from "@mui/material/Typography"
-import Slide from "@mui/material/Slide"
-import { TransitionProps } from "@mui/material/transitions"
 
 const Close = styled.div`
   position: absolute;
@@ -39,24 +37,6 @@ const DialogActions = styled(MuiDialogActions)`
     margin-left: 0;
   }
 `
-
-const Transition = React.forwardRef(
-  (
-    props: TransitionProps & {
-      children: React.ReactElement
-    },
-    ref: React.Ref<unknown>,
-  ) => {
-    return (
-      <Slide
-        direction="down"
-        ref={ref}
-        {...props}
-        timeout={process.env.NODE_ENV === "test" ? 0 : 400}
-      />
-    )
-  },
-)
 
 type DialogProps = {
   className?: string
@@ -145,9 +125,6 @@ const Dialog: React.FC<DialogProps> = ({
       slotProps={{
         paper: PaperProps,
         transition: TransitionProps,
-      }}
-      slots={{
-        transition: Transition,
       }}
       aria-labelledby={titleId}
       maxWidth={maxWidth}

--- a/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
+++ b/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
@@ -64,6 +64,7 @@ interface FormDialogProps {
   className?: string
   maxWidth?: DialogProps["maxWidth"]
   disabled?: boolean
+  TransitionProps?: DialogProps["TransitionProps"]
 }
 
 /**
@@ -91,6 +92,7 @@ const FormDialog: React.FC<FormDialogProps> = ({
   className,
   maxWidth,
   disabled = false,
+  TransitionProps,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = useCallback(
@@ -137,6 +139,7 @@ const FormDialog: React.FC<FormDialogProps> = ({
       actions={actions}
       maxWidth={maxWidth}
       disabled={isSubmitting || disabled}
+      TransitionProps={TransitionProps}
     >
       <FormContent>{children}</FormContent>
     </Dialog>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10991

### Description (What does it do?)
This PR removes the default "slide" animation from dialogs across the site, replacing it with the default "fade" animation instead.

### How can this be tested?
The easiest path to showing a dialog is to simply add a learning resource to a user list
- Ensure you have sufficient test data (a course or two is fine)
- Log in to your local instance
- Go to the search page and generate some search results
- Click the bookmark icon on any of the results
- You should see the user list dialog appear, and it should fade in rather than flying in from the top
