### PR TITLE
Remove enrollment-dashboard feature flag

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/HomeContent.test.tsx
@@ -15,14 +15,8 @@ import {
 } from "api"
 import React from "react"
 import * as mitxonline from "api/mitxonline-test-utils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
 import HomeContent from "./HomeContent"
 import invariant from "tiny-invariant"
-
-jest.mock("posthog-js/react")
-const mockedUseFeatureFlagEnabled = jest
-  .mocked(useFeatureFlagEnabled)
-  .mockImplementation(() => false)
 
 const makeSearchResponse = (
   results: LearningResource[],
@@ -96,6 +90,8 @@ describe("HomeContent", () => {
     setMockResponse.get(urls.userMe.get(), user)
     setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
     setMockResponse.get(urls.profileMe.get(), user.profile)
+    setMockResponse.get(mitxonline.urls.contracts.contractsList(), [])
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
 
     // Set Top Picks Response
     setSearchResponse(
@@ -208,41 +204,23 @@ describe("HomeContent", () => {
     within(popular).getByText(resources.popular[2].title)
   })
 
-  test.each([{ enrollmentsEnabled: true }, { enrollmentsEnabled: false }])(
-    "Shows enrollments if and only if feature flag is enabled",
-    async ({ enrollmentsEnabled }) => {
-      setupAPIs()
-      mockedUseFeatureFlagEnabled.mockImplementation((flag) => {
-        if (flag === "enrollment-dashboard") return enrollmentsEnabled
-        return false
-      })
+  test("Shows enrollments", async () => {
+    setupAPIs()
 
-      // Mock empty contracts and organizations to avoid org cards rendering
-      setMockResponse.get(mitxonline.urls.contracts.contractsList(), [])
+    const enrollments = Array.from({ length: 3 }, () =>
+      mitxonline.factories.enrollment.courseEnrollment({
+        b2b_contract_id: null, // Personal enrollment, not B2B
+      }),
+    )
+    setMockResponse.get(
+      mitxonline.urls.enrollment.enrollmentsListV3(),
+      enrollments,
+    )
 
-      if (enrollmentsEnabled) {
-        const enrollments = Array.from({ length: 3 }, () =>
-          mitxonline.factories.enrollment.courseEnrollment({
-            b2b_contract_id: null, // Personal enrollment, not B2B
-          }),
-        )
-        setMockResponse.get(
-          mitxonline.urls.enrollment.enrollmentsListV3(),
-          enrollments,
-        )
-      }
+    renderWithProviders(<HomeContent />)
 
-      renderWithProviders(<HomeContent />)
-
-      if (enrollmentsEnabled) {
-        await screen.findByRole("heading", { name: "My Learning" })
-      } else {
-        expect(
-          screen.queryByRole("heading", { name: "My Learning" }),
-        ).not.toBeInTheDocument()
-      }
-    },
-  )
+    await screen.findByRole("heading", { name: "My Learning" })
+  })
 
   test("Does not display enrollment error alert when query param is not present", async () => {
     setupAPIs()

--- a/frontends/main/src/app-pages/DashboardPage/HomeContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/HomeContent.tsx
@@ -14,8 +14,6 @@ import {
 } from "@/common/carousels"
 import ResourceCarousel from "@/page-components/ResourceCarousel/ResourceCarousel"
 import { EnrollmentDisplay } from "./CoursewareDisplay/EnrollmentDisplay"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 import { useUserMe } from "api/hooks/user"
 import { OrganizationCards } from "./CoursewareDisplay/OrganizationCards"
 import EnrollmentRedirectAlert from "./EnrollmentRedirectAlert"
@@ -78,9 +76,6 @@ const HomeContent: React.FC = () => {
   const { isLoading: isLoadingProfile, data: user } = useUserMe()
   const topics = user?.profile?.preference_search_filters.topic
   const certification = user?.profile?.preference_search_filters.certification
-  const showEnrollments = useFeatureFlagEnabled(
-    FeatureFlags.EnrollmentDashboard,
-  )
 
   return (
     <>
@@ -101,7 +96,7 @@ const HomeContent: React.FC = () => {
         <EnrollmentRedirectAlert />
       </EnrollmentRedirectAlertContainer>
       <OrganizationCards />
-      {showEnrollments ? <EnrollmentDisplay /> : null}
+      <EnrollmentDisplay />
       <Suspense>
         <StyledResourceCarousel
           titleComponent="h2"

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -13,16 +13,13 @@ import {
   urls as mitxUrls,
   factories as mitxFactories,
 } from "api/mitxonline-test-utils"
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
+import { usePostHog } from "posthog-js/react"
 import { programView } from "@/common/urls"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 import * as routes from "@/common/urls"
 import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react")
-const mockedUseFeatureFlagEnabled = jest
-  .mocked(useFeatureFlagEnabled)
-  .mockImplementation(() => false)
 const mockCapture = jest.fn()
 jest.mocked(usePostHog).mockReturnValue(
   // @ts-expect-error Not mocking all of posthog
@@ -40,10 +37,6 @@ describe("ProgramEnrollmentButton", () => {
   const ENROLL_FREE = "Enroll for Free"
 
   setupLocationMock()
-
-  beforeEach(() => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
-  })
 
   test("Shows loading state while enrollments and user loading", async () => {
     const program = makeProgram({
@@ -76,35 +69,7 @@ describe("ProgramEnrollmentButton", () => {
     expect(screen.queryByRole("progressbar", { name: "Loading" })).toBeNull()
   })
 
-  test("Shows 'Enrolled' button without link when feature flag is off", async () => {
-    const program = makeProgram({
-      enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
-    })
-    const enrollments = [
-      makeProgramEnrollment(),
-      makeProgramEnrollment({ program: { id: program.id } }),
-      makeProgramEnrollment(),
-    ]
-    const user = makeUser({ is_authenticated: true })
-
-    setMockResponse.get(
-      mitxUrls.programEnrollments.enrollmentsListV3(),
-      enrollments,
-    )
-    setMockResponse.get(urls.userMe.get(), user)
-
-    renderWithProviders(
-      <ProgramEnrollmentButton program={program} variant="primary" />,
-    )
-
-    const enrolledButton = await screen.findByText(ENROLLED)
-    // When feature flag is off, button should not have href
-    expect(enrolledButton.closest("a")).toHaveAttribute("href", "")
-  })
-
-  test("Shows 'Enrolled' button with dashboard link when feature flag is on", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-
+  test("Shows 'Enrolled' button with dashboard link", async () => {
     const program = makeProgram({
       enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
     })

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -19,8 +19,7 @@ import NiceModal from "@ebay/nice-modal-react"
 import { userQueries } from "api/hooks/user"
 import { SignupPopover } from "@/page-components/SignupPopover/SignupPopover"
 import { programView } from "@/common/urls"
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
+import { usePostHog } from "posthog-js/react"
 import {
   enrollmentAlertSuccessUrl,
   formatPrice,
@@ -58,9 +57,6 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
     ...enrollmentQueries.programEnrollmentsList(),
     throwOnError: false,
   })
-  const programDashboardEnabled = useFeatureFlagEnabled(
-    FeatureFlags.EnrollmentDashboard,
-  )
   const enrollment =
     program && enrollments.data?.find((e) => e.program.id === program.id)
 
@@ -118,7 +114,7 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
       setAnchor(e.currentTarget)
     }
   }
-  const href = programDashboardEnabled ? programView(program.id) : undefined
+  const href = programView(program.id)
 
   return (
     <>

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -7,7 +7,6 @@ export enum FeatureFlags {
   PrDrawerChatbot = "pr-drawer-chatbot",
   RecommendationBot = "recommendation-bot",
   HomePageRecommendationBot = "home-page-recommendation-bot",
-  EnrollmentDashboard = "enrollment-dashboard",
   UniversalAI = "universal-ai",
   UniversalAISearchBanner = "universal-ai-search-banner",
   VideoShorts = "video-shorts",


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/11286 

### Description (What does it do?)
Removes the `enrollments-display` feature flag. Now always show "My Learning"

### How can this be tested?

1. With MITxOnline and Learn integrated, block posthog or remove your key locally.
2. Check that `/dashboard` route still shows "My Learning"
    - Note it will only show if you are enrolled in at least one course/program (non-b2b)
