### PR TITLE
Remove video count, filter "other collections" server-side

### DIFF
--- a/frontends/api/src/hooks/learningResources/index.ts
+++ b/frontends/api/src/hooks/learningResources/index.ts
@@ -193,16 +193,6 @@ const useSimilarLearningResources = (
   })
 }
 
-const useVectorSimilarLearningResources = (
-  id: number,
-  opts?: { enabled?: boolean },
-) => {
-  return useQuery({
-    ...learningResourceQueries.vectorSimilar(id),
-    ...opts,
-  })
-}
-
 const useInfiniteLearningResourceItems = (
   id: number,
   params: Omit<ItemsListRequest, "offset">,
@@ -229,7 +219,6 @@ export {
   usePlatformsList,
   useSchoolsList,
   useSimilarLearningResources,
-  useVectorSimilarLearningResources,
   useInfiniteLearningResourceItems,
   learningResourceQueries,
   offerorQueries,

--- a/frontends/api/src/hooks/learningResources/queries.ts
+++ b/frontends/api/src/hooks/learningResources/queries.ts
@@ -22,6 +22,7 @@ import type {
   LearningResourcesApiLearningResourcesSummaryListRequest as LearningResourcesSummaryListRequest,
   PaginatedLearningResourceRelationshipList,
   VideoPlaylistResource,
+  LearningResourcesApiLearningResourcesVectorSimilarListRequest,
 } from "../../generated/v1"
 import type { VectorLearningResourcesSearchApiVectorLearningResourcesSearchRetrieveRequest as VectorLearningResourcesSearchRetrieveRequest } from "../../generated/v0"
 import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query"
@@ -54,10 +55,9 @@ const learningResourceKeys = {
   detailsRoot: () => [...learningResourceKeys.root, "detail"],
   detail: (id: number) => [...learningResourceKeys.detailsRoot(), id],
   similar: (id: number) => [...learningResourceKeys.detail(id), "similar"],
-  vectorSimilar: (id: number) => [
-    ...learningResourceKeys.detail(id),
-    "vector_similar",
-  ],
+  vectorSimilar: (
+    params: LearningResourcesApiLearningResourcesVectorSimilarListRequest,
+  ) => [...learningResourceKeys.detail(params.id), "vector_similar", params],
   itemsRoot: (id: number) => [...learningResourceKeys.detail(id), "items"],
   items: (id: number, params: ItemsListRequest) => [
     ...learningResourceKeys.itemsRoot(id),
@@ -174,12 +174,14 @@ const learningResourceQueries = {
           .learningResourcesSimilarList({ id })
           .then((res) => res.data),
     }),
-  vectorSimilar: (id: number) =>
+  vectorSimilar: (
+    params: LearningResourcesApiLearningResourcesVectorSimilarListRequest,
+  ) =>
     queryOptions({
-      queryKey: learningResourceKeys.vectorSimilar(id),
+      queryKey: learningResourceKeys.vectorSimilar(params),
       queryFn: () =>
         learningResourcesApi
-          .learningResourcesVectorSimilarList({ id })
+          .learningResourcesVectorSimilarList(params)
           .then((res) => res.data),
     }),
   list: (params: LearningResourcesListRequest) =>

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCollection.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCollection.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Typography, styled, theme } from "ol-components"
+import { styled } from "ol-components"
 import VideoContainer from "./VideoContainer"
 import type { VideoResource } from "api/v1"
 import { VideoCard, VideoCardSkeleton } from "./VideoCard"
@@ -17,22 +17,6 @@ const StyledContainer = styled(VideoContainer)(({ theme }) => ({
   },
   borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
 }))
-
-const CollectionHeader = styled.div(({ theme }) => ({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  margin: "32px 0 8px 0",
-  [theme.breakpoints.down("sm")]: {
-    margin: "24px 0 0 0",
-  },
-}))
-
-const CollectionTitle = styled(Typography)({
-  ...theme.typography.body1,
-  fontWeight: theme.typography.fontWeightMedium,
-  color: theme.custom.colors.black,
-})
 
 const VideoCardList = styled.div(({ theme }) => ({
   display: "flex",
@@ -61,10 +45,6 @@ const VideoCollection: React.FC<VideoCollectionProps> = ({
   return (
     <CollectionSection>
       <StyledContainer>
-        <CollectionHeader>
-          <CollectionTitle>{videos.length} Videos</CollectionTitle>
-        </CollectionHeader>
-
         <VideoCardList>
           {isLoading
             ? Array.from({ length: 4 }).map((_, i) => (

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
@@ -69,11 +69,11 @@ const VideoPlaylistCollectionPage: React.FC<
   )
 
   const { data: similarData, isLoading: similarLoading } = useQuery({
-    ...learningResourceQueries.vectorSimilar(playlistId),
-    select: (data) =>
-      data.filter(
-        (resource) => resource.resource_type === ResourceTypeEnum.VideoPlaylist,
-      ),
+    ...learningResourceQueries.vectorSimilar({
+      id: playlistId,
+      limit: 6,
+      resource_type: [ResourceTypeEnum.VideoPlaylist],
+    }),
   })
 
   if (!showVideoPlaylistPage) {
@@ -88,7 +88,6 @@ const VideoPlaylistCollectionPage: React.FC<
     (item): item is VideoResource =>
       item.resource_type === VideoResourceResourceTypeEnum.Video,
   )
-  const collectionVideos = videos.slice(1)
   const playlistType = isOcwPlaylist(playlist)
 
   const totalVideos = videos.length
@@ -128,7 +127,7 @@ const VideoPlaylistCollectionPage: React.FC<
       ) : null}
       {!playlistType && (
         <VideoCollection
-          videos={collectionVideos}
+          videos={videos.slice(1)} // 0th video is featured prominently
           isLoading={isLoading}
           getHref={getVideoHref}
         />

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -200,9 +200,9 @@ const getTabQuery = (tab: TabConfig): CarouselQuery => {
         tab.data.params.id,
       ) as CarouselQuery
     case "lr_vector_similar":
-      return learningResourceQueries.vectorSimilar(
-        tab.data.params.id,
-      ) as CarouselQuery
+      return learningResourceQueries.vectorSimilar({
+        id: tab.data.params.id,
+      }) as CarouselQuery
   }
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11136

### Description (What does it do?)
This PR:
- removes the video count display on `/video-playlist/:id` pages ... It is inaccurate at the moment, and needs to be moved in the UI before it can be made accurate.
- filters "Other collections" serverside since client-side is not reliable.

### Screenshots (if appropriate):
**BEFORE** 
<img width="1356" height="636" alt="Screenshot 2026-05-04 at 3 37 56 PM" src="https://github.com/user-attachments/assets/9394e16c-2c13-43a1-97f8-49d10b45edb9" />

**AFTER:**
<img width="1322" height="808" alt="Screenshot 2026-05-04 at 3 38 21 PM" src="https://github.com/user-attachments/assets/66329c95-6140-49db-b304-350d45655218" />


### How can this be tested?
If you've ingested videos recently from OVS, try for the resource shown above "Unlocking Brain Plasticity" and viewing its video page with the `video-playlist-page` feature flag on.

Alternatively, set `NEXT_PUBLIC_MITOL_API_BASE_URL=https://api.learn.mit.edu/` to view (read only) production data locally. Then view http://open.odl.local:8062/video-playlist/114879 locally.
- you shouldnt see video count
- you get server-filtered collections

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
