### PR TITLE
Add externalLinkProps utility; open external CTA links in new tab only

### DIFF
--- a/frontends/main/src/common/utils.test.ts
+++ b/frontends/main/src/common/utils.test.ts
@@ -12,6 +12,18 @@ describe("externalLinkProps", () => {
     })
   })
 
+  it("returns extra props only for external URLs", () => {
+    const extra = { endIcon: "external" }
+    expect(externalLinkProps("https://ocw.mit.edu/courses/123", extra)).toEqual(
+      {
+        target: "_blank",
+        rel: "noopener noreferrer",
+        ...extra,
+      },
+    )
+    expect(externalLinkProps("/courses/123", extra)).toEqual({})
+  })
+
   it("returns empty object for an internal absolute URL", () => {
     expect(externalLinkProps(`${NEXT_PUBLIC_ORIGIN}/courses/123`)).toEqual({})
   })

--- a/frontends/main/src/common/utils.test.ts
+++ b/frontends/main/src/common/utils.test.ts
@@ -1,4 +1,27 @@
-import { convertToEmbedUrl } from "./utils"
+import { convertToEmbedUrl, externalLinkProps } from "./utils"
+
+const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN!
+
+describe("externalLinkProps", () => {
+  it("returns blank-target props for an external URL", () => {
+    expect(externalLinkProps("https://ocw.mit.edu/courses/123")).toEqual({
+      target: "_blank",
+      rel: "noopener noreferrer",
+    })
+  })
+
+  it("returns empty object for an internal absolute URL", () => {
+    expect(externalLinkProps(`${NEXT_PUBLIC_ORIGIN}/courses/123`)).toEqual({})
+  })
+
+  it("returns empty object for a relative URL", () => {
+    expect(externalLinkProps("/courses/123")).toEqual({})
+  })
+
+  it("returns empty object for a hash-only href", () => {
+    expect(externalLinkProps("#section")).toEqual({})
+  })
+})
 
 describe("convertToEmbedUrl", () => {
   describe("invalid / unsupported input", () => {

--- a/frontends/main/src/common/utils.test.ts
+++ b/frontends/main/src/common/utils.test.ts
@@ -1,6 +1,8 @@
+import invariant from "tiny-invariant"
 import { convertToEmbedUrl, externalLinkProps } from "./utils"
 
-const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN!
+const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
+invariant(NEXT_PUBLIC_ORIGIN, "NEXT_PUBLIC_ORIGIN must be defined")
 
 describe("externalLinkProps", () => {
   it("returns blank-target props for an external URL", () => {

--- a/frontends/main/src/common/utils.ts
+++ b/frontends/main/src/common/utils.ts
@@ -145,14 +145,14 @@ const ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
  * an endIcon).
  */
 function externalLinkProps(href: string): {
-  target: "_blank"
-  rel: "noopener noreferrer"
+  target?: "_blank"
+  rel?: "noopener noreferrer"
 }
 function externalLinkProps<T extends Record<string, unknown>>(
   href: string,
   extra: T,
 ):
-  | ({ target: "_blank"; rel: "noopener noreferrer" } & T)
+  | ({ target?: "_blank"; rel?: "noopener noreferrer" } & T)
   | Record<string, never>
 function externalLinkProps(href: string, extra?: Record<string, unknown>) {
   try {

--- a/frontends/main/src/common/utils.ts
+++ b/frontends/main/src/common/utils.ts
@@ -136,6 +136,36 @@ function hexToRgba(hex: string, alpha: number): string | undefined {
 const isOcwPlaylist = (resource: VideoPlaylistResource | undefined) =>
   resource?.offered_by?.code === "ocw" ? true : false
 
+const ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
+
+/**
+ * Returns `{ target: "_blank", rel: "noopener noreferrer", ...extra }` for URLs
+ * whose origin differs from NEXT_PUBLIC_ORIGIN, or `{}` for internal / relative
+ * URLs. Pass `extra` to include additional props only for external links (e.g.,
+ * an endIcon).
+ */
+function externalLinkProps(href: string): {
+  target: "_blank"
+  rel: "noopener noreferrer"
+}
+function externalLinkProps<T extends Record<string, unknown>>(
+  href: string,
+  extra: T,
+):
+  | ({ target: "_blank"; rel: "noopener noreferrer" } & T)
+  | Record<string, never>
+function externalLinkProps(href: string, extra?: Record<string, unknown>) {
+  try {
+    const parsed = new URL(href, ORIGIN)
+    if (ORIGIN && parsed.origin === new URL(ORIGIN).origin) {
+      return {}
+    }
+  } catch {
+    return {}
+  }
+  return { target: "_blank", rel: "noopener noreferrer", ...extra }
+}
+
 export {
   isInEnum,
   matchOrganizationBySlug,
@@ -144,4 +174,5 @@ export {
   convertToEmbedUrl,
   hexToRgba,
   isOcwPlaylist,
+  externalLinkProps,
 }

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/common/urls"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { FeatureFlags } from "@/common/feature_flags"
+import { externalLinkProps } from "@/common/utils"
 import invariant from "tiny-invariant"
 
 const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
@@ -428,9 +429,10 @@ const CallToActionSection = ({
       <ImageSection resource={resource} config={imgConfig} />
       <ActionsContainer>
         <StyledLink
-          target="_blank"
+          {...externalLinkProps(url, {
+            endIcon: <RiExternalLinkLine />,
+          })}
           size="medium"
-          endIcon={<RiExternalLinkLine />}
           href={url}
           onClick={() => {
             if (process.env.NEXT_PUBLIC_POSTHOG_API_KEY) {


### PR DESCRIPTION
### What are the relevant tickets?
I think we do have an issue for this, but https://github.com/mitodl/hq/issues isn't loading right now.

### Description (What does it do?)
This PR shows the "external link" icon on resource drawer only when the URL is external.

### Screenshots (if appropriate):
**Local course:**
<img width="876" height="469" alt="Screenshot 2026-04-27 at 12 38 26 PM" src="https://github.com/user-attachments/assets/d0475b74-07f5-4616-9fb5-90e345062ff6" />

**External Course:**
<img width="895" height="551" alt="Screenshot 2026-04-27 at 12 38 13 PM" src="https://github.com/user-attachments/assets/11cbad02-6f34-48e6-87e6-d5fe2c94317e" />



### How can this be tested?
1. Visit http://open.odl.local:8062/search
2. View any resource whose url does NOT start with `open.odl.local:8062`, e.g., an xpro course
3. View any resource whose url DOES start start with `open.odl.local:8062`, e.g:
    - A video if you have `video-playlist-page` flag on
    -  an mitxonline course if you're using local mitxonline.