### PR TITLE
Cut down on repeated APISIX user DB changes and logins

### DIFF
--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -90,7 +90,9 @@ def decode_apisix_headers(request, header, model=settings.AUTH_USER_MODEL):
     }
 
 
-def get_user_from_apisix_headers(request, decoded_headers, original_header):
+def get_user_from_apisix_headers(  # noqa: C901
+    request, decoded_headers, original_header
+):
     """
     Get a user based on the APISIX headers, create user/profile if needed.
 
@@ -128,13 +130,21 @@ def get_user_from_apisix_headers(request, decoded_headers, original_header):
         user = request.user
         created = False
     else:
-        user, created = (
-            User.objects.filter(
-                Q(global_id=global_id) | Q(global_id__isnull=True, email=email)
+        try:
+            user, created = (
+                User.objects.filter(
+                    Q(global_id=global_id) | Q(global_id__isnull=True, email=email)
+                )
+                .select_related("profile")
+                .get_or_create(defaults=user_fields)
             )
-            .select_related("profile")
-            .get_or_create(defaults=user_fields)
-        )
+        except User.MultipleObjectsReturned:
+            log.exception(
+                "Ambiguous APISIX user identity for global_id=%s and email=%s",
+                global_id,
+                email,
+            )
+            return None
 
     if created:
         log.info(

--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -3,12 +3,16 @@
 import base64
 import json
 import logging
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
+from django.http import HttpRequest
+from django.http.response import HttpResponseBase
 from posthog import Posthog
 
 from authentication.api import user_created_actions
@@ -17,11 +21,20 @@ from profiles.models import filter_profile_props
 
 log = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from users.models import User
+
 # User fields synced from the APISIX user headers (defaults match update_or_create).
-USER_SYNC_FIELDS = ("global_id", "email", "username", "first_name", "last_name")
+USER_SYNC_FIELDS = (
+    "global_id",
+    "email",
+    "username",
+    "first_name",
+    "last_name",
+)
 
 
-def user_fields_from_headers(decoded_headers):
+def user_fields_from_headers(decoded_headers: Mapping[str, Any]) -> dict[str, Any]:
     """Map the decoded user headers to the synced User fields."""
     return {
         "global_id": decoded_headers.get("global_id"),
@@ -32,12 +45,12 @@ def user_fields_from_headers(decoded_headers):
     }
 
 
-def user_needs_update(user, user_fields):
+def user_needs_update(user: "User", user_fields: Mapping[str, Any]) -> bool:
     """Return True if any synced User field differs from the headers."""
     return any(getattr(user, field) != user_fields[field] for field in USER_SYNC_FIELDS)
 
 
-def profile_needs_update(user, profile_data):
+def profile_needs_update(user: "User", profile_data: Mapping[str, Any] | None) -> bool:
     """Return True if the profile is missing or any synced field differs."""
     try:
         profile = user.profile
@@ -47,7 +60,9 @@ def profile_needs_update(user, profile_data):
     return any(getattr(profile, key) != value for key, value in props.items())
 
 
-def decode_apisix_headers(request, header, model=settings.AUTH_USER_MODEL):
+def decode_apisix_headers(
+    request: HttpRequest, header: str, model: str = settings.AUTH_USER_MODEL
+) -> dict[str, Any] | None:
     """
     Decode APISIX-specific headers and return the username as a dict.
 
@@ -91,8 +106,10 @@ def decode_apisix_headers(request, header, model=settings.AUTH_USER_MODEL):
 
 
 def get_user_from_apisix_headers(  # noqa: C901
-    request, decoded_headers, original_header
-):
+    request: HttpRequest,
+    decoded_headers: Mapping[str, Any] | None,
+    original_header: str,
+) -> "User | None":
     """
     Get a user based on the APISIX headers, create user/profile if needed.
 
@@ -102,7 +119,7 @@ def get_user_from_apisix_headers(  # noqa: C901
         original_header: Original header
 
     Returns:
-        User object
+        User object, or None if no valid user could be resolved
 
     """
 
@@ -195,7 +212,7 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
 
     header = "HTTP_X_USERINFO"
 
-    def process_request(self, request):
+    def process_request(self, request: HttpRequest) -> HttpResponseBase | None:
         """
         Modify the header to contain username, pass off to RemoteUserMiddleware
         """

