### PR TITLE
MITxOnline program published status should consider include_in_learn_catalog

### DIFF
--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -650,7 +650,7 @@ def transform_programs(programs: list[dict]) -> Iterator[dict]:
                 has_product_page
                 and parse_page_attribute(program, "live")
                 and parse_page_attribute(program, "include_in_learn_catalog")
-            ),  # a program is only considered published if it has a page url
+            ),
             "format": [Format.asynchronous.name],
             "pace": pace,
             "runs": [run],

--- a/learning_resources/etl/mitxonline.py
+++ b/learning_resources/etl/mitxonline.py
@@ -647,7 +647,9 @@ def transform_programs(programs: list[dict]) -> Iterator[dict]:
             "image": _transform_image(program),
             "availability": program.get("availability"),
             "published": bool(
-                has_product_page and parse_page_attribute(program, "live")
+                has_product_page
+                and parse_page_attribute(program, "live")
+                and parse_page_attribute(program, "include_in_learn_catalog")
             ),  # a program is only considered published if it has a page url
             "format": [Format.asynchronous.name],
             "pace": pace,

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -654,6 +654,9 @@ def test_mitxonline_transform_programs(
                 "published": bool(
                     program_data.get("page", {}).get("page_url", None) is not None
                     and program_data.get("page", {}).get("live", None)
+                    and program_data.get("page", {}).get(
+                        "include_in_learn_catalog", False
+                    )
                 ),
                 "url": expected_program_url,
                 "availability": program_data["availability"],
@@ -872,6 +875,33 @@ def test_mitxonline_transform_courses_not_in_catalog(
     assert any(run["is_enrollable"] for run in course["courseruns"])
 
     result = transform_courses([course])
+    assert result[0]["published"] is bool(include_in_learn_catalog)
+
+
+@pytest.mark.parametrize("include_in_learn_catalog", [True, False, None])
+def test_mitxonline_transform_programs_not_in_catalog(
+    mock_mitxonline_programs_data,
+    mock_mitxonline_courses_data,
+    mocker,
+    include_in_learn_catalog,
+):
+    """Test that a program with include_in_learn_catalog=False/None is not published"""
+    set_up_topics(is_mitx=True)
+    mock_now = datetime(2023, 1, 1, tzinfo=UTC)
+    mocker.patch("learning_resources.etl.mitxonline.now_in_utc", return_value=mock_now)
+    mocker.patch(
+        "learning_resources.etl.mitxonline._fetch_data",
+        return_value=mock_mitxonline_courses_data["results"],
+    )
+
+    # Use only the first program and set include_in_learn_catalog to True/False/None
+    program = mock_mitxonline_programs_data["results"][0]
+    program["page"]["include_in_learn_catalog"] = include_in_learn_catalog
+    # Ensure all other publish conditions are met
+    program["page"]["page_url"] = "/programs/test-program/"
+    program["page"]["live"] = True
+
+    result = list(transform_programs([program]))
     assert result[0]["published"] is bool(include_in_learn_catalog)
 
 

--- a/learning_resources/etl/mitxonline_test.py
+++ b/learning_resources/etl/mitxonline_test.py
@@ -882,11 +882,13 @@ def test_mitxonline_transform_courses_not_in_catalog(
 def test_mitxonline_transform_programs_not_in_catalog(
     mock_mitxonline_programs_data,
     mock_mitxonline_courses_data,
+    settings,
     mocker,
     include_in_learn_catalog,
 ):
-    """Test that a program with include_in_learn_catalog=False/None is not published"""
+    """Program published mirrors bool(include_in_learn_catalog) when other publish conditions are met."""
     set_up_topics(is_mitx=True)
+    settings.MITX_ONLINE_COURSES_API_URL = "http://localhost/test/courses/api"
     mock_now = datetime(2023, 1, 1, tzinfo=UTC)
     mocker.patch("learning_resources.etl.mitxonline.now_in_utc", return_value=mock_now)
     mocker.patch(

--- a/test_json/mitxonline_programs.json
+++ b/test_json/mitxonline_programs.json
@@ -1,5 +1,5 @@
 {
-  "count": 9,
+  "count": 2,
   "next": null,
   "previous": null,
   "results": [
@@ -83,7 +83,8 @@
         "page_url": "/programs/program-v1:MITxT+18.03x/",
         "financial_assistance_form_url": "",
         "description": "\u003Cp data-block-key=\"38wzq\"\u003EScientists and engineers understand the world through differential equations. You can too.\u003C/p\u003E",
-        "live": false,
+        "live": true,
+        "include_in_learn_catalog": true,
         "length": "14 weeks",
         "effort": "7 hrs/wk",
         "price": "$175"
@@ -97,7 +98,7 @@
           "name": "Mathematics"
         }
       ],
-      "live": false,
+      "live": true,
       "topics": [
         {
           "name": "Mathematics"
@@ -114,6 +115,123 @@
       "time_commitment": "5-7 hrs/wk",
       "min_weekly_hours": "5",
       "max_weekly_hours": "7",
+      "enrollment_modes": [
+        { "mode_slug": "verified" },
+        { "mode_slug": "audit" }
+      ]
+    },
+    {
+      "title": "8.02x Electricity and Magnetism",
+      "readable_id": "program-v1:MITxT+8.02x",
+      "id": 6,
+      "courses": [81, 82, 83],
+      "requirements": {
+        "required": [81, 82, 83],
+        "electives": []
+      },
+      "req_tree": [
+        {
+          "data": {
+            "node_type": "program_root",
+            "operator": null,
+            "operator_value": null,
+            "program": 6,
+            "course": null,
+            "title": "",
+            "elective_flag": false
+          },
+          "id": 46,
+          "children": [
+            {
+              "data": {
+                "node_type": "operator",
+                "operator": "all_of",
+                "operator_value": null,
+                "program": 6,
+                "course": null,
+                "title": "Required Courses",
+                "elective_flag": false
+              },
+              "id": 47,
+              "children": [
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 81,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 48
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 82,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 49
+                },
+                {
+                  "data": {
+                    "node_type": "course",
+                    "operator": null,
+                    "operator_value": null,
+                    "program": 6,
+                    "course": 83,
+                    "title": null,
+                    "elective_flag": false
+                  },
+                  "id": 50
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "page": {
+        "feature_image_src": "/static/images/mitx-labs.png",
+        "page_url": "/programs/program-v1:MITxT+8.02x/",
+        "financial_assistance_form_url": "",
+        "description": "\u003Cp data-block-key=\"2f4sq\"\u003EExplore the core ideas of electricity and magnetism through theory and practical examples.\u003C/p\u003E",
+        "live": true,
+        "include_in_learn_catalog": false,
+        "length": "10 weeks",
+        "effort": "6 hrs/wk",
+        "price": "$149"
+      },
+      "min_price": 990,
+      "max_price": 1990,
+      "program_type": "Series",
+      "certificate_type": "Certificate of Completion",
+      "departments": [
+        {
+          "name": "Physics"
+        }
+      ],
+      "live": true,
+      "topics": [
+        {
+          "name": "Physics"
+        }
+      ],
+      "availability": "dated",
+      "start_date": "2025-09-15T00:00:00Z",
+      "end_date": "2025-12-01T00:00:00Z",
+      "enrollment_start": "2025-08-01T00:00:00Z",
+      "enrollment_end": "2025-10-15T00:00:00Z",
+      "duration": "9-10 weeks",
+      "min_weeks": 9,
+      "max_weeks": 10,
+      "time_commitment": "4-6 hrs/wk",
+      "min_weekly_hours": "4",
+      "max_weekly_hours": "6",
       "enrollment_modes": [
         { "mode_slug": "verified" },
         { "mode_slug": "audit" }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11040

### Description (What does it do?)
Adds `include_in_learn_catalog` attribute as a factor in determining if an MITxOnline program is published or not


### How can this be tested?
- Set these in your `backend.local.env` file:
```
MITX_ONLINE_BASE_URL=https://mitxonline.mit.edu/
MITX_ONLINE_COURSES_API_URL=https://mitxonline.mit.edu/api/v2/courses/
MITX_ONLINE_PROGRAMS_API_URL=https://mitxonline.mit.edu/api/v2/programs/
```
- Run `./manage.py backpopulate_mitxonline_data`.  It should complete successfully and you should have about [11 published mitxonline programs](http://open.odl.local:8065/admin/learning_resources/learningresource/?etl_source=mitxonline&published__exact=1&resource_type__exact=program).

