### PR TITLE
fix: Hide .00 on whole-dollar MITxOnline prices

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.test.tsx
@@ -180,7 +180,7 @@ describe("MitxOnlineResourceCard", () => {
         href: "/test",
         list: true,
       })
-      expect(container.textContent).toContain("$200.00")
+      expect(container.textContent).toContain("$200")
     })
 
     test("shows 'Free' when enrollment is free-only", () => {
@@ -214,7 +214,7 @@ describe("MitxOnlineResourceCard", () => {
         href: "/test",
         list: true,
       })
-      expect(container.textContent).toContain("$500.00")
+      expect(container.textContent).toContain("$500")
     })
 
     test("shows price range when min and max differ", () => {
@@ -231,7 +231,7 @@ describe("MitxOnlineResourceCard", () => {
         href: "/test",
         list: true,
       })
-      expect(container.textContent).toContain("$100.00 - $500.00")
+      expect(container.textContent).toContain("$100 - $500")
     })
 
     test("shows 'Free' and certificate price when both free and paid", () => {
@@ -251,7 +251,7 @@ describe("MitxOnlineResourceCard", () => {
         list: true,
       })
       expect(container.textContent).toContain("Free")
-      expect(container.textContent).toContain("$500.00")
+      expect(container.textContent).toContain("$500")
     })
 
     test("shows no price when no enrollment modes", () => {

--- a/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
+++ b/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
@@ -49,16 +49,16 @@ const formatResourcePrice = (
     maxPrice !== undefined &&
     minPrice !== maxPrice
   ) {
-    return `${formatPrice(minPrice)} - ${formatPrice(maxPrice)}`
+    return `${formatPrice(minPrice, { avoidCents: true })} - ${formatPrice(maxPrice, { avoidCents: true })}`
   }
 
   if (productPrice !== undefined && productPrice !== null) {
-    return formatPrice(productPrice)
+    return formatPrice(productPrice, { avoidCents: true })
   }
 
   const single = minPrice ?? maxPrice
   if (single !== null && single !== undefined) {
-    return formatPrice(single)
+    return formatPrice(single, { avoidCents: true })  
   }
 
   return null

--- a/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
+++ b/frontends/main/src/app-pages/ProductPages/MitxOnlineResourceCard.tsx
@@ -58,7 +58,7 @@ const formatResourcePrice = (
 
   const single = minPrice ?? maxPrice
   if (single !== null && single !== undefined) {
-    return formatPrice(single, { avoidCents: true })  
+    return formatPrice(single, { avoidCents: true })
   }
 
   return null

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
@@ -802,7 +802,7 @@ describe("CourseSummary", () => {
       const priceRow = screen.getByTestId(TestIds.PriceRow)
 
       expect(priceRow).toHaveTextContent(
-        `Earn a certificate: ${formatPrice(run.products[0].price)}`,
+        `Earn a certificate: ${formatPrice(run.products[0].price, { avoidCents: true })}`,
       )
       invariant(run.upgrade_deadline)
       expect(priceRow).toHaveTextContent(
@@ -852,7 +852,9 @@ describe("CourseSummary", () => {
       renderWithProviders(<CourseSummary course={course} />)
 
       const priceRow = screen.getByTestId(TestIds.PriceRow)
-      expect(priceRow).toHaveTextContent(formatPrice(product.price))
+      expect(priceRow).toHaveTextContent(
+        formatPrice(product.price, { avoidCents: true }),
+      )
       expect(priceRow).toHaveTextContent(course.certificate_type)
       expect(priceRow).not.toHaveTextContent("Free to Learn")
       expect(priceRow).not.toHaveTextContent("Earn a certificate")
@@ -1007,7 +1009,9 @@ describe("CourseSummary", () => {
       const priceRow = screen.getByTestId(TestIds.PriceRow)
 
       // Should show the regular price
-      expect(priceRow).toHaveTextContent(formatPrice(product.price))
+      expect(priceRow).toHaveTextContent(
+        formatPrice(product.price, { avoidCents: true }),
+      )
       // Should NOT show financial assistance link
       expect(
         within(priceRow).queryByRole("link", { name: /financial assistance/i }),
@@ -1285,7 +1289,9 @@ describe("ProgramSummary", () => {
       renderWithProviders(<ProgramSummary program={program} />)
 
       const priceRow = screen.getByTestId(TestIds.PriceRow)
-      expect(priceRow).toHaveTextContent(formatPrice(product.price))
+      expect(priceRow).toHaveTextContent(
+        formatPrice(product.price, { avoidCents: true }),
+      )
       expect(priceRow).toHaveTextContent(program.certificate_type)
       expect(priceRow).not.toHaveTextContent("Free to Learn")
       expect(priceRow).not.toHaveTextContent("Earn a certificate")
@@ -1301,7 +1307,9 @@ describe("ProgramSummary", () => {
       const priceRow = screen.getByTestId(TestIds.PriceRow)
       expect(priceRow).toHaveTextContent("Free to Learn")
       expect(priceRow).toHaveTextContent("Earn a certificate")
-      expect(priceRow).toHaveTextContent(formatPrice(program.products[0].price))
+      expect(priceRow).toHaveTextContent(
+        formatPrice(program.products[0].price, { avoidCents: true }),
+      )
     })
 
     test.each([

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -411,7 +411,11 @@ const CourseCertificateBox: React.FC<CourseInfoRowProps> = ({
   })
   const price =
     canPurchase && product
-      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data, avoidCents: true })
+      ? priceWithDiscount({
+          product,
+          flexiblePrice: userFlexiblePrice.data,
+          avoidCents: true,
+        })
       : null
 
   const upgradeDeadline = nextRun?.is_archived
@@ -502,7 +506,11 @@ const CoursePriceRow: React.FC<CourseInfoRowProps> = ({
   })
   const price =
     enrollmentType === "paid" && product
-      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data, avoidCents: true })
+      ? priceWithDiscount({
+          product,
+          flexiblePrice: userFlexiblePrice.data,
+          avoidCents: true,
+        })
       : null
 
   if (enrollmentType === "none") return null

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -411,7 +411,7 @@ const CourseCertificateBox: React.FC<CourseInfoRowProps> = ({
   })
   const price =
     canPurchase && product
-      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data })
+      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data, avoidCents: true })
       : null
 
   const upgradeDeadline = nextRun?.is_archived
@@ -502,7 +502,7 @@ const CoursePriceRow: React.FC<CourseInfoRowProps> = ({
   })
   const price =
     enrollmentType === "paid" && product
-      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data })
+      ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data, avoidCents: true })
       : null
 
   if (enrollmentType === "none") return null
@@ -769,7 +769,7 @@ const ProgramCertificateBox: React.FC<{ program: V2ProgramDetail }> = ({
           >
             <InfoLabel>Earn a certificate</InfoLabel>
           </UnderlinedLink>
-          : {formatPrice(price)}
+          : {formatPrice(price, { avoidCents: true })}
         </span>
       </InfoRowInner>
       {program.page.financial_assistance_form_url ? (
@@ -800,7 +800,7 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
   const paidPrice =
     enrollmentType === "paid" && program.products[0]?.price ? (
       <>
-        {formatPrice(program.products[0].price)}{" "}
+        {formatPrice(program.products[0].price, { avoidCents: true })}{" "}
         <GrayText>(includes {program.certificate_type})</GrayText>
       </>
     ) : null

--- a/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.tsx
@@ -213,7 +213,11 @@ const CertificateUpsell: React.FC<{
     enabled: enabled && !!financialAidUrl,
   })
   const price = enabled
-    ? priceWithDiscount({ product, flexiblePrice: userFlexiblePrice.data })
+    ? priceWithDiscount({
+        product,
+        flexiblePrice: userFlexiblePrice.data,
+        avoidCents: true,
+      })
     : null
   const hasFinancialAssistance = !!financialAidUrl
   const deadlineUI = courseRun?.upgrade_deadline ? (

--- a/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.tsx
@@ -68,7 +68,10 @@ const ProgramCertificateUpsell: React.FC<{
           <RiAwardFill />
           <Stack gap="4px">
             <strong>
-              Get Certificate {product ? formatPrice(product.price, { avoidCents: true }) : null}
+              Get Certificate{" "}
+              {product
+                ? formatPrice(product.price, { avoidCents: true })
+                : null}
             </strong>
           </Stack>
         </CertificatePriceRoot>

--- a/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.tsx
@@ -68,7 +68,7 @@ const ProgramCertificateUpsell: React.FC<{
           <RiAwardFill />
           <Stack gap="4px">
             <strong>
-              Get Certificate {product ? formatPrice(product.price) : null}
+              Get Certificate {product ? formatPrice(product.price, { avoidCents: true }) : null}
             </strong>
           </Stack>
         </CertificatePriceRoot>


### PR DESCRIPTION
### What are the relevant tickets?
Fixes 
-  https://github.com/mitodl/hq/issues/10998


### Description (What does it do?)
<!--- Describe your changes in detail -->
Hides unnecessary .00 on whole-dollar prices throughout the MITxOnline enrollment UI. Prices like $99.00 now display as $99, while prices with non-zero cents (e.g. $99.50) are unaffected.

Applied to all MITxOnline price display locations: the product summary page (course and program price rows, certificate upsell boxes), the course and program enrollment dialogs, and the resource card.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
Note on missing screenshots: Two UI locations couldn't be captured locally due to missing product data:

-  "Get Certificate $X" upsell (price only renders when a program has an associated product) in 
-  "Earn a certificate: $X" on a program page with free + paid enrollment options

<img width="756" height="629" alt="Screenshot 2026-04-23 at 11 40 05 AM" src="https://github.com/user-attachments/assets/7453f05c-afcc-4ad1-ad2f-4107540fb24e" />
<img width="461" height="440" alt="Screenshot 2026-04-23 at 11 46 43 AM" src="https://github.com/user-attachments/assets/505b8de5-c931-43ff-b080-852ebdb72349" />
<img width="440" height="403" alt="Screenshot 2026-04-23 at 11 39 56 AM" src="https://github.com/user-attachments/assets/9d12342a-095d-4384-a554-252f8da7f99a" />
<img width="462" height="301" alt="Screenshot 2026-04-23 at 12 24 13 PM" src="https://github.com/user-attachments/assets/66d751e4-7ed1-46ef-8142-ac7997b87640" />


- [x] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Navigate to a MITxOnline course or program with a whole-dollar price. Verify that prices display without .00 (e.g. $99 not $99.00) in:

- 
- The product summary page (price row and certificate upsell)
- The enrollment dialog (certificate upsell)
- The resource card
- Verify that prices with non-zero cents still display the full decimal.



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
