### PR TITLE
feat: added module section on course product page

### DIFF
--- a/frontends/api/src/mitxonline/hooks/courses/index.ts
+++ b/frontends/api/src/mitxonline/hooks/courses/index.ts
@@ -1,3 +1,13 @@
 import { coursesQueries } from "./queries"
+import type {
+  CourseOutlineModule,
+  CourseOutlineModuleCounts,
+  CourseOutlineResponse,
+} from "./queries"
 
 export { coursesQueries }
+export type {
+  CourseOutlineModule,
+  CourseOutlineModuleCounts,
+  CourseOutlineResponse,
+}

--- a/frontends/api/src/mitxonline/hooks/courses/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/courses/queries.ts
@@ -1,9 +1,14 @@
 import { queryOptions } from "@tanstack/react-query"
 import type {
+  CourseOutlineResponse as GeneratedCourseOutlineResponse,
   CoursesApiApiV2CoursesListRequest,
   PaginatedCourseWithCourseRunsSerializerV2List,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { coursesApi } from "../../clients"
+
+type CourseOutlineResponse = GeneratedCourseOutlineResponse
+type CourseOutlineModule = NonNullable<CourseOutlineResponse["modules"]>[number]
+type CourseOutlineModuleCounts = NonNullable<CourseOutlineModule["counts"]>
 
 const coursesKeys = {
   root: ["mitxonline", "courses"],
@@ -11,6 +16,11 @@ const coursesKeys = {
     ...coursesKeys.root,
     "list",
     opts,
+  ],
+  courseOutline: (coursewareId: string) => [
+    ...coursesKeys.root,
+    "outline",
+    coursewareId,
   ],
 }
 
@@ -23,6 +33,20 @@ const coursesQueries = {
           return coursesApi.apiV2CoursesList(opts).then((res) => res.data)
         },
     }),
+  courseOutline: (coursewareId: string) =>
+    queryOptions({
+      queryKey: coursesKeys.courseOutline(coursewareId),
+      queryFn: async (): Promise<CourseOutlineResponse> => {
+        return coursesApi
+          .courseOutlineRetrieveV3({ course_id: coursewareId })
+          .then((res) => res.data)
+      },
+    }),
 }
 
 export { coursesQueries, coursesKeys }
+export type {
+  CourseOutlineResponse,
+  CourseOutlineModule,
+  CourseOutlineModuleCounts,
+}