--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -7,13 +7,44 @@ import logging
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
 from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from posthog import Posthog
 
 from authentication.api import user_created_actions
 from main.constants import PostHogEvents
+from profiles.models import filter_profile_props
 
 log = logging.getLogger(__name__)
+
+# User fields synced from the APISIX user headers (defaults match update_or_create).
+USER_SYNC_FIELDS = ("global_id", "email", "username", "first_name", "last_name")
+
+
+def user_fields_from_headers(decoded_headers):
+    """Map the decoded user headers to the synced User fields."""
+    return {
+        "global_id": decoded_headers.get("global_id"),
+        "email": decoded_headers.get("email", ""),
+        "username": decoded_headers.get("username", ""),
+        "first_name": decoded_headers.get("first_name", ""),
+        "last_name": decoded_headers.get("last_name", ""),
+    }
+
+
+def user_needs_update(user, user_fields):
+    """Return True if any synced User field differs from the headers."""
+    return any(getattr(user, field) != user_fields[field] for field in USER_SYNC_FIELDS)
+
+
+def profile_needs_update(user, profile_data):
+    """Return True if the profile is missing or any synced field differs."""
+    try:
+        profile = user.profile
+    except ObjectDoesNotExist:
+        return True
+    props = filter_profile_props(profile_data) if profile_data else {}
+    return any(getattr(profile, key) != value for key, value in props.items())
 
 
 def decode_apisix_headers(request, header, model=settings.AUTH_USER_MODEL):
@@ -84,17 +115,26 @@ def get_user_from_apisix_headers(request, decoded_headers, original_header):
         return None
     email = decoded_headers.get("email", "")
 
-    user, created = User.objects.filter(
-        Q(global_id=global_id) | Q(global_id__isnull=True, email=email)
-    ).update_or_create(
-        defaults={
-            "global_id": global_id,
-            "email": email,
-            "username": decoded_headers.get("username", ""),
-            "first_name": decoded_headers.get("first_name", ""),
-            "last_name": decoded_headers.get("last_name", ""),
-        }
+    profile_data = decode_apisix_headers(
+        request, original_header, model="profiles.Profile"
     )
+    user_fields = user_fields_from_headers(decoded_headers)
+
+    if (
+        request.user
+        and request.user.is_authenticated
+        and request.user.global_id == global_id
+    ):
+        user = request.user
+        created = False
+    else:
+        user, created = (
+            User.objects.filter(
+                Q(global_id=global_id) | Q(global_id__isnull=True, email=email)
+            )
+            .select_related("profile")
+            .get_or_create(defaults=user_fields)
+        )
 
     if created:
         log.info(
@@ -121,23 +161,21 @@ def get_user_from_apisix_headers(request, decoded_headers, original_header):
         user.set_unusable_password()
         user.is_active = True
         user.save()
-    else:
-        log.debug(
-            "get_user_from_apisix_headers: Found existing user for %s: %s",
-            global_id,
-            user,
-        )
+    elif user_needs_update(user, user_fields):
+        for field, value in user_fields.items():
+            setattr(user, field, value)
+        user.save(update_fields=[*user_fields])
 
-    profile_data = decode_apisix_headers(
-        request, original_header, model="profiles.Profile"
-    )
-    if profile_data:
+    if created:
+        user_created_actions(user=user, is_new=True, details=profile_data)
+        user = User.objects.select_related("profile").get(pk=user.pk)
+    elif profile_needs_update(user, profile_data):
         log.debug(
-            "get_user_from_apisix_headers: Setting up additional profile for %s",
+            "get_user_from_apisix_headers: Updating profile for %s",
             global_id,
         )
-    user_created_actions(user=user, is_new=created, details=profile_data)
-    user.refresh_from_db()
+        user_created_actions(user=user, is_new=False, details=profile_data)
+        user = User.objects.select_related("profile").get(pk=user.pk)
 
     return user
 
@@ -170,6 +208,12 @@ class ApisixUserMiddleware(RemoteUserMiddleware):
                     logout(request)
                 return None
         if apisix_user:
+            if request.user.is_authenticated and request.user == apisix_user:
+                # Already logged in as this user: skip login() so we don't cycle
+                # the session and write last_login on every request.
+                request.user = apisix_user
+                return self.get_response(request)
+
             if request.user.is_authenticated and request.user != apisix_user:
                 # The user is authenticated, but doesn't match the user we got
                 # from APISIX. So, log them out so the APISIX user takes

--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -164,7 +164,7 @@ def get_user_from_apisix_headers(request, decoded_headers, original_header):
     elif user_needs_update(user, user_fields):
         for field, value in user_fields.items():
             setattr(user, field, value)
-        user.save(update_fields=[*user_fields])
+        user.save(update_fields=[*user_fields, "updated_on"])
 
     if created:
         user_created_actions(user=user, is_new=True, details=profile_data)

--- a/main/middleware/apisix_user_test.py
+++ b/main/middleware/apisix_user_test.py
@@ -140,12 +140,13 @@ def test_get_request_ambiguous_identity_fails_closed(mocker, mock_login):
         },
         user=AnonymousUser(),
     )
