### PR TITLE
adds a "Receipt" menu item 

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -1941,5 +1941,200 @@ describe.each([
         screen.getByRole("menuitem", { name: "Unenroll" }),
       ).toBeInTheDocument()
     })
+
+    test("Receipt menu item appears for verified course run enrollment", async () => {
+      setupUserApis()
+      const course = mitxOnlineCourse()
+      const run = course.courseruns[0]
+      const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
+        enrollment_mode: EnrollmentMode.Verified,
+        run: { ...run, course },
+      })
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.CourseRunEnrollment,
+            data: enrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      expect(
+        screen.getByRole("menuitem", { name: "Receipt" }),
+      ).toBeInTheDocument()
+    })
+
+    test("Receipt menu item does not appear for audit course run enrollment", async () => {
+      setupUserApis()
+      const course = mitxOnlineCourse()
+      const run = course.courseruns[0]
+      const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+        grades: [],
+        enrollment_mode: EnrollmentMode.Audit,
+        run: { ...run, course },
+      })
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.CourseRunEnrollment,
+            data: enrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      expect(
+        screen.queryByRole("menuitem", { name: "Receipt" }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Receipt menu item links to correct MITx Online URL for verified course run enrollment", async () => {
+      setupUserApis()
+      const course = mitxOnlineCourse()
+      const run = mitxonline.factories.courses.courseRun({ id: 42 })
+      const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
+        enrollment_mode: EnrollmentMode.Verified,
+        run: { ...run, course },
+      })
+
+      const windowOpenSpy = jest
+        .spyOn(window, "open")
+        .mockImplementation(() => null)
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.CourseRunEnrollment,
+            data: enrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      const receiptItem = screen.getByRole("menuitem", { name: "Receipt" })
+      await user.click(receiptItem)
+
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        mitxonlineLegacyUrl("/orders/receipt/by-run/42/"),
+        "_blank",
+      )
+      windowOpenSpy.mockRestore()
+    })
+
+    test("Receipt menu item appears for verified program enrollment", async () => {
+      setupUserApis()
+      const program = mitxonline.factories.programs.simpleProgram()
+      const programEnrollment =
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program,
+          enrollment_mode: EnrollmentMode.Verified,
+        })
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.ProgramEnrollment,
+            data: programEnrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      expect(
+        screen.getByRole("menuitem", { name: "Receipt" }),
+      ).toBeInTheDocument()
+    })
+
+    test("Receipt menu item does not appear for audit program enrollment", async () => {
+      setupUserApis()
+      const program = mitxonline.factories.programs.simpleProgram()
+      const programEnrollment =
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program,
+          enrollment_mode: EnrollmentMode.Audit,
+        })
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.ProgramEnrollment,
+            data: programEnrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      expect(
+        screen.queryByRole("menuitem", { name: "Receipt" }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Receipt menu item links to correct MITx Online URL for verified program enrollment", async () => {
+      setupUserApis()
+      const program = mitxonline.factories.programs.simpleProgram({ id: 99 })
+      const programEnrollment =
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program,
+          enrollment_mode: EnrollmentMode.Verified,
+        })
+
+      const windowOpenSpy = jest
+        .spyOn(window, "open")
+        .mockImplementation(() => null)
+
+      renderWithProviders(
+        <DashboardCard
+          resource={{
+            type: DashboardType.ProgramEnrollment,
+            data: programEnrollment,
+          }}
+        />,
+      )
+
+      const card = getCard()
+      const contextMenuButton = within(card).getByRole("button", {
+        name: "More options",
+      })
+      await user.click(contextMenuButton)
+
+      const receiptItem = screen.getByRole("menuitem", { name: "Receipt" })
+      await user.click(receiptItem)
+
+      expect(windowOpenSpy).toHaveBeenCalledWith(
+        mitxonlineLegacyUrl("/orders/receipt/by-program/99/"),
+        "_blank",
+      )
+      windowOpenSpy.mockRestore()
+    })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -2037,6 +2037,7 @@ describe.each([
       expect(windowOpenSpy).toHaveBeenCalledWith(
         mitxonlineLegacyUrl("/orders/receipt/by-run/42/"),
         "_blank",
+        "noopener,noreferrer",
       )
       windowOpenSpy.mockRestore()
     })
@@ -2133,6 +2134,7 @@ describe.each([
       expect(windowOpenSpy).toHaveBeenCalledWith(
         mitxonlineLegacyUrl("/orders/receipt/by-program/99/"),
         "_blank",
+        "noopener,noreferrer",
       )
       windowOpenSpy.mockRestore()
     })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -215,6 +215,20 @@ const getContextMenuItems = (
         },
       })
     }
