### PR TITLE
fix: change play icon for video collection detail page

### DIFF
--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
@@ -123,10 +123,31 @@ const PlayerWrapper = styled.div(({ theme }) => ({
     left: 0,
   },
   ".vjs-big-play-button": {
-    width: "64px !important",
-    height: "64px !important",
-    lineHeight: "64px !important",
+    width: "92px !important",
+    height: "92px !important",
+    lineHeight: "92px !important",
     borderRadius: "50% !important",
+    backgroundColor: "#d8daddb3 !important",
+    border: "none !important",
+    fontSize: "4em !important",
+    marginTop: "-1.25em !important",
+    marginLeft: "-1.18em !important",
+    [theme.breakpoints.down("sm")]: {
+      width: "68px !important",
+      height: "68px !important",
+      lineHeight: "68px !important",
+      marginLeft: "-1em !important",
+      marginTop: "-.7em !important",
+    },
+  },
+  "& .vjs-big-play-button": {
+    opacity: 1,
+    transform: "scale(1)",
+    transition: "opacity 0.3s ease, transform 0.3s ease",
+  },
+  "&:hover .vjs-big-play-button": {
+    opacity: 0.75,
+    transform: "scale(1.12)",
   },
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
Change the play icon on video collection detail page


### Screenshots (if appropriate):
<img width="1938" height="836" alt="image" src="https://github.com/user-attachments/assets/99dc1f09-0a99-4a78-88bb-afaf0ec25a70" />

### How can this be tested?
if you don't have playlist data locally then in frontend env file you should add the following variable `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.learn.mit.edu"` it will connect with learn backend
then we need to enable the flag which is `video-playlist-page` and then visit the following url `http://open.odl.local:8062/video-playlist/detail/88444?playlist=88443`


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
