### PR TITLE
feat: Handle nullable page field from MITx Online client update

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -30,7 +30,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2026.5.20.1",
+    "@mitodl/mitxonline-api-axios": "2026.5.21",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -30,7 +30,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "2026.5.20.1",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -30,7 +30,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2026.5.14",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "2026.5.14",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "2026.5.20.1",
+    "@mitodl/mitxonline-api-axios": "2026.5.21",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,7 +14,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "2026.5.20.1",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1910,4 +1910,29 @@ describe("ContractContent", () => {
     const coursewareButton = within(card).getByTestId("courseware-button")
     expect(coursewareButton).toHaveAttribute("href", enrolledRun.courseware_url)
   })
+
+  it("renders without crashing when program.page is null", async () => {
+    const { orgX, programA, programB } = setupProgramsAndCourses()
+    const contract = orgX.contracts[0]
+
+    setMockResponse.get(
+      urls.programs.programsList({
+        org_id: orgX.id,
+        contract_id: contract.id,
+        page_size: 30,
+      }),
+      {
+        results: [
+          { ...programA, page: null },
+          { ...programB, page: null },
+        ],
+      },
+    )
+
+    renderWithProviders(
+      <ContractContent orgSlug={orgX.slug} contractSlug={contract.slug} />,
+    )
+
+    await screen.findByRole("heading", { name: orgX.name })
+  })
 })

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1933,6 +1933,7 @@ describe("ContractContent", () => {
       <ContractContent orgSlug={orgX.slug} contractSlug={contract.slug} />,
     )
 
-    await screen.findByRole("heading", { name: orgX.name })
+    await screen.findByText(programA.title)
+    await screen.findByText(programB.title)
   })
 })

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -483,4 +483,13 @@ describe("CoursePage", () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  test("Renders without crashing when course_details.page is null", async () => {
+    const course = makeCourse({ page: null })
+    const page = makePage({ course_details: course })
+    setupApis({ course, page })
+    renderWithProviders(<CoursePage readableId={course.readable_id} />)
+
+    await screen.findByRole("heading", { name: page.title })
+  })
 })

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -75,13 +75,13 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
   }
 
   const imageSrc =
-    page.course_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    page.course_details.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
   return (
     <ProductPageTemplate
       currentBreadcrumbLabel="Course"
       title={page.title}
-      shortDescription={page.course_details.page.description}
+      shortDescription={page.course_details.page?.description}
       imageSrc={imageSrc}
       videoUrl={page.video_url}
       infoBox={<CourseInfoBox course={course} />}

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.test.tsx
@@ -1185,6 +1185,13 @@ describe("ProgramSummary", () => {
         }
       },
     )
