### PR TITLE
fix: improve the hover state of video and adjust the border of breadcrum

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -244,10 +244,10 @@ const StyledIcon = styled(RiPlayFill)({
 })
 
 const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "20px 0 4px 0",
-  borderBottom: `2px solid ${theme.custom.colors.red}`,
+  padding: "18px 0 2px 0",
+  borderBottom: `1px solid ${theme.custom.colors.red}`,
   [theme.breakpoints.down("sm")]: {
-    padding: "16px 0 0px 0",
+    padding: "12px 0 0px 0",
   },
 }))
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -144,11 +144,10 @@ const EpisodeList = styled.ul({
 })
 
 export const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "20px 0 4px 0",
-  borderBottom: `2px solid ${theme.custom.colors.red}`,
-  backgroundColor: theme.custom.colors.white,
+  padding: "18px 0 2px 0",
+  borderBottom: `1px solid ${theme.custom.colors.red}`,
   [theme.breakpoints.down("sm")]: {
-    padding: "16px 0 0 0",
+    padding: "12px 0 0 0",
   },
 }))
 

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
@@ -54,11 +54,10 @@ const EpisodeRowLink = styled(Link)(({ theme }) => ({
   flex: 1,
   "&:hover .episode-title, &:focus-visible .episode-title": {
     color: theme.custom.colors.darkRed,
-    fontWeight: theme.typography.fontWeightBold,
   },
   "&:hover .play-button, &:focus-visible .play-button": {
     color: theme.custom.colors.red,
-    border: `1px solid ${theme.custom.colors.darkGray1}`,
+    borderColor: theme.custom.colors.darkGray1,
   },
   [theme.breakpoints.down("sm")]: {
     flexDirection: "row",

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/SeriesVideoList.tsx
@@ -53,10 +53,12 @@ const EpisodeRowLink = styled(Link)(({ theme }) => ({
   textDecoration: "none",
   flex: 1,
   "&:hover .episode-title, &:focus-visible .episode-title": {
-    color: theme.custom.colors.red,
+    color: theme.custom.colors.darkRed,
+    fontWeight: theme.typography.fontWeightBold,
   },
   "&:hover .play-button, &:focus-visible .play-button": {
     color: theme.custom.colors.red,
+    border: `1px solid ${theme.custom.colors.darkGray1}`,
   },
   [theme.breakpoints.down("sm")]: {
     flexDirection: "row",
@@ -71,7 +73,7 @@ const EpisodeRow = styled.li(({ theme }) => ({
   display: "flex",
   flexDirection: "row",
   "&:last-child": {
-    boxShadow: `0 -1px 0 ${theme.custom.colors.lightGray2}, 0 1px 0 ${theme.custom.colors.lightGray2}`,
+    boxShadow: `0 1px 0 ${theme.custom.colors.lightGray2}`,
   },
   "&:has(a:hover), &:has(a:focus-visible)": {
     backgroundColor: theme.custom.colors.lightGray1,
@@ -172,7 +174,6 @@ const PlayButton = styled("div")<{
     width: "48px",
     height: "48px",
     border: `1px solid ${theme.custom.colors.silverGrayLight}`,
-    borderRadius: "8px",
     display: "flex",
     alignItems: "center",
     justifyContent: "center",

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPageHeader.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPageHeader.tsx
@@ -4,10 +4,10 @@ import type { VideoPlaylistResource } from "api/v1"
 import VideoContainer from "./VideoContainer"
 
 const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "20px 0 4px 0",
-  borderBottom: `2px solid ${theme.custom.colors.red}`,
+  padding: "18px 0 2px 0",
+  borderBottom: `1px solid ${theme.custom.colors.red}`,
   [theme.breakpoints.down("sm")]: {
-    padding: "16px 0 0px 0",
+    padding: "12px 0 0px 0",
   },
 }))
 

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.styled.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.styled.ts
@@ -15,10 +15,10 @@ export const PageWrapper = styled.div({
 })
 
 export const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "20px 0 4px 0",
-  borderBottom: `2px solid ${theme.custom.colors.red}`,
+  padding: "18px 0 2px 0",
+  borderBottom: `1px solid ${theme.custom.colors.red}`,
   [theme.breakpoints.down("sm")]: {
-    padding: "16px 0 0 0",
+    padding: "12px 0 0 0",
   },
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
- Adjust the border of breadcrum which was 2px but now it is 1px
- Change the hover effect of video item on video series page 

### Screenshots (if appropriate):
<img width="1188" height="246" alt="Screenshot 2026-05-06 at 3 03 06 PM" src="https://github.com/user-attachments/assets/8f3eadc0-fda1-406f-8029-d6c629b8c9c1" />

<img width="2840" height="486" alt="image" src="https://github.com/user-attachments/assets/137e6633-23d0-45b5-af90-ce76c52654cd" />



### How can this be tested?
if you don't have playlist data locally then in frontend env file you should add the following variable `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.learn.mit.edu"` it will connect with prod learn backend
then we need to enable the flag which is `video-playlist-page` and then visit the following url `http://open.odl.local:8062/video-playlist/88443`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
