### PR TITLE
Add authentication to load tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,5 @@ backups/
 /playwright/.cache/
 
 .claude
+
+load_testing/data/

--- a/load_testing/README.md
+++ b/load_testing/README.md
@@ -3,7 +3,7 @@
 ### Usage (Docker)
 
 ```shell
-./scripts/k6.sh -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
+./scripts/k6.sh /app/learn.smoke.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
 ```
 
 ### Usage (local k6)
@@ -11,5 +11,5 @@
 - Install [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/)
 
 ```shell
-k6 run learn.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
+k6 run learn.smoke.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
 ```

--- a/load_testing/README.md
+++ b/load_testing/README.md
@@ -3,7 +3,7 @@
 ### Usage (Docker)
 
 ```shell
-./scripts/k6.sh /app/learn.smoke.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
+./scripts/k6.sh run /app/learn.smoke.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
 ```
 
 ### Usage (local k6)

--- a/load_testing/README.md
+++ b/load_testing/README.md
@@ -13,3 +13,23 @@
 ```shell
 k6 run learn.smoke.ts -e BACKEND_BASE_URL=#### -e FRONTEND_BASE_URL=####
 ```
+
+### Available tests
+
+**Note: the numbers for average-load/stress should be updated over time**
+
+- `learn.smoke.ts` - for lightweight smoke testing of deployments (4 users)
+- `learn.average-load.ts` - simulates an average amount of user load (100 users)
+- `learn.stress.ts` - simulates a stressful amount of user load (200 users)
+
+### Environment Variables
+
+**Note: for base urls, if you access the services via a port, include the port number**
+
+| Name                  | Decription                                                                                                                                                                                  | Example value                 |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| `BACKEND_BASE_URL`    | The base url to the backend API service.                                                                                                                                                    | `https://api.learn.odl.local` |
+| `FRONTEND_BASE_URL`   | The base url to the frontend service.                                                                                                                                                       | `https://learn.odl.local`     |
+| `SSO_BASE_URL`        | The base url to the keycloak service.                                                                                                                                                       | `https://keycloak.odl.local`  |
+| `IGNORE_HTTPS_ERRORS` | Ignore https certificate errors. Only recommemded for local test certificates.                                                                                                              | `true`                        |
+| `USERS_JSON_FILE`     | Data file for users auth info. Expected to be in the format `[{"email": "<EMAIL>", "password": "<PASSWORD>"}, ...]`. Put this is the `data/` subdirectory as files in there are gitignored. | `data/users.json`             |

