### PR TITLE
podcast etl cleanup

### DIFF
--- a/learning_resources/etl/podcast.py
+++ b/learning_resources/etl/podcast.py
@@ -67,11 +67,8 @@ def validate_podcast_config(podcast_config):
         errors.append("Podcast data should be a dict")
         return errors
 
-    for required_key in ["rss_url", "website"]:
-        if required_key not in podcast_config:
-            errors.append(  # noqa: PERF401
-                f"Required key '{required_key}' is not present"
-            )
+    if "rss_url" not in podcast_config:
+        errors.append("Required key 'rss_url' is not present")
 
     return errors
 
@@ -138,7 +135,8 @@ def extract():
 
             feed = bs(response.content, "xml")
             yield (feed, playlist_config)
-
+        except ConnectionResetError:
+            log.warning("Connection reset error for rss url %s", rss_url)
         except (ConnectionError, HTTPError):
             log.exception("Invalid rss url %s", rss_url)
 
@@ -234,7 +232,7 @@ def transform(extracted_podcasts):
                 "description": clean_data(rss_data.channel.description.text),
                 "image": image,
                 "published": True,
-                "url": config_data["website"],
+                "url": config_data.get("website", None),
                 "topics": topics,
                 "episodes": (
                     transform_episode(episode_rss, offered_by, topics, image)

--- a/learning_resources/etl/podcast_test.py
+++ b/learning_resources/etl/podcast_test.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup as bs  # noqa: N813
 from dateutil.tz import tzutc
 from django.conf import settings
 from freezegun import freeze_time
+from requests.exceptions import HTTPError
 
 from learning_resources.constants import Availability, LearningResourceType, OfferedBy
 from learning_resources.etl.constants import ETLSource
@@ -230,6 +231,47 @@ def test_transform_with_error(mocker, mock_github_client):
 
     assert len(results) == 1
     assert results[0]["url"] == "http://website.url/podcast"
+
+
+def test_extract_connection_reset_error(mocker, mock_github_client):
+    """Test extract handles ConnectionResetError gracefully"""
+    mock_warning_log = mocker.patch("learning_resources.etl.podcast.log.warning")
+    mocker.patch(
+        "learning_resources.etl.podcast.requests.get",
+        side_effect=ConnectionResetError,
+    )
+    podcast_list = [mock_podcast_file()]
+    mock_github_client.return_value.get_repo.return_value.get_contents.return_value = (
+        podcast_list
+    )
+
+    results = list(extract())
+
+    assert results == []
+    mock_warning_log.assert_called_once_with(
+        "Connection reset error for rss url %s", "http://website.url/podcast/rss.xml"
+    )
+
+
+@pytest.mark.parametrize("exception_cls", [ConnectionError, HTTPError])
+def test_extract_connection_error(mocker, mock_github_client, exception_cls):
+    """Test extract handles ConnectionError and HTTPError gracefully"""
+    mock_exception_log = mocker.patch("learning_resources.etl.podcast.log.exception")
+    mocker.patch(
+        "learning_resources.etl.podcast.requests.get",
+        side_effect=exception_cls,
+    )
+    podcast_list = [mock_podcast_file()]
+    mock_github_client.return_value.get_repo.return_value.get_contents.return_value = (
+        podcast_list
+    )
+
+    results = list(extract())
+
+    assert results == []
+    mock_exception_log.assert_called_once_with(
+        "Invalid rss url %s", "http://website.url/podcast/rss.xml"
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This pr makes small cleanups to the podcast. 
1) It makes website optionally since podcasts in search now link to the new learn podcast pages and we recently added podcasts that do no have their own websites
2) Catches  ConnectionResetError when pulling podcast rss data so we don't have a sentry error. This error is temporary

https://mit-office-of-digital-learning.sentry.io/issues/7452956445/?project=4506260054540288&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20podcast&referrer=issue-stream&sort=date


### How can this be tested?
with OPEN_PODCAST_DATA_BRANCH not set or set to the default run
```
from learning_resources.etl.pipelines import podcast_etl
podcast_etl()
```

you should see warning about missing topics and not being able to load glimpse podcast but the pipeline should finish

set OPEN_PODCAST_DATA_BRANCH=  ab/cleanup

run

```
from learning_resources.etl.pipelines import podcast_etl
podcast_etl()
```

again.
You should no longer see the warnings





