### PR TITLE
prefer existing B2B enrollment over next_run_id when picking same-lan…

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -37,9 +37,9 @@ import { ResourceType, getKey } from "./CoursewareDisplay/helpers"
 import {
   getCourseRunForSelectedLanguage,
   getDistinctLanguageOptions,
-  getEnrollmentForSelectedLanguage,
   getResolvedRunForSelectedLanguage,
   getSelectedLanguageOption,
+  selectBestContractEnrollmentForLanguage,
 } from "./CoursewareDisplay/languageOptions"
 import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 
@@ -350,29 +350,34 @@ const OrgProgramCollectionDisplay: React.FC<{
             />
           ))}
         {rawCourses.map((course) => {
-          const selectedLanguageOption = getSelectedLanguageOption(
-            course,
-            selectedLanguageKey,
-          )
-          const selectedRun = getCourseRunForSelectedLanguage(
-            course,
-            selectedLanguageKey,
-          )
           // Filter enrollments to only those matching this contract
           const contractEnrollments =
             enrollments?.filter(
               (enrollment) => enrollment.b2b_contract_id === contract.id,
             ) ?? []
-          const selectedLanguageEnrollment = getEnrollmentForSelectedLanguage(
-            contractEnrollments,
-            selectedLanguageOption,
-            selectedRun,
+          // Prefer the user's existing enrollment for the selected language
+          // over the next/best run, so older-run enrollments stay visible
+          // when the contract surfaces a newer run.
+          const selectedLanguageEnrollment =
+            selectBestContractEnrollmentForLanguage(
+              course,
+              contractEnrollments,
+              selectedLanguageKey,
+            )
+          const selectedLanguageOption = getSelectedLanguageOption(
+            course,
+            selectedLanguageKey,
           )
+          const selectedRun = selectedLanguageEnrollment
+            ? ((course.courseruns ?? []).find(
+                (r) => r.id === selectedLanguageEnrollment.run.id,
+              ) ?? null)
+            : getCourseRunForSelectedLanguage(course, selectedLanguageKey)
           const resolvedRun = getResolvedRunForSelectedLanguage(
             course,
             selectedLanguageOption,
             selectedRun,
-            selectedLanguageEnrollment ?? null,
+            selectedLanguageEnrollment,
             contract.id,
           )
           return (
@@ -473,30 +478,34 @@ const OrgProgramDisplay: React.FC<{
         {programLoading || coursesQuery.isLoading
           ? skeleton
           : courses.map((course) => {
-              const selectedLanguageOption = getSelectedLanguageOption(
-                course,
-                selectedLanguageKey,
-              )
-              const selectedRun = getCourseRunForSelectedLanguage(
-                course,
-                selectedLanguageKey,
-              )
               // Filter enrollments to only those matching this contract
               const contractEnrollments =
                 courseRunEnrollments?.filter(
                   (enrollment) => enrollment.b2b_contract_id === contract?.id,
                 ) ?? []
+              // Prefer the user's existing enrollment for the selected
+              // language over the next/best run, so older-run enrollments
+              // stay visible when the contract surfaces a newer run.
               const selectedLanguageEnrollment =
-                getEnrollmentForSelectedLanguage(
+                selectBestContractEnrollmentForLanguage(
+                  course,
                   contractEnrollments,
-                  selectedLanguageOption,
-                  selectedRun,
+                  selectedLanguageKey,
                 )
+              const selectedLanguageOption = getSelectedLanguageOption(
+                course,
+                selectedLanguageKey,
+              )
+              const selectedRun = selectedLanguageEnrollment
+                ? ((course.courseruns ?? []).find(
+                    (r) => r.id === selectedLanguageEnrollment.run.id,
+                  ) ?? null)
+                : getCourseRunForSelectedLanguage(course, selectedLanguageKey)
               const resolvedRun = getResolvedRunForSelectedLanguage(
                 course,
                 selectedLanguageOption,
                 selectedRun,
-                selectedLanguageEnrollment ?? null,
+                selectedLanguageEnrollment,
                 contract?.id,
               )
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -10,6 +10,7 @@ import {
   getLanguageOptionKey,
   getResolvedRunForSelectedLanguage,
   getSelectedLanguageOption,
+  selectBestContractEnrollmentForLanguage,
 } from "./languageOptions"
 
 type LanguageOptionWithEnrollability = CourseRunLanguageOption & {
@@ -691,5 +692,174 @@ describe("languageOptions", () => {
         malformedEnrollment,
       ),
     ).toEqual(selectedRun)
+  })
+
+  describe("selectBestContractEnrollmentForLanguage", () => {
+    test("surfaces older-run enrollment when next_run_id points at unenrolled newer run", () => {
+      const oldRun = factories.courses.courseRun({
+        id: 544,
+        courseware_id: "course-v1:UAI+UAI.13+2025",
+        courseware_url: "https://example.com/2025",
+        is_enrollable: false,
+      })
+      const newRun = factories.courses.courseRun({
+        id: 2325,
+        courseware_id: "course-v1:UAI+UAI.13+2026",
+        courseware_url: "https://example.com/2026",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        courseruns: [oldRun, newRun],
+        next_run_id: newRun.id,
+        language_options: [
+          {
+            id: oldRun.id,
+            courseware_id: oldRun.courseware_id,
+            courseware_url: oldRun.courseware_url ?? "",
+            language: "en",
+            title: oldRun.title,
+            run_tag: oldRun.run_tag,
+          },
+          {
+            id: newRun.id,
+            courseware_id: newRun.courseware_id,
+            courseware_url: newRun.courseware_url ?? "",
+            language: "en",
+            title: newRun.title,
+            run_tag: newRun.run_tag,
+          },
+        ],
+      })
+
+      const oldEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: oldRun.id,
+          course: { id: course.id, title: course.title },
+          title: oldRun.title,
+          courseware_id: oldRun.courseware_id,
+          courseware_url: oldRun.courseware_url,
+        },
+      })
+
+      const result = selectBestContractEnrollmentForLanguage(
+        course,
+        [oldEnrollment],
+        "",
+      )
+
+      expect(result?.run.id).toBe(oldRun.id)
+    })
+
+    test("returns null when user has no enrollment for the selected language", () => {
+      const englishRun = factories.courses.courseRun({
+        id: 1,
+        courseware_id: "cw-en",
+        is_enrollable: true,
+      })
+      const spanishRun = factories.courses.courseRun({
+        id: 2,
+        courseware_id: "cw-es",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        courseruns: [englishRun, spanishRun],
+        next_run_id: englishRun.id,
+        language_options: [
+          {
+            id: englishRun.id,
+            courseware_id: englishRun.courseware_id,
+            courseware_url: englishRun.courseware_url ?? "",
+            language: "en",
+            title: englishRun.title,
+            run_tag: englishRun.run_tag,
+          },
+          {
+            id: spanishRun.id,
+            courseware_id: spanishRun.courseware_id,
+            courseware_url: spanishRun.courseware_url ?? "",
+            language: "es",
+            title: spanishRun.title,
+            run_tag: spanishRun.run_tag,
+          },
+        ],
+      })
+
+      const spanishEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: spanishRun.id,
+          course: { id: course.id, title: course.title },
+          title: spanishRun.title,
+          courseware_id: spanishRun.courseware_id,
+        },
+      })
+
+      expect(
+        selectBestContractEnrollmentForLanguage(
+          course,
+          [spanishEnrollment],
+          "language:en",
+        ),
+      ).toBeNull()
+    })
+
+    test("prefers higher-graded enrollment when multiple match the language", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 10,
+        courseware_id: "cw-old",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 20,
+        courseware_id: "cw-new",
+      })
+      const course = factories.courses.course({
+        courseruns: [olderRun, newerRun],
+        next_run_id: newerRun.id,
+        language_options: [
+          {
+            id: olderRun.id,
+            courseware_id: olderRun.courseware_id,
+            courseware_url: olderRun.courseware_url ?? "",
+            language: "en",
+            title: olderRun.title,
+            run_tag: olderRun.run_tag,
+          },
+          {
+            id: newerRun.id,
+            courseware_id: newerRun.courseware_id,
+            courseware_url: newerRun.courseware_url ?? "",
+            language: "en",
+            title: newerRun.title,
+            run_tag: newerRun.run_tag,
+          },
+        ],
+      })
+
+      const newerEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: newerRun.id,
+          course: { id: course.id, title: course.title },
+          title: newerRun.title,
+          courseware_id: newerRun.courseware_id,
+        },
+        grades: [factories.enrollment.grade({ grade: 0.4, passed: false })],
+      })
+      const olderEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: olderRun.id,
+          course: { id: course.id, title: course.title },
+          title: olderRun.title,
+          courseware_id: olderRun.courseware_id,
+        },
+        grades: [factories.enrollment.grade({ grade: 0.95, passed: true })],
+      })
+
+      const result = selectBestContractEnrollmentForLanguage(
+        course,
+        [newerEnrollment, olderEnrollment],
+        "language:en",
+      )
+
+      expect(result?.run.id).toBe(olderRun.id)
+    })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -304,6 +304,65 @@ const getEnrollmentForSelectedLanguage = (
   )
 }
 