+
+    test("Does not crash and hides duration row when program page is null", () => {
+      const program = factories.programs.program({ page: null })
+      renderWithProviders(<ProgramSummary program={program} />)
+
+      expect(screen.queryByTestId(TestIds.DurationRow)).toBeNull()
+    })
   })
 
   describe("Pacing Row", () => {

--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -855,8 +855,8 @@ const ProgramDurationRow: React.FC<ProgramInfoRowProps> = ({
   program,
   ...others
 }) => {
-  const duration = program.page.length ?? ""
-  const effort = program.page.effort ?? ""
+  const duration = program.page?.length ?? ""
+  const effort = program.page?.effort ?? ""
   if (!duration) return null
   const display = [duration, effort].filter(Boolean).join(", ")
 
@@ -932,7 +932,7 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
   if (enrollmentType === "none") return null
 
   const currentPrice = program.products[0]?.price
-  const listPrice = program.page.list_price
+  const listPrice = program.page?.list_price
 
   const currentAmount = toNumericPrice(currentPrice)
   const listAmount = toNumericPrice(listPrice)
@@ -980,10 +980,12 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
           </ProgramSavingsDetailText>
         </ProgramDiscountRow>
       ) : null}
-      {program.page.financial_assistance_form_url ? (
+      {program.page?.financial_assistance_form_url ? (
         <SecondaryUnderlinedLink
           color="black"
-          href={mitxonlineLegacyUrl(program.page.financial_assistance_form_url)}
+          href={mitxonlineLegacyUrl(
+            program.page?.financial_assistance_form_url,
+          )}
           target="_blank"
           rel="noopener noreferrer"
           style={{ minWidth: "fit-content" }}

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -382,4 +382,15 @@ describe("ProgramAsCoursePage", () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  test("Renders without crashing when program_details.page is null", async () => {
+    const program = makeProgramAsCourse({ page: null })
+    const page = makePage({ program_details: program })
+    setupApis({ program, page })
+    renderWithProviders(
+      <ProgramAsCoursePage readableId={program.readable_id} />,
+    )
+
+    await screen.findByRole("heading", { name: page.title })
+  })
 })

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -258,7 +258,7 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
   }
 
   const imageSrc =
-    page.program_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    page.program_details.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
   const dataLoading =
     (courseIds.length > 0 && !courses.isSuccess) ||
@@ -271,7 +271,7 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
       shortDescription={
         <DescriptionHTML
           Component="span"
-          html={page.program_details.page.description}
+          html={page.program_details.page?.description ?? ""}
         />
       }
       imageSrc={imageSrc}

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -798,4 +798,13 @@ describe("ProgramPage", () => {
       ).not.toBeInTheDocument()
     })
   })
+
+  test("Renders without crashing when program_details.page is null", async () => {
+    const program = makeProgram({ ...makeReqs(), page: null })
+    const page = makePage({ program_details: program })
+    setupApis({ program, page })
+    renderWithProviders(<ProgramPage readableId={program.readable_id} />)
+
+    await screen.findByRole("heading", { name: page.title })
+  })
 })

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -275,7 +275,7 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
   }
 
   const imageSrc =
-    page.program_details.page.feature_image_src || DEFAULT_RESOURCE_IMG
+    page.program_details.page?.feature_image_src || DEFAULT_RESOURCE_IMG
 
   const dataLoading =
     (courseIds.length > 0 && !courses.isSuccess) ||
@@ -289,7 +289,7 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
       shortDescription={
         <DescriptionHTML
           Component="span"
-          html={page.program_details.page.description}
+          html={page.program_details.page?.description ?? ""}
         />
       }
       imageSrc={imageSrc}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,13 +3332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz":
-  version: 2026.5.6
-  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
+"@mitodl/mitxonline-api-axios@npm:2026.5.1":
+  version: 2026.5.1
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.1"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/1d42c26f29b2694656877b5b3e70a97fc5075130b777d4aa83a7f91f0c4862df416aadebd88f30b2ecf9eee3a7981c27433842171f28a3cc78c416444804b9f3
+  checksum: 10/6eb179298221fc2801ce4e3c0589de0378c68b7a32503101de675a85f6e3569c78ec6cb4b1bc5aa85094637532a34d10c110a4a9cdfa96c525dc4362e0236d5c
   languageName: node
   linkType: hard
 
@@ -8939,7 +8939,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16184,7 +16184,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,13 +3332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2026.5.14":
-  version: 2026.5.14
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.14"
+"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz":
+  version: 2026.5.6
+  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/24780dbfd2c9cf50c9b3ec877b4cad18bd30ca01202445215fdaadbf627bdf961d04354e7329cd05e2d5d58ad02d539972769d4848e682eaaf5aca57fdbca63f
+  checksum: 10/1d42c26f29b2694656877b5b3e70a97fc5075130b777d4aa83a7f91f0c4862df416aadebd88f30b2ecf9eee3a7981c27433842171f28a3cc78c416444804b9f3
   languageName: node
   linkType: hard
 
