### PR TITLE
set s-maxage via NEXT_CACHE_S_MAXAGE_SECONDS

### DIFF
--- a/frontends/main/next.config.js
+++ b/frontends/main/next.config.js
@@ -8,6 +8,10 @@ const NEXT_PUBLIC_OPTIMIZE_IMAGES = Boolean(
 )
 const IS_LOCAL_DEV = process.env.NODE_ENV === "development"
 
+const NEXT_CACHE_S_MAXAGE_SECONDS =
+  process.env.NEXT_CACHE_S_MAXAGE_SECONDS || "1800"
+const PAGE_CACHE_CONTROL = `s-maxage=${NEXT_CACHE_S_MAXAGE_SECONDS}, stale-if-error=86400, stale-while-revalidate=86400`
+
 const processFeatureFlags = () => {
   const featureFlagPrefix =
     process.env.NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX || "FEATURE_"
@@ -69,8 +73,7 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value:
-              "s-maxage=1800, stale-if-error=86400, stale-while-revalidate=86400",
+            value: PAGE_CACHE_CONTROL,
           },
         ],
       },
@@ -86,8 +89,7 @@ const nextConfig = {
         headers: [
           {
             key: "Cache-Control",
-            value:
-              "s-maxage=1800, stale-if-error=86400, stale-while-revalidate=86400",
+            value: PAGE_CACHE_CONTROL,
           },
         ],
       },

--- a/frontends/main/validateEnv.js
+++ b/frontends/main/validateEnv.js
@@ -10,6 +10,7 @@ const yup = require("yup")
 const schema = yup.object().shape({
   // Server-only env vars
   MITOL_NOINDEX: yup.string().oneOf(["true", "false"]),
+  NEXT_CACHE_S_MAXAGE_SECONDS: yup.string().matches(/^\d+$/),
   // Client or Server env vars
   NEXT_PUBLIC_APPZI_URL: yup.string(),
   NEXT_PUBLIC_ORIGIN: yup.string().required(),

--- a/frontends/main/validateEnv.js
+++ b/frontends/main/validateEnv.js
@@ -10,7 +10,9 @@ const yup = require("yup")
 const schema = yup.object().shape({
   // Server-only env vars
   MITOL_NOINDEX: yup.string().oneOf(["true", "false"]),
-  NEXT_CACHE_S_MAXAGE_SECONDS: yup.string().matches(/^\d+$/),
+  NEXT_CACHE_S_MAXAGE_SECONDS: yup
+    .string()
+    .matches(/^\d+$/, { excludeEmptyString: true }),
   // Client or Server env vars
   NEXT_PUBLIC_APPZI_URL: yup.string(),
   NEXT_PUBLIC_ORIGIN: yup.string().required(),


### PR DESCRIPTION
### What are the relevant tickets?
- For https://github.com/mitodl/hq/issues/10971

### Description (What does it do?)
Sets the `s-maxage` header for CDN caching via env var, defaulting to current value.

### How can this be tested?
1. Set `NEXT_CACHE_S_MAXAGE_SECONDS=1234` or whatever in frontend.local.env
1. Check that `s-maxage` header comes through in the HTML response from nextjs 