### PR TITLE
Dashboard Refactor, useProgramDashboardData

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -36,7 +36,7 @@ import { matchOrganizationBySlug } from "@/common/utils"
 import { ResourceType, getKey } from "./CoursewareDisplay/helpers"
 import {
   getDistinctDashboardLanguageOptions,
-  resolveSlotForLanguage,
+  resolveCourseEntryForLanguage,
 } from "./CoursewareDisplay/model/dashboardViewModel"
 import UnstyledRawHTML from "@/components/UnstyledRawHTML/UnstyledRawHTML"
 
@@ -397,12 +397,13 @@ const OrgProgramCollectionDisplay: React.FC<{
             enrollments?.filter(
               (enrollment) => enrollment.b2b_contract_id === contract.id,
             ) ?? []
-          const { displayedEnrollment, displayedRun } = resolveSlotForLanguage(
-            course,
-            contractEnrollments,
-            selectedLanguageKey,
-            { contractId: contract.id },
-          )
+          const { displayedEnrollment, displayedRun } =
+            resolveCourseEntryForLanguage(
+              course,
+              contractEnrollments,
+              selectedLanguageKey,
+              { contractId: contract.id },
+            )
 
           const resource = displayedEnrollment
             ? {
@@ -508,7 +509,7 @@ const OrgProgramDisplay: React.FC<{
                   (enrollment) => enrollment.b2b_contract_id === contract?.id,
                 ) ?? []
               const { displayedEnrollment, displayedRun } =
-                resolveSlotForLanguage(
+                resolveCourseEntryForLanguage(
                   course,
                   contractEnrollments,
                   selectedLanguageKey,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Test layering — what belongs in THIS file:
+ *
+ * 1. Smoke / seam tests for the HomeEnrollmentsDisplay <-> useHomeDashboardData
+ *    integration: that the hook's output actually renders (e.g. N enrollments
+ *    -> N cards). Only the rendered component proves the seam — the hook test
+ *    asserts the data, not that it renders.
+ * 2. Genuine component-level concerns: simple display cases, a11y
+ *    roles/headings, user interactions (context-menu clicks, "Show all"
+ *    expand/collapse, empty / "My Learning" states).
+ *
+ * Exhaustive case coverage — bucketing, ordering, dedup, B2B filtering,
+ * completion math, language-key resolution — belongs in the pure model
+ * (model/dashboardViewModel.test.ts) or the hook tests
+ * (hooks/useHomeDashboardData.test.tsx), NOT here.
+ */
 import React from "react"
 import { act } from "@testing-library/react"
 import {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -1,3 +1,20 @@
+/**
+ * Test layering — what belongs in THIS file:
+ *
+ * 1. Smoke / seam tests for the ProgramEnrollmentDisplay <->
+ *    useProgramDashboardData integration: that the hook's output actually
+ *    renders (sections -> cards, the right kind per item). Only the rendered
+ *    component proves the seam.
+ * 2. Genuine component-level concerns: simple display cases, a11y
+ *    roles/headings, user interactions (enroll dialog, certificate button,
+ *    language <select>), 404 / not-enrolled state.
+ *
+ * Exhaustive case coverage — req-tree ordering, completion/elective caps,
+ * language-key resolution, program-as-course derivation — belongs in the
+ * pure model (model/dashboardViewModel.test.ts) or the hook tests
+ * (hooks/useProgramDashboardData.test.tsx, useDashboardLanguagePicker.test.ts),
+ * NOT here.
+ */
 import React from "react"
 import { waitFor } from "@testing-library/react"
 import {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -16,7 +16,7 @@ import {
   getDistinctDashboardLanguageOptions,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
-  resolveSlotForLanguage,
+  resolveCourseEntryForLanguage,
 } from "./model/dashboardViewModel"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { programsQueries } from "api/mitxonline-hooks/programs"
@@ -446,7 +446,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                   const courseEnrollments =
                     enrollmentsByCourseId[item.course.id] || []
                   const { displayedEnrollment, displayedRun } =
-                    resolveSlotForLanguage(
+                    resolveCourseEntryForLanguage(
                       item.course,
                       courseEnrollments,
                       selectedLanguageKey,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -1,5 +1,4 @@
-import React, { useEffect } from "react"
-import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
+import React from "react"
 import {
   SimpleSelectField,
   Skeleton,
@@ -9,28 +8,13 @@ import {
   theme,
 } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
-import { useQuery } from "@tanstack/react-query"
-import { getRequirementsProgress, getKey, ResourceType } from "./helpers"
+import { getKey, ResourceType } from "./helpers"
 import { DashboardCard, DashboardType } from "./DashboardCard"
-import {
-  getDistinctDashboardLanguageOptions,
-  groupCourseRunEnrollmentsByCourseId,
-  groupProgramEnrollmentsByProgramId,
-  resolveCourseEntryForLanguage,
-} from "./model/dashboardViewModel"
-import { coursesQueries } from "api/mitxonline-hooks/courses"
-import { programsQueries } from "api/mitxonline-hooks/programs"
-import {
-  CourseWithCourseRunsSerializerV2,
-  DisplayModeEnum,
-  V2ProgramDetail,
-  V2ProgramRequirement,
-  V3UserProgramEnrollment,
-} from "@mitodl/mitxonline-api-axios/v2"
 import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
-import { getIdsFromReqTree } from "@/common/mitxonline"
 import { RiAwardFill } from "@remixicon/react"
+import { useProgramDashboardData } from "./hooks/useProgramDashboardData"
+import { adaptCourseEntryToLegacyDashboardCardProps } from "./model/dashboardAdapters"
 
 const DashboardCardStyled = styled(DashboardCard)({
   borderRadius: "8px",
@@ -67,73 +51,6 @@ export const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   width: "120px",
 }))
 
-interface ResourceItem {
-  id: number
-  type: "course" | "program"
-}
-
-type CourseRequirementItem = {
-  resourceType: "course"
-  course: CourseWithCourseRunsSerializerV2
-}
-
-type ProgramAsCourseRequirementItem = {
-  resourceType: "program-as-course"
-  courseProgramId: number
-  courseProgram: V2ProgramDetail
-  courseProgramEnrollment: V3UserProgramEnrollment | undefined
-}
-
-type ProgramEnrollmentRequirementItem = {
-  resourceType: "program-enrollment"
-  enrollment: V3UserProgramEnrollment
-}
-
-type RequirementSectionItem =
-  | CourseRequirementItem
-  | ProgramAsCourseRequirementItem
-  | ProgramEnrollmentRequirementItem
-
-type RequirementSection = {
-  key: string | number | null | undefined
-  title: string
-  items: RequirementSectionItem[]
-  node: V2ProgramRequirement
-}
-
-const extractResourcesFromNode = (
-  node: V2ProgramRequirement,
-): ResourceItem[] => {
-  const resources: ResourceItem[] = []
-
-  if (node.data.node_type === "course" && node.data.course) {
-    resources.push({ id: node.data.course, type: "course" })
-  } else if (node.data.node_type === "program" && node.data.required_program) {
-    resources.push({ id: node.data.required_program, type: "program" })
-  }
-
-  if (node.children) {
-    node.children.forEach((child) => {
-      resources.push(...extractResourcesFromNode(child))
-    })
-  }
-
-  return resources
-}
-
-const getRequirementSectionTitle = (node: V2ProgramRequirement): string => {
-  if (node.data.title) {
-    return node.data.title
-  }
-  if (node.data.elective_flag) {
-    if (node.data.operator === "min_number_of" && node.data.operator_value) {
-      return `Electives (Complete ${node.data.operator_value})`
-    }
-    return "Elective Courses"
-  }
-  return "Core Courses"
-}
-
 interface ProgramEnrollmentDisplayProps {
   programId: number
 }
@@ -141,201 +58,9 @@ interface ProgramEnrollmentDisplayProps {
 const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
   programId,
 }) => {
-  const { data: rawEnrollments, isLoading: userEnrollmentsLoading } = useQuery(
-    enrollmentQueries.courseRunEnrollmentsList(),
-  )
-  const { data: program, isLoading: programLoading } = useQuery(
-    programsQueries.programDetail({ id: programId.toString() }),
-  )
+  const data = useProgramDashboardData(programId)
 
-  const { data: programEnrollments, isLoading: programEnrollmentsLoading } =
-    useQuery(enrollmentQueries.programEnrollmentsList())
-  const enrolledInProgram = programEnrollments?.some((enrollment) => {
-    return enrollment.program.id === program?.id
-  })
-
-  const programEnrollment = programEnrollments?.find(
-    (enrollment) => enrollment.program.id === program?.id,
-  )
-
-  const { data: programCourses, isLoading: programCoursesLoading } = useQuery({
-    ...coursesQueries.coursesList({
-      id: program?.courses || [],
-      page_size: program?.courses?.length || undefined,
-    }),
-    enabled: !!program && program.courses.length > 0 && enrolledInProgram,
-  })
-
-  const requiredProgramIds = React.useMemo(() => {
-    if (!program?.req_tree) return []
-
-    return [...new Set(getIdsFromReqTree(program.req_tree).programIds)]
-  }, [program?.req_tree])
-
-  const { data: requiredPrograms, isLoading: requiredProgramsLoading } =
-    useQuery({
-      ...programsQueries.programsList({
-        id: requiredProgramIds,
-        page_size: requiredProgramIds.length || undefined,
-      }),
-      enabled: Boolean(enrolledInProgram && requiredProgramIds.length > 0),
-    })
-
-  const requiredProgramList = React.useMemo(
-    () => requiredPrograms?.results ?? [],
-    [requiredPrograms?.results],
-  )
-
-  const programAsCourseCourseIds = React.useMemo(() => {
-    const uniqueIds = new Set<number>()
-
-    requiredProgramList
-      .filter(
-        (requiredProgram) =>
-          requiredProgram.display_mode === DisplayModeEnum.Course,
-      )
-      .forEach((requiredProgram) => {
-        requiredProgram.courses?.forEach((courseId) => uniqueIds.add(courseId))
-      })
-
-    return [...uniqueIds]
-  }, [requiredProgramList])
-
-  const {
-    data: requiredProgramCourses,
-    isLoading: requiredProgramCoursesLoading,
-  } = useQuery({
-    ...coursesQueries.coursesList({
-      id: programAsCourseCourseIds,
-      page_size: programAsCourseCourseIds.length || undefined,
-    }),
-    enabled: Boolean(enrolledInProgram && programAsCourseCourseIds.length > 0),
-  })
-
-  const isLoading =
-    userEnrollmentsLoading ||
-    programLoading ||
-    programEnrollmentsLoading ||
-    programCoursesLoading ||
-    requiredProgramsLoading ||
-    requiredProgramCoursesLoading
-
-  const enrollmentsByCourseId = groupCourseRunEnrollmentsByCourseId(
-    rawEnrollments ?? [],
-  )
-
-  const programEnrollmentsById = groupProgramEnrollmentsByProgramId(
-    programEnrollments ?? [],
-  )
-
-  const allProgramCourses = React.useMemo(
-    () => programCourses?.results ?? [],
-    [programCourses?.results],
-  )
-  const languageOptions = React.useMemo(
-    () =>
-      getDistinctDashboardLanguageOptions(
-        allProgramCourses,
-        rawEnrollments ?? [],
-      ),
-    [allProgramCourses, rawEnrollments],
-  )
-  const [selectedLanguageKey, setSelectedLanguageKey] = React.useState("")
-  useEffect(() => {
-    if (languageOptions.length === 0) {
-      if (selectedLanguageKey) {
-        setSelectedLanguageKey("")
-      }
-      return
-    }
-    const hasSelectedLanguage = languageOptions.some(
-      (option) => option.value === selectedLanguageKey,
-    )
-    if (!hasSelectedLanguage) {
-      setSelectedLanguageKey(String(languageOptions[0].value))
-    }
-  }, [languageOptions, selectedLanguageKey])
-
-  const requirementSections: RequirementSection[] =
-    program?.req_tree
-      .filter((node) => node.data.node_type === "operator")
-      .map((node) => {
-        const coursesById = new Map(
-          (programCourses?.results ?? []).map((c) => [c.id, c]),
-        )
-        const programsById = new Map(requiredProgramList.map((p) => [p.id, p]))
-
-        const sectionItems = extractResourcesFromNode(node)
-          .map((resource) => {
-            if (resource.type === "course") {
-              const course = coursesById.get(resource.id)
-              if (!course) return null
-              return {
-                resourceType: "course" as const,
-                course,
-              }
-            }
-
-            const requiredProgram = programsById.get(resource.id)
-            if (!requiredProgram) return null
-
-            const isProgramAsCourse =
-              requiredProgram.display_mode === DisplayModeEnum.Course
-
-            if (isProgramAsCourse) {
-              return {
-                resourceType: "program-as-course" as const,
-                courseProgramId: requiredProgram.id,
-                courseProgram: requiredProgram,
-                courseProgramEnrollment:
-                  programEnrollmentsById[requiredProgram.id],
-              }
-            }
-
-            const enrollment = programEnrollmentsById[requiredProgram.id]
-            if (!enrollment) return null
-
-            return {
-              resourceType: "program-enrollment" as const,
-              enrollment,
-            }
-          })
-          .filter((item) => item !== null)
-
-        return {
-          key: node.id,
-          title: getRequirementSectionTitle(node),
-          items: sectionItems,
-          node,
-        }
-      })
-      .filter((section) => section.items.length > 0) || []
-
-  const requiredProgramModuleCoursesByProgramId = React.useMemo(() => {
-    const courses = requiredProgramCourses?.results ?? []
-
-    return requiredProgramList.reduce<Record<number, typeof courses>>(
-      (acc, requiredProgram) => {
-        const requiredCourseIds = new Set(requiredProgram.courses ?? [])
-        acc[requiredProgram.id] = courses.filter((course) =>
-          requiredCourseIds.has(course.id),
-        )
-        return acc
-      },
-      {},
-    )
-  }, [requiredProgramList, requiredProgramCourses?.results])
-
-  const { completed: completedCount, total: totalCount } =
-    getRequirementsProgress(
-      requirementSections.map((s) => s.node),
-      enrollmentsByCourseId,
-      programEnrollmentsById,
-    )
-
-  const programCertificateUrl = programEnrollment?.certificate?.link ?? null
-
-  if (isLoading) {
+  if (data.isLoading) {
     return (
       <Stack direction="column">
         <Stack direction="column" marginBottom="56px">
@@ -351,7 +76,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
       </Stack>
     )
   }
-  if (!enrolledInProgram) {
+  if (!data.enrolledInProgram) {
     return <NotFoundPage />
   }
   return (
@@ -364,17 +89,19 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
         >
           <Typography variant="h5" color={theme.custom.colors.silverGrayDark}>
             Program
-            {program?.program_type ? `: ${program?.program_type}` : ""}
+            {data.programType ? `: ${data.programType}` : ""}
           </Typography>
-          {languageOptions.length > 1 && (
+          {data.availableLanguages.length > 1 && (
             <ProgramLanguageSelect
               size="small"
               label="Learning Language:"
-              value={selectedLanguageKey}
-              onChange={(e) => setSelectedLanguageKey(String(e.target.value))}
-              options={languageOptions}
+              value={data.selectedLanguageKey}
+              onChange={(e) =>
+                data.setSelectedLanguageKey(String(e.target.value))
+              }
+              options={data.availableLanguages}
               renderValue={(value) => {
-                const selected = languageOptions.find(
+                const selected = data.availableLanguages.find(
                   (opt) => opt.value === value,
                 )
                 return String(selected?.label ?? "")
@@ -383,23 +110,23 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
           )}
         </Stack>
         <Typography component="h1" variant="h3" paddingBottom="32px">
-          {program?.title}
+          {data.programTitle}
         </Typography>
         <Stack direction="row" justifyContent="space-between">
           <Typography variant="body2">
             You have completed
             <Typography component="span" variant="subtitle2">
-              {` ${completedCount} of ${totalCount} courses `}
+              {` ${data.completedCount} of ${data.totalCount} courses `}
             </Typography>
             for this program.
           </Typography>
           <Stack direction="column" alignItems="flex-end" gap="8px">
-            {programCertificateUrl && (
+            {data.programCertificateUrl && (
               <ProgramCertificateButton
                 variant="bordered"
                 size="small"
                 startIcon={<RiAwardFill />}
-                href={programCertificateUrl}
+                href={data.programCertificateUrl}
               >
                 Certificate
               </ProgramCertificateButton>
@@ -407,14 +134,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
           </Stack>
         </Stack>
       </Stack>
-      {requirementSections.map((section, index) => {
-        const { completed: sectionCompleted, total: sectionTotal } =
-          getRequirementsProgress(
-            [section.node],
-            enrollmentsByCourseId,
-            programEnrollmentsById,
-          )
-
+      {data.sections.map((section, index) => {
         return (
           <React.Fragment key={section.key}>
             <Stack
@@ -430,77 +150,53 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
               >
                 {section.title}
               </Typography>
-              {sectionTotal > 0 ? (
+              {section.total > 0 ? (
                 <Typography
                   data-testid="section-completion-count"
                   variant="body2"
                   color={theme.custom.colors.silverGrayDark}
                 >
-                  Completed {sectionCompleted} of {sectionTotal}
+                  Completed {section.completed} of {section.total}
                 </Typography>
               ) : null}
             </Stack>
             <Stack direction="column" gap="16px">
               {section.items.map((item) => {
-                if (item.resourceType === "course") {
-                  const courseEnrollments =
-                    enrollmentsByCourseId[item.course.id] || []
-                  const { displayedEnrollment, displayedRun } =
-                    resolveCourseEntryForLanguage(
-                      item.course,
-                      courseEnrollments,
-                      selectedLanguageKey,
-                    )
-
-                  const resource = displayedEnrollment
-                    ? {
-                        type: DashboardType.CourseRunEnrollment,
-                        data: displayedEnrollment,
-                      }
-                    : { type: DashboardType.Course, data: item.course }
-
-                  const runId = displayedEnrollment?.run.id ?? displayedRun?.id
-
+                if (item.kind === "course") {
+                  // buttonHref and contractId are also returned but not used here
+                  // (not applicable inside the program/B2C dashboard)
+                  const adapted = adaptCourseEntryToLegacyDashboardCardProps(
+                    item.entry,
+                  )
                   return (
                     <DashboardCardStyled
                       key={getKey({
                         resourceType: ResourceType.Course,
-                        id: item.course.id,
-                        runId,
+                        id: item.entry.course.id,
+                        runId:
+                          item.entry.displayedEnrollment?.run.id ??
+                          item.entry.displayedRun?.id,
                       })}
-                      resource={resource}
-                      programEnrollment={programEnrollment}
+                      resource={adapted.resource}
+                      programEnrollment={adapted.programEnrollment}
                       showNotComplete={false}
-                      selectedCourseRun={displayedRun}
+                      selectedCourseRun={adapted.selectedCourseRun}
                     />
                   )
                 }
 
-                if (item.resourceType === "program-as-course") {
+                if (item.kind === "program-as-course") {
                   return (
                     <ProgramAsCourseCard
                       key={getKey({
                         resourceType: ResourceType.Program,
-                        id: item.courseProgramId,
+                        id: item.courseProgram.id,
                       })}
                       courseProgram={item.courseProgram}
-                      moduleCourses={
-                        requiredProgramModuleCoursesByProgramId[
-                          item.courseProgramId
-                        ] ?? []
-                      }
-                      moduleEnrollmentsByCourseId={enrollmentsByCourseId}
+                      moduleCourses={item.moduleCourses}
+                      moduleEnrollmentsByCourseId={data.enrollmentsByCourseId}
                       courseProgramEnrollment={item.courseProgramEnrollment}
-                      ancestorProgramEnrollment={
-                        programEnrollment
-                          ? {
-                              readable_id:
-                                programEnrollment.program.readable_id,
-                              enrollment_mode:
-                                programEnrollment.enrollment_mode,
-                            }
-                          : undefined
-                      }
+                      ancestorProgramEnrollment={data.ancestorProgramEnrollment}
                     />
                   )
                 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
@@ -400,11 +400,65 @@ What the model layer must hold regardless: `buildRequirementSections`, slot cons
 
 **Purpose:** Move program-dashboard query orchestration, requirement-tree shaping, language policy, and slot construction out of `ProgramEnrollmentDisplay`.
 
-**Pre-decisions (settle at Phase 4 brainstorming, before code):**
+**Pre-decisions — SETTLED at Phase 4 brainstorming (2026-05-19).** Full design
+record with rationale + rejected alternatives:
+`feature_work/TODOS_AND_IDEAS/phase4-design.md` (local; gitignored). Summary:
 
-1. **Slot/adapter: prove or delete.** `DashboardCourseSlot` + `adaptCourseSlotToLegacyDashboardCardProps` (Phase 1) currently have **zero production consumers**, and `resolveSlotForLanguage` returns a fragment (`{ displayedEnrollment, displayedRun, selectedLanguageOption }`), not a slot. Home did **not** exercise them (Home is structurally enrollment-flat — one card per enrollment, heterogeneous incl. program / program-as-course — so it cannot be cleanly slot-shaped without regressing its multi-enrollment behavior; forcing degenerate per-enrollment slots would prove nothing). **Phase 4/Program is the first genuine slot consumer.** The decision: either (A) build a real `buildCourseSlot(...) → DashboardCourseSlot` constructor, have `useProgramDashboardData` emit slot-bearing requirement sections, and route them through `adaptCourseSlotToLegacyDashboardCardProps` at the render callsite — actually exercising the durable contract end-to-end; or (B) delete `DashboardCourseSlot` + `dashboardAdapters.ts` as speculative and have Program build the legacy resource union directly (keeping only the "one test-layering pattern" claim, dropping "one data contract"). Default lean: **(A)** — the slot is the whole point of the refactor's Phase 7 payoff; do not carry dead Phase-1 abstractions indefinitely, and do not let Program quietly hand-roll the resource union like the pre-refactor code did. Confirm at brainstorming.
-2. **`test-utils.ts` is infra-only, not scenario-shape.** Shared setup may own _infrastructure_ (user/org/contract identity, the `setMockResponse` plumbing) but **never the scenario shape** (the `req_tree`, the language matrix, the enrollment→run mapping). Provide a small composable `buildProgramScenario({ reqTree, courses, enrollments }) → { entities, mockAll() }` returning the built entities so each test wires its scenario-specific `coursesList`/`programsList` mocks, rather than a fixed god-`setupProgramsAndCourses`. Decide the builder shape before the first `renderHook` test, or the suite calcifies around the first test's ad-hoc shape. (Note: existing `setupProgramsAndCourses` is _contract_-shaped, not _program_-shaped — Phase 4 cannot reuse it as-is.)
-3. **Language picker — decided (option b):** `useProgramDashboardData` composes a new `useDashboardLanguagePicker(availableLanguages)` and owns `selectedLanguageKey` + the reset effect; the component is presentational. See [Resolved decision](#resolved-decision-settled-before-phase-4-hook-location-and-testing).
+1. **Slot/adapter: (A), and rename `slot` → `entry`.** Build a real
+   `buildCourseEntry(...) → DashboardCourseEntry` constructor; the composer
+   emits a discriminated-union requirement-section model; route the `course`
+   arm through `adaptCourseEntryToLegacyDashboardCardProps` at the render
+   callsite — exercising the durable contract end-to-end. Phase-1's shape is a
+   draft the first real consumer (Phase 4) finalizes. **"Slot" vocabulary
+   misleads** (reads as layout position / content projection): rename
+   `DashboardCourseSlot → DashboardCourseEntry`,
+   `buildCourseSlot → buildCourseEntry`,
+   `resolveSlotForLanguage → resolveCourseEntryForLanguage`,
+   `adaptCourseSlotToLegacyDashboardCardProps → adaptCourseEntryToLegacyDashboardCardProps`.
+   The rename spans code **and the rest of this plan doc** and is executed as
+   **step 0** (its own commit; zero production callers today). The composer
+   returns the `RequirementSectionItem` union (`course` → `entry:
+DashboardCourseEntry`; `program-as-course`; `program-enrollment`) **plus
+   shared aux** `enrollmentsByCourseId` + pre-derived
+   `ancestorProgramEnrollment` for the non-course arms (mirrors
+   `useHomeDashboardData`'s shared-map pattern; arms stay lean).
+2. **`buildProgramScenario`: option 2a (thin entities-in mock-wirer).** Tests
+   build the entities (program/courses/enrollments/req_tree) themselves with
+   existing factories + optional small composable entity helpers and pass them
+   in; `buildProgramScenario({ programId, program, programCourses,
+courseEnrollments, programEnrollments, requiredPrograms?,
+requiredProgramCourses? }) → { entities, mockAll }` only computes query keys
+   - fires `setMockResponse`. Builder owns **infra only**; tests own scenario
+     shape. (Existing `setupProgramsAndCourses` is _contract_-shaped — not
+     reusable here.)
+3. **Language picker — hook owns it.** `useProgramDashboardData` composes
+   `useDashboardLanguagePicker(availableLanguages)`; component presentational.
+   Implementation = **derive-during-render** (store raw user pick, derive
+   effective key — no reconcile effect). The composer's returned
+   `selectedLanguageKey` (and `DashboardCourseEntry.selectedLanguageKey`, and
+   `<select value>`) is the **effective** key; `setSelectedLanguageKey` records
+   the raw choice. Own test file `hooks/useDashboardLanguagePicker.test.tsx`
+   (renderHook, no API mocks — not in the pure-model suite, not in the composer
+   suite). See [Resolved decision](#resolved-decision-settled-before-phase-4-hook-location-and-testing).
+4. **Shared `parseProgramRequirementSections` in `@/common/mitxonline`.** The
+   req-tree → ordered-operator-sections → leaf `{type,id}` + elective +
+   requiredCount structural parse is shared with product `parseReqTree`
+   (`ProductPages/util.ts`). Phase 4 introduces it as a **structure-only** (hard
+   rule) helper: NO default/fallback titles, NO display copy, NO completion
+   logic, NO entity resolution — it returns ids + operator metadata +
+   `rawTitle: string | null`. Dashboard `buildRequirementSections` **composes**
+   it and owns all dashboard **display policy** (`getRequirementSectionTitle`
+   formatting incl. `min_number_of → "Electives (Complete N)"`, the
+   `items.length > 0` filter, completion counts, three-arm resolution). Product
+   `parseReqTree` is **not touched** in the Phase 4 PR; its migration to a thin
+   adapter over the shared helper is the **immediate next stacked PR**
+   (`util.test.ts` is its oracle). **Re-ask this sharing question at Phase 4
+   exit** (per the Working agreement) before declaring done.
+5. **Behavior-preservation scope.** Stable/settled render is the contract and
+   is preserved exactly. First-paint / transients may change if they converge
+   quickly to the same settled state — **except loading states**, which are
+   preserved. (Lets `useDashboardLanguagePicker` drop the legacy
+   `useState("")`+effect transient for derive-during-render.)
 
 **Files:**
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/dashboardRefactorPlan.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** This plan is **human-in-the-loop**. Do not autonomously execute multiple phases. Each phase ends at a review checkpoint with the human reviewer (see [Working agreement](#working-agreement)). The checkbox lists in each phase are **starting hypotheses**, not exhaustive specs — verify by reading current code before mechanically moving things, and surface anything you find that the plan didn't anticipate.
 
-**Goal:** Make the dashboard easier to reason about by separating data orchestration from rendering. Program and contract dashboards become slot-driven with `enrollments[]` as the source of truth, removing today's premature N→1 collapse. Visible behavior is preserved until multi-run UX is decided.
+**Goal:** Make the dashboard easier to reason about by separating data orchestration from rendering. Program and contract dashboards become entry-driven with `enrollments[]` as the source of truth, removing today's premature N→1 collapse. Visible behavior is preserved until multi-run UX is decided.
 
-**Architecture:** Use dashboard-specific data composers to move query orchestration, requirement-tree shaping, enrollment grouping, and language/run resolution out of render-heavy components. Keep `My Learning` enrollment-driven, make program/contract dashboards slot-driven, and adapt the new view model back into the existing cards before attempting card replacement.
+**Architecture:** Use dashboard-specific data composers to move query orchestration, requirement-tree shaping, enrollment grouping, and language/run resolution out of render-heavy components. Keep `My Learning` enrollment-driven, make program/contract dashboards entry-driven, and adapt the new view model back into the existing cards before attempting card replacement.
 
 **Tech Stack:** Next.js App Router, React, TypeScript, React Query, generated MITxOnline API hooks, Jest + React Testing Library, `ol-components`, `@mitodl/smoot-design`.
 
@@ -54,7 +54,7 @@ In all cases: stop, write up what you found, and pair with the human reviewer be
 
 This work is worthwhile now because the current dashboard implementation has structural risk independent of final product decisions about multi-run users. `EnrollmentDisplay.tsx` and `ContractContent.tsx` both mix data fetching, API shape translation, language selection, enrollment selection, requirement-tree shaping, and rendering. `DashboardCard.tsx` and `ModuleCard.tsx` overlap heavily, but deleting or unifying them first would preserve the wrong data contract. The code also repeatedly collapses multiple enrollments into one selected enrollment, which hides information that any future multi-run UI will need.
 
-Before introducing more new UX to the Dashboard, this plan makes the internal dashboard model honest: program and contract course slots should carry all matching enrollments, plus a clearly named temporary display choice. Current behavior should remain mostly stable while product decides whether alternate runs are shown via dropdown, dialog, inline list, expanded mode, or some other affordance.
+Before introducing more new UX to the Dashboard, this plan makes the internal dashboard model honest: program and contract course entries should carry all matching enrollments, plus a clearly named temporary display choice. Current behavior should remain mostly stable while product decides whether alternate runs are shown via dropdown, dialog, inline list, expanded mode, or some other affordance.
 
 ## Codebase review assessment
 
@@ -93,23 +93,23 @@ Based on the current code, the plan is technically correct with the constraints 
 
 ### Corrections to earlier plans
 
-- Do not make `[0]` of a sorted enrollment list the durable card contract. It is acceptable as a temporary adapter detail, but the canonical slot model must name the derived display value explicitly.
+- Do not make `[0]` of a sorted enrollment list the durable card contract. It is acceptable as a temporary adapter detail, but the canonical entry model must name the derived display value explicitly.
 - Do not change default-run selection policy to `status bucket > start_date` until product accepts the behavior. The current `selectBestEnrollment` policy may be imperfect, but replacing it is a product-visible change for multi-run users.
 - Do not ship button-label convergence, CTA run annotations, course-level certificate aggregation changes, or "Completed badge + Continue CTA" behavior as part of this structural cleanup.
 - Do not commit to deleting `DashboardCard.tsx` and `ModuleCard.tsx` on a fixed schedule. Delete them only after the new data model is in place, behavior parity is verified, and B2B/program-collection rendering has migrated safely.
-- Do not force `My Learning` into the slot model. Home currently renders one card per enrollment, which already exposes multiple enrollments. Program and contract dashboards are the places that need slot + enrollments modeling.
+- Do not force `My Learning` into the entry model. Home currently renders one card per enrollment, which already exposes multiple enrollments. Program and contract dashboards are the places that need course entry + enrollments modeling.
 
 ## Goals
 
 - Reduce dashboard complexity without waiting for final multi-run UX.
 - Move data fetching, joining, grouping, and language/run resolution out of render-heavy components.
 - Preserve visible behavior exactly during the first phases, except for explicitly called-out bug fixes or explicitly product-approved changes.
-- Make program and contract dashboard course slots carry all relevant enrollments.
+- Make program and contract dashboard course entries carry all relevant enrollments.
 - Make the selected/displayed enrollment a derived presentation choice, not the canonical data shape.
 - Keep current dashboard distinctions:
   - home is enrollment-driven,
-  - program dashboard is requirement-slot-driven,
-  - contract dashboard is contract/program/collection-slot-driven.
+  - program dashboard is requirement-entry-driven,
+  - contract dashboard is contract/program/collection-entry-driven.
 - Centralize language/run policy so future multi-run UI is additive rather than another rewrite.
 
 ## Non-goals
@@ -147,16 +147,16 @@ type HomeDashboardData = {
 :<!-- Github supports: NOTE, TIP, IMPORTANT, WARNING, CAUTION -->
 
 > [!NOTE]
-> The exact shape can change during implementation, but home should not collapse multiple enrollments into one course slot.
+> The exact shape can change during implementation, but home should not collapse multiple enrollments into one course entry.
 
-### Program and contract course slot model
+### Program and contract course entry model
 
-Program and contract dashboards should use a slot model.
+Program and contract dashboards should use a course entry model.
 
-A **slot** is the per-course data shape the dashboard arranges into its layout — one slot per course, carrying that course plus every enrollment for it plus the row's display state (language selection, derived "displayed" enrollment/run, contract scoping, ancestor program context). Slot ≠ card: the slot is the data shape, the card is the UI that renders from it. Today one slot renders as one card; once multi-run UX lands, one slot might render as multiple cards (a dropdown, an expanded list, a dialog) without the slot itself changing. The plural is what carries the term's intuition: a program dashboard arranges N slots into its requirement layout; a contract dashboard arranges N slots per program. Home (`My Learning`) is _not_ slot-driven — it's enrollment-flat (one card per enrollment, multiple cards possible for the same course).
+A **course entry** is the per-course data shape the dashboard arranges into its layout — one entry per course, carrying that course plus every enrollment for it plus the row's display state (language selection, derived "displayed" enrollment/run, contract scoping, ancestor program context). Entry ≠ card: the entry is the data shape, the card is the UI that renders from it. Today one entry renders as one card; once multi-run UX lands, one entry might render as multiple cards (a dropdown, an expanded list, a dialog) without the entry itself changing. The plural is what carries the term's intuition: a program dashboard arranges N entries into its requirement layout; a contract dashboard arranges N entries per program. Home (`My Learning`) is _not_ entry-driven — it's enrollment-flat (one card per enrollment, multiple cards possible for the same course).
 
 ```ts
-type DashboardCourseSlot = {
+type DashboardCourseEntry = {
   course: CourseWithCourseRunsSerializerV2
   enrollments: CourseRunEnrollmentV3[]
   selectedLanguageKey: string
@@ -182,13 +182,13 @@ Rules:
 - When legacy cards are replaced (Phase 8), enrolled cards consume V3 enrollment data from `enrollments[]` directly and Case 1 of the synthesis can be deleted.
 - Cases 2 and 3 of `getResolvedRunForSelectedLanguage` remain. Case 2 is a trivial passthrough (the selected language has a real `CourseRunV2` in `course.courseruns`). Case 3 (pre-enrollment, no real `CourseRunV2` for the selected language) is a load-bearing workaround for an API gap: mitxonline does not surface per-language run metadata pre-enrollment. Case 3 is removable only if/when that API gap closes.
 
-### Open question: are display fields permanent on the slot?
+### Open question: are display fields permanent on the entry?
 
-`displayedEnrollment` and `displayedRun` are not strictly necessary on the slot — the legacy adapter could compute them inline from `enrollments` + `selectedLanguageKey`. They are on the slot for convenience: the hook is computing them anyway (Phase 2's composite resolver), caching the result keeps the adapter as pure shape-conversion, and slot construction becomes unit-testable in isolation ("given course X, enrollments [A, B], lang Y → slot.displayedEnrollment = A").
+`displayedEnrollment` and `displayedRun` are not strictly necessary on the entry — the legacy adapter could compute them inline from `enrollments` + `selectedLanguageKey`. They are on the entry for convenience: the hook is computing them anyway (Phase 2's composite resolver), caching the result keeps the adapter as pure shape-conversion, and entry construction becomes unit-testable in isolation ("given course X, enrollments [A, B], lang Y → entry.displayedEnrollment = A").
 Whether these fields survive past Phase 7 hinges on multi-run UX direction:
 
-- **Parent-owned selection** (parent picks which enrollment to display, card receives `displayedEnrollment` as a controlled prop) → fields stay on the slot, expressing the parent's chosen display.
-- **Card-owned selection** (card has internal state for enrollment selection) → fields are deleted with the legacy adapter; slot becomes purer (`course`, `enrollments`, `selectedLanguageKey`, `availableLanguages`, contract/ancestor).
+- **Parent-owned selection** (parent picks which enrollment to display, card receives `displayedEnrollment` as a controlled prop) → fields stay on the entry, expressing the parent's chosen display.
+- **Card-owned selection** (card has internal state for enrollment selection) → fields are deleted with the legacy adapter; entry becomes purer (`course`, `enrollments`, `selectedLanguageKey`, `availableLanguages`, contract/ancestor).
   Recommendation: parent-owned (consistency with `selectedLanguageKey`, no prop-to-state sync, URL-deep-linkable). But this is not blocking Phases 1–6; decide when multi-run UX lands.
 
 ## Proposed file structure
@@ -208,10 +208,10 @@ frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/
 Responsibilities:
 
 - `useHomeDashboardData` (composer): owns home queries, enrollment bucketing, card-list assembly (`assembleHomeCardList`), and loading aggregation. **As shipped in Phase 3 v3: a separate exported file `CoursewareDisplay/hooks/useHomeDashboardData.ts` with a `renderHook` suite** — see [Resolved decision](#resolved-decision-settled-before-phase-4-hook-location-and-testing).
-- `useProgramDashboardData` (composer): owns program detail query, course/enrollment/program enrollment joins, requirement-section construction, language options, slot assembly, and program-as-course slot context. Separate exported file `hooks/useProgramDashboardData.ts` + `renderHook` suite (per Resolved decision).
-- `useContractDashboardData` (composer): owns contract-scoped courses/programs/collections, contract enrollment filtering, program filtering, collection shaping, language options, slot assembly, and loading aggregation. Separate exported file `hooks/useContractDashboardData.ts` + `renderHook` suite (per Resolved decision).
-- `model/dashboardViewModel.ts`: the **single pure-model home**. Owns the canonical types (`DashboardCourseSlot`, section shapes, home buckets), grouping helpers, slot constructors, requirement-section builders, language-option computation, the composite slot/language resolver introduced in Phase 2, the renamed display-policy helper, and Cases 2 + 3 of `getResolvedRunForSelectedLanguage`. By Phase 7's end, every pure helper that survives the cleanup lives here.
-- `model/dashboardAdapters.ts`: temporary adapters from the new view model to current `DashboardCard` / `ProgramAsCourseCard` props. Deletion candidate at Phase 7 — narrows or dies once the slot→variant mapping folds into `CoursewareCard`'s variant constructors. `CoursewareCard` consumes a per-row variant union, never a slot.
+- `useProgramDashboardData` (composer): owns program detail query, course/enrollment/program enrollment joins, requirement-section construction, language options, entry assembly, and program-as-course entry context. Separate exported file `hooks/useProgramDashboardData.ts` + `renderHook` suite (per Resolved decision).
+- `useContractDashboardData` (composer): owns contract-scoped courses/programs/collections, contract enrollment filtering, program filtering, collection shaping, language options, entry assembly, and loading aggregation. Separate exported file `hooks/useContractDashboardData.ts` + `renderHook` suite (per Resolved decision).
+- `model/dashboardViewModel.ts`: the **single pure-model home**. Owns the canonical types (`DashboardCourseEntry`, section shapes, home buckets), grouping helpers, entry constructors, requirement-section builders, language-option computation, the composite entry/language resolver introduced in Phase 2, the renamed display-policy helper, and Cases 2 + 3 of `getResolvedRunForSelectedLanguage`. By Phase 7's end, every pure helper that survives the cleanup lives here.
+- `model/dashboardAdapters.ts`: temporary adapters from the new view model to current `DashboardCard` / `ProgramAsCourseCard` props. Deletion candidate at Phase 7 — narrows or dies once the entry→variant mapping folds into `CoursewareCard`'s variant constructors. `CoursewareCard` consumes a per-row variant union, never a course entry.
 
 **Layer roles (illustrative, not prescriptive — boundaries may shift at phase exits):**
 
@@ -229,7 +229,7 @@ Do not move card rendering into these files. Hooks and model helpers should retu
 
 ## Phase 1: Extract pure model and adapter helpers (complete)
 
-**Purpose:** Introduce the slot vocabulary and behavior-preserving adapters without changing rendered output.
+**Purpose:** Introduce the course entry vocabulary and behavior-preserving adapters without changing rendered output.
 
 **Files:**
 
@@ -239,10 +239,10 @@ Do not move card rendering into these files. Hooks and model helpers should retu
 - Test: `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx`
 - Test: new tests for `dashboardViewModel.ts` and `dashboardAdapters.ts`
 
-- [ ] Add a `DashboardCourseSlot` type carrying `course`, `enrollments`, `selectedLanguageKey`, `displayedEnrollment`, `displayedRun`, and optional contract/ancestor context.
+- [ ] Add a `DashboardCourseEntry` type carrying `course`, `enrollments`, `selectedLanguageKey`, `displayedEnrollment`, `displayedRun`, and optional contract/ancestor context.
 - [ ] Add grouping helpers for course-run enrollments by course id and program enrollments by program id.
 - [ ] Add a clearly named display-policy helper, such as `pickDisplayedEnrollmentForLegacyDashboard`, that initially preserves the existing `selectBestEnrollment` behavior.
-- [ ] Add adapter helpers that convert a `DashboardCourseSlot` into the existing legacy props:
+- [ ] Add adapter helpers that convert a `DashboardCourseEntry` into the existing legacy props:
   - `resource`,
   - `selectedCourseRun`,
   - `buttonHref`,
@@ -267,13 +267,13 @@ Expected: all tests pass.
 
 ## Phase 2: Collapse language/run resolution to a single composite call
 
-**Purpose:** Replace the 4-call orchestration that every callsite repeats with a single composite slot-resolution function. The win is measured at callsites, not in file structure: today both `EnrollmentDisplay.tsx` and `ContractContent.tsx` call `getEnrollmentForSelectedLanguage`, `getSelectedLanguageOption`, `getCourseRunForSelectedLanguage`, and `getResolvedRunForSelectedLanguage` together every time they render a card. After Phase 2, callsites make one call and receive `{ displayedEnrollment, displayedRun, selectedLanguageOption }`.
+**Purpose:** Replace the 4-call orchestration that every callsite repeats with a single composite entry-resolution function. The win is measured at callsites, not in file structure: today both `EnrollmentDisplay.tsx` and `ContractContent.tsx` call `getEnrollmentForSelectedLanguage`, `getSelectedLanguageOption`, `getCourseRunForSelectedLanguage`, and `getResolvedRunForSelectedLanguage` together every time they render a card. After Phase 2, callsites make one call and receive `{ displayedEnrollment, displayedRun, selectedLanguageOption }`.
 
 This phase also folds in a small, isolated bug fix: enrolled-but-not-enrollable languages currently disappear from the language picker (see [Language-union bug fix](#language-union-bug-fix) below).
 
 **Hypothesised approach** (verify before executing):
 
-- [ ] Add a composite function — working name `resolveSlotForLanguage(course, enrollments, selectedLanguageKey, { contractId })` — that returns `{ displayedEnrollment, displayedRun, selectedLanguageOption }`. Internally it calls today's primitives in the same order they are called at every callsite, so behavior is preserved by construction. **Place it in `model/dashboardViewModel.ts`** (Phase 1's pure-model home), not in `languageOptions.ts`.
+- [ ] Add a composite function — working name `resolveCourseEntryForLanguage(course, enrollments, selectedLanguageKey, { contractId })` — that returns `{ displayedEnrollment, displayedRun, selectedLanguageOption }`. Internally it calls today's primitives in the same order they are called at every callsite, so behavior is preserved by construction. **Place it in `model/dashboardViewModel.ts`** (Phase 1's pure-model home), not in `languageOptions.ts`.
 - [ ] Add a composite function for the language picker — working name `getDistinctDashboardLanguageOptions(courses, enrollments)` — that returns the union of V2 `course.language_options` across the given courses and languages from the user's V3 `enrollment.run.language`. Also placed in `dashboardViewModel.ts`.
 - [ ] Update callsites in `EnrollmentDisplay.tsx` and `ContractContent.tsx` to use the composites. The 4-call dance disappears at the callsite; render code stops knowing the orchestration exists.
 - [ ] Begin migrating helpers from `languageOptions.ts` into `dashboardViewModel.ts` opportunistically (anything the composites depend on internally can move). Full deletion of `languageOptions.ts` is committed to Phase 7; this phase need only consolidate what it touches.
@@ -308,7 +308,7 @@ Expected: all tests pass; callsite line-counts in the two render components meas
 **Fix:** Compute picker options as the union of:
 
 - enrollable V2 `course.language_options`, and
-- the language of every existing V3 enrollment for that course slot (`enrollment.run.language`).
+- the language of every existing V3 enrollment for that course entry (`enrollment.run.language`).
 
 **Why this is in scope despite "preserve visible behavior exactly":** the existing behavior is a defect — the user loses access to their own enrollment. The fix is small, isolated, has a dedicated test, and is the only intentional behavior change in the structural cleanup phases.
 
@@ -387,18 +387,18 @@ Phase 3 was redone on `cc/dashboard-refactor-phase-3-v3` to set one consistent, 
 
 - **Location**: each composer is a **separate, exported** file under `CoursewareDisplay/hooks/`. Not inlined-private. The earlier "orphaned file" objection is void precisely because the file is paired with isolated `renderHook` tests.
 - **Layered tests:**
-  1. **Pure model unit tests** (`model/dashboardViewModel.test.ts`, no React/mocks) own the domain logic — every transform the composer uses is a named helper tested here (ordering, counting, slot, language, requirement-section rules).
+  1. **Pure model unit tests** (`model/dashboardViewModel.test.ts`, no React/mocks) own the domain logic — every transform the composer uses is a named helper tested here (ordering, counting, entry, language, requirement-section rules).
   2. **`renderHook` suite** per composer (`hooks/useXxxDashboardData.test.tsx`) asserts the composer wires queries → helpers → the returned contract. Reuses the **shared scenario setup** in `CoursewareDisplay/test-utils.ts`; mock setup is not duplicated.
   3. **The pre-existing component integration test is not modified by the extraction** — it is the extraction's behavior-preservation oracle. ("Not modified by the extraction commit," scoped to the extraction; if the test file is itself new earlier on the same branch, say so explicitly so branch-vs-`main` reviewers aren't misled.) It is slimmed only in a later, separate pass — never in the same PR as the extraction (a deleted test is indistinguishable from a regression in the same diff).
 - **Why `renderHook` (reversing Phase-3-v1 reasoning):** asserting on returned data is clearer and faster to bisect than DOM assertions; "duplicates mock setup" is answered by the shared `test-utils` scenario factory, not by inlining the hook.
-- **Phase-7 stability rule:** the composer emits the **durable contract** (Home: `{ cards, initiallyVisibleCount, … }`; Program: slot-bearing requirement sections — see Phase 4). It never emits adapted/legacy card props; `adaptCourseSlotToLegacyDashboardCardProps` is applied at the render callsite, never in the hook, and hook tests never assert through the adapter. This is what makes the `renderHook` investment survive the Phase 7 card unification.
-- **Language picker — decided: hook owns it (option b).** Extract `useDashboardLanguagePicker(availableLanguages)` (selected key + reset-on-options-change effect) in **Phase 4**, composed inside `useProgramDashboardData`, which returns `{ selectedLanguageKey, setSelectedLanguageKey, availableLanguages, … }`. The component becomes purely presentational (renders the `<select>` from hook-provided values; no component-side language state or effect). Rationale: Phase 4's hook must take the language key as an input to build slots regardless of a second consumer, so the YAGNI-defer argument doesn't hold — owning the key's state where its options are derived removes the hook→options→effect→key→hook cross-boundary loop (the "complexity relocated, not reduced" failure mode). Phase 5's `useContractDashboardData` reuses the same `useDashboardLanguagePicker`.
+- **Phase-7 stability rule:** the composer emits the **durable contract** (Home: `{ cards, initiallyVisibleCount, … }`; Program: entry-bearing requirement sections — see Phase 4). It never emits adapted/legacy card props; `adaptCourseEntryToLegacyDashboardCardProps` is applied at the render callsite, never in the hook, and hook tests never assert through the adapter. This is what makes the `renderHook` investment survive the Phase 7 card unification.
+- **Language picker — decided: hook owns it (option b).** Extract `useDashboardLanguagePicker(availableLanguages)` (selected key + reset-on-options-change effect) in **Phase 4**, composed inside `useProgramDashboardData`, which returns `{ selectedLanguageKey, setSelectedLanguageKey, availableLanguages, … }`. The component becomes purely presentational (renders the `<select>` from hook-provided values; no component-side language state or effect). Rationale: Phase 4's hook must take the language key as an input to build entries regardless of a second consumer, so the YAGNI-defer argument doesn't hold — owning the key's state where its options are derived removes the hook→options→effect→key→hook cross-boundary loop (the "complexity relocated, not reduced" failure mode). Phase 5's `useContractDashboardData` reuses the same `useDashboardLanguagePicker`.
 
-What the model layer must hold regardless: `buildRequirementSections`, slot constructors, contract-scoped filters (`programHasContractRuns`, `programsInCollections`, `sortedPrograms`), collection shaping. These are domain logic and need named helpers with unit tests no matter where the hook lives. The "thin composer" exit checks apply to the composer function in its `hooks/` file.
+What the model layer must hold regardless: `buildRequirementSections`, entry constructors, contract-scoped filters (`programHasContractRuns`, `programsInCollections`, `sortedPrograms`), collection shaping. These are domain logic and need named helpers with unit tests no matter where the hook lives. The "thin composer" exit checks apply to the composer function in its `hooks/` file.
 
 ## Phase 4: Extract `useProgramDashboardData`
 
-**Purpose:** Move program-dashboard query orchestration, requirement-tree shaping, language policy, and slot construction out of `ProgramEnrollmentDisplay`.
+**Purpose:** Move program-dashboard query orchestration, requirement-tree shaping, language policy, and entry construction out of `ProgramEnrollmentDisplay`.
 
 **Pre-decisions — SETTLED at Phase 4 brainstorming (2026-05-19).** Full design
 record with rationale + rejected alternatives:
@@ -476,14 +476,14 @@ requiredProgramCourses? }) → { entities, mockAll }` only computes query keys
 - [ ] Move enrollment grouping into the hook.
 - [ ] Move program enrollment lookup into the hook.
 - [ ] Move available-language computation into the hook via `dashboardLanguagePolicy.ts`.
-- [ ] Build course requirement items as `DashboardCourseSlot` objects.
+- [ ] Build course requirement items as `DashboardCourseEntry` objects.
 - [ ] Preserve current selected-language state ownership in the component unless the hook needs it as an input.
 - [ ] Return render-ready sections containing:
   - section title,
   - section node,
   - section completion counts,
-  - items for course slots,
-  - items for program-as-course slots,
+  - items for course entries,
+  - items for program-as-course entries,
   - items for nested program enrollments.
 - [ ] Use `dashboardAdapters.ts` to keep rendering through `DashboardCard` in this phase.
 - [ ] Keep `ProgramAsCourseCard` rendering through `ModuleCard` in this phase unless a minimal adapter is required.
@@ -504,9 +504,9 @@ Expected: all tests pass.
 
 **Phase exit check: thin composer.** Per the Working agreement's success criterion, this phase delivers cleanup only if `useProgramDashboardData` is a _composer_, not a re-home of inline orchestration. Concrete checks at exit:
 
-- Hook body line count: target ~80 lines or less, mostly fetch + compose + return. Requirement-section construction, enrollment grouping, language-option computation, and slot construction are named helpers in `model/dashboardViewModel.ts` (or `dashboardLanguagePolicy.ts`), not inline code.
+- Hook body line count: target ~80 lines or less, mostly fetch + compose + return. Requirement-section construction, enrollment grouping, language-option computation, and entry construction are named helpers in `model/dashboardViewModel.ts` (or `dashboardLanguagePolicy.ts`), not inline code.
 - The hook composes named helpers; it doesn't re-home orchestration. Glue like `enrollments.filter(existingPredicate)` or `enrollments.sort(existingComparator)` is fine — wrapping it in a named helper would be noise. What's not fine: predicates or comparators _defined_ inline, multi-step pipelines that together encode "what the program dashboard means," or grouping/joining inline. Those are named helpers in `model/dashboardViewModel.ts` (or `dashboardLanguagePolicy.ts`).
-- Helper test coverage: `buildRequirementSections`, slot constructors, and grouping helpers each have isolated unit tests.
+- Helper test coverage: `buildRequirementSections`, entry constructors, and grouping helpers each have isolated unit tests.
 - Consuming callsite shrinkage: `ProgramEnrollmentDisplay.tsx`'s program path measurably drops in size.
 
 If any of these fails, the phase has relocated complexity rather than reduced it. Stop and split before declaring done.
@@ -530,7 +530,7 @@ If any of these fails, the phase has relocated complexity rather than reduced it
 - [ ] Move `programHasContractRuns` into the hook.
 - [ ] Move `programsInCollections` and `sortedPrograms` computation into the hook.
 - [ ] Move program collection filtering into the hook.
-- [ ] Move `OrgProgramDisplay` course-slot data shaping into the hook or a pure helper consumed by the hook.
+- [ ] Move `OrgProgramDisplay` course-entry data shaping into the hook or a pure helper consumed by the hook.
 - [ ] Move `OrgProgramCollectionDisplay` first-course-per-program data shaping into the hook or a dedicated helper.
 - [ ] Preserve contract-scoped enrollment filtering using `b2b_contract_id`.
 - [ ] Preserve contract-scoped run filtering using `contract_id` query params and `contractId` run resolution.
@@ -553,12 +553,12 @@ Expected: all tests pass.
 
 **Phase exit check: thin composer.** Per the Working agreement's success criterion, this phase delivers cleanup only if `useContractDashboardData.ts` is a _composer_, not a re-home of inline orchestration. Concrete checks at exit:
 
-- Hook body line count: target ~80 lines or less, mostly fetch + compose + return. Contract-scoped filtering (`programHasContractRuns`, `programsInCollections`, `sortedPrograms`), collection shaping, and slot construction are named helpers in `model/dashboardViewModel.ts`, not inline code.
+- Hook body line count: target ~80 lines or less, mostly fetch + compose + return. Contract-scoped filtering (`programHasContractRuns`, `programsInCollections`, `sortedPrograms`), collection shaping, and entry construction are named helpers in `model/dashboardViewModel.ts`, not inline code.
 - The hook composes named helpers; it doesn't re-home orchestration. Glue like `enrollments.filter(existingPredicate)` or `enrollments.sort(existingComparator)` is fine — wrapping it in a named helper would be noise. What's not fine: predicates or comparators _defined_ inline, multi-step pipelines that together encode "what the contract dashboard means," or grouping/joining inline. Those are named helpers in `model/dashboardViewModel.ts`.
 - Helper test coverage: each contract-scoping helper has an isolated unit test that does not require mounting the full dashboard.
 - Consuming callsite shrinkage: `ContractContent.tsx` measurably drops in size — this is the most-watched signal because contract orchestration is currently the largest single tangle.
 - B2B-specific concern: shared helpers between `useProgramDashboardData` and `useContractDashboardData` are explicitly identified. If the same logic is being inlined twice instead of factored once, fix it before declaring done.
-- **Hard exit gate (not a soft review question):** no Contract render sub-component — specifically `OrgProgramDisplay` and `OrgProgramCollectionDisplay` — calls `resolveSlotForLanguage` or filters enrollments by `b2b_contract_id` directly. Slot resolution and contract scoping must be in the composer's returned data. Contract is the largest single tangle and the one most likely to ship with the tangle relocated rather than removed if this is only a review question; treat it as a blocking gate. (This is the residual the Phase 6 re-scope assigns here.)
+- **Hard exit gate (not a soft review question):** no Contract render sub-component — specifically `OrgProgramDisplay` and `OrgProgramCollectionDisplay` — calls `resolveCourseEntryForLanguage` or filters enrollments by `b2b_contract_id` directly. Entry resolution and contract scoping must be in the composer's returned data. Contract is the largest single tangle and the one most likely to ship with the tangle relocated rather than removed if this is only a review question; treat it as a blocking gate. (This is the residual the Phase 6 re-scope assigns here.)
 
 If any of these fails, the phase has relocated complexity rather than reduced it. Stop and split before declaring done.
 
@@ -573,7 +573,7 @@ If any of these fails, the phase has relocated complexity rather than reduced it
 - Modify: `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx`
 - Modify: `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx`
 - Modify: `frontends/main/src/app-pages/DashboardPage/ContractContent.tsx`
-- Modify: `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx` if module-slot inputs are now available
+- Modify: `frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx` if module-entry inputs are now available
 - Test: existing dashboard tests touched above
 
 - [ ] Remove now-duplicated inline query and grouping code from `HomeEnrollmentsDisplay.tsx` and `ProgramEnrollmentDisplay.tsx`.
@@ -603,7 +603,7 @@ Expected: all tests pass.
 
 This is a structural unification, not a redesign. Each variant must reproduce today's rendering exactly. Visible copy, button width, certificate link text, CTA target selection, upgrade banner behavior, context menu items — all preserved. Behavior changes (multi-run UI, button-label convergence, course-level certificate aggregation, "Completed badge + Continue" CTA) remain out of scope and would be follow-up PRs against `CoursewareCard` after this phase ships.
 
-**Why now and not earlier:** Phases 1–6 give every callsite a stable slot-shaped input. Without that, a unified card would have had to absorb the V2/V3 reconciliation that the slot model now owns. With it, `CoursewareCard`'s job shrinks to "render this slot in this variant."
+**Why now and not earlier:** Phases 1–6 give every callsite a stable entry-shaped input. Without that, a unified card would have had to absorb the V2/V3 reconciliation that the entry model now owns. With it, `CoursewareCard`'s job shrinks to "render this entry in this variant."
 
 **Hypothesised approach** (verify before executing):
 
@@ -617,7 +617,7 @@ This is a structural unification, not a redesign. Each variant must reproduce to
 - [ ] Migrate callsites in this order, with the prior step verified before moving on:
   1. Home dashboard (`HomeEnrollmentsDisplay`) — lowest risk; one card per enrollment, V3 data.
   2. Program-as-course rows (`ProgramAsCourseCard`) — replaces `ModuleCard` usage; localized to one component.
-  3. Program dashboard (`ProgramEnrollmentDisplay`) — slot-driven by Phase 4's hook.
+  3. Program dashboard (`ProgramEnrollmentDisplay`) — entry-driven by Phase 4's hook.
   4. Contract dashboard (`ContractContent.tsx`) — highest risk; B2B paths.
 - [ ] Once every callsite uses `CoursewareCard`, delete:
   - `DashboardCard.tsx`
@@ -634,13 +634,13 @@ This is a structural unification, not a redesign. Each variant must reproduce to
   - `selectBestEnrollment` (replaced by Phase 1's display-policy helper, now in viewModel).
   - `selectBestContractEnrollmentForLanguage` (replaced by Phase 2's composite resolver).
   - Case 1 of `getResolvedRunForSelectedLanguage` (V3-to-V2 enrolled-run synthesis). Cases 2 and 3 remain in viewModel — Case 3 is a permanent workaround for missing per-language unenrolled run metadata in the V2 API.
-  - The `dashboardAdapters.ts` adapter introduced in Phase 1, if `CoursewareCard` consumes the slot directly. If the adapter is still load-bearing for any variant, narrow it rather than deleting it.
+  - The `dashboardAdapters.ts` adapter introduced in Phase 1, if `CoursewareCard` consumes the entry directly. If the adapter is still load-bearing for any variant, narrow it rather than deleting it.
 - [ ] Check the LoC delta. Expected order of magnitude: net negative on the order of ~1500–2000 lines once both legacy cards and their tests are deleted. If the delta is much smaller, investigate before declaring the phase done — the duplication may not have actually been removed.
 
 **Migration safety:**
 
 - This phase can be split across multiple PRs along the callsite-migration boundary. PR 7a builds `CoursewareCard` and migrates home + program-as-course. PR 7b migrates program dashboard. PR 7c migrates contract dashboard. PR 7d does the deletion. Each is independently revertible.
-- If a variant turns out to need behavior that's genuinely different from "render today's card with the slot's data" — escalate to product before encoding it. That's the signal that an apparent unification is actually a redesign.
+- If a variant turns out to need behavior that's genuinely different from "render today's card with the entry's data" — escalate to product before encoding it. That's the signal that an apparent unification is actually a redesign.
 
 **Run:**
 
@@ -668,14 +668,14 @@ Do not answer these in this refactor:
 
 Three layers, applied uniformly to every dashboard composer (decided in Phase 3 v3, see [Resolved decision](#resolved-decision-settled-before-phase-4-hook-location-and-testing)):
 
-1. **Pure model unit tests** — `model/dashboardViewModel.test.ts`. No React, no mocks. Owns every domain rule (ordering, MIN_VISIBLE promotion, bucketing, requirement-section construction, slot/language resolution). Fast; this is where logic is exhaustively pinned.
+1. **Pure model unit tests** — `model/dashboardViewModel.test.ts`. No React, no mocks. Owns every domain rule (ordering, MIN_VISIBLE promotion, bucketing, requirement-section construction, entry/language resolution). Fast; this is where logic is exhaustively pinned.
 2. **Composer `renderHook` suites** — `hooks/useXxxDashboardData.test.tsx`. Assert the composer wires queries → helpers → the **durable returned contract**. Reuse the shared scenario setup in `CoursewareDisplay/test-utils.ts`. Never assert through the legacy adapter (keeps these Phase-7-stable).
 3. **Component integration test (the oracle)** — `HomeEnrollmentsDisplay.test.tsx` / `ProgramEnrollmentDisplay.test.tsx` / `ContractContent.test.tsx`. **Not modified by the extraction commit** (the behavior-preservation proof); slimmed only later, in a separate pass, once layers 1–2 have earned trust. If the oracle file is itself newly created earlier on the same branch, the review narrative must say so — "untouched" is scoped to the extraction, not the whole branch vs `main`.
 
-**Durable-contract assertion rule (uniform, Phase-7 robustness).** Layer-2 composer suites assert the composer's _returned_ contract (not adapted/legacy card props) and never reach through `adaptCourseSlotToLegacyDashboardCardProps`. Concretely:
+**Durable-contract assertion rule (uniform, Phase-7 robustness).** Layer-2 composer suites assert the composer's _returned_ contract (not adapted/legacy card props) and never reach through `adaptCourseEntryToLegacyDashboardCardProps`. Concretely:
 
 - Home: assert ordering, `initiallyVisibleCount`, B2B exclusion, grouping, `isLoading` — durable enrollment-flat facts. The legacy `DashboardResource`/`DashboardType` discriminant is used only for TS narrowing to read a durable id, never as the assertion subject (those types migrate into `dashboardViewModel.ts` in Phase 7 — a mechanical relocation, not semantic churn).
-- Program/Contract: the composer suite asserts the durable slot fields (`slot.enrollments`, `selectedLanguageKey`, `availableLanguages`, requirement-section structure/ordering/counts) **and a representative `displayedEnrollment` / `displayedRun` assertion** — proving the composer threads contract-scoped enrollments + `selectedLanguageKey` through the resolver and surfaces its result intact (a wiring failure the pure suite cannot catch, since it never exercises the hook). The **exhaustive** language-resolution matrix (language X vs Y, no-match → unenrolled state, contract-scope permutations) is pinned **only** in the pure `resolveSlotForLanguage` unit suite (layer 1) — fast, no mocks, and the single cheap-to-rewrite file if Phase 7 changes run-selection ownership. **The split is by which bug each layer catches (derivation vs. wiring), not by which field:** the pure suite proves the derivation; the composer suite proves the wiring. The 1–2 representative assertions are the only Phase-7-touch surface, and that revisit is unavoidable regardless of how we test now, since run-selection ownership is itself a Phase 7 product decision.
+- Program/Contract: the composer suite asserts the durable entry fields (`entry.enrollments`, `selectedLanguageKey`, `availableLanguages`, requirement-section structure/ordering/counts) **and a representative `displayedEnrollment` / `displayedRun` assertion** — proving the composer threads contract-scoped enrollments + `selectedLanguageKey` through the resolver and surfaces its result intact (a wiring failure the pure suite cannot catch, since it never exercises the hook). The **exhaustive** language-resolution matrix (language X vs Y, no-match → unenrolled state, contract-scope permutations) is pinned **only** in the pure `resolveCourseEntryForLanguage` unit suite (layer 1) — fast, no mocks, and the single cheap-to-rewrite file if Phase 7 changes run-selection ownership. **The split is by which bug each layer catches (derivation vs. wiring), not by which field:** the pure suite proves the derivation; the composer suite proves the wiring. The 1–2 representative assertions are the only Phase-7-touch surface, and that revisit is unavoidable regardless of how we test now, since run-selection ownership is itself a Phase 7 product decision.
 
 ## Validation plan
 
@@ -720,7 +720,7 @@ yarn workspace frontends run typecheck
 ## Recommended PR sequence
 
 1. Pure model and adapter helpers.
-2. Composite slot/language resolver + language-union bug fix.
+2. Composite entry/language resolver + language-union bug fix.
 3. Home data hook extraction.
 4. Program dashboard data hook extraction.
 5. Contract dashboard data hook extraction.
@@ -756,7 +756,7 @@ Test files (`*.test.tsx`, `*.test.ts`) are omitted for brevity. Each non-test so
       EnrollmentStatusIndicator.tsx                    unchanged (consumed by CoursewareCard)
       ProgressBadge.tsx                                unchanged
       receiptMenuItem.ts                               unchanged
-~     test-utils.ts                                    likely gains slot/variant helpers
+~     test-utils.ts                                    likely gains entry/variant helpers
 -     helpers.ts                                       deleted (Phase 7) — absorbed into viewModel
 -     languageOptions.ts                               deleted (Phase 7) — absorbed into viewModel
                                                          — Cases 2, 3 of getResolvedRunForSelectedLanguage migrate
@@ -765,7 +765,7 @@ Test files (`*.test.tsx`, `*.test.ts`) are omitted for brevity. Each non-test so
 
 +     model/                                           new directory (Phase 1, grows through Phase 7)
 +       dashboardViewModel.ts                          single pure-model home: types, grouping helpers,
-                                                         slot constructors, requirement-section builders,
+                                                         entry constructors, requirement-section builders,
                                                          composite resolver (Phase 2), display policy,
                                                          absorbed contents of helpers.ts + languageOptions.ts (Phase 7)
 +       dashboardAdapters.ts                           temp adapter — may be deleted in Phase 7
@@ -782,6 +782,6 @@ Test files (`*.test.tsx`, `*.test.ts`) are omitted for brevity. Each non-test so
 **Reading notes:**
 
 - The `language/` directory is bracketed by Phase 2's exit decision — it's only created if the existing primitives become internal. Otherwise the composite is added to `languageOptions.ts` and no new file appears.
-- `model/dashboardAdapters.ts` shows up as new in Phase 1 but is a deletion candidate in Phase 7 — its lifespan depends on whether the slot→variant mapping stays a freestanding adapter or folds into `CoursewareCard`'s variant constructors. `CoursewareCard` consumes a per-row variant union, not a slot.
+- `model/dashboardAdapters.ts` shows up as new in Phase 1 but is a deletion candidate in Phase 7 — its lifespan depends on whether the entry→variant mapping stays a freestanding adapter or folds into `CoursewareCard`'s variant constructors. `CoursewareCard` consumes a per-row variant union, not a course entry.
 - Net file-count effect: roughly +5 to +8 added, –4 deleted (includes a `hooks/` directory of separate exported composers per the Resolved decision); the surviving render-heavy components (`HomeEnrollmentsDisplay.tsx`, `ProgramEnrollmentDisplay.tsx`, `ContractContent.tsx`) shrink substantially.
 - The biggest LoC win is the deletion of `DashboardCard.tsx` (~1099 lines) and `ModuleCard.tsx` (~933 lines). New files are smaller and single-purpose.

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useDashboardLanguagePicker.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useDashboardLanguagePicker.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from "@/test-utils"
+import { useDashboardLanguagePicker } from "./useDashboardLanguagePicker"
+import type { SimpleSelectOption } from "ol-components"
+
+const en: SimpleSelectOption = { value: "language:en", label: "English" }
+const fr: SimpleSelectOption = { value: "language:fr", label: "French" }
+const de: SimpleSelectOption = { value: "language:de", label: "German" }
+
+describe("useDashboardLanguagePicker", () => {
+  test("returns empty string when availableLanguages is empty", () => {
+    const { result } = renderHook(() => useDashboardLanguagePicker([]))
+    expect(result.current.selectedLanguageKey).toBe("")
+  })
+
+  test("defaults to first option's value when no user pick has been made", () => {
+    const { result } = renderHook(() =>
+      useDashboardLanguagePicker([en, fr, de]),
+    )
+    expect(result.current.selectedLanguageKey).toBe(String(en.value))
+  })
+
+  test("returns the user-picked value when it is present in options", () => {
+    const { result } = renderHook(() =>
+      useDashboardLanguagePicker([en, fr, de]),
+    )
+    act(() => {
+      result.current.setSelectedLanguageKey(String(fr.value))
+    })
+    expect(result.current.selectedLanguageKey).toBe(String(fr.value))
+  })
+
+  test("falls back to first option when picked value is no longer in options after rerender", () => {
+    let options = [en, fr, de]
+    const { result, rerender } = renderHook(() =>
+      useDashboardLanguagePicker(options),
+    )
+    act(() => {
+      result.current.setSelectedLanguageKey(String(fr.value))
+    })
+    expect(result.current.selectedLanguageKey).toBe(String(fr.value))
+
+    // Remove fr from options
+    options = [en, de]
+    rerender()
+    expect(result.current.selectedLanguageKey).toBe(String(en.value))
+  })
+
+  test("persists the user pick when it is still present in updated options", () => {
+    let options = [en, fr, de]
+    const { result, rerender } = renderHook(() =>
+      useDashboardLanguagePicker(options),
+    )
+    act(() => {
+      result.current.setSelectedLanguageKey(String(fr.value))
+    })
+
+    // Add a new option but keep fr
+    options = [en, fr, de, { value: "language:zh", label: "Chinese" }]
+    rerender()
+    expect(result.current.selectedLanguageKey).toBe(String(fr.value))
+  })
+
+  test("returns empty string when options go from non-empty to empty after rerender", () => {
+    let options = [en, fr]
+    const { result, rerender } = renderHook(() =>
+      useDashboardLanguagePicker(options),
+    )
+    act(() => {
+      result.current.setSelectedLanguageKey(String(fr.value))
+    })
+    expect(result.current.selectedLanguageKey).toBe(String(fr.value))
+
+    options = []
+    rerender()
+    expect(result.current.selectedLanguageKey).toBe("")
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useDashboardLanguagePicker.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useDashboardLanguagePicker.ts
@@ -1,0 +1,25 @@
+import { useState } from "react"
+import type { SimpleSelectOption } from "ol-components"
+
+type DashboardLanguagePicker = {
+  selectedLanguageKey: string
+  setSelectedLanguageKey: (key: string) => void
+}
+
+const useDashboardLanguagePicker = (
+  availableLanguages: SimpleSelectOption[],
+): DashboardLanguagePicker => {
+  // store ONLY the raw user choice; derive the effective key (no effect)
+  const [picked, setPicked] = useState<string | null>(null)
+  const selectedLanguageKey =
+    picked !== null &&
+    availableLanguages.some((o) => String(o.value) === picked)
+      ? picked
+      : availableLanguages[0]
+        ? String(availableLanguages[0].value)
+        : ""
+  return { selectedLanguageKey, setSelectedLanguageKey: setPicked }
+}
+
+export { useDashboardLanguagePicker }
+export type { DashboardLanguagePicker }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
@@ -1,0 +1,694 @@
+import React, { act } from "react"
+import { renderHook, waitFor } from "@/test-utils"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { makeBrowserQueryClient } from "@/app/getQueryClient"
+import * as mitxonline from "api/mitxonline-test-utils"
+import { useProgramDashboardData } from "./useProgramDashboardData"
+import { buildProgramScenario } from "../test-utils"
+import type { V2ProgramDetail } from "@mitodl/mitxonline-api-axios/v2"
+
+const makeProgramEnrollment = (
+  program: V2ProgramDetail,
+  overrides: Parameters<
+    typeof mitxonline.factories.enrollment.programEnrollmentV3
+  >[0] = {},
+) =>
+  mitxonline.factories.enrollment.programEnrollmentV3({
+    program: {
+      id: program.id,
+      title: program.title,
+      live: program.live,
+      program_type: program.program_type,
+      readable_id: program.readable_id,
+    },
+    ...overrides,
+  })
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = makeBrowserQueryClient({ maxRetries: 0 })
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+const renderUseProgramDashboardData = (programId: number) =>
+  renderHook(() => useProgramDashboardData(programId), { wrapper })
+
+/**
+ * Asserts the composer's durable returned contract: sections structure,
+ * counts, language options, shared aux, and representative wiring assertions.
+ * Never asserts through `adaptCourseEntryToLegacyDashboardCardProps`
+ * (Phase-7-stable per the durable-contract assertion rule).
+ */
+describe("useProgramDashboardData", () => {
+  test("reports loading until all 6 queries resolve, then returns data", async () => {
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    section.addCourse({ course: 1 })
+
+    const program = mitxonline.factories.programs.program({
+      id: 100,
+      courses: [1],
+      req_tree: reqTree.serialize(),
+    })
+    const course = mitxonline.factories.courses.course({ id: 1 })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+
+    expect(result.current.isLoading).toBe(true)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+  })
+
+  test("returns enrolledInProgram=false when user has no matching program enrollment", async () => {
+    const program = mitxonline.factories.programs.program({
+      id: 200,
+      courses: [],
+    })
+    const otherEnrollment = mitxonline.factories.enrollment.programEnrollmentV3(
+      {
+        program: { id: 999 },
+      },
+    )
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programEnrollments: [otherEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.enrolledInProgram).toBe(false)
+  })
+
+  test("returns correct section structure and ordering for a simple program", async () => {
+    const course1 = mitxonline.factories.courses.course({ id: 10 })
+    const course2 = mitxonline.factories.courses.course({ id: 11 })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const coreSection = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    coreSection.addCourse({ course: course1.id })
+    coreSection.addCourse({ course: course2.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 300,
+      courses: [course1.id, course2.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course1, course2],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.sections).toHaveLength(1)
+    expect(result.current.sections[0].title).toBe("Core Courses")
+    expect(result.current.sections[0].items).toHaveLength(2)
+    // req_tree order preserved
+    expect(result.current.sections[0].items[0].kind).toBe("course")
+    expect(result.current.sections[0].items[1].kind).toBe("course")
+    if (result.current.sections[0].items[0].kind === "course") {
+      expect(result.current.sections[0].items[0].entry.course.id).toBe(
+        course1.id,
+      )
+    }
+    if (result.current.sections[0].items[1].kind === "course") {
+      expect(result.current.sections[0].items[1].entry.course.id).toBe(
+        course2.id,
+      )
+    }
+  })
+
+  test("completion counts: completedCount and totalCount are correct", async () => {
+    const run = mitxonline.factories.courses.courseRun({ id: 50 })
+    const course = mitxonline.factories.courses.course({
+      id: 20,
+      courseruns: [run],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 400,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+    const courseEnrollment = mitxonline.factories.enrollment.courseEnrollment({
+      run: { ...run, course: { id: course.id, title: course.title } },
+      grades: [mitxonline.factories.enrollment.grade({ passed: true })],
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+      courseEnrollments: [courseEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.completedCount).toBe(1)
+    expect(result.current.totalCount).toBe(1)
+    // per-section counts
+    expect(result.current.sections[0].completed).toBe(1)
+    expect(result.current.sections[0].total).toBe(1)
+  })
+
+  test("programTitle, programType, and programCertificateUrl are derived from program + enrollment", async () => {
+    const program = mitxonline.factories.programs.program({
+      id: 500,
+      title: "Test Program Title",
+      program_type: "Professional Certificate",
+      courses: [],
+    })
+    const certLink = "/certificate/program/some-uuid/"
+    const programEnrollment = makeProgramEnrollment(program, {
+      certificate: { uuid: "some-uuid", link: certLink },
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.programTitle).toBe("Test Program Title")
+    expect(result.current.programType).toBe("Professional Certificate")
+    expect(result.current.programCertificateUrl).toBe(certLink)
+  })
+
+  test("programCertificateUrl is null when enrollment has no certificate", async () => {
+    const program = mitxonline.factories.programs.program({
+      id: 501,
+      courses: [],
+    })
+    const programEnrollment = makeProgramEnrollment(program, {
+      certificate: null,
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.programCertificateUrl).toBeNull()
+  })
+
+  test("enrollmentsByCourseId shared aux is keyed by course id", async () => {
+    const run = mitxonline.factories.courses.courseRun({ id: 70 })
+    const course = mitxonline.factories.courses.course({
+      id: 30,
+      courseruns: [run],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({ operator: "all_of" })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 600,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+    const courseEnrollment = mitxonline.factories.enrollment.courseEnrollment({
+      run: { ...run, course: { id: course.id, title: course.title } },
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+      courseEnrollments: [courseEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.enrollmentsByCourseId[course.id]).toBeDefined()
+    expect(result.current.enrollmentsByCourseId[course.id]).toHaveLength(1)
+    expect(result.current.enrollmentsByCourseId[course.id][0].id).toBe(
+      courseEnrollment.id,
+    )
+  })
+
+  test("ancestorProgramEnrollment shared aux contains readable_id and enrollment_mode", async () => {
+    const program = mitxonline.factories.programs.program({
+      id: 700,
+      courses: [],
+    })
+    const programEnrollment = makeProgramEnrollment(program, {
+      enrollment_mode: "verified",
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.ancestorProgramEnrollment).toBeDefined()
+    expect(result.current.ancestorProgramEnrollment?.readable_id).toBe(
+      program.readable_id,
+    )
+    expect(result.current.ancestorProgramEnrollment?.enrollment_mode).toBe(
+      "verified",
+    )
+  })
+
+  test("ancestorProgramEnrollment is undefined when not enrolled", async () => {
+    const program = mitxonline.factories.programs.program({
+      id: 701,
+      courses: [],
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programEnrollments: [],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.ancestorProgramEnrollment).toBeUndefined()
+  })
+
+  test("availableLanguages reflects distinct languages across program courses", async () => {
+    const englishRun = mitxonline.factories.courses.courseRun({
+      language: "en",
+    })
+    const spanishRun = mitxonline.factories.courses.courseRun({
+      language: "es",
+    })
+    const course = mitxonline.factories.courses.course({
+      id: 40,
+      courseruns: [englishRun, spanishRun],
+      language_options: [
+        {
+          id: englishRun.id,
+          courseware_id: englishRun.courseware_id,
+          courseware_url: englishRun.courseware_url ?? "",
+          language: "en",
+          title: englishRun.title,
+          run_tag: englishRun.run_tag,
+        },
+        {
+          id: spanishRun.id,
+          courseware_id: spanishRun.courseware_id,
+          courseware_url: spanishRun.courseware_url ?? "",
+          language: "es",
+          title: spanishRun.title,
+          run_tag: spanishRun.run_tag,
+        },
+      ],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core",
+    })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 800,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.availableLanguages).toHaveLength(2)
+    const langValues = result.current.availableLanguages.map((o) => o.value)
+    expect(langValues).toContain("language:en")
+    expect(langValues).toContain("language:es")
+  })
+
+  test("selectedLanguageKey defaults to first (alphabetical) option, setSelectedLanguageKey changes it", async () => {
+    const englishRun = mitxonline.factories.courses.courseRun({
+      language: "en",
+    })
+    const spanishRun = mitxonline.factories.courses.courseRun({
+      language: "es",
+    })
+    const course = mitxonline.factories.courses.course({
+      id: 41,
+      courseruns: [englishRun, spanishRun],
+      language_options: [
+        {
+          id: englishRun.id,
+          courseware_id: englishRun.courseware_id,
+          courseware_url: englishRun.courseware_url ?? "",
+          language: "en",
+          title: "English Run",
+          run_tag: englishRun.run_tag,
+        },
+        {
+          id: spanishRun.id,
+          courseware_id: spanishRun.courseware_id,
+          courseware_url: spanishRun.courseware_url ?? "",
+          language: "es",
+          title: "Spanish Run",
+          run_tag: spanishRun.run_tag,
+        },
+      ],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({ operator: "all_of", title: "Core" })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 801,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Options are sorted alphabetically by label; "English" comes before "español"
+    expect(result.current.selectedLanguageKey).toBe("language:en")
+
+    // Changing to Spanish updates the key
+    act(() => {
+      result.current.setSelectedLanguageKey("language:es")
+    })
+    await waitFor(() =>
+      expect(result.current.selectedLanguageKey).toBe("language:es"),
+    )
+  })
+
+  test("representative displayedEnrollment/displayedRun wiring: enrolled course entry resolves displayed run", async () => {
+    const run = mitxonline.factories.courses.courseRun({
+      id: 90,
+      language: "en",
+    })
+    const course = mitxonline.factories.courses.course({
+      id: 50,
+      courseruns: [run],
+      next_run_id: run.id,
+      language_options: [
+        {
+          id: run.id,
+          courseware_id: run.courseware_id,
+          courseware_url: run.courseware_url ?? "",
+          language: "en",
+          title: run.title,
+          run_tag: run.run_tag,
+        },
+      ],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 900,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+    const courseEnrollment = mitxonline.factories.enrollment.courseEnrollment({
+      run: { ...run, course: { id: course.id, title: course.title } },
+    })
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+      courseEnrollments: [courseEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    const section0 = result.current.sections[0]
+    expect(section0.items[0].kind).toBe("course")
+    if (section0.items[0].kind === "course") {
+      const entry = section0.items[0].entry
+      // enrollments are stored uncollapsed
+      expect(entry.enrollments).toHaveLength(1)
+      expect(entry.enrollments[0].id).toBe(courseEnrollment.id)
+      // displayedEnrollment is wired from the enrollment (enrolled in this language)
+      expect(entry.displayedEnrollment).not.toBeNull()
+      expect(entry.displayedEnrollment?.id).toBe(courseEnrollment.id)
+      // displayedRun resolves to the enrolled run
+      expect(entry.displayedRun?.id).toBe(run.id)
+    }
+  })
+
+  test("language selection changes displayedRun on course entry", async () => {
+    const englishRun = mitxonline.factories.courses.courseRun({
+      id: 91,
+      language: "en",
+      is_enrollable: true,
+    })
+    const spanishRun = mitxonline.factories.courses.courseRun({
+      id: 92,
+      language: "es",
+      is_enrollable: true,
+    })
+    const course = mitxonline.factories.courses.course({
+      id: 51,
+      courseruns: [englishRun, spanishRun],
+      next_run_id: englishRun.id,
+      language_options: [
+        {
+          id: englishRun.id,
+          courseware_id: englishRun.courseware_id,
+          courseware_url: englishRun.courseware_url ?? "",
+          language: "en",
+          title: "English Module",
+          run_tag: englishRun.run_tag,
+        },
+        {
+          id: spanishRun.id,
+          courseware_id: spanishRun.courseware_id,
+          courseware_url: spanishRun.courseware_url ?? "",
+          language: "es",
+          title: "Spanish Module",
+          run_tag: spanishRun.run_tag,
+        },
+      ],
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const section = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    section.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      id: 901,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // Default language: English (alphabetically first) → English run
+    expect(result.current.selectedLanguageKey).toBe("language:en")
+    if (result.current.sections[0].items[0].kind === "course") {
+      expect(result.current.sections[0].items[0].entry.displayedRun?.id).toBe(
+        englishRun.id,
+      )
+    }
+
+    // Switch to Spanish → Spanish run
+    act(() => {
+      result.current.setSelectedLanguageKey("language:es")
+    })
+    await waitFor(() =>
+      expect(result.current.selectedLanguageKey).toBe("language:es"),
+    )
+    // After key change is confirmed, sections should reflect the Spanish run
+    await waitFor(() => {
+      const item = result.current.sections[0]?.items[0]
+      if (item?.kind === "course") {
+        expect(item.entry.displayedRun?.id).toBe(spanishRun.id)
+      }
+    })
+  })
+
+  test("program-as-course arm is correctly identified in sections", async () => {
+    const parentReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const requirements = parentReqTree.addOperator({
+      operator: "all_of",
+      title: "Requirements",
+    })
+    requirements.addProgram({ program: 900 })
+
+    const programAsCourse = mitxonline.factories.programs.program({
+      id: 900,
+      display_mode: "course",
+      courses: [11, 12],
+    })
+
+    const parentProgram = mitxonline.factories.programs.program({
+      id: 1000,
+      courses: [],
+      req_tree: parentReqTree.serialize(),
+    })
+    const parentProgramEnrollment = makeProgramEnrollment(parentProgram)
+
+    const moduleCourse1 = mitxonline.factories.courses.course({ id: 11 })
+    const moduleCourse2 = mitxonline.factories.courses.course({ id: 12 })
+
+    const { mockAll } = buildProgramScenario({
+      programId: parentProgram.id,
+      program: parentProgram,
+      programEnrollments: [parentProgramEnrollment],
+      requiredPrograms: [programAsCourse],
+      requiredProgramCourses: [moduleCourse1, moduleCourse2],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(parentProgram.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.sections).toHaveLength(1)
+    const item = result.current.sections[0].items[0]
+    expect(item.kind).toBe("program-as-course")
+    if (item.kind === "program-as-course") {
+      expect(item.courseProgram.id).toBe(900)
+      expect(item.moduleCourses).toHaveLength(2)
+    }
+  })
+
+  test("sections with no resolved items are filtered out", async () => {
+    // Two sections: one with a real course, one with a course not in programCourses
+    const course = mitxonline.factories.courses.course({ id: 60 })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const realSection = reqTree.addOperator({
+      operator: "all_of",
+      title: "Real Section",
+    })
+    realSection.addCourse({ course: course.id })
+    const emptySection = reqTree.addOperator({
+      operator: "all_of",
+      title: "Empty Section",
+    })
+    emptySection.addCourse({ course: 9999 }) // not in programCourses
+
+    const program = mitxonline.factories.programs.program({
+      id: 1100,
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment = makeProgramEnrollment(program)
+
+    const { mockAll } = buildProgramScenario({
+      programId: program.id,
+      program,
+      programCourses: [course],
+      programEnrollments: [programEnrollment],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(program.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    // The empty section should be filtered out
+    expect(result.current.sections).toHaveLength(1)
+    expect(result.current.sections[0].title).toBe("Real Section")
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
@@ -652,6 +652,49 @@ describe("useProgramDashboardData", () => {
     }
   })
 
+  test("program-enrollment arm is correctly identified in sections", async () => {
+    const parentReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const requirements = parentReqTree.addOperator({
+      operator: "all_of",
+      title: "Requirements",
+    })
+    requirements.addProgram({ program: 901 })
+
+    // Not display_mode=course, with a user enrollment in it → program-enrollment
+    // arm. Only `id` is under test; this arm reads neither courses nor req_tree
+    // of a required program, so no other overrides.
+    const requiredProgram = mitxonline.factories.programs.program({
+      id: 901,
+    })
+
+    const parentProgram = mitxonline.factories.programs.program({
+      id: 1001,
+      courses: [],
+      req_tree: parentReqTree.serialize(),
+    })
+    const parentProgramEnrollment = makeProgramEnrollment(parentProgram)
+    const requiredProgramEnrollment = makeProgramEnrollment(requiredProgram)
+
+    const { mockAll } = buildProgramScenario({
+      programId: parentProgram.id,
+      program: parentProgram,
+      programEnrollments: [parentProgramEnrollment, requiredProgramEnrollment],
+      requiredPrograms: [requiredProgram],
+    })
+    mockAll()
+
+    const { result } = renderUseProgramDashboardData(parentProgram.id)
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.sections).toHaveLength(1)
+    const item = result.current.sections[0].items[0]
+    expect(item.kind).toBe("program-enrollment")
+    if (item.kind === "program-enrollment") {
+      expect(item.enrollment.program.id).toBe(901)
+    }
+  })
+
   test("sections with no resolved items are filtered out", async () => {
     // Two sections: one with a real course, one with a course not in programCourses
     const course = mitxonline.factories.courses.course({ id: 60 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
@@ -4,10 +4,7 @@ import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { programsQueries } from "api/mitxonline-hooks/programs"
 import type { SimpleSelectOption } from "ol-components"
-import type {
-  CourseRunEnrollmentV3,
-  V3UserProgramEnrollment,
-} from "@mitodl/mitxonline-api-axios/v2"
+import type { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { getIdsFromReqTree } from "@/common/mitxonline"
 import {
@@ -58,7 +55,7 @@ export type ProgramDashboardData = {
  * hook's query→helper wiring is tested in `useProgramDashboardData.test.tsx`.
  */
 const useProgramDashboardData = (programId: number): ProgramDashboardData => {
-  // --- 6 queries (replicated exactly from ProgramEnrollmentDisplay oracle) ---
+  // --- 6 program-dashboard queries ---
 
   const { data: rawEnrollments, isLoading: userEnrollmentsLoading } = useQuery(
     enrollmentQueries.courseRunEnrollmentsList(),
@@ -207,4 +204,3 @@ const useProgramDashboardData = (programId: number): ProgramDashboardData => {
 }
 
 export { useProgramDashboardData }
-export type { V3UserProgramEnrollment }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
@@ -1,0 +1,210 @@
+import React from "react"
+import { useQuery } from "@tanstack/react-query"
+import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
+import { coursesQueries } from "api/mitxonline-hooks/courses"
+import { programsQueries } from "api/mitxonline-hooks/programs"
+import type { SimpleSelectOption } from "ol-components"
+import type {
+  CourseRunEnrollmentV3,
+  V3UserProgramEnrollment,
+} from "@mitodl/mitxonline-api-axios/v2"
+import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
+import { getIdsFromReqTree } from "@/common/mitxonline"
+import {
+  groupCourseRunEnrollmentsByCourseId,
+  groupProgramEnrollmentsByProgramId,
+  getDistinctDashboardLanguageOptions,
+  groupModuleCoursesByProgramId,
+  buildRequirementSections,
+} from "../model/dashboardViewModel"
+import type { RequirementSection } from "../model/dashboardViewModel"
+import { useDashboardLanguagePicker } from "./useDashboardLanguagePicker"
+
+export type ProgramDashboardData = {
+  sections: RequirementSection[]
+  availableLanguages: SimpleSelectOption[]
+  selectedLanguageKey: string
+  setSelectedLanguageKey: (key: string) => void
+  programTitle: string | undefined
+  programType: string | null | undefined
+  programCertificateUrl: string | null
+  completedCount: number
+  totalCount: number
+  enrolledInProgram: boolean
+  isLoading: boolean
+  /** Shared aux: course-run enrollments keyed by course id. Used by
+   * non-course arms (program-as-course) that need the dashboard-wide
+   * enrollment map from the component level. */
+  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>
+  /** Shared aux: pre-derived ancestor program enrollment shape for
+   * `ProgramAsCourseCard`. Identical across all program-as-course items
+   * in this dashboard (one top-level program per view). */
+  ancestorProgramEnrollment:
+    | { readable_id: string; enrollment_mode?: string | null }
+    | undefined
+}
+
+/**
+ * Data composer for the program dashboard.
+ *
+ * Fetches the 6 program-dashboard queries (course-run enrollments,
+ * programDetail, program enrollments, program courses, required programs,
+ * required-program courses) and composes the pure helpers in
+ * `dashboardViewModel.ts` into the durable returned contract:
+ * requirement sections with per-section counts, language picker state,
+ * overall completion counts, and shared aux for non-course arms.
+ *
+ * Pure transforms are unit-tested in `dashboardViewModel.test.ts`; this
+ * hook's query→helper wiring is tested in `useProgramDashboardData.test.tsx`.
+ */
+const useProgramDashboardData = (programId: number): ProgramDashboardData => {
+  // --- 6 queries (replicated exactly from ProgramEnrollmentDisplay oracle) ---
+
+  const { data: rawEnrollments, isLoading: userEnrollmentsLoading } = useQuery(
+    enrollmentQueries.courseRunEnrollmentsList(),
+  )
+
+  const { data: program, isLoading: programLoading } = useQuery(
+    programsQueries.programDetail({ id: programId.toString() }),
+  )
+
+  const { data: programEnrollments, isLoading: programEnrollmentsLoading } =
+    useQuery(enrollmentQueries.programEnrollmentsList())
+
+  // --- query-input derivations (inline fetch wiring, not domain logic) ---
+
+  const enrolledInProgram = programEnrollments?.some(
+    (e) => e.program.id === program?.id,
+  )
+
+  const programEnrollment = programEnrollments?.find(
+    (e) => e.program.id === program?.id,
+  )
+
+  const { data: programCourses, isLoading: programCoursesLoading } = useQuery({
+    ...coursesQueries.coursesList({
+      id: program?.courses || [],
+      page_size: program?.courses?.length || undefined,
+    }),
+    enabled: !!program && program.courses.length > 0 && enrolledInProgram,
+  })
+
+  const requiredProgramIds = React.useMemo(() => {
+    if (!program?.req_tree) return []
+    return [...new Set(getIdsFromReqTree(program.req_tree).programIds)]
+  }, [program?.req_tree])
+
+  const { data: requiredPrograms, isLoading: requiredProgramsLoading } =
+    useQuery({
+      ...programsQueries.programsList({
+        id: requiredProgramIds,
+        page_size: requiredProgramIds.length || undefined,
+      }),
+      enabled: Boolean(enrolledInProgram && requiredProgramIds.length > 0),
+    })
+
+  const requiredProgramList = React.useMemo(
+    () => requiredPrograms?.results ?? [],
+    [requiredPrograms?.results],
+  )
+
+  const programAsCourseCourseIds = React.useMemo(() => {
+    const uniqueIds = new Set<number>()
+    requiredProgramList
+      .filter(
+        (requiredProgram) =>
+          requiredProgram.display_mode === DisplayModeEnum.Course,
+      )
+      .forEach((requiredProgram) => {
+        requiredProgram.courses?.forEach((courseId) => uniqueIds.add(courseId))
+      })
+    return [...uniqueIds]
+  }, [requiredProgramList])
+
+  const {
+    data: requiredProgramCourses,
+    isLoading: requiredProgramCoursesLoading,
+  } = useQuery({
+    ...coursesQueries.coursesList({
+      id: programAsCourseCourseIds,
+      page_size: programAsCourseCourseIds.length || undefined,
+    }),
+    enabled: Boolean(enrolledInProgram && programAsCourseCourseIds.length > 0),
+  })
+
+  const isLoading =
+    userEnrollmentsLoading ||
+    programLoading ||
+    programEnrollmentsLoading ||
+    programCoursesLoading ||
+    requiredProgramsLoading ||
+    requiredProgramCoursesLoading
+
+  // --- compose named helpers ---
+
+  const enrollmentsByCourseId = groupCourseRunEnrollmentsByCourseId(
+    rawEnrollments ?? [],
+  )
+
+  const programEnrollmentsById = groupProgramEnrollmentsByProgramId(
+    programEnrollments ?? [],
+  )
+
+  const allProgramCourses = programCourses?.results ?? []
+
+  const availableLanguages = getDistinctDashboardLanguageOptions(
+    allProgramCourses,
+    rawEnrollments ?? [],
+  )
+
+  const { selectedLanguageKey, setSelectedLanguageKey } =
+    useDashboardLanguagePicker(availableLanguages)
+
+  const requiredProgramModuleCoursesByProgramId = groupModuleCoursesByProgramId(
+    requiredProgramList,
+    requiredProgramCourses?.results ?? [],
+  )
+
+  const { sections, completedCount, totalCount } = buildRequirementSections({
+    reqTree: program?.req_tree ?? [],
+    programCourses: allProgramCourses,
+    enrollmentsByCourseId,
+    programEnrollmentsById,
+    requiredPrograms: requiredProgramList,
+    requiredProgramModuleCoursesByProgramId,
+    selectedLanguageKey,
+    availableLanguages,
+    ancestorProgramEnrollment: programEnrollment,
+  })
+
+  // --- shared aux for non-course arms ---
+
+  const ancestorProgramEnrollment: ProgramDashboardData["ancestorProgramEnrollment"] =
+    programEnrollment
+      ? {
+          readable_id: programEnrollment.program.readable_id,
+          enrollment_mode: programEnrollment.enrollment_mode,
+        }
+      : undefined
+
+  const programCertificateUrl = programEnrollment?.certificate?.link ?? null
+
+  return {
+    sections,
+    availableLanguages,
+    selectedLanguageKey,
+    setSelectedLanguageKey,
+    programTitle: program?.title,
+    programType: program?.program_type,
+    programCertificateUrl,
+    completedCount,
+    totalCount,
+    enrolledInProgram: Boolean(enrolledInProgram),
+    isLoading,
+    enrollmentsByCourseId,
+    ancestorProgramEnrollment,
+  }
+}
+
+export { useProgramDashboardData }
+export type { V3UserProgramEnrollment }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
@@ -46,7 +46,7 @@ export type ProgramDashboardData = {
  *
  * Fetches the 6 program-dashboard queries (course-run enrollments,
  * programDetail, program enrollments, program courses, required programs,
- * required-program courses) and composes the pure helpers in
+ * required program-courses) and composes the pure helpers in
  * `dashboardViewModel.ts` into the durable returned contract:
  * requirement sections with per-section counts, language picker state,
  * overall completion counts, and shared aux for non-course arms.

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
@@ -1,16 +1,16 @@
 import { factories } from "api/mitxonline-test-utils"
 import {
-  adaptCourseSlotToLegacyDashboardCardProps,
+  adaptCourseEntryToLegacyDashboardCardProps,
   type LegacyDashboardCardAdapterOutput,
 } from "./dashboardAdapters"
 import {
   pickDisplayedEnrollmentForLegacyDashboard,
-  type DashboardCourseSlot,
+  type DashboardCourseEntry,
 } from "./dashboardViewModel"
 
-const makeSlot = (
-  overrides: Partial<DashboardCourseSlot>,
-): DashboardCourseSlot => {
+const makeEntry = (
+  overrides: Partial<DashboardCourseEntry>,
+): DashboardCourseEntry => {
   const defaultRun = factories.courses.courseRun({
     id: 1,
     courseware_url: "/courseware/default-run/",
@@ -44,13 +44,13 @@ const expectEnrollmentResource = (
 
 describe("dashboardAdapters", () => {
   test("no enrollment: adapts to course resource", () => {
-    const slot = makeSlot({ displayedEnrollment: null })
+    const entry = makeEntry({ displayedEnrollment: null })
 
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expect(adapted.resource.type).toBe("course")
-    expect(adapted.selectedCourseRun?.id).toBe(slot.displayedRun?.id)
-    expect(adapted.buttonHref).toBe(slot.displayedRun?.courseware_url)
+    expect(adapted.selectedCourseRun?.id).toBe(entry.displayedRun?.id)
+    expect(adapted.buttonHref).toBe(entry.displayedRun?.courseware_url)
   })
 
   test("one enrollment: adapts to enrollment resource", () => {
@@ -61,13 +61,13 @@ describe("dashboardAdapters", () => {
     const course = factories.courses.course({ id: 20, courseruns: [run] })
     const enrollment = factories.enrollment.courseEnrollment({ run })
 
-    const slot = makeSlot({
+    const entry = makeEntry({
       course,
       enrollments: [enrollment],
       displayedEnrollment: enrollment,
       displayedRun: run,
     })
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, run.id)
     expect(adapted.buttonHref).toBe(run.courseware_url)
@@ -89,13 +89,13 @@ describe("dashboardAdapters", () => {
       course,
       [noCertificate, withCertificate],
     )
-    const slot = makeSlot({
+    const entry = makeEntry({
       course,
       enrollments: [noCertificate, withCertificate],
       displayedEnrollment,
       displayedRun: run,
     })
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, withCertificate.run.id)
   })
@@ -118,13 +118,13 @@ describe("dashboardAdapters", () => {
       course,
       [lowGrade, highGrade],
     )
-    const slot = makeSlot({
+    const entry = makeEntry({
       course,
       enrollments: [lowGrade, highGrade],
       displayedEnrollment,
       displayedRun: run,
     })
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, highGrade.run.id)
   })
@@ -148,14 +148,14 @@ describe("dashboardAdapters", () => {
       run: esRun,
     })
 
-    const slot = makeSlot({
+    const entry = makeEntry({
       course,
       enrollments: [selectedLanguageEnrollment],
       selectedLanguageKey: "language:es",
       displayedEnrollment: selectedLanguageEnrollment,
       displayedRun: esRun,
     })
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, esRun.id)
     expect(adapted.buttonHref).toBe(esRun.courseware_url)
@@ -173,7 +173,7 @@ describe("dashboardAdapters", () => {
     })
     const programEnrollment = factories.enrollment.programEnrollmentV3()
 
-    const slot = makeSlot({
+    const entry = makeEntry({
       course,
       enrollments: [contractEnrollment],
       selectedLanguageKey: "language:es",
@@ -182,7 +182,7 @@ describe("dashboardAdapters", () => {
       contractId: 999,
       ancestorContext: { programEnrollment },
     })
-    const adapted = adaptCourseSlotToLegacyDashboardCardProps(slot)
+    const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, run.id)
     expect(adapted.contractId).toBe(999)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.ts
@@ -4,7 +4,7 @@ import type {
   CourseWithCourseRunsSerializerV2,
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
-import type { DashboardCourseSlot } from "./dashboardViewModel"
+import type { DashboardCourseEntry } from "./dashboardViewModel"
 
 export type LegacyDashboardCardResource =
   | { type: "course"; data: CourseWithCourseRunsSerializerV2 }
@@ -18,27 +18,27 @@ export type LegacyDashboardCardAdapterOutput = {
   programEnrollment?: V3UserProgramEnrollment
 }
 
-const adaptCourseSlotToLegacyDashboardCardProps = (
-  slot: DashboardCourseSlot,
+const adaptCourseEntryToLegacyDashboardCardProps = (
+  entry: DashboardCourseEntry,
 ): LegacyDashboardCardAdapterOutput => {
   return {
-    resource: slot.displayedEnrollment
+    resource: entry.displayedEnrollment
       ? {
           type: "courserun-enrollment",
-          data: slot.displayedEnrollment,
+          data: entry.displayedEnrollment,
         }
       : {
           type: "course",
-          data: slot.course,
+          data: entry.course,
         },
-    selectedCourseRun: slot.displayedRun,
+    selectedCourseRun: entry.displayedRun,
     buttonHref:
-      slot.displayedEnrollment?.run.courseware_url ??
-      slot.displayedRun?.courseware_url ??
+      entry.displayedEnrollment?.run.courseware_url ??
+      entry.displayedRun?.courseware_url ??
       null,
-    contractId: slot.contractId,
-    programEnrollment: slot.ancestorContext?.programEnrollment,
+    contractId: entry.contractId,
+    programEnrollment: entry.ancestorContext?.programEnrollment,
   }
 }
 
-export { adaptCourseSlotToLegacyDashboardCardProps }
+export { adaptCourseEntryToLegacyDashboardCardProps }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1,8 +1,10 @@
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
-import { factories } from "api/mitxonline-test-utils"
+import { factories, RequirementTreeBuilder } from "api/mitxonline-test-utils"
 import {
   assembleHomeCardList,
   bucketAndSortHomeEnrollments,
+  buildCourseEntry,
+  buildRequirementSections,
   enrollmentCourseIsInPrograms,
   getDistinctDashboardLanguageOptions,
   getModuleCourseIdsFromPrograms,
@@ -745,6 +747,807 @@ describe("dashboardViewModel", () => {
           writable: true,
         })
       }
+    })
+  })
+
+  describe("buildCourseEntry", () => {
+    test("returns null displayedEnrollment and a displayedRun when there are no enrollments", () => {
+      const run = factories.courses.courseRun({ id: 100 })
+      const course = factories.courses.course({
+        courseruns: [run],
+        next_run_id: run.id,
+      })
+      const availableLanguages = [{ value: "language:en", label: "English" }]
+
+      const entry = buildCourseEntry(course, [], "language:en", {
+        availableLanguages,
+      })
+
+      expect(entry.displayedEnrollment).toBeNull()
+      expect(entry.displayedRun).not.toBeNull()
+      expect(entry.displayedRun?.id).toBe(run.id)
+    })
+
+    test("returns correct displayedEnrollment for single enrollment", () => {
+      const run = factories.courses.courseRun({ id: 201 })
+      const course = factories.courses.course({
+        courseruns: [run],
+        next_run_id: run.id,
+        language_options: [
+          {
+            id: run.id,
+            courseware_id: run.courseware_id,
+            courseware_url: run.courseware_url ?? "",
+            language: "en",
+            title: run.title,
+            run_tag: run.run_tag,
+          },
+        ],
+      })
+      const enrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: run.id,
+          language: "en",
+          course: { id: course.id, title: course.title },
+          title: run.title,
+          run_tag: run.run_tag,
+          courseware_id: run.courseware_id,
+          courseware_url: run.courseware_url,
+          is_enrollable: run.is_enrollable,
+          is_upgradable: run.is_upgradable,
+          is_archived: run.is_archived,
+          is_self_paced: run.is_self_paced,
+          start_date: run.start_date,
+          end_date: run.end_date,
+          upgrade_deadline: run.upgrade_deadline,
+          certificate_available_date: run.certificate_available_date,
+          course_number: run.course_number,
+        },
+      })
+      const availableLanguages = [{ value: "language:en", label: "English" }]
+
+      const entry = buildCourseEntry(course, [enrollment], "language:en", {
+        availableLanguages,
+      })
+
+      expect(entry.displayedEnrollment).toBe(enrollment)
+      expect(entry.displayedRun?.id).toBe(run.id)
+    })
+
+    test("without selected language picks best legacy enrollment (cert > grade)", () => {
+      const run = factories.courses.courseRun({ id: 301 })
+      const course = factories.courses.course({ courseruns: [run] })
+      const noCert = factories.enrollment.courseEnrollment({
+        run: { id: run.id },
+        certificate: null,
+        grades: [factories.enrollment.grade({ grade: 0.5, passed: false })],
+      })
+      const withCert = factories.enrollment.courseEnrollment({
+        run: { id: run.id },
+        certificate: { uuid: "cert-abc" },
+        grades: [factories.enrollment.grade({ grade: 0.9, passed: true })],
+      })
+
+      // no selectedLanguageKey → legacy path
+      const entry = buildCourseEntry(course, [noCert, withCert], "", {
+        availableLanguages: [],
+      })
+
+      expect(entry.displayedEnrollment).toBe(withCert)
+    })
+
+    test("selected-language key prefers matching language enrollment", () => {
+      const enRun = factories.courses.courseRun({
+        id: 401,
+        language: "en",
+        courseware_id: "cw-en-401",
+        courseware_url: "https://example.com/en-401",
+        is_enrollable: true,
+      })
+      const esRun = factories.courses.courseRun({
+        id: 402,
+        language: "es",
+        courseware_id: "cw-es-402",
+        courseware_url: "https://example.com/es-402",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        courseruns: [enRun, esRun],
+        next_run_id: enRun.id,
+        language_options: [
+          {
+            id: enRun.id,
+            courseware_id: enRun.courseware_id,
+            courseware_url: enRun.courseware_url ?? "",
+            language: "en",
+            title: enRun.title,
+            run_tag: enRun.run_tag,
+          },
+          {
+            id: esRun.id,
+            courseware_id: esRun.courseware_id,
+            courseware_url: esRun.courseware_url ?? "",
+            language: "es",
+            title: esRun.title,
+            run_tag: esRun.run_tag,
+          },
+        ],
+      })
+      const enEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: enRun.id,
+          language: "en",
+          course: { id: course.id, title: course.title },
+          title: enRun.title,
+          run_tag: enRun.run_tag,
+          courseware_id: enRun.courseware_id,
+          courseware_url: enRun.courseware_url,
+          is_enrollable: enRun.is_enrollable,
+          is_upgradable: enRun.is_upgradable,
+          is_archived: enRun.is_archived,
+          is_self_paced: enRun.is_self_paced,
+          start_date: enRun.start_date,
+          end_date: enRun.end_date,
+          upgrade_deadline: enRun.upgrade_deadline,
+          certificate_available_date: enRun.certificate_available_date,
+          course_number: enRun.course_number,
+        },
+      })
+      const esEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: esRun.id,
+          language: "es",
+          course: { id: course.id, title: course.title },
+          title: esRun.title,
+          run_tag: esRun.run_tag,
+          courseware_id: esRun.courseware_id,
+          courseware_url: esRun.courseware_url,
+          is_enrollable: esRun.is_enrollable,
+          is_upgradable: esRun.is_upgradable,
+          is_archived: esRun.is_archived,
+          is_self_paced: esRun.is_self_paced,
+          start_date: esRun.start_date,
+          end_date: esRun.end_date,
+          upgrade_deadline: esRun.upgrade_deadline,
+          certificate_available_date: esRun.certificate_available_date,
+          course_number: esRun.course_number,
+        },
+      })
+      const availableLanguages = [
+        { value: "language:en", label: "English" },
+        { value: "language:es", label: "Spanish" },
+      ]
+
+      const entry = buildCourseEntry(
+        course,
+        [enEnrollment, esEnrollment],
+        "language:es",
+        { availableLanguages },
+      )
+
+      expect(entry.displayedEnrollment?.run.id).toBe(esRun.id)
+      expect(entry.displayedRun?.id).toBe(esRun.id)
+    })
+
+    test("contract-scoped: does not pick an enrollment from a different contract", () => {
+      const run = factories.courses.courseRun({
+        id: 501,
+        b2b_contract: 10,
+        courseware_id: "cw-501",
+        courseware_url: "https://example.com/501",
+        is_enrollable: true,
+      })
+      const course = factories.courses.course({
+        courseruns: [run],
+        next_run_id: run.id,
+        language_options: [
+          {
+            id: run.id,
+            courseware_id: run.courseware_id,
+            courseware_url: run.courseware_url ?? "",
+            language: "en",
+            title: run.title,
+            run_tag: run.run_tag,
+          },
+        ],
+      })
+      // enrollment belongs to contract 99, not contract 10
+      const otherContractEnrollment = factories.enrollment.courseEnrollment({
+        b2b_contract_id: 99,
+        run: {
+          id: run.id,
+          course: { id: course.id, title: course.title },
+          title: run.title,
+          run_tag: run.run_tag,
+          courseware_id: run.courseware_id,
+          courseware_url: run.courseware_url,
+          is_enrollable: run.is_enrollable,
+          is_upgradable: run.is_upgradable,
+          is_archived: run.is_archived,
+          is_self_paced: run.is_self_paced,
+          start_date: run.start_date,
+          end_date: run.end_date,
+          upgrade_deadline: run.upgrade_deadline,
+          certificate_available_date: run.certificate_available_date,
+          course_number: run.course_number,
+        },
+      })
+
+      const entry = buildCourseEntry(
+        course,
+        [otherContractEnrollment],
+        "language:en",
+        {
+          availableLanguages: [{ value: "language:en", label: "English" }],
+          contractId: 10,
+        },
+      )
+
+      expect(entry.displayedEnrollment).toBeNull()
+    })
+
+    test("stores all input enrollments uncollapsed regardless of displayedEnrollment choice", () => {
+      const run = factories.courses.courseRun({ id: 601 })
+      const course = factories.courses.course({ courseruns: [run] })
+      const e1 = factories.enrollment.courseEnrollment({
+        run: { id: run.id },
+        certificate: null,
+      })
+      const e2 = factories.enrollment.courseEnrollment({
+        run: { id: run.id },
+        certificate: { uuid: "cert-xyz" },
+      })
+
+      const entry = buildCourseEntry(course, [e1, e2], "", {
+        availableLanguages: [],
+      })
+
+      // displayedEnrollment picks best one (e2), but all remain on entry
+      expect(entry.enrollments).toEqual([e1, e2])
+      expect(entry.displayedEnrollment).toBe(e2)
+    })
+
+    test("passthrough: course, availableLanguages, contractId, and ancestorContext are stored verbatim", () => {
+      const run = factories.courses.courseRun({ id: 701 })
+      const course = factories.courses.course({ courseruns: [run] })
+      const availableLanguages = [
+        { value: "language:en", label: "English" },
+        { value: "language:de", label: "German" },
+      ]
+      const programEnrollment = factories.enrollment.programEnrollmentV3()
+      const ancestorContext = { programEnrollment }
+
+      const entry = buildCourseEntry(course, [], "language:en", {
+        availableLanguages,
+        contractId: 42,
+        ancestorContext,
+      })
+
+      expect(entry.course).toBe(course)
+      expect(entry.availableLanguages).toBe(availableLanguages)
+      expect(entry.contractId).toBe(42)
+      expect(entry.ancestorContext).toBe(ancestorContext)
+    })
+
+    test("isContractPageResource is stored verbatim", () => {
+      const course = factories.courses.course()
+
+      const entry = buildCourseEntry(course, [], "", {
+        availableLanguages: [],
+        isContractPageResource: true,
+      })
+
+      expect(entry.isContractPageResource).toBe(true)
+    })
+  })
+
+  describe("buildRequirementSections", () => {
+    /**
+     * Builds a flat req_tree with one all_of section containing the given course ids.
+     * Convenience helper for tests that only need one section.
+     */
+    const makeSingleSectionReqTree = (courseIds: number[]) => {
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Core Courses" })
+      courseIds.forEach((id) => op.addCourse({ course: id }))
+      return root.serialize()
+    }
+
+    test("produces a course arm item for each course found in programCourses", () => {
+      const course = factories.courses.course({ id: 1001 })
+      const reqTree = makeSingleSectionReqTree([course.id])
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [course],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(1)
+      expect(sections[0].items).toHaveLength(1)
+      expect(sections[0].items[0].kind).toBe("course")
+      if (sections[0].items[0].kind === "course") {
+        expect(sections[0].items[0].entry.course).toBe(course)
+      }
+    })
+
+    test("drops a course item when course id is not in programCourses", () => {
+      const reqTree = makeSingleSectionReqTree([9999])
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [], // 9999 not present
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      // Section has no items → filtered out
+      expect(sections).toHaveLength(0)
+    })
+
+    test("produces a program-as-course arm for programs with display_mode Course", () => {
+      const moduleCourse = factories.courses.course({ id: 2001 })
+      const requiredProgram = factories.programs.program({
+        id: 3001,
+        display_mode: DisplayModeEnum.Course,
+        courses: [moduleCourse.id],
+      })
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        program: factories.programs.simpleProgram({ id: requiredProgram.id }),
+      })
+      const programEnrollmentsById = {
+        [requiredProgram.id]: programEnrollment,
+      }
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Modules" })
+      op.addProgram({ program: requiredProgram.id })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById,
+        requiredPrograms: [requiredProgram],
+        requiredProgramModuleCoursesByProgramId: {
+          [requiredProgram.id]: [moduleCourse],
+        },
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(1)
+      expect(sections[0].items[0].kind).toBe("program-as-course")
+      if (sections[0].items[0].kind === "program-as-course") {
+        expect(sections[0].items[0].courseProgram).toBe(requiredProgram)
+        expect(sections[0].items[0].moduleCourses).toEqual([moduleCourse])
+        expect(sections[0].items[0].courseProgramEnrollment).toBe(
+          programEnrollment,
+        )
+      }
+    })
+
+    test("produces a program-enrollment arm for regular programs that have an enrollment", () => {
+      const requiredProgram = factories.programs.program({
+        id: 4001,
+        display_mode: null,
+      })
+      const programEnrollment = factories.enrollment.programEnrollmentV3({
+        program: factories.programs.simpleProgram({ id: requiredProgram.id }),
+      })
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Programs" })
+      op.addProgram({ program: requiredProgram.id })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: { [requiredProgram.id]: programEnrollment },
+        requiredPrograms: [requiredProgram],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(1)
+      expect(sections[0].items[0].kind).toBe("program-enrollment")
+      if (sections[0].items[0].kind === "program-enrollment") {
+        expect(sections[0].items[0].enrollment).toBe(programEnrollment)
+      }
+    })
+
+    test("drops a regular program item when there is no enrollment for it", () => {
+      const requiredProgram = factories.programs.program({
+        id: 5001,
+        display_mode: null,
+      })
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Programs" })
+      op.addProgram({ program: requiredProgram.id })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {}, // no enrollment for this program
+        requiredPrograms: [requiredProgram],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(0)
+    })
+
+    test("drops a program item when the program id is not in requiredPrograms", () => {
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Programs" })
+      op.addProgram({ program: 9999 })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [], // 9999 not present
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(0)
+    })
+
+    test("filters out sections with no items", () => {
+      const root = new RequirementTreeBuilder()
+      // Section A — will have an item
+      const opA = root.addOperator({ operator: "all_of", title: "Section A" })
+      const courseA = factories.courses.course({ id: 6001 })
+      opA.addCourse({ course: courseA.id })
+      // Section B — course not in programCourses → no items
+      const opB = root.addOperator({ operator: "all_of", title: "Section B" })
+      opB.addCourse({ course: 9999 })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [courseA],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections).toHaveLength(1)
+      expect(sections[0].title).toBe("Section A")
+    })
+
+    test("preserves req_tree ordering across sections", () => {
+      const c1 = factories.courses.course({ id: 7001 })
+      const c2 = factories.courses.course({ id: 7002 })
+      const c3 = factories.courses.course({ id: 7003 })
+      const root = new RequirementTreeBuilder()
+      const op1 = root.addOperator({ operator: "all_of", title: "First" })
+      op1.addCourse({ course: c1.id })
+      const op2 = root.addOperator({ operator: "all_of", title: "Second" })
+      op2.addCourse({ course: c2.id })
+      const op3 = root.addOperator({ operator: "all_of", title: "Third" })
+      op3.addCourse({ course: c3.id })
+      const reqTree = root.serialize()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [c1, c2, c3],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections.map((s) => s.title)).toEqual(["First", "Second", "Third"])
+    })
+
+    test("per-section completed/total: one passing enrollment → completed=1, total=1", () => {
+      const course = factories.courses.course({ id: 8001 })
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Core" })
+      op.addCourse({ course: course.id })
+      const reqTree = root.serialize()
+
+      const enrollment = factories.enrollment.courseEnrollment({
+        run: { course: { id: course.id } },
+        grades: [factories.enrollment.grade({ passed: true })],
+      })
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [course],
+        enrollmentsByCourseId: { [course.id]: [enrollment] },
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections[0].completed).toBe(1)
+      expect(sections[0].total).toBe(1)
+    })
+
+    test("overall counts are computed over POST-filter sections only (ghost dropped section does not inflate counts)", () => {
+      // keptCourse appears in programCourses → its section survives the filter.
+      // ghostCourseId is absent from programCourses → its section is dropped.
+      // The ghost enrollment has a passing grade, so a buggy pre-filter
+      // implementation (counting over ALL parsed sections before the
+      // `items.length > 0` filter) would report completedCount=1 and totalCount=2
+      // instead of the correct completedCount=0 and totalCount=1.
+      const keptCourse = factories.courses.course({ id: 9001 })
+      const ghostCourseId = 9999
+
+      const root = new RequirementTreeBuilder()
+      const opKept = root.addOperator({ operator: "all_of", title: "Kept" })
+      opKept.addCourse({ course: keptCourse.id })
+      const opDropped = root.addOperator({
+        operator: "all_of",
+        title: "Dropped",
+      })
+      opDropped.addCourse({ course: ghostCourseId })
+      const reqTree = root.serialize()
+
+      const ghostEnrollment = factories.enrollment.courseEnrollment({
+        run: { course: { id: ghostCourseId } },
+        grades: [factories.enrollment.grade({ passed: true })],
+      })
+
+      const result = buildRequirementSections({
+        reqTree,
+        // keptCourse is present; ghostCourseId is intentionally absent →
+        // the "Dropped" section will have no items and be filtered out.
+        programCourses: [keptCourse],
+        enrollmentsByCourseId: { [ghostCourseId]: [ghostEnrollment] },
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      // Only the "Kept" section survives; the ghost section is dropped.
+      expect(result.sections).toHaveLength(1)
+      expect(result.sections[0].title).toBe("Kept")
+      // totalCount = 1 (only the kept course); completedCount = 0 (no enrollment for keptCourse).
+      // A buggy pre-filter implementation would return totalCount=2, completedCount=1.
+      expect(result.totalCount).toBe(1)
+      expect(result.completedCount).toBe(0)
+    })
+
+    describe("getRequirementSectionTitle behavior", () => {
+      test("uses node.data.title when present", () => {
+        const c = factories.courses.course({ id: 10001 })
+        const root = new RequirementTreeBuilder()
+        const op = root.addOperator({
+          operator: "all_of",
+          title: "Custom Section Title",
+        })
+        op.addCourse({ course: c.id })
+        const reqTree = root.serialize()
+
+        const { sections } = buildRequirementSections({
+          reqTree,
+          programCourses: [c],
+          enrollmentsByCourseId: {},
+          programEnrollmentsById: {},
+          requiredPrograms: [],
+          requiredProgramModuleCoursesByProgramId: {},
+          selectedLanguageKey: "",
+          availableLanguages: [],
+        })
+
+        expect(sections[0].title).toBe("Custom Section Title")
+      })
+
+      test("returns 'Electives (Complete N)' for min_number_of elective with operator_value", () => {
+        const c = factories.courses.course({ id: 10002 })
+        const root = new RequirementTreeBuilder()
+        // RequirementTreeBuilder sets elective_flag=true for min_number_of operators
+        const op = root.addOperator({
+          operator: "min_number_of",
+          operator_value: "3",
+        })
+        op.addCourse({ course: c.id })
+        const reqTree = root.serialize()
+        // Manually clear the auto-set title so that the title fallback logic kicks in
+        reqTree[0].data.title = null
+
+        const { sections } = buildRequirementSections({
+          reqTree,
+          programCourses: [c],
+          enrollmentsByCourseId: {},
+          programEnrollmentsById: {},
+          requiredPrograms: [],
+          requiredProgramModuleCoursesByProgramId: {},
+          selectedLanguageKey: "",
+          availableLanguages: [],
+        })
+
+        expect(sections[0].title).toBe("Electives (Complete 3)")
+      })
+
+      test("returns 'Elective Courses' for elective without operator_value", () => {
+        const c = factories.courses.course({ id: 10003 })
+        // Build node manually to control all data fields precisely
+        const opNode = {
+          id: 55555,
+          data: {
+            node_type: "operator" as const,
+            operator: "all_of" as const,
+            operator_value: null,
+            elective_flag: true,
+            title: null,
+            course: null,
+            required_program: null,
+          },
+          children: [
+            {
+              id: 55556,
+              data: {
+                node_type: "course" as const,
+                course: c.id,
+                operator: null,
+                operator_value: null,
+                elective_flag: false,
+                title: null,
+                required_program: null,
+              },
+              children: [],
+            },
+          ],
+        }
+
+        const { sections } = buildRequirementSections({
+          reqTree: [opNode],
+          programCourses: [c],
+          enrollmentsByCourseId: {},
+          programEnrollmentsById: {},
+          requiredPrograms: [],
+          requiredProgramModuleCoursesByProgramId: {},
+          selectedLanguageKey: "",
+          availableLanguages: [],
+        })
+
+        expect(sections[0].title).toBe("Elective Courses")
+      })
+
+      test("returns 'Core Courses' when no title and not elective", () => {
+        const c = factories.courses.course({ id: 10004 })
+        const opNode = {
+          id: 66666,
+          data: {
+            node_type: "operator" as const,
+            operator: "all_of" as const,
+            operator_value: null,
+            elective_flag: false,
+            title: null,
+            course: null,
+            required_program: null,
+          },
+          children: [
+            {
+              id: 66667,
+              data: {
+                node_type: "course" as const,
+                course: c.id,
+                operator: null,
+                operator_value: null,
+                elective_flag: false,
+                title: null,
+                required_program: null,
+              },
+              children: [],
+            },
+          ],
+        }
+
+        const { sections } = buildRequirementSections({
+          reqTree: [opNode],
+          programCourses: [c],
+          enrollmentsByCourseId: {},
+          programEnrollmentsById: {},
+          requiredPrograms: [],
+          requiredProgramModuleCoursesByProgramId: {},
+          selectedLanguageKey: "",
+          availableLanguages: [],
+        })
+
+        expect(sections[0].title).toBe("Core Courses")
+      })
+    })
+
+    test("course arm entry carries ancestorContext from ancestorProgramEnrollment", () => {
+      const course = factories.courses.course({ id: 11001 })
+      const reqTree = makeSingleSectionReqTree([course.id])
+      const programEnrollment = factories.enrollment.programEnrollmentV3()
+
+      const { sections } = buildRequirementSections({
+        reqTree,
+        programCourses: [course],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+        ancestorProgramEnrollment: programEnrollment,
+      })
+
+      const item = sections[0].items[0]
+      expect(item.kind).toBe("course")
+      if (item.kind === "course") {
+        expect(item.entry.ancestorContext?.programEnrollment).toBe(
+          programEnrollment,
+        )
+      }
+    })
+
+    test("section key equals node id", () => {
+      const c = factories.courses.course({ id: 12001 })
+      const opNode = {
+        id: 77777,
+        data: {
+          node_type: "operator" as const,
+          operator: "all_of" as const,
+          operator_value: null,
+          elective_flag: false,
+          title: "Keyed Section",
+          course: null,
+          required_program: null,
+        },
+        children: [
+          {
+            id: 77778,
+            data: {
+              node_type: "course" as const,
+              course: c.id,
+              operator: null,
+              operator_value: null,
+              elective_flag: false,
+              title: null,
+              required_program: null,
+            },
+            children: [],
+          },
+        ],
+      }
+
+      const { sections } = buildRequirementSections({
+        reqTree: [opNode],
+        programCourses: [c],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [],
+        requiredProgramModuleCoursesByProgramId: {},
+        selectedLanguageKey: "",
+        availableLanguages: [],
+      })
+
+      expect(sections[0].key).toBe(opNode.id)
     })
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -14,7 +14,7 @@ import {
   isNonContractEnrollment,
   isProgramAsCourse,
   pickDisplayedEnrollmentForLegacyDashboard,
-  resolveSlotForLanguage,
+  resolveCourseEntryForLanguage,
 } from "./dashboardViewModel"
 
 describe("dashboardViewModel", () => {
@@ -748,7 +748,7 @@ describe("dashboardViewModel", () => {
     })
   })
 
-  describe("resolveSlotForLanguage", () => {
+  describe("resolveCourseEntryForLanguage", () => {
     test("prefers selected-language enrollment", () => {
       const englishRun = factories.courses.courseRun({
         id: 11,
@@ -829,7 +829,7 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const resolved = resolveSlotForLanguage(
+      const resolved = resolveCourseEntryForLanguage(
         course,
         [englishEnrollment, spanishEnrollment],
         "language:es",
@@ -900,7 +900,7 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const resolved = resolveSlotForLanguage(
+      const resolved = resolveCourseEntryForLanguage(
         course,
         [otherContractEnrollment],
         "language:es",
@@ -942,9 +942,14 @@ describe("dashboardViewModel", () => {
         ],
       })
 
-      const resolved = resolveSlotForLanguage(course, [], "language:es", {
-        contractId: 1,
-      })
+      const resolved = resolveCourseEntryForLanguage(
+        course,
+        [],
+        "language:es",
+        {
+          contractId: 1,
+        },
+      )
 
       expect(resolved.displayedEnrollment).toBeNull()
       expect(resolved.displayedRun?.id).toBe(32)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -15,6 +15,7 @@ import type {
   CourseRunV2,
   CourseWithCourseRunsSerializerV2,
   V2ProgramDetail,
+  V2ProgramRequirement,
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
@@ -23,8 +24,16 @@ import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 // enrollment-flat home contract; it moves into this file when the legacy
 // cards are removed (Phase 7).
 import type { DashboardResource } from "../DashboardCard"
-import { getIdsFromReqTree } from "@/common/mitxonline"
-import { EnrollmentStatus, getEnrollmentStatus } from "../helpers"
+import {
+  getIdsFromReqTree,
+  parseProgramRequirementSections,
+} from "@/common/mitxonline"
+import type { ProgramRequirementSection } from "@/common/mitxonline"
+import {
+  EnrollmentStatus,
+  getEnrollmentStatus,
+  getRequirementsProgress,
+} from "../helpers"
 import {
   getNativeLanguageName,
   // below five are used only for resolveCourseEntryForLanguage
@@ -485,6 +494,261 @@ const resolveCourseEntryForLanguage = (
   }
 }
 
+/**
+ * Dashboard's display title for a requirement section operator node.
+ *
+ * Display policy owned by the dashboard — NOT by the shared parser
+ * (`parseProgramRequirementSections`). The shared parser returns `rawTitle`
+ * (null when absent); this function layers the fallback copy on top.
+ *
+ * Title precedence:
+ * 1. `node.data.title` — explicit title wins
+ * 2. elective + `min_number_of` + numeric `operator_value` → "Electives (Complete N)"
+ * 3. elective (any other config) → "Elective Courses"
+ * 4. default → "Core Courses"
+ */
+const getRequirementSectionTitle = (node: V2ProgramRequirement): string => {
+  if (node.data.title) {
+    return node.data.title
+  }
+  if (node.data.elective_flag) {
+    if (node.data.operator === "min_number_of" && node.data.operator_value) {
+      return `Electives (Complete ${node.data.operator_value})`
+    }
+    return "Elective Courses"
+  }
+  return "Core Courses"
+}
+
+/**
+ * A single item in a requirement section — a discriminated union of three kinds.
+ *
+ * Terminology note: `item` refers to any arm of this union (heterogeneous);
+ * `entry` refers specifically to the `DashboardCourseEntry` resolved for the
+ * `course` arm (the only arm with language / contract / enrollment complexity).
+ * The other two arms are not `DashboardCourseEntry`-shaped and are intentionally
+ * left as lighter structs.
+ */
+type RequirementSectionItem =
+  | { kind: "course"; entry: DashboardCourseEntry }
+  | {
+      kind: "program-as-course"
+      courseProgram: V2ProgramDetail
+      moduleCourses: CourseWithCourseRunsSerializerV2[]
+      courseProgramEnrollment?: V3UserProgramEnrollment
+    }
+  | { kind: "program-enrollment"; enrollment: V3UserProgramEnrollment }
+
+/**
+ * A fully-resolved requirement section for the program dashboard.
+ *
+ * Carries `node` (the source operator from `req_tree`) because the dashboard
+ * feeds it to `getRequirementsProgress(V2ProgramRequirement[])` for progress
+ * counts — a dashboard-internal need. It is distinct from the shared
+ * structure-only `ProgramRequirementSection` (which carries `node` as a
+ * back-reference but has no display/completion data).
+ */
+type RequirementSection = {
+  key: string | number | null | undefined
+  title: string
+  node: V2ProgramRequirement
+  items: RequirementSectionItem[]
+  completed: number
+  total: number
+}
+
+/**
+ * Build a fully-resolved `DashboardCourseEntry` for a single course.
+ *
+ * This is a pure constructor — it delegates display-resolution to
+ * `resolveCourseEntryForLanguage` and assembles the result with the
+ * caller-supplied metadata. The caller is responsible for:
+ *  - pre-filtering `enrollments` to this course (e.g. `enrollmentsByCourseId[course.id] ?? []`)
+ *  - computing `availableLanguages` once at the composer level (NOT re-derived here)
+ *  - supplying the effective `selectedLanguageKey` (a valid option or fallback)
+ *
+ * `enrollments` is stored uncollapsed on the entry — the full list, never
+ * filtered to the displayed choice. The `displayedEnrollment`/`displayedRun`
+ * pair is derived by `resolveCourseEntryForLanguage` for the legacy card UI.
+ */
+const buildCourseEntry = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollments: CourseRunEnrollmentV3[],
+  selectedLanguageKey: string,
+  opts: {
+    availableLanguages: SimpleSelectOption[]
+    contractId?: number
+    isContractPageResource?: boolean
+    ancestorContext?: DashboardCourseEntry["ancestorContext"]
+  },
+): DashboardCourseEntry => {
+  const { displayedEnrollment, displayedRun } = resolveCourseEntryForLanguage(
+    course,
+    enrollments,
+    selectedLanguageKey,
+    opts.contractId !== undefined ? { contractId: opts.contractId } : undefined,
+  )
+  return {
+    course,
+    enrollments,
+    selectedLanguageKey,
+    availableLanguages: opts.availableLanguages,
+    contractId: opts.contractId,
+    isContractPageResource: opts.isContractPageResource,
+    ancestorContext: opts.ancestorContext,
+    displayedEnrollment,
+    displayedRun,
+  }
+}
+
+type BuildRequirementSectionsArgs = {
+  /**
+   * The program's `req_tree`. Assumes a flat structure: operators are never
+   * nested inside operators; direct children of each operator are leaves
+   * (`node_type: "course"` or `"program"`). See `getRequirementsProgress`
+   * for the same assumption and rationale.
+   */
+  reqTree: V2ProgramRequirement[]
+  /** All courses belonging to the program (fetched once by the composer). */
+  programCourses: CourseWithCourseRunsSerializerV2[]
+  /** Course-run enrollments keyed by course id (pre-grouped by the composer). */
+  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>
+  /** Program enrollments keyed by program id (pre-grouped by the composer). */
+  programEnrollmentsById: Record<number, V3UserProgramEnrollment>
+  /** Nested programs referenced in `req_tree` (fetched by the composer). */
+  requiredPrograms: V2ProgramDetail[]
+  /**
+   * Module courses for each required program (keyed by program id). Used to
+   * wire `program-as-course` items. Pre-derived by the composer via
+   * `groupModuleCoursesByProgramId`.
+   */
+  requiredProgramModuleCoursesByProgramId: Record<
+    number,
+    CourseWithCourseRunsSerializerV2[]
+  >
+  /** Effective language key (valid option or fallback ""). */
+  selectedLanguageKey: string
+  /**
+   * Dashboard-wide language options list, computed once by the composer.
+   * Stored as-is on each course entry — NOT recomputed here.
+   */
+  availableLanguages: SimpleSelectOption[]
+  /**
+   * The top-level program's own enrollment (from `programEnrollmentsById`).
+   * When present, placed on every course arm's `ancestorContext.programEnrollment`.
+   */
+  ancestorProgramEnrollment?: V3UserProgramEnrollment
+}
+
+/**
+ * Build the requirement sections for the program dashboard.
+ *
+ * Composes `parseProgramRequirementSections` for the structural parse, then
+ * layers dashboard-only enrichment: entity resolution (course/program lookups),
+ * the three-arm `RequirementSectionItem` discriminated union, section title
+ * display copy (via `getRequirementSectionTitle`), and per-section + overall
+ * progress counts (via `getRequirementsProgress`).
+ *
+ * Assumes a flat `req_tree`: operators are never nested inside operators.
+ * See `getRequirementsProgress` for the same assumption and rationale.
+ *
+ * Preserves `req_tree` ordering. Sections with no resolved items are filtered
+ * out (oracle: `.filter(section => section.items.length > 0)`).
+ * Overall counts are computed over the filtered sections' nodes (not the full
+ * `req_tree`) to match the oracle exactly.
+ */
+const buildRequirementSections = ({
+  reqTree,
+  programCourses,
+  enrollmentsByCourseId,
+  programEnrollmentsById,
+  requiredPrograms,
+  requiredProgramModuleCoursesByProgramId,
+  selectedLanguageKey,
+  availableLanguages,
+  ancestorProgramEnrollment,
+}: BuildRequirementSectionsArgs): {
+  sections: RequirementSection[]
+  completedCount: number
+  totalCount: number
+} => {
+  const coursesById = new Map(programCourses.map((c) => [c.id, c]))
+  const programsById = new Map(requiredPrograms.map((p) => [p.id, p]))
+
+  const parsedSections: ProgramRequirementSection[] =
+    parseProgramRequirementSections(reqTree)
+
+  const sections: RequirementSection[] = parsedSections
+    .map((section) => {
+      const items: RequirementSectionItem[] = section.items
+        .map((resource): RequirementSectionItem | null => {
+          if (resource.type === "course") {
+            const course = coursesById.get(resource.id)
+            if (!course) return null
+            return {
+              kind: "course",
+              entry: buildCourseEntry(
+                course,
+                enrollmentsByCourseId[course.id] ?? [],
+                selectedLanguageKey,
+                {
+                  availableLanguages,
+                  ancestorContext: ancestorProgramEnrollment
+                    ? { programEnrollment: ancestorProgramEnrollment }
+                    : undefined,
+                },
+              ),
+            }
+          }
+
+          // resource.type === "program"
+          const program = programsById.get(resource.id)
+          if (!program) return null
+
+          if (isProgramAsCourse(program)) {
+            return {
+              kind: "program-as-course",
+              courseProgram: program,
+              moduleCourses:
+                requiredProgramModuleCoursesByProgramId[program.id] ?? [],
+              courseProgramEnrollment: programEnrollmentsById[program.id],
+            }
+          }
+
+          const enrollment = programEnrollmentsById[program.id]
+          if (!enrollment) return null
+
+          return { kind: "program-enrollment", enrollment }
+        })
+        .filter((item): item is RequirementSectionItem => item !== null)
+
+      const { completed, total } = getRequirementsProgress(
+        [section.node],
+        enrollmentsByCourseId,
+        programEnrollmentsById,
+      )
+
+      return {
+        key: section.id,
+        title: getRequirementSectionTitle(section.node),
+        node: section.node,
+        items,
+        completed,
+        total,
+      }
+    })
+    .filter((section) => section.items.length > 0)
+
+  const { completed: completedCount, total: totalCount } =
+    getRequirementsProgress(
+      sections.map((s) => s.node),
+      enrollmentsByCourseId,
+      programEnrollmentsById,
+    )
+
+  return { sections, completedCount, totalCount }
+}
+
 export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
@@ -500,4 +764,8 @@ export {
   groupModuleCoursesByProgramId,
   bucketAndSortHomeEnrollments,
   assembleHomeCardList,
+  buildCourseEntry,
+  buildRequirementSections,
+  getRequirementSectionTitle,
 }
+export type { RequirementSectionItem, RequirementSection }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -766,6 +766,5 @@ export {
   assembleHomeCardList,
   buildCourseEntry,
   buildRequirementSections,
-  getRequirementSectionTitle,
 }
 export type { RequirementSectionItem, RequirementSection }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -1,8 +1,8 @@
 /**
  * Pure-model layer for the dashboard.
  *
- * Owns the canonical types (e.g. DashboardCourseSlot) and the pure transforms
- * — grouping, slot construction, display policy — that data hooks compose into
+ * Owns the canonical types (e.g. DashboardCourseEntry) and the pure transforms
+ * — grouping, entry construction, display policy — that data hooks compose into
  * render-ready shapes. No React, no queries; everything is synchronous and
  * unit-testable in isolation.
  */
@@ -27,7 +27,7 @@ import { getIdsFromReqTree } from "@/common/mitxonline"
 import { EnrollmentStatus, getEnrollmentStatus } from "../helpers"
 import {
   getNativeLanguageName,
-  // below five are used only for resolveSlotForLanguage
+  // below five are used only for resolveCourseEntryForLanguage
   getCourseRunForSelectedLanguage,
   getEnrollmentForSelectedLanguage,
   getResolvedRunForSelectedLanguage,
@@ -43,10 +43,10 @@ import {
  * `enrollments` must be course-matched (by run id) with no language filter —
  * language is a display selection (`selectedLanguageKey` → `displayedEnrollment`
  * / `displayedRun`), not a filter on the underlying list. Contract scoping,
- * when applicable, must be applied by the slot constructor before the list
- * reaches the slot.
+ * when applicable, must be applied by the entry constructor before the list
+ * reaches the entry.
  */
-export type DashboardCourseSlot = {
+export type DashboardCourseEntry = {
   course: CourseWithCourseRunsSerializerV2
   enrollments: CourseRunEnrollmentV3[]
   selectedLanguageKey: string
@@ -403,11 +403,11 @@ const getDistinctDashboardLanguageOptions = (
   return options
 }
 
-type ResolveSlotForLanguageOpts = {
+type ResolveCourseEntryForLanguageOpts = {
   contractId?: number
 }
 
-type ResolveSlotForLanguageResult = {
+type ResolveCourseEntryForLanguageResult = {
   displayedEnrollment: CourseRunEnrollmentV3 | null
   displayedRun: CourseRunV2 | null
   selectedLanguageOption: CourseRunLanguageOption | null
@@ -415,14 +415,14 @@ type ResolveSlotForLanguageResult = {
 
 /**
  * Given a language selection and course/enrollment data, pick the
- * `displayedEnrollment` and `displayedRun` for a dashboard slot.
+ * `displayedEnrollment` and `displayedRun` for a dashboard course entry.
  */
-const resolveSlotForLanguage = (
+const resolveCourseEntryForLanguage = (
   course: CourseWithCourseRunsSerializerV2,
   enrollments: CourseRunEnrollmentV3[],
   selectedLanguageKey: string,
-  opts?: ResolveSlotForLanguageOpts,
-): ResolveSlotForLanguageResult => {
+  opts?: ResolveCourseEntryForLanguageOpts,
+): ResolveCourseEntryForLanguageResult => {
   const selectedLanguageOption = getSelectedLanguageOption(
     course,
     selectedLanguageKey,
@@ -489,7 +489,7 @@ export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
-  resolveSlotForLanguage,
+  resolveCourseEntryForLanguage,
   getDistinctDashboardLanguageOptions,
   isProgramAsCourse,
   isNonContractEnrollment,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
@@ -12,6 +12,9 @@ import {
   OrganizationPage,
   User,
   V2Program,
+  V2ProgramDetail,
+  V3UserProgramEnrollment,
+  DisplayModeEnum,
 } from "@mitodl/mitxonline-api-axios/v2"
 
 const makeCourses = factories.courses.courses
@@ -410,6 +413,150 @@ const createCoursesWithContractRuns = (contracts: ContractPage[]) => {
   })
 }
 
+type BuildProgramScenarioInput = {
+  programId: number
+  program: V2ProgramDetail
+  programCourses?: CourseWithCourseRunsSerializerV2[]
+  courseEnrollments?: CourseRunEnrollmentV3[]
+  programEnrollments?: V3UserProgramEnrollment[]
+  requiredPrograms?: V2ProgramDetail[]
+  requiredProgramCourses?: CourseWithCourseRunsSerializerV2[]
+}
+
+type BuildProgramScenarioResult = {
+  entities: {
+    programId: number
+    program: V2ProgramDetail
+    programCourses: CourseWithCourseRunsSerializerV2[]
+    courseEnrollments: CourseRunEnrollmentV3[]
+    programEnrollments: V3UserProgramEnrollment[]
+    requiredPrograms: V2ProgramDetail[]
+    requiredProgramCourses: CourseWithCourseRunsSerializerV2[]
+  }
+  mockAll: () => void
+}
+
+/**
+ * Thin entities-in mock-wirer for `useProgramDashboardData` renderHook tests.
+ *
+ * Tests build the scenario-specific entities (programs, courses, enrollments,
+ * req_tree shape) and pass them in; this builder only wires the standard
+ * `setMockResponse` calls that match the hook's 6 queries exactly (same
+ * query keys, params, page_size, enabled gating). The returned `mockAll()`
+ * also mocks the mitxonline user identity endpoint that the test harness needs.
+ *
+ * Tests may add/override raw `setMockResponse` after `mockAll()` for edge cases.
+ *
+ * Builder owns INFRA ONLY — scenario shape (req_tree, languages, enrollment→run
+ * mapping) lives in each test.
+ */
+const buildProgramScenario = (
+  input: BuildProgramScenarioInput,
+): BuildProgramScenarioResult => {
+  const {
+    programId,
+    program,
+    programCourses = [],
+    courseEnrollments = [],
+    programEnrollments = [],
+    requiredPrograms = [],
+    requiredProgramCourses = [],
+  } = input
+
+  const entities = {
+    programId,
+    program,
+    programCourses,
+    courseEnrollments,
+    programEnrollments,
+    requiredPrograms,
+    requiredProgramCourses,
+  }
+
+  const mockAll = () => {
+    // Infra: identity endpoint needed by the test harness
+    const mitxOnlineUser = factories.user.user()
+    setMockResponse.get(urls.userMe.get(), mitxOnlineUser)
+
+    // Query 1: course-run enrollments list
+    setMockResponse.get(urls.enrollment.enrollmentsListV3(), courseEnrollments)
+
+    // Query 2: program detail
+    setMockResponse.get(urls.programs.programDetail(programId), program)
+
+    // Query 3: program enrollments list
+    setMockResponse.get(
+      urls.programEnrollments.enrollmentsListV3(),
+      programEnrollments,
+    )
+
+    // Query 4: program courses
+    // enabled: !!program && program.courses.length > 0 && enrolledInProgram
+    // Always mock it; tests that need enabled=false just won't call it.
+    if (program.courses && program.courses.length > 0) {
+      setMockResponse.get(
+        urls.courses.coursesList({
+          id: program.courses,
+          page_size: program.courses.length || undefined,
+        }),
+        {
+          count: programCourses.length,
+          next: null,
+          previous: null,
+          results: programCourses,
+        },
+      )
+    }
+
+    // Query 5: required programs list
+    // enabled: Boolean(enrolledInProgram && requiredProgramIds.length > 0)
+    // Must mirror useProgramDashboardData.ts requiredProgramIds useMemo exactly — if that changes, mock query keys drift and these scenarios silently fail.
+    const requiredProgramIds = requiredPrograms.map((p) => p.id)
+    if (requiredProgramIds.length > 0) {
+      setMockResponse.get(
+        urls.programs.programsList({
+          id: requiredProgramIds,
+          page_size: requiredProgramIds.length || undefined,
+        }),
+        {
+          count: requiredPrograms.length,
+          next: null,
+          previous: null,
+          results: requiredPrograms,
+        },
+      )
+    }
+
+    // Query 6: required-program courses (program-as-course module courses)
+    // enabled: Boolean(enrolledInProgram && programAsCourseCourseIds.length > 0)
+    // Must mirror useProgramDashboardData.ts programAsCourseCourseIds useMemo exactly — same drift risk.
+    const uniqueIds = new Set<number>()
+    requiredPrograms
+      .filter((p) => p.display_mode === DisplayModeEnum.Course)
+      .forEach((p) => {
+        p.courses?.forEach((courseId) => uniqueIds.add(courseId))
+      })
+    const programAsCourseCourseIds = [...uniqueIds]
+
+    if (programAsCourseCourseIds.length > 0) {
+      setMockResponse.get(
+        urls.courses.coursesList({
+          id: programAsCourseCourseIds,
+          page_size: programAsCourseCourseIds.length || undefined,
+        }),
+        {
+          count: requiredProgramCourses.length,
+          next: null,
+          previous: null,
+          results: requiredProgramCourses,
+        },
+      )
+    }
+  }
+
+  return { entities, mockAll }
+}
+
 export {
   dashboardCourse,
   dashboardProgram,
@@ -420,4 +567,5 @@ export {
   createTestContracts,
   createCoursesWithContractRuns,
   createEnrollmentsForContractRuns,
+  buildProgramScenario,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
@@ -16,6 +16,7 @@ import {
   V3UserProgramEnrollment,
   DisplayModeEnum,
 } from "@mitodl/mitxonline-api-axios/v2"
+import { getIdsFromReqTree } from "@/common/mitxonline"
 
 const makeCourses = factories.courses.courses
 const makeProgram = factories.programs.program
@@ -510,8 +511,12 @@ const buildProgramScenario = (
 
     // Query 5: required programs list
     // enabled: Boolean(enrolledInProgram && requiredProgramIds.length > 0)
-    // Must mirror useProgramDashboardData.ts requiredProgramIds useMemo exactly — if that changes, mock query keys drift and these scenarios silently fail.
-    const requiredProgramIds = requiredPrograms.map((p) => p.id)
+    // Mirrors useProgramDashboardData.ts requiredProgramIds useMemo exactly:
+    //   [...new Set(getIdsFromReqTree(program.req_tree).programIds)]
+    // If that changes, mock query keys drift and these scenarios silently fail.
+    const requiredProgramIds = program.req_tree
+      ? [...new Set(getIdsFromReqTree(program.req_tree).programIds)]
+      : []
     if (requiredProgramIds.length > 0) {
       setMockResponse.get(
         urls.programs.programsList({

--- a/frontends/main/src/common/mitxonline.test.ts
+++ b/frontends/main/src/common/mitxonline.test.ts
@@ -1,9 +1,10 @@
 import { factories, RequirementTreeBuilder } from "api/mitxonline-test-utils"
-import { DiscountTypeEnum } from "@mitodl/mitxonline-api-axios/v2"
+import { DiscountTypeEnum, NodeTypeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import {
   formatPrice,
   getFlexiblePriceForProduct,
   getIdsFromReqTree,
+  parseProgramRequirementSections,
   priceWithDiscount,
 } from "@/common/mitxonline"
 
@@ -218,6 +219,207 @@ describe("priceWithDiscount", () => {
     expect(result.finalPrice).toBe("$100")
     expect(result.isDiscounted).toBe(false)
     expect(result.approvedFinancialAid).toBe(true) // Has financial aid approval, just no discount
+  })
+})
+
+describe("parseProgramRequirementSections", () => {
+  test("returns empty array for empty reqTree", () => {
+    const root = new RequirementTreeBuilder()
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections).toEqual([])
+  })
+
+  test("preserves req_tree order across multiple operator sections", () => {
+    const root = new RequirementTreeBuilder()
+    const first = root.addOperator({ operator: "all_of", title: "First" })
+    first.addCourse()
+    const second = root.addOperator({ operator: "all_of", title: "Second" })
+    second.addCourse()
+    const third = root.addOperator({
+      operator: "min_number_of",
+      operator_value: "1",
+      title: "Third",
+    })
+    third.addCourse()
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections).toHaveLength(3)
+    expect(sections[0].rawTitle).toBe("First")
+    expect(sections[1].rawTitle).toBe("Second")
+    expect(sections[2].rawTitle).toBe("Third")
+  })
+
+  test("items preserve order and capture both course and program leaves", () => {
+    const root = new RequirementTreeBuilder()
+    const op = root.addOperator({ operator: "all_of" })
+    op.addCourse({ course: 10 })
+    op.addProgram({ program: 99 })
+    op.addCourse({ course: 20 })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections).toHaveLength(1)
+    expect(sections[0].items).toEqual([
+      { type: "course", id: 10 },
+      { type: "program", id: 99 },
+      { type: "course", id: 20 },
+    ])
+  })
+
+  test("rawTitle is the node title when set", () => {
+    const root = new RequirementTreeBuilder()
+    root.addOperator({ operator: "all_of", title: "My Section Title" })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections[0].rawTitle).toBe("My Section Title")
+  })
+
+  test("rawTitle is null when node has no title", () => {
+    // RequirementTreeBuilder.addOperator always sets a faker title, so we
+    // test via the contract: rawTitle must be null when data.title is null.
+    // We construct a minimal V2ProgramRequirement directly.
+    const reqTree = [
+      {
+        id: 1,
+        data: {
+          node_type: NodeTypeEnum.Operator,
+          operator: "all_of",
+          operator_value: null,
+          title: null,
+          elective_flag: false,
+          course: null,
+          required_program: null,
+          program: 1,
+        },
+        children: [],
+      },
+    ]
+    const sections = parseProgramRequirementSections(reqTree)
+    expect(sections[0].rawTitle).toBeNull()
+    // Explicitly confirm no default/fallback string is produced
+    expect(sections[0].rawTitle).not.toBe("Core Courses")
+    expect(sections[0].rawTitle).not.toBe("Elective Courses")
+  })
+
+  test("elective reflects elective_flag: false for all_of", () => {
+    const root = new RequirementTreeBuilder()
+    root.addOperator({ operator: "all_of" })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections[0].elective).toBe(false)
+  })
+
+  test("elective reflects elective_flag: true for min_number_of", () => {
+    const root = new RequirementTreeBuilder()
+    root.addOperator({ operator: "min_number_of", operator_value: "2" })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections[0].elective).toBe(true)
+  })
+
+  test("requiredCount equals operator_value for min_number_of", () => {
+    const root = new RequirementTreeBuilder()
+    const op = root.addOperator({
+      operator: "min_number_of",
+      operator_value: "2",
+    })
+    op.addCourse()
+    op.addCourse()
+    op.addCourse()
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections[0].requiredCount).toBe(2)
+  })
+
+  test("requiredCount equals items.length for all_of", () => {
+    const root = new RequirementTreeBuilder()
+    const op = root.addOperator({ operator: "all_of" })
+    op.addCourse()
+    op.addCourse()
+    op.addCourse()
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections[0].requiredCount).toBe(3)
+  })
+
+  test("non-operator root nodes are skipped", () => {
+    // Mix of operator and non-operator nodes at the root
+    const reqTree = [
+      {
+        id: 1,
+        data: {
+          node_type: NodeTypeEnum.Course,
+          operator: null,
+          operator_value: null,
+          title: null,
+          elective_flag: false,
+          course: 42,
+          required_program: null,
+          program: 1,
+        },
+      },
+      {
+        id: 2,
+        data: {
+          node_type: NodeTypeEnum.Operator,
+          operator: "all_of",
+          operator_value: null,
+          title: "Valid Section",
+          elective_flag: false,
+          course: null,
+          required_program: null,
+          program: 1,
+        },
+        children: [
+          {
+            id: 3,
+            data: {
+              node_type: NodeTypeEnum.Course,
+              operator: null,
+              operator_value: null,
+              title: null,
+              elective_flag: false,
+              course: 55,
+              required_program: null,
+              program: 1,
+            },
+          },
+        ],
+      },
+    ]
+    const sections = parseProgramRequirementSections(reqTree)
+    expect(sections).toHaveLength(1)
+    expect(sections[0].rawTitle).toBe("Valid Section")
+    expect(sections[0].items).toEqual([{ type: "course", id: 55 }])
+  })
+
+  test("operator field reflects the node's operator string", () => {
+    const root = new RequirementTreeBuilder()
+    root.addOperator({ operator: "all_of" })
+    root.addOperator({ operator: "min_number_of", operator_value: "1" })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections).toHaveLength(2)
+    expect(sections[0].operator).toBe("all_of")
+    expect(sections[1].operator).toBe("min_number_of")
+  })
+
+  test("items are collected recursively from nested children", () => {
+    const root = new RequirementTreeBuilder()
+    const op = root.addOperator({ operator: "all_of" })
+    op.addCourse({ course: 10 })
+    // Add a nested operator inside the operator (recursive case)
+    const nested = op.addOperator({ operator: "all_of" })
+    nested.addCourse({ course: 20 })
+    nested.addProgram({ program: 77 })
+
+    const sections = parseProgramRequirementSections(root.serialize())
+    expect(sections).toHaveLength(1)
+    // Recursive walk should collect 10, 20, 77
+    expect(sections[0].items).toEqual([
+      { type: "course", id: 10 },
+      { type: "course", id: 20 },
+      { type: "program", id: 77 },
+    ])
   })
 })
 

--- a/frontends/main/src/common/mitxonline/index.ts
+++ b/frontends/main/src/common/mitxonline/index.ts
@@ -189,6 +189,80 @@ const getCourseEnrollmentAction = (
   return { type: "none" }
 }
 
+type ProgramRequirementSection = {
+  /**
+   * The source operator node, returned as a convenience back-reference for
+   * consumers that still need raw-tree operations (e.g. the dashboard's
+   * `getRequirementsProgress(V2ProgramRequirement[])`). It is NOT an invitation
+   * to bypass the derived fields (`items`, `operator`, `requiredCount`,
+   * `rawTitle`, `elective`). Note: `id === node.id` — a convenience stable
+   * identifier.
+   */
+  node: V2ProgramRequirement
+  id: number | null | undefined
+  elective: boolean
+  operator: string | null
+  requiredCount: number
+  rawTitle: string | null
+  items: { type: "course" | "program"; id: number }[]
+}
+
+/**
+ * Parse a program's req_tree into ordered operator sections.
+ *
+ * Structure-only: returns ids + operator metadata + rawTitle.
+ * No default/fallback titles, no display copy, no completion/progress logic,
+ * no entity resolution, no logging. Consumer is responsible for all of that.
+ *
+ * Note: the product `parseReqTree` (`ProductPages/util.ts`) will migrate onto
+ * this helper in a later separate PR — that is why two structurally-similar
+ * functions currently coexist.
+ */
+const parseProgramRequirementSections = (
+  reqTree: V2ProgramRequirement[],
+): ProgramRequirementSection[] => {
+  return reqTree
+    .filter((node) => node.data.node_type === NodeTypeEnum.Operator)
+    .map((node) => {
+      const items: { type: "course" | "program"; id: number }[] = []
+      const walk = (children: V2ProgramRequirement[]) => {
+        for (const child of children) {
+          if (
+            child.data.node_type === NodeTypeEnum.Course &&
+            typeof child.data.course === "number"
+          ) {
+            items.push({ type: "course", id: child.data.course })
+          } else if (
+            child.data.node_type === NodeTypeEnum.Program &&
+            typeof child.data.required_program === "number"
+          ) {
+            items.push({ type: "program", id: child.data.required_program })
+          }
+          if (child.children) walk(child.children)
+        }
+      }
+      walk(node.children ?? [])
+
+      // Mirrors parseReqTree's formula exactly on purpose (including NaN when
+      // operator_value is absent/non-numeric) so the deferred product migration
+      // is a behavior no-op — do not "fix" the NaN path here.
+      const requiredCount =
+        node.data.operator === "min_number_of"
+          ? Number(node.data.operator_value)
+          : items.length
+
+      return {
+        node,
+        id: node.id,
+        elective: node.data.elective_flag ?? false,
+        operator: node.data.operator ?? null,
+        requiredCount,
+        rawTitle: node.data.title ?? null,
+        items,
+      }
+    })
+}
+
 /**
  * Extract all course and program IDs from a program's req_tree.
  * This is the single source of truth for which courses/programs belong to a program.
@@ -254,7 +328,13 @@ export {
   getEnrollmentType,
   getCourseEnrollmentAction,
   getIdsFromReqTree,
+  parseProgramRequirementSections,
   getBestRun,
   isVerifiedEnrollmentMode,
 }
-export type { PriceWithDiscount, EnrollmentType, CourseEnrollmentAction }
+export type {
+  PriceWithDiscount,
+  EnrollmentType,
+  CourseEnrollmentAction,
+  ProgramRequirementSection,
+}

--- a/frontends/main/src/common/mitxonline/index.ts
+++ b/frontends/main/src/common/mitxonline/index.ts
@@ -217,6 +217,12 @@ type ProgramRequirementSection = {
  * Note: the product `parseReqTree` (`ProductPages/util.ts`) will migrate onto
  * this helper in a later separate PR — that is why two structurally-similar
  * functions currently coexist.
+ *
+ * The parser walks the tree recursively for parity with the legacy
+ * `extractResourcesFromNode`. The flat-`req_tree` invariant (operators never
+ * nest operators) makes recursion equivalent to iterating direct children, so
+ * this stays consistent with `getRequirementsProgress`, which counts direct
+ * children only.
  */
 const parseProgramRequirementSections = (
   reqTree: V2ProgramRequirement[],


### PR DESCRIPTION
### What are the relevant tickets?
For https://github.com/mitodl/hq/issues/11205

### Description (What does it do?)
This PR moves logic out of ProgramEnrollmentDisplay. Now:
1. Changed: `ProgramEnrollmentDisplay` is display only, essentially zero  computation, makes no queries of its own; delgates to useProgramDashboardData
2. New: `useProgramDashboardData` makes queries and organizes data for the UI via pure functional utilities (most notability `buildRequirementSections`). Also new is `useDashboardLanguagePicker`
    - In addition to keeping the UI components simple, the orchestrating hooks are easier to test directly.
3. New: `buildRequirementSections` and other utilities.

The new utilities are thoroughly tested. New tests also for `useProgramDashboardData` verify it is calling the utilities correctly, and tests for `useDashboardLanguagePicker` check its state / state mutation behaviors.

### How can this be tested?
1. Enroll in an mitxonline program locally. Use a program with multiple requirement sections and some program-as-course children. (Such as UAI.) Check that:
     - completion counts display correctly
     - cards display correctly (same as main)
     - In general, we should have confidence by the existing (untouched) ProgramEnrollmentDisplay.test.tsx file passing.
2. Set up langauges for a B2C program as descirbed in https://github.com/mitodl/mit-learn/pull/3269
    - The language picker should still work.
    - Note: The B2C program langauge feature is not really used / supported in production by real data , but it should work on this branch exactly as it does on `main`.
