### PR TITLE
use ocw videos and youtube playlists

### DIFF
--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/FeaturedVideo.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/FeaturedVideo.tsx
@@ -184,7 +184,9 @@ const FeaturedVideo: React.FC<FeaturedVideoProps> = ({
   totalVideos,
   totalTime,
 }) => {
-  const imageUrl = video.image?.url ?? null
+  const imageUrl =
+    video.image?.url ?? video.content_files?.[0]?.image_src ?? null
+
   const duration = video.video?.duration
     ? formatDurationClockTime(video.video.duration)
     : null
@@ -231,7 +233,9 @@ const FeaturedVideo: React.FC<FeaturedVideoProps> = ({
                 </Link>
               </FeaturedTitle>
               {description && (
-                <FeaturedDescription>{description}</FeaturedDescription>
+                <FeaturedDescription
+                  dangerouslySetInnerHTML={{ __html: description }}
+                />
               )}
             </TextSide>
           ) : (

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
@@ -227,9 +227,12 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
               {episode.title}
             </EpisodeTitleLink>
 
-            <EpisodeDescription variant="body2">
-              {episode.description}
-            </EpisodeDescription>
+            <EpisodeDescription
+              variant="body2"
+              dangerouslySetInnerHTML={{
+                __html: episode.description ?? "",
+              }}
+            />
           </EpisodeInfo>
 
           <EpisodeRight>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
@@ -142,8 +142,11 @@ type VideoCardProps = {
 
 const VideoCard: React.FC<VideoCardProps> = ({ resource, href }) => {
   const [imgError, setImgError] = useState(false)
-  const imageUrl =
-    !imgError && resource.image?.url ? resource.image.url : PLACEHOLDER_IMG
+  const imageUrl = !imgError
+    ? (resource?.image?.url ??
+      resource.content_files?.[0]?.image_src ??
+      PLACEHOLDER_IMG)
+    : PLACEHOLDER_IMG
   const description = resource.description ?? ""
   const duration = resource.video?.duration
     ? formatDurationClockTime(resource.video.duration)
@@ -171,7 +174,7 @@ const VideoCard: React.FC<VideoCardProps> = ({ resource, href }) => {
         </CardTitleRow>
         <CardMetaRow>
           <CardMetaGroup>
-            <CardMetaValue>{description}</CardMetaValue>
+            <CardMetaValue dangerouslySetInnerHTML={{ __html: description }} />
           </CardMetaGroup>
         </CardMetaRow>
       </CardContent>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
@@ -388,7 +388,13 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
 
   const sources = useMemo(
     () =>
-      video ? resolveVideoSources(video.video?.streaming_url, video.url) : [],
+      video
+        ? resolveVideoSources(
+            video.video?.streaming_url,
+            video.url,
+            video.content_files?.[0]?.youtube_id,
+          )
+        : [],
     [video],
   )
 
@@ -523,6 +529,7 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
                   sources[0]?.type === "video/youtube"
                     ? undefined
                     : (video?.video?.cover_image_url ??
+                      video?.content_files?.[0]?.image_src ??
                       video?.image?.url ??
                       undefined)
                 }
@@ -532,10 +539,12 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
                 ariaLabel={`Video: ${videoTitleLabel}`}
                 ariaDescribedBy="video-description"
               />
-            ) : video?.image?.url ? (
+            ) : video?.image?.url || video?.content_files?.[0]?.image_src ? (
               <ThumbnailWrapper>
                 <Image
-                  src={video.image.url}
+                  src={
+                    (video?.image?.url ?? video?.content_files?.[0]?.image_src)!
+                  }
                   alt={videoThumbnailAlt}
                   fill
                   sizes="100vw"
@@ -556,9 +565,10 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
           <BorderLine />
 
           {!isLoading && video?.description && (
-            <DescriptionText id="video-description">
-              {video?.description}
-            </DescriptionText>
+            <DescriptionText
+              id="video-description"
+              dangerouslySetInnerHTML={{ __html: video.description }}
+            />
           )}
 
           {!isLoading && !video?.description && (
@@ -627,7 +637,10 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
                       const itemDuration = item.video?.duration
                         ? formatDurationClockTime(item.video.duration)
                         : null
-                      const imageUrl = item.image?.url ?? null
+                      const imageUrl =
+                        item.image?.url ??
+                        item.content_files?.[0]?.image_src ??
+                        null
                       const itemTopicNames = (item.topics ?? [])
                         .map((topic) => topic.name)
                         .filter(Boolean)
@@ -660,9 +673,11 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
                                 {item.title}
                               </MoreFromItemTitle>
                               {item.description && (
-                                <MoreFromItemMeta>
-                                  {item.description}
-                                </MoreFromItemMeta>
+                                <MoreFromItemMeta
+                                  dangerouslySetInnerHTML={{
+                                    __html: item.description,
+                                  }}
+                                />
                               )}
                             </MoreFromTextSide>
                           </MoreFromItem>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.tsx
@@ -64,7 +64,13 @@ const VideoSeriesDetailPage: React.FC<VideoSeriesDetailPageProps> = ({
 
   const sources = useMemo(
     () =>
-      video ? resolveVideoSources(video.video?.streaming_url, video.url) : [],
+      video
+        ? resolveVideoSources(
+            video.video?.streaming_url,
+            video.url,
+            video.content_files?.[0]?.youtube_id,
+          )
+        : [],
     [video],
   )
 
@@ -274,9 +280,10 @@ const VideoSeriesDetailPage: React.FC<VideoSeriesDetailPageProps> = ({
 
           {/* Description */}
           {!isLoading && video?.description && (
-            <Styled.DescriptionText id="video-description">
-              {video.description}
-            </Styled.DescriptionText>
+            <Styled.DescriptionText
+              id="video-description"
+              dangerouslySetInnerHTML={{ __html: video.description }}
+            />
           )}
 
           {!isLoading && !video?.description && (

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.test.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.test.ts
@@ -5,6 +5,7 @@ describe("resolveVideoSources", () => {
     const result = resolveVideoSources(
       "https://cdn.example.com/video/index.m3u8",
       null,
+      null,
     )
     expect(result).toEqual([
       {
@@ -17,6 +18,7 @@ describe("resolveVideoSources", () => {
   it("returns DASH source for .mpd streaming URL", () => {
     const result = resolveVideoSources(
       "https://cdn.example.com/video/manifest.mpd",
+      null,
       null,
     )
     expect(result).toEqual([
@@ -31,6 +33,7 @@ describe("resolveVideoSources", () => {
     const result = resolveVideoSources(
       "https://cdn.example.com/video/clip.mp4",
       null,
+      null,
     )
     expect(result).toEqual([
       { src: "https://cdn.example.com/video/clip.mp4", type: "video/mp4" },
@@ -41,6 +44,7 @@ describe("resolveVideoSources", () => {
     const result = resolveVideoSources(
       "https://cdn.example.com/video/stream",
       "https://www.youtube.com/watch?v=abc",
+      null,
     )
     // streamingUrl takes precedence over pageUrl
     expect(result).toEqual([
@@ -52,6 +56,7 @@ describe("resolveVideoSources", () => {
     const result = resolveVideoSources(
       null,
       "https://www.youtube.com/watch?v=abc123",
+      null,
     )
     expect(result).toEqual([
       { src: "https://www.youtube.com/watch?v=abc123", type: "video/youtube" },
@@ -59,23 +64,47 @@ describe("resolveVideoSources", () => {
   })
 
   it("returns YouTube source when pageUrl is a youtu.be short link", () => {
-    const result = resolveVideoSources(null, "https://youtu.be/abc123")
+    const result = resolveVideoSources(null, "https://youtu.be/abc123", null)
     expect(result).toEqual([
       { src: "https://youtu.be/abc123", type: "video/youtube" },
     ])
   })
 
-  it("returns an empty array when both arguments are null", () => {
-    expect(resolveVideoSources(null, null)).toEqual([])
+  it("returns YouTube source from youtubeId when no streaming URL", () => {
+    const result = resolveVideoSources(null, null, "dQw4w9WgXcQ")
+    expect(result).toEqual([
+      {
+        src: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        type: "video/youtube",
+      },
+    ])
   })
 
-  it("returns an empty array when both arguments are undefined", () => {
-    expect(resolveVideoSources(undefined, undefined)).toEqual([])
-  })
-
-  it("returns an empty array when there is no streaming URL and pageUrl is not a YouTube link", () => {
-    expect(resolveVideoSources(null, "https://ocw.mit.edu/some-video")).toEqual(
-      [],
+  it("prefers youtubeId over a non-YouTube pageUrl", () => {
+    const result = resolveVideoSources(
+      null,
+      "https://ocw.mit.edu/some-video",
+      "dQw4w9WgXcQ",
     )
+    expect(result).toEqual([
+      {
+        src: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        type: "video/youtube",
+      },
+    ])
+  })
+
+  it("returns an empty array when all arguments are null", () => {
+    expect(resolveVideoSources(null, null, null)).toEqual([])
+  })
+
+  it("returns an empty array when all arguments are undefined", () => {
+    expect(resolveVideoSources(undefined, undefined, undefined)).toEqual([])
+  })
+
+  it("returns an empty array when there is no streaming URL, no youtubeId, and pageUrl is not a YouTube link", () => {
+    expect(
+      resolveVideoSources(null, "https://ocw.mit.edu/some-video", null),
+    ).toEqual([])
   })
 })

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/videoSources.ts
@@ -10,6 +10,7 @@ import type { VideoJsSource } from "./VideoJsPlayer"
 export function resolveVideoSources(
   streamingUrl: string | null | undefined,
   pageUrl: string | null | undefined,
+  youtubeId: string | null | undefined,
 ): VideoJsSource[] {
   if (streamingUrl) {
     // HLS
@@ -22,6 +23,15 @@ export function resolveVideoSources(
     }
     // MP4 or generic
     return [{ src: streamingUrl, type: "video/mp4" }]
+  }
+
+  if (youtubeId) {
+    return [
+      {
+        src: `https://www.youtube.com/watch?v=${youtubeId}`,
+        type: "video/youtube",
+      },
+    ]
   }
 
   if (pageUrl && /youtube\.com|youtu\.be/.test(pageUrl)) {

--- a/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
@@ -529,7 +529,13 @@ const INFO_ITEMS: InfoItemConfig = [
     label: "Parent Course:",
     Icon: RiBookLine,
     selector: (resource: LearningResource) => {
-      return formattedParentCourseName(resource)
+      const name = formattedParentCourseName(resource)
+      if (!name || !resource.url) return name
+      return (
+        <Link href={resource.url} color="red" size="small">
+          {name}
+        </Link>
+      )
     },
   },
   {

--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Iterable
 from typing import NamedTuple
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.cache import caches
 from django.db import transaction
@@ -11,6 +12,7 @@ from django.db.models import Q
 
 from learning_resources.constants import (
     CONTENT_TYPE_PAGE,
+    OCW_CONTENT_CATEGORY_LECTURE_VIDEOS,
     OCW_COURSE_CONTENT_CATEGORY_MAPPING,
     VIDEO_CONTENT_CATEGORIES,
     LearningResourceDelivery,
@@ -1030,11 +1032,20 @@ def load_learning_materials(
     """
     material_ids = []
 
+    if settings.CREATE_OCW_LEARNING_MATERIALS:
+        promoted_ocw_file_types = set(OCW_COURSE_CONTENT_CATEGORY_MAPPING.keys())
+    elif settings.SHOW_OCW_LECTURE_VIDEOS:
+        promoted_ocw_file_types = {OCW_CONTENT_CATEGORY_LECTURE_VIDEOS}
+    else:
+        promoted_ocw_file_types = set()
+
     for content_file_id in content_file_ids:
         content_file = ContentFile.objects.get(id=content_file_id)
-        learning_material_tags = set(
-            content_file.content_tags.values_list("name", flat=True)
-        ) & set(OCW_COURSE_CONTENT_CATEGORY_MAPPING.keys())
+
+        learning_material_tags = (
+            set(content_file.content_tags.values_list("name", flat=True))
+            & promoted_ocw_file_types
+        )
         if content_file.content_type != CONTENT_TYPE_PAGE and learning_material_tags:
             material_ids.append(
                 load_learning_material(course_run, content_file, learning_material_tags)
@@ -1330,6 +1341,7 @@ def load_video(video_data: dict) -> LearningResource:
     video_fields = video_data.pop("video", {})
     image_data = video_data.pop("image", None)
     video_data["resource_category"] = LearningResourceType.video.value
+    video_data.pop("youtube_id", None)
 
     with transaction.atomic():
         (
@@ -1443,7 +1455,7 @@ def load_documents(
     return document_resources
 
 
-def load_ovs_playlist(playlist_data: dict) -> LearningResource:
+def load_ovs_playlist(playlist_data: dict) -> LearningResource | None:
     """
     Load a single OVS playlist (collection) and its videos into the database.
 
@@ -1451,7 +1463,8 @@ def load_ovs_playlist(playlist_data: dict) -> LearningResource:
         playlist_data (dict): playlist data including nested videos list
 
     Returns:
-        LearningResource: the created or updated playlist resource
+        LearningResource | None: the created or updated playlist resource,
+            or None if not all videos could be matched
     """
     channel, _ = VideoChannel.objects.get_or_create(
         channel_id="ovs",
@@ -1519,7 +1532,9 @@ def load_ovs_playlists(playlists_data: iter) -> list[LearningResource]:
     return playlists
 
 
-def load_playlist(video_channel: VideoChannel, playlist_data: dict) -> LearningResource:
+def load_playlist(
+    video_channel: VideoChannel, playlist_data: dict
+) -> LearningResource | None:
     """
     Load a video playlist into the database
 
@@ -1528,13 +1543,38 @@ def load_playlist(video_channel: VideoChannel, playlist_data: dict) -> LearningR
         playlist_data (dict): the video playlist
 
     Returns:
-        LearningResource: the created or updated playlist resource
+        LearningResource | None: the created or updated playlist resource,
+            or None if create_videos is False and not all videos could be matched
     """
 
     playlist_id = playlist_data.pop("playlist_id")
     thumbnail_data = playlist_data.pop("image", None)
     videos_data = playlist_data.pop("videos", [])
     offered_bys_data = playlist_data.pop("offered_by", None)
+    create_videos = playlist_data.pop("create_videos", True)
+
+    if create_videos:
+        video_resources = load_videos(videos_data)
+    else:
+        video_resources = find_existing_videos(videos_data)
+
+        if video_resources is None:
+            log.info(
+                "Skipping playlist %s: not all videos have matching video. ",
+                playlist_id,
+            )
+
+            existing_resource = LearningResource.objects.filter(
+                readable_id=playlist_id,
+                resource_type=LearningResourceType.video_playlist.name,
+                published=True,
+            ).first()
+            if existing_resource:
+                existing_resource.published = False
+                existing_resource.save()
+                update_index(existing_resource, newly_created=False)
+            return None
+
     playlist_data["resource_category"] = LearningResourceType.video_playlist.value
     with transaction.atomic():
         if thumbnail_data:
@@ -1557,10 +1597,13 @@ def load_playlist(video_channel: VideoChannel, playlist_data: dict) -> LearningR
         )
         load_offered_by(playlist_resource, offered_bys_data)
 
-    video_resources = load_videos(videos_data)
     load_topics(playlist_resource, most_common_topics(video_resources))
+
+    # Unpublish any videos from youtube that are no longer in the playlist
+    # OCW content file videos are removed from the playlist but not unpublished
     unpublished_videos = playlist_resource.resources.filter(
         resource_type=LearningResourceType.video.name,
+        platform=PlatformType.youtube.name,
         published=True,
     ).exclude(id__in=[video.id for video in video_resources])
     unpublished_video_ids = list(unpublished_videos.values_list("id", flat=True))
@@ -1584,6 +1627,42 @@ def load_playlist(video_channel: VideoChannel, playlist_data: dict) -> LearningR
     return playlist_resource
 
 
+def find_existing_videos(videos_data: list[dict]) -> list[LearningResource] | None:
+    """
+    Find existing video resources matching the given video data.
+
+    Args:
+        videos_data (list of dict): list of video data dicts
+
+    Returns:
+        list of LearningResource | None: list of existing video resources,
+            or None if any video is not found
+    """
+    videos = []
+    for video_data in videos_data:
+        youtube_id = video_data.get("youtube_id")
+        if not youtube_id:
+            return None
+        learning_resource = (
+            ContentFile.objects.filter(
+                youtube_id=youtube_id,
+                direct_learning_resource__resource_type=LearningResourceType.video.name,
+                direct_learning_resource__published=True,
+            )
+            .select_related("direct_learning_resource")
+            .first()
+        )
+        if learning_resource:
+            videos.append(learning_resource.direct_learning_resource)
+        else:
+            log.info(
+                "No existing published video resource found for youtube_id=%s",
+                youtube_id,
+            )
+            return None
+    return videos
+
+
 def load_playlists(
     video_channel: VideoChannel, playlists_data: iter
 ) -> list[LearningResource]:
@@ -1599,7 +1678,12 @@ def load_playlists(
             the created or updated LearningResources for the playlists
     """
     playlists = [
-        load_playlist(video_channel, playlist_data) for playlist_data in playlists_data
+        playlist
+        for playlist in (
+            load_playlist(video_channel, playlist_data)
+            for playlist_data in playlists_data
+        )
+        if playlist is not None
     ]
     playlist_ids = [playlist.id for playlist in playlists]
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -34,6 +34,7 @@ from learning_resources.etl.exceptions import ExtractException
 from learning_resources.etl.loaders import (
     ProgramLoadResult,
     calculate_completeness,
+    find_existing_videos,
     load_content_file,
     load_content_files,
     load_course,
@@ -2094,6 +2095,7 @@ def test_load_video(mocker, video_exists, is_published, pass_topics):
         "offered_by": {"code": offered_by.code},
         "published": is_published,
         "video": {"duration": video_resource.video.duration},
+        "youtube_id": "youtube123",
     }
     if pass_topics:
         props["topics"] = expected_topics
@@ -2210,6 +2212,200 @@ def test_load_playlist(mocker, playlist_exists, mock_get_similar_topics_qdrant):
             [],
             LearningResourceType.video.name,
         )
+
+
+def test_load_playlist_removed_videos_unpublished(
+    mocker, mock_get_similar_topics_qdrant
+):
+    """Test that load_playlist unpublishes removed YouTube videos but not OCW videos"""
+    expected_topics = [{"name": "Biology"}]
+    LearningResourceTopicFactory.create(name="Biology")
+    mocker.patch(
+        "learning_resources.etl.loaders.most_common_topics",
+        return_value=expected_topics,
+    )
+    mock_bulk_unpublish = mocker.patch(
+        "learning_resources.etl.loaders.bulk_resources_unpublished_actions",
+    )
+
+    channel = VideoChannelFactory.create()
+    ocw_platform = LearningResourcePlatformFactory.create(code=PlatformType.ocw.name)
+
+    # Create an existing playlist with both a YouTube and OCW video
+    playlist = VideoPlaylistFactory.create(channel=channel).learning_resource
+
+    youtube_video = VideoFactory.create().learning_resource
+    ocw_video = LearningResourceFactory.create(
+        resource_type=LearningResourceType.video.name,
+        platform=ocw_platform,
+        published=True,
+    )
+
+    playlist.resources.add(
+        youtube_video,
+        through_defaults={
+            "relation_type": LearningResourceRelationTypes.PLAYLIST_VIDEOS,
+            "position": 0,
+        },
+    )
+    playlist.resources.add(
+        ocw_video,
+        through_defaults={
+            "relation_type": LearningResourceRelationTypes.PLAYLIST_VIDEOS,
+            "position": 1,
+        },
+    )
+
+    # Load playlist with new videos (excluding the old youtube and ocw videos)
+    new_video_resources = [
+        video.learning_resource for video in VideoFactory.build_batch(2)
+    ]
+    videos_data = [
+        {
+            **model_to_dict(video, exclude=non_transformable_attributes),
+            "platform": PlatformType.youtube.name,
+            "offered_by": {"code": LearningResourceOfferorFactory.create().code},
+        }
+        for video in new_video_resources
+    ]
+
+    props = {
+        **model_to_dict(playlist, exclude=["topics", *non_transformable_attributes]),
+        "platform": PlatformType.youtube.name,
+        "offered_by": {"code": LearningResourceOfferorFactory.create().code},
+        "playlist_id": playlist.readable_id,
+        "url": f"https://youtube.com/playlist?list={playlist.readable_id}",
+        "image": {
+            "url": f"https://i.ytimg.com/vi/{playlist.readable_id}/hqdefault.jpg",
+            "alt": playlist.title,
+        },
+        "videos": videos_data,
+    }
+
+    load_playlist(channel, props)
+
+    # YouTube video should be unpublished
+    youtube_video.refresh_from_db()
+    assert youtube_video.published is False
+
+    # OCW video should NOT be unpublished
+    ocw_video.refresh_from_db()
+    assert ocw_video.published is True
+
+    # bulk_resources_unpublished_actions called only with the youtube video
+    mock_bulk_unpublish.assert_called_once_with(
+        [youtube_video.id],
+        LearningResourceType.video.name,
+    )
+
+
+@pytest.mark.parametrize("all_videos_exist", [True, False])
+def test_find_existing_videos(all_videos_exist):
+    """Test that find_existing_videos returns matching video resources or None"""
+    video_resource_1 = VideoFactory.create().learning_resource
+    video_resource_2 = VideoFactory.create().learning_resource
+    run = LearningResourceRunFactory.create()
+
+    # Create content files with youtube_id linked to video resources
+    ContentFileFactory.create(
+        run=run,
+        youtube_id="yt_id_1",
+        direct_learning_resource=video_resource_1,
+    )
+    ContentFileFactory.create(
+        run=run,
+        youtube_id="yt_id_2",
+        direct_learning_resource=video_resource_2,
+    )
+
+    if all_videos_exist:
+        videos_data = [
+            {"youtube_id": "yt_id_1"},
+            {"youtube_id": "yt_id_2"},
+        ]
+        result = find_existing_videos(videos_data)
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].id == video_resource_1.id
+        assert result[1].id == video_resource_2.id
+    else:
+        videos_data = [
+            {"youtube_id": "yt_id_1"},
+            {"youtube_id": "missing_yt_id"},
+        ]
+        result = find_existing_videos(videos_data)
+        assert result is None
+
+
+def test_find_existing_videos_empty_list():
+    """Test that find_existing_videos returns an empty list for empty input"""
+    result = find_existing_videos([])
+    assert result == []
+
+
+@pytest.mark.parametrize("all_videos_exist", [True, False])
+def test_load_playlist_create_videos_false(
+    mocker, all_videos_exist, mock_get_similar_topics_qdrant
+):
+    """Test load_playlist with create_videos=False uses find_existing_videos"""
+    expected_topics = [{"name": "Biology"}, {"name": "Physics"}]
+    [
+        LearningResourceTopicFactory.create(name=topic["name"])
+        for topic in expected_topics
+    ]
+    mocker.patch(
+        "learning_resources.etl.loaders.most_common_topics",
+        return_value=expected_topics,
+    )
+    mocker.patch(
+        "learning_resources.etl.loaders.bulk_resources_unpublished_actions",
+    )
+    mock_update_index = mocker.patch(
+        "learning_resources.etl.loaders.update_index",
+    )
+
+    channel = VideoChannelFactory.create()
+    run = LearningResourceRunFactory.create()
+
+    if all_videos_exist:
+        video_resource = VideoFactory.create().learning_resource
+        ContentFileFactory.create(
+            run=run,
+            youtube_id="yt_existing",
+            direct_learning_resource=video_resource,
+        )
+        videos_data = [{"youtube_id": "yt_existing"}]
+    else:
+        videos_data = [{"youtube_id": "yt_missing"}]
+
+    playlist = VideoPlaylistFactory.build().learning_resource
+    props = {
+        **model_to_dict(
+            playlist,
+            exclude=["topics", "offered_by", *non_transformable_attributes],
+        ),
+        "platform": PlatformType.youtube.name,
+        "playlist_id": playlist.readable_id,
+        "url": f"https://youtube.com/playlist?list={playlist.readable_id}",
+        "image": {
+            "url": f"https://i.ytimg.com/vi/{playlist.readable_id}/hqdefault.jpg",
+            "alt": playlist.title,
+        },
+        "videos": videos_data,
+        "create_videos": False,
+    }
+
+    result = load_playlist(channel, props)
+
+    if all_videos_exist:
+        assert isinstance(result, LearningResource)
+        assert result.resources.count() == 1
+        assert result.video_playlist.channel == channel
+    else:
+        assert result is None
+        # update_index should not be called for the playlist
+        # (only possibly for unpublishing an existing one)
+        mock_update_index.assert_not_called()
 
 
 def test_load_playlists_unpublish(mocker):
@@ -2985,11 +3181,24 @@ def test_load_documents(mocker, climate_platform, mock_get_similar_topics_qdrant
 
 
 @pytest.mark.django_db
-def test_load_learning_materials(mocker):
+@pytest.mark.parametrize(
+    ("create_ocw_learning_materials", "show_ocw_lecture_videos"),
+    [
+        (True, False),
+        (False, True),
+        (False, False),
+    ],
+)
+def test_load_learning_materials(
+    mocker, settings, create_ocw_learning_materials, show_ocw_lecture_videos
+):
     """
     Test that load_learning_materials runs load_learning_material
-    if a ocw content file has content_tags in OCW_COURSE_CONTENT_CATEGORY_MAPPING
+    based on CREATE_OCW_LEARNING_MATERIALS and SHOW_OCW_LECTURE_VIDEOS settings
     """
+
+    settings.CREATE_OCW_LEARNING_MATERIALS = create_ocw_learning_materials
+    settings.SHOW_OCW_LECTURE_VIDEOS = show_ocw_lecture_videos
 
     ocw = LearningResourcePlatformFactory.create(code=PlatformType.ocw.name)
     ocw_course = CourseFactory.create(
@@ -3000,6 +3209,7 @@ def test_load_learning_materials(mocker):
     relevant_content_tag = LearningResourceContentTagFactory.create(
         name="Programming Assignments"
     )
+    lecture_video_tag = LearningResourceContentTagFactory.create(name="Lecture Videos")
     irrelevant_content_tag = LearningResourceContentTagFactory.create(name="Syllabus")
 
     no_longer_relevant_resource = LearningResourceFactory.create()
@@ -3007,6 +3217,12 @@ def test_load_learning_materials(mocker):
     learning_material_content_file = ContentFileFactory.create(
         run=ocw_course.learning_resource.runs.first(),
         content_tags=[relevant_content_tag],
+        content_type=CONTENT_TYPE_FILE,
+    )
+
+    lecture_video_content_file = ContentFileFactory.create(
+        run=ocw_course.learning_resource.runs.first(),
+        content_tags=[lecture_video_tag],
         content_type=CONTENT_TYPE_FILE,
     )
 
@@ -3025,32 +3241,53 @@ def test_load_learning_materials(mocker):
         course_run=ocw_course.learning_resource.runs.first(),
         content_file_ids=[
             learning_material_content_file.id,
+            lecture_video_content_file.id,
             other_content_file.id,
         ],
     )
 
-    assert load_learning_materials_spy.call_count == 1
-    load_learning_materials_spy.assert_called_with(
-        ocw_course.learning_resource.runs.first(),
-        learning_material_content_file,
-        {"Programming Assignments"},
-    )
-
-    learning_material_content_file.refresh_from_db()
-
-    learning_material = learning_material_content_file.direct_learning_resource
-
-    resource_relationships = ocw_course.learning_resource.children.all()
-
-    assert resource_relationships.count() == 1
-
-    assert resource_relationships.first().child.id == learning_material.id
-    assert (
-        resource_relationships.first().relation_type
-        == LearningResourceRelationTypes.COURSE_LEARNING_MATERIALS.value
-    )
-
-    assert mock_index.call_count == 2
+    if create_ocw_learning_materials:
+        # Both programming assignments and lecture videos are promoted
+        assert load_learning_materials_spy.call_count == 2
+        load_learning_materials_spy.assert_any_call(
+            ocw_course.learning_resource.runs.first(),
+            learning_material_content_file,
+            {"Programming Assignments"},
+        )
+        load_learning_materials_spy.assert_any_call(
+            ocw_course.learning_resource.runs.first(),
+            lecture_video_content_file,
+            {"Lecture Videos"},
+        )
+        resource_relationships = ocw_course.learning_resource.children.all()
+        assert resource_relationships.count() == 2
+        # 2 load_learning_material calls (each calls update_index)
+        # + 1 for unpublishing no_longer_relevant_resource
+        assert mock_index.call_count == 3
+    elif show_ocw_lecture_videos:
+        # Only lecture videos are promoted
+        assert load_learning_materials_spy.call_count == 1
+        load_learning_materials_spy.assert_called_with(
+            ocw_course.learning_resource.runs.first(),
+            lecture_video_content_file,
+            {"Lecture Videos"},
+        )
+        resource_relationships = ocw_course.learning_resource.children.all()
+        assert resource_relationships.count() == 1
+        lecture_video_content_file.refresh_from_db()
+        assert (
+            resource_relationships.first().child.id
+            == lecture_video_content_file.direct_learning_resource.id
+        )
+        # 1 load_learning_material call + 1 for unpublishing no_longer_relevant_resource
+        assert mock_index.call_count == 2
+    else:
+        # Nothing is promoted
+        assert load_learning_materials_spy.call_count == 0
+        resource_relationships = ocw_course.learning_resource.children.all()
+        assert resource_relationships.count() == 0
+        # 1 for unpublishing no_longer_relevant_resource
+        assert mock_index.call_count == 1
 
     no_longer_relevant_resource.refresh_from_db()
     assert no_longer_relevant_resource.published is False

--- a/learning_resources/etl/pipelines.py
+++ b/learning_resources/etl/pipelines.py
@@ -160,7 +160,10 @@ def ocw_courses_etl(
                         calc_completeness=True,
                     )
 
-                    if settings.CREATE_OCW_LEARNING_MATERIALS:
+                    if (
+                        settings.CREATE_OCW_LEARNING_MATERIALS
+                        or settings.SHOW_OCW_LECTURE_VIDEOS
+                    ):
                         loaders.load_learning_materials(course_run, content_file_ids)
             else:
                 log.info("No course data found for %s", url_path)

--- a/learning_resources/etl/youtube.py
+++ b/learning_resources/etl/youtube.py
@@ -192,7 +192,11 @@ def extract_playlist_items(
 
 
 def _extract_playlists(
-    youtube_client: Resource, request: BatchHttpRequest, playlist_configs: dict
+    youtube_client: Resource,
+    request: BatchHttpRequest,
+    playlist_configs: dict,
+    *,
+    create_videos_channel_setting: bool,
 ) -> Generator[tuple, None, None]:
     """
     Extract a list of playlists
@@ -201,6 +205,8 @@ def _extract_playlists(
         youtube_client (Resource): Youtube api client
         request (BatchHttpRequest): Youtube api BatchHttpRequest object
         playlist_configs (dict): dict of playlist configurations
+        create_videos_channel_setting (bool): whether the channel config
+            is to create videos from youtube data
 
     Returns:
         A generator that yields playlist data
@@ -216,15 +222,20 @@ def _extract_playlists(
                 playlist_id = playlist_data["id"]
                 if playlist_id in playlist_configs:
                     playlist_config = playlist_configs[playlist_id]
+                    create_videos = playlist_config.get(
+                        "create_videos", create_videos_channel_setting
+                    )
                 else:
                     playlist_config = playlist_configs.get(
                         WILDCARD_PLAYLIST_ID, {"ignore": True}
                     )
+                    create_videos = create_videos_channel_setting
 
                 if not playlist_config.get("ignore", False):
                     yield (
                         playlist_data,
                         extract_playlist_items(youtube_client, playlist_id),
+                        create_videos,
                     )
 
             request = youtube_client.playlists().list_next(request, response)
@@ -237,7 +248,11 @@ def _extract_playlists(
 
 
 def extract_playlists(
-    youtube_client: Resource, playlist_configs: list[dict], channel_id: str
+    youtube_client: Resource,
+    playlist_configs: list[dict],
+    channel_id: str,
+    *,
+    create_videos_channel_setting: bool,
 ) -> Generator[tuple, None, None]:
     """
     Extract a list of playlists for a channel
@@ -245,6 +260,8 @@ def extract_playlists(
         youtube_client (object): Youtube api client
         playlist_configs (list of dict): list of playlist configurations
         channel_id (str): youtube's id for the channel
+        create_videos_channel_setting (bool): whether the channel config
+            is to create videos from youtube data
     Returns:
         A generator that yields playlist data
     """
@@ -272,7 +289,12 @@ def extract_playlists(
         )
 
     for request in requests:
-        yield from _extract_playlists(youtube_client, request, playlist_configs_by_id)
+        yield from _extract_playlists(
+            youtube_client,
+            request,
+            playlist_configs_by_id,
+            create_videos_channel_setting=create_videos_channel_setting,
+        )
 
 
 def extract_channels(
@@ -311,11 +333,13 @@ def extract_channels(
                 channel_id = channel_data["id"]
                 channel_config = channel_configs_by_ids[channel_id]
                 offered_by = channel_config.get("offered_by", None)
+                create_videos = channel_config.get("create_videos", True)
                 playlist_configs = channel_config.get("playlists", [])
-
-                # if we hit any error on a playlist, we simply abort
                 playlists = extract_playlists(
-                    youtube_client, playlist_configs, channel_id
+                    youtube_client,
+                    playlist_configs,
+                    channel_id,
+                    create_videos_channel_setting=create_videos,
                 )
                 yield (offered_by, channel_data, playlists)
 
@@ -481,11 +505,16 @@ def transform_video(video_data: dict, offered_by_code: str) -> dict:
             "duration": video_data["contentDetails"]["duration"],
         },
         "availability": Availability.anytime.name,
+        "youtube_id": video_data["id"],
     }
 
 
 def transform_playlist(
-    playlist_data: dict, videos: Generator[dict, None, None], offered_by_code: str
+    playlist_data: dict,
+    videos: Generator[dict, None, None],
+    offered_by_code: str,
+    *,
+    create_videos: bool,
 ) -> dict:
     """
     Transform a playlist into our normalized data
@@ -494,6 +523,8 @@ def transform_playlist(
         playlist_data (dict): the extracted playlist data
         videos (generator): generator for data for the playlist's videos
         offered_by_code (str): the offered_by code for this playlist
+        create_videos (bool): whether to create videos from this playlist
+            or match to existing videos without creating new ones
     Returns:
         dict: normalized playlist data
     """
@@ -515,6 +546,7 @@ def transform_playlist(
             "alt": playlist_data["snippet"]["title"],
         },
         "availability": Availability.anytime.name,
+        "create_videos": create_videos,
     }
 
 
@@ -539,8 +571,10 @@ def transform(extracted_channels: iter) -> Generator[dict, None, None]:
             "published": True,
             # intentional generator expression
             "playlists": (
-                transform_playlist(playlist, videos, offered_by)
-                for playlist, videos in playlists
+                transform_playlist(
+                    playlist, videos, offered_by, create_videos=create_videos
+                )
+                for playlist, videos, create_videos in playlists
             ),
         }
 

--- a/learning_resources/etl/youtube_test.py
+++ b/learning_resources/etl/youtube_test.py
@@ -176,18 +176,18 @@ def extracted_and_transformed_values(youtube_api_responses):
         (
             OfferedBy.ocw.name,
             channels_list[0]["items"][0],
-            [(playlists_list[0]["items"][0], ocw_videos)],
+            [(playlists_list[0]["items"][0], ocw_videos, True)],
         ),
         (
             OfferedBy.mitx.name,
             channels_list[0]["items"][1],
-            [(playlists_list[1]["items"][0], mitx_videos)],
+            [(playlists_list[1]["items"][0], mitx_videos, True)],
         ),
         (
             "csail",
             channels_list[0]["items"][2],
             [
-                (playlists_list[2]["items"][1], csail_videos),
+                (playlists_list[2]["items"][1], csail_videos, True),
             ],
         ),
     ]
@@ -236,11 +236,13 @@ def extracted_and_transformed_values(youtube_api_responses):
                             "video": {
                                 "duration": video["contentDetails"]["duration"],
                             },
+                            "youtube_id": video["id"],
                         }
                         for video in videos
                     ],
+                    "create_videos": create_videos,
                 }
-                for playlist, videos in playlists
+                for playlist, videos, create_videos in playlists
             ],
         }
         for offered_by, channel, playlists in extracted
@@ -263,8 +265,8 @@ def _resolve_extracted_channels(channels):
 
 def _resolve_extracted_playlist(playlist):
     """Resolve a playlist and its nested generators"""
-    playlist_data, videos = playlist
-    return (playlist_data, list(videos))
+    playlist_data, videos, create_videos = playlist
+    return (playlist_data, list(videos), create_videos)
 
 
 @pytest.fixture
@@ -423,8 +425,52 @@ def test_extract_playlists_errors(
     request = Mock(execute=Mock(side_effect=error(Mock(), b"")))
     if raised_exception:
         with pytest.raises(raised_exception) as err:
-            list(youtube._extract_playlists(mock_youtube_client, request, {}))  # noqa: SLF001
+            list(
+                youtube._extract_playlists(  # noqa: SLF001
+                    mock_youtube_client, request, {}, create_videos_channel_setting=True
+                )
+            )
         assert message in str(err)
+
+
+@pytest.mark.parametrize(
+    ("channel_create_videos", "playlist_create_videos", "expected"),
+    [
+        (True, None, True),
+        (False, None, False),
+        (True, False, False),
+        (False, True, True),
+    ],
+)
+def test_extract_playlists_create_videos(
+    mock_youtube_client,
+    channel_create_videos,
+    playlist_create_videos,
+    expected,
+):
+    """Test that create_videos is resolved from playlist config or channel setting"""
+    playlist_id = "PL_test_123"
+    playlist_data = {"id": playlist_id, "snippet": {"title": "Test"}}
+    request = Mock(execute=Mock(return_value={"items": [playlist_data]}))
+    mock_youtube_client.return_value.playlists.return_value.list_next.return_value = (
+        None
+    )
+
+    playlist_config = {"id": playlist_id}
+    if playlist_create_videos is not None:
+        playlist_config["create_videos"] = playlist_create_videos
+
+    results = list(
+        youtube._extract_playlists(  # noqa: SLF001
+            mock_youtube_client.return_value,
+            request,
+            {playlist_id: playlist_config},
+            create_videos_channel_setting=channel_create_videos,
+        )
+    )
+    assert len(results) == 1
+    _, _, create_videos = results[0]
+    assert create_videos is expected
 
 
 @pytest.mark.django_db
@@ -462,6 +508,7 @@ def test_transform_playlist(
         extracted[0][2][0][0],
         extracted[0][2][0][1],
         OfferedBy.ocw.name,
+        create_videos=True,
     )
     assert {**result, "videos": list(result["videos"])} == {
         **transformed[0]["playlists"][0],

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -402,10 +402,14 @@ def update_ocw_learning_material_resources(self):  # noqa: ARG001
     ocw courses or content files
     """
 
-    if not settings.CREATE_OCW_LEARNING_MATERIALS:
+    if (
+        not settings.CREATE_OCW_LEARNING_MATERIALS
+        and not settings.SHOW_OCW_LECTURE_VIDEOS
+    ):
         message = (
-            "CREATE_OCW_LEARNING_MATERIALS flag is set to False."
-            " update_ocw_learning_material_resources cannont run"
+            "update_ocw_learning_material_resources cannot run because "
+            "CREATE_OCW_LEARNING_MATERIALS and SHOW_OCW_LECTURE_VIDEOS "
+            "flags are set to False."
         )
         raise RuntimeError(message)
 

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -480,23 +480,26 @@ def generate_filter_clauses(search_params):
     if search_params.get("endpoint") == LEARNING_RESOURCE and not search_params.get(
         "show_ocw_files"
     ):
+        ocw_should = [
+            {
+                "bool": {
+                    "must_not": [
+                        {
+                            "nested": {
+                                "path": "platform",
+                                "query": {"term": {"platform.code": "ocw"}},
+                            }
+                        }
+                    ]
+                }
+            },
+            {"term": {"resource_type": "course"}},
+        ]
+        if settings.SHOW_OCW_LECTURE_VIDEOS:
+            ocw_should.append({"term": {"resource_category": "Lecture Videos"}})
         ocw_clause = {
             "bool": {
-                "should": [
-                    {
-                        "bool": {
-                            "must_not": [
-                                {
-                                    "nested": {
-                                        "path": "platform",
-                                        "query": {"term": {"platform.code": "ocw"}},
-                                    }
-                                }
-                            ]
-                        }
-                    },
-                    {"term": {"resource_type": "course"}},
-                ],
+                "should": ocw_should,
                 "minimum_should_match": 1,
             }
         }

--- a/main/settings.py
+++ b/main/settings.py
@@ -934,3 +934,13 @@ VIDEO_SHORTS_COUNT = get_int("VIDEO_SHORTS_COUNT", 12)
 
 # Hubspot settings
 MITOL_HUBSPOT_API_PRIVATE_TOKEN = get_string("MITOL_HUBSPOT_API_PRIVATE_TOKEN", None)
+
+# Create all learning material resources for OCW courses
+# Learning material resources are behind show_ocw_files flag in search
+CREATE_OCW_LEARNING_MATERIALS = get_bool("CREATE_OCW_LEARNING_MATERIALS", default=False)
+# Create just lecture video resources for OCW courses.
+# OCW lecture video resources will be displayed in search
+# regardless of show_ocw_files flag
+# If the video config is set to `create_videos`=False ocw videos will be added to
+# playlists
+SHOW_OCW_LECTURE_VIDEOS = get_bool("SHOW_OCW_LECTURE_VIDEOS", default=False)

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -145,4 +145,3 @@ CONTENT_BASE_URL_OLL = get_string(
     "CONTENT_BASE_URL_OLL", "https://openlearninglibrary.mit.edu"
 )
 CONTENT_BASE_URL_EDX = get_string("CONTENT_BASE_URL_EDX", "https://courses.edx.org")
-CREATE_OCW_LEARNING_MATERIALS = get_bool("CREATE_OCW_LEARNING_MATERIALS", default=False)


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/10953

### Description (What does it do?)
This pr updates the youtube etl to no longer create lecture videos for ocw but only create playlists and populate them with lecture videos that were created from ocw files.

SHOW_OCW_LECTURE_VIDEOS=True creates just ocw lecture videos from ocw files (even if CREATE_OCW_LEARNING_MATERIALS=False) and shows them in search

If video-playlist-page is set to true in posthog videos created from ocw should link to the new video player page from search 


### Screenshots (if appropriate):
<img width="1727" height="896" alt="Screenshot 2026-04-27 at 10 39 46 PM" src="https://github.com/user-attachments/assets/3a5204f5-654c-40eb-8b62-62ec42c563d0" />


### How can this be tested?
set video-playlist-page = True in posthog

set YOUTUBE_CONFIG_URL='https://raw.githubusercontent.com/mitodl/open-video-data/refs/heads/mitopen/youtube/channels.yaml' (the current value)

CREATE_OCW_LEARNING_MATERIALS=True
SHOW_OCW_LECTURE_VIDEOS=True

set 
Run manage.py backpopulate_youtube_data --overwrite

The task takes a while so you can kill it prematurely once you start seeing youtube resources in your search index.

Go to http://open.odl.local:8062/search?offered_by=ocw&resource_type_group=learning_material
you should see ocw video playlists and ocw "Video" objects in the search
you may see some "Lecture Video" objects as well if you created ocw learning material resources for  some ocw courses
in the past



Set

YOUTUBE_CONFIG_URL='https://raw.githubusercontent.com/mitodl/open-video-data/refs/heads/ab/update-ocw-config/youtube/channels.yaml'

Run
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 21h-151-dynastic-china-fall-2024  --overwrite

docker-compose run web ./manage.py backpopulate_ocw_data --course-name 9-35-perception-spring-2024  --overwrite

Run manage.py backpopulate_youtube_data --overwrite


Go to
http://open.odl.local:8062/search?offered_by=ocw&resource_type_group=learning_material

You should see three video playlists:
"MIT 9.35 Perception, Spring 2024"
"MIT 21H.151 Dynastic China, Fall 2024 (Selected Lectures)"
and
"MIT AI + Open Education Initiative Speaker Series" which is a playlist that i whitelisted in the config to continue getting data from youtube


The course video playlists should link to "lecture video" objects and clicking "Learn More" will go to the video playlist page

The  only ocw learning resources with resource_category "Video" which should remain in the search after the celery tasks finish updating should be the two videos from "MIT AI + Open Education Initiative Speaker Series". It will take a few minutes after backpopulate_youtube_data is done for the deindex tasks to finish running.

Mitx videos and playlists should not be affected


 
