### PR TITLE
Show (and count) only published items in userlists/paths

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -2263,7 +2263,7 @@ export interface LearningPath {
    */
   id: number
   /**
-   *
+   * Number of published items in the list.
    * @type {number}
    * @memberof LearningPath
    */

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -2263,7 +2263,7 @@ export interface LearningPath {
    */
   id: number
   /**
-   * Return the number of items in the list
+   *
    * @type {number}
    * @memberof LearningPath
    */

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3173,7 +3173,7 @@ export interface LearningPath {
    */
   id: number
   /**
-   *
+   * Number of published items in the list.
    * @type {number}
    * @memberof LearningPath
    */
@@ -8941,7 +8941,7 @@ export interface UserList {
    */
   topics?: Array<LearningResourceTopic>
   /**
-   *
+   * Number of published items in the list.
    * @type {number}
    * @memberof UserList
    */

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -3173,7 +3173,7 @@ export interface LearningPath {
    */
   id: number
   /**
-   * Return the number of items in the list
+   *
    * @type {number}
    * @memberof LearningPath
    */
@@ -8941,7 +8941,7 @@ export interface UserList {
    */
   topics?: Array<LearningResourceTopic>
   /**
-   * Return the number of items in the list
+   *
    * @type {number}
    * @memberof UserList
    */

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -986,7 +986,10 @@ class LearningPathQuerySet(LearningResourceDetailQuerySet):
         return self.annotate(
             item_count=Count(
                 "learning_resource__children",
-                filter=Q(learning_resource__children__child__published=True),
+                filter=Q(
+                    learning_resource__children__relation_type=LearningResourceRelationTypes.LEARNING_PATH_ITEMS.value,
+                    learning_resource__children__child__published=True,
+                ),
             )
         )
 
@@ -1016,7 +1019,10 @@ class LearningPath(LearningResourceDetailModel):
     @cached_property
     def item_count(self) -> int:
         """Number of published resources in the learning path."""
-        return self.learning_resource.children.filter(child__published=True).count()
+        return self.learning_resource.children.filter(
+            relation_type=LearningResourceRelationTypes.LEARNING_PATH_ITEMS.value,
+            child__published=True,
+        ).count()
 
 
 class LearningResourceRelationshipQuerySet(TimestampedModelQuerySet):
@@ -1324,14 +1330,10 @@ class UserListRelationshipQuerySet(TimestampedModelQuerySet):
 
     def for_serialization(self):
         """Prefetch related objects used by API serializers"""
-        return (
-            self.select_related("parent", "parent__author")
-            .filter(child__published=True)
-            .prefetch_related(
-                Prefetch(
-                    "child",
-                    queryset=LearningResource.objects.for_serialization(),
-                )
+        return self.select_related("parent", "parent__author").prefetch_related(
+            Prefetch(
+                "child",
+                queryset=LearningResource.objects.for_serialization(),
             )
         )
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -1026,7 +1026,10 @@ class LearningResourceRelationshipQuerySet(TimestampedModelQuerySet):
         """Prefetch related objects used by API serializers"""
         return (
             self.select_related("child", "child__image")
-            .filter(child__published=True)
+            .exclude(
+                relation_type=LearningResourceRelationTypes.LEARNING_PATH_ITEMS.value,
+                child__published=False,
+            )
             .order_by("position", "id")
         )
 
@@ -1305,9 +1308,9 @@ class UserListQuerySet(TimestampedModelQuerySet):
             ),
             Prefetch(
                 "children",
-                queryset=UserListRelationship.objects.select_related(
-                    "child", "child__image"
-                ).order_by("position"),
+                queryset=UserListRelationship.objects.filter(child__published=True)
+                .select_related("child", "child__image")
+                .order_by("position"),
                 to_attr="_children",
             ),
         )
@@ -1321,12 +1324,14 @@ class UserListRelationshipQuerySet(TimestampedModelQuerySet):
 
     def for_serialization(self):
         """Prefetch related objects used by API serializers"""
-        return self.select_related("parent", "parent__author").prefetch_related(
-            Prefetch(
-                "child",
-                queryset=LearningResource.objects.filter(
-                    published=True
-                ).for_serialization(),
+        return (
+            self.select_related("parent", "parent__author")
+            .filter(child__published=True)
+            .prefetch_related(
+                Prefetch(
+                    "child",
+                    queryset=LearningResource.objects.for_serialization(),
+                )
             )
         )
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -982,8 +982,13 @@ class LearningPathQuerySet(LearningResourceDetailQuerySet):
     """QuerySet for LearningPath"""
 
     def for_serialization(self):
-        """Prefetch for serialization"""
-        return self
+        """Annotate item_count for serialization"""
+        return self.annotate(
+            item_count=Count(
+                "learning_resource__children",
+                filter=Q(learning_resource__children__child__published=True),
+            )
+        )
 
 
 class LearningPath(LearningResourceDetailModel):
@@ -1008,13 +1013,22 @@ class LearningPath(LearningResourceDetailModel):
     def __str__(self):
         return f"Learning Path: {self.learning_resource.title}"
 
+    @cached_property
+    def item_count(self) -> int:
+        """Number of published resources in the learning path."""
+        return self.learning_resource.children.filter(child__published=True).count()
+
 
 class LearningResourceRelationshipQuerySet(TimestampedModelQuerySet):
     """QuerySet for LearningResourceRelationship"""
 
     def for_serialization(self):
         """Prefetch related objects used by API serializers"""
-        return self.select_related("child", "child__image").order_by("position", "id")
+        return (
+            self.select_related("child", "child__image")
+            .filter(child__published=True)
+            .order_by("position", "id")
+        )
 
 
 class LearningResourceRelationship(TimestampedModel):
@@ -1272,6 +1286,11 @@ class UserList(TimestampedModel):
             return self.children.order_by("position").first()
         return children[0] if children else None
 
+    @cached_property
+    def item_count(self) -> int:
+        """Number of published resources in the list."""
+        return self.resources.filter(published=True).count()
+
 
 class UserListQuerySet(TimestampedModelQuerySet):
     """QuerySet for UserList"""
@@ -1303,7 +1322,12 @@ class UserListRelationshipQuerySet(TimestampedModelQuerySet):
     def for_serialization(self):
         """Prefetch related objects used by API serializers"""
         return self.select_related("parent", "parent__author").prefetch_related(
-            Prefetch("child", queryset=LearningResource.objects.for_serialization())
+            Prefetch(
+                "child",
+                queryset=LearningResource.objects.filter(
+                    published=True
+                ).for_serialization(),
+            )
         )
 
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -397,7 +397,10 @@ class LearningResourceRunSerializer(serializers.ModelSerializer):
 class ResourceListMixin(serializers.Serializer):
     """Common fields for LearningPath and other future resource lists"""
 
-    item_count = serializers.IntegerField(read_only=True)
+    item_count = serializers.IntegerField(
+        read_only=True,
+        help_text="Number of published items in the list.",
+    )
 
 
 class CourseNumberSerializer(serializers.Serializer):
@@ -1619,7 +1622,10 @@ class UserListSerializer(serializers.ModelSerializer, WriteableTopicsMixin):
     Simplified serializer for UserList model.
     """
 
-    item_count = serializers.IntegerField(read_only=True)
+    item_count = serializers.IntegerField(
+        read_only=True,
+        help_text="Number of published items in the list.",
+    )
     image = serializers.SerializerMethodField()
 
     def get_image(self, instance) -> dict:

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -397,14 +397,7 @@ class LearningResourceRunSerializer(serializers.ModelSerializer):
 class ResourceListMixin(serializers.Serializer):
     """Common fields for LearningPath and other future resource lists"""
 
-    item_count = serializers.SerializerMethodField()
-
-    def get_item_count(self, instance) -> int:
-        """Return the number of items in the list"""
-        return (
-            getattr(instance, "item_count", None)
-            or instance.learning_resource.children.count()
-        )
+    item_count = serializers.IntegerField(read_only=True)
 
 
 class CourseNumberSerializer(serializers.Serializer):
@@ -1626,7 +1619,7 @@ class UserListSerializer(serializers.ModelSerializer, WriteableTopicsMixin):
     Simplified serializer for UserList model.
     """
 
-    item_count = serializers.SerializerMethodField()
+    item_count = serializers.IntegerField(read_only=True)
     image = serializers.SerializerMethodField()
 
     def get_image(self, instance) -> dict:
@@ -1635,10 +1628,6 @@ class UserListSerializer(serializers.ModelSerializer, WriteableTopicsMixin):
         if list_item and list_item.child.image:
             return LearningResourceImageSerializer(instance=list_item.child.image).data
         return None
-
-    def get_item_count(self, instance) -> int:
-        """Return the number of items in the list"""
-        return getattr(instance, "item_count", None) or instance.resources.count()
 
     def create(self, validated_data):
         """Create a new user list"""

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -979,7 +979,7 @@ class UserListViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         """Return a queryset for this user"""
         return UserList.objects.for_serialization().annotate(
-            item_count=Count("children")
+            item_count=Count("children", filter=Q(children__child__published=True))
         )
 
     def list(self, request, **kwargs):  # noqa: ARG002
@@ -1052,6 +1052,10 @@ class UserListItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     permission_classes = (HasUserListItemPermissions,)
     http_method_names = VALID_HTTP_METHODS
     parent_lookup_kwargs = {"userlist_id": "parent"}
+
+    def list(self, request, *args, **kwargs):
+        self.queryset = self.queryset.filter(child__published=True)
+        return super().list(request, *args, **kwargs)
 
     def create(self, request, *args, **kwargs):  # noqa: ARG002
         data = request.data.copy()

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1053,6 +1053,17 @@ class UserListItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     http_method_names = VALID_HTTP_METHODS
     parent_lookup_kwargs = {"userlist_id": "parent"}
 
+    def get_queryset(self):
+        """Hide unpublished children from read actions only.
+
+        Create/update/destroy still see all relationships so users can manage
+        items whose child resource was unpublished after being added.
+        """
+        queryset = super().get_queryset()
+        if self.action in ("list", "retrieve"):
+            queryset = queryset.filter(child__published=True)
+        return queryset
+
     def create(self, request, *args, **kwargs):  # noqa: ARG002
         data = request.data.copy()
         data["parent"] = kwargs.get("userlist_id")

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -1053,10 +1053,6 @@ class UserListItemViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     http_method_names = VALID_HTTP_METHODS
     parent_lookup_kwargs = {"userlist_id": "parent"}
 
-    def list(self, request, *args, **kwargs):
-        self.queryset = self.queryset.filter(child__published=True)
-        return super().list(request, *args, **kwargs)
-
     def create(self, request, *args, **kwargs):  # noqa: ARG002
         data = request.data.copy()
         data["parent"] = kwargs.get("userlist_id")

--- a/learning_resources/views_learningpath_test.py
+++ b/learning_resources/views_learningpath_test.py
@@ -345,6 +345,52 @@ def test_learning_path_items_endpoint_delete_items(client, user, is_editor, num_
         assert item.position == (old_position - 1 if is_editor else old_position)
 
 
+def test_learning_path_endpoint_item_count_excludes_unpublished(client, user):
+    """LearningPath item_count should only include published children"""
+    update_editor_group(user, True)  # noqa: FBT003
+    learning_path_res = factories.LearningResourceFactory.create(
+        is_learning_path=True, published=True
+    )
+    learning_path_res.children.all().delete()
+    factories.LearningPathRelationshipFactory.create(
+        parent=learning_path_res, position=1
+    )
+    factories.LearningPathRelationshipFactory.create(
+        parent=learning_path_res, position=2, child__published=False
+    )
+
+    client.force_login(user)
+    resp = client.get(
+        reverse("lr:v1:learningpaths_api-detail", args=[learning_path_res.id])
+    )
+    assert resp.status_code == 200
+    assert resp.data["learning_path"]["item_count"] == 1
+
+
+def test_learning_path_items_endpoint_excludes_unpublished(client):
+    """Items list endpoint should only return relationships with published children"""
+    learning_path = factories.LearningPathFactory.create()
+    learning_path.learning_resource.children.all().delete()
+    published_rel = factories.LearningPathRelationshipFactory.create(
+        parent=learning_path.learning_resource, position=1
+    )
+    factories.LearningPathRelationshipFactory.create(
+        parent=learning_path.learning_resource,
+        position=2,
+        child__published=False,
+    )
+
+    resp = client.get(
+        reverse(
+            "lr:v1:learningpathitems_api-list",
+            args=[learning_path.learning_resource.id],
+        )
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert [item["child"] for item in results] == [published_rel.child_id]
+
+
 @pytest.mark.parametrize("is_editor", [True, False])
 def test_learning_path_endpoint_delete(client, user, is_editor):
     """Test learningpath endpoint for deleting a LearningPath"""

--- a/learning_resources/views_userlist_test.py
+++ b/learning_resources/views_userlist_test.py
@@ -99,6 +99,39 @@ def test_user_list_endpoint_list_query_count_constant(
     assert expanded_resp.status_code == 200
 
 
+def test_user_list_endpoint_item_count_excludes_unpublished(client):
+    """item_count should only include published resources"""
+    author = UserFactory.create()
+    user_list = factories.UserListFactory.create(author=author)
+    factories.UserListRelationshipFactory.create(parent=user_list, position=1)
+    factories.UserListRelationshipFactory.create(
+        parent=user_list, position=2, child__published=False
+    )
+
+    client.force_login(author)
+    resp = client.get(reverse("lr:v1:userlists_api-detail", args=[user_list.id]))
+    assert resp.status_code == 200
+    assert resp.data.get("item_count") == 1
+
+
+def test_user_list_items_endpoint_excludes_unpublished(client):
+    """Items list endpoint should only return relationships with published children"""
+    author = UserFactory.create()
+    user_list = factories.UserListFactory.create(author=author)
+    published_rel = factories.UserListRelationshipFactory.create(
+        parent=user_list, position=1
+    )
+    factories.UserListRelationshipFactory.create(
+        parent=user_list, position=2, child__published=False
+    )
+
+    client.force_login(author)
+    resp = client.get(reverse("lr:v1:userlistitems_api-list", args=[user_list.id]))
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert [item["child"] for item in results] == [published_rel.child_id]
+
+
 @pytest.mark.parametrize("is_anonymous", [True, False])
 def test_user_list_endpoint_create(  # pylint: disable=too-many-arguments
     client, is_anonymous

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3151,6 +3151,7 @@ components:
         item_count:
           type: integer
           readOnly: true
+          description: Number of published items in the list.
       required:
       - id
       - item_count

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -3150,7 +3150,6 @@ components:
           readOnly: true
         item_count:
           type: integer
-          description: Return the number of items in the list
           readOnly: true
       required:
       - id

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -11895,6 +11895,7 @@ components:
         item_count:
           type: integer
           readOnly: true
+          description: Number of published items in the list.
       required:
       - id
       - item_count
@@ -16332,6 +16333,7 @@ components:
         item_count:
           type: integer
           readOnly: true
+          description: Number of published items in the list.
         image:
           type: object
           additionalProperties: {}

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -11894,7 +11894,6 @@ components:
           readOnly: true
         item_count:
           type: integer
-          description: Return the number of items in the list
           readOnly: true
       required:
       - id
@@ -16332,7 +16331,6 @@ components:
             $ref: '#/components/schemas/LearningResourceTopic'
         item_count:
           type: integer
-          description: Return the number of items in the list
           readOnly: true
         image:
           type: object


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10177

### Description (What does it do?)
<!--- Describe your changes in detail -->
Filters out unpublished resources from user lists and learning paths.


### How can this be tested?
- While logged in as an admin, add a particular resource to both your Favorites list and a learning path.
- View the items in both the favorites list and learning path in the UI, and verify the resource shows up there, and that the counts are accurate.
- In a django shell, run the following:
   ```python
    from learning_resources.models import *
    from learning_resources.utils import *

    lr = LearningResource.objects.get(id=<resource_id>)
    lr.published=False
    lr.save()
    resource_unpublished_actions(lr)
    ```
- Refresh both the Favorites page and learning path page.  Verify that the unpublished resource no longer appears and the count is reduced by 1.
- In the django shell, republish the resource
  ```python
  lr.published=True
  lr.save()
  resource_upserted_actions(lr, False, true)
  ```
- Refresh both the Favorites page and learning path page.   The resource should appear again, and the counts should be back to what they were originally.