+
+    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
+      menuItems.push({
+        className: "dashboard-card-menu-item",
+        key: "receipt",
+        label: "Receipt",
+        onClick: () => {
+          window.open(
+            mitxonlineLegacyUrl(`/orders/receipt/by-program/${program.id}/`),
+            "_blank",
+          )
+        },
+      })
+    }
   }
   if (resource.type === DashboardType.CourseRunEnrollment) {
     const detailsUrl = useProductPages
@@ -253,6 +267,22 @@ const getContextMenuItems = (
         },
       },
     )
+
+    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
+      courseMenuItems.push({
+        className: "dashboard-card-menu-item",
+        key: "receipt",
+        label: "Receipt",
+        onClick: () => {
+          window.open(
+            mitxonlineLegacyUrl(
+              `/orders/receipt/by-run/${resource.data.run.id}/`,
+            ),
+            "_blank",
+          )
+        },
+      })
+    }
 
     menuItems.push(...courseMenuItems)
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -21,6 +21,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
 
 import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
+import { getReceiptMenuItem } from "./receiptMenuItem"
 import {
   EmailSettingsDialog,
   JustInTimeDialog,
@@ -37,9 +38,9 @@ import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
 import { coursePageView, programPageView, programView } from "@/common/urls"
 import {
-  mitxonlineLegacyUrl,
   getCourseEnrollmentAction,
   isVerifiedEnrollmentMode,
+  mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
 import { EnrollmentStatus, getBestRun, getEnrollmentStatus } from "./helpers"
@@ -216,19 +217,11 @@ const getContextMenuItems = (
       })
     }
 
-    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
-      menuItems.push({
-        className: "dashboard-card-menu-item",
-        key: "receipt",
-        label: "Receipt",
-        onClick: () => {
-          window.open(
-            mitxonlineLegacyUrl(`/orders/receipt/by-program/${program.id}/`),
-            "_blank",
-          )
-        },
-      })
-    }
+    const receiptMenuItem = getReceiptMenuItem(
+      resource.data.enrollment_mode,
+      `/orders/receipt/by-program/${program.id}/`,
+    )
+    if (receiptMenuItem) menuItems.push(receiptMenuItem)
   }
   if (resource.type === DashboardType.CourseRunEnrollment) {
     const detailsUrl = useProductPages
@@ -268,21 +261,11 @@ const getContextMenuItems = (
       },
     )
 
-    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
-      courseMenuItems.push({
-        className: "dashboard-card-menu-item",
-        key: "receipt",
-        label: "Receipt",
-        onClick: () => {
-          window.open(
-            mitxonlineLegacyUrl(
-              `/orders/receipt/by-run/${resource.data.run.id}/`,
-            ),
-            "_blank",
-          )
-        },
-      })
-    }
+    const receiptMenuItem = getReceiptMenuItem(
+      resource.data.enrollment_mode,
+      `/orders/receipt/by-run/${resource.data.run.id}/`,
+    )
+    if (receiptMenuItem) courseMenuItems.push(receiptMenuItem)
 
     menuItems.push(...courseMenuItems)
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
@@ -1,18 +1,14 @@
 import * as mitxonline from "api/mitxonline-test-utils"