+/**
+ * Among contract-scoped enrollments, pick the user's best existing enrollment
+ * whose run is for the selected language on this course. Returns null when the
+ * user has no enrollment matching the language.
+ *
+ * Run language is determined via `course.language_options` (matching by id or
+ * courseware_id), independent of `is_enrollable` — we want to surface
+ * enrollments in older/closed runs too.
+ *
+ * Tiebreak across multiple matches: certificate > highest grade > first.
+ */
+const selectBestContractEnrollmentForLanguage = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollments: CourseRunEnrollmentV3[],
+  selectedLanguageKey: string,
+): CourseRunEnrollmentV3 | null => {
+  const resolvedKey =
+    selectedLanguageKey || getDefaultLanguageOptionKey(course) || ""
+  if (!resolvedKey) {
+    return null
+  }
+
+  const matchingOptions = (course.language_options ?? []).filter(
+    (option) => getLanguageOptionKey(option) === resolvedKey,
+  )
+  if (matchingOptions.length === 0) {
+    return null
+  }
+
+  const optionRunIds = new Set<number>()
+  const optionCoursewareIds = new Set<string>()
+  matchingOptions.forEach((option) => {
+    optionRunIds.add(option.id)
+    if (option.courseware_id) {
+      optionCoursewareIds.add(option.courseware_id)
+    }
+  })
+
+  const matching = enrollments.filter(
+    (enrollment) =>
+      optionRunIds.has(enrollment.run.id) ||
+      optionCoursewareIds.has(enrollment.run.courseware_id),
+  )
+
+  if (matching.length === 0) {
+    return null
+  }
+
+  return matching.reduce((best, current) => {
+    const bestHasCert = !!best.certificate?.uuid
+    const currentHasCert = !!current.certificate?.uuid
+    if (currentHasCert && !bestHasCert) return current
+    if (bestHasCert && !currentHasCert) return best
+    const bestGrade = Math.max(0, ...best.grades.map((g) => g.grade ?? 0))
+    const currentGrade = Math.max(0, ...current.grades.map((g) => g.grade ?? 0))
+    return currentGrade > bestGrade ? current : best
+  }, matching[0])
+}
+
 const getResolvedRunForSelectedLanguage = (
   course: CourseWithCourseRunsSerializerV2,
   selectedLanguageOption: CourseRunLanguageOption | null,
@@ -402,6 +461,7 @@ const getResolvedRunForSelectedLanguage = (
 export {
   getLanguageCodeFromOptionKey,
   getLanguageOptionKey,
+  selectBestContractEnrollmentForLanguage,
   getDistinctLanguageOptions,
   getSelectedLanguageOption,
   getCourseRunForSelectedLanguage,


### PR DESCRIPTION
### What are the relevant tickets?
Fix a bug on prod

### Description (What does it do?)
This fixes a bug on prod where b2b contracts were not picking up enrollments correctly.

In particular, if a course has 2 runs and user is enrolled in the older once (i.e., not the `next_run_id`) then it was not picking up that enrollment.

**Summary of changes:**
- New `selectBestContractEnrollmentForLanguage` helper in `languageOptions.ts`: matches contract-scoped enrollments to the selected language via `language_options.id` / `courseware_id` (regardless of `is_enrollable`, so older/closed runs still match), with certificate > grade > first tiebreak.
- `ContractContent.tsx` calls the helper from both B2B render paths (`OrgProgramDisplay` and `OrgProgramCollectionDisplay`) before falling back to the existing `next_run_id`-pinned `getCourseRunForSelectedLanguage`. When a matching enrollment is found, `selectedRun` is seeded from the user's enrolled run; otherwise the unenrolled UX is unchanged.
- New tests in `languageOptions.test.ts` covering the regression case, no-enrollment-for-language, and the grade tiebreaker.

### How can this be tested? (On RC)

Assuming you have an admin user on RC:
1. Add some user to the MIT Org. The org is number [224 (admin page)](https://rc.mitxonline.mit.edu/admin/b2b/organizationpage/224/change/)), add your user by adding to row in https://rc.mitxonline.mit.edu/admin/b2b/userorganization/
2. Find your user (https://rc.mitxonline.mit.edu/admin/users/user/) add your user to contract to "550 - Cert Selection Test Contract 20260504230107"
3. View the org dashboard (https://rc.learn.mit.edu/dashboard/organization/mit-universal-ai/contract/cert-selection-test-20260504230107) You should not yet be enrolled in any of the org courses, so you should see all NEW RUN S (these are the runs specified by `course.next_run_id`).  
    ```
    Course 1 OLD Run ... 396
    Course 1 NEW Run ... 397
    Course 2 OLD Run ... 398
    Course 2 NEW Run ... 399
    Course 3 OLD Run ... 400
    Course 3 NEW Run ... 401
    ```
5. Create enrollments via Django admin. The runs for these courses are:
    - Create an enrollment in Course 1 Old Run
    - Create an enrollment in Course 2 New Run
6. Refresh dashboard. Your enrollments should be accurately reflected.
7. Try enrolling in Course 3... you should get the NEW Run. 


### How can this be tested? (local)
Set up a B2B contract in MITxOnline with at least three courses and manually enroll yourself in the course urns as follows:
```
Course 1 ... two runs , you are enrolled in OLD one ... NOT the next_run_id one
Course 2 ... two runs, you are enrolled in NEW one
Course 3 ... two runs, you are enrolled in neither
```
1. Check that the contract dashboard shows you enrolled for both Course 1 and Course 2
8. Check that enrolling in Course 3 goes to the NEW run.