### PR TITLE
fix: remove the breadcrum separator style

### DIFF
--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPageHeader.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPageHeader.tsx
@@ -88,9 +88,7 @@ const VideoPageHeader: React.FC<VideoPageHeaderProps> = ({
       <BreadcrumbBar>
         <VideoContainer>
           <StyledBreadcrumbs
-            separatorStyle={{ margin: "0 4px" }}
             variant="light"
-            separatorStyle={{ margin: "0 4px" }}
             ancestors={[{ href: "/", label: "Home" }]}
             current={playlist?.title}
           />


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
Before we were adding the style margin for separator of breadcurm on Videos and podcast pages but now we have decided that we should apply this to all over the places of mit learn pages. So this PR is about removal the custom style for separator. 

### Screenshots (if appropriate):
Before
<img width="2806" height="724" alt="image" src="https://github.com/user-attachments/assets/ba2fefd7-644f-4ec3-bcf5-6ba1f25f42b5" />


After
<img width="2848" height="714" alt="image" src="https://github.com/user-attachments/assets/903d4908-37c9-4b86-88f5-172fa7377e4e" />


### How can this be tested?
For now you need to relay on my added screenshots I have separate PR for handling the breadcrum in this PR we are just removing the custom style

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