@@ -7655,6 +7655,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/validator@npm:^13.7.6":
+  version: 13.15.10
+  resolution: "@types/validator@npm:13.15.10"
+  checksum: 10/63117a776ced4d066d7fb63130d90ba487d38209dd45c25641ca1a6f5040e8394cc9a855750b919b72a923c5ffb51f8474f213b10b5aaa27d9db108bef07ad10
+  languageName: node
+  linkType: hard
+
 "@types/whatwg-mimetype@npm:^3.0.2":
   version: 3.0.2
   resolution: "@types/whatwg-mimetype@npm:3.0.2"
@@ -8932,7 +8939,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.14"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16177,7 +16184,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.14"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/96cb88a7aeac5ec38aeaf688b0784a0abeb7af47/src/typescript/mitxonline-api-axios/package.tgz"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"
@@ -17804,6 +17811,7 @@ __metadata:
     "@types/react-google-recaptcha": "npm:^2.1.9"
     "@types/react-slick": "npm:^0.23.13"
     "@types/tinycolor2": "npm:^1.4.6"
+    "@types/validator": "npm:^13.7.6"
     api: "workspace:*"
     dotenv: "npm:^17.0.0"
     embla-carousel-react: "npm:^8.6.0"
@@ -17823,6 +17831,7 @@ __metadata:
     storybook: "npm:^10.2.4"
     tiny-invariant: "npm:^1.3.3"
     typescript: "npm:^5.5.4"
+    validator: "npm:^13.11.0"
     wheel-indicator: "npm:^1.3.0"
   peerDependencies:
     "@mitodl/smoot-design": ^6.27.0
@@ -22971,6 +22980,13 @@ __metadata:
   version: 5.0.1
   resolution: "validate-npm-package-name@npm:5.0.1"
   checksum: 10/0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
+  languageName: node
+  linkType: hard
+
+"validator@npm:^13.11.0":
+  version: 13.12.0
+  resolution: "validator@npm:13.12.0"
+  checksum: 10/db6eb0725e2b67d60d30073ae8573982713b5903195d031dc3c7db7e82df8b74e8c13baef8e2106d146d979599fd61a06cde1fec5c148e4abd53d52817ff0fd9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,13 +3332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2026.5.1":
-  version: 2026.5.1
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.1"
+"@mitodl/mitxonline-api-axios@npm:2026.5.21":
+  version: 2026.5.21
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.5.21"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/6eb179298221fc2801ce4e3c0589de0378c68b7a32503101de675a85f6e3569c78ec6cb4b1bc5aa85094637532a34d10c110a4a9cdfa96c525dc4362e0236d5c
+  checksum: 10/01f91379031fff433fe511ad7fd49f7b0f77d4d45c22c693ab07e191586c98f0e90ba15bca966a3a5cba0039e1a1b85fa776128742a84b626fb6c736270df7f3
   languageName: node
   linkType: hard
 
@@ -7655,13 +7655,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/validator@npm:^13.7.6":
-  version: 13.15.10
-  resolution: "@types/validator@npm:13.15.10"
-  checksum: 10/63117a776ced4d066d7fb63130d90ba487d38209dd45c25641ca1a6f5040e8394cc9a855750b919b72a923c5ffb51f8474f213b10b5aaa27d9db108bef07ad10
-  languageName: node
-  linkType: hard
-
 "@types/whatwg-mimetype@npm:^3.0.2":
   version: 3.0.2
   resolution: "@types/whatwg-mimetype@npm:3.0.2"
@@ -8939,7 +8932,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.21"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16184,7 +16177,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:2026.5.1"
+    "@mitodl/mitxonline-api-axios": "npm:2026.5.21"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"
@@ -17811,7 +17804,6 @@ __metadata:
     "@types/react-google-recaptcha": "npm:^2.1.9"
     "@types/react-slick": "npm:^0.23.13"
     "@types/tinycolor2": "npm:^1.4.6"
