### PR TITLE
Add configurable cookie tombstone middleware

### DIFF
--- a/main/middleware/cookie_tombstones.py
+++ b/main/middleware/cookie_tombstones.py
@@ -1,15 +1,14 @@
 """Middleware for deleting legacy cookies during migrations."""
 
+import json
 import re
 from dataclasses import dataclass
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-TOMBSTONE_FORMAT_PARTS = 3
-DOMAIN_PART_INDEX = 1
-PATH_PART_INDEX = 2
 VALID_COOKIE_DOMAIN_RE = re.compile(r"^\.?[A-Za-z0-9.-]+$")
+ALLOWED_TOMBSTONE_FIELDS = {"name", "domain", "path"}
 
 
 @dataclass(frozen=True)
@@ -21,20 +20,20 @@ class CookieTombstone:
     path: str = "/"
 
 
-def parse_cookie_tombstones(tombstones: list[str]) -> list[CookieTombstone]:
+def parse_cookie_tombstones(tombstones_json: str) -> list[CookieTombstone]:
     """
-    Parse tombstones from a list of pipe-delimited values.
+    Parse tombstones from a JSON array of objects.
 
-    Each item uses the positional format ``name|domain|path``. Trailing parts
-    may be omitted, so accepted forms are ``name``, ``name|domain``, and
-    ``name|domain|path``. To specify a ``path`` without a ``domain``, include
-    an empty domain placeholder: ``name||/path``.
+    Each object supports:
+    - ``name`` (required string)
+    - ``domain`` (optional string or null)
+    - ``path`` (optional string, defaults to ``/``)
 
     Examples:
         Input:
             [
-                "csrftoken|.learn.mit.edu|/",
-                "legacy_cookie",
+                {"name": "csrftoken", "domain": ".learn.mit.edu", "path": "/"},
+                {"name": "legacy_cookie"},
             ]
 
         Output:
@@ -43,46 +42,85 @@ def parse_cookie_tombstones(tombstones: list[str]) -> list[CookieTombstone]:
                 CookieTombstone(name="legacy_cookie", domain=None, path="/"),
             ]
     """
-    parsed_tombstones: list[CookieTombstone] = []
+    try:
+        tombstones = json.loads(tombstones_json)
+    except json.JSONDecodeError as ex:
+        msg = "COOKIE_TOMBSTONES must be valid JSON"
+        raise ImproperlyConfigured(msg) from ex
 
-    for tombstone in tombstones:
-        parts = [part.strip() for part in tombstone.split("|")]
-        if len(parts) > TOMBSTONE_FORMAT_PARTS:
-            msg = (
-                "CSRF_COOKIE_TOMBSTONES entries must use 'name|domain|path' format: "
-                f"{tombstone}"
-            )
-            raise ImproperlyConfigured(msg)
+    if not isinstance(tombstones, list):
+        msg = "COOKIE_TOMBSTONES must be a JSON array"
+        raise ImproperlyConfigured(msg)
 
-        name = parts[0]
-        domain = parts[DOMAIN_PART_INDEX] if len(parts) > DOMAIN_PART_INDEX else None
-        path = parts[PATH_PART_INDEX] if len(parts) > PATH_PART_INDEX else "/"
+    return [_parse_tombstone(tombstone) for tombstone in tombstones]
 
-        if not name:
-            msg = "CSRF_COOKIE_TOMBSTONES entries must include a cookie name"
-            raise ImproperlyConfigured(msg)
 
-        if domain == "":
-            domain = None
-        elif domain and not _is_valid_cookie_domain(domain):
-            msg = (
-                "CSRF_COOKIE_TOMBSTONES entries must use a valid domain when provided: "
-                f"{tombstone}"
-            )
-            raise ImproperlyConfigured(msg)
+def _parse_tombstone(tombstone: object) -> CookieTombstone:
+    """Parse a single tombstone object into a CookieTombstone."""
+    if not isinstance(tombstone, dict):
+        msg = "COOKIE_TOMBSTONES entries must be objects with name/domain/path fields"
+        raise ImproperlyConfigured(msg)
 
-        if not path:
-            path = "/"
-        elif not path.startswith("/"):
-            msg = (
-                "CSRF_COOKIE_TOMBSTONES entries must use a path starting with '/': "
-                f"{tombstone}"
-            )
-            raise ImproperlyConfigured(msg)
+    extra_fields = set(tombstone.keys()) - ALLOWED_TOMBSTONE_FIELDS
+    if extra_fields:
+        msg = (
+            "COOKIE_TOMBSTONES entries include unsupported field(s): "
+            f"{sorted(extra_fields)}"
+        )
+        raise ImproperlyConfigured(msg)
 
