### PR TITLE
fix: assert run.title in DashboardCard heading test (broken on main)

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -126,7 +126,7 @@ describe.each([
     })
     expect(courseLink).toHaveAttribute("href", coursewareUrl)
     expect(
-      within(card).getByRole("heading", { name: course.title, level: 3 }),
+      within(card).getByRole("heading", { name: courseRun.title, level: 3 }),
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fix a flaky test... #3253 was merged with stale CI from before #3269 changed getTitle to use run.title for CourseRunEnrollment. The new heading-level assertion still expected course.title.

### How can this be tested?

Run `./scripts/test/jest-repeat.sh 30 -j 4 -- frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx` to see this passes consistently.