-    "@types/validator": "npm:^13.7.6"
     api: "workspace:*"
     dotenv: "npm:^17.0.0"
     embla-carousel-react: "npm:^8.6.0"
@@ -17831,7 +17823,6 @@ __metadata:
     storybook: "npm:^10.2.4"
     tiny-invariant: "npm:^1.3.3"
     typescript: "npm:^5.5.4"
-    validator: "npm:^13.11.0"
     wheel-indicator: "npm:^1.3.0"
   peerDependencies:
     "@mitodl/smoot-design": ^6.27.0
@@ -22980,13 +22971,6 @@ __metadata:
   version: 5.0.1
   resolution: "validate-npm-package-name@npm:5.0.1"
   checksum: 10/0d583a1af23aeffea7748742cf22b6802458736fb8b60323ba5949763824d46f796474b0e1b9206beb716f9d75269e19dbd7795d6b038b29d561be95dd827381
-  languageName: node
-  linkType: hard
-
-"validator@npm:^13.11.0":
-  version: 13.12.0
-  resolution: "validator@npm:13.12.0"
-  checksum: 10/db6eb0725e2b67d60d30073ae8573982713b5903195d031dc3c7db7e82df8b74e8c13baef8e2106d146d979599fd61a06cde1fec5c148e4abd53d52817ff0fd9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10652
https://github.com/mitodl/mitxonline/pull/3426#issuecomment-4384096689
### Description (What does it do?)


