### PR TITLE
feat: display MicroMasters® label on MITxOnline program product pages

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   HEADER_HEIGHT,
   Grid2,
+  Chip,
 } from "ol-components"
 import { DEFAULT_RESOURCE_IMG, useImageWithFallback } from "ol-utilities"
 import { convertToEmbedUrl, hexToRgba } from "@/common/utils"
@@ -271,6 +272,7 @@ export type ResourceInfo = {
 
 type ProductPageTemplateProps = {
   currentBreadcrumbLabel: string
+  label?: string
   title: string
   shortDescription: React.ReactNode
   imageSrc: string
@@ -284,6 +286,7 @@ type ProductPageTemplateProps = {
 )
 const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   currentBreadcrumbLabel,
+  label,
   title,
   shortDescription,
   imageSrc,
@@ -342,6 +345,14 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
                         title={title}
                       />
                     </SidebarCol>
+                    {label ? (
+                      <Chip
+                        label={label}
+                        data-testid="program-type-label"
+                        variant="outlinedWhite"
+                        size="large"
+                      />
+                    ) : null}
                     <Typography
                       component="h1"
                       typography={{ xs: "h4", sm: "h4", md: "h3" }}

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -349,7 +349,7 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
                       {label ? (
                         <Chip
                           label={label}
-                          data-testid="program-type-label"
+                          data-testid="product-page-label"
                           variant="outlinedWhite"
                           size="large"
                           sx={{ typography: "subtitle2" }}

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -345,22 +345,24 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
                         title={title}
                       />
                     </SidebarCol>
-                    {label ? (
-                      <Chip
-                        label={label}
-                        data-testid="program-type-label"
-                        variant="outlinedWhite"
-                        size="large"
-                        sx={{ typography: "subtitle2" }}
-                      />
-                    ) : null}
-                    <Typography
-                      component="h1"
-                      typography={{ xs: "h4", sm: "h4", md: "h3" }}
-                      style={{ lineHeight: "2.25rem" }}
-                    >
-                      {title}
-                    </Typography>
+                    <Stack alignItems="flex-start" gap="16px">
+                      {label ? (
+                        <Chip
+                          label={label}
+                          data-testid="program-type-label"
+                          variant="outlinedWhite"
+                          size="large"
+                          sx={{ typography: "subtitle2" }}
+                        />
+                      ) : null}
+                      <Typography
+                        component="h1"
+                        typography={{ xs: "h4", sm: "h4", md: "h3" }}
+                        style={{ lineHeight: "2.25rem" }}
+                      >
+                        {title}
+                      </Typography>
+                    </Stack>
                     <ShortDescription>{shortDescription}</ShortDescription>
                     <Stack
                       direction={{ xs: "column", md: "row" }}

--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -351,6 +351,7 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
                         data-testid="program-type-label"
                         variant="outlinedWhite"
                         size="large"
+                        sx={{ typography: "subtitle2" }}
                       />
                     ) : null}
                     <Typography

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -691,7 +691,9 @@ describe("ProgramPage", () => {
         renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
         await screen.findByRole("heading", { name: page.title })
-        expect(screen.getByText("MicroMasters®")).toBeInTheDocument()
+        const programTypeLabel = screen.getByTestId("program-type-label")
+        expect(programTypeLabel).toBeInTheDocument()
+        expect(within(programTypeLabel).getByText("MicroMasters®")).toBeInTheDocument()
       },
     )
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -682,7 +682,10 @@ describe("ProgramPage", () => {
     test.each(["MicroMasters®", "MicroMasters"])(
       "Shows 'MicroMasters®' label when program_type is '%s'",
       async (programType) => {
-        const program = makeProgram({ ...makeReqs(), program_type: programType })
+        const program = makeProgram({
+          ...makeReqs(),
+          program_type: programType,
+        })
         const page = makePage({ program_details: program })
         setupApis({ program, page })
         renderWithProviders(<ProgramPage readableId={program.readable_id} />)
@@ -699,9 +702,7 @@ describe("ProgramPage", () => {
       renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
       await screen.findByRole("heading", { name: page.title })
-      expect(
-        screen.queryByTestId("program-type-label"),
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId("program-type-label")).not.toBeInTheDocument()
     })
 
     test("Shows no label when program_type is null", async () => {
@@ -711,9 +712,7 @@ describe("ProgramPage", () => {
       renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
       await screen.findByRole("heading", { name: page.title })
-      expect(
-        screen.queryByTestId("program-type-label"),
-      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId("program-type-label")).not.toBeInTheDocument()
     })
   })
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -693,7 +693,9 @@ describe("ProgramPage", () => {
         await screen.findByRole("heading", { name: page.title })
         const programTypeLabel = screen.getByTestId("program-type-label")
         expect(programTypeLabel).toBeInTheDocument()
-        expect(within(programTypeLabel).getByText("MicroMasters®")).toBeInTheDocument()
+        expect(
+          within(programTypeLabel).getByText("MicroMasters®"),
+        ).toBeInTheDocument()
       },
     )
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -691,7 +691,7 @@ describe("ProgramPage", () => {
         renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
         await screen.findByRole("heading", { name: page.title })
-        const programTypeLabel = screen.getByTestId("program-type-label")
+        const programTypeLabel = screen.getByTestId("product-page-label")
         expect(programTypeLabel).toBeInTheDocument()
         expect(
           within(programTypeLabel).getByText("MicroMasters®"),
@@ -706,7 +706,7 @@ describe("ProgramPage", () => {
       renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
       await screen.findByRole("heading", { name: page.title })
-      expect(screen.queryByTestId("program-type-label")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("product-page-label")).not.toBeInTheDocument()
     })
 
     test("Shows no label when program_type is null", async () => {
@@ -716,7 +716,7 @@ describe("ProgramPage", () => {
       renderWithProviders(<ProgramPage readableId={program.readable_id} />)
 
       await screen.findByRole("heading", { name: page.title })
-      expect(screen.queryByTestId("program-type-label")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("product-page-label")).not.toBeInTheDocument()
     })
   })
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -678,6 +678,45 @@ describe("ProgramPage", () => {
     delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
   })
 
+  describe("Program type label", () => {
+    test.each(["MicroMasters®", "MicroMasters"])(
+      "Shows 'MicroMasters®' label when program_type is '%s'",
+      async (programType) => {
+        const program = makeProgram({ ...makeReqs(), program_type: programType })
+        const page = makePage({ program_details: program })
+        setupApis({ program, page })
+        renderWithProviders(<ProgramPage readableId={program.readable_id} />)
+
+        await screen.findByRole("heading", { name: page.title })
+        expect(screen.getByText("MicroMasters®")).toBeInTheDocument()
+      },
+    )
+
+    test("Shows no label for unbranded types like 'Series'", async () => {
+      const program = makeProgram({ ...makeReqs(), program_type: "Series" })
+      const page = makePage({ program_details: program })
+      setupApis({ program, page })
+      renderWithProviders(<ProgramPage readableId={program.readable_id} />)
+
+      await screen.findByRole("heading", { name: page.title })
+      expect(
+        screen.queryByTestId("program-type-label"),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Shows no label when program_type is null", async () => {
+      const program = makeProgram({ ...makeReqs(), program_type: null })
+      const page = makePage({ program_details: program })
+      setupApis({ program, page })
+      renderWithProviders(<ProgramPage readableId={program.readable_id} />)
+
+      await screen.findByRole("heading", { name: page.title })
+      expect(
+        screen.queryByTestId("program-type-label"),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe("Stay Updated button", () => {
     useStayUpdatedEnv()
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -217,6 +217,18 @@ const RequirementsSection: React.FC<RequirementsSectionProps> = ({
   )
 }
 
+const PROGRAM_TYPE_DISPLAY: Record<string, string> = {
+  "MicroMasters®": "MicroMasters®",
+  MicroMasters: "MicroMasters®",
+}
+
+const formatProgramTypeLabel = (
+  programType: string | null | undefined,
+): string | undefined => {
+  if (!programType) return undefined
+  return PROGRAM_TYPE_DISPLAY[programType]
+}
+
 const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
   const pages = useQuery(pagesQueries.programPages(readableId))
   const programs = useQuery(
@@ -272,6 +284,7 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
   return (
     <ProductPageTemplate
       currentBreadcrumbLabel="Program"
+      label={formatProgramTypeLabel(program.program_type)}
       title={page.title}
       shortDescription={
         <DescriptionHTML


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10533
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Adds an optional `label` prop to `ProductPageTemplate` that renders a `Chip` above the page title when provided
- Introduces `formatProgramTypeLabel` in `ProgramPage` to map `program_type` values ("MicroMasters" and "MicroMasters®") to the canonical display label "MicroMasters®"
- Chip uses subtitle2 typography (14px medium) with the outlinedWhite variant request by @mbilalmughal 
- No label is shown for unbranded program types (e.g. "Series") or when program_type is null

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [ ] Mobile width screenshots

non-MicroMasters
<img width="1910" height="1047" alt="Screenshot 2026-05-08 at 2 53 35 PM" src="https://github.com/user-attachments/assets/4ca91bdb-96a9-478a-a4e7-4f85fcd88ef2" />

MicroMasters
<img width="1898" height="1044" alt="Screenshot 2026-05-08 at 2 52 55 PM" src="https://github.com/user-attachments/assets/3c01095f-ee14-4e32-86a5-f0159f9d80ae" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- [ ] Visit a MITxOnline program page with program_type: "MicroMasters" or "MicroMasters®" — confirm the MicroMasters® chip appears above the title
- [ ] Visit a program page with a non-MicroMasters type (e.g. "Series") — confirm no chip appears
- [ ] Unit tests cover all three cases: branded type with ®, branded type without ®, unbranded/null type

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
