### PR TITLE
fix: add heading tags to My Learning course titles for screen readers

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -125,7 +125,9 @@ describe.each([
       name: course.title,
     })
     expect(courseLink).toHaveAttribute("href", coursewareUrl)
-    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
+    expect(
+      within(card).getByRole("heading", { name: course.title }),
+    ).toBeInTheDocument()
   })
 
   test("It shows course title as clickable text (not link) when not enrolled (non-B2B)", async () => {
@@ -149,7 +151,9 @@ describe.each([
       within(card).queryByRole("link", { name: course.title }),
     ).not.toBeInTheDocument()
     // Should be clickable text wrapped in a heading
-    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
+    expect(
+      within(card).getByRole("heading", { name: course.title }),
+    ).toBeInTheDocument()
   })
 
   test("It shows course title as clickable text if not enrolled but has B2B contract", async () => {
@@ -177,7 +181,9 @@ describe.each([
     expect(
       within(card).queryByRole("link", { name: course.title }),
     ).not.toBeInTheDocument()
-    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
+    expect(
+      within(card).getByRole("heading", { name: course.title }),
+    ).toBeInTheDocument()
   })
 
   test("Accepts a classname", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -126,7 +126,7 @@ describe.each([
     })
     expect(courseLink).toHaveAttribute("href", coursewareUrl)
     expect(
-      within(card).getByRole("heading", { name: course.title }),
+      within(card).getByRole("heading", { name: course.title, level: 3 }),
     ).toBeInTheDocument()
   })
 
@@ -152,7 +152,7 @@ describe.each([
     ).not.toBeInTheDocument()
     // Should be clickable text wrapped in a heading
     expect(
-      within(card).getByRole("heading", { name: course.title }),
+      within(card).getByRole("heading", { name: course.title, level: 3 }),
     ).toBeInTheDocument()
   })
 
@@ -182,7 +182,7 @@ describe.each([
       within(card).queryByRole("link", { name: course.title }),
     ).not.toBeInTheDocument()
     expect(
-      within(card).getByRole("heading", { name: course.title }),
+      within(card).getByRole("heading", { name: course.title, level: 3 }),
     ).toBeInTheDocument()
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -125,6 +125,7 @@ describe.each([
       name: course.title,
     })
     expect(courseLink).toHaveAttribute("href", coursewareUrl)
+    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
   })
 
   test("It shows course title as clickable text (not link) when not enrolled (non-B2B)", async () => {
@@ -147,9 +148,8 @@ describe.each([
     expect(
       within(card).queryByRole("link", { name: course.title }),
     ).not.toBeInTheDocument()
-    // Should be clickable text
-    const titleText = within(card).getByText(course.title)
-    expect(titleText).toBeInTheDocument()
+    // Should be clickable text wrapped in a heading
+    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
   })
 
   test("It shows course title as clickable text if not enrolled but has B2B contract", async () => {
@@ -177,8 +177,7 @@ describe.each([
     expect(
       within(card).queryByRole("link", { name: course.title }),
     ).not.toBeInTheDocument()
-    const titleText = within(card).getByText(course.title)
-    expect(titleText).toBeInTheDocument()
+    expect(within(card).getByRole("heading", { name: course.title })).toBeInTheDocument()
   })
 
   test("Accepts a classname", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -139,14 +139,18 @@ const CardRoot = styled.div<{
   },
 ])
 
-const TitleLink = styled(Link)(({ theme }) => ({
+const TitleHeading = styled.h3(({ theme }) => ({
+  margin: 0,
   [theme.breakpoints.down("md")]: {
     maxWidth: "calc(100% - 16px)",
   },
 }))
 
-const TitleText = styled.div<{ clickable?: boolean }>(
+const TitleLink = styled(Link)()
+
+const TitleText = styled.h3<{ clickable?: boolean }>(
   ({ theme, clickable }) => ({
+    margin: 0,
     ...theme.typography.subtitle2,
     color: theme.custom.colors.darkGray2,
     cursor: clickable ? "pointer" : "default",
@@ -806,14 +810,16 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   ) : (
     <>
       {titleHref ? (
-        <TitleLink
-          size="medium"
-          color="black"
-          href={titleHref}
-          onClick={titleClick}
-        >
-          {title}
-        </TitleLink>
+        <TitleHeading>
+          <TitleLink
+            size="medium"
+            color="black"
+            href={titleHref}
+            onClick={titleClick}
+          >
+            {title}
+          </TitleLink>
+        </TitleHeading>
       ) : titleClick ? (
         <TitleText clickable onClick={titleClick}>
           {title}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -117,14 +117,18 @@ const CardRoot = styled.div<{
   },
 ])
 
-const TitleLink = styled(Link)(({ theme }) => ({
+const TitleHeading = styled.h3(({ theme }) => ({
+  margin: 0,
   [theme.breakpoints.down("md")]: {
     maxWidth: "calc(100% - 16px)",
   },
 }))
 
-const TitleText = styled.div<{ clickable?: boolean }>(
+const TitleLink = styled(Link)()
+
+const TitleText = styled.h3<{ clickable?: boolean }>(
   ({ theme, clickable }) => ({
+    margin: 0,
     ...theme.typography.subtitle2,
     color: theme.custom.colors.darkGray2,
     cursor: clickable ? "pointer" : "default",
@@ -788,14 +792,16 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
   ) : (
     <>
       {titleHref ? (
-        <TitleLink
-          size="medium"
-          color="black"
-          href={titleHref}
-          onClick={titleClick}
-        >
-          {title}
-        </TitleLink>
+        <TitleHeading>
+          <TitleLink
+            size="medium"
+            color="black"
+            href={titleHref}
+            onClick={titleClick}
+          >
+            {title}
+          </TitleLink>
+        </TitleHeading>
       ) : (
         <TitleText clickable={Boolean(titleClick)} onClick={titleClick}>
           {title}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -606,6 +606,7 @@ type DashboardCardProps = {
   useVerifiedEnrollment?: boolean
   parentProgramIds?: string[]
   onUpgradeError?: (error: string) => void
+  headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
 }
 
 type DashboardCardSharedProps = Omit<DashboardCardProps, "resource">
@@ -707,6 +708,7 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
   useVerifiedEnrollment,
   parentProgramIds,
   onUpgradeError,
+  headingLevel = "h3",
 }) => {
   const enrollment = useEnrollmentHandler()
   const mitxOnlineUser = enrollment.mitxOnlineUser
@@ -792,7 +794,7 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
   ) : (
     <>
       {titleHref ? (
-        <TitleHeading>
+        <TitleHeading as={headingLevel}>
           <TitleLink
             size="medium"
             color="black"
@@ -803,7 +805,11 @@ const DashboardCourseCard: React.FC<DashboardCourseCardProps> = ({
           </TitleLink>
         </TitleHeading>
       ) : (
-        <TitleText clickable={Boolean(titleClick)} onClick={titleClick}>
+        <TitleText
+          as={headingLevel}
+          clickable={Boolean(titleClick)}
+          onClick={titleClick}
+        >
           {title}
         </TitleText>
       )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -103,7 +103,10 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
     expect(screen.getByText("2 Modules (0 of 2 complete)")).toBeInTheDocument()
     expect(
       screen.getAllByText(cardData.moduleCourses[0].title).length,
@@ -125,7 +128,10 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
     expect(screen.getByText("Not Started")).toBeInTheDocument()
   })
 
@@ -163,7 +169,10 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
     const rows = await screen.findAllByTestId("enrollment-card-desktop")
     // req_tree has moduleOne first, moduleTwo second (from setupCardData)
     expect(rows[0]).toHaveTextContent(moduleOne.title)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -470,6 +470,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
               useVerifiedEnrollment={useVerifiedEnrollment}
               parentProgramIds={parentProgramIds}
               variant="stacked"
+              headingLevel="h4"
             />
           )
         })}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -436,7 +436,9 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
               </>
             )}
           </StatusContainer>
-          <Typography variant="subtitle2">{courseProgram?.title}</Typography>
+          <Typography variant="subtitle2" component="h3">
+            {courseProgram?.title}
+          </Typography>
         </ProgramCardHeaderInner>
       </ProgramCardHeaderOuter>
       <ProgramCardSubHeader>


### PR DESCRIPTION


### What are the relevant tickets?

 Closes https://github.com/mitodl/hq/issues/10527


### Description (What does it do?)
<!--- Describe your changes in detail -->

Course and module titles in the "My Learning" section of the dashboard were rendered as plain divs and a tags, making them invisible to screen readers navigating by headings. This adds h3 semantics to all course/module title elements so they appear in the heading outline under the existing h2 "My Learning" section heading.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [ ] Mobile width screenshots

BEFORE:
<img width="1823" height="917" alt="Screenshot 2026-04-27 at 12 24 43 PM" src="https://github.com/user-attachments/assets/89dbf5e3-30bd-450b-baaf-9455043b5ee0" />
AFTER:
<img width="1856" height="690" alt="Screenshot 2026-04-27 at 12 23 31 PM" src="https://github.com/user-attachments/assets/42027d26-d1f2-4d29-a511-afbe9c4c2506" />

BEFORE:
<img width="1906" height="933" alt="Screenshot 2026-04-29 at 3 01 39 PM" src="https://github.com/user-attachments/assets/4e796316-5d03-47db-a6ad-7d86aec8f496" />
AFTER: 
<img width="1844" height="858" alt="Screenshot 2026-04-29 at 2 53 06 PM" src="https://github.com/user-attachments/assets/c5b5f42f-9d84-4f71-bafa-d870f748d918" />



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Enable the enrollment-dashboard feature flag in PostHog
2. Log in with an account that has MITxOnline enrollments (or set up a local mock — see below)
3. Navigate to /dashboard
4. Open NVDA and browse by headings (NVDA key + H) — course/module titles in the "My Learning" section should now be announced as level 3 headings under the "My Learning" level 2 heading
5. Alternatively, inspect the DOM and verify course/module titles render as `<h3>` elements

**Local mock setup (if no MITxOnline enrollments)**

1. Set NEXT_PUBLIC_MITX_ONLINE_BASE_URL=http://mitxonline.odl.local:4001 in env/frontend.local.env
2. Run a local mock server returning fake enrollment data on port 4001
3. Run docker compose up watch to pick up the env change




<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