--- a/frontends/api/src/mitxonline/hooks/courses/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/courses/queries.ts
@@ -7,8 +7,8 @@ import type {
 import { coursesApi } from "../../clients"
 
 type CourseOutlineResponse = GeneratedCourseOutlineResponse
-type CourseOutlineModule = NonNullable<CourseOutlineResponse["modules"]>[number]
-type CourseOutlineModuleCounts = NonNullable<CourseOutlineModule["counts"]>
+type CourseOutlineModule = CourseOutlineResponse["modules"][number]
+type CourseOutlineModuleCounts = CourseOutlineModule["counts"]
 
 const coursesKeys = {
   root: ["mitxonline", "courses"],

--- a/frontends/api/src/mitxonline/test-utils/factories/orders.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/orders.ts
@@ -7,13 +7,13 @@ const transactionLine = (
   quantity: 1,
   CEUs: "0.0",
   content_title: faker.company.catchPhrase(),
+  content_type: "",
   readable_id: `course-v1:MITxT+${faker.string.alphanumeric(6)}`,
   start_date: faker.date.past().toISOString(),
   end_date: faker.date.future().toISOString(),
   total_paid: faker.commerce.price({ min: 50, max: 500 }),
   discount: "0.00",
   price: faker.commerce.price({ min: 50, max: 500 }),
-  content_type: "",
   ...overrides,
 })
 

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -51,6 +51,8 @@ const programCollections = {
 const courses = {
   coursesList: (opts?: CoursesApiApiV2CoursesListRequest) =>
     `${API_BASE_URL}/api/v2/courses/${queryify(opts, { explode: false })}`,
+  courseOutline: (coursewareId: string) =>
+    `${API_BASE_URL}/api/v3/courses/${encodeURIComponent(coursewareId)}/ol_openedx_outline/`,
 }
 
 const pages = {

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
@@ -26,6 +26,7 @@ describe("CourseOutlineSection", () => {
       makeModule({ id: "m2", title: "Under one hour", effort_time: 3599 }),
       makeModule({ id: "m3", title: "Exactly one hour", effort_time: 3600 }),
       makeModule({ id: "m4", title: "Plural hours", effort_time: 7200 }),
+      makeModule({ id: "m5", title: "Rounded hours", effort_time: 9540 }),
     ]
 
     renderWithProviders(<CourseOutlineSection modules={modules} />)
@@ -35,13 +36,16 @@ describe("CourseOutlineSection", () => {
     })
 
     expect(
-      within(section).queryByText("0 Videos . 0 Readings . 0 Assignments"),
+      within(section).queryByText(
+        /0 Videos\s*•\s*0 Readings\s*•\s*0 Assignments/,
+      ),
     ).not.toBeInTheDocument()
     expect(
       within(section).getByText("Less than 1 hour to complete"),
     ).toBeInTheDocument()
     expect(within(section).getByText("1 hour to complete")).toBeInTheDocument()
     expect(within(section).getByText("2 hours to complete")).toBeInTheDocument()
+    expect(within(section).getByText("3 hours to complete")).toBeInTheDocument()
   })
 
   test("shows counts inline without requiring expansion", async () => {
@@ -74,10 +78,12 @@ describe("CourseOutlineSection", () => {
       name: "Course content",
     })
     expect(
-      within(section).getByText("1 Video . 2 Readings . 3 Assignments"),
+      within(section).getByText(/1 Video\s*•\s*2 Readings\s*•\s*3 Assignments/),
     ).toBeInTheDocument()
     expect(
-      within(section).getByText("4 Videos . 5 Readings . 6 Assignments"),
+      within(section).getByText(
+        /4 Videos\s*•\s*5 Readings\s*•\s*6 Assignments/,
+      ),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole("button", { name: /Intro/i }),

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
@@ -35,9 +35,6 @@ describe("CourseOutlineSection", () => {
     })
 
     expect(
-      within(section).getByText("There are 4 lectures in this course"),
-    ).toBeInTheDocument()
-    expect(
       within(section).getByText("0 Videos . 0 Readings . 0 Assignments"),
     ).toBeInTheDocument()
     expect(

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import { renderWithProviders, screen, within } from "@/test-utils"
+import type { CourseOutlineModule } from "api/mitxonline-hooks/courses"
+import CourseOutlineSection from "./CourseOutlineSection"
+
+const makeModule = (
+  module: Partial<CourseOutlineModule> &
+    Pick<CourseOutlineModule, "id" | "title">,
+): CourseOutlineModule => ({
+  effort_time: 0,
+  effort_activities: 0,
+  counts: {
+    videos: 0,
+    readings: 0,
+    problems: 0,
+    assignments: 0,
+    app_items: 0,
+  },
+  ...module,
+})
+
+describe("CourseOutlineSection", () => {
+  test("renders static course content cards with metadata line", async () => {
+    const modules: CourseOutlineModule[] = [
+      makeModule({ id: "m1", title: "No effort" }),
+      makeModule({ id: "m2", title: "Under one hour", effort_time: 3599 }),
+      makeModule({ id: "m3", title: "Exactly one hour", effort_time: 3600 }),
+      makeModule({ id: "m4", title: "Plural hours", effort_time: 7200 }),
+    ]
+
+    renderWithProviders(<CourseOutlineSection modules={modules} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+
+    expect(
+      within(section).getByText("There are 4 lectures in this course"),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText("0 Videos . 0 Readings . 0 Assignments"),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText(
+        "Less than 1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText(
+        "1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText(
+        "2 hours to complete . 0 Videos . 0 Readings . 0 Assignments",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test("shows counts inline without requiring expansion", async () => {
+    const modules: CourseOutlineModule[] = [
+      {
+        ...makeModule({ id: "m1", title: "Intro" }),
+        counts: {
+          videos: 1,
+          readings: 2,
+          problems: 0,
+          assignments: 3,
+          app_items: 0,
+        },
+      },
+      {
+        ...makeModule({ id: "m2", title: "Deep dive" }),
+        counts: {
+          videos: 4,
+          readings: 5,
+          problems: 0,
+          assignments: 6,
+          app_items: 0,
+        },
+      },
+    ]
+
+    renderWithProviders(<CourseOutlineSection modules={modules} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+    expect(
+      within(section).getByText("1 Video . 2 Readings . 3 Assignments"),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText("4 Videos . 5 Readings . 6 Assignments"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /Intro/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("falls back to Module N title when title is missing", async () => {
+    const modules: CourseOutlineModule[] = [
+      makeModule({ id: "m1", title: "   " }),
+      makeModule({ id: "m2", title: "" }),
+    ]
+
+    renderWithProviders(<CourseOutlineSection modules={modules} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+    expect(within(section).getByText("Module 1")).toBeInTheDocument()
+    expect(within(section).getByText("Module 2")).toBeInTheDocument()
+  })
+
+  test("defaults included counts to zero when module counts are missing", async () => {
+    const modules: CourseOutlineModule[] = [
+      makeModule({ id: "m1", title: "Intro" }),
+    ]
+
+    renderWithProviders(<CourseOutlineSection modules={modules} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+
+    expect(
+      within(section).getByText("0 Videos . 0 Readings . 0 Assignments"),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.test.tsx
@@ -35,23 +35,13 @@ describe("CourseOutlineSection", () => {
     })
 
     expect(
-      within(section).getByText("0 Videos . 0 Readings . 0 Assignments"),
-    ).toBeInTheDocument()
+      within(section).queryByText("0 Videos . 0 Readings . 0 Assignments"),
+    ).not.toBeInTheDocument()
     expect(
-      within(section).getByText(
-        "Less than 1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
-      ),
+      within(section).getByText("Less than 1 hour to complete"),
     ).toBeInTheDocument()
-    expect(
-      within(section).getByText(
-        "1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
-      ),
-    ).toBeInTheDocument()
-    expect(
-      within(section).getByText(
-        "2 hours to complete . 0 Videos . 0 Readings . 0 Assignments",
-      ),
-    ).toBeInTheDocument()
+    expect(within(section).getByText("1 hour to complete")).toBeInTheDocument()
+    expect(within(section).getByText("2 hours to complete")).toBeInTheDocument()
   })
 
   test("shows counts inline without requiring expansion", async () => {
@@ -109,7 +99,7 @@ describe("CourseOutlineSection", () => {
     expect(within(section).getByText("Module 2")).toBeInTheDocument()
   })
 
-  test("defaults included counts to zero when module counts are missing", async () => {
+  test("omits zero-value counts when module counts are missing", async () => {
     const modules: CourseOutlineModule[] = [
       makeModule({ id: "m1", title: "Intro" }),
     ]
@@ -121,7 +111,7 @@ describe("CourseOutlineSection", () => {
     })
 
     expect(
-      within(section).getByText("0 Videos . 0 Readings . 0 Assignments"),
-    ).toBeInTheDocument()
+      within(section).queryByText(/0 (Videos|Readings|Assignments)/),
+    ).toBeNull()
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
@@ -1,0 +1,145 @@
+"use client"
+
+import React from "react"
+import { Typography } from "ol-components"
+import { styled } from "@mitodl/smoot-design"
+import type { CourseOutlineModule } from "api/mitxonline-hooks/courses"
+import { HeadingIds } from "./util"
+
+const SectionRoot = styled.section({
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+})
+
+const SummaryText = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.black,
+}))
+
+const ModuleStack = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: "12px",
+})
+
+const ModuleShell = styled.article(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  padding: "24px",
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  backgroundColor: theme.custom.colors.lightGray1,
+}))
+
+const TitleBlock = styled.div({
+  width: "100%",
+  minHeight: "24px",
+})
+
+const ModuleTitle = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  fontSize: "16px",
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: 1.5,
+  color: theme.custom.colors.darkGray2,
+}))
+
+const ModuleSubtitle = styled.span(({ theme }) => ({
+  ...theme.typography.body3,
+  fontSize: "12px",
+  lineHeight: "16px",
+  color: theme.custom.colors.silverGrayDark,
+  display: "inline-flex",
+  flexWrap: "wrap",
+  rowGap: "4px",
+}))
+
+const getModuleTitle = (module: CourseOutlineModule, index: number): string => {
+  if (module.title && module.title.trim().length > 0) {
+    return module.title
+  }
+  return `Module ${index + 1}`
+}
+
+const formatHours = (seconds: number): string => {
+  const hours = seconds / 3600
+  // Keep one decimal for short modules, but avoid trailing ".0".
+  const rounded = hours < 10 ? Math.round(hours * 10) / 10 : Math.round(hours)
+  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1)
+}
+
+const formatEffort = (seconds?: number | null): string | null => {
+  if (seconds === undefined || seconds === null || seconds <= 0) {
+    return null
+  }
+  if (seconds < 3600) {
+    return "Less than 1 hour to complete"
+  }
+  const hourLabel = formatHours(seconds)
+  const isSingular = Number(hourLabel) === 1
+  return `${hourLabel} ${isSingular ? "hour" : "hours"} to complete`
+}
+
+const formatCount = (
+  count: number,
+  singularLabel: string,
+  pluralLabel: string,
+): string => `${count} ${count === 1 ? singularLabel : pluralLabel}`
+
+const getMetaLine = (module: CourseOutlineModule): string => {
+  const counts = module.counts ?? {}
+  const videos = counts.videos ?? 0
+  const readings = counts.readings ?? 0
+  const assignments = counts.assignments ?? 0
+
+  const metaParts = [
+    formatCount(videos, "Video", "Videos"),
+    formatCount(readings, "Reading", "Readings"),
+    formatCount(assignments, "Assignment", "Assignments"),
+  ]
+  const effort = formatEffort(module.effort_time)
+  if (effort) {
+    metaParts.unshift(effort)
+  }
+  return metaParts.join(" . ")
+}
+
+const CourseOutlineSection: React.FC<{
+  modules: CourseOutlineModule[]
+}> = ({ modules }) => {
+  if (modules.length === 0) {
+    return null
+  }
+
+  const countLabel =
+    modules.length === 1
+      ? "There is 1 lecture in this course"
+      : `There are ${modules.length} lectures in this course`
+
+  return (
+    <SectionRoot aria-labelledby={HeadingIds.CourseContent}>
+      <Typography variant="h4" component="h2" id={HeadingIds.CourseContent}>
+        Course content
+      </Typography>
+      <SummaryText variant="body1">{countLabel}</SummaryText>
+      <ModuleStack>
+        {modules.map((module, index) => {
+          const title = getModuleTitle(module, index)
+          const subtitle = getMetaLine(module)
+
+          return (
+            <ModuleShell key={module.id ?? `${title}-${index}`}>
+              <TitleBlock>
+                <ModuleTitle>{title}</ModuleTitle>
+              </TitleBlock>
+              <ModuleSubtitle>{subtitle}</ModuleSubtitle>
+            </ModuleShell>
+          )
+        })}
+      </ModuleStack>
+    </SectionRoot>
+  )
+}
+
+export default CourseOutlineSection

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
@@ -90,10 +90,12 @@ const getMetaLine = (module: CourseOutlineModule): string => {
   const assignments = counts.assignments ?? 0
 
   const metaParts = [
-    formatCount(videos, "Video", "Videos"),
-    formatCount(readings, "Reading", "Readings"),
-    formatCount(assignments, "Assignment", "Assignments"),
-  ]
+    videos > 0 ? formatCount(videos, "Video", "Videos") : null,
+    readings > 0 ? formatCount(readings, "Reading", "Readings") : null,
+    assignments > 0
+      ? formatCount(assignments, "Assignment", "Assignments")
+      : null,
+  ].filter((part): part is string => Boolean(part))
   const effort = formatEffort(module.effort_time)
   if (effort) {
     metaParts.unshift(effort)

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
@@ -12,10 +12,6 @@ const SectionRoot = styled.section({
   gap: "16px",
 })
 
-const SummaryText = styled(Typography)(({ theme }) => ({
-  color: theme.custom.colors.black,
-}))
-
 const ModuleStack = styled.div({
   display: "flex",
   flexDirection: "column",
@@ -112,17 +108,11 @@ const CourseOutlineSection: React.FC<{
     return null
   }
 
-  const countLabel =
-    modules.length === 1
-      ? "There is 1 lecture in this course"
-      : `There are ${modules.length} lectures in this course`
-
   return (
     <SectionRoot aria-labelledby={HeadingIds.CourseContent}>
       <Typography variant="h4" component="h2" id={HeadingIds.CourseContent}>
         Course content
       </Typography>
-      <SummaryText variant="body1">{countLabel}</SummaryText>
       <ModuleStack>
         {modules.map((module, index) => {
           const title = getModuleTitle(module, index)

--- a/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseOutlineSection.tsx
@@ -60,9 +60,7 @@ const getModuleTitle = (module: CourseOutlineModule, index: number): string => {
 
 const formatHours = (seconds: number): string => {
   const hours = seconds / 3600
-  // Keep one decimal for short modules, but avoid trailing ".0".
-  const rounded = hours < 10 ? Math.round(hours * 10) / 10 : Math.round(hours)
-  return Number.isInteger(rounded) ? `${rounded}` : rounded.toFixed(1)
+  return `${Math.round(hours)}`
 }
 
 const formatEffort = (seconds?: number | null): string | null => {
@@ -90,17 +88,16 @@ const getMetaLine = (module: CourseOutlineModule): string => {
   const assignments = counts.assignments ?? 0
 
   const metaParts = [
+    formatEffort(module.effort_time),
     videos > 0 ? formatCount(videos, "Video", "Videos") : null,
     readings > 0 ? formatCount(readings, "Reading", "Readings") : null,
     assignments > 0
       ? formatCount(assignments, "Assignment", "Assignments")
       : null,
   ].filter((part): part is string => Boolean(part))
-  const effort = formatEffort(module.effort_time)
-  if (effort) {
-    metaParts.unshift(effort)
-  }
-  return metaParts.join(" . ")
+
+  // Use en-spaces around bullets for slightly wider visual separation.
+  return metaParts.join("\u2002•\u2002")
 }
 
 const CourseOutlineSection: React.FC<{

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -236,7 +236,7 @@ describe("CoursePage", () => {
     })
     expect(
       within(section).getByText(
-        "Less than 1 hour to complete . 30 Videos . 2 Readings . 1 Assignment",
+        /Less than 1 hour to complete\s*•\s*30 Videos\s*•\s*2 Readings\s*•\s*1 Assignment/,
       ),
     ).toBeInTheDocument()
     const coreConceptsCard = within(section)

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -18,6 +18,7 @@ import { useStayUpdatedEnv } from "./test-utils/stayUpdated"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import invariant from "tiny-invariant"
+import { getOutlineCoursewareId } from "./util"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
@@ -48,6 +49,41 @@ const setupApis = ({
   setMockResponse.get(urls.pages.coursePages(course.readable_id), {
     items: [page],
   })
+  const outlineCoursewareId = getOutlineCoursewareId(course)
+  if (outlineCoursewareId) {
+    setMockResponse.get(urls.courses.courseOutline(outlineCoursewareId), {
+      course_id: course.readable_id,
+      generated_at: new Date().toISOString(),
+      modules: [
+        {
+          id: "m1",
+          title: "Introduction",
+          effort_time: 540,
+          effort_activities: 0,
+          counts: {
+            videos: 30,
+            readings: 2,
+            problems: 0,
+            assignments: 1,
+            app_items: 0,
+          },
+        },
+        {
+          id: "m2",
+          title: "Core concepts",
+          effort_time: 60,
+          effort_activities: 0,
+          counts: {
+            videos: 0,
+            readings: 0,
+            problems: 0,
+            assignments: 0,
+            app_items: 0,
+          },
+        },
+      ],
+    })
+  }
 
   setMockResponse.get(
     learnUrls.userMe.get(),
@@ -112,6 +148,7 @@ describe("CoursePage", () => {
         { level: 2, name: "Course Information" },
         { level: 2, name: "About this Course" },
         { level: 2, name: "What you'll learn" },
+        { level: 2, name: "Course content" },
         { level: 2, name: "How you'll learn" },
         { level: 2, name: "Prerequisites" },
         { level: 2, name: "Meet your instructors" },
@@ -173,6 +210,46 @@ describe("CoursePage", () => {
 
     const section = await screen.findByRole("region", { name: "Prerequisites" })
     expectRawContent(section, page.prerequisites)
+  })
+
+  test("Course content section renders lecture titles and summary", async () => {
+    const course = makeCourse()
+    const page = makePage({ course_details: course })
+    setupApis({ course, page })
+    renderWithProviders(<CoursePage readableId={course.readable_id} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+    expect(
+      within(section).getByText("There are 2 lectures in this course"),
+    ).toBeInTheDocument()
+    expect(within(section).getByText("Introduction")).toBeInTheDocument()
+    expect(within(section).getByText("Core concepts")).toBeInTheDocument()
+  })
+
+  test("Course content section shows metadata inline", async () => {
+    const course = makeCourse()
+    const page = makePage({ course_details: course })
+    setupApis({ course, page })
+    renderWithProviders(<CoursePage readableId={course.readable_id} />)
+
+    const section = await screen.findByRole("region", {
+      name: "Course content",
+    })
+    expect(
+      within(section).getByText(
+        "Less than 1 hour to complete . 30 Videos . 2 Readings . 1 Assignment",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(section).getByText(
+        "Less than 1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      within(section).queryByRole("button", { name: /Introduction/i }),
+    ).not.toBeInTheDocument()
   })
 
   test("Renders program bundle upsell when course belongs to a program (content tested in ProgramBundleUpsell.test)", async () => {
@@ -259,6 +336,16 @@ describe("CoursePage", () => {
       urls.courses.coursesList({ readable_id: "readable_id" }),
       { results: courses },
     )
+    if (courses.length > 0) {
+      const outlineCoursewareId = getOutlineCoursewareId(courses[0])
+      if (outlineCoursewareId) {
+        setMockResponse.get(urls.courses.courseOutline(outlineCoursewareId), {
+          course_id: courses[0].readable_id,
+          generated_at: new Date().toISOString(),
+          modules: [],
+        })
+      }
+    }
     setMockResponse.get(urls.pages.coursePages("readable_id"), {
       items: pages,
     })

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -240,8 +240,10 @@ describe("CoursePage", () => {
       ),
     ).toBeInTheDocument()
     expect(
-      within(section).getByText(
-        "Less than 1 hour to complete . 0 Videos . 0 Readings . 0 Assignments",
+      within(section).getByText((content) =>
+        /^(Less than 1 hour to complete \. )?0 Videos \. 0 Readings \. 0 Assignments$/.test(
+          content,
+        ),
       ),
     ).toBeInTheDocument()
     expect(

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -212,7 +212,7 @@ describe("CoursePage", () => {
     expectRawContent(section, page.prerequisites)
   })
 
-  test("Course content section renders lecture titles and summary", async () => {
+  test("Course content section renders lecture titles", async () => {
     const course = makeCourse()
     const page = makePage({ course_details: course })
     setupApis({ course, page })
@@ -221,9 +221,6 @@ describe("CoursePage", () => {
     const section = await screen.findByRole("region", {
       name: "Course content",
     })
-    expect(
-      within(section).getByText("There are 2 lectures in this course"),
-    ).toBeInTheDocument()
     expect(within(section).getByText("Introduction")).toBeInTheDocument()
     expect(within(section).getByText("Core concepts")).toBeInTheDocument()
   })

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -239,11 +239,13 @@ describe("CoursePage", () => {
         "Less than 1 hour to complete . 30 Videos . 2 Readings . 1 Assignment",
       ),
     ).toBeInTheDocument()
+    const coreConceptsCard = within(section)
+      .getByText("Core concepts")
+      .closest("article")
+    expect(coreConceptsCard).toBeInTheDocument()
     expect(
-      within(section).getByText((content) =>
-        /^(Less than 1 hour to complete \. )?0 Videos \. 0 Readings \. 0 Assignments$/.test(
-          content,
-        ),
+      within(coreConceptsCard as HTMLElement).getByText(
+        "Less than 1 hour to complete",
       ),
     ).toBeInTheDocument()
     expect(

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -19,6 +19,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import invariant from "tiny-invariant"
 import { getOutlineCoursewareId } from "./util"
+import { FeatureFlags } from "@/common/feature_flags"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
@@ -223,6 +224,23 @@ describe("CoursePage", () => {
     })
     expect(within(section).getByText("Introduction")).toBeInTheDocument()
     expect(within(section).getByText("Core concepts")).toBeInTheDocument()
+  })
+
+  test("Hides course content section when course outline flag is disabled", async () => {
+    mockedUseFeatureFlagEnabled.mockImplementation(
+      (flag) => flag !== FeatureFlags.CourseOutlineSection,
+    )
+    const course = makeCourse()
+    const page = makePage({ course_details: course })
+    setupApis({ course, page })
+    renderWithProviders(<CoursePage readableId={course.readable_id} />)
+
+    await screen.findByRole("heading", { name: page.title })
+    expect(
+      screen.queryByRole("region", {
+        name: "Course content",
+      }),
+    ).not.toBeInTheDocument()
   })
 
   test("Course content section shows metadata inline", async () => {

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -55,6 +55,9 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
     enabled: Boolean(effectiveOutlineCoursewareId),
   })
   const enabled = useFeatureFlagEnabled(FeatureFlags.MitxOnlineProductPages)
+  const showCourseOutline = useFeatureFlagEnabled(
+    FeatureFlags.CourseOutlineSection,
+  )
   const flagsLoaded = useFeatureFlagsLoaded()
 
   if (!enabled) {
@@ -106,7 +109,9 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
       {page.what_you_learn ? (
         <WhatYoullLearnSection html={page.what_you_learn} />
       ) : null}
-      <CourseOutlineSection modules={outline.data?.modules ?? []} />
+      {showCourseOutline ? (
+        <CourseOutlineSection modules={outline.data?.modules ?? []} />
+      ) : null}
       <HowYoullLearnSection page={page} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -26,7 +26,6 @@ import CourseOutlineSection from "./CourseOutlineSection"
 
 type CoursePageProps = {
   readableId: string
-  outlineCoursewareId?: string
 }
 
 const StyledCourseEnrollmentButton = styled(CourseEnrollmentButton)(
@@ -41,10 +40,7 @@ const PrerequisitesSection = styled.section({
   gap: "16px",
 })
 
-const CoursePage: React.FC<CoursePageProps> = ({
-  readableId,
-  outlineCoursewareId,
-}) => {
+const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
   const pages = useQuery(pagesQueries.coursePages(readableId))
   const courses = useQuery(
     coursesQueries.coursesList({ readable_id: readableId }),
@@ -52,7 +48,7 @@ const CoursePage: React.FC<CoursePageProps> = ({
   const page = pages.data?.items[0]
   const course = courses.data?.results?.[0]
   const effectiveOutlineCoursewareId = course
-    ? (outlineCoursewareId ?? getOutlineCoursewareId(course))
+    ? getOutlineCoursewareId(course)
     : undefined
   const outline = useQuery({
     ...coursesQueries.courseOutline(effectiveOutlineCoursewareId ?? ""),

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -10,7 +10,7 @@ import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 import { notFound } from "next/navigation"
-import { HeadingIds } from "./util"
+import { getOutlineCoursewareId, HeadingIds } from "./util"
 import InstructorsSection from "./InstructorsSection"
 import RawHTML from "./RawHTML"
 import AboutSection from "./AboutSection"
@@ -22,9 +22,11 @@ import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import CourseInfoBox from "./InfoBoxCourse"
 import CourseEnrollmentButton from "./CourseEnrollmentButton"
+import CourseOutlineSection from "./CourseOutlineSection"
 
 type CoursePageProps = {
   readableId: string
+  outlineCoursewareId?: string
 }
 
 const StyledCourseEnrollmentButton = styled(CourseEnrollmentButton)(
@@ -39,13 +41,23 @@ const PrerequisitesSection = styled.section({
   gap: "16px",
 })
 
-const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
+const CoursePage: React.FC<CoursePageProps> = ({
+  readableId,
+  outlineCoursewareId,
+}) => {
   const pages = useQuery(pagesQueries.coursePages(readableId))
   const courses = useQuery(
     coursesQueries.coursesList({ readable_id: readableId }),
   )
   const page = pages.data?.items[0]
   const course = courses.data?.results?.[0]
+  const effectiveOutlineCoursewareId = course
+    ? (outlineCoursewareId ?? getOutlineCoursewareId(course))
+    : undefined
+  const outline = useQuery({
+    ...coursesQueries.courseOutline(effectiveOutlineCoursewareId ?? ""),
+    enabled: Boolean(effectiveOutlineCoursewareId),
+  })
   const enabled = useFeatureFlagEnabled(FeatureFlags.MitxOnlineProductPages)
   const flagsLoaded = useFeatureFlagsLoaded()
 
@@ -98,6 +110,7 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
       {page.what_you_learn ? (
         <WhatYoullLearnSection html={page.what_you_learn} />
       ) : null}
+      <CourseOutlineSection modules={outline.data?.modules ?? []} />
       <HowYoullLearnSection page={page} />
       {page.prerequisites ? (
         <PrerequisitesSection aria-labelledby={HeadingIds.Prereqs}>

--- a/frontends/main/src/app-pages/ProductPages/util.test.ts
+++ b/frontends/main/src/app-pages/ProductPages/util.test.ts
@@ -1,5 +1,5 @@
-import { parseReqTree } from "./util"
-import { RequirementTreeBuilder } from "api/mitxonline-test-utils"
+import { parseReqTree, getOutlineCoursewareId } from "./util"
+import { RequirementTreeBuilder, factories } from "api/mitxonline-test-utils"
 
 describe("parseReqTree", () => {
   test("parses courses as requirement items", () => {
@@ -56,5 +56,50 @@ describe("parseReqTree", () => {
     const result = parseReqTree(tree.serialize())
     expect(result[0].requiredCount).toBe(2)
     expect(result[0].items).toHaveLength(3)
+  })
+})
+
+describe("getOutlineCoursewareId", () => {
+  test("uses next_run_id courseware_id when available", () => {
+    const run1 = factories.courses.courseRun({
+      id: 10,
+      courseware_id: "course-v1:Org+A+Run1",
+    })
+    const run2 = factories.courses.courseRun({
+      id: 20,
+      courseware_id: "course-v1:Org+A+Run2",
+    })
+    const course = factories.courses.course({
+      readable_id: "course-v1:Org+A",
+      next_run_id: 20,
+      courseruns: [run1, run2],
+    })
+
+    expect(getOutlineCoursewareId(course)).toBe("course-v1:Org+A+Run2")
+  })
+
+  test("falls back to first run courseware_id", () => {
+    const course = factories.courses.course({
+      readable_id: "course-v1:Org+A",
+      next_run_id: null,
+      courseruns: [
+        factories.courses.courseRun({
+          id: 1,
+          courseware_id: "course-v1:Org+A+Run1",
+        }),
+      ],
+    })
+
+    expect(getOutlineCoursewareId(course)).toBe("course-v1:Org+A+Run1")
+  })
+
+  test("returns undefined when no run courseware_id exists", () => {
+    const course = factories.courses.course({
+      readable_id: "course-v1:Org+A",
+      next_run_id: null,
+      courseruns: [factories.courses.courseRun({ id: 1, courseware_id: "" })],
+    })
+
+    expect(getOutlineCoursewareId(course)).toBeUndefined()
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/util.ts
+++ b/frontends/main/src/app-pages/ProductPages/util.ts
@@ -1,9 +1,13 @@
-import type { V2Program } from "@mitodl/mitxonline-api-axios/v2"
-import { NodeTypeEnum } from "@mitodl/mitxonline-api-axios/v2"
+import {
+  NodeTypeEnum,
+  type CourseWithCourseRunsSerializerV2,
+  type V2Program,
+} from "@mitodl/mitxonline-api-axios/v2"
 
 enum HeadingIds {
   About = "about",
   What = "what-you-will-learn",
+  CourseContent = "course-content",
   How = "how-you-will-learn",
   Prereqs = "prerequisites",
   Instructors = "instructors",
@@ -70,7 +74,25 @@ const parseReqTree = (reqTree: V2Program["req_tree"]): RequirementData[] => {
     })
 }
 
+const getOutlineCoursewareId = (
+  course: CourseWithCourseRunsSerializerV2,
+): string | undefined => {
+  const runs = course.courseruns ?? []
+  const nextRun = runs.find((run) => run.id === course.next_run_id)
+  if (nextRun?.courseware_id) {
+    return nextRun.courseware_id
+  }
+
+  const firstRunWithCoursewareId = runs.find((run) =>
+    Boolean(run.courseware_id),
+  )
+  if (firstRunWithCoursewareId?.courseware_id) {
+    return firstRunWithCoursewareId.courseware_id
+  }
+  return undefined
+}
+
 type ProductNoun = "Course" | "Program"
 
-export { HeadingIds, parseReqTree }
+export { HeadingIds, parseReqTree, getOutlineCoursewareId }
 export type { ProductNoun, RequirementData, RequirementItem }

--- a/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
@@ -69,10 +69,7 @@ const Page: React.FC<PageProps<"/courses/[readable_id]">> = async (props) => {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <CoursePage
-        readableId={readableId}
-        outlineCoursewareId={outlineCoursewareId}
-      />
+      <CoursePage readableId={readableId} />
     </HydrationBoundary>
   )
 }

--- a/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
@@ -7,6 +7,7 @@ import { pagesQueries } from "api/mitxonline-hooks/pages"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { getQueryClient } from "@/app/getQueryClient"
+import { getOutlineCoursewareId } from "@/app-pages/ProductPages/util"
 
 export const generateMetadata = async (
   props: PageProps<"/courses/[readable_id]">,
@@ -57,9 +58,21 @@ const Page: React.FC<PageProps<"/courses/[readable_id]">> = async (props) => {
     notFound()
   }
 
+  const [course] = courses.results
+  const outlineCoursewareId = getOutlineCoursewareId(course)
+
+  if (outlineCoursewareId) {
+    await queryClient.prefetchQuery(
+      coursesQueries.courseOutline(outlineCoursewareId),
+    )
+  }
+
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <CoursePage readableId={readableId} />
+      <CoursePage
+        readableId={readableId}
+        outlineCoursewareId={outlineCoursewareId}
+      />
     </HydrationBoundary>
   )
 }

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -12,6 +12,7 @@ export enum FeatureFlags {
   UniversalAISearchBanner = "universal-ai-search-banner",
   VideoShorts = "video-shorts",
   MitxOnlineProductPages = "mitxonline-product-pages",
+  CourseOutlineSection = "course-outline-section",
   VideoPlaylistPage = "video-playlist-page",
   PodcastDetailPage = "podcast-detail-page",
 }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10908

### Description (What does it do?)
Added Course Modules on MIT Learn course product pages by integrating the MITx Online/Open edX outline flow end-to-end.

Fixed some additional things(failing test cases) as in this PR, I bumped @mitodl/mitxonline-api-axios to a newer version, which has stricter types (content_type required, how_youll_learn required/typed array). 

### Screenshots (if appropriate):
<img width="1414" height="965" alt="Screenshot 2026-05-05 at 5 10 41 PM" src="https://github.com/user-attachments/assets/8b3f7769-1a62-4459-8791-54809c6f924e" />

<img width="1233" height="908" alt="Screenshot 2026-05-05 at 5 10 35 PM" src="https://github.com/user-attachments/assets/a7d39fe3-d925-4310-b1bd-090eec0544e2" />

<img width="1547" height="971" alt="Screenshot 2026-05-05 at 5 10 21 PM" src="https://github.com/user-attachments/assets/7c6b34cf-0da4-46c5-8b06-8ec220555df2" />


## Test Setup

Choose one backend mode:

- **Local MITx Online**: run MITx Online locally and point MIT Learn to that local API.
- **RC MITx Online**: configure MIT Learn to use the MITx Online RC backend.

If selected Local, use any of your local system course URLs in MIT Learn.

If selected RC, use either of these course URLs in MIT Learn:

- `http://open.odl.local:8062/courses/course-v1:MITxT+14.740x`
- `http://open.odl.local:8062/courses/course-v1:UGross+BrianCourse`

## Functional Verification

1. Open a course page with outline data, for example:  
   `http://open.odl.local:8062/courses/course-v1:MITxT+STL.162x`
2. Confirm the **Modules** section is visible when outline data exists.
3. Expand one or more module cards.
4. Verify module items include only:
   - videos
   - readings
   - assignments
5. Verify **app** items are **not** shown in expanded module cards.

## Compare With Design

- Cross-check the rendered module/card behavior against the mockups in this comment:  
  [Issue comment with mockups](https://github.com/mitodl/hq/issues/10460#issuecomment-4237793341)

## Optional Regression Checks

- Test at least one course with no outline data and confirm Modules section behavior is still correct (hidden/empty state as expected).
- Refresh the page and re-expand modules to ensure filtering is stable across re-renders. 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