+import { EnrollmentModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 import { DashboardType, getContextMenuItems } from "./ModuleCard"
-
-const EnrollmentMode = {
-  Audit: "audit",
-  Verified: "verified",
-} as const
 
 describe("ModuleCard context menu receipt item", () => {
   test("shows Receipt item for verified enrollment", () => {
     const course = mitxonline.factories.courses.course()
     const run = mitxonline.factories.courses.courseRun({ id: 42 })
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
-      enrollment_mode: EnrollmentMode.Verified,
+      enrollment_mode: EnrollmentModeEnum.Verified,
       run: { ...run, course },
     })
 
@@ -28,7 +24,7 @@ describe("ModuleCard context menu receipt item", () => {
     const course = mitxonline.factories.courses.course()
     const run = mitxonline.factories.courses.courseRun({ id: 42 })
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
-      enrollment_mode: EnrollmentMode.Audit,
+      enrollment_mode: EnrollmentModeEnum.Audit,
       run: { ...run, course },
     })
 
@@ -44,7 +40,7 @@ describe("ModuleCard context menu receipt item", () => {
     const course = mitxonline.factories.courses.course()
     const run = mitxonline.factories.courses.courseRun({ id: 42 })
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
-      enrollment_mode: EnrollmentMode.Verified,
+      enrollment_mode: EnrollmentModeEnum.Verified,
       run: { ...run, course },
     })
     const windowOpenSpy = jest

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
@@ -1,0 +1,68 @@
+import * as mitxonline from "api/mitxonline-test-utils"
+import { mitxonlineLegacyUrl } from "@/common/mitxonline"
+import { DashboardType, getContextMenuItems } from "./ModuleCard"
+
+const EnrollmentMode = {
+  Audit: "audit",
+  Verified: "verified",
+} as const
+
+describe("ModuleCard context menu receipt item", () => {
+  test("shows Receipt item for verified enrollment", () => {
+    const course = mitxonline.factories.courses.course()
+    const run = mitxonline.factories.courses.courseRun({ id: 42 })
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Verified,
+      run: { ...run, course },
+    })
+
+    const items = getContextMenuItems("Test Course", {
+      type: DashboardType.CourseRunEnrollment,
+      data: enrollment,
+    })
+
+    expect(items.some((item) => item.label === "Receipt")).toBe(true)
+  })
+
+  test("does not show Receipt item for audit enrollment", () => {
+    const course = mitxonline.factories.courses.course()
+    const run = mitxonline.factories.courses.courseRun({ id: 42 })
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      run: { ...run, course },
+    })
+
+    const items = getContextMenuItems("Test Course", {
+      type: DashboardType.CourseRunEnrollment,
+      data: enrollment,
+    })
+
+    expect(items.some((item) => item.label === "Receipt")).toBe(false)
+  })
+
+  test("Receipt item opens the expected MITx Online URL", () => {
+    const course = mitxonline.factories.courses.course()
+    const run = mitxonline.factories.courses.courseRun({ id: 42 })
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Verified,
+      run: { ...run, course },
+    })
+    const windowOpenSpy = jest
+      .spyOn(window, "open")
+      .mockImplementation(() => null)
+
+    const items = getContextMenuItems("Test Course", {
+      type: DashboardType.CourseRunEnrollment,
+      data: enrollment,
+    })
+    const receiptItem = items.find((item) => item.label === "Receipt")
+
+    receiptItem?.onClick?.()
+
+    expect(windowOpenSpy).toHaveBeenCalledWith(
+      mitxonlineLegacyUrl("/orders/receipt/by-run/42/"),
+      "_blank",
+    )
+    windowOpenSpy.mockRestore()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.test.tsx
@@ -62,6 +62,7 @@ describe("ModuleCard context menu receipt item", () => {
     expect(windowOpenSpy).toHaveBeenCalledWith(
       mitxonlineLegacyUrl("/orders/receipt/by-run/42/"),
       "_blank",
+      "noopener,noreferrer",
     )
     windowOpenSpy.mockRestore()
   })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -27,11 +27,11 @@ import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
 import {
   getCourseEnrollmentAction,
-  isVerifiedEnrollmentMode,
   mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
 import { EnrollmentStatus, getBestRun, getEnrollmentStatus } from "./helpers"
+import { getReceiptMenuItem } from "./receiptMenuItem"
 import {
   CourseWithCourseRunsSerializerV2,
   CourseRunEnrollmentV3,
@@ -227,21 +227,11 @@ const getContextMenuItems = (
       },
     )
 
-    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
-      courseMenuItems.push({
-        className: "dashboard-card-menu-item",
-        key: "receipt",
-        label: "Receipt",
-        onClick: () => {
-          window.open(
-            mitxonlineLegacyUrl(
-              `/orders/receipt/by-run/${resource.data.run.id}/`,
-            ),
-            "_blank",
-          )
-        },
-      })
-    }
+    const receiptMenuItem = getReceiptMenuItem(
+      resource.data.enrollment_mode,
+      `/orders/receipt/by-run/${resource.data.run.id}/`,
+    )
+    if (receiptMenuItem) courseMenuItems.push(receiptMenuItem)
 
     menuItems.push(...courseMenuItems)
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -27,6 +27,7 @@ import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
 import {
   getCourseEnrollmentAction,
+  isVerifiedEnrollmentMode,
   mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
@@ -225,6 +226,22 @@ const getContextMenuItems = (
         },
       },
     )
