### PR TITLE
show resource_category in channel pages

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
@@ -310,4 +310,63 @@ describe("ChannelSearch", () => {
     await user.click(screen.getByRole("button", { name: "Search" }))
     expect(location.current.searchParams.get("q")).toBe("woof")
   })
+
+  test.each([
+    { channelType: ChannelTypeEnum.Topic },
+    { channelType: ChannelTypeEnum.Department },
+    { channelType: ChannelTypeEnum.Unit },
+  ])(
+    "Shows Resource Category facet only when resource_type_group=learning_material ($channelType)",
+    async ({ channelType }) => {
+      const { channel } = setMockApiResponses({
+        channelPatch: { channel_type: channelType },
+        search: {
+          count: 700,
+          metadata: {
+            aggregations: {
+              resource_type_group: [
+                { key: "course", doc_count: 100 },
+                { key: "learning_material", doc_count: 200 },
+              ],
+              resource_category: [
+                { key: "Course", doc_count: 100 },
+                { key: "Video", doc_count: 100 },
+              ],
+              topic: [{ key: "physics", doc_count: 100 }],
+              department: [{ key: "1", doc_count: 100 }],
+              certification_type: [{ key: "micromasters", doc_count: 100 }],
+              delivery: [{ key: "online", doc_count: 100 }],
+              offered_by: [{ key: "ocw", doc_count: 100 }],
+            },
+            suggestions: [],
+          },
+        },
+      })
+
+      const {
+        view: { unmount },
+      } = renderWithProviders(<ChannelPage />, {
+        url: `/c/${channel.channel_type}/${channel.name}/`,
+      })
+
+      const facetsContainer = await screen.findByTestId("facets-container")
+      await within(facetsContainer).findByText("Certificate")
+      expect(
+        within(facetsContainer).queryByText("Resource Category"),
+      ).toBeNull()
+
+      unmount()
+
+      // Re-render with resource_type_group=learning_material
+      renderWithProviders(<ChannelPage />, {
+        url: `/c/${channel.channel_type}/${channel.name}/?resource_type_group=learning_material`,
+      })
+
+      expect(
+        await within(await screen.findByTestId("facets-container")).findByText(
+          "Resource Category",
+        ),
+      ).toBeInTheDocument()
+    },
+  )
 })

--- a/frontends/main/src/app-pages/ChannelPage/searchRequests.ts
+++ b/frontends/main/src/app-pages/ChannelPage/searchRequests.ts
@@ -30,6 +30,7 @@ export const getConstantSearchParams = (searchFilter?: string) => {
 const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   [ChannelTypeEnum.Topic]: [
     "free",
+    "resource_category",
     "resource_type",
     "certification_type",
     "delivery",
@@ -38,6 +39,7 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   ],
   [ChannelTypeEnum.Department]: [
     "free",
+    "resource_category",
     "resource_type",
     "certification_type",
     "topic",
@@ -46,6 +48,7 @@ const FACETS_BY_CHANNEL_TYPE: Record<ChannelTypeEnum, string[]> = {
   ],
   [ChannelTypeEnum.Unit]: [
     "free",
+    "resource_category",
     "resource_type",
     "topic",
     "certification_type",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11064

### Description (What does it do?)
This pr updates the channel search to show the resource_category facet in channel pages

### Screenshots (if appropriate):
<img width="1725" height="890" alt="Screenshot 2026-04-28 at 2 35 29 PM" src="https://github.com/user-attachments/assets/6628e537-4390-493e-a274-43f56f1b99e8" />



### How can this be tested?
If you don't have learning materials attached to a unit with a channel run
`docker-compose run web ./manage.py  manage.py backpopulate_youtube_data`

Go to 

http://open.odl.local:8062/c/unit/ocw?resource_type_group=learning_material

and verify that you see the resource category facet

Switch to the "course" and "all" tabs and verify that you do not see the  resource category facet