### PR TITLE
fix b2b dashboard empty language code

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -802,6 +802,59 @@ describe("languageOptions", () => {
       ).toBeNull()
     })
 
+    test("falls back to legacy best enrollment when all language metadata is blank", () => {
+      const run1 = factories.courses.courseRun({
+        id: 701,
+        courseware_id: "cw-run-1",
+        is_enrollable: false,
+      })
+      const run2 = factories.courses.courseRun({
+        id: 702,
+        courseware_id: "cw-run-2",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        courseruns: [run1, run2],
+        next_run_id: run2.id,
+        language_options: [
+          {
+            id: run1.id,
+            courseware_id: run1.courseware_id,
+            courseware_url: run1.courseware_url ?? "",
+            language: "",
+            title: run1.title,
+            run_tag: run1.run_tag,
+          },
+          {
+            id: run2.id,
+            courseware_id: run2.courseware_id,
+            courseware_url: run2.courseware_url ?? "",
+            language: "",
+            title: run2.title,
+            run_tag: run2.run_tag,
+          },
+        ],
+      })
+
+      const enrolledRun = factories.enrollment.courseEnrollment({
+        run: {
+          id: run1.id,
+          course: { id: course.id, title: course.title },
+          title: run1.title,
+          courseware_id: run1.courseware_id,
+          courseware_url: run1.courseware_url,
+        },
+      })
+
+      const result = selectBestContractEnrollmentForLanguage(
+        course,
+        [enrolledRun],
+        "",
+      )
+
+      expect(result?.run.id).toBe(run1.id)
+    })
+
     test("falls back to legacy best enrollment on single-language courses when language-option run matching fails", () => {
       const languageRunA = factories.courses.courseRun({
         id: 101,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -802,6 +802,65 @@ describe("languageOptions", () => {
       ).toBeNull()
     })
 
+    test("falls back to legacy best enrollment on single-language courses when language-option run matching fails", () => {
+      const languageRunA = factories.courses.courseRun({
+        id: 101,
+        courseware_id: "cw-en-a",
+        is_enrollable: true,
+      })
+      const languageRunB = factories.courses.courseRun({
+        id: 102,
+        courseware_id: "cw-en-b",
+        is_enrollable: true,
+      })
+      const enrolledRun = factories.courses.courseRun({
+        id: 103,
+        courseware_id: "cw-enrolled",
+        is_enrollable: false,
+      })
+
+      const course = factories.courses.course({
+        courseruns: [languageRunA, languageRunB, enrolledRun],
+        next_run_id: languageRunA.id,
+        language_options: [
+          {
+            id: languageRunA.id,
+            courseware_id: languageRunA.courseware_id,
+            courseware_url: languageRunA.courseware_url ?? "",
+            language: "en",
+            title: languageRunA.title,
+            run_tag: languageRunA.run_tag,
+          },
+          {
+            id: languageRunB.id,
+            courseware_id: languageRunB.courseware_id,
+            courseware_url: languageRunB.courseware_url ?? "",
+            language: "en",
+            title: languageRunB.title,
+            run_tag: languageRunB.run_tag,
+          },
+        ],
+      })
+
+      const enrolledRunEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: enrolledRun.id,
+          course: { id: course.id, title: course.title },
+          title: enrolledRun.title,
+          courseware_id: enrolledRun.courseware_id,
+          courseware_url: enrolledRun.courseware_url,
+        },
+      })
+
+      const result = selectBestContractEnrollmentForLanguage(
+        course,
+        [enrolledRunEnrollment],
+        "",
+      )
+
+      expect(result?.run.id).toBe(enrolledRun.id)
+    })
+
     test("prefers higher-graded enrollment when multiple match the language", () => {
       const olderRun = factories.courses.courseRun({
         id: 10,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -855,6 +855,60 @@ describe("languageOptions", () => {
       expect(result?.run.id).toBe(run1.id)
     })
 
+    test("falls back to legacy best enrollment when selected language is en but this course has only blank language metadata", () => {
+      const run1 = factories.courses.courseRun({
+        id: 801,
+        courseware_id: "cw-blank-1",
+        is_enrollable: false,
+      })
+      const run2 = factories.courses.courseRun({
+        id: 802,
+        courseware_id: "cw-blank-2",
+        is_enrollable: true,
+      })
+
+      const course = factories.courses.course({
+        courseruns: [run1, run2],
+        next_run_id: run2.id,
+        language_options: [
+          {
+            id: run1.id,
+            courseware_id: run1.courseware_id,
+            courseware_url: run1.courseware_url ?? "",
+            language: "",
+            title: run1.title,
+            run_tag: run1.run_tag,
+          },
+          {
+            id: run2.id,
+            courseware_id: run2.courseware_id,
+            courseware_url: run2.courseware_url ?? "",
+            language: "",
+            title: run2.title,
+            run_tag: run2.run_tag,
+          },
+        ],
+      })
+
+      const oldEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: run1.id,
+          course: { id: course.id, title: course.title },
+          title: run1.title,
+          courseware_id: run1.courseware_id,
+          courseware_url: run1.courseware_url,
+        },
+      })
+
+      const result = selectBestContractEnrollmentForLanguage(
+        course,
+        [oldEnrollment],
+        "language:en",
+      )
+
+      expect(result?.run.id).toBe(run1.id)
+    })
+
     test("falls back to legacy best enrollment on single-language courses when language-option run matching fails", () => {
       const languageRunA = factories.courses.courseRun({
         id: 101,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -5,7 +5,7 @@ import type {
   CourseRunV2,
   CourseWithCourseRunsSerializerV2,
 } from "@mitodl/mitxonline-api-axios/v2"
-import { getBestRun } from "./helpers"
+import { getBestRun, selectBestEnrollment } from "./helpers"
 
 const LANGUAGE_CODE_TO_NATIVE_NAME: Record<string, string> = {
   ar: "العربية",
@@ -349,6 +349,16 @@ const selectBestContractEnrollmentForLanguage = (
   )
 
   if (matching.length === 0) {
+    const usableLanguageKeys = new Set(
+      (course.language_options ?? [])
+        .map((option) => getLanguageOptionKey(option))
+        .filter((key) => Boolean(key)),
+    )
+    // If this course effectively has a single usable language (or none),
+    // preserve legacy behavior by using best enrollment association.
+    if (usableLanguageKeys.size <= 1) {
+      return selectBestEnrollment(course, enrollments)
+    }
     return null
   }
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -114,6 +114,16 @@ const getEnrollableLanguageOptions = (
   })
 }
 
+const getUsableLanguageKeys = (
+  course: CourseWithCourseRunsSerializerV2,
+): Set<string> => {
+  return new Set(
+    (course.language_options ?? [])
+      .map((option) => getLanguageOptionKey(option))
+      .filter((key) => Boolean(key)),
+  )
+}
+
 const getDefaultLanguageOptionKey = (
   course: CourseWithCourseRunsSerializerV2,
 ): string | null => {
@@ -322,6 +332,7 @@ const selectBestContractEnrollmentForLanguage = (
 ): CourseRunEnrollmentV3 | null => {
   const resolvedKey =
     selectedLanguageKey || getDefaultLanguageOptionKey(course) || ""
+  const usableLanguageKeys = getUsableLanguageKeys(course)
   if (!resolvedKey) {
     return selectBestEnrollment(course, enrollments)
   }
@@ -330,6 +341,9 @@ const selectBestContractEnrollmentForLanguage = (
     (option) => getLanguageOptionKey(option) === resolvedKey,
   )
   if (matchingOptions.length === 0) {
+    if (usableLanguageKeys.size === 0) {
+      return selectBestEnrollment(course, enrollments)
+    }
     return null
   }
 
@@ -349,11 +363,6 @@ const selectBestContractEnrollmentForLanguage = (
   )
 
   if (matching.length === 0) {
-    const usableLanguageKeys = new Set(
-      (course.language_options ?? [])
-        .map((option) => getLanguageOptionKey(option))
-        .filter((key) => Boolean(key)),
-    )
     // If this course effectively has a single usable language (or none),
     // preserve legacy behavior by using best enrollment association.
     if (usableLanguageKeys.size <= 1) {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -323,7 +323,7 @@ const selectBestContractEnrollmentForLanguage = (
   const resolvedKey =
     selectedLanguageKey || getDefaultLanguageOptionKey(course) || ""
   if (!resolvedKey) {
-    return null
+    return selectBestEnrollment(course, enrollments)
   }
 
   const matchingOptions = (course.language_options ?? []).filter(


### PR DESCRIPTION
### What are the relevant tickets?
Another follow-up on https://github.com/mitodl/mit-learn/pull/3286

### Description (What does it do?)
This PR fixes another issue with enrollment association on the B2B dashboard caused by introducing language selection. If language_code is blank, then null is returned from `selectBestContractEnrollmentForLanguage`. This fixes that by falling back to selectBestEnrollment

### How can this be tested?
- Ensure you have MIT Learn and MITx Online configured and connected
- Make sure you have at least one B2B contract that your user is enrolled in without language options, and it should contain at least one program with an enrollable course with the language_code set blank
- Go to the dashboard, click the org tab on the left and attempt to enroll in a course
- You should be redirected to the courseware
- If you go back to the dashboard, the card for that course should now reflect your enrollment status