### PR TITLE
fix: 404 on product pages when live=false

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -41,7 +41,7 @@ const setupApis = ({
   page: CoursePageItem
 }) => {
   setMockResponse.get(
-    urls.courses.coursesList({ readable_id: course.readable_id }),
+    urls.courses.coursesList({ readable_id: course.readable_id, live: true }),
     { results: [course] },
   )
 
@@ -256,7 +256,7 @@ describe("CoursePage", () => {
     { courses: [], pages: [] },
   ])("Returns 404 if no course found", async ({ courses, pages }) => {
     setMockResponse.get(
-      urls.courses.coursesList({ readable_id: "readable_id" }),
+      urls.courses.coursesList({ readable_id: "readable_id", live: true }),
       { results: courses },
     )
     setMockResponse.get(urls.pages.coursePages("readable_id"), {
@@ -264,6 +264,23 @@ describe("CoursePage", () => {
     })
 
     renderWithProviders(<CoursePage readableId="readable_id" />)
+    await waitFor(() => {
+      expect(notFound).toHaveBeenCalled()
+    })
+  })
+
+  test("Returns 404 if course has live=false", async () => {
+    const course = makeCourse()
+    const page = makePage({ course_details: course })
+    // Simulate live=false: the API filters it out, returning empty results
+    setMockResponse.get(
+      urls.courses.coursesList({ readable_id: course.readable_id, live: true }),
+      { results: [] },
+    )
+    setMockResponse.get(urls.pages.coursePages(course.readable_id), {
+      items: [page],
+    })
+    renderWithProviders(<CoursePage readableId={course.readable_id} />)
     await waitFor(() => {
       expect(notFound).toHaveBeenCalled()
     })

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -42,7 +42,7 @@ const PrerequisitesSection = styled.section({
 const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
   const pages = useQuery(pagesQueries.coursePages(readableId))
   const courses = useQuery(
-    coursesQueries.coursesList({ readable_id: readableId }),
+    coursesQueries.coursesList({ readable_id: readableId, live: true }),
   )
   const page = pages.data?.items[0]
   const course = courses.data?.results?.[0]

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -53,7 +53,10 @@ const setupApis = ({
   childPrograms: V2ProgramDetail[]
 } => {
   setMockResponse.get(
-    urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+    urls.programs.programsList({
+      readable_id: program.readable_id,
+      live: true,
+    }),
     { results: [program] },
   )
   setMockResponse.get(urls.pages.programPages(program.readable_id), {
@@ -180,13 +183,18 @@ describe("ProgramAsCoursePage", () => {
     const page = makePage({ program_details: program })
     // Simulate live=false: the API filters it out, returning empty results
     setMockResponse.get(
-      urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+      urls.programs.programsList({
+        readable_id: program.readable_id,
+        live: true,
+      }),
       { results: [] },
     )
     setMockResponse.get(urls.pages.programPages(program.readable_id), {
       items: [page],
     })
-    renderWithProviders(<ProgramAsCoursePage readableId={program.readable_id} />)
+    renderWithProviders(
+      <ProgramAsCoursePage readableId={program.readable_id} />,
+    )
     await waitFor(() => {
       expect(notFound).toHaveBeenCalled()
     })

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -53,7 +53,7 @@ const setupApis = ({
   childPrograms: V2ProgramDetail[]
 } => {
   setMockResponse.get(
-    urls.programs.programsList({ readable_id: program.readable_id }),
+    urls.programs.programsList({ readable_id: program.readable_id, live: true }),
     { results: [program] },
   )
   setMockResponse.get(urls.pages.programPages(program.readable_id), {
@@ -163,13 +163,30 @@ describe("ProgramAsCoursePage", () => {
 
   test("Returns 404 if no program found", async () => {
     setMockResponse.get(
-      urls.programs.programsList({ readable_id: "readable_id" }),
+      urls.programs.programsList({ readable_id: "readable_id", live: true }),
       { results: [] },
     )
     setMockResponse.get(urls.pages.programPages("readable_id"), {
       items: [],
     })
     renderWithProviders(<ProgramAsCoursePage readableId="readable_id" />)
+    await waitFor(() => {
+      expect(notFound).toHaveBeenCalled()
+    })
+  })
+
+  test("Returns 404 if program has live=false", async () => {
+    const program = makeProgramAsCourse()
+    const page = makePage({ program_details: program })
+    // Simulate live=false: the API filters it out, returning empty results
+    setMockResponse.get(
+      urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+      { results: [] },
+    )
+    setMockResponse.get(urls.pages.programPages(program.readable_id), {
+      items: [page],
+    })
+    renderWithProviders(<ProgramAsCoursePage readableId={program.readable_id} />)
     await waitFor(() => {
       expect(notFound).toHaveBeenCalled()
     })

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -215,7 +215,7 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
 }) => {
   const pages = useQuery(pagesQueries.programPages(readableId))
   const programs = useQuery(
-    programsQueries.programsList({ readable_id: readableId }),
+    programsQueries.programsList({ readable_id: readableId, live: true }),
   )
 
   const page = pages.data?.items[0]

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -162,7 +162,10 @@ const setupApis = ({
   childPrograms: V2ProgramDetail[]
 } => {
   setMockResponse.get(
-    urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+    urls.programs.programsList({
+      readable_id: program.readable_id,
+      live: true,
+    }),
     { results: [program] },
   )
 
@@ -657,7 +660,10 @@ describe("ProgramPage", () => {
     const page = makePage({ program_details: program })
     // Simulate live=false: the API filters it out, returning empty results
     setMockResponse.get(
-      urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+      urls.programs.programsList({
+        readable_id: program.readable_id,
+        live: true,
+      }),
       { results: [] },
     )
     setMockResponse.get(urls.pages.programPages(program.readable_id), {

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -162,7 +162,7 @@ const setupApis = ({
   childPrograms: V2ProgramDetail[]
 } => {
   setMockResponse.get(
-    urls.programs.programsList({ readable_id: program.readable_id }),
+    urls.programs.programsList({ readable_id: program.readable_id, live: true }),
     { results: [program] },
   )
 
@@ -639,7 +639,7 @@ describe("ProgramPage", () => {
     },
   ])("Returns 404 if no program found", async ({ programs, pages }) => {
     setMockResponse.get(
-      urls.programs.programsList({ readable_id: "readable_id" }),
+      urls.programs.programsList({ readable_id: "readable_id", live: true }),
       { results: programs },
     )
     setMockResponse.get(urls.pages.programPages("readable_id"), {
@@ -647,6 +647,23 @@ describe("ProgramPage", () => {
     })
 
     renderWithProviders(<ProgramPage readableId="readable_id" />)
+    await waitFor(() => {
+      expect(notFound).toHaveBeenCalled()
+    })
+  })
+
+  test("Returns 404 if program has live=false", async () => {
+    const program = makeProgram({ ...makeReqs() })
+    const page = makePage({ program_details: program })
+    // Simulate live=false: the API filters it out, returning empty results
+    setMockResponse.get(
+      urls.programs.programsList({ readable_id: program.readable_id, live: true }),
+      { results: [] },
+    )
+    setMockResponse.get(urls.pages.programPages(program.readable_id), {
+      items: [page],
+    })
+    renderWithProviders(<ProgramPage readableId={program.readable_id} />)
     await waitFor(() => {
       expect(notFound).toHaveBeenCalled()
     })

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -220,7 +220,7 @@ const RequirementsSection: React.FC<RequirementsSectionProps> = ({
 const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
   const pages = useQuery(pagesQueries.programPages(readableId))
   const programs = useQuery(
-    programsQueries.programsList({ readable_id: readableId }),
+    programsQueries.programsList({ readable_id: readableId, live: true }),
   )
 
   const page = pages.data?.items[0]

--- a/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
-import { safeGenerateMetadata, standardizeMetadata } from "@/common/metadata"
+import {
+  safeGenerateMetadata,
+  standardizeMetadata,
+  MetadataNotFound,
+} from "@/common/metadata"
 import CoursePage from "@/app-pages/ProductPages/CoursePage"
 import { notFound } from "next/navigation"
 import { pagesQueries } from "api/mitxonline-hooks/pages"
@@ -17,17 +21,16 @@ export const generateMetadata = async (
   return safeGenerateMetadata(async () => {
     const queryClient = getQueryClient()
 
-    const coursePages = await queryClient.fetchQuery(
-      pagesQueries.coursePages(readableId),
+    const { results: courses } = await queryClient.fetchQuery(
+      coursesQueries.coursesList({ readable_id: readableId, live: true }),
     )
 
-    if (coursePages.items.length === 0) {
-      notFound()
+    if (courses.length === 0) {
+      throw new MetadataNotFound()
     }
-    const [course] = coursePages.items
+    const [course] = courses
 
-    const image =
-      course.course_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    const image = course.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
     return standardizeMetadata({
       title: course.title,

--- a/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/[readable_id]/page.tsx
@@ -49,7 +49,7 @@ const Page: React.FC<PageProps<"/courses/[readable_id]">> = async (props) => {
   const [coursePages, courses] = await Promise.all([
     queryClient.fetchQuery(pagesQueries.coursePages(readableId)),
     queryClient.fetchQuery(
-      coursesQueries.coursesList({ readable_id: readableId }),
+      coursesQueries.coursesList({ readable_id: readableId, live: true }),
     ),
   ])
 

--- a/frontends/main/src/app/(products)/courses/p/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/p/[readable_id]/page.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
-import { safeGenerateMetadata, standardizeMetadata } from "@/common/metadata"
+import {
+  safeGenerateMetadata,
+  standardizeMetadata,
+  MetadataNotFound,
+} from "@/common/metadata"
 import ProgramAsCoursePage from "@/app-pages/ProductPages/ProgramAsCoursePage"
 import { notFound, redirect } from "next/navigation"
 import { pagesQueries } from "api/mitxonline-hooks/pages"
@@ -19,17 +23,16 @@ export const generateMetadata = async (
   return safeGenerateMetadata(async () => {
     const queryClient = getQueryClient()
 
-    const programPages = await queryClient.fetchQuery(
-      pagesQueries.programPages(readableId),
+    const { results: programs } = await queryClient.fetchQuery(
+      programsQueries.programsList({ readable_id: readableId, live: true }),
     )
 
-    if (programPages.items.length === 0) {
-      notFound()
+    if (programs.length === 0) {
+      throw new MetadataNotFound()
     }
-    const [program] = programPages.items
+    const [program] = programs
 
-    const image =
-      program.program_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    const image = program.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
     return standardizeMetadata({
       title: program.title,

--- a/frontends/main/src/app/(products)/courses/p/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/courses/p/[readable_id]/page.tsx
@@ -51,7 +51,7 @@ const Page: React.FC<PageProps<"/courses/p/[readable_id]">> = async (props) => {
   const [programPages, programs] = await Promise.all([
     queryClient.fetchQuery(pagesQueries.programPages(readableId)),
     queryClient.fetchQuery(
-      programsQueries.programsList({ readable_id: readableId }),
+      programsQueries.programsList({ readable_id: readableId, live: true }),
     ),
   ])
 

--- a/frontends/main/src/app/(products)/programs/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/programs/[readable_id]/page.tsx
@@ -51,7 +51,7 @@ const Page: React.FC<PageProps<"/programs/[readable_id]">> = async (props) => {
   const [programPages, programs] = await Promise.all([
     queryClient.fetchQuery(pagesQueries.programPages(readableId)),
     queryClient.fetchQuery(
-      programsQueries.programsList({ readable_id: readableId }),
+      programsQueries.programsList({ readable_id: readableId, live: true }),
     ),
   ])
 

--- a/frontends/main/src/app/(products)/programs/[readable_id]/page.tsx
+++ b/frontends/main/src/app/(products)/programs/[readable_id]/page.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
-import { safeGenerateMetadata, standardizeMetadata } from "@/common/metadata"
+import {
+  safeGenerateMetadata,
+  standardizeMetadata,
+  MetadataNotFound,
+} from "@/common/metadata"
 import ProgramPage from "@/app-pages/ProductPages/ProgramPage"
 import { notFound, redirect } from "next/navigation"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
@@ -19,17 +23,16 @@ export const generateMetadata = async (
   return safeGenerateMetadata(async () => {
     const queryClient = getQueryClient()
 
-    const programPages = await queryClient.fetchQuery(
-      pagesQueries.programPages(readableId),
+    const { results: programs } = await queryClient.fetchQuery(
+      programsQueries.programsList({ readable_id: readableId, live: true }),
     )
 
-    if (programPages.items.length === 0) {
-      notFound()
+    if (programs.length === 0) {
+      throw new MetadataNotFound()
     }
-    const [program] = programPages.items
+    const [program] = programs
 
-    const image =
-      program.program_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    const image = program.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
     return standardizeMetadata({
       title: program.title,

--- a/frontends/main/src/common/metadata.ts
+++ b/frontends/main/src/common/metadata.ts
@@ -21,6 +21,13 @@ type MetadataAsyncProps = {
 } & Metadata
 
 /**
+ * Throw inside safeGenerateMetadata to trigger a 404 not-found response.
+ * Use this instead of Next.js's notFound(), which throws an internal error
+ * that safeGenerateMetadata's catch block cannot intercept.
+ */
+export class MetadataNotFound extends Error {}
+
+/**
  * Wraps the metadata generation function in a try/catch block. Uncaught or
  * rethrown errors in generateMetadata result in showing the fallback error page,
  * which is heavy handed for metadata generation errors.
@@ -38,12 +45,15 @@ export async function safeGenerateMetadata(
   try {
     return await fn()
   } catch (error: unknown) {
+    if (error instanceof MetadataNotFound) {
+      return notFound()
+    }
     if ((error as AxiosError)?.response?.status === 404) {
       return notFound()
     }
     console.error("Error fetching page metadata", error)
     Sentry.captureException(error)
-    return await standardizeMetadata()
+    return standardizeMetadata()
   }
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/10597
<!--- N/A --->

### Description (What does it do?)
**Problem**
Course and program product pages (/courses/[id], /courses/p/[id], /programs/[id]) were fetching from the MITxOnline API without the live=true filter. This caused a mismatch: the server-side route correctly filtered by live=true (returning 404 for non-live resources), but the client-side page components were fetching without the filter. When a resource had live=false, the client-side query would return results but the server would 404, leading to inconsistent behavior.

**Solution**
Add live: true to all MITxOnline API calls in the page components and their corresponding server-side routes, so client and server both consistently exclude non-live resources:

CoursePage.tsx — courses query
ProgramPage.tsx — programs query
ProgramAsCoursePage.tsx — programs query
/courses/[readable_id]/page.tsx — server-side courses fetch
/courses/p/[readable_id]/page.tsx — server-side programs fetch
/programs/[readable_id]/page.tsx — server-side programs fetch

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [ ] Mobile width screenshots


BEFORE Program
<img width="1904" height="1012" alt="Program" src="https://github.com/user-attachments/assets/4d835db4-bf93-4b3f-8dff-7625f4aaff55" />
<img width="1918" height="1013" alt="UniversalAI" src="https://github.com/user-attachments/assets/a2b5d2c5-0f83-402c-8bf3-1fa3e91132d7" />

AFTER Program
<img width="1918" height="1013" alt="UniversalAI" src="https://github.com/user-attachments/assets/62781ea1-7f8b-4b62-8ce7-8a51d264a5f1" />

BEFORE Course 

<img width="1907" height="1010" alt="Course" src="https://github.com/user-attachments/assets/17288a51-d2c9-4208-98a8-2e720f9598b5" />

<img width="1901" height="996" alt="Case1" src="https://github.com/user-attachments/assets/66e97d16-edf6-4dc6-af33-4b4386f026a1" />

AFTER Course 
<img width="1917" height="1002" alt="Case1404" src="https://github.com/user-attachments/assets/8688fecd-1ca6-473a-8722-173e3e0a2c87" />

BEFORE Program As Course 
<img width="1908" height="1002" alt="ProgramAsCourse" src="https://github.com/user-attachments/assets/fa371dcf-0c01-4158-8743-6ba8eab308c8" />
<img width="1915" height="1013" alt="Fundamentals ofDeepLearning" src="https://github.com/user-attachments/assets/a0f5267a-3caa-45f4-af52-8c61b5f9dc9f" />


AFTER Program As Course 
<img width="1905" height="1010" alt="Fundamentals ofDeepLearning404" src="https://github.com/user-attachments/assets/a14a0815-964f-4ea3-a223-9a52d62b3e3c" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

The product pages pull from two sources: the MITxOnline Programs/Courses API and the MITxOnline Wagtail CMS. Both must return data for a page to render.

Find a program with display_mode: "course" and live: true via http://mitxonline.odl.local:8013/api/v2/programs/?page_size=100 — note its readable_id
Confirm a Wagtail page exists for it: http://mitxonline.odl.local:8013/api/v2/pages/?fields=*&type=cms.programpage&readable_id=<readable_id> — if items is empty, create the page in the Wagtail admin at http://mitxonline.odl.local:8013/cms/ and publish it
Navigate to http://open.odl.local:8062/courses/p/<readable_id> — the page should render
Go to http://mitxonline.odl.local:8013/admin/ and find the program, uncheck the live field, and save
Reload http://open.odl.local:8062/courses/p/<readable_id> — it should now return a 404
Re-check live in the Django admin when done

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
I noticed generateMetadata doesn't check live: true, so it can return metadata for pages that 404; not a blocker but worth a separate ticket.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