-    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
+    mock_get_response = mocker.Mock(return_value="response")
+    apisix_middleware = ApisixUserMiddleware(mock_get_response)
 
-    with pytest.raises(User.MultipleObjectsReturned):
-        apisix_middleware.process_request(mock_request)
+    assert apisix_middleware.process_request(mock_request) == "response"
 
     mock_login.assert_not_called()
+    mock_get_response.assert_called_once_with(mock_request)
     legacy_user.refresh_from_db()
     exact_user.refresh_from_db()
     assert legacy_user.global_id is None

--- a/main/middleware/apisix_user_test.py
+++ b/main/middleware/apisix_user_test.py
@@ -41,6 +41,16 @@ def setup_test_database():
     close_old_connections()
 
 
+@pytest.fixture
+def synced_user(mocker, mock_login):
+    """Run an initial APISIX request to create the user, then return it."""
+    header = b64encode(json.dumps(apisix_user_info).encode())
+    ApisixUserMiddleware(mocker.Mock()).process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
+    )
+    return User.objects.get(global_id=apisix_user_info["sub"])
+
+
 @pytest.mark.django_db(transaction=True)
 def test_get_request(mocker, mock_login, settings):
     """Test that a valid request creates a new user."""
@@ -193,24 +203,13 @@ def test_get_request_logged_in_no_header(mocker, client, user):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_unchanged_identity_skips_writes(mocker, mock_login):
+def test_unchanged_identity_skips_writes(mocker, mock_login, synced_user):
     """A repeat request with an unchanged identity issues no writes or re-login."""
-    close_old_connections()
     header = b64encode(json.dumps(apisix_user_info).encode())
-    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
-
-    # First request creates the user and profile.
-    apisix_middleware.process_request(
-        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
-    )
-    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
-
-    # Second request, now authenticated as that user with the same header:
-    # nothing changed, so no user save, no profile sync, and no re-login.
     mock_login.reset_mock()
     mock_save = mocker.patch.object(User, "save")
     mock_actions = mocker.patch("main.middleware.apisix_user.user_created_actions")
