### PR TITLE
refactor API mocks: Use Axios Adapter

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -12,6 +12,7 @@
     "./constants": "./src/common/constants.ts",
     "./ssr/*": "./src/ssr/*.ts",
     "./test-utils/factories": "./src/test-utils/factories/index.ts",
+    "./test-utils/mockAxios": "./src/test-utils/mockAxios.ts",
     "./test-utils": "./src/test-utils/index.ts",
     "./mitxonline-hooks/*": "./src/mitxonline/hooks/*/index.ts",
     "./mitxonline-test-utils": "./src/mitxonline/test-utils/index.ts"

--- a/frontends/api/src/hooks/hubspot/index.test.ts
+++ b/frontends/api/src/hooks/hubspot/index.test.ts
@@ -42,11 +42,9 @@ const assertApiCalled = async (
   data: unknown,
 ) => {
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(
-    makeRequest.mock.calls.some((args) => {
-      return args[0].toUpperCase() === method && args[1] === url
-    }),
-  ).toBe(true)
+  expect(makeRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ method: method.toLowerCase(), url }),
+  )
   expect(result.current.data).toEqual(data)
 }
 
@@ -83,14 +81,14 @@ describe("useHubspotFormSubmit", () => {
     result.current.mutate({ formId, fields, pageUri })
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith(
-      "post",
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
       url,
-      expect.objectContaining({
+      body: expect.objectContaining({
         fields,
         page_uri: pageUri,
       }),
-    )
+    })
     expect(result.current.data).toEqual(response)
   })
 
@@ -112,14 +110,14 @@ describe("useHubspotFormSubmit", () => {
     result.current.mutate({ formId, fields })
 
     await waitFor(() => {
-      expect(makeRequest).toHaveBeenCalledWith(
-        "post",
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "post",
         url,
-        expect.objectContaining({
+        body: expect.objectContaining({
           fields,
           page_uri: "http://localhost/programs/test-program",
         }),
-      )
+      })
     })
     expect(result.current.data).toEqual(response)
   })
@@ -153,10 +151,10 @@ describe("useHubspotFormSubmit", () => {
 
     // Verify context properties were captured
     const call = makeRequest.mock.calls.find(
-      (args) => args[0] === "post" && args[1] === url,
+      ([args]) => args.method === "post" && args.url === url,
     )
     expect(call).toBeDefined()
-    const requestBody = call![2]
+    const requestBody = call![0].body
 
     const body = requestBody
     if (!isHubspotSubmitBody(body)) {
@@ -189,9 +187,9 @@ describe("useHubspotFormSubmit", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const call = makeRequest.mock.calls.find(
-      (args) => args[0] === "post" && args[1] === url,
+      ([args]) => args.method === "post" && args.url === url,
     )
-    const requestBody = call![2]
+    const requestBody = call![0].body
 
     if (!isHubspotSubmitBody(requestBody)) {
       throw new Error("Request body does not match expected shape")
@@ -235,9 +233,9 @@ describe("useHubspotFormSubmit", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     const call = makeRequest.mock.calls.find(
-      (args) => args[0] === "post" && args[1] === url,
+      ([args]) => args.method === "post" && args.url === url,
     )
-    const requestBody = call![2]
+    const requestBody = call![0].body
 
     if (!isHubspotSubmitBody(requestBody)) {
       throw new Error("Request body does not match expected shape")

--- a/frontends/api/src/hooks/learningPaths/index.test.ts
+++ b/frontends/api/src/hooks/learningPaths/index.test.ts
@@ -29,12 +29,9 @@ const assertApiCalled = async (
   data: unknown,
 ) => {
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(
-    makeRequest.mock.calls.some((args) => {
-      // Don't use toHaveBeenCalledWith. It doesn't handle undefined 3rd arg.
-      return args[0].toUpperCase() === method && args[1] === url
-    }),
-  ).toBe(true)
+  expect(makeRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ method: method.toLowerCase(), url }),
+  )
   expect(result.current.data).toEqual(data)
 }
 
@@ -86,12 +83,16 @@ describe("useInfiniteLearningPathItems", () => {
     // First page
     const { result } = renderHook(useTestHook, { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("get", url1, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "get", url: url1 }),
+    )
 
     // Second page
     result.current.fetchNextPage()
     await waitFor(() => expect(result.current.isFetching).toBe(false))
-    expect(makeRequest).toHaveBeenCalledWith("get", url2, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "get", url: url2 }),
+    )
   })
 })
 
@@ -149,7 +150,11 @@ describe("LearningPath CRUD", () => {
     result.current.mutate(requestData)
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
+      url,
+      body: requestData,
+    })
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["learningPaths", "list"],
@@ -169,7 +174,9 @@ describe("LearningPath CRUD", () => {
     })
     result.current.mutate({ id: path.id })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "delete", url }),
+    )
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["learningPaths", "list"],
@@ -192,7 +199,11 @@ describe("LearningPath CRUD", () => {
     result.current.mutate(patch)
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("patch", url, patch)
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url,
+      body: patch,
+    })
 
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: ["learningPaths", "list"],

--- a/frontends/api/src/hooks/learningResources/index.test.ts
+++ b/frontends/api/src/hooks/learningResources/index.test.ts
@@ -22,12 +22,9 @@ const assertApiCalled = async (
   data: unknown,
 ) => {
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(
-    makeRequest.mock.calls.some((args) => {
-      // Don't use toHaveBeenCalledWith. It doesn't handle undefined 3rd arg.
-      return args[0].toUpperCase() === method && args[1] === url
-    }),
-  ).toBe(true)
+  expect(makeRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ method: method.toLowerCase(), url }),
+  )
   expect(result.current.data).toEqual(data)
 }
 

--- a/frontends/api/src/hooks/testimonials/index.test.ts
+++ b/frontends/api/src/hooks/testimonials/index.test.ts
@@ -17,7 +17,9 @@ const assertApiCalled = async (
   data: unknown,
 ) => {
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(makeRequest).toHaveBeenCalledWith(method, url, expect.anything())
+  expect(makeRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ method: method.toLowerCase(), url }),
+  )
   expect(result.current.data).toEqual(data)
 }
 
@@ -32,7 +34,7 @@ describe("useTestimonialList", () => {
       setMockResponse.get(url, data)
       const useTestHook = () => useTestimonialList(params)
       const { result } = renderHook(useTestHook, { wrapper })
-      assertApiCalled(result, url, "GET", data)
+      await assertApiCalled(result, url, "GET", data)
     },
   )
 })
@@ -47,6 +49,6 @@ describe("useTestimonialDetail", () => {
     const useTestHook = () => useTestimonialDetail(data.id)
     const { result } = renderHook(useTestHook, { wrapper })
 
-    assertApiCalled(result, url, "GET", data)
+    await assertApiCalled(result, url, "GET", data)
   })
 })

--- a/frontends/api/src/hooks/website_content/index.test.ts
+++ b/frontends/api/src/hooks/website_content/index.test.ts
@@ -24,7 +24,9 @@ const assertApiCalled = async (
   data: unknown,
 ) => {
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(makeRequest).toHaveBeenCalledWith(method, url, expect.anything())
+  expect(makeRequest).toHaveBeenCalledWith(
+    expect.objectContaining({ method: method.toLowerCase(), url }),
+  )
   expect(result.current.data).toEqual(data)
 }
 
@@ -38,7 +40,7 @@ describe("useWebsiteContentList", () => {
       setMockResponse.get(url, data)
       const useTestHook = () => useWebsiteContentList(params)
       const { result } = renderHook(useTestHook, { wrapper })
-      assertApiCalled(result, url, "GET", data)
+      await assertApiCalled(result, url, "GET", data)
     },
   )
 })