--- a/load_testing/auth.ts
+++ b/load_testing/auth.ts
@@ -14,7 +14,7 @@ export function hasAccessToken(): boolean {
 }
 
 function _validate_credentials(credentials) {
-  if (typeof credentials !== "array") {
+  if (!Array.isArray(credentials)) {
     throw Error("Expected an array of credentials")
   }
 
@@ -37,6 +37,8 @@ export const credentials: AuthCredential[] = new SharedArray(
     }
 
     const parsed = JSON.parse(open(__ENV.USERS_JSON_FILE))
+
+    console.log(parsed)
 
     _validate_credentials(parsed)
 

--- a/load_testing/auth.ts
+++ b/load_testing/auth.ts
@@ -38,8 +38,6 @@ export const credentials: AuthCredential[] = new SharedArray(
 
     const parsed = JSON.parse(open(__ENV.USERS_JSON_FILE))
 
-    console.log(parsed)
-
     _validate_credentials(parsed)
 
     return parsed

--- a/load_testing/auth.ts
+++ b/load_testing/auth.ts
@@ -1,12 +1,16 @@
 import { SharedArray } from "k6/data"
 
 export type AuthCredential = {
-  username: string
+  email: string
   password: string
 }
 
 export function getAccessToken(): string | null {
   return __ENV.AUTH_ACCESS_TOKEN
+}
+
+export function hasAccessToken(): boolean {
+  return !getAccessToken()
 }
 
 function _validate_credentials(credentials) {

--- a/load_testing/auth.ts
+++ b/load_testing/auth.ts
@@ -1,13 +1,41 @@
 import { SharedArray } from "k6/data"
 
-export function getAccessToken(): String {
+export type AuthCredential = {
+  username: string
+  password: string
+}
+
+export function getAccessToken(): string | null {
   return __ENV.AUTH_ACCESS_TOKEN
 }
 
-export const users = new SharedArray("users", function () {
-  if (!__ENV.USERS_JSON_FILE) {
-    return []
+function _validate_credentials(credentials) {
+  if (typeof credentials !== "array") {
+    throw Error("Expected an array of credentials")
   }
 
-  return JSON.parse(open(__ENV.USERS_JSON_FILE))
-})
+  for (let index = 0; index < credentials.length; index++) {
+    const credential = credentials[index]
+    if (!Object.hasOwn(credential, "email")) {
+      throw Error(`User entry is missing 'email' at index ${index}`)
+    }
+    if (!Object.hasOwn(credential, "password")) {
+      throw Error(`User entry is missing 'password' at index ${index}`)
+    }
+  }
+}
+
+export const credentials: AuthCredential[] = new SharedArray(
+  "credentials",
+  function () {
+    if (!__ENV.USERS_JSON_FILE) {
+      return []
+    }
+
+    const parsed = JSON.parse(open(__ENV.USERS_JSON_FILE))
+
+    _validate_credentials(parsed)
+
+    return parsed
+  },
+)

--- a/load_testing/auth.ts
+++ b/load_testing/auth.ts
@@ -10,7 +10,7 @@ export function getAccessToken(): string | null {
 }
 
 export function hasAccessToken(): boolean {
-  return !getAccessToken()
+  return !!getAccessToken()
 }
 
 function _validate_credentials(credentials) {

--- a/load_testing/backend/test.ts
+++ b/load_testing/backend/test.ts
@@ -16,23 +16,32 @@ export function testBackend() {
       exec.vu.metrics.tags.apiVersion = "v0"
 
       const client = createV0Client()
-      let res = client.videoShortsList({ limit: 50 })
+      group("video shorts", () => {
+        const res = client.videoShortsList({ limit: 50 })
 
-      check(res, {
-        "is status 200": (r) => r.response.status === 200,
-        "has results": (r) => r.response.json("results").length > 0,
+        group
+        check(res, {
+          "is status 200": (r) => r.response.status === 200,
+          "has results": (r) => r.response.json("results").length > 0,
+        })
       })
 
-      res = client.usersMeRetrieve()
-      check(res, {
-        "is status 200": (r) => r.response.status === 200,
+      group("users/me", () => {
+        const res = client.usersMeRetrieve()
+        check(res, {
+          "is status 200": (r) => r.response.status === 200,
+          "expected auth state": (r) =>
+            r.response.json("is_authenticated") === hasAccessToken(),
+        })
       })
 
-      res = client.testimonialsList({ position: 1 })
+      group("testimonials", () => {
+        const res = client.testimonialsList({ position: 1 })
 
-      check(res, {
-        "is status 200": (r) => r.response.status === 200,
-        "has results": (r) => r.response.json("results").length > 0,
+        check(res, {
+          "is status 200": (r) => r.response.status === 200,
+          "has results": (r) => r.response.json("results").length > 0,
+        })
       })
 
       group("news", function () {
@@ -56,14 +65,6 @@ export function testBackend() {
             "has results": (r) => r.response.json("results").length > 0,
           })
         })
-      })
-
-      res = client.usersMeRetrieve()
-
-      check(res, {
-        "is status 200": (r) => r.response.status === 200,
-        "expected auth state": (r) =>
-          r.response.json("is_authenticated") === hasAccessToken(),
       })
 
       delete exec.vu.metrics.tags.apiVersion

--- a/load_testing/backend/test.ts
+++ b/load_testing/backend/test.ts
@@ -8,6 +8,7 @@ import {
 import { createV0Client, createV1Client } from "./client/client.ts"
 import { NewsEventsListParams } from "./client/v0/api.schemas.ts"
 import { FeaturedListParams } from "./client/v1/api.schemas.ts"
+import { hasAccessToken } from "../auth.ts"
 
 export function testBackend() {
   group("api", function () {
@@ -55,6 +56,14 @@ export function testBackend() {
             "has results": (r) => r.response.json("results").length > 0,
           })
         })
+      })
+
+      res = client.usersMeRetrieve()
+
+      check(res, {
+        "is status 200": (r) => r.response.status === 200,
+        "expected auth state": (r) =>
+          r.response.json("is_authenticated") === hasAccessToken(),
       })
 
       delete exec.vu.metrics.tags.apiVersion

--- a/load_testing/backend/test.ts
+++ b/load_testing/backend/test.ts
@@ -19,7 +19,6 @@ export function testBackend() {
       group("video shorts", () => {
         const res = client.videoShortsList({ limit: 50 })
 
-        group
         check(res, {
           "is status 200": (r) => r.response.status === 200,
           "has results": (r) => r.response.json("results").length > 0,

--- a/load_testing/config.ts
+++ b/load_testing/config.ts
@@ -3,8 +3,9 @@ import { NewBrowserContextOptions } from "k6/browser"
 export const BACKEND_BASE_URL: string = __ENV.BACKEND_BASE_URL
 export const FRONTEND_BASE_URL: string = __ENV.FRONTEND_BASE_URL
 
+export const IGNORE_HTTPS_ERRORS: boolean =
+  (__ENV.IGNORE_HTTPS_ERRORS || "false").toLowerCase() == "true"
+
 export const BROWSER_CONTEXT_OPTIONS: NewBrowserContextOptions = {
-  ignoreHTTPSErrors: Object.hasOwn(__ENV, "BROWSER_IGNORE_HTTPS_ERRORS")
-    ? __ENV.BROWSER_IGNORE_HTTPS_ERRORS
-    : false,
+  ignoreHTTPSErrors: IGNORE_HTTPS_ERRORS,
 }

--- a/load_testing/config.ts
+++ b/load_testing/config.ts
@@ -2,6 +2,7 @@ import { NewBrowserContextOptions } from "k6/browser"
 
 export const BACKEND_BASE_URL: string = __ENV.BACKEND_BASE_URL
 export const FRONTEND_BASE_URL: string = __ENV.FRONTEND_BASE_URL
+export const SSO_BASE_URL: string = __ENV.SSO_BASE_URL
 
 export const IGNORE_HTTPS_ERRORS: boolean =
   (__ENV.IGNORE_HTTPS_ERRORS || "false").toLowerCase() == "true"

--- a/load_testing/config.ts
+++ b/load_testing/config.ts
@@ -1,8 +1,14 @@
 import { NewBrowserContextOptions } from "k6/browser"
 
-export const BACKEND_BASE_URL: string = __ENV.BACKEND_BASE_URL
-export const FRONTEND_BASE_URL: string = __ENV.FRONTEND_BASE_URL
-export const SSO_BASE_URL: string = __ENV.SSO_BASE_URL
+export const BACKEND_BASE_URL: string = __ENV.BACKEND_BASE_URL?.replace(
+  /\/$/,
+  "",
+)
+export const FRONTEND_BASE_URL: string = __ENV.FRONTEND_BASE_URL?.replace(
+  /\/$/,
+  "",
+)
+export const SSO_BASE_URL: string = __ENV.SSO_BASE_URL?.replace(/\/$/, "")
 
 export const IGNORE_HTTPS_ERRORS: boolean =
   (__ENV.IGNORE_HTTPS_ERRORS || "false").toLowerCase() == "true"

--- a/load_testing/config.ts
+++ b/load_testing/config.ts
@@ -8,7 +8,9 @@ export const FRONTEND_BASE_URL: string = __ENV.FRONTEND_BASE_URL?.replace(
   /\/$/,
   "",
 )
-export const SSO_BASE_URL: string = __ENV.SSO_BASE_URL?.replace(/\/$/, "")
+export const SSO_BASE_URL: string = (
+  __ENV.SSO_BASE_URL ?? "http://localhost"
+).replace(/\/$/, "")
 
 export const IGNORE_HTTPS_ERRORS: boolean =
   (__ENV.IGNORE_HTTPS_ERRORS || "false").toLowerCase() == "true"

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -46,7 +46,7 @@ async function login(page: Page) {
   const credential: AuthCredential = randomItem(credentials)
 
   if (!!credential) {
-    log.debug("Skipping login because no credentials provided")
+    console.debug("Skipping login because no credentials provided")
     return
   }
 
@@ -64,12 +64,16 @@ async function loginKeycloak(page: Page, credential: AuthCredential) {
   )
 
   const credentialnameInput = await page.locator("input#username")
-  await credentialnameInput.type(user.email)
+  await credentialnameInput.type(credential.email)
   await page.locator("button#kc-login").click()
 
   const passwordInput = await page.locator("input#password")
   await passwordInput.type(credential.password)
   await page.locator("button#kc-login").click()
+}
+
+async function dashboard(page: Page) {
+  await page.goto(`${FRONTEND_BASE_URL}/dashboard`)
 }
 
 export async function testFrontend() {
@@ -83,6 +87,7 @@ export async function testFrontend() {
     await departments(page)
     await units(page)
     await login(page)
+    await dashboard(page)
   } finally {
     await page.close()
   }

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -12,13 +12,18 @@ import {
 import { AuthCredential, credentials } from "../auth.ts"
 import { escapeRegex } from "../utils.ts"
 
-async function home(page: Page) {
+type Context = {
+  loggedIn: boolean
+  credential: AuthCredential | null
+}
+
+async function home(page: Page, context: Context) {
   await page.goto(FRONTEND_BASE_URL)
 
   const carousel = await page.getByTestId("resource-carousel")
   const articlesCount = await carousel.locator("article").count()
   await check(carousel, {
-    "has 12 items": () => articlesCount === 12,
+    "home page carousel has 12 items": () => articlesCount === 12,
   })
 
   await carousel
@@ -27,7 +32,7 @@ async function home(page: Page) {
     .click()
 }
 
-async function search(page: Page) {
+async function search(page: Page, context: Context) {
   await page.goto(`${FRONTEND_BASE_URL}/search?sortby=-views`)
   await page.goto(`${FRONTEND_BASE_URL}/search?resource_type_group=program`)
   await page.goto(
@@ -35,75 +40,114 @@ async function search(page: Page) {
   )
 }
 
-async function topics(page: Page) {
+async function topics(page: Page, context: Context) {
   await page.goto(`${FRONTEND_BASE_URL}/topics`)
 }
 
-async function departments(page: Page) {
+async function departments(page: Page, context: Context) {
   await page.goto(`${FRONTEND_BASE_URL}/departments`)
 }
 
-async function units(page: Page) {
+async function units(page: Page, context: Context) {
   await page.goto(`${FRONTEND_BASE_URL}/units`)
 }
 
-async function login(page: Page) {
+async function login(page: Page, context: Context) {
   const credential: AuthCredential = randomItem(credentials)
 
-  if (!!credential) {
-    console.debug("Skipping login because no credentials provided")
-    return false
+  if (credential == null) {
+    console.log("Login > skipping because no credentials provided")
   }
+  if (page.url() == "about:blank") {
+    await page.goto(FRONTEND_BASE_URL)
+  }
+
+  console.log(`Login > using '${credential.email}'`)
 
   const loginButton = page.getByTestId("login-button-desktop")
   await loginButton.first().click()
 
-  await loginKeycloak(page)
+  await loginKeycloak(page, credential, context)
 
   await page.waitForURL(/.*\/dashboard.*/)
 
-  return true
+  console.log("Login > reached dashboard")
 }
 
-const KEYCLOAK_OIDC_RE = new RegExp(
-  `${escapeRegex(SSO_BASE_URL)}\/realms\/olapps\/protocol\/openid-connect\/auth.*`,
+const ESCAPED_SSO_URL = escapeRegex(SSO_BASE_URL)
+
+const KEYCLOAK_USERNAME_URL_RE = new RegExp(
+  `${ESCAPED_SSO_URL}\/realms\/[a-z\-]+\/protocol\/openid-connect\/auth.*`,
+)
+const KEYCLOAK_PASSWORD_URL_RE = new RegExp(
+  `${ESCAPED_SSO_URL}\/realms\/[a-z\-]+\/login-actions\/authenticate.*`,
 )
 
-async function loginKeycloak(page: Page, credential: AuthCredential) {
-  await page.waitForURL(KEYCLOAK_OIDC_RE)
+async function loginKeycloak(
+  page: Page,
+  credential: AuthCredential,
+  context: Context,
+) {
+  await page.waitForURL(KEYCLOAK_USERNAME_URL_RE, {
+    waitUntil: "load",
+  })
 
-  const credentialnameInput = await page.locator("input#username")
-  await credentialnameInput.type(credential.email)
-  await page.locator("button#kc-login").click()
+  console.log("Login > Keycloak > on login email page")
+
+  const credentialnameInput = await page.locator("input[name=username]")
+  console.log("Login > Keycloak > found username input")
+  await credentialnameInput.focus()
+  await credentialnameInput.fill(credential.email)
+  console.log("Login > Keycloak > entered email address")
+
+  await page.locator("button[type=submit]").click()
+  console.log("Login > Keycloak > submitting email address")
+
+  await page.waitForNavigation(KEYCLOAK_PASSWORD_URL_RE)
+  console.log("Login > Keycloak > on login password page")
+
+  const passwordInput = await page.locator("input[name=password]")
+  console.log("Login > Keycloak > found password input")
+  await passwordInput.focus()
+  await passwordInput.fill(credential.password, {
+    force: true,
+  })
+  await page.locator("button[type=submit]").click()
+  console.log("Login > Keycloak > submitting password")
   await page.waitForNavigation()
-  console.log(page.url())
 
-  const passwordInput = await page.locator("input#password")
-  await passwordInput.type(credential.password)
-  await page.locator("button#kc-login").click()
-  await page.waitForNavigation()
-
-  console.log(page.url())
+  context.loggedIn = true
+  context.credential = credential
 }
 
-async function dashboard(page: Page) {
+async function dashboard(page: Page, context: Context) {
+  if (!context.loggedIn) {
+    return
+  }
   await page.goto(`${FRONTEND_BASE_URL}/dashboard`)
 }
 
 export async function testFrontend() {
   const page = await browser.newPage(BROWSER_CONTEXT_OPTIONS)
+  const context: Context = {
+    loggedIn: false,
+    credential: null,
+  }
 
   try {
     // always home page first
-    await home(page)
-    await search(page)
-    await topics(page)
-    await departments(page)
-    await units(page)
-    const loggedIn = await login(page)
-    if (loggedIn) {
-      await dashboard(page)
-    }
+    await home(page, context)
+    await search(page, context)
+    await topics(page, context)
+    await departments(page, context)
+    await units(page, context)
+    await login(page, context)
+    await dashboard(page, context)
+    await search(page, context)
+    await topics(page, context)
+    await departments(page, context)
+    await units(page, context)
+    await home(page, context)
   } finally {
     await page.close()
   }

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -77,10 +77,10 @@ async function login(page: Page, context: Context) {
 const ESCAPED_SSO_URL = escapeRegex(SSO_BASE_URL)
 
 const KEYCLOAK_USERNAME_URL_RE = new RegExp(
-  `${ESCAPED_SSO_URL}\/realms\/[a-z\-]+\/protocol\/openid-connect\/auth.*`,
+  `${ESCAPED_SSO_URL}\/realms\/[a-z-]+\/protocol\/openid-connect\/auth.*`,
 )
 const KEYCLOAK_PASSWORD_URL_RE = new RegExp(
-  `${ESCAPED_SSO_URL}\/realms\/[a-z\-]+\/login-actions\/authenticate.*`,
+  `${ESCAPED_SSO_URL}\/realms\/[a-z-]+\/login-actions\/authenticate.*`,
 )
 
 async function loginKeycloak(

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -75,10 +75,15 @@ async function loginKeycloak(page: Page, credential: AuthCredential) {
   const credentialnameInput = await page.locator("input#username")
   await credentialnameInput.type(credential.email)
   await page.locator("button#kc-login").click()
+  await page.waitForNavigation()
+  console.log(page.url())
 
   const passwordInput = await page.locator("input#password")
   await passwordInput.type(credential.password)
   await page.locator("button#kc-login").click()
+  await page.waitForNavigation()
+
+  console.log(page.url())
 }
 
 async function dashboard(page: Page) {

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -1,7 +1,11 @@
 import { check } from "k6"
 import { browser, Page } from "k6/browser"
-import { randomIntBetween } from "https://jslib.k6.io/k6-utils/1.2.0/index.js"
+import {
+  randomIntBetween,
+  randomItem,
+} from "https://jslib.k6.io/k6-utils/1.2.0/index.js"
 import { BROWSER_CONTEXT_OPTIONS, FRONTEND_BASE_URL } from "../config.ts"
+import { AuthCredential, credentials } from "../auth.ts"
 
 async function home(page: Page) {
   await page.goto(FRONTEND_BASE_URL)
@@ -38,15 +42,47 @@ async function units(page: Page) {
   await page.goto(`${FRONTEND_BASE_URL}/units`)
 }
 
+async function login(page: Page) {
+  const credential: AuthCredential = randomItem(credentials)
+
+  if (!!credential) {
+    log.debug("Skipping login because no credentials provided")
+    return
+  }
+
+  const loginButton = page.getByTestId("login-button-desktop")
+  await loginButton.first().click()
+
+  await loginKeycloak(page)
+
+  await page.waitForURL(/.*\/dashboard.*/)
+}
+
+async function loginKeycloak(page: Page, credential: AuthCredential) {
+  await page.waitForURL(
+    /https:\/sso(\-qa)?\.ol\.mit\.edu\/realms\/olapps\/protocol\/openid-connect\/auth.*/,
+  )
+
+  const credentialnameInput = await page.locator("input#username")
+  await credentialnameInput.type(user.email)
+  await page.locator("button#kc-login").click()
+
+  const passwordInput = await page.locator("input#password")
+  await passwordInput.type(credential.password)
+  await page.locator("button#kc-login").click()
+}
+
 export async function testFrontend() {
   const page = await browser.newPage(BROWSER_CONTEXT_OPTIONS)
 
   try {
+    // always home page first
     await home(page)
     await search(page)
     await topics(page)
     await departments(page)
     await units(page)
+    await login(page)
   } finally {
     await page.close()
   }

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -4,8 +4,13 @@ import {
   randomIntBetween,
   randomItem,
 } from "https://jslib.k6.io/k6-utils/1.2.0/index.js"
-import { BROWSER_CONTEXT_OPTIONS, FRONTEND_BASE_URL } from "../config.ts"
+import {
+  BROWSER_CONTEXT_OPTIONS,
+  FRONTEND_BASE_URL,
+  SSO_BASE_URL,
+} from "../config.ts"
 import { AuthCredential, credentials } from "../auth.ts"
+import { escapeRegex } from "../utils.ts"
 
 async function home(page: Page) {
   await page.goto(FRONTEND_BASE_URL)
@@ -47,7 +52,7 @@ async function login(page: Page) {
 
   if (!!credential) {
     console.debug("Skipping login because no credentials provided")
-    return
+    return false
   }
 
   const loginButton = page.getByTestId("login-button-desktop")
@@ -56,12 +61,16 @@ async function login(page: Page) {
   await loginKeycloak(page)
 
   await page.waitForURL(/.*\/dashboard.*/)
+
+  return true
 }
 
+const KEYCLOAK_OIDC_RE = new RegExp(
+  `${escapeRegex(SSO_BASE_URL)}\/realms\/olapps\/protocol\/openid-connect\/auth.*`,
+)
+
 async function loginKeycloak(page: Page, credential: AuthCredential) {
-  await page.waitForURL(
-    /https:\/sso(\-qa)?\.ol\.mit\.edu\/realms\/olapps\/protocol\/openid-connect\/auth.*/,
-  )
+  await page.waitForURL(KEYCLOAK_OIDC_RE)
 
   const credentialnameInput = await page.locator("input#username")
   await credentialnameInput.type(credential.email)
@@ -86,8 +95,10 @@ export async function testFrontend() {
     await topics(page)
     await departments(page)
     await units(page)
-    await login(page)
-    await dashboard(page)
+    const loggedIn = await login(page)
+    if (loggedIn) {
+      await dashboard(page)
+    }
   } finally {
     await page.close()
   }

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -21,15 +21,25 @@ async function home(page: Page, context: Context) {
   await page.goto(FRONTEND_BASE_URL)
 
   const carousel = await page.getByTestId("resource-carousel")
-  const articlesCount = await carousel.locator("article").count()
+  const articles = carousel.locator("article")
+
+  try {
+    await articles.first().waitFor({ timeout: 10_000 })
+  } catch {
+    // carousel never populated; let the assertion below report it
+  }
+
+  const articlesCount = await articles.count()
+
   await check(carousel, {
     "home page carousel has 12 items": () => articlesCount === 12,
   })
 
-  await carousel
-    .locator("article")
-    .nth(randomIntBetween(0, articlesCount - 1))
-    .click()
+  if (articlesCount === 0) {
+    return
+  }
+
+  await articles.nth(randomIntBetween(0, articlesCount - 1)).click()
 }
 
 async function search(page: Page, context: Context) {
@@ -53,12 +63,18 @@ async function units(page: Page, context: Context) {
 }
 
 async function login(page: Page, context: Context) {
-  const credential: AuthCredential = randomItem(credentials)
+  const credential: AuthCredential | undefined = randomItem(credentials)
 
   if (credential == null) {
     console.log("Login > skipping because no credentials provided")
+    return
   }
-  if (page.url() == "about:blank") {
+
+  if (!SSO_BASE_URL) {
+    throw Error("SSO_BASE_URL must be set to run the login flow")
+  }
+
+  if (page.url() === "about:blank") {
     await page.goto(FRONTEND_BASE_URL)
   }
 
@@ -67,11 +83,22 @@ async function login(page: Page, context: Context) {
   const loginButton = page.getByTestId("login-button-desktop")
   await loginButton.first().click()
 
-  await loginKeycloak(page, credential, context)
+  let loggedIn = false
 
-  await page.waitForURL(/.*\/dashboard.*/)
+  try {
+    await loginKeycloak(page, credential, context)
+    await page.locator('[aria-label="User Menu"]').waitFor({ timeout: 10_000 })
+    loggedIn = true
+    console.log("Login > authenticated; user menu visible")
+  } catch (err) {
+    console.log(
+      `Login > failed for '${credential.email}' at URL '${page.url()}': ${err}`,
+    )
+  }
 
-  console.log("Login > reached dashboard")
+  check(null, {
+    "login succeeded": () => loggedIn,
+  })
 }
 
 const ESCAPED_SSO_URL = escapeRegex(SSO_BASE_URL)

--- a/load_testing/frontend/test.ts
+++ b/load_testing/frontend/test.ts
@@ -103,7 +103,7 @@ async function loginKeycloak(
   await page.locator("button[type=submit]").click()
   console.log("Login > Keycloak > submitting email address")
 
-  await page.waitForNavigation(KEYCLOAK_PASSWORD_URL_RE)
+  await page.waitForURL(KEYCLOAK_PASSWORD_URL_RE)
   console.log("Login > Keycloak > on login password page")
 
   const passwordInput = await page.locator("input[name=password]")

--- a/load_testing/learn.average-load.ts
+++ b/load_testing/learn.average-load.ts
@@ -1,0 +1,44 @@
+import { IGNORE_HTTPS_ERRORS } from "./config.ts"
+
+export { testBackend } from "./backend/test.ts"
+export { testFrontend } from "./frontend/test.ts"
+
+const MAX_VUS = 100
+const BROWSER_VU_SHARE = 0.5
+const BACKEND_VU_SHARE = 1 - BROWSER_VU_SHARE
+
+const BROWSER_VUS = Math.floor(MAX_VUS * BROWSER_VU_SHARE)
+const BACKEND_VUS = Math.floor(MAX_VUS * BACKEND_VU_SHARE)
+
+export const options = {
+  scenarios: {
+    browser: {
+      exec: "testFrontend",
+      executor: "ramping-vus",
+      options: {
+        browser: {
+          type: "chromium",
+        },
+      },
+      stages: [
+        { duration: "5m", target: BROWSER_VUS },
+        { duration: "30m", target: BROWSER_VUS },
+        { duration: "5m", target: 0 },
+      ],
+    },
+    backend: {
+      exec: "testBackend",
+      executor: "ramping-vus",
+      stages: [
+        { duration: "5m", target: BACKEND_VUS },
+        { duration: "30m", target: BACKEND_VUS },
+        { duration: "5m", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    // the rate of successful checks should be higher than 90%
+    checks: ["rate>0.9"],
+  },
+  insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
+}

--- a/load_testing/learn.average-load.ts
+++ b/load_testing/learn.average-load.ts
@@ -39,6 +39,8 @@ export const options = {
   thresholds: {
     // the rate of successful checks should be higher than 90%
     checks: ["rate>0.9"],
+    http_req_failed: ["rate<0.01"],
+    browser_http_req_failed: ["rate<0.05"],
   },
   insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
 }

--- a/load_testing/learn.smoke.ts
+++ b/load_testing/learn.smoke.ts
@@ -1,13 +1,19 @@
+import { IGNORE_HTTPS_ERRORS } from "./config.ts"
+
 export { testBackend } from "./backend/test.ts"
 export { testFrontend } from "./frontend/test.ts"
+
+const MAX_VUS = 4
+const BROWSER_VU_SHARE = 0.5
+const BACKEND_VU_SHARE = 1 - BROWSER_VU_SHARE
 
 export const options = {
   scenarios: {
     browser: {
       exec: "testFrontend",
       executor: "constant-vus",
-      vus: 10,
-      duration: "30s",
+      vus: Math.floor(MAX_VUS * BROWSER_VU_SHARE),
+      duration: "1m",
       options: {
         browser: {
           type: "chromium",
@@ -17,12 +23,13 @@ export const options = {
     backend: {
       exec: "testBackend",
       executor: "constant-vus",
-      vus: 10,
-      duration: "30s",
+      vus: Math.floor(MAX_VUS * BACKEND_VU_SHARE),
+      duration: "1m",
     },
   },
   thresholds: {
     // the rate of successful checks should be higher than 90%
     checks: ["rate>0.9"],
   },
+  insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
 }

--- a/load_testing/learn.smoke.ts
+++ b/load_testing/learn.smoke.ts
@@ -30,6 +30,8 @@ export const options = {
   thresholds: {
     // the rate of successful checks should be higher than 90%
     checks: ["rate>0.9"],
+    http_req_failed: ["rate<0.01"],
+    browser_http_req_failed: ["rate<0.05"],
   },
   insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
 }

--- a/load_testing/learn.stress.ts
+++ b/load_testing/learn.stress.ts
@@ -1,0 +1,44 @@
+import { IGNORE_HTTPS_ERRORS } from "./config.ts"
+
+export { testBackend } from "./backend/test.ts"
+export { testFrontend } from "./frontend/test.ts"
+
+const MAX_VUS = 200
+const BROWSER_VU_SHARE = 0.5
+const BACKEND_VU_SHARE = 1 - BROWSER_VU_SHARE
+
+const BROWSER_VUS = Math.floor(MAX_VUS * BROWSER_VU_SHARE)
+const BACKEND_VUS = Math.floor(MAX_VUS * BACKEND_VU_SHARE)
+
+export const options = {
+  scenarios: {
+    browser: {
+      exec: "testFrontend",
+      executor: "ramping-vus",
+      options: {
+        browser: {
+          type: "chromium",
+        },
+      },
+      stages: [
+        { duration: "5m", target: BROWSER_VUS },
+        { duration: "30m", target: BROWSER_VUS },
+        { duration: "5m", target: 0 },
+      ],
+    },
+    backend: {
+      exec: "testBackend",
+      executor: "ramping-vus",
+      stages: [
+        { duration: "5m", target: BACKEND_VUS },
+        { duration: "30m", target: BACKEND_VUS },
+        { duration: "5m", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    // the rate of successful checks should be higher than 90%
+    checks: ["rate>0.9"],
+  },
+  insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
+}

--- a/load_testing/learn.stress.ts
+++ b/load_testing/learn.stress.ts
@@ -39,6 +39,8 @@ export const options = {
   thresholds: {
     // the rate of successful checks should be higher than 90%
     checks: ["rate>0.9"],
+    http_req_failed: ["rate<0.01"],
+    browser_http_req_failed: ["rate<0.05"],
   },
   insecureSkipTLSVerify: IGNORE_HTTPS_ERRORS,
 }

--- a/load_testing/utils.ts
+++ b/load_testing/utils.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(str: string): string {
+  return str.replace(/[\.\+\*\$\?\^\(\)\{\}\\\[\]\|]/g, "\\$&")
+}

--- a/scripts/k6.sh
+++ b/scripts/k6.sh
@@ -11,4 +11,4 @@ docker run --rm -ti \
 	-v $ROOT_DIR/load_testing:/app \
 	--add-host learn.odl.local:host-gateway \
 	grafana/k6:master-with-browser \
-	run /app/learn.ts "$@"
+	run "$@"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/11039

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds code that logs the tests in via Keycloak so they can poke around as an authenticated user.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Create a file for test user auth info in `load_testing/data/` (e.g. `load_testing/data/users.json`) per the readme instructions.
- Run the load tests with user auth:
  ```shell
  k6 run learn.smoke.ts \
    -e BACKEND_BASE_URL=https://api.learn.odl.local \
    -e FRONTEND_BASE_URL=https://learn.odl.local \
    -e USERS_JSON_FILE=data/users.json \
    -e SSO_BASE_URL=https://keycloak.odl.local \
    -e IGNORE_HTTPS_ERRORS=true \
    --console-output test.log
  ```
- Inspect the output in `test.log`, you should see log statements regarding successful logins