### PR TITLE
Send task-rejected event when a celery task is manually rejected, so Leek picks it up

### DIFF
--- a/main/constants.py
+++ b/main/constants.py
@@ -40,6 +40,7 @@ ALLOWED_HTML_TAGS = {
     "ul",
 }
 ALLOWED_HTML_ATTRIBUTES = {}
+TASK_REJECTED = "task-rejected"
 
 
 class PostHogEvents(Enum):

--- a/main/decorators.py
+++ b/main/decorators.py
@@ -9,6 +9,8 @@ from celery import current_task, states
 from celery.exceptions import Reject
 from django.core.cache import caches
 
+from main.constants import TASK_REJECTED
+
 log = logging.getLogger(__name__)
 
 KEY_PREFIX = "cooldown"
@@ -80,6 +82,12 @@ def cooldown_task(
                         state=states.REJECTED,
                         meta={"reason": "cooldown", "key": lock_key},
                     )
+                    try:
+                        current_task.send_event(TASK_REJECTED, requeue=False)
+                    except Exception:  # noqa: BLE001
+                        log.warning(
+                            "Failed to emit task-rejected event for %s", lock_key
+                        )
                     reason = "cooldown active"
                     raise Reject(reason, requeue=False)
                 return None

--- a/main/decorators_test.py
+++ b/main/decorators_test.py
@@ -3,6 +3,7 @@
 import pytest
 from celery.exceptions import Reject
 
+from main.constants import TASK_REJECTED
 from main.decorators import cooldown_task
 
 
@@ -167,6 +168,7 @@ def test_cooldown_task_raises_reject_inside_celery_worker(mock_redis, mocker):
     mock_task.update_state.assert_called_once()
     assert mock_task.update_state.call_args.kwargs["state"] == "REJECTED"
     assert mock_task.update_state.call_args.kwargs["meta"]["reason"] == "cooldown"
+    mock_task.send_event.assert_called_once_with(TASK_REJECTED, requeue=False)
 
 
 def test_cooldown_task_returns_none_when_called_directly(mock_redis, mocker):
@@ -181,3 +183,4 @@ def test_cooldown_task_returns_none_when_called_directly(mock_redis, mocker):
 
     assert my_task() is None
     mock_task.update_state.assert_not_called()
+    mock_task.send_event.assert_not_called()


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/mit-learn/pull/3363 

### Description (What does it do?)
<!--- Describe your changes in detail -->
The changes made in https://github.com/mitodl/mit-learn/pull/3363 are correctly causing tasks to be rejected within the cooldown period (`task.status` == `REJECTED`) but Leek is not picking up that status change, so it is shown as stuck in "STARTED" status.

This PR modifies the decorator to send a "task-rejected" event, which in theory should let Leek pick up the status change to REJECTED.


### How can this be tested?
- Start up containers.
- Run this in a django shell:
```python
import threading
import time

from django.core.cache import caches

from learning_resources.tasks import get_mitxonline_data
from main.celery import app
from main.decorators import KEY_PREFIX

TASK = get_mitxonline_data
LOCK_KEY = f"{KEY_PREFIX}:{TASK.name}"
QUEUE = "edx_content"
MAX_WAIT = 30 

events = []
seen_rejected = threading.Event()


def handler(event):
    if not event.get("type", "").startswith("task-"):
        return
    events.append(event)
    if event["type"] == "task-rejected":
        seen_rejected.set()


def listen():
    with app.connection() as conn:
        recv = app.events.Receiver(conn, handlers={"*": handler})
        recv.capture(limit=None, timeout=None, wakeup=True)


listener = threading.Thread(target=listen, daemon=True)
listener.start()
time.sleep(3)  # let the receiver bind its queue before we dispatch

caches["redis"].set(LOCK_KEY, "1", timeout=900)
result = TASK.apply_async(queue=QUEUE)
print(f"dispatched {TASK.name} id={result.id} queue={QUEUE}")

seen_rejected.wait(timeout=MAX_WAIT)
caches["redis"].delete(LOCK_KEY)

mine = [e for e in events if e.get("uuid") == result.id]
print("events for this run:")
for e in mine:
    print(f"  {e['type']:<14} requeue={e.get('requeue')}")

print("\nresult backend state:", result.state)
rejected = [e for e in mine if e["type"] == "task-rejected"]
if rejected and rejected[0].get("requeue") is False:
    print("PASS: task-rejected event emitted (Leek will show REJECTED)")
else:
    print("FAIL: no task-rejected event seen on the stream")
```    