Bumps `@mitodl/mitxonline-api-axios` to a pre-release build from
[mitxonline#3426](https://github.com/mitodl/mitxonline/pull/3426), which
corrects the OpenAPI spec so that the `page` field on `V2Program`,
`V2ProgramDetail`, `V2Course`, and `CourseWithCourseRunsSerializerV2` is
now typed as `T | null`.

**Once the changes are validated in this PR, we will merge the https://github.com/mitodl/mitxonline/pull/3426 and use the latest mitxonline-api-clients version instead of the pre-release.**

**Why the type change?** The API was already returning `null` for `page`
on courses/programs without a Wagtail CMS page — the spec just wasn't
reflecting it. The v2 programs serializer was also returning an
inconsistent fallback object (`{"feature_image_src": url}`) instead of
`null`; that is removed in the upstream PR.

This PR guards every `page` field access with optional chaining so
resources without a linked CMS page render gracefully instead of crashing.

### Changes

| File | Guards added |
|---|---|
| `ContractContent.tsx` | `program.page?.description` |
| `CoursePage.tsx` | `page.course_details.page?.feature_image_src`, `?.description` |
| `ProgramPage.tsx` | `page.program_details.page?.feature_image_src`, `?.description` |
| `ProgramAsCoursePage.tsx` | `page.program_details.page?.feature_image_src`, `?.description` |
| `ProductSummary.tsx` | `page?.length`, `page?.effort`, `page?.financial_assistance_form_url` |

### Screenshots (if appropriate):



### How can this be tested?
Page loads without crash, falls back to default placeholder image, description is empty:

<img width="1837" height="894" alt="Screenshot 2026-05-18 at 5 05 05 PM" src="https://github.com/user-attachments/assets/916f025e-df79-4976-a11f-1f26b097cfa7" />

Product page with CMS page: Hero image, description, and info box all render correctly.
<img width="1680" height="1042" alt="Screenshot 2026-05-18 at 4 13 37 PM" src="https://github.com/user-attachments/assets/773a5cfa-d3f3-4de6-9b36-2268db2f703a" />


## Start Services

### Terminal 1 — MITx Online

```bash
cd /path/to/mitxonline
docker compose up
```

### Terminal 2 — MIT Learn

```bash
cd /path/to/mit-learn
docker compose up
```

### Backpopulate MITx Online Data

From `mit-learn/`:

```bash
docker compose run --rm web python manage.py backpopulate_mitxonline_data
```

---

# Select a Test Program

Pick any published program from the backpopulate output, or find one manually:

```bash
docker compose run --rm web python manage.py shell -c "
from learning_resources.models import LearningResource

p = LearningResource.objects.filter(
    resource_type='program',
    published=True,
    platform__code='mitxonline'
).first()

print(p.readable_id, '|', p.title)
"
```

---

# Test A — Unit Tests

Covers the `page === null` scenario end-to-end.

```bash
docker exec mit-learn-watch-1 yarn test \
  frontends/main/src/app-pages/ProductPages/ \
  frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx \
  --watchAll=false
```

## Expected Result

* [ ] All tests pass

---

# Test B — Baseline Program With Full CMS Page

Visit:

```text
http://open.odl.local:8062/programs/<readable_id>
```

## Expected Result

* [x] Hero image renders
* [x] Description renders
* [x] Info box renders
* [x] No JavaScript errors in browser console

---

# Test C — Program With `feature_image_src: null`

This test removes the hero image from a program CMS page so
`feature_image_src` returns `null`, exercising the image fallback guard.

---

## 3a. In MITx Online — Remove the Program Image

From `mitxonline/`:

```bash
docker compose run --rm web python manage.py shell
```

```python
from cms.models import ProgramPage

# Use any program that has a page
page = ProgramPage.objects.filter(program__isnull=False).first()

print(f"Using: {page.program.readable_id} | image={page.image}")

# Save the image so you can restore it later
original_image = page.image

# Remove image
page.image = None

revision = page.save_revision()
revision.publish()

print("Done — feature_image_src is now null")
```

---

## 3b. In MIT Learn — Sync the Change

```bash
docker compose run --rm web python manage.py backpopulate_mitxonline_data
```

---

## 3c. Visit the Program URL

```text
http://open.odl.local:8062/programs/<same readable_id>
```

## Expected Result

* [x] Page loads without crashing
* [x] No `TypeError` in browser console
* [x] Hero image falls back to default placeholder
* [x] Title renders
* [x] Description renders
* [x] Enrollment button renders
* [x] Course list renders

---

## 3d. Restore the Image

Back in the MITx Online shell from step 3a:

```python
page.image = original_image

revision = page.save_revision()
revision.publish()

print("Restored")
```

Then re-sync MIT Learn:

```bash
docker compose run --rm web python manage.py backpopulate_mitxonline_data
```

---

# Test D — Dashboard With Program That Has No CMS Page

This tests `ContractContent` where `program.page` is genuinely `null`
at runtime. This reads the MITx Online Programs API directly rather than
MIT Learn's database.

---

## 4a. In MITx Online — Create a Program With No Page

```bash
docker compose run --rm web python manage.py shell
```

```python
from courses.models import Program, ProgramEnrollment
from django.contrib.auth import get_user_model

User = get_user_model()

# Find a program that has no Wagtail CMS page
p = Program.objects.filter(page__isnull=True, live=True).first()

if not p:
    # Create one
    p = Program.objects.create(
        readable_id="program-v1:test+no-page",
        title="Test Program No Page",
        live=True,
    )

    print(f"Created: {p.readable_id}")
else:
    print(f"Using existing: {p.readable_id} | {p.title}")

# Enroll your test user
user = User.objects.get(email="<your-test-user@email.com>")

enrollment, created = ProgramEnrollment.objects.get_or_create(
    user=user,
    program=p,
    defaults={
        "enrollment_mode": "honor",
        "status": "enrolled",
    },
)

print(f"Enrollment {'created' if created else 'already existed'}")
```

---

## 4b. Verify Dashboard Behavior

Log into MIT Learn as the enrolled test user and visit:

```text
http://open.odl.local:8062/dashboard
```

Find the no-page program in the enrolled programs list.

## Expected Result

* [x] Dashboard loads without crashing
* [x] No `TypeError: Cannot read properties of null` in console
* [x] Program card renders successfully
* [x] Description is empty instead of causing a crash