-        parsed_tombstones.append(CookieTombstone(name=name, domain=domain, path=path))
+    return CookieTombstone(
+        name=_parse_tombstone_name(tombstone.get("name")),
+        domain=_parse_tombstone_domain(tombstone.get("domain")),
+        path=_parse_tombstone_path(tombstone.get("path", "/")),
+    )
 
-    return parsed_tombstones
+
+def _parse_tombstone_name(name: object) -> str:
+    """Validate and normalize tombstone name."""
+    if not isinstance(name, str):
+        msg = "COOKIE_TOMBSTONES entries must include a string cookie name"
+        raise ImproperlyConfigured(msg)
+
+    name = name.strip()
+    if not name:
+        msg = "COOKIE_TOMBSTONES entries must include a cookie name"
+        raise ImproperlyConfigured(msg)
+    return name
+
+
+def _parse_tombstone_domain(domain: object) -> str | None:
+    """Validate and normalize tombstone domain."""
+    if domain is None:
+        return None
+    if not isinstance(domain, str):
+        msg = "COOKIE_TOMBSTONES entries must use a string domain when provided"
+        raise ImproperlyConfigured(msg)
+
+    domain = domain.strip()
+    if not domain:
+        return None
+    if not _is_valid_cookie_domain(domain):
+        msg = (
+            f"COOKIE_TOMBSTONES entries must use a valid domain when provided: {domain}"
+        )
+        raise ImproperlyConfigured(msg)
+    return domain
+
+
+def _parse_tombstone_path(path: object) -> str:
+    """Validate and normalize tombstone path."""
+    if path is None:
+        return "/"
+    if not isinstance(path, str):
+        msg = "COOKIE_TOMBSTONES entries must use a string path when provided"
+        raise ImproperlyConfigured(msg)
+
+    path = path.strip() or "/"
+    if not path.startswith("/"):
+        msg = f"COOKIE_TOMBSTONES entries must use a path starting with '/': {path}"
+        raise ImproperlyConfigured(msg)
+    return path
 
 
 def _host_in_domain_scope(host: str, domain: str | None) -> bool:
@@ -118,7 +156,7 @@ class CookieTombstoneMiddleware:
     """
     Delete configured legacy cookies from matching responses.
 
-    Expected pre-parsed values in ``settings.CSRF_COOKIE_TOMBSTONES``:
+    Expected pre-parsed values in ``settings.COOKIE_TOMBSTONES``:
     [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
         CookieTombstone(name="legacy_cookie", domain=None, path="/"),
@@ -149,7 +187,7 @@ class CookieTombstoneMiddleware:
         """Delete configured cookies from matching responses."""
         response = self.get_response(request)
 
-        tombstones = settings.CSRF_COOKIE_TOMBSTONES
+        tombstones = settings.COOKIE_TOMBSTONES
         if not tombstones or not request.COOKIES:
             return response
 

--- a/main/middleware/cookie_tombstones.py
+++ b/main/middleware/cookie_tombstones.py
@@ -1,0 +1,160 @@
+"""Middleware for deleting legacy cookies during migrations."""
+
+from dataclasses import dataclass
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+TOMBSTONE_FORMAT_PARTS = 3
+DOMAIN_PART_INDEX = 1
+PATH_PART_INDEX = 2
+
+
+@dataclass(frozen=True)
+class CookieTombstone:
+    """Cookie signature that should be deleted from responses."""
+
+    name: str
+    domain: str | None = None
+    path: str = "/"
+
+
+def parse_cookie_tombstones(tombstones: list[str]) -> list[CookieTombstone]:
+    """
+    Parse tombstones from a list of pipe-delimited values.
+
+    Each item has shape: ``name|domain|path``, where ``domain`` and ``path``
+    are optional.
+
+    Examples:
+        Input:
+            [
+                "csrftoken|.learn.mit.edu|/",
+                "legacy_cookie",
+            ]
+
+        Output:
+            [
+                CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
+                CookieTombstone(name="legacy_cookie", domain=None, path="/"),
+            ]
+    """
+    parsed_tombstones: list[CookieTombstone] = []
+
+    for tombstone in tombstones:
+        parts = [part.strip() for part in tombstone.split("|")]
+        if len(parts) > TOMBSTONE_FORMAT_PARTS:
+            msg = (
+                "CSRF_COOKIE_TOMBSTONES entries must use 'name|domain|path' format: "
+                f"{tombstone}"
+            )
+            raise ImproperlyConfigured(msg)
+
+        name = parts[0]
+        domain = parts[DOMAIN_PART_INDEX] if len(parts) > DOMAIN_PART_INDEX else None
+        path = parts[PATH_PART_INDEX] if len(parts) > PATH_PART_INDEX else "/"
+
+        if not name:
+            msg = "CSRF_COOKIE_TOMBSTONES entries must include a cookie name"
+            raise ImproperlyConfigured(msg)
+
+        if domain == "":
+            domain = None
+        elif domain and not domain.lstrip("."):
+            msg = (
+                "CSRF_COOKIE_TOMBSTONES entries must use a valid domain when provided: "
+                f"{tombstone}"
+            )
+            raise ImproperlyConfigured(msg)
+
+        if not path:
+            path = "/"
+        elif not path.startswith("/"):
+            msg = (
+                "CSRF_COOKIE_TOMBSTONES entries must use a path starting with '/': "
+                f"{tombstone}"
+            )
+            raise ImproperlyConfigured(msg)
+
+        parsed_tombstones.append(CookieTombstone(name=name, domain=domain, path=path))
+
+    return parsed_tombstones
+
+
+def _host_in_domain_scope(host: str, domain: str | None) -> bool:
+    """Check whether a request host is in scope for a cookie domain."""
+    if domain is None:
+        return True
+
+    normalized_domain = domain.lstrip(".").lower()
+    normalized_host = host.split(":", 1)[0].lower()
+    return normalized_host == normalized_domain or normalized_host.endswith(
+        f".{normalized_domain}"
+    )
+
+
+class CookieTombstoneMiddleware:
+    """
+    Delete configured legacy cookies from matching responses.
+
+    Expected pre-parsed values in ``settings.CSRF_COOKIE_TOMBSTONES``:
+    [
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
+        CookieTombstone(name="legacy_cookie", domain=None, path="/"),
+    ]
+    """
+
+    def __init__(self, get_response):
+        """Initialize middleware with Django's response callable."""
+        self.get_response = get_response
+
+    def _delete_cookie_once(
+        self,
+        response,
+        deleted_signatures: set[tuple[str, str, str | None]],
+        *,
+        name: str,
+        path: str,
+        domain: str | None,
+    ) -> None:
+        signature = (name, path, domain)
+        if signature in deleted_signatures:
+            return
+
+        response.delete_cookie(name, path=path, domain=domain)
+        deleted_signatures.add(signature)
+
+    def __call__(self, request):
+        """Delete configured cookies from matching responses."""
+        response = self.get_response(request)
+
+        tombstones = settings.CSRF_COOKIE_TOMBSTONES
+        if not tombstones or not request.COOKIES:
+            return response
+
+        request_host = request.get_host()
+        deleted_signatures: set[tuple[str, str, str | None]] = set()
+        for tombstone in tombstones:
+            if tombstone.name not in request.COOKIES:
+                continue
+            if not _host_in_domain_scope(request_host, tombstone.domain):
+                continue
+
+            self._delete_cookie_once(
+                response,
+                deleted_signatures,
+                name=tombstone.name,
+                path=tombstone.path,
+                domain=tombstone.domain,
+            )
+            # Also clear host-only cookie variants while the migration is active.
+            if tombstone.domain is not None:
+                self._delete_cookie_once(
+                    response,
+                    deleted_signatures,
+                    name=tombstone.name,
+                    path=tombstone.path,
+                    domain=None,
+                )
+
+        return response

