### PR TITLE
Both ETL and webhook should populate OVS resource_category when appli…

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -15,7 +15,6 @@ from learning_resources.constants import (
     OCW_CONTENT_CATEGORY_LECTURE_VIDEOS,
     OCW_COURSE_CONTENT_CATEGORY_MAPPING,
     VIDEO_CONTENT_CATEGORIES,
-    VIDEO_SHORT_RESOURCE_CATEGORY,
     LearningResourceDelivery,
     LearningResourceRelationTypes,
     LearningResourceType,
@@ -1493,8 +1492,6 @@ def load_ovs_video_from_webhook(video_payload: dict) -> LearningResource | None:
     if video_data is None:
         return None
     collection = video_payload.get("collection") or {}
-    if collection.get("for_shorts"):
-        video_data["resource_category"] = VIDEO_SHORT_RESOURCE_CATEGORY
 
     with transaction.atomic():
         playlist = (

--- a/learning_resources/etl/ovs.py
+++ b/learning_resources/etl/ovs.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db.models import QuerySet
 
 from learning_resources.constants import (
+    VIDEO_SHORT_RESOURCE_CATEGORY,
     Availability,
     LearningResourceType,
     PlatformType,
@@ -221,7 +222,7 @@ def transform_video(video_data: dict) -> dict | None:
     cover_image_url = _get_cover_image_url(video_data)
     image_data = {"url": cover_image_url} if cover_image_url else None
 
-    return {
+    video_dict = {
         "readable_id": video_data["key"],
         "platform": PlatformType.ovs.name,
         "etl_source": ETLSource.ovs.name,
@@ -240,6 +241,10 @@ def transform_video(video_data: dict) -> dict | None:
             "cover_image_url": cover_image_url or "",
         },
     }
+
+    if (video_data.get("collection") or {}).get("for_shorts", False):
+        video_dict["resource_category"] = VIDEO_SHORT_RESOURCE_CATEGORY
+    return video_dict
 
 
 def transform_collection(collection_data: dict) -> dict:

--- a/learning_resources/etl/ovs_test.py
+++ b/learning_resources/etl/ovs_test.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 
 from learning_resources.constants import (
+    VIDEO_SHORT_RESOURCE_CATEGORY,
     Availability,
     LearningResourceType,
     PlatformType,
@@ -568,6 +569,37 @@ class TestTransform:
             "duration": 0,
         }
         assert transform_video(video_data) is None
+
+
+@pytest.mark.parametrize(
+    ("collection", "expected_category"),
+    [
+        pytest.param(
+            {"key": "c1", "for_shorts": True},
+            VIDEO_SHORT_RESOURCE_CATEGORY,
+            id="for_shorts_true",
+        ),
+        pytest.param({"key": "c1", "for_shorts": False}, None, id="for_shorts_false"),
+        pytest.param({"key": "c1"}, None, id="for_shorts_missing"),
+        pytest.param(None, None, id="collection_none"),
+    ],
+)
+def test_transform_video_resource_category(collection, expected_category):
+    """resource_category is set only when the video's collection has for_shorts=True"""
+    video_data = {
+        "key": "test_key",
+        "title": "Test",
+        "description": "",
+        "created_at": "2020-01-01T00:00:00Z",
+        "sources": [{"src": "https://example.com/video__index.m3u8"}],
+        "videothumbnail_set": [],
+        "videosubtitle_set": [],
+        "cta_link": None,
+        "duration": 0,
+        "collection": collection,
+    }
+    result = transform_video(video_data)
+    assert result.get("resource_category") == expected_category
 
 
 @pytest.fixture


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/mit-learn/pull/3275

### Description (What does it do?)
<!--- Describe your changes in detail -->
Moves a few lines of code so that the OVS webhook and ETL both assign "Video Short" as resource category when applicable.


### How can this be tested?
- Set `OVS_API_BASE_URL=https://video-rc.odl.mit.edu`
- Run `docker compose run --rm web python manage.py backpopulate_ovs_data`
- Check that some ingested videos have a resource_category of `Video Short", such as ""Professor Elizabeth Siler explains how she uses MIT OCW as an open educational resource.""

