### PR TITLE
fix: add sitemap for video and podcast page

### DIFF
--- a/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
@@ -1,0 +1,91 @@
+import { faker } from "@faker-js/faker/locale/en"
+import { generateSitemaps, default as sitemap } from "./sitemap"
+import { setMockResponse, urls, factories } from "api/test-utils"
+import { ResourceTypeEnum } from "api"
+
+const RESOURCE_TYPES = [
+  ResourceTypeEnum.Podcast,
+  ResourceTypeEnum.PodcastEpisode,
+]
+
+describe("Podcast Sitemaps", () => {
+  it("returns expected sitemap params", async () => {
+    const pages = faker.number.int({ min: 4, max: 6 })
+    const resources = factories.learningResources.resources({
+      count: pages * 1_000 - 350,
+      pageSize: 10,
+    })
+
+    setMockResponse.get(
+      urls.learningResources.list({
+        limit: 1_000,
+        resource_type: RESOURCE_TYPES,
+      }),
+      resources,
+    )
+
+    const result = await generateSitemaps()
+    expect(result).toHaveLength(pages)
+    expect(result).toEqual(
+      new Array(pages).fill(null).map((_, index) => ({
+        id: index,
+        location: `http://test.learn.odl.local:8062/sitemaps/podcast/sitemap/${index}.xml`,
+      })),
+    )
+  })
+
+  it("generates expected URLs for podcast resources", async () => {
+    const page = faker.number.int({ min: 5, max: 10 })
+    const podcastList = factories.learningResources.podcasts({
+      count: 3,
+      pageSize: 3,
+    })
+
+    setMockResponse.get(
+      urls.learningResources.list({
+        limit: 1_000,
+        offset: page * 1_000,
+        resource_type: RESOURCE_TYPES,
+      }),
+      podcastList,
+    )
+
+    const sitemapPage = await sitemap({ id: String(page) })
+    expect(sitemapPage).toEqual(
+      podcastList.results.map((resource) => ({
+        url: `http://test.learn.odl.local:8062/podcast/${resource.id}`,
+        lastModified: resource.last_modified ?? undefined,
+      })),
+    )
+  })
+
+  it("generates expected URLs for podcast episode resources", async () => {
+    const page = faker.number.int({ min: 5, max: 10 })
+    const parentPodcastId = String(faker.number.int())
+    const episodeWithParent = factories.learningResources.podcastEpisode({
+      podcast_episode: { podcasts: [parentPodcastId] },
+    })
+    const episodeWithoutParent = factories.learningResources.podcastEpisode({
+      podcast_episode: { podcasts: [] },
+    })
+    const results = [episodeWithParent, episodeWithoutParent]
+
+    setMockResponse.get(
+      urls.learningResources.list({
+        limit: 1_000,
+        offset: page * 1_000,
+        resource_type: RESOURCE_TYPES,
+      }),
+      { count: results.length, next: null, previous: null, results },
+    )
+
+    const sitemapPage = await sitemap({ id: String(page) })
+    // episodeWithoutParent should be excluded
+    expect(sitemapPage).toEqual([
+      {
+        url: `http://test.learn.odl.local:8062/podcast/${parentPodcastId}/podcast_episode/${episodeWithParent.id}`,
+        lastModified: episodeWithParent.last_modified ?? undefined,
+      },
+    ])
+  })
+})

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
@@ -11,17 +11,17 @@ const RESOURCE_TYPES = [
 describe("Podcast Sitemaps", () => {
   it("returns expected sitemap params", async () => {
     const pages = faker.number.int({ min: 4, max: 6 })
-    const resources = factories.learningResources.resources({
+    const summaries = factories.learningResources.resourceSummaries({
       count: pages * 1_000 - 350,
-      pageSize: 10,
+      pageSize: 1,
     })
 
     setMockResponse.get(
-      urls.learningResources.list({
-        limit: 1_000,
+      urls.learningResources.summaryList({
+        limit: 1,
         resource_type: RESOURCE_TYPES,
       }),
-      resources,
+      summaries,
     )
 
     const result = await generateSitemaps()
@@ -60,15 +60,26 @@ describe("Podcast Sitemaps", () => {
   })
 
   it("generates expected URLs for podcast episode resources", async () => {
-    const page = faker.number.int({ min: 5, max: 10 })
-    const parentPodcastId = String(faker.number.int())
-    const episodeWithParent = factories.learningResources.podcastEpisode({
-      podcast_episode: { podcasts: [parentPodcastId] },
+    // Use a non-overlapping range from the podcast test (which uses { min: 5, max: 10 })
+    // to avoid query cache collisions on the same list URL.
+    const page = faker.number.int({ min: 11, max: 20 })
+    const podcastId1 = String(faker.number.int())
+    const podcastId2 = String(faker.number.int())
+    const episodeWithMultipleParents =
+      factories.learningResources.podcastEpisode({
+        podcast_episode: { podcasts: [podcastId1, podcastId2] },
+      })
+    const episodeWithOneParent = factories.learningResources.podcastEpisode({
+      podcast_episode: { podcasts: [podcastId1] },
     })
     const episodeWithoutParent = factories.learningResources.podcastEpisode({
       podcast_episode: { podcasts: [] },
     })
-    const results = [episodeWithParent, episodeWithoutParent]
+    const results = [
+      episodeWithMultipleParents,
+      episodeWithOneParent,
+      episodeWithoutParent,
+    ]
 
     setMockResponse.get(
       urls.learningResources.list({
@@ -80,11 +91,19 @@ describe("Podcast Sitemaps", () => {
     )
 
     const sitemapPage = await sitemap({ id: String(page) })
-    // episodeWithoutParent should be excluded
+    // episodeWithoutParent should be excluded; episodeWithMultipleParents emits one entry per parent
     expect(sitemapPage).toEqual([
       {
-        url: `http://test.learn.odl.local:8062/podcast/${parentPodcastId}/podcast_episode/${episodeWithParent.id}`,
-        lastModified: episodeWithParent.last_modified ?? undefined,
+        url: `http://test.learn.odl.local:8062/podcast/${podcastId1}/podcast_episode/${episodeWithMultipleParents.id}`,
+        lastModified: episodeWithMultipleParents.last_modified ?? undefined,
+      },
+      {
+        url: `http://test.learn.odl.local:8062/podcast/${podcastId2}/podcast_episode/${episodeWithMultipleParents.id}`,
+        lastModified: episodeWithMultipleParents.last_modified ?? undefined,
+      },
+      {
+        url: `http://test.learn.odl.local:8062/podcast/${podcastId1}/podcast_episode/${episodeWithOneParent.id}`,
+        lastModified: episodeWithOneParent.last_modified ?? undefined,
       },
     ])
   })

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.ts
@@ -32,8 +32,8 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
   const queryClient = getQueryClient()
   const { count } = await queryClient.fetchQuery(
-    learningResourceQueries.list({
-      limit: PAGE_SIZE,
+    learningResourceQueries.summaryList({
+      limit: 1,
       resource_type: RESOURCE_TYPES,
     }),
   )
@@ -70,14 +70,11 @@ export default async function sitemap({
       ]
     }
     if (resource.resource_type === ResourceTypeEnum.PodcastEpisode) {
-      const parentPodcastId = resource.podcast_episode?.podcasts?.[0]
-      if (!parentPodcastId) return []
-      return [
-        {
-          url: `${BASE_URL}/podcast/${parentPodcastId}/podcast_episode/${resource.id}`,
-          lastModified: resource.last_modified ?? undefined,
-        },
-      ]
+      const parentPodcastIds = resource.podcast_episode?.podcasts ?? []
+      return parentPodcastIds.map((parentPodcastId) => ({
+        url: `${BASE_URL}/podcast/${parentPodcastId}/podcast_episode/${resource.id}`,
+        lastModified: resource.last_modified ?? undefined,
+      }))
     }
     return []
   })

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.ts
@@ -1,0 +1,84 @@
+import type { MetadataRoute } from "next"
+import { getQueryClient } from "@/app/getQueryClient"
+import { learningResourceQueries } from "api/hooks/learningResources"
+import { ResourceTypeEnum } from "api"
+import invariant from "tiny-invariant"
+import type { GenerateSitemapResult } from "../types"
+import { dangerouslyDetectProductionBuildPhase } from "../util"
+
+const BASE_URL = process.env.NEXT_PUBLIC_ORIGIN
+invariant(BASE_URL, "NEXT_PUBLIC_ORIGIN must be defined")
+
+const PAGE_SIZE = 1_000
+
+const RESOURCE_TYPES = [
+  ResourceTypeEnum.Podcast,
+  ResourceTypeEnum.PodcastEpisode,
+]
+
+/**
+ * As of NextJS 15.5.3, sitemaps are ALWAYS generated at build time, even with
+ * the force-dynamic below (this may be a NextJS bug?). However, the
+ * force-dynamic does force re-generation when requests are made in production.
+ */
+export const dynamic = "force-dynamic"
+
+export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
+  /**
+   * NextJS runs this at build time (despite force-dynamic above).
+   * Early exit here to avoid the useless build-time API calls.
+   */
+  if (dangerouslyDetectProductionBuildPhase()) return []
+
+  const queryClient = getQueryClient()
+  const { count } = await queryClient.fetchQuery(
+    learningResourceQueries.list({
+      limit: PAGE_SIZE,
+      resource_type: RESOURCE_TYPES,
+    }),
+  )
+
+  const pages = Math.ceil(count / PAGE_SIZE)
+
+  return new Array(pages).fill(null).map((_, index) => ({
+    id: index,
+    location: `${BASE_URL}/sitemaps/podcast/sitemap/${index}.xml`,
+  }))
+}
+
+export default async function sitemap({
+  id,
+}: {
+  id: string
+}): Promise<MetadataRoute.Sitemap> {
+  const queryClient = getQueryClient()
+  const data = await queryClient.fetchQuery(
+    learningResourceQueries.list({
+      limit: PAGE_SIZE,
+      offset: +id * PAGE_SIZE,
+      resource_type: RESOURCE_TYPES,
+    }),
+  )
+
+  return data.results.flatMap((resource) => {
+    if (resource.resource_type === ResourceTypeEnum.Podcast) {
+      return [
+        {
+          url: `${BASE_URL}/podcast/${resource.id}`,
+          lastModified: resource.last_modified ?? undefined,
+        },
+      ]
+    }
+    if (resource.resource_type === ResourceTypeEnum.PodcastEpisode) {
+      const parentPodcastId = resource.podcast_episode?.podcasts?.[0]
+      if (!parentPodcastId) return []
+      return [
+        {
+          url: `${BASE_URL}/podcast/${parentPodcastId}/podcast_episode/${resource.id}`,
+          lastModified: resource.last_modified ?? undefined,
+        },
+      ]
+    }
+    return []
+  })
+}

--- a/frontends/main/src/app/sitemaps/sitemap-index.xml/route.ts
+++ b/frontends/main/src/app/sitemaps/sitemap-index.xml/route.ts
@@ -3,6 +3,8 @@ import invariant from "tiny-invariant"
 import * as resourceSitemap from "../resources/sitemap"
 import * as channelsSitemap from "../channels/sitemap"
 import * as productsSitemap from "../products/sitemap"
+import * as videoSitemap from "../video/sitemap"
+import * as podcastSitemap from "../podcast/sitemap"
 
 invariant(process.env.NEXT_PUBLIC_ORIGIN, "NEXT_PUBLIC_ORIGIN must be defined")
 const BASE_URL: string = process.env.NEXT_PUBLIC_ORIGIN
@@ -22,6 +24,8 @@ async function buildSitemapIndex(): Promise<string> {
     resourceSitemap.generateSitemaps(),
     channelsSitemap.generateSitemaps(),
     productsSitemap.generateSitemaps(),
+    videoSitemap.generateSitemaps(),
+    podcastSitemap.generateSitemaps(),
   ])
   const sitemapUrls = [
     `${BASE_URL}/sitemaps/static/sitemap.xml`,

--- a/frontends/main/src/app/sitemaps/video/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.test.ts
@@ -1,0 +1,71 @@
+import { faker } from "@faker-js/faker/locale/en"
+import { generateSitemaps, default as sitemap } from "./sitemap"
+import { setMockResponse, urls, factories } from "api/test-utils"
+import { ResourceTypeEnum } from "api"
+
+const RESOURCE_TYPES = [ResourceTypeEnum.Video, ResourceTypeEnum.VideoPlaylist]
+
+describe("Video Sitemaps", () => {
+  it("returns expected sitemap params", async () => {
+    const pages = faker.number.int({ min: 4, max: 6 })
+    const resources = factories.learningResources.resources({
+      count: pages * 1_000 - 350,
+      pageSize: 10,
+    })
+
+    setMockResponse.get(
+      urls.learningResources.list({
+        limit: 1_000,
+        resource_type: RESOURCE_TYPES,
+      }),
+      resources,
+    )
+
+    const result = await generateSitemaps()
+    expect(result).toHaveLength(pages)
+    expect(result).toEqual(
+      new Array(pages).fill(null).map((_, index) => ({
+        id: index,
+        location: `http://test.learn.odl.local:8062/sitemaps/video/sitemap/${index}.xml`,
+      })),
+    )
+  })
+
+  it("generates expected URLs for video and video playlist resources", async () => {
+    const page = faker.number.int({ min: 5, max: 10 })
+    const videoList = factories.learningResources.videos({
+      count: 3,
+      pageSize: 3,
+    })
+    const playlistList = factories.learningResources.videoPlaylists({
+      count: 2,
+      pageSize: 2,
+    })
+    const results = [...videoList.results, ...playlistList.results]
+
+    setMockResponse.get(
+      urls.learningResources.list({
+        limit: 1_000,
+        offset: page * 1_000,
+        resource_type: RESOURCE_TYPES,
+      }),
+      { count: results.length, next: null, previous: null, results },
+    )
+
+    const sitemapPage = await sitemap({ id: String(page) })
+    expect(sitemapPage).toEqual(
+      results.map((resource) => {
+        if (resource.resource_type === ResourceTypeEnum.VideoPlaylist) {
+          return {
+            url: `http://test.learn.odl.local:8062/video-playlist/${resource.id}`,
+            lastModified: resource.last_modified ?? undefined,
+          }
+        }
+        return {
+          url: `http://test.learn.odl.local:8062/video/${resource.id}`,
+          lastModified: resource.last_modified ?? undefined,
+        }
+      }),
+    )
+  })
+})

--- a/frontends/main/src/app/sitemaps/video/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.test.ts
@@ -8,17 +8,17 @@ const RESOURCE_TYPES = [ResourceTypeEnum.Video, ResourceTypeEnum.VideoPlaylist]
 describe("Video Sitemaps", () => {
   it("returns expected sitemap params", async () => {
     const pages = faker.number.int({ min: 4, max: 6 })
-    const resources = factories.learningResources.resources({
+    const summaries = factories.learningResources.resourceSummaries({
       count: pages * 1_000 - 350,
-      pageSize: 10,
+      pageSize: 1,
     })
 
     setMockResponse.get(
-      urls.learningResources.list({
-        limit: 1_000,
+      urls.learningResources.summaryList({
+        limit: 1,
         resource_type: RESOURCE_TYPES,
       }),
-      resources,
+      summaries,
     )
 
     const result = await generateSitemaps()

--- a/frontends/main/src/app/sitemaps/video/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.ts
@@ -29,8 +29,8 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
   const queryClient = getQueryClient()
   const { count } = await queryClient.fetchQuery(
-    learningResourceQueries.list({
-      limit: PAGE_SIZE,
+    learningResourceQueries.summaryList({
+      limit: 1,
       resource_type: RESOURCE_TYPES,
     }),
   )

--- a/frontends/main/src/app/sitemaps/video/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.ts
@@ -1,0 +1,79 @@
+import type { MetadataRoute } from "next"
+import { getQueryClient } from "@/app/getQueryClient"
+import { learningResourceQueries } from "api/hooks/learningResources"
+import { ResourceTypeEnum } from "api"
+import invariant from "tiny-invariant"
+import type { GenerateSitemapResult } from "../types"
+import { dangerouslyDetectProductionBuildPhase } from "../util"
+
+const BASE_URL = process.env.NEXT_PUBLIC_ORIGIN
+invariant(BASE_URL, "NEXT_PUBLIC_ORIGIN must be defined")
+
+const PAGE_SIZE = 1_000
+
+const RESOURCE_TYPES = [ResourceTypeEnum.Video, ResourceTypeEnum.VideoPlaylist]
+
+/**
+ * As of NextJS 15.5.3, sitemaps are ALWAYS generated at build time, even with
+ * the force-dynamic below (this may be a NextJS bug?). However, the
+ * force-dynamic does force re-generation when requests are made in production.
+ */
+export const dynamic = "force-dynamic"
+
+export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
+  /**
+   * NextJS runs this at build time (despite force-dynamic above).
+   * Early exit here to avoid the useless build-time API calls.
+   */
+  if (dangerouslyDetectProductionBuildPhase()) return []
+
+  const queryClient = getQueryClient()
+  const { count } = await queryClient.fetchQuery(
+    learningResourceQueries.list({
+      limit: PAGE_SIZE,
+      resource_type: RESOURCE_TYPES,
+    }),
+  )
+
+  const pages = Math.ceil(count / PAGE_SIZE)
+
+  return new Array(pages).fill(null).map((_, index) => ({
+    id: index,
+    location: `${BASE_URL}/sitemaps/video/sitemap/${index}.xml`,
+  }))
+}
+
+export default async function sitemap({
+  id,
+}: {
+  id: string
+}): Promise<MetadataRoute.Sitemap> {
+  const queryClient = getQueryClient()
+  const data = await queryClient.fetchQuery(
+    learningResourceQueries.list({
+      limit: PAGE_SIZE,
+      offset: +id * PAGE_SIZE,
+      resource_type: RESOURCE_TYPES,
+    }),
+  )
+
+  return data.results.flatMap((resource) => {
+    if (resource.resource_type === ResourceTypeEnum.Video) {
+      return [
+        {
+          url: `${BASE_URL}/video/${resource.id}`,
+          lastModified: resource.last_modified ?? undefined,
+        },
+      ]
+    }
+    if (resource.resource_type === ResourceTypeEnum.VideoPlaylist) {
+      return [
+        {
+          url: `${BASE_URL}/video-playlist/${resource.id}`,
+          lastModified: resource.last_modified ?? undefined,
+        },
+      ]
+    }
+    return []
+  })
+}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11214

### Description (What does it do?)

MIT Learn has dedicated detail pages for videos, video playlists, podcasts, and podcast episodes, but these routes were not included in the sitemap index served at `/sitemaps/sitemap-index.xml`. This means search engines could not reliably discover the following pages:

- `/video/[id]` — individual video detail pages
- `/video-playlist/[id]` — video playlist collection pages
- `/podcast/[podcastId]` — podcast detail pages
- `/podcast/[podcastId]/podcast_episode/[episodeId]` — podcast episode detail pages

Two new sitemap modules need to be created and registered in the sitemap index, following the existing pattern used by `resources/`, `products/`, and `channels/` sitemaps.

### Screenshots (if appropriate):
<img width="2880" height="2856" alt="image" src="https://github.com/user-attachments/assets/5e986706-96eb-49a7-8565-84665869d0c0" />

### How can this be tested?
Verify the sitemap index includes products sitemap:

Visit: http://open.odl.local:8062/sitemaps/sitemap-index.xml and see if there are entries for video and podcast url.



### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
