### PR TITLE
fix: link the podcast episode to its detail page and fix the video count on collection page

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -122,8 +122,10 @@ const HeaderTextContent = styled.div({
 
 /* ── Episodes list ── */
 
-const EpisodesSection = styled.div(({ theme }) => ({
-  padding: "0 48px",
+const EpisodesSection = styled("div", {
+  shouldForwardProp: (prop) => prop !== "hasMoreEpisodes",
+})<{ hasMoreEpisodes?: boolean }>(({ theme, hasMoreEpisodes }) => ({
+  padding: hasMoreEpisodes ? "0 48px" : "0 48px 40px 48px",
   [theme.breakpoints.down("sm")]: {
     padding: "0 0 48px",
   },
@@ -150,7 +152,6 @@ const EpisodesHeading = styled(Typography)(({ theme }) => ({
 }))
 
 const EpisodeList = styled.div({
-  listStyle: "none",
   margin: 0,
   padding: 0,
   display: "grid",
@@ -183,6 +184,10 @@ const EpisodeRow = styled("div", {
   "&:hover": {
     backgroundColor: theme.custom.colors.lightGray1,
     cursor: "pointer",
+  },
+  "&:focus-visible": {
+    outline: `2px solid ${theme.custom.colors.red}`,
+    outlineOffset: "-2px",
   },
   "&:hover .episode-title, &:focus-visible .episode-title": {
     color: theme.custom.colors.red,
@@ -330,6 +335,10 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   isEpisodePage = false,
 }) => {
   const router = useRouter()
+
+  const handleRowNavigate = () => {
+    if (href) router.push(href)
+  }
   const podcastEpisode =
     episode.resource_type === "podcast_episode" ? episode.podcast_episode : null
 
@@ -344,7 +353,18 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   const metaParts = [duration ? `${duration} min` : null, date].filter(Boolean)
 
   return (
-    <EpisodeRow onClick={() => router.push(href)} isEpisodePage={isEpisodePage}>
+    <EpisodeRow
+      onClick={handleRowNavigate}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          handleRowNavigate()
+        }
+      }}
+      role="link"
+      tabIndex={0}
+      isEpisodePage={isEpisodePage}
+    >
       <EpisodeInfo>
         <EpisodeTitleLink className="episode-title">
           {episode.title}
@@ -577,26 +597,27 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
         </HeaderSection>
 
         <PodcastContainer>
-          <EpisodesSection>
+          <EpisodesSection hasMoreEpisodes={!!hasNextPage}>
             <EpisodesHeading variant="subtitle3">Episodes</EpisodesHeading>
 
             {episodes && episodes.length > 0 && (
-              <EpisodeList>
+              <EpisodeList role="list">
                 {episodes.map((episode) => (
-                  <EpisodeItem
-                    key={episode.id}
-                    episode={episode}
-                    href={podcastEpisodePageView(
-                      String(episode.id),
-                      String(id),
-                    )}
-                    onPlayClick={handlePlayClick}
-                    onPauseClick={() => playerRef.current?.pause()}
-                    isPlaying={
-                      playingEpisode?.id === episode.id && isAudioPlaying
-                    }
-                    isPlayable={Boolean(getEpisodeAudioUrl(episode))}
-                  />
+                  <div key={episode.id} role="listitem">
+                    <EpisodeItem
+                      episode={episode}
+                      href={podcastEpisodePageView(
+                        String(episode.id),
+                        String(id),
+                      )}
+                      onPlayClick={handlePlayClick}
+                      onPauseClick={() => playerRef.current?.pause()}
+                      isPlaying={
+                        playingEpisode?.id === episode.id && isAudioPlaying
+                      }
+                      isPlayable={Boolean(getEpisodeAudioUrl(episode))}
+                    />
+                  </div>
                 ))}
               </EpisodeList>
             )}

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import React, { useState, useEffect, useRef } from "react"
+import { notFound } from "next/navigation"
+import { useRouter } from "next-nprogress-bar"
 import { Breadcrumbs, Typography, styled, useMediaQuery } from "ol-components"
 import type { Theme } from "ol-components"
 import { Button, ActionButton } from "@mitodl/smoot-design"
@@ -15,12 +17,11 @@ import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource } from "api/v1"
 import moment from "moment"
 import { formatDate } from "ol-utilities"
-import { HOME } from "@/common/urls"
+import { HOME, podcastEpisodePageView } from "@/common/urls"
 import PodcastContainer from "./PodcastContainer"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { FeatureFlags } from "@/common/feature_flags"
-import { notFound } from "next/navigation"
 
 const HeaderSection = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
@@ -148,7 +149,7 @@ const EpisodesHeading = styled(Typography)(({ theme }) => ({
   },
 }))
 
-const EpisodeList = styled.ul({
+const EpisodeList = styled.div({
   listStyle: "none",
   margin: 0,
   padding: 0,
@@ -156,9 +157,10 @@ const EpisodeList = styled.ul({
   gridTemplateColumns: "1fr",
 })
 
-const EpisodeRow = styled("li", {
+const EpisodeRow = styled("div", {
   shouldForwardProp: (prop) => prop !== "isEpisodePage",
 })<{ isEpisodePage?: boolean }>(({ theme, isEpisodePage }) => ({
+  cursor: "pointer",
   margin: 0,
   display: "flex",
   flexDirection: "row",
@@ -310,6 +312,7 @@ const PlayButton = styled(ActionButton, {
 
 export type EpisodeItemProps = {
   episode: LearningResource
+  href: string
   onPlayClick: (episode: LearningResource) => void
   onPauseClick?: () => void
   isPlaying: boolean
@@ -319,12 +322,14 @@ export type EpisodeItemProps = {
 
 export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   episode,
+  href,
   onPlayClick,
   onPauseClick,
   isPlaying,
   isPlayable,
   isEpisodePage = false,
 }) => {
+  const router = useRouter()
   const podcastEpisode =
     episode.resource_type === "podcast_episode" ? episode.podcast_episode : null
 
@@ -339,10 +344,7 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   const metaParts = [duration ? `${duration} min` : null, date].filter(Boolean)
 
   return (
-    <EpisodeRow
-      onClick={() => (isPlaying ? onPauseClick?.() : onPlayClick(episode))}
-      isEpisodePage={isEpisodePage}
-    >
+    <EpisodeRow onClick={() => router.push(href)} isEpisodePage={isEpisodePage}>
       <EpisodeInfo>
         <EpisodeTitleLink className="episode-title">
           {episode.title}
@@ -364,6 +366,15 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
           aria-label={
             isPlaying ? `Pause ${episode.title}` : `Play ${episode.title}`
           }
+          onClick={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            if (isPlaying) {
+              onPauseClick?.()
+            } else {
+              onPlayClick(episode)
+            }
+          }}
           isPlaying={isPlaying}
           disabled={!isPlayable}
           variant="secondary"
@@ -575,6 +586,10 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
                   <EpisodeItem
                     key={episode.id}
                     episode={episode}
+                    href={podcastEpisodePageView(
+                      String(episode.id),
+                      String(id),
+                    )}
                     onPlayClick={handlePlayClick}
                     onPauseClick={() => playerRef.current?.pause()}
                     isPlaying={

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from "react"
 import { notFound } from "next/navigation"
-import { useRouter } from "next-nprogress-bar"
+import Link from "next/link"
 import { Breadcrumbs, Typography, styled, useMediaQuery } from "ol-components"
 import type { Theme } from "ol-components"
 import { Button, ActionButton } from "@mitodl/smoot-design"
@@ -158,10 +158,10 @@ const EpisodeList = styled.div({
   gridTemplateColumns: "1fr",
 })
 
-const EpisodeRow = styled("div", {
+const EpisodeRow = styled(Link, {
   shouldForwardProp: (prop) => prop !== "isEpisodePage",
 })<{ isEpisodePage?: boolean }>(({ theme, isEpisodePage }) => ({
-  cursor: "pointer",
+  textDecoration: "none",
   margin: 0,
   display: "flex",
   flexDirection: "row",
@@ -318,6 +318,7 @@ const PlayButton = styled(ActionButton, {
 export type EpisodeItemProps = {
   episode: LearningResource
   href: string
+  role?: string
   onPlayClick: (episode: LearningResource) => void
   onPauseClick?: () => void
   isPlaying: boolean
@@ -328,17 +329,13 @@ export type EpisodeItemProps = {
 export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   episode,
   href,
+  role,
   onPlayClick,
   onPauseClick,
   isPlaying,
   isPlayable,
   isEpisodePage = false,
 }) => {
-  const router = useRouter()
-
-  const handleRowNavigate = () => {
-    if (href) router.push(href)
-  }
   const podcastEpisode =
     episode.resource_type === "podcast_episode" ? episode.podcast_episode : null
 
@@ -353,18 +350,7 @@ export const EpisodeItem: React.FC<EpisodeItemProps> = ({
   const metaParts = [duration ? `${duration} min` : null, date].filter(Boolean)
 
   return (
-    <EpisodeRow
-      onClick={handleRowNavigate}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault()
-          handleRowNavigate()
-        }
-      }}
-      role="link"
-      tabIndex={0}
-      isEpisodePage={isEpisodePage}
-    >
+    <EpisodeRow href={href} role={role} isEpisodePage={isEpisodePage}>
       <EpisodeInfo>
         <EpisodeTitleLink className="episode-title">
           {episode.title}
@@ -603,21 +589,21 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
             {episodes && episodes.length > 0 && (
               <EpisodeList role="list">
                 {episodes.map((episode) => (
-                  <div key={episode.id} role="listitem">
-                    <EpisodeItem
-                      episode={episode}
-                      href={podcastEpisodePageView(
-                        String(episode.id),
-                        String(id),
-                      )}
-                      onPlayClick={handlePlayClick}
-                      onPauseClick={() => playerRef.current?.pause()}
-                      isPlaying={
-                        playingEpisode?.id === episode.id && isAudioPlaying
-                      }
-                      isPlayable={Boolean(getEpisodeAudioUrl(episode))}
-                    />
-                  </div>
+                  <EpisodeItem
+                    role="listitem"
+                    key={episode.id}
+                    episode={episode}
+                    href={podcastEpisodePageView(
+                      String(episode.id),
+                      String(id),
+                    )}
+                    onPlayClick={handlePlayClick}
+                    onPauseClick={() => playerRef.current?.pause()}
+                    isPlaying={
+                      playingEpisode?.id === episode.id && isAudioPlaying
+                    }
+                    isPlayable={Boolean(getEpisodeAudioUrl(episode))}
+                  />
                 ))}
               </EpisodeList>
             )}

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -25,7 +25,7 @@ import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource } from "api/v1"
 import moment from "moment"
 import { formatDate } from "ol-utilities"
-import { HOME, podcastPageView } from "@/common/urls"
+import { HOME, podcastPageView, podcastEpisodePageView } from "@/common/urls"
 import DOMPurify from "isomorphic-dompurify"
 import { EpisodeItem } from "./PodcastDetailPage"
 import PodcastContainer from "./PodcastContainer"
@@ -354,6 +354,11 @@ export const PodcastEpisodeDetailPage: React.FC<
                 <EpisodeItem
                   key={episode.id}
                   episode={episode}
+                  href={
+                    podcastId
+                      ? podcastEpisodePageView(String(episode.id), podcastId)
+                      : "#"
+                  }
                   isPlaying={
                     playingEpisode?.id === episode.id && isAudioPlaying
                   }

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -47,9 +47,13 @@ const PageSection = styled.div(({ theme }) => ({
   minHeight: "100vh",
 }))
 
-const HeaderSection = styled.div(({ theme }) => ({
-  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-  marginBottom: "64px",
+const HeaderSection = styled("div", {
+  shouldForwardProp: (prop) => prop !== "hasEpisodes",
+})<{ hasEpisodes?: boolean }>(({ theme, hasEpisodes }) => ({
+  ...(hasEpisodes && {
+    borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+    marginBottom: "64px",
+  }),
   paddingBottom: "64px",
   [theme.breakpoints.down("sm")]: {
     marginBottom: "24px",
@@ -305,7 +309,7 @@ export const PodcastEpisodeDetailPage: React.FC<
             />
           </PodcastContainer>
         </BreadcrumbBar>
-        <HeaderSection>
+        <HeaderSection hasEpisodes={episodes.length > 0}>
           <EpisodeContainer>
             {podcast?.title && (
               <EpisodeLabel href={podcastHref}>{podcast.title}</EpisodeLabel>
@@ -357,7 +361,7 @@ export const PodcastEpisodeDetailPage: React.FC<
                   href={
                     podcastId
                       ? podcastEpisodePageView(String(episode.id), podcastId)
-                      : "#"
+                      : ""
                   }
                   isPlaying={
                     playingEpisode?.id === episode.id && isAudioPlaying

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
@@ -90,7 +90,7 @@ const VideoPlaylistCollectionPage: React.FC<
     learning_resource_id: playlistId,
     limit: VIDEOS_PAGE_SIZE,
   })
-
+  console.log("itemsData", itemsData)
   const { data: similarData, isLoading: similarLoading } = useQuery({
     ...learningResourceQueries.vectorSimilar({
       id: playlistId,
@@ -99,7 +99,7 @@ const VideoPlaylistCollectionPage: React.FC<
     }),
   })
 
-  if (!showVideoPlaylistPage) {
+  if (showVideoPlaylistPage) {
     return flagsLoaded ? notFound() : null
   }
 
@@ -107,6 +107,7 @@ const VideoPlaylistCollectionPage: React.FC<
     return notFound()
   }
   const isLoading = playlistLoading || itemsLoading
+  const totalCount = itemsData?.pages[0]?.count ?? 0
   const videos = (
     itemsData?.pages.flatMap((page) =>
       page.results.map((rel) => rel.resource),
@@ -117,7 +118,6 @@ const VideoPlaylistCollectionPage: React.FC<
   )
   const playlistType = isOcwPlaylist(playlist)
 
-  const totalVideos = videos.length
   const totalVideoSeconds = videos.reduce((acc, video) => {
     const duration = video.video?.duration ?? ""
     const match = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(duration)
@@ -141,7 +141,7 @@ const VideoPlaylistCollectionPage: React.FC<
       <VideoPageHeader
         playlist={playlist}
         isSeries={playlistType}
-        totalVideos={videos.length}
+        totalVideos={totalCount}
       />
 
       {isLoading ? (
@@ -151,7 +151,7 @@ const VideoPlaylistCollectionPage: React.FC<
           video={videos[0]}
           href={getVideoHref(videos[0])}
           isSeries={playlistType}
-          totalVideos={totalVideos}
+          totalVideos={totalCount}
           totalTime={totalTime}
         />
       ) : null}

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoPlaylistCollectionPage.tsx
@@ -90,7 +90,7 @@ const VideoPlaylistCollectionPage: React.FC<
     learning_resource_id: playlistId,
     limit: VIDEOS_PAGE_SIZE,
   })
-  console.log("itemsData", itemsData)
+
   const { data: similarData, isLoading: similarLoading } = useQuery({
     ...learningResourceQueries.vectorSimilar({
       id: playlistId,
@@ -99,7 +99,7 @@ const VideoPlaylistCollectionPage: React.FC<
     }),
   })
 
-  if (showVideoPlaylistPage) {
+  if (!showVideoPlaylistPage) {
     return flagsLoaded ? notFound() : null
   }
 


### PR DESCRIPTION


### What are the relevant tickets?
n/a

### Description (What does it do?)
- Podcast episode having hover and it should link to its detail page instead of playing it
- The video count on video collection page should be total of all the video count which are part of that particular playlist
- Some spaces issues are fixed which happens in case there is single episode in podcast or no episode at all

### Screenshots (if appropriate):


https://github.com/user-attachments/assets/cb45c494-81a3-4bbc-b3d3-1836c19986b7



### How can this be tested?
if you don't have playlist data locally then in frontend env file you should add the following variable `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.rc.learn.mit.edu"` it will connect with RC learn backend
then we need to enable the flag which is `podcast-detail-page` and then visit the following url `http://open.odl.local:8062/podcast/detail/15261?podcast=15260`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
