### PR TITLE
fix: dashboard card courserun association

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -72,6 +72,35 @@ describe("dashboardViewModel", () => {
         pickDisplayedEnrollmentForLegacyDashboard(course, [lower, higher]),
       ).toEqual(higher)
     })
+
+    test("keeps an older enrolled run when the course payload only lists the newer run", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 101,
+        title: "Older run",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 202,
+        title: "Newer run",
+      })
+      const course = factories.courses.course({
+        id: 77,
+        courseruns: [newerRun],
+        next_run_id: newerRun.id,
+      })
+      const olderEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: olderRun.id,
+          title: olderRun.title,
+          course: { id: course.id, title: course.title },
+        },
+        certificate: null,
+        grades: [],
+      })
+
+      expect(
+        pickDisplayedEnrollmentForLegacyDashboard(course, [olderEnrollment]),
+      ).toEqual(olderEnrollment)
+    })
   })
 
   describe("groupCourseRunEnrollmentsByCourseId", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -77,6 +77,17 @@ const getMaxEnrollmentGrade = (enrollment: CourseRunEnrollmentV3): number => {
   return Math.max(0, ...enrollment.grades.map((grade) => grade.grade ?? 0))
 }
 
+const enrollmentBelongsToCourse = (
+  course: CourseWithCourseRunsSerializerV2,
+  enrollment: CourseRunEnrollmentV3,
+): boolean => {
+  if (enrollment.run.course?.id === course.id) {
+    return true
+  }
+
+  return course.courseruns.some((run) => run.id === enrollment.run.id)
+}
+
 /**
  * Legacy display policy used by dashboard cards.
  *
@@ -90,7 +101,7 @@ const pickDisplayedEnrollmentForLegacyDashboard = (
   enrollments: CourseRunEnrollmentV3[],
 ): CourseRunEnrollmentV3 | null => {
   const courseEnrollments = enrollments.filter((enrollment) =>
-    course.courseruns.some((run) => run.id === enrollment.run.id),
+    enrollmentBelongsToCourse(course, enrollment),
   )
   if (courseEnrollments.length === 0) {
     return null


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11387

### Description (What does it do?)
This fixes a dashboard regression where a learner could appear unenrolled from a course after a newer run supplanted the run they were actually enrolled in.

The dashboard card selection logic was only treating an enrollment as relevant when its run id was still present in the course's current `courseruns` payload. In the B2B contract case from the linked issue, that meant older enrolled runs could be dropped from the card context once a newer run became the current/default run, which also hid certificate/completion context.

This change updates the legacy dashboard enrollment selection logic to associate enrollments to a course by course id first, with the existing run-id match kept as a fallback. That allows the dashboard to continue surfacing a learner's real enrolled run even when the course payload only lists a newer run.

A regression test was added for the exact failure mode: an older enrolled run should still be selected when the course payload only contains the newer supplanting run.

### How can this be tested?
Automated testing:
- Ran `docker compose exec watch yarn test frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts`
- Verified the new regression test passes
- Confirmed the touched files have no TypeScript diagnostics

Manual testing:
1. Set up a B2B contract with a course run and a learner attached to the contract.
2. Enroll the learner in the original contract run and confirm the dashboard shows the course as enrolled.
3. Create a newer run that supplants the original run.
4. Reload the dashboard.
5. Confirm the learner still sees the course as enrolled via their existing run, rather than appearing unenrolled.
6. If the learner has a passing grade/certificate on the original run, confirm that status still appears on the dashboard after the newer run is created.
7. Switch back to `main` and verify that you can reproduce the original bug

Reviewer validation:
1. Review the update to the dashboard enrollment selection logic in `dashboardViewModel.ts`.
2. Review the added regression coverage in `dashboardViewModel.test.ts`.
3. Reproduce the B2B scenario above, or rely on the focused unit test that covers the same failure mode.