### PR TITLE
Product page: list prices and actual prices

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -29,7 +29,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2026.5.1",
+    "@mitodl/mitxonline-api-axios": "2026.5.14",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/src/mitxonline/test-utils/factories/programs.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/programs.ts
@@ -40,6 +40,7 @@ const program: PartialFactory<V2ProgramDetail> = (overrides = {}) => {
       length: `${faker.number.int({ min: 1, max: 12 })} weeks`,
       effort: `${faker.number.int({ min: 1, max: 10 })} hours/week`,
       price: faker.commerce.price(),
+      list_price: faker.commerce.price(),
     },
     program_type: faker.helpers.arrayElement([
       "certificate",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "2026.5.1",
+    "@mitodl/mitxonline-api-axios": "2026.5.14",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
@@ -1280,7 +1280,7 @@ describe("ProgramSummary", () => {
       expect(priceRow).not.toHaveTextContent("Earn a certificate")
     })
 
-    test("Shows paid price with certificate type and no cert box when all enrollment modes are paid", () => {
+    test("Shows paid price with no cert box when all enrollment modes are paid", () => {
       const product = factories.courses.product({ price: "1499.00" })
       const program = factories.programs.program({
         enrollment_modes: [paidMode()],
@@ -1292,12 +1292,13 @@ describe("ProgramSummary", () => {
       expect(priceRow).toHaveTextContent(
         formatPrice(product.price, { avoidCents: true }),
       )
-      expect(priceRow).toHaveTextContent(program.certificate_type)
+      expect(priceRow).toHaveTextContent("full program")
       expect(priceRow).not.toHaveTextContent("Free to Learn")
       expect(priceRow).not.toHaveTextContent("Earn a certificate")
+      expect(priceRow).not.toHaveTextContent("Audit for free")
     })
 
-    test("Shows 'Free to Learn' and cert box when enrollment modes include both free and paid", () => {
+    test("Shows paid price and 'Start for free' callout when enrollment modes include both free and paid", () => {
       const program = factories.programs.program({
         enrollment_modes: bothModes(),
       })
@@ -1305,11 +1306,14 @@ describe("ProgramSummary", () => {
       renderWithProviders(<ProgramSummary program={program} />)
 
       const priceRow = screen.getByTestId(TestIds.PriceRow)
-      expect(priceRow).toHaveTextContent("Free to Learn")
-      expect(priceRow).toHaveTextContent("Earn a certificate")
+      expect(priceRow).toHaveTextContent("Audit for free")
+      expect(priceRow).toHaveTextContent("or upgrade to")
+      expect(priceRow).toHaveTextContent("certificate")
       expect(priceRow).toHaveTextContent(
         formatPrice(program.products[0].price, { avoidCents: true }),
       )
+      expect(priceRow).not.toHaveTextContent("Free to Learn")
+      expect(priceRow).not.toHaveTextContent("Earn a certificate")
     })
 
     test.each([

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -378,6 +378,83 @@ const GrayText = styled.span(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
 }))
 
+const ProgramPaySection = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "4px",
+  width: "100%",
+  maxWidth: "346px",
+  color: theme.custom.colors.darkGray2,
+}))
+
+const ProgramPayLabel = styled.span(({ theme }) => ({
+  ...theme.typography.body4,
+  fontWeight: theme.typography.fontWeightMedium,
+  color: theme.custom.colors.silverGrayDark,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+}))
+
+const ProgramPayContent = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "12px",
+  width: "100%",
+  maxWidth: "320px",
+  [theme.breakpoints.down("sm")]: {
+    maxWidth: "100%",
+  },
+}))
+
+const ProgramPriceLine = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "flex-end",
+  gap: "4px",
+  flexWrap: "wrap",
+  color: theme.custom.colors.darkGray2,
+}))
+
+const ProgramPriceAmount = styled.span(({ theme }) => ({
+  ...theme.typography.h3,
+  fontWeight: theme.typography.fontWeightBold,
+  lineHeight: "36px",
+}))
+
+const ProgramPriceSuffix = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  fontWeight: theme.typography.fontWeightMedium,
+  color: theme.custom.colors.silverGrayDark,
+}))
+
+const ProgramDiscountBlock = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "4px",
+  color: theme.custom.colors.darkGray2,
+}))
+
+const ProgramSavingsText = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.green,
+}))
+
+const ProgramListPriceText = styled.span(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  textDecoration: "line-through",
+}))
+
+const ProgramPriceDivider = styled.div(({ theme }) => ({
+  width: "100%",
+  maxWidth: "346px",
+  borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
+  flex: "none",
+  alignSelf: "stretch",
+}))
+
 const CertificateBoxRoot = styled.div(({ theme }) => ({
   width: "100%",
   backgroundColor: theme.custom.colors.lightGray1,
@@ -796,40 +873,87 @@ const ProgramCertificateBox: React.FC<{ program: V2ProgramDetail }> = ({
 }
 
 type ProgramPriceRowProps = HTMLAttributes<HTMLDivElement> & {
-  program: V2ProgramDetail
+  program: V2ProgramDetail & {
+    // Temporary local extension while list_price rolls into upstream API typings.
+    list_price?: number | string | null
+  }
 }
 const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
   program,
   ...others
 }) => {
   const enrollmentType = getEnrollmentType(program.enrollment_modes)
-  if (enrollmentType === "none") return null
+  // if (enrollmentType === "none") return null
 
-  const paidPrice =
-    enrollmentType === "paid" && program.products[0]?.price ? (
-      <>
-        {formatPrice(program.products[0].price, { avoidCents: true })}{" "}
-        <GrayText>(includes {program.certificate_type})</GrayText>
-      </>
-    ) : null
+  const currentPrice = program.products[0]?.price
+  const listPrice = program.list_price
+
+  const currentAmount = toNumericPrice(currentPrice)
+  const listAmount = toNumericPrice(listPrice)
+  const hasSavings =
+    currentAmount !== null && listAmount !== null && listAmount > currentAmount
+  const savingsAmount = hasSavings ? listAmount - currentAmount : null
+
+  const paidSection =
+    enrollmentType === "paid" && currentPrice ? (
+      <ProgramPaySection>
+        <ProgramPayLabel>Price</ProgramPayLabel>
+        <ProgramPayContent>
+          <ProgramPriceLine>
+            <ProgramPriceAmount>
+              {formatPrice(currentPrice, { avoidCents: true })}
+            </ProgramPriceAmount>
+            <ProgramPriceSuffix>/ full program</ProgramPriceSuffix>
+          </ProgramPriceLine>
+          {hasSavings && savingsAmount !== null && listAmount !== null ? (
+            <ProgramDiscountBlock>
+              <ProgramSavingsText>
+                Save {formatPrice(savingsAmount, { avoidCents: true })}
+              </ProgramSavingsText>
+              <ProgramListPriceText>
+                {formatPrice(listAmount, { avoidCents: true })} total for
+                courses purchased separately
+              </ProgramListPriceText>
+            </ProgramDiscountBlock>
+          ) : null}
+          <GrayText>(includes {program.certificate_type})</GrayText>
+        </ProgramPayContent>
+      </ProgramPaySection>
+    ) : (
+      <InfoLabelValue label="Price" value="Price unavailable" />
+    )
 
   return (
-    <InfoRow {...others}>
-      <InfoRowIcon>
-        <RiPriceTag3Line aria-hidden="true" />
-      </InfoRowIcon>
-      <InfoRowInner>
+    <Stack {...others} gap="8px" width="100%">
+      {enrollmentType === "paid" ? <ProgramPriceDivider /> : null}
+      <InfoRow>
         {enrollmentType === "paid" ? (
-          <InfoLabelValue label="Price" value={paidPrice} />
+          paidSection
         ) : (
-          <InfoLabelValue label="Price" value="Free to Learn" />
+          <>
+            <InfoRowIcon>
+              <RiPriceTag3Line aria-hidden="true" />
+            </InfoRowIcon>
+            <InfoRowInner>
+              <InfoLabelValue label="Price" value="Free to Learn" />
+              {enrollmentType === "both" ? (
+                <ProgramCertificateBox program={program} />
+              ) : null}
+            </InfoRowInner>
+          </>
         )}
-        {enrollmentType === "both" ? (
-          <ProgramCertificateBox program={program} />
-        ) : null}
-      </InfoRowInner>
-    </InfoRow>
+      </InfoRow>
+    </Stack>
   )
+}
+
+const toNumericPrice = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return null
 }
 
 const ProgramSummary: React.FC<{

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -955,11 +955,13 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
         {hasSavings && listAmount !== null ? (
           <>
             <ProgramVerticalDivider />
-            <ProgramListPriceBlock>
-              <ProgramListPriceAmount>
+            <ProgramListPriceBlock role="group"
+              aria-label={`Original price: ${formatPrice(listAmount, { avoidCents: true })} purchased separately`}
+            >
+              <ProgramListPriceAmount aria-hidden="true">
                 {formatPrice(listAmount, { avoidCents: true })}
               </ProgramListPriceAmount>
-              <ProgramListPriceSubLabel>
+              <ProgramListPriceSubLabel aria-hidden="true">
                 purchased separately
               </ProgramListPriceSubLabel>
             </ProgramListPriceBlock>

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -430,13 +430,13 @@ const ProgramPriceAmount = styled.span(({ theme }) => ({
 
 const ProgramPriceSuffix = styled.span(({ theme }) => ({
   ...theme.typography.body3,
-  color: "#626A73",
+  color: theme.custom.colors.silverGrayDark,
 }))
 
 const ProgramVerticalDivider = styled.div(() => ({
   width: "1px",
   height: "48px",
-  backgroundColor: "#CBD2D9",
+  backgroundColor: theme.custom.colors.lightGray2,
   flexShrink: 0,
 }))
 
@@ -455,7 +455,7 @@ const ProgramListPriceAmount = styled.span({
   display: "flex",
   alignItems: "flex-end" as const,
   textDecoration: "line-through",
-  color: "#626A73",
+  color: theme.custom.colors.silverGrayDark,
 })
 
 const ProgramListPriceSubLabel = styled.span({

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -405,14 +405,14 @@ const ProgramPayLabel = styled.span(({ theme }) => ({
 }))
 
 /** Horizontal row: [current price block] | [vertical divider] | [list price block] */
-const ProgramPriceRowInner = styled.div<{}>({
+const ProgramPriceRowInner = styled.div({
   display: "flex",
   flexDirection: "row" as const,
   alignItems: "flex-end" as const,
   gap: "24px",
 })
 
-const ProgramCurrentPriceBlock = styled.div<{}>({
+const ProgramCurrentPriceBlock = styled.div({
   display: "flex",
   flexDirection: "column" as const,
   justifyContent: "flex-end" as const,
@@ -440,7 +440,7 @@ const ProgramVerticalDivider = styled.div(() => ({
   flexShrink: 0,
 }))
 
-const ProgramListPriceBlock = styled.div<{}>({
+const ProgramListPriceBlock = styled.div({
   display: "flex",
   flexDirection: "column" as const,
   justifyContent: "flex-end" as const,
@@ -464,7 +464,7 @@ const ProgramListPriceSubLabel = styled.span({
 })
 
 /** Inline row: "Save $X  compared to purchasing N courses separately" */
-const ProgramDiscountRow = styled.div<{}>({
+const ProgramDiscountRow = styled.div({
   display: "flex",
   flexDirection: "row" as const,
   alignItems: "center" as const,

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -1,7 +1,7 @@
 import React, { HTMLAttributes, useState } from "react"
 import { ActionButton, Alert, styled } from "@mitodl/smoot-design"
 import { productQueries } from "api/mitxonline-hooks/products"
-import { Dialog, Link, Skeleton, Stack, Typography } from "ol-components"
+import { Dialog, Link, Skeleton, Stack, theme, Typography } from "ol-components"
 import type { StackProps } from "ol-components"
 import {
   RiCalendarLine,
@@ -37,6 +37,14 @@ const ResponsiveLink = styled(Link)(({ theme }) => ({
 const UnderlinedLink = styled(ResponsiveLink)({
   textDecoration: "underline",
 })
+
+const SecondaryUnderlinedLink = styled(UnderlinedLink)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+  [theme.breakpoints.down("sm")]: {
+    ...theme.typography.body4,
+  },
+}))
 
 const InfoRow = styled.div(({ theme }) => ({
   width: "100%",
@@ -382,77 +390,153 @@ const ProgramPaySection = styled.div(({ theme }) => ({
   display: "flex",
   flexDirection: "column",
   alignItems: "flex-start",
-  gap: "4px",
-  width: "100%",
-  maxWidth: "346px",
+  gap: "12px",
+  width: "346px",
+  alignSelf: "stretch",
+  flex: "none",
   color: theme.custom.colors.darkGray2,
 }))
 
 const ProgramPayLabel = styled.span(({ theme }) => ({
-  ...theme.typography.body4,
-  fontWeight: theme.typography.fontWeightMedium,
+  ...theme.typography.subtitle3,
   color: theme.custom.colors.silverGrayDark,
   textTransform: "uppercase",
   letterSpacing: "0.04em",
 }))
 
-const ProgramPayContent = styled.div(({ theme }) => ({
+/** Horizontal row: [current price block] | [vertical divider] | [list price block] */
+const ProgramPriceRowInner = styled.div<{}>({
   display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  gap: "12px",
-  width: "100%",
-  maxWidth: "320px",
-  [theme.breakpoints.down("sm")]: {
-    maxWidth: "100%",
-  },
-}))
+  flexDirection: "row" as const,
+  alignItems: "flex-end" as const,
+  gap: "24px",
+})
 
-const ProgramPriceLine = styled.div(({ theme }) => ({
+const ProgramCurrentPriceBlock = styled.div<{}>({
   display: "flex",
-  alignItems: "flex-end",
-  gap: "4px",
-  flexWrap: "wrap",
-  color: theme.custom.colors.darkGray2,
-}))
+  flexDirection: "column" as const,
+  justifyContent: "flex-end" as const,
+  alignItems: "flex-start" as const,
+})
 
 const ProgramPriceAmount = styled.span(({ theme }) => ({
-  ...theme.typography.h3,
+  ...theme.typography.subtitle2,
+  fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
   fontWeight: theme.typography.fontWeightBold,
-  lineHeight: "36px",
+  fontSize: "34px",
+  lineHeight: "40px",
+  color: theme.custom.colors.darkGray2,
 }))
 
 const ProgramPriceSuffix = styled.span(({ theme }) => ({
-  ...theme.typography.subtitle1,
-  fontWeight: theme.typography.fontWeightMedium,
-  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.body3,
+  color: "#626A73",
 }))
 
-const ProgramDiscountBlock = styled.div(({ theme }) => ({
+const ProgramVerticalDivider = styled.div(() => ({
+  width: "1px",
+  height: "48px",
+  backgroundColor: "#CBD2D9",
+  flexShrink: 0,
+}))
+
+const ProgramListPriceBlock = styled.div<{}>({
   display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  gap: "4px",
-  color: theme.custom.colors.darkGray2,
-}))
+  flexDirection: "column" as const,
+  justifyContent: "flex-end" as const,
+  alignItems: "flex-start" as const,
+})
 
-const ProgramSavingsText = styled.span(({ theme }) => ({
-  ...theme.typography.subtitle2,
-  color: theme.custom.colors.green,
-}))
-
-const ProgramListPriceText = styled.span(({ theme }) => ({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
+const ProgramListPriceAmount = styled.span({
+  ...theme.typography.body3,
+  fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+  fontSize: "28px",
+  lineHeight: "36px",
+  display: "flex",
+  alignItems: "flex-end" as const,
   textDecoration: "line-through",
-}))
+  color: "#626A73",
+})
+
+const ProgramListPriceSubLabel = styled.span({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+})
+
+/** Inline row: "Save $X  compared to purchasing N courses separately" */
+const ProgramDiscountRow = styled.div<{}>({
+  display: "flex",
+  flexDirection: "row" as const,
+  alignItems: "center" as const,
+  gap: "4px",
+  width: "100%",
+})
+
+const ProgramSavingsText = styled.span({
+  ...theme.typography.subtitle3,
+  fontWeight: theme.typography.fontWeightBold,
+  color: "#008000",
+})
+
+const ProgramSavingsDetailText = styled.span({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+})
 
 const ProgramPriceDivider = styled.div(({ theme }) => ({
   width: "100%",
   maxWidth: "346px",
   borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
+  marginBottom: "20px",
   flex: "none",
   alignSelf: "stretch",
+}))
+
+const ProgramStartForFreeBox = styled.div((_theme) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  padding: "8px 16px",
+  borderRadius: "8px",
+  background:
+    "linear-gradient(0deg, rgba(255, 255, 255, 0.94), rgba(255, 255, 255, 0.94)), #004D1A",
+}))
+
+const ProgramStartForFreeIcon = styled.svg(() => ({
+  width: "24px",
+  height: "24px",
+  flexShrink: 0,
+  path: {
+    fill: "#008000",
+  },
+}))
+
+const ProgramStartForFreeTextContainer = styled.span(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  ...theme.typography.body2,
+}))
+
+const ProgramStartForFreeTextStrong = styled.span({
+  ...theme.typography.subtitle2,
+  color: "#008000",
+})
+
+const ProgramStartForFreeTextRegular = styled.span({
+  ...theme.typography.body2,
+  color: theme.custom.colors.darkGray2,
+})
+
+const ProgramStartForFreeInfoIcon = styled.span(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  flexShrink: 0,
+  color: theme.custom.colors.silverGrayDark,
+  "& svg": {
+    width: "20px",
+    height: "20px",
+  },
 }))
 
 const CertificateBoxRoot = styled.div(({ theme }) => ({
@@ -644,7 +728,6 @@ enum TestIds {
   DurationRow = "duration-row",
   PriceRow = "price-row",
   RequirementsRow = "requirements-row",
-  CertificateTrackRow = "certificate-track-row",
 }
 
 const ArchivedAlert: React.FC = () => {
@@ -734,15 +817,16 @@ type ProgramInfoRowProps = {
   program: V2ProgramDetail
 } & HTMLAttributes<HTMLDivElement>
 
+const getTotalRequiredCourses = (program: V2ProgramDetail) => {
+  const parsedReqs = parseReqTree(program.req_tree)
+  return parsedReqs.reduce((sum, req) => sum + req.requiredCount, 0)
+}
+
 const RequirementsRow: React.FC<ProgramInfoRowProps> = ({
   program,
   ...others
 }) => {
-  const parsedReqs = parseReqTree(program.req_tree)
-  const totalRequired = parsedReqs.reduce(
-    (sum, req) => sum + req.requiredCount,
-    0,
-  )
+  const totalRequired = getTotalRequiredCourses(program)
   if (totalRequired === 0) return null
 
   // Always say "Courses" here. Whether a child program should be labeled
@@ -837,56 +921,18 @@ const ProgramPaceRow: React.FC<
 const PROGRAM_CERT_INFO_HREF =
   "https://mitxonline.zendesk.com/hc/en-us/articles/28158506908699-What-is-the-Certificate-Track-What-are-Course-and-Program-Certificates"
 
-const ProgramCertificateBox: React.FC<{ program: V2ProgramDetail }> = ({
-  program,
-}) => {
-  const price = program.products[0]?.price
-  if (!price) return null
-  return (
-    <CertificateBoxRoot>
-      <InfoRowInner flexWrap="nowrap">
-        <span>
-          <UnderlinedLink
-            href={PROGRAM_CERT_INFO_HREF}
-            target="_blank"
-            rel="noopener noreferrer"
-            color="black"
-          >
-            <InfoLabel>Earn a certificate</InfoLabel>
-          </UnderlinedLink>
-          : {formatPrice(price, { avoidCents: true })}
-        </span>
-      </InfoRowInner>
-      {program.page.financial_assistance_form_url ? (
-        <UnderlinedLink
-          color="black"
-          href={mitxonlineLegacyUrl(program.page.financial_assistance_form_url)}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ minWidth: "fit-content" }}
-        >
-          Financial assistance available
-        </UnderlinedLink>
-      ) : null}
-    </CertificateBoxRoot>
-  )
-}
-
 type ProgramPriceRowProps = HTMLAttributes<HTMLDivElement> & {
-  program: V2ProgramDetail & {
-    // Temporary local extension while list_price rolls into upstream API typings.
-    list_price?: number | string | null
-  }
+  program: V2ProgramDetail
 }
 const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
   program,
   ...others
 }) => {
   const enrollmentType = getEnrollmentType(program.enrollment_modes)
-  // if (enrollmentType === "none") return null
+  if (enrollmentType === "none") return null
 
   const currentPrice = program.products[0]?.price
-  const listPrice = program.list_price
+  const listPrice = program.page.list_price
 
   const currentAmount = toNumericPrice(currentPrice)
   const listAmount = toNumericPrice(listPrice)
@@ -894,40 +940,99 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
     currentAmount !== null && listAmount !== null && listAmount > currentAmount
   const savingsAmount = hasSavings ? listAmount - currentAmount : null
 
-  const paidSection =
-    enrollmentType === "paid" && currentPrice ? (
-      <ProgramPaySection>
-        <ProgramPayLabel>Price</ProgramPayLabel>
-        <ProgramPayContent>
-          <ProgramPriceLine>
-            <ProgramPriceAmount>
-              {formatPrice(currentPrice, { avoidCents: true })}
-            </ProgramPriceAmount>
-            <ProgramPriceSuffix>/ full program</ProgramPriceSuffix>
-          </ProgramPriceLine>
-          {hasSavings && savingsAmount !== null && listAmount !== null ? (
-            <ProgramDiscountBlock>
-              <ProgramSavingsText>
-                Save {formatPrice(savingsAmount, { avoidCents: true })}
-              </ProgramSavingsText>
-              <ProgramListPriceText>
-                {formatPrice(listAmount, { avoidCents: true })} total for
-                courses purchased separately
-              </ProgramListPriceText>
-            </ProgramDiscountBlock>
-          ) : null}
-          <GrayText>(includes {program.certificate_type})</GrayText>
-        </ProgramPayContent>
-      </ProgramPaySection>
-    ) : (
-      <InfoLabelValue label="Price" value="Price unavailable" />
-    )
+  const totalRequired = getTotalRequiredCourses(program)
+
+  const paidSection = currentPrice ? (
+    <ProgramPaySection>
+      <ProgramPayLabel>Price</ProgramPayLabel>
+      <ProgramPriceRowInner>
+        <ProgramCurrentPriceBlock>
+          <ProgramPriceAmount>
+            {formatPrice(currentPrice, { avoidCents: true })}
+          </ProgramPriceAmount>
+          <ProgramPriceSuffix>full program</ProgramPriceSuffix>
+        </ProgramCurrentPriceBlock>
+        {hasSavings && listAmount !== null ? (
+          <>
+            <ProgramVerticalDivider />
+            <ProgramListPriceBlock>
+              <ProgramListPriceAmount>
+                {formatPrice(listAmount, { avoidCents: true })}
+              </ProgramListPriceAmount>
+              <ProgramListPriceSubLabel>
+                purchased separately
+              </ProgramListPriceSubLabel>
+            </ProgramListPriceBlock>
+          </>
+        ) : null}
+      </ProgramPriceRowInner>
+      {hasSavings && savingsAmount !== null ? (
+        <ProgramDiscountRow>
+          <ProgramSavingsText>
+            Save {formatPrice(savingsAmount, { avoidCents: true })}
+          </ProgramSavingsText>
+          <ProgramSavingsDetailText>
+            compared to purchasing {totalRequired}{" "}
+            {pluralize("course", totalRequired)} separately
+          </ProgramSavingsDetailText>
+        </ProgramDiscountRow>
+      ) : null}
+      {program.page.financial_assistance_form_url ? (
+        <SecondaryUnderlinedLink
+          color="black"
+          href={mitxonlineLegacyUrl(program.page.financial_assistance_form_url)}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ minWidth: "fit-content" }}
+        >
+          Financial assistance available
+        </SecondaryUnderlinedLink>
+      ) : null}
+      {enrollmentType === "both" ? (
+        <ProgramStartForFreeBox>
+          <ProgramStartForFreeIcon
+            width="24"
+            height="24"
+            viewBox="0 0 22 19"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path d="M14 0C16.2091 0 18 1.79086 18 4C18 4.72903 17.8049 5.41251 17.4642 6.00111L22 6V7.99999H20V18C20 18.5523 19.5523 19 19 19H3C2.44772 19 2 18.5523 2 18V7.99999H0V6L4.53577 6.00111C4.19504 5.41251 4 4.72903 4 4C4 1.79086 5.79086 0 8 0C9.19522 0 10.268 0.52421 11.0009 1.35526C11.732 0.52421 12.8048 0 14 0ZM10 7.99999H4V17H10V7.99999ZM18 7.99999H12V17H18V7.99999ZM8 2C6.89543 2 6 2.89543 6 4C6 5.05436 6.81588 5.91816 7.85074 5.99451L8 6H10V4C10 2.99835 9.26372 2.16869 8.30278 2.02277L8.14927 2.00548L8 2ZM14 2C12.9456 2 12.0818 2.81588 12.0055 3.85074L12 4V6H14C15.0543 6 15.9181 5.18412 15.9945 4.14926L16 4C16 2.89543 15.1046 2 14 2Z" />
+          </ProgramStartForFreeIcon>
+          <ProgramStartForFreeTextContainer>
+            <ProgramStartForFreeTextStrong>
+              Audit for free
+            </ProgramStartForFreeTextStrong>
+            <ProgramStartForFreeTextRegular>
+              or upgrade to certificate
+            </ProgramStartForFreeTextRegular>
+          </ProgramStartForFreeTextContainer>
+          <a
+            href={PROGRAM_CERT_INFO_HREF}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Learn more about program certificates"
+            style={{ display: "inline-flex", alignItems: "center" }}
+          >
+            <ProgramStartForFreeInfoIcon>
+              <RiInformation2Line aria-hidden="true" />
+            </ProgramStartForFreeInfoIcon>
+          </a>
+        </ProgramStartForFreeBox>
+      ) : null}
+    </ProgramPaySection>
+  ) : (
+    <InfoLabelValue label="Price" value="Price unavailable" />
+  )
 
   return (
-    <Stack {...others} gap="8px" width="100%">
-      {enrollmentType === "paid" ? <ProgramPriceDivider /> : null}
+    <Stack {...others} gap="0px" width="100%">
+      {enrollmentType === "paid" || enrollmentType === "both" ? (
+        <ProgramPriceDivider />
+      ) : null}
       <InfoRow>
-        {enrollmentType === "paid" ? (
+        {enrollmentType === "paid" || enrollmentType === "both" ? (
           paidSection
         ) : (
           <>
@@ -936,9 +1041,6 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
             </InfoRowIcon>
             <InfoRowInner>
               <InfoLabelValue label="Price" value="Free to Learn" />
-              {enrollmentType === "both" ? (
-                <ProgramCertificateBox program={program} />
-              ) : null}
             </InfoRowInner>
           </>
         )}

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -34,7 +34,8 @@ const makeUser = factories.user.user
 
 describe("ProgramEnrollmentButton", () => {
   const ENROLLED = "Enrolled"
-  const ENROLL_FREE = "Enroll for Free"
+  const ENROLL_FREE = "Enroll in Program"
+  const ENROLL_PROGRAM = "Enroll in Program"
 
   setupLocationMock()
 
@@ -94,7 +95,7 @@ describe("ProgramEnrollmentButton", () => {
     expect(enrolledLink).toHaveAttribute("href", programView(program.id))
   })
 
-  test("Free-only: clicking 'Enroll for Free' enrolls and redirects to the dashboard success URL with title in params", async () => {
+  test("Free-only: clicking 'Enroll in Program' enrolls and redirects to the dashboard success URL with title in params", async () => {
     const program = makeProgram({
       enrollment_modes: [makeEnrollmentMode({ requires_payment: false })],
     })
@@ -134,7 +135,7 @@ describe("ProgramEnrollmentButton", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
-  test("Both: clicking 'Enroll for Free' opens enrollment dialog", async () => {
+  test("Both: clicking 'Enroll in Program' opens enrollment dialog", async () => {
     const program = makeProgram({
       enrollment_modes: [
         makeEnrollmentMode({ requires_payment: false }),
@@ -157,7 +158,7 @@ describe("ProgramEnrollmentButton", () => {
     await screen.findByRole("dialog", { name: program.title })
   })
 
-  test("Paid-only: clicking 'Enroll Now' clears basket, adds product, and redirects", async () => {
+  test("Paid-only: clicking 'Enroll in Program' clears basket, adds product, and redirects", async () => {
     const assign = jest.mocked(window.location.assign)
     const product = makeProduct({ price: "500" })
     const program = makeProgram({
@@ -177,7 +178,7 @@ describe("ProgramEnrollmentButton", () => {
     )
 
     const enrollButton = await screen.findByRole("button", {
-      name: /Enroll Now/,
+      name: ENROLL_PROGRAM,
     })
     await user.click(enrollButton)
 
@@ -208,12 +209,12 @@ describe("ProgramEnrollmentButton", () => {
       <ProgramEnrollmentButton program={program} variant="primary" />,
     )
 
-    const button = await screen.findByRole("button", { name: /Enroll Now/ })
+    const button = await screen.findByRole("button", { name: ENROLL_PROGRAM })
     await user.click(button)
 
     await screen.findByRole("progressbar", { name: "Loading" })
     expect(button).toBeDisabled()
-    expect(button).toHaveTextContent("Enroll Now—$500")
+    expect(button).toHaveTextContent(ENROLL_PROGRAM)
   })
 
   test("Shows error alert when basket operation fails (paid)", async () => {
@@ -231,7 +232,7 @@ describe("ProgramEnrollmentButton", () => {
       <ProgramEnrollmentButton program={program} variant="primary" />,
     )
 
-    const button = await screen.findByRole("button", { name: /Enroll Now/ })
+    const button = await screen.findByRole("button", { name: ENROLL_PROGRAM })
     await user.click(button)
 
     await screen.findByText(
@@ -281,7 +282,7 @@ describe("ProgramEnrollmentButton", () => {
     )
 
     const button = await screen.findByRole("button", {
-      name: "Enroll Now—$1,500",
+      name: ENROLL_PROGRAM,
     })
     expect(button).toBeInTheDocument()
     expect(button).not.toBeDisabled()
@@ -319,7 +320,7 @@ describe("ProgramEnrollmentButton", () => {
       <ProgramEnrollmentButton program={program} variant="primary" />,
     )
 
-    const button = await screen.findByRole("button", { name: "Enroll Now" })
+    const button = await screen.findByRole("button", { name: ENROLL_PROGRAM })
     expect(button).toBeDisabled()
   })
 
@@ -398,9 +399,7 @@ describe("ProgramEnrollmentButton", () => {
       renderWithProviders(
         <ProgramEnrollmentButton program={program} variant="primary" />,
       )
-      await user.click(
-        await screen.findByRole("button", { name: "Enroll for Free" }),
-      )
+      await user.click(await screen.findByRole("button", { name: ENROLL_FREE }))
 
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,
@@ -426,9 +425,7 @@ describe("ProgramEnrollmentButton", () => {
       renderWithProviders(
         <ProgramEnrollmentButton program={program} variant="primary" />,
       )
-      await user.click(
-        await screen.findByRole("button", { name: "Enroll for Free" }),
-      )
+      await user.click(await screen.findByRole("button", { name: ENROLL_FREE }))
 
       expect(mockCapture).toHaveBeenCalledWith(
         PostHogEvents.CallToActionClicked,

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -1,12 +1,12 @@
 import React from "react"
-import { LoadingSpinner, Stack } from "ol-components"
+import { LoadingSpinner, Stack, theme } from "ol-components"
 import {
   enrollmentQueries,
   useCreateProgramEnrollment,
 } from "api/mitxonline-hooks/enrollment"
 import { useQuery } from "@tanstack/react-query"
 import { V2ProgramDetail } from "@mitodl/mitxonline-api-axios/v2"
-import { RiCheckLine } from "@remixicon/react"
+import { RiArrowRightSLine, RiCheckLine } from "@remixicon/react"
 import {
   Alert,
   Button,
@@ -34,6 +34,20 @@ const ButtonLinkWithDisabled = styled(ButtonLink)(({ href }) => [
     cursor: "default",
   },
 ])
+
+const EnrollButtonIcon = styled.span({
+  width: "24px",
+  height: "24px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+  color: theme.custom.colors.white,
+  "> svg": {
+    width: "24px",
+    height: "24px",
+  },
+})
 
 type ProgramEnrollmentButtonProps = {
   program: V2ProgramDetail
@@ -134,7 +148,11 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
             endIcon={
               isLoading || isPending ? (
                 <LoadingSpinner size="16px" loading={true} color="inherit" />
-              ) : undefined
+              ) : (
+                <EnrollButtonIcon>
+                  <RiArrowRightSLine aria-hidden="true" />
+                </EnrollButtonIcon>
+              )
             }
           >
             {isLoading ? null : enrollButtonLabel}

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.tsx
@@ -22,7 +22,6 @@ import { programView } from "@/common/urls"
 import { usePostHog } from "posthog-js/react"
 import {
   enrollmentAlertSuccessUrl,
-  formatPrice,
   getEnrollmentType,
 } from "@/common/mitxonline"
 import { useReplaceBasketItem } from "api/mitxonline-hooks/baskets"
@@ -63,16 +62,7 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
   const enrollmentType = getEnrollmentType(program.enrollment_modes)
   const isPaidWithoutPrice =
     enrollmentType === "paid" && !program.products[0]?.price
-
-  const getEnrollButtonText = () => {
-    if (enrollmentType === "paid") {
-      const price = program.products[0]?.price
-      return price
-        ? `Enroll Now—${formatPrice(price, { avoidCents: true })}`
-        : "Enroll Now"
-    }
-    return "Enroll for Free"
-  }
+  const enrollButtonLabel = "Enroll in Program"
 
   const isLoading = enrollments.isLoading || me.isLoading
   const isPending =
@@ -88,7 +78,7 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
       posthog.capture(PostHogEvents.CallToActionClicked, {
         readableId: program.readable_id,
         resourceType: "program",
-        label: getEnrollButtonText(),
+        label: enrollButtonLabel,
       })
     }
     if (me.data?.is_authenticated) {
@@ -147,7 +137,7 @@ const ProgramEnrollmentButton: React.FC<ProgramEnrollmentButtonProps> = ({
               ) : undefined
             }
           >
-            {isLoading ? null : getEnrollButtonText()}
+            {isLoading ? null : enrollButtonLabel}
           </Button>
         )}
         {isError && (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,13 +3332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2026.5.1":
-  version: 2026.5.1
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.1"
+"@mitodl/mitxonline-api-axios@npm:2026.5.14":
+  version: 2026.5.14
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.14"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/6eb179298221fc2801ce4e3c0589de0378c68b7a32503101de675a85f6e3569c78ec6cb4b1bc5aa85094637532a34d10c110a4a9cdfa96c525dc4362e0236d5c
+  checksum: 10/24780dbfd2c9cf50c9b3ec877b4cad18bd30ca01202445215fdaadbf627bdf961d04354e7329cd05e2d5d58ad02d539972769d4848e682eaaf5aca57fdbca63f
   languageName: node
   linkType: hard
 
@@ -8939,7 +8939,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.14"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16184,7 +16184,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.14"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"


### PR DESCRIPTION
### What are the relevant tickets?
Fix https://github.com/mitodl/hq/issues/11119

### Description (What does it do?)
Adds a new Price section with shows List and current price and the amount saved.

### Screenshots (if appropriate):

If Audit is available, and FinAid:
<img width="469" height="465" alt="Screenshot 2026-05-15 at 12 16 29 PM" src="https://github.com/user-attachments/assets/9682de4a-2646-4529-aa3c-0791da729b1f" />

Both, no FinAid:
<img width="481" height="588" alt="Screenshot 2026-05-15 at 12 19 39 PM" src="https://github.com/user-attachments/assets/ed616db8-185b-4ea6-b8e0-6b812e6e4a31" />

Only Paid:
<img width="489" height="529" alt="Screenshot 2026-05-15 at 12 21 19 PM" src="https://github.com/user-attachments/assets/85a680ca-0bd1-4ec2-aef9-d2c4ec1b8f07" />




### How can this be tested?

