### PR TITLE
Fix eslint config to ignore node_modules

### DIFF
--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   settings: {
     "import/resolver": {
       typescript: {
-    project: ["tsconfig.json", "*/tsconfig.json"]
+        project: ["tsconfig.json", "*/tsconfig.json"],
       },
     },
     "jsx-a11y": {

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   settings: {
     "import/resolver": {
       typescript: {
-        project: "**/tsconfig.json",
+        project: "*/tsconfig.json",
       },
     },
     "jsx-a11y": {

--- a/frontends/.eslintrc.js
+++ b/frontends/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
   settings: {
     "import/resolver": {
       typescript: {
-        project: "*/tsconfig.json",
+    project: ["tsconfig.json", "*/tsconfig.json"]
       },
     },
     "jsx-a11y": {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes eslint config so pre-commit doesn't traverse and load tsconfigs from node_modules.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You should be able to run `pre-commit run eslint -a` and it should pass and run much faster.