### PR TITLE
video ui tweaks

### DIFF
--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
@@ -55,14 +55,14 @@ describe("CallToActionSection", () => {
       {
         resourceType: ResourceTypeEnum.Video,
         platform: PlatformEnum.Youtube,
-        resourceCategory: "Lecture Video",
-        expectedText: "Learn More",
+        resourceCategory: "Video",
+        expectedText: "Watch Video",
       },
       {
         resourceType: ResourceTypeEnum.Video,
         platform: PlatformEnum.Ocw,
         resourceCategory: "Lecture Video",
-        expectedText: "Access Learning Material",
+        expectedText: "Watch Video",
       },
       {
         resourceType: ResourceTypeEnum.VideoPlaylist,

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -261,11 +261,12 @@ const getCallToActionText = (resource: LearningResource): string => {
   const listenToPodcast = "Listen to Podcast"
   const viewArticle = "View Article"
   const learnMore = "Learn More"
+  const watchVideo = "Watch Video"
   const callsToAction = {
     [ResourceTypeEnum.Course]: learnMore,
     [ResourceTypeEnum.Program]: learnMore,
     [ResourceTypeEnum.LearningPath]: learnMore,
-    [ResourceTypeEnum.Video]: learnMore,
+    [ResourceTypeEnum.Video]: watchVideo,
     [ResourceTypeEnum.VideoPlaylist]: learnMore,
     [ResourceTypeEnum.Podcast]: listenToPodcast,
     [ResourceTypeEnum.PodcastEpisode]: listenToPodcast,
@@ -279,7 +280,7 @@ const getCallToActionText = (resource: LearningResource): string => {
   if (resource?.platform?.code === PlatformEnum.Ocw) {
     if (resource.resource_type === ResourceTypeEnum.Course) {
       return accessCourseMaterials
-    } else {
+    } else if (resource.resource_type === ResourceTypeEnum.Document) {
       return accessLearningMaterial
     }
   }
@@ -463,7 +464,10 @@ const CallToActionSection = ({
         >
           {cta}
         </StyledLink>
-        {platformImage ? (
+        {platformImage &&
+        (resource.resource_type === ResourceTypeEnum.Course ||
+          resource.resource_type === ResourceTypeEnum.Program ||
+          resource.resource_type === ResourceTypeEnum.Document) ? (
           <PlatformContainer>
             <Platform>
               <OnPlatform>on</OnPlatform>

--- a/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
@@ -532,7 +532,7 @@ const INFO_ITEMS: InfoItemConfig = [
       const name = formattedParentCourseName(resource)
       if (!name || !resource.url) return name
       return (
-        <Link href={resource.url} color="red" size="small">
+        <Link href={resource.url} color="red" hovercolor="red" size="small">
           {name}
         </Link>
       )

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -167,25 +167,43 @@ describe("Learning Resource Expanded", () => {
     },
   )
 
-  test.each([ResourceTypeEnum.PodcastEpisode])(
-    "Renders xpro logo conditionally on offered_by=xpro and not platform.code",
+  test.each([
+    ResourceTypeEnum.Course,
+    ResourceTypeEnum.Program,
+    ResourceTypeEnum.Document,
+  ])("Renders xpro logo for %s with offered_by=xpro", (resourceType) => {
+    const resource = factories.learningResources.resource({
+      resource_type: resourceType,
+      platform: { code: "test" },
+      offered_by: { code: "xpro" },
+    })
+
+    setup({ resource })
+    const xproImage = screen
+      .getAllByRole("img")
+      .find((img) => img.getAttribute("alt")?.includes("xPRO"))
+
+    expect(xproImage).toBeInTheDocument()
+    expect(xproImage).toHaveAttribute("alt", PLATFORM_LOGOS["xpro"].name)
+  })
+
+  test.each([ResourceTypeEnum.PodcastEpisode, ResourceTypeEnum.Video])(
+    "Does not render platform logo for resource type %s",
     (resourceType) => {
       const resource = factories.learningResources.resource({
         resource_type: resourceType,
-        platform: { code: "test" },
-        offered_by: { code: "xpro" },
-        podcast_episode: {
-          episode_link: "https://example.com",
-        },
+        platform: { code: "ocw" },
+        offered_by: { code: "ocw" },
       })
 
       setup({ resource })
-      const xproImage = screen
-        .getAllByRole("img")
-        .find((img) => img.getAttribute("alt")?.includes("xPRO"))
+      const platformLogo = screen
+        .queryAllByRole("img")
+        .find((img) =>
+          img.getAttribute("alt")?.includes(PLATFORM_LOGOS["ocw"]?.name ?? ""),
+        )
 
-      expect(xproImage).toBeInTheDocument()
-      expect(xproImage).toHaveAttribute("alt", PLATFORM_LOGOS["xpro"].name)
+      expect(platformLogo).toBeUndefined()
     },
   )
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/3308 updated the video etl for ocw videos so it combines youtube and ocw data

This pr makes a few ui tweaks to the video cards
1. Changes the call to action on all videos to read "Watch Video" instead of "Learn More". Video playlists will continue to be "Learn More"
2. Removes the OCW logo from under the call to action button for ocw videos since the link goes to the learn player page and not ocw 

### Screenshots (if appropriate):
<img width="1728" height="897" alt="Screenshot 2026-05-10 at 8 52 53 PM" src="https://github.com/user-attachments/assets/064ab9d9-d980-464f-b7f5-c68b8566c020" />

### How can this be tested?
set video-playlist-page = True in posthog
Set YOUTUBE_CONFIG_URL='https://raw.githubusercontent.com/mitodl/open-video-data/refs/heads/ab/update-ocw-config/youtube/channels.yaml'

Run
docker-compose run web ./manage.py backpopulate_ocw_data --course-name 21h-151-dynastic-china-fall-2024 --overwrite

Run manage.py backpopulate_youtube_data --overwrite

Go to http://open.odl.local:8062/search?resource_category=Lecture+Video&resource_type_group=learning_material

Verify that the changes in the description were made 
