### PR TITLE
feat: Added Program Record Link to Learn Dashboard Program Card .

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -2045,6 +2045,46 @@ describe.each([
     })
 
     test.each([{ useProductPages: false }, { useProductPages: true }])(
+      "Context menu for program enrollment includes Program Record to mitxonline (flag=$useProductPages)",
+      async ({ useProductPages }) => {
+        mockedUseFeatureFlagEnabled.mockReturnValue(useProductPages)
+        setupUserApis()
+
+        const program = mitxonline.factories.programs.simpleProgram({
+          id: 99,
+          readable_id: "program-for-record-test",
+        })
+        const programEnrollment =
+          mitxonline.factories.enrollment.programEnrollmentV3({
+            program,
+          })
+
+        renderWithProviders(
+          <DashboardCard
+            resource={{
+              type: DashboardType.ProgramEnrollment,
+              data: programEnrollment,
+            }}
+          />,
+        )
+
+        const card = getCard()
+        const contextMenuButton = within(card).getByRole("button", {
+          name: "More options",
+        })
+        await user.click(contextMenuButton)
+
+        const programRecordItem = screen.getByRole("menuitem", {
+          name: "Program Record",
+        })
+        expect(programRecordItem).toHaveAttribute(
+          "href",
+          mitxonlineLegacyUrl("/records/99/"),
+        )
+      },
+    )
+
+    test.each([{ useProductPages: false }, { useProductPages: true }])(
       "Context menu for course enrollment shows View Details (flag=$useProductPages) using readable_id",
       async ({ useProductPages }) => {
         setupUserApis()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -205,6 +205,13 @@ const getContextMenuItems = (
       })
     }
 
+    menuItems.push({
+      className: "dashboard-card-menu-item",
+      key: "program-record",
+      label: "Program Record",
+      href: mitxonlineLegacyUrl(`/records/${program.id}/`),
+    })
+
     if (
       program.display_mode !== DisplayModeEnum.Course &&
       !isVerifiedEnrollmentMode(resource.data.enrollment_mode)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -16,6 +16,7 @@ import moment from "moment"
 import NiceModal from "@ebay/nice-modal-react"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
+import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
@@ -466,6 +467,13 @@ describe("ProgramAsCourseCard", () => {
       "href",
       expect.stringContaining("ecom-service=true"),
     )
+
+    expect(
+      screen.getByRole("menuitem", { name: "Program Record" }),
+    ).toHaveAttribute(
+      "href",
+      mitxonlineLegacyUrl(`/records/${cardData.courseProgram.id}/`),
+    )
   })
 
   test("shows product-page details link in context menu when product pages flag is enabled", async () => {
@@ -491,6 +499,13 @@ describe("ProgramAsCourseCard", () => {
     expect(detailsLink).toHaveAttribute(
       "href",
       `/courses/p/${cardData.courseProgram.readable_id}`,
+    )
+
+    expect(
+      screen.getByRole("menuitem", { name: "Program Record" }),
+    ).toHaveAttribute(
+      "href",
+      mitxonlineLegacyUrl(`/records/${cardData.courseProgram.id}/`),
     )
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -306,6 +306,13 @@ const getContextMenuItems = (
     })
   }
 
+  courseMenuItems.push({
+    className: "dashboard-card-menu-item",
+    key: "program-record",
+    label: "Program Record",
+    href: mitxonlineLegacyUrl(`/records/${resource.id}/`),
+  })
+
   if (enrollmentMode && !isVerifiedEnrollmentMode(enrollmentMode)) {
     courseMenuItems.push({
       className: "dashboard-card-menu-item",


### PR DESCRIPTION

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11120

### Description

Adds a "Program Record" item to the overflow (⋮) menu on program cards in the Learn dashboard. Clicking it navigates the learner to the existing MITx Online program record page at `/records/<program_id>/?ecom-service=true`. The link appears on both standard program enrollment cards and program-as-course cards.


### Screenshots (if appropriate):
<img width="1765" height="1012" alt="Screenshot 2026-05-13 at 5 41 25 PM" src="https://github.com/user-attachments/assets/34b786ae-2bf8-474c-9b69-079c8c426c3e" />

<img width="1637" height="971" alt="Screenshot 2026-05-13 at 5 40 59 PM" src="https://github.com/user-attachments/assets/622bb25b-477f-4176-8477-0c21ffb1a6f7" />


### How can this be tested?

**Pre-requisites:**
- A program exists in MITx Online with courses in its requirement tree
- The test user has a program enrollment in that program
- The test user has at least one course run enrollment in one of the program's courses (so the record table isn't empty)

**Steps:**
1. Log in to Learn(http://open.odl.local:8062) and go to `http://open.odl.local:8062/dashboard`
2. On a program card, click the ⋮ overflow menu
3. Verify "Program Record" appears in the menu
4. Click "Program Record" — it should open the MITx Online learner record page at `http://mitxonline.odl.local:9080/records/<program_id>/`
5. Verify the record page loads without errors and shows the program's courses
6. Verify the MITx Online site header and footer are not shown (the `?ecom-service=true` param should hide them)
7. Repeat for a program-as-course card if available
