### PR TITLE
dashboard refactor stage 2

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -35,12 +35,9 @@ import { ErrorContent } from "../ErrorPage/ErrorPageTemplate"
 import { matchOrganizationBySlug } from "@/common/utils"
 import { ResourceType, getKey } from "./CoursewareDisplay/helpers"
 import {
-  getCourseRunForSelectedLanguage,
-  getDistinctLanguageOptions,
-  getResolvedRunForSelectedLanguage,
-  getSelectedLanguageOption,
-  selectBestContractEnrollmentForLanguage,
-} from "./CoursewareDisplay/languageOptions"
+  getDistinctDashboardLanguageOptions,
+  resolveCardDataForLanguage,
+} from "./CoursewareDisplay/model/dashboardViewModel"
 import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 
 const HeaderRoot = styled.div(({ theme }) => ({
@@ -398,54 +395,37 @@ const OrgProgramCollectionDisplay: React.FC<{
             enrollments?.filter(
               (enrollment) => enrollment.b2b_contract_id === contract.id,
             ) ?? []
-          // Prefer the user's existing enrollment for the selected language
-          // over the next/best run, so older-run enrollments stay visible
-          // when the contract surfaces a newer run.
-          const selectedLanguageEnrollment =
-            selectBestContractEnrollmentForLanguage(
+          const { displayedEnrollment, displayedRun } =
+            resolveCardDataForLanguage(
               course,
               contractEnrollments,
               selectedLanguageKey,
+              { contractId: contract.id },
             )
-          const selectedLanguageOption = getSelectedLanguageOption(
-            course,
-            selectedLanguageKey,
-          )
-          const selectedRun = selectedLanguageEnrollment
-            ? ((course.courseruns ?? []).find(
-                (r) => r.id === selectedLanguageEnrollment.run.id,
-              ) ?? null)
-            : getCourseRunForSelectedLanguage(course, selectedLanguageKey)
-          const resolvedRun = getResolvedRunForSelectedLanguage(
-            course,
-            selectedLanguageOption,
-            selectedRun,
-            selectedLanguageEnrollment,
-            contract.id,
-          )
+
+          const resource = displayedEnrollment
+            ? {
+                type: DashboardType.CourseRunEnrollment,
+                data: displayedEnrollment,
+              }
+            : { type: DashboardType.Course, data: course }
+
           return (
             <DashboardCardStyled
               Component="li"
               key={getKey({
                 resourceType: ResourceType.Course,
                 id: course.id,
-                runId: selectedLanguageEnrollment?.run.id ?? resolvedRun?.id,
+                runId: displayedEnrollment?.run.id ?? displayedRun?.id,
               })}
-              resource={
-                selectedLanguageEnrollment
-                  ? {
-                      type: DashboardType.CourseRunEnrollment,
-                      data: selectedLanguageEnrollment,
-                    }
-                  : { type: DashboardType.Course, data: course }
-              }
+              resource={resource}
               noun="Module"
               offerUpgrade={false}
               buttonHref={
-                selectedLanguageEnrollment?.run.courseware_url ??
-                resolvedRun?.courseware_url
+                displayedEnrollment?.run.courseware_url ??
+                displayedRun?.courseware_url
               }
-              selectedCourseRun={resolvedRun}
+              selectedCourseRun={displayedRun}
               contractId={contract.id}
             />
           )
@@ -526,31 +506,20 @@ const OrgProgramDisplay: React.FC<{
                 courseRunEnrollments?.filter(
                   (enrollment) => enrollment.b2b_contract_id === contract?.id,
                 ) ?? []
-              // Prefer the user's existing enrollment for the selected
-              // language over the next/best run, so older-run enrollments
-              // stay visible when the contract surfaces a newer run.
-              const selectedLanguageEnrollment =
-                selectBestContractEnrollmentForLanguage(
+              const { displayedEnrollment, displayedRun } =
+                resolveCardDataForLanguage(
                   course,
                   contractEnrollments,
                   selectedLanguageKey,
+                  { contractId: contract?.id },
                 )
-              const selectedLanguageOption = getSelectedLanguageOption(
-                course,
-                selectedLanguageKey,
-              )
-              const selectedRun = selectedLanguageEnrollment
-                ? ((course.courseruns ?? []).find(
-                    (r) => r.id === selectedLanguageEnrollment.run.id,
-                  ) ?? null)
-                : getCourseRunForSelectedLanguage(course, selectedLanguageKey)
-              const resolvedRun = getResolvedRunForSelectedLanguage(
-                course,
-                selectedLanguageOption,
-                selectedRun,
-                selectedLanguageEnrollment,
-                contract?.id,
-              )
+
+              const resource = displayedEnrollment
+                ? {
+                    type: DashboardType.CourseRunEnrollment,
+                    data: displayedEnrollment,
+                  }
+                : { type: DashboardType.Course, data: course }
 
               return (
                 <DashboardCardStyled
@@ -558,24 +527,16 @@ const OrgProgramDisplay: React.FC<{
                   key={getKey({
                     resourceType: ResourceType.Course,
                     id: course.id,
-                    runId:
-                      selectedLanguageEnrollment?.run.id ?? resolvedRun?.id,
+                    runId: displayedEnrollment?.run.id ?? displayedRun?.id,
                   })}
-                  resource={
-                    selectedLanguageEnrollment
-                      ? {
-                          type: DashboardType.CourseRunEnrollment,
-                          data: selectedLanguageEnrollment,
-                        }
-                      : { type: DashboardType.Course, data: course }
-                  }
+                  resource={resource}
                   noun="Module"
                   offerUpgrade={false}
                   buttonHref={
-                    selectedLanguageEnrollment?.run.courseware_url ??
-                    resolvedRun?.courseware_url
+                    displayedEnrollment?.run.courseware_url ??
+                    displayedRun?.courseware_url
                   }
-                  selectedCourseRun={resolvedRun}
+                  selectedCourseRun={displayedRun}
                   contractId={contract?.id}
                 />
               )
@@ -644,8 +605,13 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
     [coursesQuery.data?.results],
   )
   const languageOptions = React.useMemo(
-    () => getDistinctLanguageOptions(contractCourses),
-    [contractCourses],
+    () =>
+      getDistinctDashboardLanguageOptions(
+        contractCourses,
+        courseRunEnrollmentsQuery.data ?? [],
+        { contractId: contract.id },
+      ),
+    [contract.id, contractCourses, courseRunEnrollmentsQuery.data],
   )
   const [selectedLanguageKey, setSelectedLanguageKey] = React.useState("")
 

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -36,7 +36,7 @@ import { matchOrganizationBySlug } from "@/common/utils"
 import { ResourceType, getKey } from "./CoursewareDisplay/helpers"
 import {
   getDistinctDashboardLanguageOptions,
-  resolveCardDataForLanguage,
+  resolveSlotForLanguage,
 } from "./CoursewareDisplay/model/dashboardViewModel"
 import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 
@@ -395,13 +395,12 @@ const OrgProgramCollectionDisplay: React.FC<{
             enrollments?.filter(
               (enrollment) => enrollment.b2b_contract_id === contract.id,
             ) ?? []
-          const { displayedEnrollment, displayedRun } =
-            resolveCardDataForLanguage(
-              course,
-              contractEnrollments,
-              selectedLanguageKey,
-              { contractId: contract.id },
-            )
+          const { displayedEnrollment, displayedRun } = resolveSlotForLanguage(
+            course,
+            contractEnrollments,
+            selectedLanguageKey,
+            { contractId: contract.id },
+          )
 
           const resource = displayedEnrollment
             ? {
@@ -507,7 +506,7 @@ const OrgProgramDisplay: React.FC<{
                   (enrollment) => enrollment.b2b_contract_id === contract?.id,
                 ) ?? []
               const { displayedEnrollment, displayedRun } =
-                resolveCardDataForLanguage(
+                resolveSlotForLanguage(
                   course,
                   contractEnrollments,
                   selectedLanguageKey,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -22,7 +22,6 @@ import {
   getRequirementsProgress,
   getKey,
   ResourceType,
-  selectBestEnrollment,
 } from "./helpers"
 import {
   DashboardCard,
@@ -30,12 +29,9 @@ import {
   DashboardType,
 } from "./DashboardCard"
 import {
-  getDistinctLanguageOptions,
-  getSelectedLanguageOption,
-  getCourseRunForSelectedLanguage,
-  getEnrollmentForSelectedLanguage,
-  getResolvedRunForSelectedLanguage,
-} from "./languageOptions"
+  getDistinctDashboardLanguageOptions,
+  resolveCardDataForLanguage,
+} from "./model/dashboardViewModel"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { programsQueries } from "api/mitxonline-hooks/programs"
 import {
@@ -520,8 +516,12 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
     [programCourses?.results],
   )
   const languageOptions = React.useMemo(
-    () => getDistinctLanguageOptions(allProgramCourses),
-    [allProgramCourses],
+    () =>
+      getDistinctDashboardLanguageOptions(
+        allProgramCourses,
+        rawEnrollments ?? [],
+      ),
+    [allProgramCourses, rawEnrollments],
   )
   const [selectedLanguageKey, setSelectedLanguageKey] = React.useState("")
   useEffect(() => {
@@ -728,56 +728,33 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                 if (item.resourceType === "course") {
                   const courseEnrollments =
                     enrollmentsByCourseId[item.course.id] || []
-                  const selectedLanguageOption = getSelectedLanguageOption(
-                    item.course,
-                    selectedLanguageKey,
-                  )
-                  const selectedRun = getCourseRunForSelectedLanguage(
-                    item.course,
-                    selectedLanguageKey,
-                  )
-                  const selectedLanguageEnrollment =
-                    getEnrollmentForSelectedLanguage(
+                  const { displayedEnrollment, displayedRun } =
+                    resolveCardDataForLanguage(
+                      item.course,
                       courseEnrollments,
-                      selectedLanguageOption,
-                      selectedRun,
+                      selectedLanguageKey,
                     )
-                  const resolvedRun = getResolvedRunForSelectedLanguage(
-                    item.course,
-                    selectedLanguageOption,
-                    selectedRun,
-                    selectedLanguageEnrollment,
-                  )
 
-                  // When a language is selected, only use an enrollment that
-                  // matches that specific language run. Don't fall back to a
-                  // different-language enrollment, which would show the wrong
-                  // title/URL and a misleading "Continue" CTA.
-                  const hasLanguageSelected = Boolean(
-                    selectedLanguageKey && languageOptions.length > 0,
-                  )
-                  const effectiveEnrollment = hasLanguageSelected
-                    ? selectedLanguageEnrollment
-                    : selectBestEnrollment(item.course, courseEnrollments)
-
-                  const resource = effectiveEnrollment
+                  const resource = displayedEnrollment
                     ? {
                         type: DashboardType.CourseRunEnrollment,
-                        data: effectiveEnrollment,
+                        data: displayedEnrollment,
                       }
                     : { type: DashboardType.Course, data: item.course }
+
+                  const runId = displayedEnrollment?.run.id ?? displayedRun?.id
 
                   return (
                     <DashboardCardStyled
                       key={getKey({
                         resourceType: ResourceType.Course,
                         id: item.course.id,
-                        runId: effectiveEnrollment?.run.id ?? resolvedRun?.id,
+                        runId,
                       })}
                       resource={resource}
                       programEnrollment={programEnrollment}
                       showNotComplete={false}
-                      selectedCourseRun={resolvedRun}
+                      selectedCourseRun={displayedRun}
                     />
                   )
                 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentDisplay.tsx
@@ -30,7 +30,7 @@ import {
 } from "./DashboardCard"
 import {
   getDistinctDashboardLanguageOptions,
-  resolveCardDataForLanguage,
+  resolveSlotForLanguage,
 } from "./model/dashboardViewModel"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { programsQueries } from "api/mitxonline-hooks/programs"
@@ -729,7 +729,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                   const courseEnrollments =
                     enrollmentsByCourseId[item.course.id] || []
                   const { displayedEnrollment, displayedRun } =
-                    resolveCardDataForLanguage(
+                    resolveSlotForLanguage(
                       item.course,
                       courseEnrollments,
                       selectedLanguageKey,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
@@ -265,7 +265,7 @@ This phase also folds in a small, isolated bug fix: enrolled-but-not-enrollable 
 **Hypothesised approach** (verify before executing):
 
 - [ ] Add a composite function — working name `resolveSlotForLanguage(course, enrollments, selectedLanguageKey, { contractId })` — that returns `{ displayedEnrollment, displayedRun, selectedLanguageOption }`. Internally it calls today's primitives in the same order they are called at every callsite, so behavior is preserved by construction. **Place it in `model/dashboardViewModel.ts`** (Phase 1's pure-model home), not in `languageOptions.ts`.
-- [ ] Add a composite function for the language picker — working name `getDashboardLanguageOptions(course, enrollments)` — that returns the union of enrollable V2 `course.language_options` and languages from the user's V3 `enrollment.run.language`. Also placed in `dashboardViewModel.ts`.
+- [ ] Add a composite function for the language picker — working name `getDistinctDashboardLanguageOptions(courses, enrollments)` — that returns the union of V2 `course.language_options` across the given courses and languages from the user's V3 `enrollment.run.language`. Also placed in `dashboardViewModel.ts`.
 - [ ] Update callsites in `EnrollmentDisplay.tsx` and `ContractContent.tsx` to use the composites. The 4-call dance disappears at the callsite; render code stops knowing the orchestration exists.
 - [ ] Begin migrating helpers from `languageOptions.ts` into `dashboardViewModel.ts` opportunistically (anything the composites depend on internally can move). Full deletion of `languageOptions.ts` is committed to Phase 7; this phase need only consolidate what it touches.
 - [ ] Do not introduce a multi-run selector.

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
@@ -18,6 +18,14 @@ This plan is not a script. Every phase is a judgment opportunity, not a checklis
 
 **Success criterion: complexity is reduced, not relocated.** The user-visible improvement of this refactor is "the dashboard is easier to reason about." That improvement is _not_ delivered by adding new directories or by colocating queries into hooks. It is delivered by **each artifact having a single, name-able responsibility that fits in your head**. A hook that composes 6 named helpers fits in your head; a hook that inlines 6 transforms does not. Moving a 700-line orchestration into a 700-line hook is a failure of this phase, even if every checkbox is ticked. Every extracted unit must be smaller, more focused, and more testable than what it replaced — or the extraction has not delivered cleanup.
 
+**Discover dead code and bad assumptions as you go, not at the boundary.** Phase-exit review (question 2 below) is a safety net, not the primary mechanism. Surface findings in the moment:
+
+- **When you stop calling an existing function, check for remaining callers.** If it now has no production consumer (only tests, or nothing at all), propose deletion in the same PR. Don't leave dangling helpers for "later" — the next phase inherits more cleanup work, and reviewers can't tell intentional preservation from oversight.
+- **When you introduce a new helper, check whether an existing one already covers the case.** Composing on top of a helper you should have replaced costs cleanup work twice.
+- **When you read an existing helper before composing it, check whether its premise still holds.** A filter that targets data shapes the codebase no longer produces — or never produced — is dead even if it has callers. Surface it; don't propagate it.
+
+The cost of catching these during the phase is one extra lookup per touched symbol. The cost of catching them at phase exit is a ballooning cleanup PR and a reviewer who can't tell what's deliberate.
+
 **Phase-boundary review questions.** At the end of every phase, the agent and reviewer answer together:
 
 1. **Did this phase make the dashboard easier to reason about?** Concretely — what is now smaller, more isolated, or better tested? If the answer is "not really," investigate why before continuing.
@@ -144,6 +152,8 @@ type HomeDashboardData = {
 ### Program and contract course slot model
 
 Program and contract dashboards should use a slot model.
+
+A **slot** is the per-course data shape the dashboard arranges into its layout — one slot per course, carrying that course plus every enrollment for it plus the row's display state (language selection, derived "displayed" enrollment/run, contract scoping, ancestor program context). Slot ≠ card: the slot is the data shape, the card is the UI that renders from it. Today one slot renders as one card; once multi-run UX lands, one slot might render as multiple cards (a dropdown, an expanded list, a dialog) without the slot itself changing. The plural is what carries the term's intuition: a program dashboard arranges N slots into its requirement layout; a contract dashboard arranges N slots per program. Home (`My Learning`) is _not_ slot-driven — it's enrollment-flat (one card per enrollment, multiple cards possible for the same course).
 
 ```ts
 type DashboardCourseSlot = {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.test.ts
@@ -1,21 +1,13 @@
 import { factories } from "api/mitxonline-test-utils"
-import type {
-  CourseRunEnrollmentV3,
-  CourseRunLanguageOption,
-} from "@mitodl/mitxonline-api-axios/v2"
+import type { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   getCourseRunForSelectedLanguage,
-  getDistinctLanguageOptions,
   getEnrollmentForSelectedLanguage,
-  getLanguageOptionKey,
+  getNativeLanguageName,
   getResolvedRunForSelectedLanguage,
   getSelectedLanguageOption,
   selectBestContractEnrollmentForLanguage,
 } from "./languageOptions"
-
-type LanguageOptionWithEnrollability = CourseRunLanguageOption & {
-  is_enrollable: boolean
-}
 
 describe("languageOptions", () => {
   const setIntlDisplayNames = (
@@ -28,236 +20,11 @@ describe("languageOptions", () => {
     })
   }
 
-  test("normalizes language keys", () => {
-    expect(
-      getLanguageOptionKey({
-        id: 1,
-        courseware_id: "cw-1",
-        courseware_url: "https://example.com/cw-1",
-        language: "pt_BR",
-        title: "Run",
-        run_tag: "R1",
-      }),
-    ).toBe("language:pt-br")
-  })
-
-  test("builds distinct language options sorted by majority default language", () => {
-    const englishRunA = factories.courses.courseRun({
-      id: 101,
-      title: "English A",
-      courseware_id: "cw-en-a",
-      courseware_url: "https://example.com/cw-en-a",
-      is_enrollable: true,
-    })
-    const spanishRunA = factories.courses.courseRun({
-      id: 102,
-      title: "Espanol A",
-      courseware_id: "cw-es-a",
-      courseware_url: "https://example.com/cw-es-a",
-      is_enrollable: true,
-    })
-    const englishRunB = factories.courses.courseRun({
-      id: 201,
-      title: "English B",
-      courseware_id: "cw-en-b",
-      courseware_url: "https://example.com/cw-en-b",
-      is_enrollable: true,
-    })
-    const spanishRunB = factories.courses.courseRun({
-      id: 202,
-      title: "Espanol B",
-      courseware_id: "cw-es-b",
-      courseware_url: "https://example.com/cw-es-b",
-      is_enrollable: true,
-    })
-    const spanishRunC = factories.courses.courseRun({
-      id: 302,
-      title: "Espanol C",
-      courseware_id: "cw-es-c",
-      courseware_url: "https://example.com/cw-es-c",
-      is_enrollable: true,
-    })
-    const englishRunC = factories.courses.courseRun({
-      id: 301,
-      title: "English C",
-      courseware_id: "cw-en-c",
-      courseware_url: "https://example.com/cw-en-c",
-      is_enrollable: true,
-    })
-
-    const courseA = factories.courses.course({
-      courseruns: [englishRunA, spanishRunA],
-      next_run_id: englishRunA.id,
-      language_options: [
-        {
-          id: englishRunA.id,
-          courseware_id: englishRunA.courseware_id,
-          courseware_url: englishRunA.courseware_url ?? "",
-          language: "en",
-          title: englishRunA.title,
-          run_tag: englishRunA.run_tag,
-        },
-        {
-          id: spanishRunA.id,
-          courseware_id: spanishRunA.courseware_id,
-          courseware_url: spanishRunA.courseware_url ?? "",
-          language: "es",
-          title: spanishRunA.title,
-          run_tag: spanishRunA.run_tag,
-        },
-        {
-          id: 999,
-          courseware_id: "cw-empty",
-          courseware_url: "https://example.com/cw-empty",
-          language: "",
-          title: "No Language",
-          run_tag: "R0",
-        },
-      ],
-    })
-    const courseB = factories.courses.course({
-      courseruns: [englishRunB, spanishRunB],
-      next_run_id: englishRunB.id,
-      language_options: [
-        {
-          id: englishRunB.id,
-          courseware_id: englishRunB.courseware_id,
-          courseware_url: englishRunB.courseware_url ?? "",
-          language: "en",
-          title: englishRunB.title,
-          run_tag: englishRunB.run_tag,
-        },
-        {
-          id: spanishRunB.id,
-          courseware_id: spanishRunB.courseware_id,
-          courseware_url: spanishRunB.courseware_url ?? "",
-          language: "es",
-          title: spanishRunB.title,
-          run_tag: spanishRunB.run_tag,
-        },
-      ],
-    })
-    const courseC = factories.courses.course({
-      courseruns: [englishRunC, spanishRunC],
-      next_run_id: spanishRunC.id,
-      language_options: [
-        {
-          id: englishRunC.id,
-          courseware_id: englishRunC.courseware_id,
-          courseware_url: englishRunC.courseware_url ?? "",
-          language: "en",
-          title: englishRunC.title,
-          run_tag: englishRunC.run_tag,
-        },
-        {
-          id: spanishRunC.id,
-          courseware_id: spanishRunC.courseware_id,
-          courseware_url: spanishRunC.courseware_url ?? "",
-          language: "es",
-          title: spanishRunC.title,
-          run_tag: spanishRunC.run_tag,
-        },
-      ],
-    })
-
-    const options = getDistinctLanguageOptions([courseA, courseB, courseC])
-
-    expect(options).toHaveLength(2)
-    expect(options[0]).toEqual({
-      value: "language:en",
-      label: "English",
-    })
-    expect(options[1]).toEqual({
-      value: "language:es",
-      label: "español",
-    })
-  })
-
-  test("builds distinct options when language option ids differ from run ids", () => {
-    const englishRun = factories.courses.courseRun({
-      id: 4001,
-      title: "English Run",
-      courseware_id: "cw-en-4001",
-      courseware_url: "https://example.com/cw-en-4001",
-      is_enrollable: true,
-    })
-    const spanishRun = factories.courses.courseRun({
-      id: 4002,
-      title: "Spanish Run",
-      courseware_id: "cw-es-4002",
-      courseware_url: "https://example.com/cw-es-4002",
-      is_enrollable: true,
-    })
-
-    const course = factories.courses.course({
-      courseruns: [englishRun, spanishRun],
-      next_run_id: englishRun.id,
-      language_options: [
-        {
-          id: 9001,
-          courseware_id: englishRun.courseware_id,
-          courseware_url: englishRun.courseware_url ?? "",
-          language: "en",
-          title: englishRun.title,
-          run_tag: englishRun.run_tag,
-        },
-        {
-          id: 9002,
-          courseware_id: spanishRun.courseware_id,
-          courseware_url: spanishRun.courseware_url ?? "",
-          language: "es",
-          title: spanishRun.title,
-          run_tag: spanishRun.run_tag,
-        },
-      ],
-    })
-
-    const options = getDistinctLanguageOptions([course])
-    const selectedRun = getCourseRunForSelectedLanguage(course, "language:es")
-
-    expect(options).toHaveLength(2)
-    expect(options.map((option) => option.value)).toEqual([
-      "language:en",
-      "language:es",
-    ])
-    expect(selectedRun?.id).toBe(spanishRun.id)
-  })
-
-  test("uses static fallback labels when Intl.DisplayNames is unavailable", () => {
+  test("uses static fallback label when Intl.DisplayNames is unavailable", () => {
     const originalDisplayNames = Intl.DisplayNames
     setIntlDisplayNames(undefined)
-
     try {
-      const run = factories.courses.courseRun({
-        id: 7001,
-        title: "Spanish LATAM",
-        courseware_id: "cw-es-419",
-        courseware_url: "https://example.com/cw-es-419",
-        is_enrollable: true,
-      })
-
-      const course = factories.courses.course({
-        courseruns: [run],
-        next_run_id: run.id,
-        language_options: [
-          {
-            id: run.id,
-            courseware_id: run.courseware_id,
-            courseware_url: run.courseware_url ?? "",
-            language: "es-419",
-            title: run.title,
-            run_tag: run.run_tag,
-          },
-        ],
-      })
-
-      const options = getDistinctLanguageOptions([course])
-      expect(options).toEqual([
-        {
-          value: "language:es-419",
-          label: "español (Latinoamérica)",
-        },
-      ])
+      expect(getNativeLanguageName("es-419")).toBe("español (Latinoamérica)")
     } finally {
       setIntlDisplayNames(originalDisplayNames)
     }
@@ -268,49 +35,15 @@ describe("languageOptions", () => {
 
     class MockDisplayNames {
       of(code: string): string | undefined {
-        if (code === "zz-419") {
-          return undefined
-        }
-        if (code === "zz") {
-          return "Zed"
-        }
+        if (code === "zz-419") return undefined
+        if (code === "zz") return "Zed"
         return undefined
       }
     }
 
     setIntlDisplayNames(MockDisplayNames as unknown as typeof Intl.DisplayNames)
-
     try {
-      const run = factories.courses.courseRun({
-        id: 7002,
-        title: "Mock Regional",
-        courseware_id: "cw-zz-419",
-        courseware_url: "https://example.com/cw-zz-419",
-        is_enrollable: true,
-      })
-
-      const course = factories.courses.course({
-        courseruns: [run],
-        next_run_id: run.id,
-        language_options: [
-          {
-            id: run.id,
-            courseware_id: run.courseware_id,
-            courseware_url: run.courseware_url ?? "",
-            language: "zz-419",
-            title: run.title,
-            run_tag: run.run_tag,
-          },
-        ],
-      })
-
-      const options = getDistinctLanguageOptions([course])
-      expect(options).toEqual([
-        {
-          value: "language:zz-419",
-          label: "Zed",
-        },
-      ])
+      expect(getNativeLanguageName("zz-419")).toBe("Zed")
     } finally {
       setIntlDisplayNames(originalDisplayNames)
     }
@@ -324,211 +57,20 @@ describe("languageOptions", () => {
       constructor() {
         constructorCalls += 1
       }
-
       of(code: string): string | undefined {
-        if (code === "es") {
-          return "español"
-        }
+        if (code === "es") return "español"
         return undefined
       }
     }
 
     setIntlDisplayNames(MockDisplayNames as unknown as typeof Intl.DisplayNames)
-
     try {
-      const runA = factories.courses.courseRun({
-        id: 7101,
-        title: "Spanish A",
-        courseware_id: "cw-es-7101",
-        courseware_url: "https://example.com/cw-es-7101",
-        is_enrollable: true,
-      })
-
-      const runB = factories.courses.courseRun({
-        id: 7102,
-        title: "Spanish B",
-        courseware_id: "cw-es-7102",
-        courseware_url: "https://example.com/cw-es-7102",
-        is_enrollable: true,
-      })
-
-      const courseA = factories.courses.course({
-        courseruns: [runA],
-        next_run_id: runA.id,
-        language_options: [
-          {
-            id: runA.id,
-            courseware_id: runA.courseware_id,
-            courseware_url: runA.courseware_url ?? "",
-            language: "es",
-            title: runA.title,
-            run_tag: runA.run_tag,
-          },
-        ],
-      })
-
-      const courseB = factories.courses.course({
-        courseruns: [runB],
-        next_run_id: runB.id,
-        language_options: [
-          {
-            id: runB.id,
-            courseware_id: runB.courseware_id,
-            courseware_url: runB.courseware_url ?? "",
-            language: "es",
-            title: runB.title,
-            run_tag: runB.run_tag,
-          },
-        ],
-      })
-
-      const options = getDistinctLanguageOptions([courseA, courseB])
-
-      expect(options).toEqual([
-        {
-          value: "language:es",
-          label: "español",
-        },
-      ])
+      expect(getNativeLanguageName("es")).toBe("español")
+      expect(getNativeLanguageName("es")).toBe("español")
       expect(constructorCalls).toBe(1)
     } finally {
       setIntlDisplayNames(originalDisplayNames)
     }
-  })
-
-  test("keeps language when one of multiple matching runs is enrollable", () => {
-    const englishRun = factories.courses.courseRun({
-      id: 6101,
-      title: "English",
-      courseware_id: "cw-en-6101",
-      courseware_url: "https://example.com/cw-en-6101",
-      is_enrollable: true,
-    })
-    const spanishUnenrollable = factories.courses.courseRun({
-      id: 6102,
-      title: "Spanish Old",
-      courseware_id: "cw-es-shared",
-      courseware_url: "https://example.com/cw-es-shared",
-      is_enrollable: false,
-    })
-    const spanishEnrollable = factories.courses.courseRun({
-      id: 6103,
-      title: "Spanish New",
-      courseware_id: "cw-es-shared",
-      courseware_url: "https://example.com/cw-es-shared",
-      is_enrollable: true,
-    })
-
-    const course = factories.courses.course({
-      courseruns: [englishRun, spanishUnenrollable, spanishEnrollable],
-      next_run_id: englishRun.id,
-      language_options: [
-        {
-          id: 9101,
-          courseware_id: englishRun.courseware_id,
-          courseware_url: englishRun.courseware_url ?? "",
-          language: "en",
-          title: englishRun.title,
-          run_tag: englishRun.run_tag,
-        },
-        {
-          id: 9102,
-          courseware_id: spanishEnrollable.courseware_id,
-          courseware_url: spanishEnrollable.courseware_url ?? "",
-          language: "es",
-          title: spanishEnrollable.title,
-          run_tag: spanishEnrollable.run_tag,
-        },
-      ],
-    })
-
-    const options = getDistinctLanguageOptions([course])
-    const selectedOption = getSelectedLanguageOption(course, "language:es")
-    const selectedRun = getCourseRunForSelectedLanguage(course, "language:es")
-
-    expect(options.map((option) => option.value)).toEqual([
-      "language:en",
-      "language:es",
-    ])
-    expect(selectedOption).not.toBeNull()
-    expect(selectedRun?.id).toBe(spanishEnrollable.id)
-  })
-
-  test("includes language options even when no language variant exists in courseruns", () => {
-    const templateRun = factories.courses.courseRun({
-      id: 6201,
-      title: "English Template",
-      courseware_id: "cw-template-en",
-      courseware_url: "https://example.com/cw-template-en",
-      is_enrollable: true,
-    })
-
-    const course = factories.courses.course({
-      courseruns: [templateRun],
-      next_run_id: templateRun.id,
-      language_options: [
-        {
-          id: templateRun.id,
-          courseware_id: templateRun.courseware_id,
-          courseware_url: templateRun.courseware_url ?? "",
-          language: "en",
-          title: templateRun.title,
-          run_tag: templateRun.run_tag,
-        },
-        {
-          id: 6202,
-          courseware_id: "cw-template-es",
-          courseware_url: "https://example.com/cw-template-es",
-          language: "es",
-          title: "Modulo Espanol",
-          run_tag: templateRun.run_tag,
-        },
-      ],
-    })
-
-    const options = getDistinctLanguageOptions([course])
-    expect(options.map((option) => option.value)).toEqual([
-      "language:en",
-      "language:es",
-    ])
-  })
-
-  test("filters out unenrollable options when is_enrollable is provided", () => {
-    const run = factories.courses.courseRun({
-      id: 6301,
-      title: "English",
-      courseware_id: "cw-en-6301",
-      courseware_url: "https://example.com/cw-en-6301",
-      is_enrollable: true,
-    })
-
-    const course = factories.courses.course({
-      courseruns: [run],
-      next_run_id: run.id,
-      language_options: [
-        {
-          id: run.id,
-          courseware_id: run.courseware_id,
-          courseware_url: run.courseware_url ?? "",
-          language: "en",
-          title: run.title,
-          run_tag: run.run_tag,
-          is_enrollable: true,
-        } as LanguageOptionWithEnrollability,
-        {
-          id: 6302,
-          courseware_id: "cw-es-6302",
-          courseware_url: "https://example.com/cw-es-6302",
-          language: "es",
-          title: "Modulo Espanol",
-          run_tag: run.run_tag,
-          is_enrollable: false,
-        } as LanguageOptionWithEnrollability,
-      ],
-    })
-
-    const options = getDistinctLanguageOptions([course])
-    expect(options.map((option) => option.value)).toEqual(["language:en"])
   })
 
   test("matches selected enrollment by language option courseware id", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -1,3 +1,10 @@
+/**
+ * Helpers for resolving language selection against course/enrollment data.
+ *
+ * **Note:** `course.courseruns` and `course.language_options` are
+ * mostly disjoint. `language_options` describes which languages the course is
+ * offered; `courseruns` materializes only the default-language runs.
+ */
 import type {
   CourseRunEnrollmentV3,
   CourseRunLanguageOption,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -557,4 +557,5 @@ export {
   getCourseRunForSelectedLanguage,
   getEnrollmentForSelectedLanguage,
   getResolvedRunForSelectedLanguage,
+  getNativeLanguageName,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/languageOptions.ts
@@ -1,4 +1,3 @@
-import type { SimpleSelectOption } from "ol-components"
 import type {
   CourseRunEnrollmentV3,
   CourseRunLanguageOption,
@@ -15,14 +14,6 @@ const getLanguageCode = (option: CourseRunLanguageOption): string | null => {
 const getLanguageOptionKey = (option: CourseRunLanguageOption): string => {
   const languageCode = getLanguageCode(option)
   return languageCode ? `language:${languageCode}` : ""
-}
-
-const getLanguageCodeFromOptionKey = (optionKey: string): string | null => {
-  if (!optionKey.startsWith("language:")) {
-    return null
-  }
-  const code = optionKey.replace("language:", "").trim().toLowerCase()
-  return code || null
 }
 
 const FALLBACK_NATIVE_LANGUAGE_NAMES: Record<string, string> = {
@@ -116,15 +107,6 @@ const getNativeLanguageName = (languageCode: string): string => {
 
   nativeLanguageNameCache.set(normalizedLanguageCode, finalLabel)
   return finalLabel
-}
-
-const getLanguageOptionLabel = (option: CourseRunLanguageOption): string => {
-  const languageCode = getLanguageCode(option)
-  if (!languageCode) {
-    return ""
-  }
-
-  return getNativeLanguageName(languageCode)
 }
 
 type ExtendedLanguageOption = CourseRunLanguageOption & {
@@ -226,46 +208,6 @@ const getDefaultLanguageOptionKey = (
 
   const key = getLanguageOptionKey(byCoursewareId)
   return key || null
-}
-
-const getDistinctLanguageOptions = (
-  courses: CourseWithCourseRunsSerializerV2[],
-): SimpleSelectOption[] => {
-  const optionsByKey = new Map<string, SimpleSelectOption>()
-  const defaultLanguageCounts = new Map<string, number>()
-
-  courses.forEach((course) => {
-    const defaultLanguageKey = getDefaultLanguageOptionKey(course)
-    if (defaultLanguageKey) {
-      defaultLanguageCounts.set(
-        defaultLanguageKey,
-        (defaultLanguageCounts.get(defaultLanguageKey) ?? 0) + 1,
-      )
-    }
-
-    getEnrollableLanguageOptions(course).forEach((option) => {
-      const key = getLanguageOptionKey(option)
-      const label = getLanguageOptionLabel(option)
-      if (!key || !label) {
-        return
-      }
-      if (!optionsByKey.has(key)) {
-        optionsByKey.set(key, {
-          value: key,
-          label,
-        })
-      }
-    })
-  })
-
-  return Array.from(optionsByKey.values()).sort((a, b) => {
-    const defaultCountA = defaultLanguageCounts.get(String(a.value)) ?? 0
-    const defaultCountB = defaultLanguageCounts.get(String(b.value)) ?? 0
-    if (defaultCountA !== defaultCountB) {
-      return defaultCountB - defaultCountA
-    }
-    return String(a.label).localeCompare(String(b.label))
-  })
 }
 
 const getSelectedLanguageOption = (
@@ -549,10 +491,7 @@ const getResolvedRunForSelectedLanguage = (
 }
 
 export {
-  getLanguageCodeFromOptionKey,
-  getLanguageOptionKey,
   selectBestContractEnrollmentForLanguage,
-  getDistinctLanguageOptions,
   getSelectedLanguageOption,
   getCourseRunForSelectedLanguage,
   getEnrollmentForSelectedLanguage,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1,6 +1,5 @@
 import { factories } from "api/mitxonline-test-utils"
 import {
-  getDashboardLanguageOptions,
   getDistinctDashboardLanguageOptions,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
@@ -110,7 +109,7 @@ describe("dashboardViewModel", () => {
     })
   })
 
-  describe("getDashboardLanguageOptions", () => {
+  describe("getDistinctDashboardLanguageOptions", () => {
     test("includes enrollment language not present in enrollable language options", () => {
       const englishRun = factories.courses.courseRun({
         id: 101,
@@ -158,7 +157,10 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const options = getDashboardLanguageOptions(course, [spanishEnrollment])
+      const options = getDistinctDashboardLanguageOptions(
+        [course],
+        [spanishEnrollment],
+      )
 
       expect(options.map((option) => option.value)).toEqual([
         "language:en",
@@ -267,10 +269,10 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const options = getDashboardLanguageOptions(course, [
-        frenchEnrollment,
-        spanishEnrollment,
-      ])
+      const options = getDistinctDashboardLanguageOptions(
+        [course],
+        [frenchEnrollment, spanishEnrollment],
+      )
 
       expect(options.map((option) => option.value)).toEqual([
         "language:es",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1,8 +1,11 @@
 import { factories } from "api/mitxonline-test-utils"
 import {
+  getDashboardLanguageOptions,
+  getDistinctDashboardLanguageOptions,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
   pickDisplayedEnrollmentForLegacyDashboard,
+  resolveCardDataForLanguage,
 } from "./dashboardViewModel"
 
 describe("dashboardViewModel", () => {
@@ -104,6 +107,320 @@ describe("dashboardViewModel", () => {
 
       expect(grouped[101]).toEqual(enrollment1)
       expect(grouped[202]).toEqual(enrollment2)
+    })
+  })
+
+  describe("getDashboardLanguageOptions", () => {
+    test("includes enrollment language not present in enrollable language options", () => {
+      const englishRun = factories.courses.courseRun({
+        id: 101,
+        language: "en",
+        courseware_id: "cw-en-101",
+        courseware_url: "https://example.com/en-101",
+        is_enrollable: true,
+      })
+
+      const course = factories.courses.course({
+        id: 1,
+        courseruns: [englishRun],
+        next_run_id: englishRun.id,
+        language_options: [
+          {
+            id: englishRun.id,
+            courseware_id: englishRun.courseware_id,
+            courseware_url: englishRun.courseware_url ?? "",
+            language: "en",
+            title: englishRun.title,
+            run_tag: englishRun.run_tag,
+          },
+        ],
+      })
+
+      const spanishEnrollment = factories.enrollment.courseEnrollment({
+        b2b_contract_id: null,
+        run: {
+          id: 999,
+          language: "es",
+          title: "Modulo Espanol",
+          run_tag: "ES-1",
+          course: { id: course.id, title: course.title },
+          courseware_id: "cw-es-999",
+          courseware_url: "https://example.com/es-999",
+          is_enrollable: false,
+          is_upgradable: false,
+          is_archived: false,
+          is_self_paced: true,
+          start_date: null,
+          end_date: null,
+          upgrade_deadline: null,
+          certificate_available_date: null,
+          course_number: "",
+        },
+      })
+
+      const options = getDashboardLanguageOptions(course, [spanishEnrollment])
+
+      expect(options.map((option) => option.value)).toEqual([
+        "language:en",
+        "language:es",
+      ])
+    })
+
+    test("adds only relevant enrollment languages for the provided course set", () => {
+      const courseA = factories.courses.course({ id: 10, language_options: [] })
+      const courseB = factories.courses.course({ id: 20, language_options: [] })
+
+      const enrollmentA = factories.enrollment.courseEnrollment({
+        run: {
+          id: 1,
+          language: "fr",
+          title: "Run FR",
+          run_tag: "FR-1",
+          course: { id: 10, title: "Course A" },
+          courseware_id: "cw-fr-1",
+          courseware_url: "https://example.com/fr-1",
+          is_enrollable: true,
+          is_upgradable: false,
+          is_archived: false,
+          is_self_paced: true,
+          start_date: null,
+          end_date: null,
+          upgrade_deadline: null,
+          certificate_available_date: null,
+          course_number: "",
+        },
+      })
+      const enrollmentOtherCourse = factories.enrollment.courseEnrollment({
+        run: {
+          id: 2,
+          language: "de",
+          title: "Run DE",
+          run_tag: "DE-1",
+          course: { id: 999, title: "Outside" },
+          courseware_id: "cw-de-2",
+          courseware_url: "https://example.com/de-2",
+          is_enrollable: true,
+          is_upgradable: false,
+          is_archived: false,
+          is_self_paced: true,
+          start_date: null,
+          end_date: null,
+          upgrade_deadline: null,
+          certificate_available_date: null,
+          course_number: "",
+        },
+      })
+
+      const options = getDistinctDashboardLanguageOptions(
+        [courseA, courseB],
+        [enrollmentA, enrollmentOtherCourse],
+      )
+
+      expect(options.map((option) => option.value)).toEqual(["language:fr"])
+    })
+  })
+
+  describe("resolveSlotForLanguage", () => {
+    test("prefers selected-language enrollment", () => {
+      const englishRun = factories.courses.courseRun({
+        id: 11,
+        language: "en",
+        courseware_id: "cw-en-11",
+        courseware_url: "https://example.com/en-11",
+        is_enrollable: true,
+      })
+      const spanishRun = factories.courses.courseRun({
+        id: 12,
+        language: "es",
+        courseware_id: "cw-es-12",
+        courseware_url: "https://example.com/es-12",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        id: 1,
+        courseruns: [englishRun, spanishRun],
+        next_run_id: englishRun.id,
+        language_options: [
+          {
+            id: englishRun.id,
+            courseware_id: englishRun.courseware_id,
+            courseware_url: englishRun.courseware_url ?? "",
+            language: "en",
+            title: englishRun.title,
+            run_tag: englishRun.run_tag,
+          },
+          {
+            id: spanishRun.id,
+            courseware_id: spanishRun.courseware_id,
+            courseware_url: spanishRun.courseware_url ?? "",
+            language: "es",
+            title: spanishRun.title,
+            run_tag: spanishRun.run_tag,
+          },
+        ],
+      })
+
+      const englishEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: englishRun.id,
+          language: "en",
+          course: { id: course.id, title: course.title },
+          title: englishRun.title,
+          run_tag: englishRun.run_tag,
+          courseware_id: englishRun.courseware_id,
+          courseware_url: englishRun.courseware_url,
+          is_enrollable: englishRun.is_enrollable,
+          is_upgradable: englishRun.is_upgradable,
+          is_archived: englishRun.is_archived,
+          is_self_paced: englishRun.is_self_paced,
+          start_date: englishRun.start_date,
+          end_date: englishRun.end_date,
+          upgrade_deadline: englishRun.upgrade_deadline,
+          certificate_available_date: englishRun.certificate_available_date,
+          course_number: englishRun.course_number,
+        },
+      })
+      const spanishEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: spanishRun.id,
+          language: "es",
+          course: { id: course.id, title: course.title },
+          title: spanishRun.title,
+          run_tag: spanishRun.run_tag,
+          courseware_id: spanishRun.courseware_id,
+          courseware_url: spanishRun.courseware_url,
+          is_enrollable: spanishRun.is_enrollable,
+          is_upgradable: spanishRun.is_upgradable,
+          is_archived: spanishRun.is_archived,
+          is_self_paced: spanishRun.is_self_paced,
+          start_date: spanishRun.start_date,
+          end_date: spanishRun.end_date,
+          upgrade_deadline: spanishRun.upgrade_deadline,
+          certificate_available_date: spanishRun.certificate_available_date,
+          course_number: spanishRun.course_number,
+        },
+      })
+
+      const resolved = resolveCardDataForLanguage(
+        course,
+        [englishEnrollment, spanishEnrollment],
+        "language:es",
+      )
+
+      expect(resolved.displayedEnrollment?.run.id).toBe(spanishRun.id)
+      expect(resolved.displayedRun?.id).toBe(spanishRun.id)
+    })
+
+    test("does not pick enrollment from another contract", () => {
+      const englishRun = factories.courses.courseRun({
+        id: 21,
+        b2b_contract: 1,
+        courseware_id: "cw-en-21",
+        courseware_url: "https://example.com/en-21",
+        is_enrollable: true,
+      })
+      const spanishRun = factories.courses.courseRun({
+        id: 22,
+        b2b_contract: 2,
+        courseware_id: "cw-es-22",
+        courseware_url: "https://example.com/es-22",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        id: 2,
+        courseruns: [englishRun, spanishRun],
+        next_run_id: englishRun.id,
+        language_options: [
+          {
+            id: englishRun.id,
+            courseware_id: englishRun.courseware_id,
+            courseware_url: englishRun.courseware_url ?? "",
+            language: "en",
+            title: englishRun.title,
+            run_tag: englishRun.run_tag,
+          },
+          {
+            id: spanishRun.id,
+            courseware_id: spanishRun.courseware_id,
+            courseware_url: spanishRun.courseware_url ?? "",
+            language: "es",
+            title: spanishRun.title,
+            run_tag: spanishRun.run_tag,
+          },
+        ],
+      })
+
+      const otherContractEnrollment = factories.enrollment.courseEnrollment({
+        b2b_contract_id: 2,
+        run: {
+          id: spanishRun.id,
+          language: "es",
+          course: { id: course.id, title: course.title },
+          title: spanishRun.title,
+          run_tag: spanishRun.run_tag,
+          courseware_id: spanishRun.courseware_id,
+          courseware_url: spanishRun.courseware_url,
+          is_enrollable: spanishRun.is_enrollable,
+          is_upgradable: spanishRun.is_upgradable,
+          is_archived: spanishRun.is_archived,
+          is_self_paced: spanishRun.is_self_paced,
+          start_date: spanishRun.start_date,
+          end_date: spanishRun.end_date,
+          upgrade_deadline: spanishRun.upgrade_deadline,
+          certificate_available_date: spanishRun.certificate_available_date,
+          course_number: spanishRun.course_number,
+        },
+      })
+
+      const resolved = resolveCardDataForLanguage(
+        course,
+        [otherContractEnrollment],
+        "language:es",
+        { contractId: 1 },
+      )
+
+      expect(resolved.displayedEnrollment).toBeNull()
+    })
+
+    test("keeps fallback synthesized run for unenrolled selected language", () => {
+      const templateRun = factories.courses.courseRun({
+        id: 31,
+        b2b_contract: 1,
+        courseware_id: "cw-en-31",
+        courseware_url: "https://example.com/en-31",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        id: 3,
+        courseruns: [templateRun],
+        next_run_id: templateRun.id,
+        language_options: [
+          {
+            id: templateRun.id,
+            courseware_id: templateRun.courseware_id,
+            courseware_url: templateRun.courseware_url ?? "",
+            language: "en",
+            title: templateRun.title,
+            run_tag: templateRun.run_tag,
+          },
+          {
+            id: 32,
+            courseware_id: "cw-es-32",
+            courseware_url: "https://example.com/es-32",
+            language: "es",
+            title: "Modulo Espanol",
+            run_tag: "ES-32",
+          },
+        ],
+      })
+
+      const resolved = resolveCardDataForLanguage(course, [], "language:es", {
+        contractId: 1,
+      })
+
+      expect(resolved.displayedEnrollment).toBeNull()
+      expect(resolved.displayedRun?.id).toBe(32)
+      expect(resolved.displayedRun?.courseware_id).toBe("cw-es-32")
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -220,6 +220,65 @@ describe("dashboardViewModel", () => {
       expect(options.map((option) => option.value)).toEqual(["language:fr"])
     })
 
+    test("sorts enrollment-derived language options by label", () => {
+      const course = factories.courses.course({
+        id: 50,
+        language_options: [],
+        courseruns: [],
+      })
+
+      const frenchEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: 500,
+          language: "fr",
+          title: "Run FR",
+          run_tag: "FR-1",
+          course: { id: 50, title: course.title },
+          courseware_id: "cw-fr-500",
+          courseware_url: "https://example.com/fr-500",
+          is_enrollable: true,
+          is_upgradable: false,
+          is_archived: false,
+          is_self_paced: true,
+          start_date: null,
+          end_date: null,
+          upgrade_deadline: null,
+          certificate_available_date: null,
+          course_number: "",
+        },
+      })
+      const spanishEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: 501,
+          language: "es",
+          title: "Run ES",
+          run_tag: "ES-1",
+          course: { id: 50, title: course.title },
+          courseware_id: "cw-es-501",
+          courseware_url: "https://example.com/es-501",
+          is_enrollable: true,
+          is_upgradable: false,
+          is_archived: false,
+          is_self_paced: true,
+          start_date: null,
+          end_date: null,
+          upgrade_deadline: null,
+          certificate_available_date: null,
+          course_number: "",
+        },
+      })
+
+      const options = getDashboardLanguageOptions(course, [
+        frenchEnrollment,
+        spanishEnrollment,
+      ])
+
+      expect(options.map((option) => option.value)).toEqual([
+        "language:es",
+        "language:fr",
+      ])
+    })
+
     test("skips enrollments with missing runs", () => {
       const course = factories.courses.course({ id: 30, language_options: [] })
       const missingRunEnrollment = {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1,5 +1,4 @@
 import { factories } from "api/mitxonline-test-utils"
-import type { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   getDashboardLanguageOptions,
   getDistinctDashboardLanguageOptions,
@@ -277,20 +276,6 @@ describe("dashboardViewModel", () => {
         "language:es",
         "language:fr",
       ])
-    })
-
-    test("skips enrollments with missing runs", () => {
-      const course = factories.courses.course({ id: 30, language_options: [] })
-      const missingRunEnrollment = {
-        run: undefined,
-      } as unknown as CourseRunEnrollmentV3
-
-      const options = getDistinctDashboardLanguageOptions(
-        [course],
-        [missingRunEnrollment],
-      )
-
-      expect(options).toEqual([])
     })
 
     test("uses the shared native language fallback label for enrollment-derived options", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1,4 +1,5 @@
 import { factories } from "api/mitxonline-test-utils"
+import type { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   getDashboardLanguageOptions,
   getDistinctDashboardLanguageOptions,
@@ -217,6 +218,20 @@ describe("dashboardViewModel", () => {
       )
 
       expect(options.map((option) => option.value)).toEqual(["language:fr"])
+    })
+
+    test("skips enrollments with missing runs", () => {
+      const course = factories.courses.course({ id: 30, language_options: [] })
+      const missingRunEnrollment = {
+        run: undefined,
+      } as unknown as CourseRunEnrollmentV3
+
+      const options = getDistinctDashboardLanguageOptions(
+        [course],
+        [missingRunEnrollment],
+      )
+
+      expect(options).toEqual([])
     })
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -5,7 +5,7 @@ import {
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
   pickDisplayedEnrollmentForLegacyDashboard,
-  resolveCardDataForLanguage,
+  resolveSlotForLanguage,
 } from "./dashboardViewModel"
 
 describe("dashboardViewModel", () => {
@@ -301,7 +301,7 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const resolved = resolveCardDataForLanguage(
+      const resolved = resolveSlotForLanguage(
         course,
         [englishEnrollment, spanishEnrollment],
         "language:es",
@@ -372,7 +372,7 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const resolved = resolveCardDataForLanguage(
+      const resolved = resolveSlotForLanguage(
         course,
         [otherContractEnrollment],
         "language:es",
@@ -414,7 +414,7 @@ describe("dashboardViewModel", () => {
         ],
       })
 
-      const resolved = resolveCardDataForLanguage(course, [], "language:es", {
+      const resolved = resolveSlotForLanguage(course, [], "language:es", {
         contractId: 1,
       })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -233,6 +233,61 @@ describe("dashboardViewModel", () => {
 
       expect(options).toEqual([])
     })
+
+    test("uses the shared native language fallback label for enrollment-derived options", () => {
+      const originalDisplayNames = Intl.DisplayNames
+      Object.defineProperty(Intl, "DisplayNames", {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      })
+
+      try {
+        const course = factories.courses.course({
+          id: 40,
+          language_options: [],
+          courseruns: [],
+        })
+        const enrollment = factories.enrollment.courseEnrollment({
+          run: {
+            id: 400,
+            language: "es",
+            title: "Spanish Run",
+            run_tag: "ES-1",
+            course: { id: 40, title: course.title },
+            courseware_id: "cw-es-400",
+            courseware_url: "https://example.com/es-400",
+            is_enrollable: true,
+            is_upgradable: false,
+            is_archived: false,
+            is_self_paced: true,
+            start_date: null,
+            end_date: null,
+            upgrade_deadline: null,
+            certificate_available_date: null,
+            course_number: "",
+          },
+        })
+
+        const options = getDistinctDashboardLanguageOptions(
+          [course],
+          [enrollment],
+        )
+
+        expect(options).toEqual([
+          {
+            value: "language:es",
+            label: "español",
+          },
+        ])
+      } finally {
+        Object.defineProperty(Intl, "DisplayNames", {
+          value: originalDisplayNames,
+          configurable: true,
+          writable: true,
+        })
+      }
+    })
   })
 
   describe("resolveSlotForLanguage", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -9,10 +9,20 @@
 import type { SimpleSelectOption } from "ol-components"
 import type {
   CourseRunEnrollmentV3,
+  CourseRunLanguageOption,
   CourseRunV2,
   CourseWithCourseRunsSerializerV2,
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
+import { selectBestEnrollment } from "../helpers"
+import {
+  getCourseRunForSelectedLanguage,
+  getDistinctLanguageOptions,
+  getEnrollmentForSelectedLanguage,
+  getResolvedRunForSelectedLanguage,
+  getSelectedLanguageOption,
+  selectBestContractEnrollmentForLanguage,
+} from "../languageOptions"
 
 /**
  * A program/contract dashboard's view of a course: every enrollment whose run
@@ -116,8 +126,244 @@ const groupProgramEnrollmentsByProgramId = (
   )
 }
 
+const getLanguageCodeFromText = (language?: string | null): string | null => {
+  const normalized = language?.trim().toLowerCase().replace(/_/g, "-")
+  return normalized || null
+}
+
+const getLanguageLabelFromCode = (languageCode: string): string => {
+  const normalized = languageCode.trim().toLowerCase()
+  const baseLanguageCode = normalized.split("-")[0]
+
+  try {
+    if (typeof Intl.DisplayNames === "function") {
+      const displayNames = new Intl.DisplayNames([normalized], {
+        type: "language",
+      })
+      const exact = displayNames.of(normalized)
+      if (exact && exact.toLowerCase() !== normalized) {
+        return exact
+      }
+
+      if (baseLanguageCode && baseLanguageCode !== normalized) {
+        const base = displayNames.of(baseLanguageCode)
+        if (base && base.toLowerCase() !== baseLanguageCode) {
+          return base
+        }
+      }
+    }
+  } catch {
+    // Fall through and use normalized code.
+  }
+
+  return baseLanguageCode || normalized
+}
+
+const getLanguageOptionFromEnrollment = (
+  enrollment: CourseRunEnrollmentV3,
+): SimpleSelectOption | null => {
+  const languageCode = getLanguageCodeFromText(enrollment.run.language)
+  if (!languageCode) {
+    return null
+  }
+
+  return {
+    value: `language:${languageCode}`,
+    label: getLanguageLabelFromCode(languageCode),
+  }
+}
+
+const enrollmentMatchesCourse = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollment: CourseRunEnrollmentV3,
+): boolean => {
+  const run = enrollment.run
+  if (!run) {
+    return false
+  }
+
+  if (run.course.id === course.id) {
+    return true
+  }
+
+  return course.courseruns.some((courseRun) => courseRun.id === run.id)
+}
+
+type LanguageOptionScope = {
+  contractId?: number
+}
+
+const getDashboardLanguageOptions = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollments: CourseRunEnrollmentV3[],
+  opts?: LanguageOptionScope,
+): SimpleSelectOption[] => {
+  const optionsByKey = new Map<string, SimpleSelectOption>()
+
+  getDistinctLanguageOptions([course]).forEach((option) => {
+    optionsByKey.set(String(option.value), option)
+  })
+
+  const scopedEnrollments =
+    typeof opts?.contractId === "number"
+      ? enrollments.filter(
+          (enrollment) => enrollment.b2b_contract_id === opts.contractId,
+        )
+      : enrollments
+
+  scopedEnrollments.forEach((enrollment) => {
+    if (!enrollmentMatchesCourse(course, enrollment)) {
+      return
+    }
+
+    const derivedOption = getLanguageOptionFromEnrollment(enrollment)
+    if (!derivedOption) {
+      return
+    }
+
+    if (!optionsByKey.has(String(derivedOption.value))) {
+      optionsByKey.set(String(derivedOption.value), derivedOption)
+    }
+  })
+
+  return Array.from(optionsByKey.values())
+}
+
+const getDistinctDashboardLanguageOptions = (
+  courses: CourseWithCourseRunsSerializerV2[],
+  enrollments: CourseRunEnrollmentV3[],
+  opts?: LanguageOptionScope,
+): SimpleSelectOption[] => {
+  const baseOptions = getDistinctLanguageOptions(courses)
+  const optionsByKey = new Map<string, SimpleSelectOption>()
+  baseOptions.forEach((option) => {
+    optionsByKey.set(String(option.value), option)
+  })
+
+  const courseIds = new Set(courses.map((course) => course.id))
+  const scopedEnrollments =
+    typeof opts?.contractId === "number"
+      ? enrollments.filter(
+          (enrollment) => enrollment.b2b_contract_id === opts.contractId,
+        )
+      : enrollments
+
+  scopedEnrollments.forEach((enrollment) => {
+    if (!courseIds.has(enrollment.run.course.id)) {
+      return
+    }
+
+    const derivedOption = getLanguageOptionFromEnrollment(enrollment)
+    if (!derivedOption) {
+      return
+    }
+
+    if (!optionsByKey.has(String(derivedOption.value))) {
+      optionsByKey.set(String(derivedOption.value), derivedOption)
+    }
+  })
+
+  const additionalOptions = Array.from(optionsByKey.values()).filter(
+    (option) =>
+      !baseOptions.some(
+        (base) =>
+          getLanguageOptionKeyValue(base) === getLanguageOptionKeyValue(option),
+      ),
+  )
+
+  additionalOptions.sort((a, b) =>
+    String(a.label).localeCompare(String(b.label)),
+  )
+
+  return [...baseOptions, ...additionalOptions]
+}
+
+const getLanguageOptionKeyValue = (option: SimpleSelectOption): string =>
+  String(option.value)
+
+type ResolveCardDataForLanguageOpts = {
+  contractId?: number
+}
+
+type ResolveCardDataForLanguageResult = {
+  displayedEnrollment: CourseRunEnrollmentV3 | null
+  displayedRun: CourseRunV2 | null
+  selectedLanguageOption: CourseRunLanguageOption | null
+}
+
+const resolveCardDataForLanguage = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollments: CourseRunEnrollmentV3[],
+  selectedLanguageKey: string,
+  opts?: ResolveCardDataForLanguageOpts,
+): ResolveCardDataForLanguageResult => {
+  const selectedLanguageOption = getSelectedLanguageOption(
+    course,
+    selectedLanguageKey,
+  )
+  const selectedRun = getCourseRunForSelectedLanguage(
+    course,
+    selectedLanguageKey,
+  )
+
+  if (typeof opts?.contractId === "number") {
+    const contractEnrollments = enrollments.filter(
+      (enrollment) => enrollment.b2b_contract_id === opts.contractId,
+    )
+    const displayedEnrollment = selectBestContractEnrollmentForLanguage(
+      course,
+      contractEnrollments,
+      selectedLanguageKey,
+    )
+    const selectedRunForResolution = displayedEnrollment
+      ? ((course.courseruns ?? []).find(
+          (run) => run.id === displayedEnrollment.run.id,
+        ) ?? null)
+      : selectedRun
+
+    const displayedRun = getResolvedRunForSelectedLanguage(
+      course,
+      selectedLanguageOption,
+      selectedRunForResolution,
+      displayedEnrollment,
+      opts.contractId,
+    )
+
+    return {
+      displayedEnrollment,
+      displayedRun,
+      selectedLanguageOption,
+    }
+  }
+
+  const selectedLanguageEnrollment = getEnrollmentForSelectedLanguage(
+    enrollments,
+    selectedLanguageOption,
+    selectedRun,
+  )
+  const displayedEnrollment = selectedLanguageKey
+    ? selectedLanguageEnrollment
+    : selectBestEnrollment(course, enrollments)
+
+  const displayedRun = getResolvedRunForSelectedLanguage(
+    course,
+    selectedLanguageOption,
+    selectedRun,
+    selectedLanguageEnrollment,
+  )
+
+  return {
+    displayedEnrollment,
+    displayedRun,
+    selectedLanguageOption,
+  }
+}
+
 export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
+  resolveCardDataForLanguage,
+  getDashboardLanguageOptions,
+  getDistinctDashboardLanguageOptions,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -16,12 +16,13 @@ import type {
 } from "@mitodl/mitxonline-api-axios/v2"
 import { selectBestEnrollment } from "../helpers"
 import {
-  getCourseRunForSelectedLanguage,
+  getNativeLanguageName,
   getDistinctLanguageOptions,
+  // below five are used only for resolveSlotForLanguage
+  getCourseRunForSelectedLanguage,
   getEnrollmentForSelectedLanguage,
   getResolvedRunForSelectedLanguage,
   getSelectedLanguageOption,
-  getNativeLanguageName,
   selectBestContractEnrollmentForLanguage,
 } from "../languageOptions"
 
@@ -127,15 +128,22 @@ const groupProgramEnrollmentsByProgramId = (
   )
 }
 
-const getLanguageCodeFromText = (language?: string | null): string | null => {
-  const normalized = language?.trim().toLowerCase().replace(/_/g, "-")
-  return normalized || null
+/**
+ * The mitxonline API emits language codes in POSIX form (`de_de`,
+ * `pt_br`, `zh_hans`); convert to BCP 47 (`de-de`, `pt-br`, `zh-hans`)
+ * so `Intl.DisplayNames` can resolve them, and to give picker options a
+ * canonical key shape.
+ */
+const getLanguageCodeFromText = (language: string): string => {
+  return language.trim().toLowerCase().replace(/_/g, "-")
 }
 
 const getLanguageOptionFromEnrollment = (
   enrollment: CourseRunEnrollmentV3,
 ): SimpleSelectOption | null => {
-  const languageCode = getLanguageCodeFromText(enrollment.run.language)
+  const languageCode = enrollment.run.language
+    ? getLanguageCodeFromText(enrollment.run.language)
+    : null
   if (!languageCode) {
     return null
   }
@@ -161,6 +169,28 @@ const enrollmentMatchesCourse = (
 
   return course.courseruns.some((courseRun) => courseRun.id === run.id)
 }
+
+const filterEnrollmentsToCourses = (
+  enrollments: CourseRunEnrollmentV3[],
+  courses: CourseWithCourseRunsSerializerV2[],
+) => {
+  const courseIds = new Set(courses.map((course) => course.id))
+  return enrollments.filter((enrollment) =>
+    courseIds.has(enrollment.run.course.id),
+  )
+}
+
+/**
+ * Filter enrollments to exclusively those matching the given contractId.
+ * If no contractId is given, filter to enrollments with no contract.
+ */
+const enrollmentMatchesContract =
+  (contractId?: number | null) => (enrollment: CourseRunEnrollmentV3) => {
+    if (typeof contractId !== "number") {
+      return enrollment.b2b_contract_id === null
+    }
+    return enrollment.b2b_contract_id === contractId
+  }
 
 type LanguageOptionScope = {
   contractId?: number
@@ -224,52 +254,34 @@ const getDistinctDashboardLanguageOptions = (
   enrollments: CourseRunEnrollmentV3[],
   opts?: LanguageOptionScope,
 ): SimpleSelectOption[] => {
-  const baseOptions = getDistinctLanguageOptions(courses)
-  const optionsByKey = new Map<string, SimpleSelectOption>()
-  baseOptions.forEach((option) => {
-    optionsByKey.set(String(option.value), option)
-  })
-
-  const courseIds = new Set(courses.map((course) => course.id))
-  const scopedEnrollments =
-    typeof opts?.contractId === "number"
-      ? enrollments.filter(
-          (enrollment) => enrollment.b2b_contract_id === opts.contractId,
-        )
-      : enrollments
-
-  scopedEnrollments.forEach((enrollment) => {
-    if (!enrollment.run) {
-      return
-    }
-
-    if (!courseIds.has(enrollment.run.course.id)) {
-      return
-    }
-
-    const derivedOption = getLanguageOptionFromEnrollment(enrollment)
-    if (!derivedOption) {
-      return
-    }
-
-    if (!optionsByKey.has(String(derivedOption.value))) {
-      optionsByKey.set(String(derivedOption.value), derivedOption)
-    }
-  })
-
-  const additionalOptions = Array.from(optionsByKey.values()).filter(
-    (option) =>
-      !baseOptions.some(
-        (base) =>
-          getLanguageOptionKeyValue(base) === getLanguageOptionKeyValue(option),
+  const coursesLanguages = courses.flatMap((c) =>
+    c.language_options
+      .map((opt) => opt.language)
+      .filter((lang): lang is string => !!lang),
+  )
+  const enrollmentLanguages = filterEnrollmentsToCourses(enrollments, courses)
+    .filter(enrollmentMatchesContract(opts?.contractId))
+    .map((e) => e.run.language)
+    .filter((lang): lang is string => !!lang)
+  const distinctCodes = Array.from(
+    new Set(
+      [...coursesLanguages, ...enrollmentLanguages].map(
+        getLanguageCodeFromText,
       ),
+    ),
   )
-
-  additionalOptions.sort((a, b) =>
-    String(a.label).localeCompare(String(b.label)),
+  const options: SimpleSelectOption[] = distinctCodes.map((code) => {
+    return {
+      value: `language:${code}`,
+      label: getNativeLanguageName(code),
+    }
+  })
+  options.sort((a, b) =>
+    String(a.label).localeCompare(String(b.label), undefined, {
+      sensitivity: "base",
+    }),
   )
-
-  return [...baseOptions, ...additionalOptions]
+  return options
 }
 
 const getLanguageOptionKeyValue = (option: SimpleSelectOption): string =>
@@ -285,6 +297,10 @@ type ResolveSlotForLanguageResult = {
   selectedLanguageOption: CourseRunLanguageOption | null
 }
 
+/**
+ * Given a language selection and course/enrollment data, pick the
+ * `displayedEnrollment` and `displayedRun` for a dashboard slot.
+ */
 const resolveSlotForLanguage = (
   course: CourseWithCourseRunsSerializerV2,
   enrollments: CourseRunEnrollmentV3[],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -281,22 +281,22 @@ const getDistinctDashboardLanguageOptions = (
 const getLanguageOptionKeyValue = (option: SimpleSelectOption): string =>
   String(option.value)
 
-type ResolveCardDataForLanguageOpts = {
+type ResolveSlotForLanguageOpts = {
   contractId?: number
 }
 
-type ResolveCardDataForLanguageResult = {
+type ResolveSlotForLanguageResult = {
   displayedEnrollment: CourseRunEnrollmentV3 | null
   displayedRun: CourseRunV2 | null
   selectedLanguageOption: CourseRunLanguageOption | null
 }
 
-const resolveCardDataForLanguage = (
+const resolveSlotForLanguage = (
   course: CourseWithCourseRunsSerializerV2,
   enrollments: CourseRunEnrollmentV3[],
   selectedLanguageKey: string,
-  opts?: ResolveCardDataForLanguageOpts,
-): ResolveCardDataForLanguageResult => {
+  opts?: ResolveSlotForLanguageOpts,
+): ResolveSlotForLanguageResult => {
   const selectedLanguageOption = getSelectedLanguageOption(
     course,
     selectedLanguageKey,
@@ -363,7 +363,7 @@ export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
-  resolveCardDataForLanguage,
+  resolveSlotForLanguage,
   getDashboardLanguageOptions,
   getDistinctDashboardLanguageOptions,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -17,7 +17,6 @@ import type {
 import { selectBestEnrollment } from "../helpers"
 import {
   getNativeLanguageName,
-  getDistinctLanguageOptions,
   // below five are used only for resolveSlotForLanguage
   getCourseRunForSelectedLanguage,
   getEnrollmentForSelectedLanguage,
@@ -138,38 +137,6 @@ const getLanguageCodeFromText = (language: string): string => {
   return language.trim().toLowerCase().replace(/_/g, "-")
 }
 
-const getLanguageOptionFromEnrollment = (
-  enrollment: CourseRunEnrollmentV3,
-): SimpleSelectOption | null => {
-  const languageCode = enrollment.run.language
-    ? getLanguageCodeFromText(enrollment.run.language)
-    : null
-  if (!languageCode) {
-    return null
-  }
-
-  return {
-    value: `language:${languageCode}`,
-    label: getNativeLanguageName(languageCode),
-  }
-}
-
-const enrollmentMatchesCourse = (
-  course: CourseWithCourseRunsSerializerV2,
-  enrollment: CourseRunEnrollmentV3,
-): boolean => {
-  const run = enrollment.run
-  if (!run) {
-    return false
-  }
-
-  if (run.course.id === course.id) {
-    return true
-  }
-
-  return course.courseruns.some((courseRun) => courseRun.id === run.id)
-}
-
 const filterEnrollmentsToCourses = (
   enrollments: CourseRunEnrollmentV3[],
   courses: CourseWithCourseRunsSerializerV2[],
@@ -194,59 +161,6 @@ const enrollmentMatchesContract =
 
 type LanguageOptionScope = {
   contractId?: number
-}
-
-const getDashboardLanguageOptions = (
-  course: CourseWithCourseRunsSerializerV2,
-  enrollments: CourseRunEnrollmentV3[],
-  opts?: LanguageOptionScope,
-): SimpleSelectOption[] => {
-  const baseOptions = getDistinctLanguageOptions([course])
-  const optionsByKey = new Map<string, SimpleSelectOption>()
-
-  baseOptions.forEach((option) => {
-    optionsByKey.set(String(option.value), option)
-  })
-
-  const scopedEnrollments =
-    typeof opts?.contractId === "number"
-      ? enrollments.filter(
-          (enrollment) => enrollment.b2b_contract_id === opts.contractId,
-        )
-      : enrollments
-
-  scopedEnrollments.forEach((enrollment) => {
-    if (!enrollment.run) {
-      return
-    }
-
-    if (!enrollmentMatchesCourse(course, enrollment)) {
-      return
-    }
-
-    const derivedOption = getLanguageOptionFromEnrollment(enrollment)
-    if (!derivedOption) {
-      return
-    }
-
-    if (!optionsByKey.has(String(derivedOption.value))) {
-      optionsByKey.set(String(derivedOption.value), derivedOption)
-    }
-  })
-
-  const additionalOptions = Array.from(optionsByKey.values()).filter(
-    (option) =>
-      !baseOptions.some(
-        (base) =>
-          getLanguageOptionKeyValue(base) === getLanguageOptionKeyValue(option),
-      ),
-  )
-
-  additionalOptions.sort((a, b) =>
-    String(a.label).localeCompare(String(b.label)),
-  )
-
-  return [...baseOptions, ...additionalOptions]
 }
 
 const getDistinctDashboardLanguageOptions = (
@@ -283,9 +197,6 @@ const getDistinctDashboardLanguageOptions = (
   )
   return options
 }
-
-const getLanguageOptionKeyValue = (option: SimpleSelectOption): string =>
-  String(option.value)
 
 type ResolveSlotForLanguageOpts = {
   contractId?: number
@@ -374,6 +285,5 @@ export {
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
   resolveSlotForLanguage,
-  getDashboardLanguageOptions,
   getDistinctDashboardLanguageOptions,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -21,6 +21,7 @@ import {
   getEnrollmentForSelectedLanguage,
   getResolvedRunForSelectedLanguage,
   getSelectedLanguageOption,
+  getNativeLanguageName,
   selectBestContractEnrollmentForLanguage,
 } from "../languageOptions"
 
@@ -131,34 +132,6 @@ const getLanguageCodeFromText = (language?: string | null): string | null => {
   return normalized || null
 }
 
-const getLanguageLabelFromCode = (languageCode: string): string => {
-  const normalized = languageCode.trim().toLowerCase()
-  const baseLanguageCode = normalized.split("-")[0]
-
-  try {
-    if (typeof Intl.DisplayNames === "function") {
-      const displayNames = new Intl.DisplayNames([normalized], {
-        type: "language",
-      })
-      const exact = displayNames.of(normalized)
-      if (exact && exact.toLowerCase() !== normalized) {
-        return exact
-      }
-
-      if (baseLanguageCode && baseLanguageCode !== normalized) {
-        const base = displayNames.of(baseLanguageCode)
-        if (base && base.toLowerCase() !== baseLanguageCode) {
-          return base
-        }
-      }
-    }
-  } catch {
-    // Fall through and use normalized code.
-  }
-
-  return baseLanguageCode || normalized
-}
-
 const getLanguageOptionFromEnrollment = (
   enrollment: CourseRunEnrollmentV3,
 ): SimpleSelectOption | null => {
@@ -169,7 +142,7 @@ const getLanguageOptionFromEnrollment = (
 
   return {
     value: `language:${languageCode}`,
-    label: getLanguageLabelFromCode(languageCode),
+    label: getNativeLanguageName(languageCode),
   }
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -212,6 +212,10 @@ const getDashboardLanguageOptions = (
       : enrollments
 
   scopedEnrollments.forEach((enrollment) => {
+    if (!enrollment.run) {
+      return
+    }
+
     if (!enrollmentMatchesCourse(course, enrollment)) {
       return
     }
@@ -249,6 +253,10 @@ const getDistinctDashboardLanguageOptions = (
       : enrollments
 
   scopedEnrollments.forEach((enrollment) => {
+    if (!enrollment.run) {
+      return
+    }
+
     if (!courseIds.has(enrollment.run.course.id)) {
       return
     }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -171,9 +171,10 @@ const getDashboardLanguageOptions = (
   enrollments: CourseRunEnrollmentV3[],
   opts?: LanguageOptionScope,
 ): SimpleSelectOption[] => {
+  const baseOptions = getDistinctLanguageOptions([course])
   const optionsByKey = new Map<string, SimpleSelectOption>()
 
-  getDistinctLanguageOptions([course]).forEach((option) => {
+  baseOptions.forEach((option) => {
     optionsByKey.set(String(option.value), option)
   })
 
@@ -203,7 +204,19 @@ const getDashboardLanguageOptions = (
     }
   })
 
-  return Array.from(optionsByKey.values())
+  const additionalOptions = Array.from(optionsByKey.values()).filter(
+    (option) =>
+      !baseOptions.some(
+        (base) =>
+          getLanguageOptionKeyValue(base) === getLanguageOptionKeyValue(option),
+      ),
+  )
+
+  additionalOptions.sort((a, b) =>
+    String(a.label).localeCompare(String(b.label)),
+  )
+
+  return [...baseOptions, ...additionalOptions]
 }
 
 const getDistinctDashboardLanguageOptions = (


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/11205

### Description (What does it do?)
This PR executes phase 2 of the dashboard refactoring plan detailed [here](https://gist.github.com/ChristopherChudzicki/d4a0204ba15abc3bdfee33d462fbae78), also now checked into the repo at `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md`, to be deleted after refactor is complete.

Phase 2 deduplicates some logic in the B2B and B2C components (`ContractContent` / `EnrollmentDisplay`) surrounding multiple steps that are taken to associate an enrollment / course run with language selection. This process was moved into the view model (`dashboardViewModel.ts`) and the components were updated to use this.

### How can this be tested?
- Ensure you have MITx Online running and connected to Learn as is described in the readme
- Ensure that you have sufficient test data to test all aspects of the Learn dashboard's ability to display a learner's enrolled contracts and individual programs and courses
- Compare how the following pages display with your test data on `main` vs this branch:
  - B2B contract dashboard
  - My Learning (dashboard home page)
    - Course run enrollments
    - Program enrollments
  - Program dashboard page (click View Program on a personal program enrollment)