### PR TITLE
remove authentication requirement from hybrid search 

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductSummary.tsx
@@ -955,7 +955,8 @@ const ProgramPriceRow: React.FC<ProgramPriceRowProps> = ({
         {hasSavings && listAmount !== null ? (
           <>
             <ProgramVerticalDivider />
-            <ProgramListPriceBlock role="group"
+            <ProgramListPriceBlock
+              role="group"
               aria-label={`Original price: ${formatPrice(listAmount, { avoidCents: true })} purchased separately`}
             >
               <ProgramListPriceAmount aria-hidden="true">

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -767,7 +767,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
     return keyBy(offerorsQuery.data?.results ?? [], (o) => o.code)
   }, [offerorsQuery.data?.results])
 
-  const { data: user, isLoading: isUserLoading } = useUserMe()
+  const { data: user } = useUserMe()
 
   const isVectorSearch = searchParams.get("vector_search") === "true"
 
@@ -787,7 +787,6 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   // @ts-expect-error Typescript has trouble unifying the different query key types
   const { data, isLoading, isFetching } = useQuery({
     ...queryOptions,
-    enabled: !isVectorSearch || !isUserLoading,
     placeholderData: keepPreviousData,
     select: (timedData: {
       result:

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -769,8 +769,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
 
   const { data: user, isLoading: isUserLoading } = useUserMe()
 
-  const wantsVectorSearch = searchParams.get("vector_search") === "true"
-  const isVectorSearch = wantsVectorSearch && user?.is_learning_path_editor
+  const isVectorSearch = searchParams.get("vector_search") === "true"
+
   const isVectorQuerySearch =
     isVectorSearch &&
     typeof allParams.q === "string" &&
@@ -787,7 +787,7 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   // @ts-expect-error Typescript has trouble unifying the different query key types
   const { data, isLoading, isFetching } = useQuery({
     ...queryOptions,
-    enabled: !wantsVectorSearch || !isUserLoading,
+    enabled: !isVectorSearch || !isUserLoading,
     placeholderData: keepPreviousData,
     select: (timedData: {
       result:


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11337
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR removes the authentication check for the vector_search=True parameter on the search page. This isn't really a feature that needs to require authentication to view it and it was causing confusion for folks passing links around and testing hybrid search.


### How can this be tested?
1. checkout main
2. make sure you have learning resources embedded locally
3. login as an admin user and visit the[ search page](open.odl.local:8062/search) - search for something
4. enable the "hybrid search" via the admin checkbox - note that it adds a vector_search=true get parameter and vector search results are loaded 
5. copy the url and logout - re-visit the url and see that it does not load the vector search results (you can double confirm via web inspector to see the endpoint it attempts to load)
6. checkout this branch and attempt to load the url as an anonymous user and note that it loads the vector search results