--- a/main/middleware/cookie_tombstones.py
+++ b/main/middleware/cookie_tombstones.py
@@ -1,5 +1,6 @@
 """Middleware for deleting legacy cookies during migrations."""
 
+import re
 from dataclasses import dataclass
 
 from django.conf import settings
@@ -8,6 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 TOMBSTONE_FORMAT_PARTS = 3
 DOMAIN_PART_INDEX = 1
 PATH_PART_INDEX = 2
+VALID_COOKIE_DOMAIN_RE = re.compile(r"^\.?[A-Za-z0-9.-]+$")
 
 
 @dataclass(frozen=True)
@@ -23,8 +25,10 @@ def parse_cookie_tombstones(tombstones: list[str]) -> list[CookieTombstone]:
     """
     Parse tombstones from a list of pipe-delimited values.
 
-    Each item has shape: ``name|domain|path``, where ``domain`` and ``path``
-    are optional.
+    Each item uses the positional format ``name|domain|path``. Trailing parts
+    may be omitted, so accepted forms are ``name``, ``name|domain``, and
+    ``name|domain|path``. To specify a ``path`` without a ``domain``, include
+    an empty domain placeholder: ``name||/path``.
 
     Examples:
         Input:
@@ -60,7 +64,7 @@ def parse_cookie_tombstones(tombstones: list[str]) -> list[CookieTombstone]:
 
         if domain == "":
             domain = None
-        elif domain and not domain.lstrip("."):
+        elif domain and not _is_valid_cookie_domain(domain):
             msg = (
                 "CSRF_COOKIE_TOMBSTONES entries must use a valid domain when provided: "
                 f"{tombstone}"
@@ -90,6 +94,23 @@ def _host_in_domain_scope(host: str, domain: str | None) -> bool:
     normalized_host = host.split(":", 1)[0].lower()
     return normalized_host == normalized_domain or normalized_host.endswith(
         f".{normalized_domain}"
+    )
+
+
+def _is_valid_cookie_domain(domain: str) -> bool:
+    """Validate cookie domain format."""
+    normalized_domain = domain.lstrip(".")
+    if not normalized_domain:
+        return False
+    if not VALID_COOKIE_DOMAIN_RE.fullmatch(domain):
+        return False
+    if ".." in normalized_domain:
+        return False
+
+    labels = normalized_domain.split(".")
+    return all(
+        label and not label.startswith("-") and not label.endswith("-")
+        for label in labels
     )
 
 
@@ -132,13 +153,16 @@ class CookieTombstoneMiddleware:
         if not tombstones or not request.COOKIES:
             return response
 
-        request_host = request.get_host()
+        request_host: str | None = None
         deleted_signatures: set[tuple[str, str, str | None]] = set()
         for tombstone in tombstones:
             if tombstone.name not in request.COOKIES:
                 continue
-            if not _host_in_domain_scope(request_host, tombstone.domain):
-                continue
+            if tombstone.domain is not None:
+                if request_host is None:
+                    request_host = request.get_host()
+                if not _host_in_domain_scope(request_host, tombstone.domain):
+                    continue
 
             self._delete_cookie_once(
                 response,

--- a/main/middleware/cookie_tombstones_test.py
+++ b/main/middleware/cookie_tombstones_test.py
@@ -19,10 +19,13 @@ def middleware(mocker):
 
 def test_parse_cookie_tombstones():
     """Cookie tombstones should parse from pipe-delimited values."""
-    parsed = parse_cookie_tombstones(["csrftoken|.learn.mit.edu|/", "csrftoken"])
+    parsed = parse_cookie_tombstones(
+        ["csrftoken|.learn.mit.edu|/", "csrftoken", "sessionid||/accounts"]
+    )
     assert parsed == [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
         CookieTombstone(name="csrftoken", domain=None, path="/"),
+        CookieTombstone(name="sessionid", domain=None, path="/accounts"),
     ]
 
 
@@ -30,6 +33,9 @@ def test_parse_cookie_tombstones_invalid():
     """Invalid cookie tombstone values should raise ImproperlyConfigured."""
     with pytest.raises(ImproperlyConfigured):
         parse_cookie_tombstones(["|.learn.mit.edu|/"])
+
+    with pytest.raises(ImproperlyConfigured):
+        parse_cookie_tombstones(["csrftoken|/accounts"])
 
 
 def test_delete_matching_domain_cookie_and_host_only(middleware, mocker, settings):
@@ -85,3 +91,45 @@ def test_skip_when_cookie_not_present(middleware, mocker, settings):
 
     response = middleware.get_response.return_value
     response.delete_cookie.assert_not_called()
+    request.get_host.assert_not_called()
+
+
+def test_skip_host_lookup_for_host_only_tombstones(middleware, mocker, settings):
+    """Host lookups should be skipped when only host-only tombstones apply."""
+    settings.CSRF_COOKIE_TOMBSTONES = [
+        CookieTombstone(name="csrftoken", domain=None, path="/")
+    ]
+    request = mocker.Mock()
+    request.COOKIES = {"csrftoken": "abc"}
+
+    middleware(request)
+
+    response = middleware.get_response.return_value
+    response.delete_cookie.assert_called_once_with(
+        "csrftoken",
+        path="/",
+        domain=None,
+    )
+    request.get_host.assert_not_called()
+
+
+def test_domain_host_lookup_is_lazy_and_single_call(middleware, mocker, settings):
+    """Host should be fetched lazily and at most once for domain tombstones."""
+    settings.CSRF_COOKIE_TOMBSTONES = [
+        CookieTombstone(name="other_cookie", domain=".learn.mit.edu", path="/"),
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
+        CookieTombstone(name="csrftoken", domain=".open.edx.org", path="/"),
+    ]
+    request = mocker.Mock()
+    request.COOKIES = {"csrftoken": "abc"}
+    request.get_host.return_value = "api.learn.mit.edu"
+
+    middleware(request)
+
+    response = middleware.get_response.return_value
+    response.delete_cookie.assert_any_call(
+        "csrftoken",
+        path="/",
+        domain=".learn.mit.edu",
+    )
+    request.get_host.assert_called_once_with()

--- a/main/middleware/cookie_tombstones_test.py
+++ b/main/middleware/cookie_tombstones_test.py
@@ -18,9 +18,15 @@ def middleware(mocker):
 
 
 def test_parse_cookie_tombstones():
-    """Cookie tombstones should parse from pipe-delimited values."""
+    """Cookie tombstones should parse from JSON object values."""
     parsed = parse_cookie_tombstones(
-        ["csrftoken|.learn.mit.edu|/", "csrftoken", "sessionid||/accounts"]
+        """
+        [
+            {"name": "csrftoken", "domain": ".learn.mit.edu", "path": "/"},
+            {"name": "csrftoken"},
+            {"name": "sessionid", "path": "/accounts"}
+        ]
+        """
     )
     assert parsed == [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
@@ -32,15 +38,26 @@ def test_parse_cookie_tombstones():
 def test_parse_cookie_tombstones_invalid():
     """Invalid cookie tombstone values should raise ImproperlyConfigured."""
     with pytest.raises(ImproperlyConfigured):
-        parse_cookie_tombstones(["|.learn.mit.edu|/"])
+        parse_cookie_tombstones(
+            """
+            [{"name": "csrftoken", "domain": "/accounts"}]
+            """
+        )
 
     with pytest.raises(ImproperlyConfigured):
-        parse_cookie_tombstones(["csrftoken|/accounts"])
+        parse_cookie_tombstones(
+            """
+            [{"domain": ".learn.mit.edu"}]
+            """
+        )
+
+    with pytest.raises(ImproperlyConfigured):
+        parse_cookie_tombstones("not-json")
 
 
 def test_delete_matching_domain_cookie_and_host_only(middleware, mocker, settings):
     """Matching domain tombstones should delete both domain and host-only cookies."""
-    settings.CSRF_COOKIE_TOMBSTONES = [
+    settings.COOKIE_TOMBSTONES = [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
     ]
     request = mocker.Mock()
@@ -65,7 +82,7 @@ def test_delete_matching_domain_cookie_and_host_only(middleware, mocker, setting
 
 def test_skip_when_host_not_in_cookie_domain(middleware, mocker, settings):
     """Domain tombstones should not apply outside the tombstone domain scope."""
-    settings.CSRF_COOKIE_TOMBSTONES = [
+    settings.COOKIE_TOMBSTONES = [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
     ]
     request = mocker.Mock()
@@ -80,7 +97,7 @@ def test_skip_when_host_not_in_cookie_domain(middleware, mocker, settings):
 
 def test_skip_when_cookie_not_present(middleware, mocker, settings):
     """No deletion should occur when the cookie name is not present in request cookies."""
-    settings.CSRF_COOKIE_TOMBSTONES = [
+    settings.COOKIE_TOMBSTONES = [
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
     ]
     request = mocker.Mock()
@@ -96,7 +113,7 @@ def test_skip_when_cookie_not_present(middleware, mocker, settings):
 
 def test_skip_host_lookup_for_host_only_tombstones(middleware, mocker, settings):
     """Host lookups should be skipped when only host-only tombstones apply."""
-    settings.CSRF_COOKIE_TOMBSTONES = [
+    settings.COOKIE_TOMBSTONES = [
         CookieTombstone(name="csrftoken", domain=None, path="/")
     ]
     request = mocker.Mock()
@@ -115,7 +132,7 @@ def test_skip_host_lookup_for_host_only_tombstones(middleware, mocker, settings)
 
 def test_domain_host_lookup_is_lazy_and_single_call(middleware, mocker, settings):
     """Host should be fetched lazily and at most once for domain tombstones."""
-    settings.CSRF_COOKIE_TOMBSTONES = [
+    settings.COOKIE_TOMBSTONES = [
         CookieTombstone(name="other_cookie", domain=".learn.mit.edu", path="/"),
         CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
         CookieTombstone(name="csrftoken", domain=".open.edx.org", path="/"),

--- a/main/middleware/cookie_tombstones_test.py
+++ b/main/middleware/cookie_tombstones_test.py
@@ -1,0 +1,87 @@
+"""Tests for cookie tombstone middleware."""
+
+# pylint: disable=redefined-outer-name
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from main.middleware.cookie_tombstones import (
+    CookieTombstone,
+    CookieTombstoneMiddleware,
+    parse_cookie_tombstones,
+)
+
+
+@pytest.fixture
+def middleware(mocker):
+    """Create middleware with mocked get_response."""
+    return CookieTombstoneMiddleware(mocker.Mock())
+
+
+def test_parse_cookie_tombstones():
+    """Cookie tombstones should parse from pipe-delimited values."""
+    parsed = parse_cookie_tombstones(["csrftoken|.learn.mit.edu|/", "csrftoken"])
+    assert parsed == [
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/"),
+        CookieTombstone(name="csrftoken", domain=None, path="/"),
+    ]
+
+
+def test_parse_cookie_tombstones_invalid():
+    """Invalid cookie tombstone values should raise ImproperlyConfigured."""
+    with pytest.raises(ImproperlyConfigured):
+        parse_cookie_tombstones(["|.learn.mit.edu|/"])
+
+
+def test_delete_matching_domain_cookie_and_host_only(middleware, mocker, settings):
+    """Matching domain tombstones should delete both domain and host-only cookies."""
+    settings.CSRF_COOKIE_TOMBSTONES = [
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
+    ]
+    request = mocker.Mock()
+    request.COOKIES = {"csrftoken": "abc"}
+    request.get_host.return_value = "api.learn.mit.edu"
+
+    middleware(request)
+
+    response = middleware.get_response.return_value
+    assert response.delete_cookie.call_count == 2
+    response.delete_cookie.assert_any_call(
+        "csrftoken",
+        path="/",
+        domain=".learn.mit.edu",
+    )
+    response.delete_cookie.assert_any_call(
+        "csrftoken",
+        path="/",
+        domain=None,
+    )
+
+
+def test_skip_when_host_not_in_cookie_domain(middleware, mocker, settings):
+    """Domain tombstones should not apply outside the tombstone domain scope."""
+    settings.CSRF_COOKIE_TOMBSTONES = [
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
+    ]
+    request = mocker.Mock()
+    request.COOKIES = {"csrftoken": "abc"}
+    request.get_host.return_value = "example.org"
+
+    middleware(request)
+
+    response = middleware.get_response.return_value
+    response.delete_cookie.assert_not_called()
+
+
+def test_skip_when_cookie_not_present(middleware, mocker, settings):
+    """No deletion should occur when the cookie name is not present in request cookies."""
+    settings.CSRF_COOKIE_TOMBSTONES = [
+        CookieTombstone(name="csrftoken", domain=".learn.mit.edu", path="/")
+    ]
+    request = mocker.Mock()
+    request.COOKIES = {"other_cookie": "abc"}
+    request.get_host.return_value = "api.learn.mit.edu"
+
+    middleware(request)
+
+    response = middleware.get_response.return_value
+    response.delete_cookie.assert_not_called()

--- a/main/settings.py
+++ b/main/settings.py
@@ -242,9 +242,7 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = get_string(
 CSRF_COOKIE_SECURE = get_bool("CSRF_COOKIE_SECURE", True)  # noqa: FBT003
 CSRF_COOKIE_DOMAIN = get_string("CSRF_COOKIE_DOMAIN", None)
 CSRF_COOKIE_NAME = get_string("CSRF_COOKIE_NAME", "csrftoken")
-CSRF_COOKIE_TOMBSTONES = parse_cookie_tombstones(
-    get_list_of_str("CSRF_COOKIE_TOMBSTONES", [])
-)
+COOKIE_TOMBSTONES = parse_cookie_tombstones(get_string("COOKIE_TOMBSTONES", "[]"))
 
 CSRF_HEADER_NAME = get_string("CSRF_HEADER_NAME", "HTTP_X_CSRFTOKEN")
 
@@ -253,7 +251,7 @@ CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
 SESSION_COOKIE_DOMAIN = get_string("SESSION_COOKIE_DOMAIN", None)
 SESSION_COOKIE_NAME = get_string("SESSION_COOKIE_NAME", "sessionid")
 
-if CSRF_COOKIE_TOMBSTONES:
+if COOKIE_TOMBSTONES:
     tombstone_middleware = "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
     MIDDLEWARE = (tombstone_middleware, *MIDDLEWARE)
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -28,6 +28,7 @@ from main.envs import (
     get_list_of_str,
     get_string,
 )
+from main.middleware.cookie_tombstones import parse_cookie_tombstones
 from main.sentry import init_sentry
 from main.settings_celery import *  # noqa: F403
 from main.settings_course_etl import *  # noqa: F403
@@ -241,6 +242,9 @@ SECURE_CROSS_ORIGIN_OPENER_POLICY = get_string(
 CSRF_COOKIE_SECURE = get_bool("CSRF_COOKIE_SECURE", True)  # noqa: FBT003
 CSRF_COOKIE_DOMAIN = get_string("CSRF_COOKIE_DOMAIN", None)
 CSRF_COOKIE_NAME = get_string("CSRF_COOKIE_NAME", "csrftoken")
+CSRF_COOKIE_TOMBSTONES = parse_cookie_tombstones(
+    get_list_of_str("CSRF_COOKIE_TOMBSTONES", [])
+)
 
 CSRF_HEADER_NAME = get_string("CSRF_HEADER_NAME", "HTTP_X_CSRFTOKEN")
 
@@ -248,6 +252,9 @@ CSRF_TRUSTED_ORIGINS = get_list_of_str("CSRF_TRUSTED_ORIGINS", [])
 
 SESSION_COOKIE_DOMAIN = get_string("SESSION_COOKIE_DOMAIN", None)
 SESSION_COOKIE_NAME = get_string("SESSION_COOKIE_NAME", "sessionid")
+
+if CSRF_COOKIE_TOMBSTONES:
+    MIDDLEWARE += ("main.middleware.cookie_tombstones.CookieTombstoneMiddleware",)
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:

--- a/main/settings.py
+++ b/main/settings.py
@@ -254,7 +254,17 @@ SESSION_COOKIE_DOMAIN = get_string("SESSION_COOKIE_DOMAIN", None)
 SESSION_COOKIE_NAME = get_string("SESSION_COOKIE_NAME", "sessionid")
 
 if CSRF_COOKIE_TOMBSTONES:
-    MIDDLEWARE += ("main.middleware.cookie_tombstones.CookieTombstoneMiddleware",)
+    tombstone_middleware = "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
+    csrf_middleware = "django.middleware.csrf.CsrfViewMiddleware"
+    if csrf_middleware in MIDDLEWARE:
+        csrf_index = MIDDLEWARE.index(csrf_middleware)
+        MIDDLEWARE = (
+            *MIDDLEWARE[:csrf_index],
+            tombstone_middleware,
+            *MIDDLEWARE[csrf_index:],
+        )
+    else:
+        MIDDLEWARE += (tombstone_middleware,)
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:

--- a/main/settings.py
+++ b/main/settings.py
@@ -255,16 +255,7 @@ SESSION_COOKIE_NAME = get_string("SESSION_COOKIE_NAME", "sessionid")
 
 if CSRF_COOKIE_TOMBSTONES:
     tombstone_middleware = "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
-    csrf_middleware = "django.middleware.csrf.CsrfViewMiddleware"
-    if csrf_middleware in MIDDLEWARE:
-        csrf_index = MIDDLEWARE.index(csrf_middleware)
-        MIDDLEWARE = (
-            *MIDDLEWARE[:csrf_index],
-            tombstone_middleware,
-            *MIDDLEWARE[csrf_index:],
-        )
-    else:
-        MIDDLEWARE += (tombstone_middleware,)
+    MIDDLEWARE = (tombstone_middleware, *MIDDLEWARE)
 
 # enable the nplusone profiler only in debug mode
 if DEBUG:

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -203,6 +203,31 @@ class TestSettings(TestCase):
                 is False
             )
 
+    def test_cookie_tombstone_middleware_enabled(self):
+        """Cookie tombstone middleware should be enabled when tombstones are configured."""
+        with mock.patch.dict(
+            "os.environ",
+            {
+                **REQUIRED_SETTINGS,
+                "CSRF_COOKIE_TOMBSTONES": '["csrftoken|.learn.mit.edu|/"]',
+            },
+            clear=True,
+        ):
+            settings_vars = self.reload_settings()
+            assert (
+                "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
+                in (settings_vars["MIDDLEWARE"])
+            )
+
+    def test_cookie_tombstone_middleware_disabled(self):
+        """Cookie tombstone middleware should be disabled when tombstones are unset."""
+        with mock.patch.dict("os.environ", REQUIRED_SETTINGS, clear=True):
+            settings_vars = self.reload_settings()
+            assert (
+                "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
+                not in (settings_vars["MIDDLEWARE"])
+            )
+
     def test_celery_beat_disabled(self):
         """Test that we can disable celery beat with an env var"""
         with mock.patch.dict(

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -209,7 +209,9 @@ class TestSettings(TestCase):
             "os.environ",
             {
                 **REQUIRED_SETTINGS,
-                "CSRF_COOKIE_TOMBSTONES": '["csrftoken|.learn.mit.edu|/"]',
+                "COOKIE_TOMBSTONES": (
+                    '[{"name":"csrftoken","domain":".learn.mit.edu","path":"/"}]'
+                ),
             },
             clear=True,
         ):
@@ -234,7 +236,9 @@ class TestSettings(TestCase):
             "os.environ",
             {
                 **REQUIRED_SETTINGS,
-                "CSRF_COOKIE_TOMBSTONES": '["csrftoken|.learn.mit.edu|/"]',
+                "COOKIE_TOMBSTONES": (
+                    '[{"name":"csrftoken","domain":".learn.mit.edu","path":"/"}]'
+                ),
             },
             clear=True,
         ):

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -228,6 +228,24 @@ class TestSettings(TestCase):
                 not in (settings_vars["MIDDLEWARE"])
             )
 
+    def test_cookie_tombstone_middleware_ordering(self):
+        """Cookie tombstone middleware should run after CSRF on response."""
+        with mock.patch.dict(
+            "os.environ",
+            {
+                **REQUIRED_SETTINGS,
+                "CSRF_COOKIE_TOMBSTONES": '["csrftoken|.learn.mit.edu|/"]',
+            },
+            clear=True,
+        ):
+            settings_vars = self.reload_settings()
+            middleware = settings_vars["MIDDLEWARE"]
+            tombstone_index = middleware.index(
+                "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
+            )
+            csrf_index = middleware.index("django.middleware.csrf.CsrfViewMiddleware")
+            assert tombstone_index < csrf_index
+
     def test_celery_beat_disabled(self):
         """Test that we can disable celery beat with an env var"""
         with mock.patch.dict(

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -229,7 +229,7 @@ class TestSettings(TestCase):
             )
 
     def test_cookie_tombstone_middleware_ordering(self):
-        """Cookie tombstone middleware should run after CSRF on response."""
+        """Cookie tombstone middleware should be first in the middleware stack."""
         with mock.patch.dict(
             "os.environ",
             {
@@ -240,11 +240,10 @@ class TestSettings(TestCase):
         ):
             settings_vars = self.reload_settings()
             middleware = settings_vars["MIDDLEWARE"]
-            tombstone_index = middleware.index(
-                "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
+            assert (
+                middleware[0]
+                == "main.middleware.cookie_tombstones.CookieTombstoneMiddleware"
             )
-            csrf_index = middleware.index("django.middleware.csrf.CsrfViewMiddleware")
-            assert tombstone_index < csrf_index
 
     def test_celery_beat_disabled(self):
         """Test that we can disable celery beat with an env var"""


### PR DESCRIPTION
# Add configurable CSRF cookie tombstone middleware
<!-- PR is: https://github.com/mitodl/mit-learn/pull/3234 -->

### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/11013
- Related to https://github.com/mitodl/hq/issues/10926

### Description (What does it do?)
Adds a configurable CookieTombstoneMiddleware designed to (A) terminate problematic cookies and (B) be very low impact if the problematic cookies are not present.

**Changes at a glance:**
- Added `main.middleware.cookie_tombstones` with:
    - `CookieTombstoneMiddleware` to delete configured legacy cookies from matching responses.
    - `parse_cookie_tombstones` with env-driven parsing of `COOKIE_TOMBSTONES` JSON entries (`name` required, `domain`/`path` optional).
- Wired middleware in `main/settings.py` so it is enabled only when `COOKIE_TOMBSTONES` is non-empty.

### How can this be tested?

**Option 1:** Test with curl:

1. Add `COOKIE_TOMBSTONES='[{"name":"csrftoken-bad","domain":".open.odl.local","path":"/"}]'`
2. `curl -si 'http://api.open.odl.local:8065/api/v0/users/me/'  -H 'Cookie: csrftoken-bad=bogus123' | grep -Ei '^(HTTP/|Set-Cookie:)'`; Check for a line like `csrftoken-bad=""`
3. `curl -si 'http://api.open.odl.local:8065/api/v0/users/me/'  -H 'Cookie: csrftoken-good=bogus123' | grep -Ei '^(HTTP/|Set-Cookie:)'`; no line unsetting the csrftoken-bad cookie; request didn't have it.
4. Cookie scope mismatch examples (domain/path via cookie-jar format):
   ```bash
   # Scope match (successful): cookie is scoped for api.open.odl.local + /api path.
   printf '# Netscape HTTP Cookie File\napi.open.odl.local\tFALSE\t/api\tFALSE\t0\tcsrftoken-bad\tbogus123\n' > /tmp/tombstone-cookies.txt
   curl -si 'http://api.open.odl.local:8065/api/v0/users/me/' \
     --cookie /tmp/tombstone-cookies.txt \
     | grep -Ei '^(HTTP/|Set-Cookie:)'

   # Path mismatch: cookie path is /not-api, request path is /api/v0/users/me.
   printf '# Netscape HTTP Cookie File\napi.open.odl.local\tFALSE\t/not-api\tFALSE\t0\tcsrftoken-bad\tbogus123\n' > /tmp/tombstone-cookies.txt
   curl -si 'http://api.open.odl.local:8065/api/v0/users/me/' \
     --cookie /tmp/tombstone-cookies.txt \
     | grep -Ei '^(HTTP/|Set-Cookie:)'

   # Domain mismatch: cookie domain is other.open.odl.local, request host is api.open.odl.local.
   printf '# Netscape HTTP Cookie File\nother.open.odl.local\tFALSE\t/\tFALSE\t0\tcsrftoken-bad\tbogus123\n' > /tmp/tombstone-cookies.txt
   curl -si 'http://api.open.odl.local:8065/api/v0/users/me/' \
     --cookie /tmp/tombstone-cookies.txt \
     | grep -Ei '^(HTTP/|Set-Cookie:)'
   ```

**Option 2:** Test in browser

1. Add `COOKIE_TOMBSTONES='[{"name":"csrftoken-bad","domain":".open.odl.local","path":"/"}]'` to your backend.local.env
2. Load the frontend at http://open.odl.local:8062/
3. In browser devtools (Application tab in Chrome Devtools) manually add a cookie like:
    - Name: `csrftoken-bad`
    - Domain: `open.odl.local`
    - Path: `/`
4. In network tab, manually retry a request like `users/me`, (right click the request and click "Replay XHR")
    - or click into the webpage, which will automatically retry the `/users/me` request because of the way we have that auth-related query setup on the frontend.
5. View the `user/me` request/response from step 4; it should include something like `
csrftoken-bad=""; Domain=open.odl.local; expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/` to unset the cookie value