@@ -53,7 +55,7 @@ describe("useWebsiteContentDetail", () => {
     const useTestHook = () => useWebsiteContentDetail(data.id)
     const { result } = renderHook(useTestHook, { wrapper })
 
-    assertApiCalled(result, url, "GET", data)
+    await assertApiCalled(result, url, "GET", data)
   })
 })
 
@@ -70,7 +72,11 @@ describe("Website Content CRUD", () => {
     result.current.mutate(requestData)
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("post", url, requestData)
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
+      url,
+      body: requestData,
+    })
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: websiteContentKeys.listRoot(),
     })
@@ -88,7 +94,11 @@ describe("Website Content CRUD", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     const { id, ...patchData } = article
-    expect(makeRequest).toHaveBeenCalledWith("patch", url, patchData)
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url,
+      body: patchData,
+    })
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: websiteContentKeys.detail(article.id),
     })
@@ -105,7 +115,9 @@ describe("Website Content CRUD", () => {
     result.current.mutate(id)
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "delete", url }),
+    )
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: websiteContentKeys.listRoot(),
     })

--- a/frontends/api/src/test-utils/index.ts
+++ b/frontends/api/src/test-utils/index.ts
@@ -1,4 +1,3 @@
 export * as urls from "./urls"
 export * from "./mockAxios"
 export * as factories from "./factories"
-export { mockAxiosInstance as axios } from "./mockAxios"

--- a/frontends/api/src/test-utils/mock-requests-example.test.ts
+++ b/frontends/api/src/test-utils/mock-requests-example.test.ts
@@ -1,5 +1,5 @@
 import axiosBase from "axios"
-import { setMockResponse } from "./mockAxios"
+import { setMockResponse, makeRequest } from "./mockAxios"
 import { ControlledPromise, allowConsoleErrors } from "ol-test-utilities"
 
 const axios = axiosBase.create()