-    apisix_middleware.process_request(
+    ApisixUserMiddleware(mocker.Mock()).process_request(
         mocker.Mock(META={"HTTP_X_USERINFO": header}, user=synced_user)
     )
     mock_save.assert_not_called()
@@ -219,15 +218,30 @@ def test_unchanged_identity_skips_writes(mocker, mock_login):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_changed_user_field_triggers_update(mocker, mock_login):
-    """A changed user header field updates the user."""
-    close_old_connections()
-    header = b64encode(json.dumps(apisix_user_info).encode())
-    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
-    apisix_middleware.process_request(
-        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
+@pytest.mark.parametrize(
+    ("changed_field", "new_value", "get_attr"),
+    [
+        ("family_name", "changed", lambda u: u.last_name),
+        ("name", "New Name", lambda u: u.profile.name),
+    ],
+)
+def test_changed_field_triggers_update(
+    mocker, synced_user, changed_field, new_value, get_attr
+):
+    """A changed header field updates the synced user or profile."""
+    changed_header = b64encode(
+        json.dumps({**apisix_user_info, changed_field: new_value}).encode()
     )
-    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
+    mock_request = mocker.Mock(
+        META={"HTTP_X_USERINFO": changed_header}, user=synced_user
+    )
+    ApisixUserMiddleware(mocker.Mock()).process_request(mock_request)
+    assert get_attr(mock_request.user) == new_value
+
+
+@pytest.mark.django_db(transaction=True)
+def test_user_update_bumps_updated_on(mocker, synced_user):
+    """A user-field change should advance updated_on."""
     User.objects.filter(pk=synced_user.pk).update(
         updated_on=synced_user.updated_on - timedelta(days=1)
     )
@@ -237,33 +251,8 @@ def test_changed_user_field_triggers_update(mocker, mock_login):
     changed_header = b64encode(
         json.dumps({**apisix_user_info, "family_name": "changed"}).encode()
     )
-    mock_request = mocker.Mock(
-        META={"HTTP_X_USERINFO": changed_header}, user=synced_user
+    ApisixUserMiddleware(mocker.Mock()).process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": changed_header}, user=synced_user)
     )
-    apisix_middleware.process_request(mock_request)
     synced_user.refresh_from_db()
-    assert synced_user.last_name == "changed"
     assert synced_user.updated_on > original_updated_on
-    assert mock_request.user.last_name == "changed"
-
-
-@pytest.mark.django_db(transaction=True)
-def test_changed_profile_field_triggers_update(mocker, mock_login):
-    """A changed profile header field updates the profile."""
-    close_old_connections()
-    header = b64encode(json.dumps(apisix_user_info).encode())
-    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
-    apisix_middleware.process_request(
-        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
-    )
-    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
-    assert synced_user.profile.name == apisix_user_info["name"]
-
-    changed_header = b64encode(
-        json.dumps({**apisix_user_info, "name": "New Name"}).encode()
-    )
-    mock_request = mocker.Mock(
-        META={"HTTP_X_USERINFO": changed_header}, user=synced_user
-    )
-    apisix_middleware.process_request(mock_request)
-    assert mock_request.user.profile.name == "New Name"

--- a/main/middleware/apisix_user_test.py
+++ b/main/middleware/apisix_user_test.py
@@ -126,6 +126,32 @@ def test_get_request_existing_user_with_global_id_diff_email(mocker, mock_login)
 
 
 @pytest.mark.django_db(transaction=True)
+def test_get_request_ambiguous_identity_fails_closed(mocker, mock_login):
+    """An ambiguous APISIX identity match should not silently pick a user."""
+    close_old_connections()
+    legacy_user = UserFactory.create(email=apisix_user_info["email"], global_id=None)
+    exact_user = UserFactory.create(
+        email="old_email@test.edu", global_id=apisix_user_info["sub"]
+    )
+    mock_request = mocker.Mock(
+        META={
+            "HTTP_X_USERINFO": b64encode(json.dumps(apisix_user_info).encode()),
+        },
+        user=AnonymousUser(),
+    )
+    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
+
+    with pytest.raises(User.MultipleObjectsReturned):
+        apisix_middleware.process_request(mock_request)
+
+    mock_login.assert_not_called()
+    legacy_user.refresh_from_db()
+    exact_user.refresh_from_db()
+    assert legacy_user.global_id is None
+    assert exact_user.email == "old_email@test.edu"
+
+
+@pytest.mark.django_db(transaction=True)
 @pytest.mark.parametrize("same_user", [False, True])
 def test_get_request_different_user_logout(mocker, client, same_user):
     """Test that a request with mismatched users logs user out"""
@@ -162,3 +188,74 @@ def test_get_request_logged_in_no_header(mocker, client, user):
     apisix_middleware = ApisixUserMiddleware(mocker.Mock())
     apisix_middleware.process_request(mock_request)
     mock_logout.assert_called_once()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_unchanged_identity_skips_writes(mocker, mock_login):
+    """A repeat request with an unchanged identity issues no writes or re-login."""
+    close_old_connections()
+    header = b64encode(json.dumps(apisix_user_info).encode())
+    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
+
+    # First request creates the user and profile.
+    apisix_middleware.process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
+    )
+    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
+
+    # Second request, now authenticated as that user with the same header:
+    # nothing changed, so no user save, no profile sync, and no re-login.
+    mock_login.reset_mock()
+    mock_save = mocker.patch.object(User, "save")
+    mock_actions = mocker.patch("main.middleware.apisix_user.user_created_actions")
+    apisix_middleware.process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=synced_user)
+    )
+    mock_save.assert_not_called()
+    mock_actions.assert_not_called()
+    mock_login.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_changed_user_field_triggers_update(mocker, mock_login):
+    """A changed user header field updates the user."""
+    close_old_connections()
+    header = b64encode(json.dumps(apisix_user_info).encode())
+    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
+    apisix_middleware.process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
+    )
+    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
+
+    changed_header = b64encode(
+        json.dumps({**apisix_user_info, "family_name": "changed"}).encode()
+    )
+    mock_request = mocker.Mock(
+        META={"HTTP_X_USERINFO": changed_header}, user=synced_user
+    )
+    apisix_middleware.process_request(mock_request)
+    synced_user.refresh_from_db()
+    assert synced_user.last_name == "changed"
+    assert mock_request.user.last_name == "changed"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_changed_profile_field_triggers_update(mocker, mock_login):
+    """A changed profile header field updates the profile."""
+    close_old_connections()
+    header = b64encode(json.dumps(apisix_user_info).encode())
+    apisix_middleware = ApisixUserMiddleware(mocker.Mock())
+    apisix_middleware.process_request(
+        mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
+    )
+    synced_user = User.objects.get(global_id=apisix_user_info["sub"])
+    assert synced_user.profile.name == apisix_user_info["name"]
+
+    changed_header = b64encode(
+        json.dumps({**apisix_user_info, "name": "New Name"}).encode()
+    )
+    mock_request = mocker.Mock(
+        META={"HTTP_X_USERINFO": changed_header}, user=synced_user
+    )
+    apisix_middleware.process_request(mock_request)
+    assert mock_request.user.profile.name == "New Name"