+
+    if (isVerifiedEnrollmentMode(resource.data.enrollment_mode)) {
+      courseMenuItems.push({
+        className: "dashboard-card-menu-item",
+        key: "receipt",
+        label: "Receipt",
+        onClick: () => {
+          window.open(
+            mitxonlineLegacyUrl(
+              `/orders/receipt/by-run/${resource.data.run.id}/`,
+            ),
+            "_blank",
+          )
+        },
+      })
+    }
 
     menuItems.push(...courseMenuItems)
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/receiptMenuItem.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/receiptMenuItem.test.ts
@@ -1,0 +1,11 @@
+import { getReceiptMenuItem } from "./receiptMenuItem"
+
+describe("getReceiptMenuItem", () => {
+  test("returns null when enrollment mode is undefined", () => {
+    const menuItem = getReceiptMenuItem(
+      undefined,
+      "/orders/receipt/by-program/99/",
+    )
+    expect(menuItem).toBeNull()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/receiptMenuItem.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/receiptMenuItem.ts
@@ -1,0 +1,27 @@
+import { SimpleMenuItem } from "ol-components"
+import {
+  isVerifiedEnrollmentMode,
+  mitxonlineLegacyUrl,
+} from "@/common/mitxonline"
+
+const getReceiptMenuItem = (
+  enrollmentMode: string | null | undefined,
+  receiptPath: string,
+): SimpleMenuItem | null => {
+  if (!enrollmentMode || !isVerifiedEnrollmentMode(enrollmentMode)) return null
+
+  return {
+    className: "dashboard-card-menu-item",
+    key: "receipt",
+    label: "Receipt",
+    onClick: () => {
+      window.open(
+        mitxonlineLegacyUrl(receiptPath),
+        "_blank",
+        "noopener,noreferrer",
+      )
+    },
+  }
+}
+
+export { getReceiptMenuItem }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10626

### Description (What does it do?)
Adds a **"Receipt"** menu item to the ⋮ overflow (context) menu on dashboard course and program cards, visible **only for verified (paid) enrollments**. Clicking it opens a new tab to MITx Online's receipt lookup routes (from PR https://github.com/mitodl/mitxonline/pull/3527).

- **Course run cards** → links to `{MITX_ONLINE_BASE_URL}/orders/receipt/by-run/{run_id}/`
- **Program cards** → links to `{MITX_ONLINE_BASE_URL}/orders/receipt/by-program/{program_id}/`
- **Audit enrollments** → no Receipt item shown

Changes span `DashboardCard.tsx`, `DashboardCard.test.tsx`, `ModuleCard.tsx`, and a new `ModuleCard.test.tsx`.


### Screenshots (if appropriate):
**With Receipt Showing:**
<img width="1436" height="846" alt="Screenshot 2026-04-29 at 4 20 41 PM" src="https://github.com/user-attachments/assets/fc83c883-d5f5-4cbc-8d91-047a815f3eb0" />
**Without Receipt (Audit Mode)**
<img width="1352" height="812" alt="Screenshot 2026-04-29 at 4 20 50 PM" src="https://github.com/user-attachments/assets/1a14bb88-55e6-44f8-a10f-61a6af06e981" />
**With Receipt (Program)**
<img width="1423" height="816" alt="Screenshot 2026-04-29 at 4 21 00 PM" src="https://github.com/user-attachments/assets/e63e465e-b39b-41c8-af0d-a83470447841" />



### How can this be tested?
**Pre-requisites:**

* A local MITx Online setup is required
* Check out [https://github.com/mitodl/mitxonline/pull/3527](https://github.com/mitodl/mitxonline/pull/3527) if it has not been merged yet
* If the PR is merged and deployed, you can connect to the MITx Online RC server instead

 **Testing Steps:**
* Log in to MIT Learn and navigate to the Dashboard.
* Find a verified (paid) course run enrollment → click the ⋮ menu → confirm "Receipt" item appears → click it → verify it opens {MITX_ONLINE_BASE_URL}/orders/receipt/by-run/{run_id}/ in a new tab.
* Find a verified (paid) program enrollment → click the ⋮ menu → confirm "Receipt" item appears → click it → verify it opens {MITX_ONLINE_BASE_URL}/orders/receipt/by-program/{program_id}/ in a new tab.
* Find an audit enrollment → click the ⋮ menu → confirm "Receipt" item is not shown

### Additional Context
This PR is the frontend counterpart to https://github.com/mitodl/mitxonline/pull/3527, which adds the backend redirect endpoints. Deploy #3527 before merging this PR to avoid broken receipt links.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->

