### PR TITLE
fix: add heading tags to B2B org section

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -156,7 +156,9 @@ const WelcomeMessage: React.FC<{ contract?: ContractPage }> = ({
   return (
     <Stack gap="12px" paddingTop="40px" paddingBottom="24px">
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Typography variant="h5" component="h2">{welcomeMessage}</Typography>
+        <Typography variant="h5" component="h2">
+          {welcomeMessage}
+        </Typography>
         <Link
           scroll={false}
           color="red"

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -156,7 +156,7 @@ const WelcomeMessage: React.FC<{ contract?: ContractPage }> = ({
   return (
     <Stack gap="12px" paddingTop="40px" paddingBottom="24px">
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Typography variant="h5">{welcomeMessage}</Typography>
+        <Typography variant="h5" component="h2">{welcomeMessage}</Typography>
         <Link
           scroll={false}
           color="red"
@@ -775,7 +775,7 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
         </ProgramCollectionsList>
         {programsQuery.data?.results.length === 0 && (
           <HeaderRoot>
-            <Typography variant="h3" component="h1">
+            <Typography variant="h3" component="h2">
               No programs found
             </Typography>
           </HeaderRoot>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
@@ -74,6 +74,9 @@ describe("OrganizationCards", () => {
         )
       })
       expect(elements.length).toBeGreaterThan(0)
+      await screen.findByRole("heading", {
+        name: `As a member of ${org.name} you have access to:`,
+      })
     }
   })
 
@@ -135,6 +138,9 @@ describe("OrganizationCards", () => {
       expect(screen.getAllByRole("link", { name: "Contract 2" })).toHaveLength(
         2,
       )
+      // Contract names should be wrapped in heading elements
+      expect(screen.getAllByRole("heading", { name: "Contract 1" })).toHaveLength(2)
+      expect(screen.getAllByRole("heading", { name: "Contract 2" })).toHaveLength(2)
     })
 
     it("renders Continue buttons with correct organization URLs", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
@@ -139,8 +139,12 @@ describe("OrganizationCards", () => {
         2,
       )
       // Contract names should be wrapped in heading elements
-      expect(screen.getAllByRole("heading", { name: "Contract 1" })).toHaveLength(2)
-      expect(screen.getAllByRole("heading", { name: "Contract 2" })).toHaveLength(2)
+      expect(
+        screen.getAllByRole("heading", { name: "Contract 1" }),
+      ).toHaveLength(2)
+      expect(
+        screen.getAllByRole("heading", { name: "Contract 2" }),
+      ).toHaveLength(2)
     })
 
     it("renders Continue buttons with correct organization URLs", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.tsx
@@ -56,6 +56,11 @@ const CardRootStyled = styled(DashboardCardRoot)({
   },
 })
 
+const ContractTitleHeading = styled.h3({
+  margin: 0,
+  width: "100%",
+})
+
 const TitleLink = styled(Link)({
   width: "100%",
 })
@@ -107,9 +112,11 @@ const OrganizationContracts: React.FC<OrganizationContractsProps> = ({
       const href = contractView(org.slug.replace("org-", ""), contract.slug)
       return (
         <CardContent key={contract.id} direction="row">
-          <TitleLink size="medium" color="black" href={href}>
-            {contract.name}
-          </TitleLink>
+          <ContractTitleHeading>
+            <TitleLink size="medium" color="black" href={href}>
+              {contract.name}
+            </TitleLink>
+          </ContractTitleHeading>
           <CardButton size="small" href={href} endIcon={<RiArrowRightLine />}>
             Continue
           </CardButton>
@@ -127,7 +134,7 @@ const OrganizationContracts: React.FC<OrganizationContractsProps> = ({
             style={{ objectFit: "contain" }}
           />
         </ImageContainer>
-        <Typography variant="body2">
+        <Typography variant="body2" component="h2">
           {"As a member of "}
           <Typography variant="subtitle2" component="span">
             {org.name}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/11297 
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds heading tags to the B2B organization section of the dashboard for screen reader accessibility. This is a follow-up to #3253, which added headings to the My Learning section.

- OrganizationCards (home dashboard): The "As a member of [Org] you have access to:" label is now an `h2`, and each contract name link is wrapped in an `h3`, establishing a proper heading hierarchy beneath the page's `h1`.
- ContractContent (contract detail page): The welcome message title had `variant="h5"` which rendered as` <h5>`, skipping heading levels after the org name `h1`. Fixed to `component="h2"`. The "No programs found" state had an incorrect duplicate `h1` and fixed to `h2`.
- Tests: Added `getByRole("heading")` assertions to `OrganizationCards.test.tsx` to verify both the org section and contract name headings are accessible.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [x] Desktop screenshots
- [ ] Mobile width screenshots

BEFORE Dashboard Page
<img width="1909" height="919" alt="Screenshot 2026-05-15 at 11 28 13 AM" src="https://github.com/user-attachments/assets/48347266-3b4e-404c-988f-ac9374deeb59" />

AFTER Dashboard Page
<img width="1906" height="919" alt="Screenshot 2026-05-15 at 11 27 41 AM" src="https://github.com/user-attachments/assets/dc142735-67a6-4159-95ef-52a7697e695c" />

BEFORE Contact Page
<img width="1937" height="928" alt="Screenshot 2026-05-15 at 11 52 11 AM" src="https://github.com/user-attachments/assets/8e5b65f4-42a5-421a-a5a7-5c16dfbff480" />

AFTER Contact Page
<img width="1917" height="923" alt="Screenshot 2026-05-15 at 11 50 23 AM" src="https://github.com/user-attachments/assets/c437d756-87af-4344-b06d-1099b195cd54" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
**Prerequisites:**

1. A local MITx Online instance with a B2B organization and contract configured. 
2. In MITx Online admin → B2B → Organizations, create a test org
3. In B2B → Contracts, create a contract linked to that org
4. In B2B → User organizations, add your local user to the org
5. Assign the contract to the user

This change is best verified by inspecting the DOM in browser DevTools:

1. Log into the dashboard as a user who is a member of a B2B organization
2. On the home dashboard, open DevTools → Elements and inspect the org section ("As a member of [Org] you have access to:") — it should be an `<h2>` element, and each contract name below it should be an `<h3>`
3. Click into a contract to open the contract detail page and inspect:
4. The org name should be `<h1>`
5. The welcome message title (if present) should be `<h2>`


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
