### PR TITLE
feat: Adds Google Tag Manager (GTM) support

### DIFF
--- a/env/frontend.env
+++ b/env/frontend.env
@@ -37,7 +37,7 @@ NEXT_PUBLIC_HUBSPOT_PORTAL_ID=${HUBSPOT_PORTAL_ID}
 
 # Google Tag Manager configured server-side (no NEXT_PUBLIC_*); values will be included in the GTM script/iframe URLs
 GTM_TRACKING_ID=${GTM_TRACKING_ID}
-GTM_AUTH=${GTM_AUTH}
+GTM_AUTH=${GTM_AUTH} # NOTE: This is not a secret.
 GTM_PREVIEW=${GTM_PREVIEW}
 GTM_COOKIES_WIN=${GTM_COOKIES_WIN}
 

--- a/env/frontend.env
+++ b/env/frontend.env
@@ -35,6 +35,12 @@ NEXT_PUBLIC_VERSION="local-dev"
 # Hubspot tracking - xprodev account for dev/RC environments
 NEXT_PUBLIC_HUBSPOT_PORTAL_ID=${HUBSPOT_PORTAL_ID}
 
+# Google Tag Manager configured server-side (no NEXT_PUBLIC_*); values will be included in the GTM script/iframe URLs
+GTM_TRACKING_ID=${GTM_TRACKING_ID}
+GTM_AUTH=${GTM_AUTH}
+GTM_PREVIEW=${GTM_PREVIEW}
+GTM_COOKIES_WIN=${GTM_COOKIES_WIN}
+
 # OpenTelemetry tracing (server-side only — no NEXT_PUBLIC_ prefix needed)
 # These are read at runtime by the OTEL NodeSDK and injected by Kubernetes for
 # deployed environments. Sampling is disabled locally (0.0); set

--- a/env/frontend.local.example.env
+++ b/env/frontend.local.example.env
@@ -1,2 +1,8 @@
 NEXT_PUBLIC_EMBEDLY_KEY=""
 NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=""
+
+# Optional local GTM overrides (server-side runtime)
+# GTM_TRACKING_ID=
+# GTM_AUTH=
+# GTM_PREVIEW=
+# GTM_COOKIES_WIN=

--- a/env/shared.local.example.env
+++ b/env/shared.local.example.env
@@ -12,3 +12,10 @@ MITOL_API_DOMAIN=api.open.odl.local # dev only, should match domain of above
 # https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do
 # RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
 # RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
+
+# Google Tag Manager (server-side frontend runtime variables)
+# GTM_TRACKING_ID=
+# GTM_AUTH=
+# GTM_PREVIEW=
+# GTM_COOKIES_WIN=
+# DEV values should be copied from GTM Environments UI.

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -85,7 +85,7 @@ j=d.createElement(s),dl=l!=='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <html lang="en">
       <head>
         {gtmHeadScript ? (
-          <Script id="google-tag-manager" strategy="beforeInteractive">
+          <Script id="google-tag-manager" strategy="afterInteractive">
             {gtmHeadScript}
           </Script>
         ) : null}

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -10,6 +10,44 @@ import "./GlobalStyles"
 
 const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
 
+const getGtmConfig = () => {
+  const trackingId = process.env.GTM_TRACKING_ID?.trim()
+  const auth = process.env.GTM_AUTH?.trim()
+  const preview = process.env.GTM_PREVIEW?.trim()
+  const cookiesWin = process.env.GTM_COOKIES_WIN?.trim() || "x"
+
+  if (!trackingId || !auth || !preview) {
+    return null
+  }
+
+  return {
+    trackingId,
+    auth,
+    preview,
+    cookiesWin,
+  }
+}
+
+const buildGtmUrlQuery = ({
+  trackingId,
+  auth,
+  preview,
+  cookiesWin,
+}: {
+  trackingId: string
+  auth: string
+  preview: string
+  cookiesWin: string
+}) => {
+  const params = new URLSearchParams({
+    id: trackingId,
+    gtm_auth: auth,
+    gtm_preview: preview,
+    gtm_cookies_win: cookiesWin,
+  })
+  return params.toString()
+}
+
 /**
  * As part of the root layout, this metadata object is site-wide defaults
  */
@@ -32,9 +70,25 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const gtmConfig = getGtmConfig()
+  const gtmQuery = gtmConfig ? buildGtmUrlQuery(gtmConfig) : null
+  const gtmHeadScript =
+    gtmQuery !== null
+      ? `(function(w,d,s,l,q){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!=='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?'+q+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer',${JSON.stringify(gtmQuery)});`
+      : null
+
   return (
     <html lang="en">
       <head>
+        {gtmHeadScript ? (
+          <Script id="google-tag-manager" strategy="beforeInteractive">
+            {gtmHeadScript}
+          </Script>
+        ) : null}
         {/*
           Font files for Adobe neue haas grotesk.
           WARNING: This is linked to chudzick@mit.edu's Adobe account.
@@ -51,6 +105,17 @@ export default function RootLayout({
         />
       </head>
       <body>
+        {gtmQuery ? (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?${gtmQuery}`}
+              title="Google Tag Manager"
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            />
+          </noscript>
+        ) : null}
         <Providers>
           <MITLearnGlobalStyles />
           <PageWrapper>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11014

### Description (What does it do?)
Adds Google Tag Manager (GTM) support to the frontends/main Next.js App Router application by conditionally injecting the GTM script and noscript iframe based on server-side environment variables.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Open **http://localhost:8062/** and confirm:

no request to googletagmanager.com/gtm.js

no GTM noscript iframe (googletagmanager.com/ns.html) in DOM/source.

Set `GTM env vars` in `.env.local` (these can be picked from the [issue](https://github.com/mitodl/hq/issues/11014)) and restart server:
GTM_TRACKING_ID=
GTM_AUTH=<env-specific-auth>
GTM_PREVIEW=<env-specific-preview>
GTM_COOKIES_WIN=


Open http://localhost:8062/ and confirm:

GTM script is present in <head> (via injected script with id google-tag-manager)
GTM noscript iframe is present immediately after <body> open
Network tab shows https://www.googletagmanager.com/gtm.js?...
URL includes `id, gtm_auth, gtm_preview, gtm_cookies_win`.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
