### PR TITLE
translations UI design revisions

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -50,11 +50,12 @@ const HeaderRoot = styled.div({
 })
 
 const ImageContainer = styled.div(({ theme }) => ({
-  width: "120px",
-  height: "118px",
-  padding: "0 24px",
   display: "flex",
+  width: "80px",
+  height: "80px",
+  padding: "16px",
   alignItems: "center",
+  justifyContent: "center",
   borderRadius: "8px",
   backgroundColor: theme.custom.colors.white,
   boxShadow: "0px 1px 3px 0px rgba(120, 147, 172, 0.40)",
@@ -62,6 +63,10 @@ const ImageContainer = styled.div(({ theme }) => ({
     width: "100%",
     height: "auto",
   },
+}))
+
+const SubHeaderText = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
 }))
 
 const ContractHeader: React.FC<{
@@ -87,7 +92,7 @@ const ContractHeader: React.FC<{
         <Typography variant="h3" component="h1">
           {org?.name}
         </Typography>
-        <Typography variant="body1">{contract?.name}</Typography>
+        <SubHeaderText variant="subtitle1">{contract?.name}</SubHeaderText>
       </Stack>
     </HeaderRoot>
   )
@@ -218,12 +223,10 @@ const ProgramLanguageSelect = styled(SimpleSelectField)(({ theme }) => ({
     marginBottom: "0",
   },
   "> label": {
+    ...theme.typography.body3,
+    color: theme.custom.colors.silverGrayDark,
     marginBottom: "0",
     whiteSpace: "nowrap",
-  },
-  "> .MuiInputBase-root": {
-    width: "fit-content",
-    maxWidth: "100%",
   },
   [theme.breakpoints.down("sm")]: {
     "> .MuiInputBase-root": {
@@ -550,9 +553,13 @@ const ContractRoot = styled.div({
 
 const ContractHeaderSection = styled.div(({ theme }) => ({
   display: "flex",
+  padding: "24px",
+  alignItems: "center",
   justifyContent: "space-between",
-  alignItems: "flex-start",
-  gap: "16px",
+  gap: "24px",
+  borderRadius: "8px",
+  backgroundColor: theme.custom.colors.white,
+  boxShadow: "0 1px 6px 0 rgba(3, 21, 45, 0.05)",
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
   },
@@ -669,21 +676,6 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
         <Stack>
           <ContractHeaderSection>
             <ContractHeader org={org} contract={contract} />
-            {languageOptions.length > 1 && (
-              <ProgramLanguageSelect
-                size="small"
-                label="Learning Language:"
-                value={selectedLanguageKey}
-                onChange={(e) => setSelectedLanguageKey(String(e.target.value))}
-                options={languageOptions}
-                renderValue={(value) => {
-                  const selected = languageOptions.find(
-                    (opt) => opt.value === value,
-                  )
-                  return String(selected?.label ?? "")
-                }}
-              />
-            )}
           </ContractHeaderSection>
           <WelcomeMessage contract={contract} />
         </Stack>
@@ -708,7 +700,11 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
                 const selected = languageOptions.find(
                   (opt) => opt.value === value,
                 )
-                return String(selected?.label ?? "")
+                return (
+                  <Typography variant="subtitle3" marginRight="16px">
+                    {selected?.label ?? ""}
+                  </Typography>
+                )
               }}
             />
           )}

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -217,6 +217,7 @@ const ProgramLanguageSelect = styled(SimpleSelectField)(({ theme }) => ({
   display: "inline-flex",
   flexDirection: "row",
   alignItems: "center",
+  margin: "10px",
   gap: "8px",
   width: "auto",
   "> *:not(:last-child)": {

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -351,7 +351,7 @@ const OrgProgramCollectionDisplay: React.FC<{
   const header = (
     <ProgramHeader>
       <ProgramHeaderText>
-        <Typography variant="h5" component="h2">
+        <Typography variant="subtitle1" component="h2">
           {collection.title}
         </Typography>
         <ProgramDescription html={collection.description ?? ""} />
@@ -499,7 +499,7 @@ const OrgProgramDisplay: React.FC<{
     <ProgramRoot data-testid="org-program-root">
       <ProgramHeader>
         <ProgramHeaderText>
-          <Typography variant="h5" component="h2">
+          <Typography variant="subtitle1" component="h2">
             {program.title}
           </Typography>
           <ProgramDescription html={program.page.description ?? ""} />

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -258,6 +258,7 @@ const ProgramLanguageSelect = styled(SimpleSelectField)(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {
     width: "100%",
     padding: "12px 16px",
+    borderRadius: "0 0 8px 8px",
     justifyContent: "space-between",
     ".MuiInputBase-root": {
       width: "100%",

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -495,8 +495,8 @@ const OrgProgramDisplay: React.FC<{
           </Typography>
           <ProgramDescription html={program.page.description ?? ""} />
         </ProgramHeaderText>
-        <ProgramControls>
-          {hasValidCertificate && (
+        {hasValidCertificate && (
+          <ProgramControls>
             <ProgramCertificateButton
               size="small"
               variant="bordered"
@@ -505,8 +505,8 @@ const OrgProgramDisplay: React.FC<{
             >
               {`View ${program.program_type ? `${program.program_type} ` : ""}Certificate`}
             </ProgramCertificateButton>
-          )}
-        </ProgramControls>
+          </ProgramControls>
+        )}
       </ProgramHeader>
       <PlainList>
         {programLoading || coursesQuery.isLoading

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -43,11 +43,16 @@ import {
 } from "./CoursewareDisplay/languageOptions"
 import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 
-const HeaderRoot = styled.div({
+const HeaderRoot = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: "24px",
-})
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+    padding: "0 16px",
+    gap: "16px",
+  },
+}))
 
 const ImageContainer = styled.div(({ theme }) => ({
   display: "flex",
@@ -63,11 +68,28 @@ const ImageContainer = styled.div(({ theme }) => ({
     width: "100%",
     height: "auto",
   },
+  [theme.breakpoints.down("sm")]: {
+    width: "56px",
+    height: "56px",
+    padding: "8px",
+  },
 }))
 
+const HeaderText = styled(Typography)(({ theme }) => ({
+  ...theme.typography.h3,
+  color: theme.custom.colors.darkGray2,
+  [theme.breakpoints.down("sm")]: {
+    ...theme.typography.h5,
+  },
+})) as typeof Typography
+
 const SubHeaderText = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle1,
   color: theme.custom.colors.silverGrayDark,
-}))
+  [theme.breakpoints.down("sm")]: {
+    ...theme.typography.subtitle2,
+  },
+})) as typeof Typography
 
 const ContractHeader: React.FC<{
   org?: OrganizationPage
@@ -89,10 +111,8 @@ const ContractHeader: React.FC<{
         />
       </ImageContainer>
       <Stack gap="8px">
-        <Typography variant="h3" component="h1">
-          {org?.name}
-        </Typography>
-        <SubHeaderText variant="subtitle1">{contract?.name}</SubHeaderText>
+        <HeaderText component="h1">{org?.name}</HeaderText>
+        <SubHeaderText>{contract?.name}</SubHeaderText>
       </Stack>
     </HeaderRoot>
   )
@@ -172,13 +192,19 @@ const ProgramHeader = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.custom.colors.red}`,
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
+    padding: "16px",
+    backgroundColor: theme.custom.colors.lightGray1,
+    borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
   },
 }))
 
-const ProgramHeaderText = styled.div({
+const ProgramHeaderText = styled.div(({ theme }) => ({
   flexDirection: "column",
   gap: "8px",
-})
+  [theme.breakpoints.down("sm")]: {
+    gap: "0",
+  },
+}))
 
 const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   color: theme.custom.colors.red,
@@ -217,7 +243,7 @@ const ProgramLanguageSelect = styled(SimpleSelectField)(({ theme }) => ({
   display: "inline-flex",
   flexDirection: "row",
   alignItems: "center",
-  margin: "10px",
+  padding: "10px",
   gap: "8px",
   width: "auto",
   "> *:not(:last-child)": {
@@ -230,10 +256,13 @@ const ProgramLanguageSelect = styled(SimpleSelectField)(({ theme }) => ({
     whiteSpace: "nowrap",
   },
   [theme.breakpoints.down("sm")]: {
-    "> .MuiInputBase-root": {
-      width: "fit-content",
-      maxWidth: "100%",
+    width: "100%",
+    padding: "12px 16px",
+    justifyContent: "space-between",
+    ".MuiInputBase-root": {
+      width: "100%",
     },
+    backgroundColor: theme.custom.colors.lightGray1,
   },
 })) as typeof SimpleSelectField
 
@@ -563,6 +592,8 @@ const ContractHeaderSection = styled.div(({ theme }) => ({
   boxShadow: "0 1px 6px 0 rgba(3, 21, 45, 0.05)",
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
+    gap: "16px",
+    padding: "16px 0 0 0",
   },
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -75,6 +75,15 @@ const ImageContainer = styled.div(({ theme }) => ({
   },
 }))
 
+const HeaderTextContainer = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  [theme.breakpoints.down("sm")]: {
+    gap: "0px",
+  },
+}))
+
 const HeaderText = styled(Typography)(({ theme }) => ({
   ...theme.typography.h3,
   color: theme.custom.colors.darkGray2,
@@ -110,10 +119,10 @@ const ContractHeader: React.FC<{
           alt=""
         />
       </ImageContainer>
-      <Stack gap="8px">
+      <HeaderTextContainer>
         <HeaderText component="h1">{org?.name}</HeaderText>
         <SubHeaderText>{contract?.name}</SubHeaderText>
-      </Stack>
+      </HeaderTextContainer>
     </HeaderRoot>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -590,7 +590,7 @@ const ContractHeaderSection = styled.div(({ theme }) => ({
   gap: "24px",
   borderRadius: "8px",
   backgroundColor: theme.custom.colors.white,
-  boxShadow: "0 1px 6px 0 rgba(3, 21, 45, 0.05)",
+  boxShadow: "0 1px 3px 0 rgba(120, 147, 172, 0.40)",
   [theme.breakpoints.down("sm")]: {
     flexDirection: "column",
     gap: "16px",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11196

### Description (What does it do?)
This PR implements some style changes to both mobile and desktop on the B2B contract page, focusing mostly on the header and the new translation language selection dropdown.

### Screenshots (if appropriate):
<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/cf0dff4e-7d69-45fc-b6fe-ea71e7222cb6" />
<img width="1854" height="1048" alt="image" src="https://github.com/user-attachments/assets/561a8366-7768-45ff-9845-03cd3701c010" />

### How can this be tested?
- Follow the instructions in https://github.com/mitodl/mit-learn/pull/3269 to get set up with test data sufficient to test a B2B program in the dashboard
- Compare the design on both desktop and mobile to the Figma designs linked in the above issue and make sure that it looks correct