### PR TITLE
dashboard b2c series certificate display

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -2291,5 +2291,103 @@ describe("EnrollmentDisplay", () => {
       expect(cards[1]).toHaveTextContent(courseA.title)
       expect(cards[2]).toHaveTextContent(courseB.title)
     })
+
+    test("displays certificate button when program enrollment has a certificate", async () => {
+      const mitxOnlineUser = mitxonline.factories.user.user()
+      setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+      const certUuid = "test-program-cert-uuid"
+      const program = mitxonline.factories.programs.program({
+        id: 456,
+        title: "Program With Certificate",
+        courses: [10, 11],
+      })
+      const programEnrollment =
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program: {
+            id: program.id,
+            title: program.title,
+            live: program.live,
+            program_type: program.program_type,
+            readable_id: program.readable_id,
+          },
+          certificate: {
+            uuid: certUuid,
+            link: `/certificate/program/${certUuid}/`,
+          },
+        })
+      const courses = mitxonline.factories.courses.courses({ count: 2 })
+
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+      setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
+      setMockResponse.get(
+        mitxonline.urls.programEnrollments.enrollmentsListV3(),
+        [programEnrollment],
+      )
+      setMockResponse.get(mitxonline.urls.programs.programDetail(456), program)
+      setMockResponse.get(
+        mitxonline.urls.courses.coursesList({
+          id: program.courses,
+          page_size: program.courses.length,
+        }),
+        courses,
+      )
+
+      renderWithProviders(<EnrollmentDisplay programId={456} />)
+
+      await screen.findByText("Program With Certificate")
+      const certButton = screen.getByRole("link", { name: "Certificate" })
+      expect(certButton).toBeInTheDocument()
+      expect(certButton).toHaveAttribute(
+        "href",
+        `/certificate/program/${certUuid}`,
+      )
+      expect(certButton).toHaveAttribute("target", "_blank")
+      expect(certButton).toHaveAttribute("rel", "noopener noreferrer")
+    })
+
+    test("does not display certificate button when program enrollment has no certificate", async () => {
+      const mitxOnlineUser = mitxonline.factories.user.user()
+      setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+      const program = mitxonline.factories.programs.program({
+        id: 457,
+        title: "Program Without Certificate",
+        courses: [12, 13],
+      })
+      const programEnrollment =
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program: {
+            id: program.id,
+            title: program.title,
+            live: program.live,
+            program_type: program.program_type,
+            readable_id: program.readable_id,
+          },
+          certificate: null,
+        })
+      const courses = mitxonline.factories.courses.courses({ count: 2 })
+
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+      setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
+      setMockResponse.get(
+        mitxonline.urls.programEnrollments.enrollmentsListV3(),
+        [programEnrollment],
+      )
+      setMockResponse.get(mitxonline.urls.programs.programDetail(457), program)
+      setMockResponse.get(
+        mitxonline.urls.courses.coursesList({
+          id: program.courses,
+          page_size: program.courses.length,
+        }),
+        courses,
+      )
+
+      renderWithProviders(<EnrollmentDisplay programId={457} />)
+
+      await screen.findByText("Program Without Certificate")
+      const certButton = screen.queryByRole("link", { name: "Certificate" })
+      expect(certButton).not.toBeInTheDocument()
+    })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -2337,11 +2337,12 @@ describe("EnrollmentDisplay", () => {
 
       await screen.findByText("Program With Certificate")
       const certButton = screen.getByRole("link", { name: "Certificate" })
-      expect(certButton).toBeInTheDocument()
-      expect(certButton).toHaveAttribute(
-        "href",
-        `/certificate/program/${certUuid}`,
+      const expectedCertHref = programEnrollment.certificate?.link?.replace(
+        /\/$/,
+        "",
       )
+      expect(certButton).toBeInTheDocument()
+      expect(certButton).toHaveAttribute("href", expectedCertHref)
       expect(certButton).not.toHaveAttribute("target")
     })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.test.tsx
@@ -2342,8 +2342,7 @@ describe("EnrollmentDisplay", () => {
         "href",
         `/certificate/program/${certUuid}`,
       )
-      expect(certButton).toHaveAttribute("target", "_blank")
-      expect(certButton).toHaveAttribute("rel", "noopener noreferrer")
+      expect(certButton).not.toHaveAttribute("target")
     })
 
     test("does not display certificate button when program enrollment has no certificate", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -13,7 +13,7 @@ import {
   styled,
   theme,
 } from "ol-components"
-import { Alert } from "@mitodl/smoot-design"
+import { Alert, ButtonLink } from "@mitodl/smoot-design"
 import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import {
   EnrollmentStatus,
@@ -43,6 +43,7 @@ import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { getIdsFromReqTree } from "@/common/mitxonline"
+import { RiAwardFill } from "@remixicon/react"
 
 const Wrapper = styled.div(({ theme }) => ({
   marginTop: "32px",
@@ -105,6 +106,17 @@ const ShowAllContainer = styled.div(({ theme }) => ({
   [theme.breakpoints.down("md")]: {
     marginBottom: "24px",
   },
+}))
+
+const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
+  color: theme.custom.colors.red,
+  display: "flex",
+  width: "120px",
+  height: "32px",
+  padding: "12px 12px 12px 8px",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "10px",
 }))
 
 const alphabeticalSort = (a: CourseRunEnrollmentV3, b: CourseRunEnrollmentV3) =>
@@ -550,6 +562,10 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
       programEnrollmentsById,
     )
 
+  const programCertificateUrl = programEnrollment?.certificate
+    ? `/certificate/program/${programEnrollment.certificate.uuid}`
+    : null
+
   if (isLoading) {
     return (
       <Stack direction="column">
@@ -578,14 +594,28 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
         <Typography component="h1" variant="h3" paddingBottom="32px">
           {program?.title}
         </Typography>
-        <Typography variant="body2">
-          You have completed
-          <Typography component="span" variant="subtitle2">
-            {" "}
-            {completedCount} of {totalCount} courses{" "}
+        <Stack direction="row" justifyContent="space-between">
+          <Typography variant="body2">
+            You have completed
+            <Typography component="span" variant="subtitle2">
+              {" "}
+              {completedCount} of {totalCount} courses{" "}
+            </Typography>
+            for this program.
           </Typography>
-          for this program.
-        </Typography>
+          {programCertificateUrl && (
+            <ProgramCertificateButton
+              variant="bordered"
+              size="small"
+              startIcon={<RiAwardFill />}
+              href={programCertificateUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Certificate
+            </ProgramCertificateButton>
+          )}
+        </Stack>
       </Stack>
       {requirementSections.map((section, index) => {
         const { completed: sectionCompleted, total: sectionTotal } =

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -110,13 +110,7 @@ const ShowAllContainer = styled.div(({ theme }) => ({
 
 export const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   color: theme.custom.colors.red,
-  display: "flex",
   width: "120px",
-  height: "32px",
-  padding: "12px 12px 12px 8px",
-  justifyContent: "center",
-  alignItems: "center",
-  gap: "10px",
 }))
 
 const alphabeticalSort = (a: CourseRunEnrollmentV3, b: CourseRunEnrollmentV3) =>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -601,8 +601,6 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
               size="small"
               startIcon={<RiAwardFill />}
               href={programCertificateUrl}
-              target="_blank"
-              rel="noopener noreferrer"
             >
               Certificate
             </ProgramCertificateButton>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -562,9 +562,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
       programEnrollmentsById,
     )
 
-  const programCertificateUrl = programEnrollment?.certificate
-    ? `/certificate/program/${programEnrollment.certificate.uuid}`
-    : null
+  const programCertificateUrl = programEnrollment?.certificate?.link ?? null
 
   if (isLoading) {
     return (

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -108,7 +108,7 @@ const ShowAllContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
+export const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   color: theme.custom.colors.red,
   display: "flex",
   width: "120px",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -488,6 +488,8 @@ describe("ProgramAsCourseCard", () => {
   test("clicking Unenroll menu item opens UnenrollProgramDialog with readable_id", async () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(false)
     const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    cardData.courseProgramEnrollment.enrollment_mode = "audit"
     const modalShowSpy = jest.spyOn(NiceModal, "show")
 
     renderWithProviders(
@@ -509,5 +511,29 @@ describe("ProgramAsCourseCard", () => {
       enrollment: cardData.courseProgram.readable_id,
     })
     modalShowSpy.mockRestore()
+  })
+
+  test("does not show Unenroll option in context menu for verified enrollment", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(false)
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    cardData.courseProgramEnrollment.enrollment_mode = "verified"
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const programCard = screen.getByTestId("program-as-course-card")
+    await user.click(within(programCard).getAllByLabelText("More options")[0])
+
+    expect(
+      screen.queryByRole("menuitem", { name: "Unenroll" }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -401,8 +401,7 @@ describe("ProgramAsCourseCard", () => {
       "href",
       `/certificate/program/${certUuid}`,
     )
-    expect(certButton).toHaveAttribute("target", "_blank")
-    expect(certButton).toHaveAttribute("rel", "noopener noreferrer")
+    expect(certButton).not.toHaveAttribute("target")
   })
 
   test("does not display certificate button when program enrollment has no certificate", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -375,6 +375,7 @@ describe("ProgramAsCourseCard", () => {
 
   test("displays certificate button when program enrollment has a certificate", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
     const certUuid = "test-certificate-uuid-123"
     const programEnrollmentWithCert = {
       ...cardData.courseProgramEnrollment,
@@ -406,6 +407,7 @@ describe("ProgramAsCourseCard", () => {
 
   test("does not display certificate button when program enrollment has no certificate", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
     const programEnrollmentNoCert = {
       ...cardData.courseProgramEnrollment,
       certificate: null,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -396,11 +396,12 @@ describe("ProgramAsCourseCard", () => {
 
     await screen.findByText(cardData.courseProgram.title)
     const certButton = screen.getByRole("link", { name: "Certificate" })
-    expect(certButton).toBeInTheDocument()
-    expect(certButton).toHaveAttribute(
-      "href",
-      `/certificate/program/${certUuid}`,
+    const expectedCertHref = programEnrollmentWithCert.certificate.link.replace(
+      /\/$/,
+      "",
     )
+    expect(certButton).toBeInTheDocument()
+    expect(certButton).toHaveAttribute("href", expectedCertHref)
     expect(certButton).not.toHaveAttribute("target")
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -364,4 +364,56 @@ describe("ProgramAsCourseCard", () => {
       screen.queryByRole("dialog", { name: moduleWithRun.title }),
     ).not.toBeInTheDocument()
   })
+
+  test("displays certificate button when program enrollment has a certificate", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    const certUuid = "test-certificate-uuid-123"
+    const programEnrollmentWithCert = {
+      ...cardData.courseProgramEnrollment,
+      certificate: {
+        uuid: certUuid,
+        link: `/certificate/program/${certUuid}/`,
+      },
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollmentWithCert}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const certButton = screen.getByRole("link", { name: "Certificate" })
+    expect(certButton).toBeInTheDocument()
+    expect(certButton).toHaveAttribute(
+      "href",
+      `/certificate/program/${certUuid}`,
+    )
+    expect(certButton).toHaveAttribute("target", "_blank")
+    expect(certButton).toHaveAttribute("rel", "noopener noreferrer")
+  })
+
+  test("does not display certificate button when program enrollment has no certificate", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    const programEnrollmentNoCert = {
+      ...cardData.courseProgramEnrollment,
+      certificate: null,
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollmentNoCert}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const certButton = screen.queryByRole("link", { name: "Certificate" })
+    expect(certButton).not.toBeInTheDocument()
+  })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -13,6 +13,14 @@ import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { waitFor } from "@testing-library/react"
 import invariant from "tiny-invariant"
 import moment from "moment"
+import NiceModal from "@ebay/nice-modal-react"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { UnenrollProgramDialog } from "./DashboardDialogs"
+
+jest.mock("posthog-js/react")
+const mockedUseFeatureFlagEnabled = jest
+  .mocked(useFeatureFlagEnabled)
+  .mockImplementation(() => false)
 
 describe("ProgramAsCourseCard", () => {
   setupLocationMock()
@@ -415,5 +423,89 @@ describe("ProgramAsCourseCard", () => {
     await screen.findByText(cardData.courseProgram.title)
     const certButton = screen.queryByRole("link", { name: "Certificate" })
     expect(certButton).not.toBeInTheDocument()
+  })
+
+  test("shows legacy details link in context menu when product pages flag is disabled", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(false)
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const programCard = screen.getByTestId("program-as-course-card")
+    await user.click(within(programCard).getAllByLabelText("More options")[0])
+
+    const detailsLink = await screen.findByRole("menuitem", {
+      name: "View Course Details",
+    })
+    expect(detailsLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        `/programs/${cardData.courseProgram.readable_id}`,
+      ),
+    )
+    expect(detailsLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("ecom-service=true"),
+    )
+  })
+
+  test("shows product-page details link in context menu when product pages flag is enabled", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const programCard = screen.getByTestId("program-as-course-card")
+    await user.click(within(programCard).getAllByLabelText("More options")[0])
+
+    const detailsLink = await screen.findByRole("menuitem", {
+      name: "View Course Details",
+    })
+    expect(detailsLink).toHaveAttribute(
+      "href",
+      `/courses/p/${cardData.courseProgram.readable_id}`,
+    )
+  })
+
+  test("clicking Unenroll menu item opens UnenrollProgramDialog with readable_id", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(false)
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    const modalShowSpy = jest.spyOn(NiceModal, "show")
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    const programCard = screen.getByTestId("program-as-course-card")
+    await user.click(within(programCard).getAllByLabelText("More options")[0])
+    await user.click(await screen.findByRole("menuitem", { name: "Unenroll" }))
+
+    expect(modalShowSpy).toHaveBeenCalledWith(UnenrollProgramDialog, {
+      title: cardData.courseProgram.title,
+      enrollment: cardData.courseProgram.readable_id,
+    })
+    modalShowSpy.mockRestore()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -466,9 +466,8 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     ancestorProgramEnrollment?.enrollment_mode,
   ].some(isVerifiedEnrollmentMode)
 
-  const programCertificateUrl = courseProgramEnrollment?.certificate
-    ? `/certificate/program/${courseProgramEnrollment.certificate.uuid}`
-    : null
+  const programCertificateUrl =
+    courseProgramEnrollment?.certificate?.link ?? null
 
   // Build context menu
   const menuItems = getContextMenuItems(

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -1,5 +1,13 @@
 import React from "react"
-import { Link, Popover, Stack, Typography, styled } from "ol-components"
+import {
+  Link,
+  Popover,
+  SimpleMenu,
+  SimpleMenuItem,
+  Stack,
+  Typography,
+  styled,
+} from "ol-components"
 import {
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
@@ -23,7 +31,14 @@ import { formatDate } from "ol-utilities"
 import {
   getIdsFromReqTree,
   isVerifiedEnrollmentMode,
+  mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
+import { ActionButton, ButtonLink } from "@mitodl/smoot-design"
+import { RiAwardFill, RiMore2Line } from "@remixicon/react"
+import NiceModal from "@ebay/nice-modal-react"
+import { UnenrollProgramDialog } from "./DashboardDialogs"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { FeatureFlags } from "@/common/feature_flags"
 
 const ProgramCardRoot = styled.div(({ theme }) => ({
   display: "flex",
@@ -126,6 +141,34 @@ const ProgramCardBody = styled.div({
   overflow: "hidden",
   borderRadius: "0 0 8px 8px",
 })
+
+const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
+  color: theme.custom.colors.red,
+  display: "flex",
+  width: "120px",
+  height: "32px",
+  padding: "12px 12px 12px 8px",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "10px",
+}))
+
+const MenuButton = styled(ActionButton)<{
+  status: EnrollmentStatus
+}>(({ theme, status }) => [
+  {
+    marginLeft: "-8px",
+    [theme.breakpoints.down("md")]: {
+      position: "absolute",
+      top: "0",
+      right: "0",
+    },
+  },
+  status !== EnrollmentStatus.Completed &&
+    status !== EnrollmentStatus.Enrolled && {
+      visibility: "hidden",
+    },
+])
 
 const getTimezone = (dateString: string): string => {
   const tz =
@@ -246,19 +289,57 @@ const getRelativeDateContent = (
   }
 }
 
+const getContextMenuItems = (
+  title: string,
+  resource: ProgramAsCourse,
+  additionalItems: SimpleMenuItem[] = [],
+  hideDetailsUrl = false,
+) => {
+  const menuItems = []
+  const detailsUrl = mitxonlineLegacyUrl(`/courses/${resource.readable_id}`)
+
+  const courseMenuItems = []
+
+  if (!hideDetailsUrl && detailsUrl) {
+    courseMenuItems.push({
+      className: "dashboard-card-menu-item",
+      key: "view-course-details",
+      label: "View Course Details",
+      href: detailsUrl,
+    })
+  }
+
+  courseMenuItems.push({
+    className: "dashboard-card-menu-item",
+    key: "unenroll",
+    label: "Unenroll",
+    onClick: () => {
+      NiceModal.show(UnenrollProgramDialog, {
+        title,
+        enrollment: resource.readable_id,
+      })
+    },
+  })
+
+  menuItems.push(...courseMenuItems)
+  return [...menuItems, ...additionalItems]
+}
+
+interface ProgramAsCourse {
+  id: number
+  readable_id: string
+  title?: string | null
+  start_date?: string | null
+  end_date?: string | null
+  courses?: number[]
+  req_tree?: V2ProgramRequirement[]
+}
+
 interface ProgramAsCourseCardProps {
   /**
    * The courselike program to display.
    */
-  courseProgram: {
-    id: number
-    readable_id: string
-    title?: string | null
-    start_date?: string | null
-    end_date?: string | null
-    courses?: number[]
-    req_tree?: V2ProgramRequirement[]
-  }
+  courseProgram: ProgramAsCourse
   /**
    * child courses of the program. These correspond to nodes in the req_tree.
    */
@@ -289,6 +370,7 @@ interface ProgramAsCourseCardProps {
     enrollment_mode?: string | null
   }
   Component?: React.ElementType
+  contextMenuItems?: SimpleMenuItem[]
   className?: string
 }
 
@@ -313,8 +395,12 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
   courseProgramEnrollment,
   ancestorProgramEnrollment,
   Component,
+  contextMenuItems = [],
   className,
 }) => {
+  const useProductPages = useFeatureFlagEnabled(
+    FeatureFlags.MitxOnlineProductPages,
+  )
   const moduleRequirementSection = courseProgram?.req_tree?.find(
     (node) => node.data.node_type === "operator",
   )
@@ -384,6 +470,41 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     ancestorProgramEnrollment?.enrollment_mode,
   ].some(isVerifiedEnrollmentMode)
 
+  const programCertificateUrl = courseProgramEnrollment?.certificate
+    ? `/certificate/program/${courseProgramEnrollment.certificate.uuid}`
+    : null
+
+  const enrollmentStatus = getProgramEnrollmentStatus(
+    courseProgramEnrollment,
+    enrolledCount,
+    completedCount,
+  )
+
+  // Build context menu
+  const menuItems = getContextMenuItems(
+    courseProgram.title ?? "",
+    courseProgram,
+    contextMenuItems,
+    useProductPages ?? false,
+  )
+
+  const contextMenu = (
+    <SimpleMenu
+      items={menuItems}
+      trigger={
+        <MenuButton
+          size="small"
+          variant="text"
+          aria-label="More options"
+          status={enrollmentStatus}
+          hidden={menuItems.length === 0}
+        >
+          <RiMore2Line />
+        </MenuButton>
+      }
+    />
+  )
+
   return (
     <ProgramCardRoot
       as={Component}
@@ -438,6 +559,21 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
           </StatusContainer>
           <Typography variant="subtitle2">{courseProgram?.title}</Typography>
         </ProgramCardHeaderInner>
+        <>
+          {programCertificateUrl && (
+            <ProgramCertificateButton
+              variant="bordered"
+              size="small"
+              startIcon={<RiAwardFill />}
+              href={programCertificateUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Certificate
+            </ProgramCertificateButton>
+          )}
+          {contextMenu}
+        </>
       </ProgramCardHeaderOuter>
       <ProgramCardSubHeader>
         <ProgramCardSubHeaderText variant="subtitle3">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -474,12 +474,6 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     ? `/certificate/program/${courseProgramEnrollment.certificate.uuid}`
     : null
 
-  const enrollmentStatus = getProgramEnrollmentStatus(
-    courseProgramEnrollment,
-    enrolledCount,
-    completedCount,
-  )
-
   // Build context menu
   const menuItems = getContextMenuItems(
     courseProgram.title ?? "",
@@ -496,7 +490,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
           size="small"
           variant="text"
           aria-label="More options"
-          status={enrollmentStatus}
+          status={programEnrollmentStatus}
           hidden={menuItems.length === 0}
         >
           <RiMore2Line />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -40,6 +40,7 @@ import { UnenrollProgramDialog } from "./DashboardDialogs"
 import { ProgramCertificateButton } from "./EnrollmentDisplay"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
+import { programPageView } from "@/common/urls"
 
 const ProgramCardRoot = styled.div(({ theme }) => ({
   display: "flex",
@@ -283,14 +284,19 @@ const getContextMenuItems = (
   title: string,
   resource: ProgramAsCourse,
   additionalItems: SimpleMenuItem[] = [],
-  hideDetailsUrl = false,
+  useProductPages = false,
 ) => {
   const menuItems = []
-  const detailsUrl = mitxonlineLegacyUrl(`/courses/${resource.readable_id}`)
+  const detailsUrl = useProductPages
+    ? programPageView({
+        readable_id: resource.readable_id,
+        display_mode: "course",
+      })
+    : mitxonlineLegacyUrl(`/programs/${resource.readable_id}`)
 
   const courseMenuItems = []
 
-  if (!hideDetailsUrl && detailsUrl) {
+  if (detailsUrl) {
     courseMenuItems.push({
       className: "dashboard-card-menu-item",
       key: "view-course-details",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -33,10 +33,11 @@ import {
   isVerifiedEnrollmentMode,
   mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
-import { ActionButton, ButtonLink } from "@mitodl/smoot-design"
+import { ActionButton } from "@mitodl/smoot-design"
 import { RiAwardFill, RiMore2Line } from "@remixicon/react"
 import NiceModal from "@ebay/nice-modal-react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
+import { ProgramCertificateButton } from "./EnrollmentDisplay"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 
@@ -141,17 +142,6 @@ const ProgramCardBody = styled.div({
   overflow: "hidden",
   borderRadius: "0 0 8px 8px",
 })
-
-const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
-  color: theme.custom.colors.red,
-  display: "flex",
-  width: "120px",
-  height: "32px",
-  padding: "12px 12px 12px 8px",
-  justifyContent: "center",
-  alignItems: "center",
-  gap: "10px",
-}))
 
 const MenuButton = styled(ActionButton)<{
   status: EnrollmentStatus

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -283,6 +283,7 @@ const getRelativeDateContent = (
 const getContextMenuItems = (
   title: string,
   resource: ProgramAsCourse,
+  enrollmentMode: string | null | undefined,
   additionalItems: SimpleMenuItem[] = [],
   useProductPages = false,
 ) => {
@@ -305,17 +306,19 @@ const getContextMenuItems = (
     })
   }
 
-  courseMenuItems.push({
-    className: "dashboard-card-menu-item",
-    key: "unenroll",
-    label: "Unenroll",
-    onClick: () => {
-      NiceModal.show(UnenrollProgramDialog, {
-        title,
-        enrollment: resource.readable_id,
-      })
-    },
-  })
+  if (enrollmentMode && !isVerifiedEnrollmentMode(enrollmentMode)) {
+    courseMenuItems.push({
+      className: "dashboard-card-menu-item",
+      key: "unenroll",
+      label: "Unenroll",
+      onClick: () => {
+        NiceModal.show(UnenrollProgramDialog, {
+          title,
+          enrollment: resource.readable_id,
+        })
+      },
+    })
+  }
 
   menuItems.push(...courseMenuItems)
   return [...menuItems, ...additionalItems]
@@ -473,6 +476,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
   const menuItems = getContextMenuItems(
     courseProgram.title ?? "",
     courseProgram,
+    courseProgramEnrollment?.enrollment_mode,
     contextMenuItems,
     useProductPages ?? false,
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -559,8 +559,6 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
               size="small"
               startIcon={<RiAwardFill />}
               href={programCertificateUrl}
-              target="_blank"
-              rel="noopener noreferrer"
             >
               Certificate
             </ProgramCertificateButton>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11041

### Description (What does it do?)
This PR adds a certificate button link to both the "program as course" cards on the dashboard home page's My Learning section as well as the dashboard's individual program enrollment display. A context menu was also added to the "program as course" cards.

### Screenshots (if appropriate):
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/6c7991ee-8d5f-4496-bd7a-2d232742d366" />
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/4987490a-e5a8-40ba-ba53-fbf9072d3453" />
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/233060b7-1ae8-4bd3-aa32-a0ce5fea632d" />
<img width="2494" height="1408" alt="image" src="https://github.com/user-attachments/assets/96ebee69-de79-4c09-bbe9-f9aa9484a15c" />

### How can this be tested?
- Ensure you have MITx Online set up and connected to Learn based on the instructions in the README
- Your test user should have at least:
  - One "program as course" enrollment directly
  - One normal program enrollment
  - Completion / certificate for both enrollments
- Log into Learn and go to the dashboard. Ensure that you see a card for both your "program as course" enrollment as well as a card for the program enrollment
- Verify that the certificate button on the program as course card links you to the appropriate certificate
- Verify that the certificate link on the normal program card links to the appropriate certificate as well
- Click View Program on the normal program card and verify that the certificate link button in the upper right links to the same certificate