### PR TITLE
fix: certificate page being indexed in google search which should not be 

### DIFF
--- a/frontends/main/src/app/certificate/[certificateType]/[uuid]/page.tsx
+++ b/frontends/main/src/app/certificate/[certificateType]/[uuid]/page.tsx
@@ -52,6 +52,7 @@ export async function generateMetadata({
     return standardizeMetadata({
       title: `${userName}'s ${displayType}`,
       description: `${userName} has successfully completed: ${title}`,
+      robots: { index: false },
     })
   })
 }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11232

### Description (What does it do?)
Certificates should not be indexed by Google search. They are public, for ease of sharing, but they shouldn’t be searchable.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
For testing you should get connected with prod backend `NEXT_PUBLIC_MITOL_API_BASE_URL="https://api.learn.mit.edu"`
and visit the following url `http://open.odl.local:8062/certificate/course/8a2ebafe-40b3-4178-8860-ea9bd063f3cd` and View page source you should see `<meta name="robots" content="noindex"/>`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
