### PR TITLE
fix fallback when no language is selected

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1677,6 +1677,61 @@ describe("ContractContent", () => {
     expect(screen.queryByText("Learning Language:")).not.toBeInTheDocument()
   })
 
+  test("disables CTA for non-enrolled B2B course when no translations and no enrollable runs", async () => {
+    const { orgX, user, mitxOnlineUser } = setupOrgAndUser()
+
+    const course = factories.courses.course()
+    const program = factories.programs.program({
+      courses: [course.id],
+    })
+    const contracts = createTestContracts(orgX.id, 1, [program.id])
+    orgX.contracts = contracts
+    mitxOnlineUser.b2b_organizations[0].contracts = contracts
+
+    const contractRun = factories.courses.courseRun({
+      b2b_contract: contracts[0].id,
+      language: "en",
+      run_tag: undefined,
+      is_enrollable: false,
+      courseware_url: "https://openedx.example.com/unenrollable-run",
+    })
+
+    const courseWithoutTranslations = {
+      ...course,
+      courseruns: [contractRun],
+      language_options: [],
+      next_run_id: contractRun.id,
+      next_run: null,
+    }
+
+    setupOrgDashboardMocks(
+      orgX,
+      user,
+      mitxOnlineUser,
+      [program],
+      [courseWithoutTranslations],
+      contracts,
+    )
+
+    setMockResponse.get(urls.enrollment.enrollmentsListV3(), [])
+
+    renderWithProviders(
+      <ContractContent
+        orgSlug={orgX.slug}
+        contractSlug={orgX.contracts[0].slug}
+      />,
+    )
+
+    const programElement = await screen.findByTestId("org-program-root")
+    const card = await within(programElement).findByTestId(
+      "enrollment-card-desktop",
+    )
+
+    const coursewareButton = within(card).getByTestId("courseware-button")
+    expect(coursewareButton).toHaveTextContent("Start Module")
+    expect(coursewareButton).toBeDisabled()
+  })
+
   test("displays correct run URL when user is enrolled in one of multiple runs", async () => {
     const { orgX, user, mitxOnlineUser } = setupOrgAndUser()
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -392,6 +392,42 @@ describe("languageOptions", () => {
     expect(selectedEnrollment?.run.courseware_id).toBe(spanishRun.courseware_id)
   })
 
+  test("matches enrollment when course has no language options", () => {
+    const run = factories.courses.courseRun({
+      id: 7001,
+      title: "Enrolled Course",
+      courseware_id: "cw-enrolled-7001",
+      courseware_url: "https://example.com/cw-enrolled-7001",
+      is_enrollable: true,
+    })
+
+    const course = factories.courses.course({
+      courseruns: [run],
+      next_run_id: run.id,
+      language_options: [],
+    })
+
+    const selectedRun = getCourseRunForSelectedLanguage(course, "")
+    const enrollment = factories.enrollment.courseEnrollment({
+      run: {
+        id: run.id,
+        course: { id: course.id, title: course.title },
+        title: run.title,
+        courseware_id: run.courseware_id,
+        courseware_url: run.courseware_url,
+      },
+    })
+
+    const selectedEnrollment = getEnrollmentForSelectedLanguage(
+      [enrollment],
+      null,
+      selectedRun,
+    )
+
+    expect(selectedRun?.id).toBe(run.id)
+    expect(selectedEnrollment?.run.id).toBe(run.id)
+  })
+
   test("adapts V3 enrollment run into V2-shaped run context", () => {
     const templateRun = factories.courses.courseRun({
       id: 500,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -237,8 +237,6 @@ const getCourseRunForSelectedLanguage = (
   if (!languageOption) {
     return (
       getBestRun(course, { enrollableOnly: true }) ??
-      course.courseruns.find((run) => run.id === course.next_run_id) ??
-      course.courseruns.find((run) => run.is_enrollable) ??
       course.courseruns[0] ??
       null
     )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -235,7 +235,13 @@ const getCourseRunForSelectedLanguage = (
 ): CourseRunV2 | null => {
   const languageOption = getSelectedLanguageOption(course, selectedLanguageKey)
   if (!languageOption) {
-    return null
+    return (
+      getBestRun(course, { enrollableOnly: true }) ??
+      course.courseruns.find((run) => run.id === course.next_run_id) ??
+      course.courseruns.find((run) => run.is_enrollable) ??
+      course.courseruns[0] ??
+      null
+    )
   }
 
   const matchingRuns = getRunsForLanguageOption(course, languageOption)
@@ -267,7 +273,22 @@ const getEnrollmentForSelectedLanguage = (
   selectedRun: CourseRunV2 | null,
 ): CourseRunEnrollmentV3 | null => {
   if (!selectedLanguageOption) {
-    return null
+    if (!selectedRun) {
+      return null
+    }
+
+    return (
+      enrollments.find((enrollment) => {
+        if (!enrollment.run) {
+          return false
+        }
+
+        return (
+          enrollment.run.id === selectedRun.id ||
+          enrollment.run.courseware_id === selectedRun.courseware_id
+        )
+      }) ?? null
+    )
   }
 
   return (


### PR DESCRIPTION
### What are the relevant tickets?
Fixes a regression caused by https://github.com/mitodl/mit-learn/pull/3269

### Description (What does it do?)
This PR fixes a regression caused by merging the above PR. A fallback was not properly set up on `getSelectedLanguageOption`, which caused course run association to fail when no language options are present. This PR restores the fallback so that if there are no language options, the proper course run is selected and associated with the dashboard card.

### How can this be tested?
- Ensure you have MIT Learn and MITx Online configured and connected
- Make sure you have at least one B2B contract that your user is enrolled in without language options, and it should contain at least one program with an enrollable course
- Go to the dashboard, click the org tab on the left and attempt to enroll in a course
- You should be redirected to the courseware
- If you go back to the dashboard, the card for that course should now reflect your enrollment status