@@ -30,19 +30,25 @@ describe("request mocking", () => {
     const r3 = await axios.post("/some-example", { cat: "meow", a: 5 })
 
     // toHaveBeenNthCalledWith is 1-indexed
-    expect(axios.post).toHaveBeenNthCalledWith(1, "/some-example", {
-      dog: "woof",
+    expect(makeRequest).toHaveBeenNthCalledWith(1, {
+      method: "post",
+      url: "/some-example",
+      body: { dog: "woof" },
     })
-    expect(axios.patch).toHaveBeenNthCalledWith(1, "/another-example", {
-      dog: "bark bark",
+    expect(makeRequest).toHaveBeenNthCalledWith(2, {
+      method: "patch",
+      url: "/another-example",
+      body: { dog: "bark bark" },
     })
-    expect(axios.post).toHaveBeenNthCalledWith(2, "/some-example", {
-      baby: "sleep",
-      b: 10,
+    expect(makeRequest).toHaveBeenNthCalledWith(3, {
+      method: "post",
+      url: "/some-example",
+      body: { baby: "sleep", b: 10 },
     })
-    expect(axios.post).toHaveBeenNthCalledWith(3, "/some-example", {
-      cat: "meow",
-      a: 5,
+    expect(makeRequest).toHaveBeenNthCalledWith(4, {
+      method: "post",
+      url: "/some-example",
+      body: { cat: "meow", a: 5 },
     })
 
     expect(r0.data).toEqual({ someResponseKey: "fallback post response" })
@@ -59,7 +65,10 @@ describe("request mocking", () => {
     setMockResponse.post("/some-example", "Bad request", { code: 400 })
     await expect(axios.post("/some-example", { a: 5 })).rejects.toEqual(
       expect.objectContaining({
-        response: { data: "Bad request", status: 400 },
+        response: expect.objectContaining({
+          data: "Bad request",
+          status: 400,
+        }),
       }),
     )
   })

--- a/frontends/api/src/test-utils/mockAxios.ts
+++ b/frontends/api/src/test-utils/mockAxios.ts
@@ -1,23 +1,30 @@
 import { when } from "jest-when"
 import { isFunction } from "lodash"
-import type { AxiosResponse } from "axios"
+import type { AxiosAdapter, AxiosRequestConfig, AxiosResponse } from "axios"
 
-const AxiosError = jest.requireActual("axios").AxiosError
+const actualAxios = jest.requireActual<typeof import("axios")>("axios")
+const { AxiosError } = actualAxios
+// Fresh real-axios instance used purely to delegate URL resolution to axios's
+// own buildFullPath / buildURL via getUri(). No requests are ever sent
+// through it — getUri is synchronous.
+const urlResolver = actualAxios.default.create()
 
-type Method = "get" | "post" | "patch" | "delete"
+type Method = "get" | "post" | "put" | "patch" | "delete"
 
 type PartialAxiosResponse = Pick<AxiosResponse, "data" | "status">
 
-type RequestMaker = (
-  method: Method,
-  url: string,
-  body?: unknown,
-) => Promise<PartialAxiosResponse>
+type RequestArgs<TBody = unknown> = {
+  method: Method
+  url: string
+  body?: TBody
+}
 
-const alwaysError: RequestMaker = (method, url, body) => {
+type RequestMaker = (args: RequestArgs) => Promise<PartialAxiosResponse>
+
+const alwaysError: RequestMaker = ({ method, url, body }) => {
   const msg = `No response specified for ${method} ${url}`
   console.error(msg)
-  if (body) {
+  if (body !== undefined) {
     console.error("and body:")
     console.error(body)
   }
@@ -35,58 +42,69 @@ const standardizeUrl = (url: string) => {
 }
 
 /**
- * A jest mock function that makes fake network requests.
+ * A jest mock function that records every fake network request. Call sites
+ * receive a single object `{ method, url, body }`.
  *
- * Spy on it to check its calls. For example, to assert that it has been called
- * with a specific value:
+ * Example assertion:
  * ```ts
- * expect(makeRequest).toHaveBeenCalledWith([
- *  'post',
- *  '/some/url/to/thing',
- *   expect.objectContaining({ some: 'value' }) // request body
- * ])
- *
- * NOTE: URLs called by this function are first
+ * expect(makeRequest).toHaveBeenCalledWith(
+ *   expect.objectContaining({
+ *     method: "post",
+ *     url: "/some/url",
+ *   }),
+ * )
  * ```
+ *
+ * Method is always lowercase. URL is the fully-resolved URL (baseURL + url +
+ * sorted query string). Body is deserialized (OpenAPI Generator stringifies on
+ * the way out; the adapter parses it back).
  */
 const makeRequest = jest.fn(alwaysError)
-const makeSortedRequest: RequestMaker = (method, url, body) =>
-  makeRequest(method, standardizeUrl(url), body)
+const makeSortedRequest: RequestMaker = ({ method, url, body }) =>
+  makeRequest({ method, url: standardizeUrl(url), body })
 
-const mockAxiosInstance = {
-  get: jest.fn((url: string) => makeSortedRequest("get", url, undefined)),
-  post: jest.fn((url: string, body: unknown) =>
-    makeSortedRequest("post", url, body),
-  ),
-  patch: jest.fn((url: string, body: unknown) =>
-    makeSortedRequest("patch", url, body),
-  ),
-  delete: jest.fn((url: string) => makeSortedRequest("delete", url, undefined)),
-  request: jest.fn(
-    (
-      {
-        method,
-        url,
-        data,
-      }: {
-        method: string
-        url: string
-        data: unknown
-      }, // Axios accepts lowercase or capital method names
-    ) => {
-      // OpenAPI Generator *always* serializes request bodies before passing to
-      // axios. This is fine, but annoying for tests where we may want to assert
-      // on object shape.
-      const deserialized =
-        typeof data === "string" ? JSON.parse(data) : undefined
-      return makeSortedRequest(
-        method.toLowerCase() as Method,
-        url,
-        deserialized,
-      )
-    },
-  ),
-  defaults: {}, // OpenAPI Generator accesses this, so it needs to exist
+/**
+ * The mock axios adapter — the single point where tests divert from real
+ * axios. Installed on `axios.defaults.adapter` in setupJest so it intercepts
+ * every request regardless of whether it goes through the default export, an
+ * instance, or `.create()`.
+ *
+ * Name must start with `mock` to satisfy jest.mock factory hoist rules
+ * (factories may only reference outer-scope vars whose names begin with
+ * `mock`).
+ */
+const mockAdapter: AxiosAdapter = async (config) => {
+  const fullUrl = urlResolver.getUri({
+    baseURL: config.baseURL,
+    url: config.url,
+    params: config.params,
+  })
+  const method = (config.method ?? "get").toLowerCase() as Method
+  // OpenAPI Generator pre-serializes request bodies; deserialize so tests can
+  // assert on object shape rather than the stringified form. Non-JSON string
+  // bodies (e.g. text/plain) pass through unparsed.
+  let body = config.data
+  if (typeof config.data === "string") {
+    try {
+      body = JSON.parse(config.data)
+    } catch {
+      body = config.data
+    }
+  }
+
+  const response = await makeSortedRequest({ method, url: fullUrl, body })
+
+  // For successful responses, return in axios's expected shape so its default
+  // validateStatus doesn't reject. For error responses, makeRequest throws an
+  // AxiosError directly (see mockRequest below).
+  return {
+    data: response.data,
+    status: response.status,
+    statusText: "OK",
+    headers: {},
+    config,
+    request: {},
+  }
 }
 
 /**
@@ -100,14 +118,24 @@ const expectAnythingOrNil = expect.toBeOneOf([
 
 const mockRequest = <T, U>(
   method: Method,
-  url: string,
+  // Callers may pass a literal URL string or a jest asymmetric matcher
+  // (e.g. `expect.stringContaining("/api/v1/foo")`) to match URLs loosely.
+  url: string | jest.AsymmetricMatcher,
   requestBody: T = expectAnythingOrNil,
   responseBody: U | ((req: T) => U) | undefined = undefined,
   code: number,
 ) => {
   const urlMatcher = typeof url === "string" ? standardizeUrl(url) : url
+  // jest-when's `calledWith` types its arg strictly, but at runtime it
+  // accepts asymmetric matchers (e.g. `expect.stringContaining(...)`) in any
+  // field. Cast through `unknown` so we can pass a matcher in `url` or
+  // `requestBody` while keeping the public signature accurate.
   when(makeRequest)
-    .calledWith(method, urlMatcher, requestBody)
+    .calledWith({
+      method,
+      url: urlMatcher,
+      body: requestBody,
+    } as unknown as RequestArgs)
     .mockImplementation(async () => {
       let data
       if (isFunction(responseBody)) {
@@ -141,6 +169,12 @@ interface MockResponseOptions {
   code?: number
 }
 
+/**
+ * A URL or a jest asymmetric matcher (e.g. `expect.stringContaining(...)`)
+ * used to match request URLs in `setMockResponse.*`.
+ */
+type UrlMatcher = string | jest.AsymmetricMatcher
+
 const setMockResponse = {
   /**
    * Set mock response for a GET request; default response status is 200.
@@ -149,7 +183,7 @@ const setMockResponse = {
    * `responseBody` when `responseBody` resolves.
    */
   get: (
-    url: string,
+    url: UrlMatcher,
     responseBody: unknown,
     { code = 200, requestBody }: MockResponseOptions = {},
   ) => mockRequest("get", url, requestBody, responseBody, code),
@@ -160,10 +194,21 @@ const setMockResponse = {
    * `responseBody` when `responseBody` resolves.
    */
   post: (
-    url: string,
+    url: UrlMatcher,
     responseBody?: unknown,
     { code = 201, requestBody }: MockResponseOptions = {},
   ) => mockRequest("post", url, requestBody, responseBody, code),
+  /**
+   * Set mock response for a PUT request; default response status is 200.
+   *
+   * If `responseBody` is a Promise, the request will resolve to the value of
+   * `responseBody` when `responseBody` resolves.
+   */
+  put: (
+    url: UrlMatcher,
+    responseBody?: unknown,
+    { code = 200, requestBody }: MockResponseOptions = {},
+  ) => mockRequest("put", url, requestBody, responseBody, code),
   /**
    * Set mock response for a PATCH request; default response status is 200.
    *
@@ -171,7 +216,7 @@ const setMockResponse = {
    * `responseBody` when `responseBody` resolves.
    */
   patch: (
-    url: string,
+    url: UrlMatcher,
     responseBody?: unknown,
     { code = 200, requestBody }: MockResponseOptions = {},
   ) => mockRequest("patch", url, requestBody, responseBody, code),
@@ -182,7 +227,7 @@ const setMockResponse = {
    * `responseBody` when `responseBody` resolves.
    */
   delete: (
-    url: string,
+    url: UrlMatcher,
     responseBody?: unknown,
     { code = 204, requestBody }: MockResponseOptions = {},
   ) => mockRequest("delete", url, requestBody, responseBody, code),
@@ -195,4 +240,79 @@ const setMockResponse = {
   defaultImplementation: when(makeRequest).defaultImplementation,
 }
 
-export { setMockResponse, mockAxiosInstance, makeRequest }
+/**
+ * Mock factory for `jest.mock("axios", mockAxiosFactory)`. Routes ALL requests
+ * through the mock adapter — both the default export (`axios.get(...)`) and
+ * instances returned by `axios.create()` (even if the caller passed an
+ * explicit adapter in config). Tests never reach a real network adapter.
+ *
+ * Must be passed via `jest.mock("axios", …)` at the TOP LEVEL of a
+ * setupFilesAfterEnv module (i.e. setupJest), so @swc/jest's babel transform
+ * hoists the registration above all imports — including the test file's
+ * imports. Without hoisting, modules that import axios at module load (e.g.
+ * frontends/api/src/axios.ts) would call `axios.create()` before the factory
+ * could install the wrap.
+ *
+ * The name begins with `mock` so jest's hoist-protection rule allows the
+ * factory to be referenced from the outer scope of the setup file.
+ */
+const mockAxiosFactory = () => {
+  const real = jest.requireActual<typeof import("axios")>("axios")
+
+  // Layer 1: route the default export through the mock adapter. Caught:
+  // `axios.get(...)`, `axios.request(...)` on the default export, and any
+  // instance that inherits the default adapter via `axios.create()`.
+  real.default.defaults.adapter = mockAdapter
+
+  // Layer 2: force the mock adapter onto every `axios.create()` instance,
+  // overriding any explicit adapter passed in config. Belt-and-suspenders
+  // for layer 1.
+  const originalCreate = real.default.create.bind(real.default)
+  real.default.create = (config?: AxiosRequestConfig) => {
+    const instance = originalCreate(config)
+    instance.defaults.adapter = mockAdapter
+    return instance
+  }
+
+  return real
+}
+
+/**
+ * Fail-loud assertion: confirms the mock adapter is still installed on real
+ * axios. Call from `beforeEach` in test setup so that if a future change ever
+ * unhooks the adapter, tests scream rather than silently start hitting the
+ * network.
+ *
+ * Uses `jest.requireMock` to ensure the mock factory has run (lazy factories
+ * only execute on first axios import; test files that never touch axios would
+ * otherwise see the un-mutated module). `requireMock` returns the mocked
+ * module, which is the same real-axios object the factory mutates.
+ *
+ * Checks both install layers: the default-export adapter (layer 1) and a
+ * freshly-created instance (layer 2). Either layer regressing alone would let
+ * some axios usage slip through.
+ */
+const assertMockAdapterInstalled = () => {
+  const axios = jest.requireMock<typeof import("axios")>("axios").default
+  // Layer 1: default adapter on the module-level export.
+  expect(axios.defaults.adapter).toBe(mockAdapter)
+  // Layer 2: create()-time override. Pass an explicit `adapter` in config so
+  // we exercise the override path — not the merge-from-defaults fallback,
+  // which would silently succeed via Layer 1 even if the create wrapper is
+  // missing.
+  const stubAdapter: AxiosAdapter = async () => {
+    throw new Error("stub")
+  }
+  expect(axios.create({ adapter: stubAdapter }).defaults.adapter).toBe(
+    mockAdapter,
+  )
+}
+
+export {
+  setMockResponse,
+  makeRequest,
+  mockAdapter,
+  mockAxiosFactory,
+  assertMockAdapterInstalled,
+}
+export type { RequestArgs }

--- a/frontends/api/src/test-utils/setupJest.ts
+++ b/frontends/api/src/test-utils/setupJest.ts
@@ -1,10 +1,11 @@
-import { mockAxiosInstance } from "./mockAxios"
+import { mockAxiosFactory, assertMockAdapterInstalled } from "./mockAxios"
 
-jest.mock("axios", () => {
-  return {
-    __esModule: true,
-    default: {
-      create: () => mockAxiosInstance,
-    },
-  }
+// Wrapped in `() => …` to defer the identifier lookup past TDZ — jest.mock
+// is hoisted above imports, so passing `mockAxiosFactory` directly would
+// evaluate the (still-unbound) reference at registration time.
+// https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter
+jest.mock("axios", () => mockAxiosFactory())
+
+beforeEach(() => {
+  assertMockAdapterInstalled()
 })

--- a/frontends/main/src/app-pages/ChannelPage/ChannelPage.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelPage.test.tsx
@@ -417,9 +417,13 @@ describe("Channel Pages, Unit only", () => {
 
     await waitFor(() => {
       expect(makeRequest).toHaveBeenCalledWith(
-        "get",
-        urls.learningResources.featured({ limit: 12, offered_by: ["ocw"] }),
-        undefined,
+        expect.objectContaining({
+          method: "get",
+          url: urls.learningResources.featured({
+            limit: 12,
+            offered_by: ["ocw"],
+          }),
+        }),
       )
     })
   })

--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
@@ -98,13 +98,12 @@ const setMockApiResponses = ({
 }
 
 const getLastApiSearchParams = () => {
-  const call = makeRequest.mock.calls.find(([method, url]) => {
-    if (method !== "get") return false
-    return url.startsWith(urls.search.resources())
+  const call = makeRequest.mock.calls.find(([args]) => {
+    if (args.method !== "get") return false
+    return args.url.startsWith(urls.search.resources())
   })
   invariant(call)
-  const [_method, url] = call
-  const fullUrl = new URL(url, "http://mit.edu")
+  const fullUrl = new URL(call[0].url, "http://mit.edu")
   return fullUrl.searchParams
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
-import { mockAxiosInstance } from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import {
   DashboardCard,
   DashboardType,
@@ -677,17 +677,17 @@ describe.each([
     await user.click(upgradeLink)
 
     // Verify clear basket API was called first
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+    expect(makeRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "DELETE",
+        method: "delete",
         url: clearUrl,
       }),
     )
 
     // Verify create basket API was called
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+    expect(makeRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "POST",
+        method: "post",
         url: basketUrl,
       }),
     )
@@ -1202,8 +1202,8 @@ describe.each([
 
       await user.click(triggerElement)
 
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "POST", url: enrollmentUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: enrollmentUrl }),
       )
     },
   )
@@ -1242,8 +1242,8 @@ describe.each([
       await user.click(triggerElement)
 
       await screen.findByRole("dialog", { name: "Just a Few More Details" })
-      expect(mockAxiosInstance.request).not.toHaveBeenCalledWith(
-        expect.objectContaining({ method: "POST" }),
+      expect(makeRequest).not.toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post" }),
       )
     },
   )
@@ -1333,8 +1333,8 @@ describe.each([
         await user.click(triggerElement)
 
         await waitFor(() => {
-          expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-            expect.objectContaining({ method: "POST", url: enrollmentUrl }),
+          expect(makeRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ method: "post", url: enrollmentUrl }),
           )
         })
 
@@ -1386,8 +1386,8 @@ describe.each([
         await user.click(triggerElement)
 
         await waitFor(() => {
-          expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-            expect.objectContaining({ method: "POST", url: basketUrl }),
+          expect(makeRequest).toHaveBeenCalledWith(
+            expect.objectContaining({ method: "post", url: basketUrl }),
           )
         })
 
@@ -1448,11 +1448,11 @@ describe.each([
       await user.click(button)
 
       await waitFor(() => {
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+        expect(makeRequest).toHaveBeenCalledWith(
           expect.objectContaining({
-            method: "POST",
+            method: "post",
             url: enrollmentUrl,
-            data: JSON.stringify({ run_id: selectedLanguageRun.id }),
+            body: { run_id: selectedLanguageRun.id },
           }),
         )
       })
@@ -1507,9 +1507,9 @@ describe.each([
 
         // Should call enrollment endpoint
         await waitFor(() => {
-          expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+          expect(makeRequest).toHaveBeenCalledWith(
             expect.objectContaining({
-              method: "POST",
+              method: "post",
               url: programEnrollmentEndpoint,
             }),
           )
@@ -1618,8 +1618,8 @@ describe.each([
       await user.click(button)
 
       await waitFor(() => {
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-          expect.objectContaining({ method: "POST", url: verifiedEndpoint }),
+        expect(makeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({ method: "post", url: verifiedEndpoint }),
         )
       })
 
@@ -1668,8 +1668,8 @@ describe.each([
       await user.click(button)
 
       await waitFor(() => {
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-          expect.objectContaining({ method: "POST", url: enrollmentUrl }),
+        expect(makeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({ method: "post", url: enrollmentUrl }),
         )
       })
 
@@ -1721,8 +1721,8 @@ describe.each([
       await user.click(button)
 
       await waitFor(() => {
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-          expect.objectContaining({ method: "POST", url: basketUrl }),
+        expect(makeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({ method: "post", url: basketUrl }),
         )
       })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -14,7 +14,7 @@ import * as mitxonline from "api/mitxonline-test-utils"
 import {
   urls as testUrls,
   factories as testFactories,
-  mockAxiosInstance,
+  makeRequest,
 } from "api/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { faker } from "@faker-js/faker/locale/en"
@@ -95,9 +95,9 @@ describe("DashboardDialogs", () => {
 
     await user.click(confirmButton)
 
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+    expect(makeRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "PATCH",
+        method: "patch",
         url: mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
       }),
     )
@@ -138,9 +138,9 @@ describe("DashboardDialogs", () => {
 
     await user.click(confirmButton)
 
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+    expect(makeRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "DELETE",
+        method: "delete",
         url: mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
       }),
     )
@@ -270,9 +270,9 @@ describe("UnenrollProgramDialog", () => {
     })
     await user.click(confirmButton)
 
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+    expect(makeRequest).toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "DELETE",
+        method: "delete",
         url: mitxonline.urls.programEnrollments.programEnrollment(
           programEnrollment.program.id,
         ),
@@ -303,8 +303,8 @@ describe("UnenrollProgramDialog", () => {
 
     await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    expect(mockAxiosInstance.request).not.toHaveBeenCalledWith(
-      expect.objectContaining({ method: "DELETE" }),
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "delete" }),
     )
   })
 
@@ -555,9 +555,9 @@ describe("JustInTimeDialog", () => {
     await user.click(cancelButton)
 
     // No PATCH calls should have been made
-    expect(mockAxiosInstance.request).not.toHaveBeenCalledWith(
+    expect(makeRequest).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        method: "PATCH",
+        method: "patch",
         url: mitxonline.urls.userMe.get(),
       }),
     )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -7,7 +7,7 @@ import {
   user,
   within,
 } from "@/test-utils"
-import { mockAxiosInstance } from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { waitFor } from "@testing-library/react"
@@ -229,14 +229,11 @@ describe("ProgramAsCourseCard", () => {
     await user.click(startButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: "POST",
+          method: "post",
           url: enrollmentEndpoint,
-          data: JSON.stringify([
-            cardData.courseProgram.readable_id,
-            "grandparent-program",
-          ]),
+          body: [cardData.courseProgram.readable_id, "grandparent-program"],
         }),
       )
     })
@@ -322,8 +319,8 @@ describe("ProgramAsCourseCard", () => {
     await user.click(startButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "POST", url: enrollmentUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: enrollmentUrl }),
       )
     })
     expect(
@@ -374,8 +371,8 @@ describe("ProgramAsCourseCard", () => {
     await user.click(startButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "POST", url: basketUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: basketUrl }),
       )
     })
     expect(

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/test-utils"
 import { ProgramEnrollmentDisplay } from "./ProgramEnrollmentDisplay"
 import * as mitxonline from "api/mitxonline-test-utils"
-import { mockAxiosInstance } from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { faker } from "@faker-js/faker/locale/en"
 import invariant from "tiny-invariant"
@@ -1378,11 +1378,11 @@ describe("ProgramEnrollmentDisplay", () => {
     await user.click(startButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: "POST",
+          method: "post",
           url: childCourseEnrollmentEndpoint,
-          data: JSON.stringify([parentProgramEnrollment.program.readable_id]),
+          body: [parentProgramEnrollment.program.readable_id],
         }),
       )
     })
@@ -1423,14 +1423,14 @@ describe("ProgramEnrollmentDisplay", () => {
     await user.click(startButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: "POST",
+          method: "post",
           url: moduleCourseEnrollmentEndpoint,
-          data: JSON.stringify([
+          body: [
             programAsCourse.readable_id,
             parentProgramEnrollment.program.readable_id,
-          ]),
+          ],
         }),
       )
     })

--- a/frontends/main/src/app-pages/DashboardPage/SettingsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/SettingsContent.test.tsx
@@ -65,9 +65,10 @@ describe("SettingsPage", () => {
     const unsubscribeButton = await screen.findByTestId("dialog-unfollow")
     await user.click(unsubscribeButton)
     expect(makeRequest).toHaveBeenCalledWith(
-      "delete",
-      unsubscribeUrls[0],
-      undefined,
+      expect.objectContaining({
+        method: "delete",
+        url: unsubscribeUrls[0],
+      }),
     )
   })
 
@@ -84,7 +85,9 @@ describe("SettingsPage", () => {
     const unsubscribeButton = await screen.findByTestId("dialog-unfollow")
     await user.click(unsubscribeButton)
     for (const unsubUrl of unsubscribeUrls) {
-      expect(makeRequest).toHaveBeenCalledWith("delete", unsubUrl, undefined)
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "delete", url: unsubUrl }),
+      )
     }
   })
   test("Unsubscribe from all is hidden if there are no subscriptions", async () => {

--- a/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.test.tsx
+++ b/frontends/main/src/app-pages/EnrollmentCodePage/EnrollmentCodePage.test.tsx
@@ -94,7 +94,9 @@ describe("EnrollmentCodePage", () => {
     })
 
     await waitFor(() => {
-      expect(makeRequest).toHaveBeenCalledWith("post", attachUrl, undefined)
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: attachUrl }),
+      )
     })
 
     await waitFor(() => {
@@ -124,7 +126,9 @@ describe("EnrollmentCodePage", () => {
     })
 
     await waitFor(() => {
-      expect(makeRequest).toHaveBeenCalledWith("post", attachUrl, undefined)
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: attachUrl }),
+      )
     })
 
     await waitFor(() => {
@@ -146,7 +150,9 @@ describe("EnrollmentCodePage", () => {
     })
 
     await waitFor(() => {
-      expect(makeRequest).toHaveBeenCalledWith("post", attachUrl, undefined)
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: attachUrl }),
+      )
     })
 
     await waitFor(() => {

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollmentButton.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@/test-utils"
 import CourseEnrollmentButton from "./CourseEnrollmentButton"
-import { mockAxiosInstance, urls, factories } from "api/test-utils"
+import { makeRequest, urls, factories } from "api/test-utils"
 import {
   factories as mitxFactories,
   urls as mitxUrls,
@@ -205,12 +205,12 @@ describe("CourseEnrollmentButton", () => {
     await user.click(button)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "DELETE", url: clearUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "delete", url: clearUrl }),
       )
     })
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "POST", url: basketUrl }),
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "post", url: basketUrl }),
     )
     expect(assign).toHaveBeenCalledWith(mitxonlineLegacyUrl("/cart/"))
   })

--- a/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramEnrollmentButton.test.tsx
@@ -7,7 +7,7 @@ import {
   user,
   waitFor,
 } from "@/test-utils"
-import { mockAxiosInstance, makeRequest, urls, factories } from "api/test-utils"
+import { makeRequest, urls, factories } from "api/test-utils"
 import ProgramEnrollmentButton from "./ProgramEnrollmentButton"
 import {
   urls as mitxUrls,
@@ -117,11 +117,11 @@ describe("ProgramEnrollmentButton", () => {
     await user.click(enrollButton)
 
     await waitFor(() => {
-      expect(makeRequest).toHaveBeenCalledWith(
-        "post",
-        mitxUrls.programEnrollments.enrollmentsListV3(),
-        { program_id: program.id },
-      )
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "post",
+        url: mitxUrls.programEnrollments.enrollmentsListV3(),
+        body: { program_id: program.id },
+      })
     })
     await waitFor(() => {
       expect(location.current.pathname).toBe(routes.DASHBOARD_HOME)
@@ -183,12 +183,12 @@ describe("ProgramEnrollmentButton", () => {
     await user.click(enrollButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "DELETE", url: clearUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "delete", url: clearUrl }),
       )
     })
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "POST", url: basketUrl }),
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "post", url: basketUrl }),
     )
     expect(assign).toHaveBeenCalledWith(mitxonlineLegacyUrl("/cart/"))
   })

--- a/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/StayUpdatedModal.test.tsx
@@ -200,10 +200,10 @@ describe("StayUpdatedModal", () => {
     await screen.findByRole("dialog", { name: "Stay Updated" })
     await user.click(screen.getByRole("button", { name: "Notify Me" }))
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "post",
-      urls.hubspot.submit(STAY_UPDATED_FORM_ID),
-      expect.objectContaining({
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
+      url: urls.hubspot.submit(STAY_UPDATED_FORM_ID),
+      body: expect.objectContaining({
         fields: expect.arrayContaining([
           { name: "email", value: TEST_EMAIL },
           {
@@ -212,7 +212,7 @@ describe("StayUpdatedModal", () => {
           },
         ]),
       }),
-    )
+    })
   })
 
   it("submits product_of_interest when the HubSpot response uses field_groups", async () => {
@@ -245,10 +245,10 @@ describe("StayUpdatedModal", () => {
     await screen.findByRole("dialog", { name: "Stay Updated" })
     await user.click(screen.getByRole("button", { name: "Notify Me" }))
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "post",
-      urls.hubspot.submit(STAY_UPDATED_FORM_ID),
-      expect.objectContaining({
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
+      url: urls.hubspot.submit(STAY_UPDATED_FORM_ID),
+      body: expect.objectContaining({
         fields: expect.arrayContaining([
           { name: "email", value: TEST_EMAIL },
           {
@@ -257,7 +257,7 @@ describe("StayUpdatedModal", () => {
           },
         ]),
       }),
-    )
+    })
   })
 
   it("omits product_of_interest when the readable id has no matching option value", async () => {
@@ -291,12 +291,13 @@ describe("StayUpdatedModal", () => {
     await user.click(screen.getByRole("button", { name: "Notify Me" }))
 
     const postCall = makeRequest.mock.calls.find(
-      ([method, url]) =>
-        method === "post" && url === urls.hubspot.submit(STAY_UPDATED_FORM_ID),
+      ([args]) =>
+        args.method === "post" &&
+        args.url === urls.hubspot.submit(STAY_UPDATED_FORM_ID),
     )
     expect(postCall).toBeDefined()
 
-    const requestBody = postCall?.[2] as {
+    const requestBody = postCall?.[0].body as {
       fields?: Array<{ name: string; value: unknown }>
     }
     expect(requestBody.fields).toEqual(

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -76,13 +76,12 @@ const setMockApiResponses = ({
 }
 
 const getLastApiSearchParams = () => {
-  const call = makeRequest.mock.calls.find(([method, url]) => {
-    if (method !== "get") return false
-    return url.startsWith(urls.search.resources())
+  const call = makeRequest.mock.calls.find(([args]) => {
+    if (args.method !== "get") return false
+    return args.url.startsWith(urls.search.resources())
   })
   invariant(call)
-  const [_method, url] = call
-  const fullUrl = new URL(url, "http://mit.edu")
+  const fullUrl = new URL(call[0].url, "http://mit.edu")
   return fullUrl.searchParams
 }
 
@@ -286,9 +285,7 @@ describe("SearchPage", () => {
     })
 
     expect(makeRequest).not.toHaveBeenCalledWith(
-      "get",
-      urls.adminSearchParams,
-      expect.anything(),
+      expect.objectContaining({ method: "get", url: urls.adminSearchParams }),
     )
   })
 
@@ -325,9 +322,7 @@ describe("SearchPage", () => {
     })
 
     expect(makeRequest).not.toHaveBeenCalledWith(
-      "get",
-      urls.adminSearchParams,
-      expect.anything(),
+      expect.objectContaining({ method: "get", url: urls.adminSearchParams }),
     )
   })
 
@@ -1051,17 +1046,17 @@ describe("UniversalAIBanner", () => {
     renderWithProviders(<SearchPage />, { url: "?vector_search=true&q=test" })
 
     await waitFor(() => {
-      const call = makeRequest.mock.calls.find(([_method, url]) => {
-        return url.includes(urls.search.vectorResources())
+      const call = makeRequest.mock.calls.find(([args]) => {
+        return args.url.includes(urls.search.vectorResources())
       })
       expect(call).toBeDefined()
     })
 
-    const call = makeRequest.mock.calls.find(([_method, url]) =>
-      url.includes(urls.search.vectorResources()),
+    const call = makeRequest.mock.calls.find(([args]) =>
+      args.url.includes(urls.search.vectorResources()),
     )
     invariant(call)
-    const fullUrl = new URL(call[1], "http://mit.edu")
+    const fullUrl = new URL(call[0].url, "http://mit.edu")
     const apiSearchParams = fullUrl.searchParams
 
     expect(apiSearchParams.get("hybrid_search")).toBe("true")
@@ -1135,8 +1130,9 @@ describe("UniversalAIBanner", () => {
     ).not.toBeInTheDocument()
 
     const initialVectorRequestCount = makeRequest.mock.calls.filter(
-      ([method, url]) =>
-        method === "get" && url.includes(urls.search.vectorResources()),
+      ([args]) =>
+        args.method === "get" &&
+        args.url.includes(urls.search.vectorResources()),
     ).length
 
     await user.click(screen.getByRole("button", { name: /Topic/i }))
@@ -1150,8 +1146,9 @@ describe("UniversalAIBanner", () => {
     expect(screen.queryByText("Chemistry Result")).not.toBeInTheDocument()
 
     const finalVectorRequestCount = makeRequest.mock.calls.filter(
-      ([method, url]) =>
-        method === "get" && url.includes(urls.search.vectorResources()),
+      ([args]) =>
+        args.method === "get" &&
+        args.url.includes(urls.search.vectorResources()),
     ).length
     expect(finalVectorRequestCount).toBe(initialVectorRequestCount)
   })

--- a/frontends/main/src/page-components/Dialogs/AddToListDialog.test.tsx
+++ b/frontends/main/src/page-components/Dialogs/AddToListDialog.test.tsx
@@ -184,7 +184,11 @@ describe.each([ListType.LearningPath, ListType.UserList])(
       const saveButton = await screen.findByRole("button", { name: "Save" })
       await user.click(saveButton)
 
-      expect(makeRequest).toHaveBeenCalledWith("patch", setRelationshipsUrl, {})
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "patch",
+        url: setRelationshipsUrl,
+        body: {},
+      })
     })
 
     test("Clicking a checked list and clicking save removes item from that list", async () => {
@@ -239,7 +243,11 @@ describe.each([ListType.LearningPath, ListType.UserList])(
       const saveButton = await screen.findByRole("button", { name: "Save" })
       await user.click(saveButton)
 
-      expect(makeRequest).toHaveBeenCalledWith("patch", setRelationshipUrl, {})
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "patch",
+        url: setRelationshipUrl,
+        body: {},
+      })
     })
 
     test("Clicking 'Create New list' opens the create list dialog", async () => {

--- a/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
@@ -7,7 +7,7 @@ import {
   user,
   setupLocationMock,
 } from "@/test-utils"
-import { makeRequest, mockAxiosInstance, setMockResponse } from "api/test-utils"
+import { makeRequest, setMockResponse } from "api/test-utils"
 import {
   urls as mitxUrls,
   factories as mitxFactories,
@@ -345,11 +345,11 @@ describe("CourseEnrollmentDialog", () => {
       await user.click(enrollButton)
 
       await waitFor(() => {
-        expect(makeRequest).toHaveBeenCalledWith(
-          "post",
-          mitxUrls.enrollment.enrollmentsListV1(),
-          { run_id: run.id },
-        )
+        expect(makeRequest).toHaveBeenCalledWith({
+          method: "post",
+          url: mitxUrls.enrollment.enrollmentsListV1(),
+          body: { run_id: run.id },
+        })
       })
     })
 
@@ -380,18 +380,18 @@ describe("CourseEnrollmentDialog", () => {
 
       // Verify clear basket API was called first
       await waitFor(() => {
-        expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+        expect(makeRequest).toHaveBeenCalledWith(
           expect.objectContaining({
-            method: "DELETE",
+            method: "delete",
             url: clearUrl,
           }),
         )
       })
 
       // Verify create basket API was called
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+      expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({
-          method: "POST",
+          method: "post",
           url: basketUrl,
         }),
       )

--- a/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/ProgramEnrollmentDialog.test.tsx
@@ -6,7 +6,7 @@ import {
   user,
   setupLocationMock,
 } from "@/test-utils"
-import { mockAxiosInstance, setMockResponse } from "api/test-utils"
+import { makeRequest, setMockResponse } from "api/test-utils"
 import {
   urls as mitxUrls,
   factories as mitxFactories,
@@ -100,12 +100,12 @@ describe("ProgramEnrollmentDialog", () => {
     await user.click(addToCartButton)
 
     await waitFor(() => {
-      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-        expect.objectContaining({ method: "DELETE", url: clearUrl }),
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "delete", url: clearUrl }),
       )
     })
-    expect(mockAxiosInstance.request).toHaveBeenCalledWith(
-      expect.objectContaining({ method: "POST", url: basketUrl }),
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "post", url: basketUrl }),
     )
     const expectedCartUrl = mitxonlineLegacyUrl("/cart/")
     expect(assign).toHaveBeenCalledWith(expectedCartUrl)

--- a/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
+++ b/frontends/main/src/page-components/ItemsListing/ItemsListing.test.tsx
@@ -282,13 +282,13 @@ describe.each([ListType.LearningPath, ListType.UserList])(
       act(() => simulateDrag(from, to))
 
       await waitFor(() => {
-        expect(makeRequest).toHaveBeenCalledWith(
-          "patch",
-          patchUrl(listType, active.id),
-          {
+        expect(makeRequest).toHaveBeenCalledWith({
+          method: "patch",
+          url: patchUrl(listType, active.id),
+          body: {
             position: over.position,
           },
-        )
+        })
       })
     })
 
@@ -302,11 +302,11 @@ describe.each([ListType.LearningPath, ListType.UserList])(
 
       act(() => simulateDrag(from, to))
       await waitFor(() => {
-        expect(makeRequest).toHaveBeenCalledWith(
-          "patch",
-          patchUrl(listType, active.id),
-          expect.anything(),
-        )
+        expect(makeRequest).toHaveBeenCalledWith({
+          method: "patch",
+          url: patchUrl(listType, active.id),
+          body: expect.anything(),
+        })
       })
 
       expectProps(spySortableItem, { disabled: true })

--- a/frontends/main/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
+++ b/frontends/main/src/page-components/ManageListDialogs/ManageListDialogs.test.tsx
@@ -109,9 +109,7 @@ describe("manageListDialogs.upsertLearningPath", () => {
     screen.getByRole("dialog")
     await user.click(inputs.cancel())
     expect(makeRequest).not.toHaveBeenCalledWith(
-      "patch",
-      expect.anything(),
-      expect.anything(),
+      expect.objectContaining({ method: "patch" }),
     )
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -188,11 +186,11 @@ describe("manageListDialogs.upsertLearningPath", () => {
     setMockResponse.patch(patchUrl, { ...resource, ...patch })
     await user.click(inputs.submit())
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "patch",
-      patchUrl,
-      expect.objectContaining({ ...patch }),
-    )
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url: patchUrl,
+      body: expect.objectContaining({ ...patch }),
+    })
   }, 10000)
 
   test("Displays overall error if form validates but API call fails", async () => {
@@ -207,11 +205,11 @@ describe("manageListDialogs.upsertLearningPath", () => {
     setMockResponse.patch(patchUrl, {}, { code: 408 })
     await user.click(inputs.submit())
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "patch",
-      patchUrl,
-      expect.anything(),
-    )
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url: patchUrl,
+      body: expect.anything(),
+    })
     const alertMessage = await screen.findByRole("alert")
 
     expect(alertMessage).toHaveTextContent(
@@ -263,9 +261,7 @@ describe("manageListDialogs.upsertUserList", () => {
     screen.getByRole("dialog")
     await user.click(inputs.cancel())
     expect(makeRequest).not.toHaveBeenCalledWith(
-      "patch",
-      expect.anything(),
-      expect.anything(),
+      expect.objectContaining({ method: "patch" }),
     )
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
@@ -318,11 +314,11 @@ describe("manageListDialogs.upsertUserList", () => {
     setMockResponse.patch(patchUrl, { ...userList, ...patch })
     await user.click(inputs.submit("Update"))
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "patch",
-      patchUrl,
-      expect.objectContaining({ ...patch }),
-    )
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url: patchUrl,
+      body: expect.objectContaining({ ...patch }),
+    })
   })
 
   test("Displays overall error if form validates but API call fails", async () => {
@@ -334,11 +330,11 @@ describe("manageListDialogs.upsertUserList", () => {
     setMockResponse.patch(patchUrl, {}, { code: 408 })
     await user.click(inputs.submit("Update"))
 
-    expect(makeRequest).toHaveBeenCalledWith(
-      "patch",
-      patchUrl,
-      expect.anything(),
-    )
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "patch",
+      url: patchUrl,
+      body: expect.anything(),
+    })
     const alertMessage = await screen.findByRole("alert")
 
     expect(alertMessage).toHaveTextContent(
@@ -396,7 +392,9 @@ describe("manageListDialogs.destroyLearningPath", () => {
     setMockResponse.delete(url, undefined)
     await user.click(inputs.delete())
 
-    expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "delete", url }),
+    )
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })
@@ -439,7 +437,9 @@ describe("manageListDialogs.destroyUserList", () => {
     setMockResponse.delete(url, undefined)
     await user.click(inputs.delete())
 
-    expect(makeRequest).toHaveBeenCalledWith("delete", url, undefined)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "delete", url }),
+    )
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     })

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -128,7 +128,7 @@ describe("ResourceCarousel", () => {
   )
 
   it.each([{ isLoading: true }, { isLoading: false }])(
-    "Makes no API calls in loading state (isLoading=$isLoading)",
+    "Hits the carousel endpoint iff not in loading state (isLoading=$isLoading)",
     async ({ isLoading }) => {
       const config: ResourceCarouselProps["config"] = [
         {
@@ -151,23 +151,16 @@ describe("ResourceCarousel", () => {
         return new Promise((resolve) => setTimeout(resolve, 0))
       })
 
+      const carouselCall = expect.objectContaining({
+        method: "get",
+        url: expect.stringContaining(urls.search.resources()),
+      })
       if (isLoading) {
-        /**
-         * makeRequest is actually called, just not with the carousel URL.
-         * The ResourceCard components call `useUserMe` regardless of their
-         * loading state.
-         */
-        expect(makeRequest).not.toHaveBeenCalledWith([
-          "get",
-          expect.stringContaining(urls.search.resources()),
-          undefined,
-        ])
+        // Other requests (e.g. useUserMe from ResourceCard) may fire, but the
+        // carousel endpoint specifically should not.
+        expect(makeRequest).not.toHaveBeenCalledWith(carouselCall)
       } else {
-        expect(makeRequest).not.toHaveBeenCalledWith([
-          "get",
-          expect.stringContaining(urls.search.resources()),
-          undefined,
-        ])
+        expect(makeRequest).toHaveBeenCalledWith(carouselCall)
       }
     },
   )
@@ -230,15 +223,16 @@ describe("ResourceCarousel", () => {
     )
     await waitFor(() => {
       expect(makeRequest).toHaveBeenCalledWith(
-        "get",
-        expect.stringContaining(urls.learningResources.list()),
-        undefined,
+        expect.objectContaining({
+          method: "get",
+          url: expect.stringContaining(urls.learningResources.list()),
+        }),
       )
     })
-    const [_method, url] =
-      makeRequest.mock.calls.find(([_method, url]) => {
-        return url.includes(urls.learningResources.list())
-      }) ?? []
+    const call = makeRequest.mock.calls.find(([args]) => {
+      return args.url.includes(urls.learningResources.list())
+    })
+    const url = call?.[0].url
     invariant(url)
     const urlParams = new URLSearchParams(url.split("?")[1])
     expect(urlParams.getAll("resource_type")).toEqual(["course", "program"])

--- a/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
+++ b/frontends/main/src/page-components/SearchSubscriptionToggle/SearchSubscriptionToggle.test.tsx
@@ -81,9 +81,13 @@ test.each(Object.values(SourceTypeEnum))(
 
     const followButton = screen.getByTestId("action-follow")
     await user.click(followButton)
-    expect(makeRequest).toHaveBeenCalledWith("post", subscribeUrl, {
-      source_type: sourceType,
-      offered_by: ["ocw"],
+    expect(makeRequest).toHaveBeenCalledWith({
+      method: "post",
+      url: subscribeUrl,
+      body: {
+        source_type: sourceType,
+        offered_by: ["ocw"],
+      },
     })
   },
 )
@@ -118,9 +122,7 @@ test.each(Object.values(SourceTypeEnum))(
     await user.click(unsubscribeButton)
 
     expect(makeRequest).toHaveBeenCalledWith(
-      "delete",
-      unsubscribeUrl,
-      undefined,
+      expect.objectContaining({ method: "delete", url: unsubscribeUrl }),
     )
   },
 )

--- a/frontends/main/src/page-components/TiptapEditor/contentTypes/news/NewsEditor.happydom.test.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/contentTypes/news/NewsEditor.happydom.test.tsx
@@ -140,16 +140,16 @@ describe("NewsEditor - Content Editing and Saving", () => {
 
       await userEvent.click(updateButton)
 
-      expect(makeRequest).toHaveBeenCalledWith(
-        "patch",
-        urls.websiteContent.details(article.id),
-        expect.objectContaining({
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "patch",
+        url: urls.websiteContent.details(article.id),
+        body: expect.objectContaining({
           content: updatedArticle.content,
           is_published: true,
           title: updatedArticle.title,
           author_name: "",
         }),
-      )
+      })
 
       expect(mockOnSave).toHaveBeenCalled()
     })
@@ -249,16 +249,16 @@ describe("NewsEditor - Content Editing and Saving", () => {
 
       await userEvent.click(updateButton)
 
-      expect(makeRequest).toHaveBeenCalledWith(
-        "patch",
-        urls.websiteContent.details(article.id),
-        expect.objectContaining({
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "patch",
+        url: urls.websiteContent.details(article.id),
+        body: expect.objectContaining({
           content: updatedArticle.content,
           is_published: true,
           title: updatedArticle.title,
           author_name: "",
         }),
-      )
+      })
     })
   })
 
@@ -434,14 +434,14 @@ describe("NewsEditor - Content Editing and Saving", () => {
 
       await userEvent.click(saveDraftButton)
 
-      expect(makeRequest).toHaveBeenCalledWith(
-        "patch",
-        urls.websiteContent.details(newsItem.id),
-        expect.objectContaining({
+      expect(makeRequest).toHaveBeenCalledWith({
+        method: "patch",
+        url: urls.websiteContent.details(newsItem.id),
+        body: expect.objectContaining({
           is_published: false,
           author_name: "",
         }),
-      )
+      })
     })
   })
 
@@ -552,10 +552,10 @@ describe("NewsEditor - Content Editing and Saving", () => {
 
       await waitFor(
         () => {
-          expect(makeRequest).toHaveBeenCalledWith(
-            "post",
-            urls.websiteContent.list(),
-            expect.objectContaining({
+          expect(makeRequest).toHaveBeenCalledWith({
+            method: "post",
+            url: urls.websiteContent.list(),
+            body: expect.objectContaining({
               title: "My Article",
               author_name: "",
               content: {
@@ -588,7 +588,7 @@ describe("NewsEditor - Content Editing and Saving", () => {
               },
               is_published: true,
             }),
-          )
+          })
         },
         { timeout: 5000 },
       )

--- a/frontends/main/src/test-utils/setupJest.tsx
+++ b/frontends/main/src/test-utils/setupJest.tsx
@@ -1,18 +1,19 @@
+// React is referenced by the JSX in the jest.mock factory below; @swc/jest's
+// transform inlines React.createElement, so the import must stay even though
+// TS sees it as unused.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from "react"
-import { mockAxiosInstance } from "api/test-utils"
+import {
+  mockAxiosFactory,
+  assertMockAdapterInstalled,
+} from "api/test-utils/mockAxios"
 import preloadAll from "jest-next-dynamic-ts"
 
-jest.mock("axios", () => {
-  const AxiosError = jest.requireActual("axios").AxiosError
-  return {
-    __esModule: true,
-    default: {
-      create: () => mockAxiosInstance,
-      AxiosError,
-    },
-    AxiosError,
-  }
-})
+// Wrapped in `() => …` to defer the identifier lookup past TDZ — jest.mock
+// is hoisted above imports, so passing `mockAxiosFactory` directly would
+// evaluate the (still-unbound) reference at registration time.
+// https://jestjs.io/docs/es6-class-mocks#calling-jestmock-with-the-module-factory-parameter
+jest.mock("axios", () => mockAxiosFactory())
 
 jest.mock("react-markdown", () => {
   return {
@@ -32,6 +33,8 @@ beforeEach(() => {
   // container. So we need to clear it manually.
   // document.head.innerHTML = ""
   document.querySelector("title")?.remove()
+
+  assertMockAdapterInstalled()
 })
 
 window.scrollTo = jest.fn()


### PR DESCRIPTION
### What are the relevant tickets?
Facilitates
- https://github.com/mitodl/mit-learn/pull/3380
- https://github.com/mitodl/mit-learn/pull/3364

### Description (What does it do?)
This PR changes a bit how we mock API calls in tests:
1. **We no longer mock `axios` during tests.** Instead, we use an adapter to avoid making actual network requests. `setMockResponse` seeds data for the adapter. [^1]
    - We do *patch* axios via `jest.mock` during test setup to ensure that the adapter is always used.
2. **Changes `makeRequest` call signature.** This is mostly unrelated to the above change, but we needed to replace many `axios.request` test assertions to `makeRequest` anyway. I changed the `makeRequest` signature to be an object instead of positional arguments. This facilitates partial matching via `expect.objectContaining(...)`

**There is no change in how we actually use the mocks, apart from (2) above.**

**Motivation:** As part of https://github.com/mitodl/mit-learn/pull/3380, which is required for https://github.com/mitodl/mit-learn/pull/3364, `baseUrl` configuration (e.g., `https://api.learn.mit.edu/mitxonline` for the mitxonline api calls) moves from the client to the axios instance. This broke the way we had been asserting things.

This change makes our tests do a bit less mocking—real axios used—so are now less fragile to that sort of detail.


### How can this be tested?
Tests should pass.

**Note:** I also tested this by running `/scripts/test/jest-repeat.sh -- ''`, to run all tests 20 times. (Frontend tests, anyway)

### Why is the diff so big?

Mostly because:
1. There are more comments now
2. Roughly 30 `expect(axios.request).toHaveBeenCalledWith` calls were changed to `expect(makeRequest).toHaveBeenCalledWith`, and the new object form gets split across 4 or 5 lines, so ~100 new lines from that.