--- a/main/middleware/apisix_user_test.py
+++ b/main/middleware/apisix_user_test.py
@@ -2,6 +2,7 @@
 
 import json
 from base64 import b64encode
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -226,6 +227,11 @@ def test_changed_user_field_triggers_update(mocker, mock_login):
         mocker.Mock(META={"HTTP_X_USERINFO": header}, user=AnonymousUser())
     )
     synced_user = User.objects.get(global_id=apisix_user_info["sub"])
+    User.objects.filter(pk=synced_user.pk).update(
+        updated_on=synced_user.updated_on - timedelta(days=1)
+    )
+    synced_user.refresh_from_db()
+    original_updated_on = synced_user.updated_on
 
     changed_header = b64encode(
         json.dumps({**apisix_user_info, "family_name": "changed"}).encode()
@@ -236,6 +242,7 @@ def test_changed_user_field_triggers_update(mocker, mock_login):
     apisix_middleware.process_request(mock_request)
     synced_user.refresh_from_db()
     assert synced_user.last_name == "changed"
+    assert synced_user.updated_on > original_updated_on
     assert mock_request.user.last_name == "changed"
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Related: mitodl/hq#11506

### Description (What does it do?)
Updates ApisixUserMiddleware so requests avoid unnecessary User/Profile saves or logins when APISIX-provided identity data has not changed.

This keeps APISIX/Keycloak/Django identity data synchronized by still comparing the APISIX-controlled user and profile fields on each request, while only saving the User, syncing the Profile, or calling login() when the current request actually requires it.

### How can this be tested?

1. Run the app locally with the normal APISIX/Keycloak auth stack enabled.
2. Sign in as an existing Keycloak/APISIX user that already has a matching Django User. Confirm the app signs in normally, the user menu/profile identity is correct, and there are no logout loops.
3. Capture the Django User/Profile values after the first successful sign-in, especially User `last_login`, User `updated_on`, and Profile `updated_at`. Refresh the app and visit several authenticated and user-aware pages, such as search/results, a resource detail page, dashboard/profile, and a saved/favorites flow. Re-check those timestamps and confirm they do not change just from browsing with unchanged APISIX identity data.
4. While still signed in as that existing user, confirm normal API-backed pages continue to work and the user remains authenticated across additional page loads.
5. Sign out completely. Confirm the app returns to an anonymous state and authenticated UI/actions are no longer available.
6. Sign in as a brand-new Keycloak/APISIX user that does not yet exist in Django. Confirm a Django User is created, the Profile exists with the expected APISIX profile values, first-time user setup still runs, and the user can browse the same set of pages without errors.
7. Sign out, then sign back in as the original existing user. Confirm the Django session switches cleanly to the APISIX user and the visible account identity is correct.
8. If convenient in the local Keycloak admin, change an APISIX-controlled claim for the existing user, such as first name, last name, or email. Sign in or refresh with the updated claim and confirm the corresponding Django User/Profile field updates exactly when the header value changes.