### PR TITLE
fix: remove the top border when there is only single item and removed the current episode from the more episode list

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -167,6 +167,11 @@ const EpisodeRow = styled("li", {
   padding: !isEpisodePage ? "28px 16px" : "28px 0px",
   ...(isEpisodePage && {
     "&:first-of-type": { paddingTop: 0, boxShadow: "none" },
+    // When there is only one episode (first AND last), keep only the bottom
+    // shadow — the top shadow from :first-of-type should remain removed.
+    "&:first-of-type:last-child": {
+      boxShadow: `0 1px 0 ${theme.custom.colors.lightGray2}`,
+    },
   }),
   boxShadow: `0 -1px 0 ${theme.custom.colors.lightGray2}`,
   gap: "16px",

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
@@ -119,7 +119,8 @@ describe("PodcastEpisodeDetailPage", () => {
   })
 
   test("renders 'More from <podcast>' section header", async () => {
-    const { episode, podcast } = setupApis()
+    const moreEpisodes = [makePodcastEpisode(), makePodcastEpisode()]
+    const { episode, podcast } = setupApis({ moreEpisodes })
 
     renderWithProviders(
       <PodcastEpisodeDetailPage

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "ol-components"
 import type { Theme } from "ol-components"
 import { Button } from "@mitodl/smoot-design"
-import { RiPlayFill } from "@remixicon/react"
+import { RiPlayFill, RiPauseFill } from "@remixicon/react"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
@@ -220,7 +220,11 @@ export const PodcastEpisodeDetailPage: React.FC<
     episodesData?.pages.flatMap((page) =>
       page.results
         .map((rel) => rel.resource)
-        .filter((r) => r.resource_type === ResourceTypeEnum.PodcastEpisode),
+        .filter(
+          (r) =>
+            r.resource_type === ResourceTypeEnum.PodcastEpisode &&
+            r.id !== Number(episodeId),
+        ),
     ) ?? []
   const duration = podcastEpisode?.duration
     ? Math.round(moment.duration(podcastEpisode.duration).asMinutes())
@@ -241,8 +245,18 @@ export const PodcastEpisodeDetailPage: React.FC<
     return candidate?.trim() ? candidate : null
   }
 
+  const isCurrentEpisodePlaying =
+    !!episode && playingEpisode?.id === episode.id && isAudioPlaying
+
   const handlePlay = () => {
-    if (episode && getAudioUrl(episode)) {
+    if (!episode) return
+    if (playingEpisode?.id === episode.id) {
+      if (isAudioPlaying) {
+        playerRef.current?.pause()
+      } else {
+        playerRef.current?.resume()
+      }
+    } else if (getAudioUrl(episode)) {
       setPlayingEpisode(episode)
     }
   }
@@ -311,10 +325,12 @@ export const PodcastEpisodeDetailPage: React.FC<
               <StyledButton
                 onClick={handlePlay}
                 variant="primary"
-                startIcon={<RiPlayFill />}
+                startIcon={
+                  isCurrentEpisodePlaying ? <RiPauseFill /> : <RiPlayFill />
+                }
                 disabled={!episode || !getAudioUrl(episode)}
               >
-                Play Episode
+                {isCurrentEpisodePlaying ? "Pause Episode" : "Play Episode"}
               </StyledButton>
             )}
 
@@ -328,11 +344,12 @@ export const PodcastEpisodeDetailPage: React.FC<
             )}
           </EpisodeContainer>
         </HeaderSection>
-        <EpisodeContainer>
-          <MoreItemDescription>
-            More from {podcast?.title ?? "Podcast"}
-          </MoreItemDescription>
-          {episodes && episodes.length > 0 && (
+        {episodes && episodes.length > 0 && (
+          <EpisodeContainer>
+            <MoreItemDescription>
+              More from {podcast?.title ?? "Podcast"}
+            </MoreItemDescription>
+
             <EpisodeList>
               {episodes.map((episode) => (
                 <EpisodeItem
@@ -355,11 +372,11 @@ export const PodcastEpisodeDetailPage: React.FC<
                 />
               ))}
             </EpisodeList>
-          )}
-          {podcastId && (
-            <ViewAllLink href={podcastHref}>View all episodes →</ViewAllLink>
-          )}
-        </EpisodeContainer>
+            {podcastId && (
+              <ViewAllLink href={podcastHref}>View all episodes →</ViewAllLink>
+            )}
+          </EpisodeContainer>
+        )}
       </PageSection>
 
       {currentTrack && (

--- a/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
@@ -259,11 +259,11 @@ const CloseButton = styled.button(({ theme }) => ({
   alignItems: "center",
   color: theme.custom.colors.darkGray2,
   flexShrink: 0,
+  width: "32px",
+  height: "32px",
   "&:hover": {
     backgroundColor: theme.custom.colors.red,
     color: theme.custom.colors.white,
-    width: "32px",
-    height: "32px",
     alignItems: "center",
     justifyContent: "center",
     borderRadius: "4px",


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
- There was edge case that if there is only single episode then the top border was rendering which should not so this is about removing the top border in case single item
- one more change in this PR that the current episode should not be the part of `More from  <podcast>` which was previously part of this list so I removed it from that more episode list.


### Screenshots (if appropriate):
Before
<img width="1490" height="316" alt="image" src="https://github.com/user-attachments/assets/d0dfb715-6c7d-4b0e-b090-802f92e92528" />

After
<img width="1628" height="424" alt="image" src="https://github.com/user-attachments/assets/d3fa6325-37c4-4f3a-8ac9-5ab69b9d9ddb" />


### How can this be tested?
if you don't have playlist data locally then in frontend env file you should add the following variable `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.rc.learn.mit.edu"` it will connect with RC learn backend
then we need to enable the flag which is `podcast-detail-page` and then visit the following url `http://open.odl.local:8062/podcast/128673/podcast_episode/128674`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
