### PR TITLE
Revert "Update dependency opensearch-py to v3 (#2764)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "onnxruntime==1.24.4",
     "openai>=2.0.0,<3",
     "opensearch-dsl>=2.0.0,<3",
-    "opensearch-py>=3.1,<4",
+    "opensearch-py>=2.0.0,<3",
     "opentelemetry-instrumentation-celery>=0.52b0",
     "opentelemetry-instrumentation-django>=0.52b0",
     "opentelemetry-instrumentation-psycopg>=0.52b0",

--- a/uv.lock
+++ b/uv.lock
@@ -2694,7 +2694,7 @@ requires-dist = [
     { name = "opencv-python", specifier = ">=4.12.0.88,<5" },
     { name = "opendataloader-pdf", specifier = ">=1.3.0,<2" },
     { name = "opensearch-dsl", specifier = ">=2.0.0,<3" },
-    { name = "opensearch-py", specifier = ">=3.1,<4" },
+    { name = "opensearch-py", specifier = ">=2.0.0,<3" },
     { name = "opentelemetry-instrumentation-celery", specifier = ">=0.52b0" },
     { name = "opentelemetry-instrumentation-django", specifier = ">=0.52b0" },
     { name = "opentelemetry-instrumentation-psycopg", specifier = ">=0.52b0" },
@@ -3148,32 +3148,19 @@ wheels = [
 ]
 
 [[package]]
-name = "opensearch-protobufs"
-version = "0.19.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "grpcio" },
-    { name = "protobuf" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/e2/8a09dbdbfe51e30dfecb625a0f5c524a53bfa4b1fba168f73ac85621dba2/opensearch_protobufs-0.19.0-py3-none-any.whl", hash = "sha256:5137c9c2323cc7debb694754b820ca4cfb5fc8eb180c41ff125698c3ee11bfc2", size = 39778, upload-time = "2025-09-29T20:05:52.379Z" },
-]
-
-[[package]]
 name = "opensearch-py"
-version = "3.1.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "events" },
-    { name = "opensearch-protobufs" },
     { name = "python-dateutil" },
     { name = "requests" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/9f/d4969f7e8fa221bfebf254cc3056e7c743ce36ac9874e06110474f7c947d/opensearch_py-3.1.0.tar.gz", hash = "sha256:883573af13175ff102b61c80b77934a9e937bdcc40cda2b92051ad53336bc055", size = 258616, upload-time = "2025-11-20T16:37:36.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/e4/192c97ca676c81f69e138a22e10fb03f64e14a55633cb2acffb41bf6d061/opensearch_py-2.8.0.tar.gz", hash = "sha256:6598df0bc7a003294edd0ba88a331e0793acbb8c910c43edf398791e3b2eccda", size = 237923, upload-time = "2024-11-29T21:06:02.952Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/a1/293c8ad81768ad625283d960685bde07c6302abf20a685e693b48ab6eb91/opensearch_py-3.1.0-py3-none-any.whl", hash = "sha256:e5af83d0454323e6ea9ddee8c0dcc185c0181054592d23cb701da46271a3b65b", size = 385729, upload-time = "2025-11-20T16:37:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/23/35/a957c6fb88ff6874996be688448b889475cf0ea978446cd5a30e764e0561/opensearch_py-2.8.0-py3-none-any.whl", hash = "sha256:52c60fdb5d4dcf6cce3ee746c13b194529b0161e0f41268b98ab8f1624abe2fa", size = 353492, upload-time = "2024-11-29T21:05:56.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This reverts commit f7e8da7dbf4129489452393b7cf6b996521447df.

### What are the relevant tickets?
This commit reverts the opensearch-py upgrade: https://github.com/mitodl/mit-learn/pull/2764



### Description (What does it do?)
This PR reverts the upgrade to opensearch-py. There are lots of changes and there may be subtle bugs introduced until we do a full sweep of the diff-log

### How can this be tested?
1. checkout this branch
2. rebuild web and celery containers
3. commands such as ```python manage.py recreate_index --all``` should succeed without errors.
