### PR TITLE
upgrade qdrant client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     "python-dateutil>=2.8.2,<3",
     "python-rapidjson>=1.8,<2",
     "pyyaml>=6.0.0,<7",
-    "qdrant-client[fastembed]==1.18.0",
+    "qdrant-client[fastembed]==1.18.0,<2",
     "redis>=7.0.0,<8",
     "requests>=2.31.0,<3",
     "retry2>=0.9.5,<0.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     "python-dateutil>=2.8.2,<3",
     "python-rapidjson>=1.8,<2",
     "pyyaml>=6.0.0,<7",
-    "qdrant-client[fastembed]>=1.14.3,<2",
+    "qdrant-client[fastembed]==1.18.0",
     "redis>=7.0.0,<8",
     "requests>=2.31.0,<3",
     "retry2>=0.9.5,<0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -2716,7 +2716,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
     { name = "python-rapidjson", specifier = ">=1.8,<2" },
     { name = "pyyaml", specifier = ">=6.0.0,<7" },
-    { name = "qdrant-client", extras = ["fastembed"], specifier = "==1.18.0" },
+    { name = "qdrant-client", extras = ["fastembed"], specifier = "==1.18.0,<2" },
     { name = "redis", specifier = ">=7.0.0,<8" },
     { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "retry2", specifier = ">=0.9.5,<0.10" },

--- a/uv.lock
+++ b/uv.lock
@@ -1135,7 +1135,7 @@ wheels = [
 
 [[package]]
 name = "fastembed"
-version = "0.7.4"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -1149,9 +1149,9 @@ dependencies = [
     { name = "tokenizers" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/c2/9c708680de1b54480161e0505f9d6d3d8eb47a1dc1a1f7f3c5106ba355d2/fastembed-0.7.4.tar.gz", hash = "sha256:8b8a4ea860ca295002f4754e8f5820a636e1065a9444959e18d5988d7f27093b", size = 68807, upload-time = "2025-12-05T12:08:10.447Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/3b/8da01492bc8b69184257d0c951bf0e77aec8ce110f06d8ce16c6ed9084f7/fastembed-0.7.4-py3-none-any.whl", hash = "sha256:79250a775f70bd6addb0e054204df042b5029ecae501e40e5bbd08e75844ad83", size = 108491, upload-time = "2025-12-05T12:08:09.059Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/e8/26b7d78bb8972498c467ca34cb12ee2e60d26ba5eae6d8443189a1af37a5/fastembed-0.8.0-py3-none-any.whl", hash = "sha256:40bee672657574a1009e35ec50030a55f2b426842cb011845379817641bbbbd0", size = 116572, upload-time = "2026-03-23T16:34:40.69Z" },
 ]
 
 [[package]]
@@ -2716,7 +2716,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
     { name = "python-rapidjson", specifier = ">=1.8,<2" },
     { name = "pyyaml", specifier = ">=6.0.0,<7" },
-    { name = "qdrant-client", extras = ["fastembed"], specifier = ">=1.14.3,<2" },
+    { name = "qdrant-client", extras = ["fastembed"], specifier = "==1.18.0" },
     { name = "redis", specifier = ">=7.0.0,<8" },
     { name = "requests", specifier = ">=2.31.0,<3" },
     { name = "retry2", specifier = ">=0.9.5,<0.10" },
@@ -4262,7 +4262,7 @@ wheels = [
 
 [[package]]
 name = "qdrant-client"
-version = "1.17.1"
+version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
@@ -4273,9 +4273,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/dd/f8a8261b83946af3cd65943c93c4f83e044f01184e8525404989d22a81a5/qdrant_client-1.17.1.tar.gz", hash = "sha256:22f990bbd63485ed97ba551a4c498181fcb723f71dcab5d6e4e43fe1050a2bc0", size = 344979, upload-time = "2026-03-13T17:13:44.678Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/45/5b1bdd15a3c7730eefb9c113600829e20d689b82b5a23f9e07d107094004/qdrant_client-1.18.0.tar.gz", hash = "sha256:52e8ece1a7d40519801bf0b70713bfa0f6b7ae28c7275bbe0b0286fbed7f6db4", size = 352580, upload-time = "2026-05-11T14:12:38.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/69/77d1a971c4b933e8c79403e99bcbb790463da5e48333cc4fd5d412c63c98/qdrant_client-1.17.1-py3-none-any.whl", hash = "sha256:6cda4064adfeaf211c751f3fbc00edbbdb499850918c7aff4855a9a759d56cbd", size = 389947, upload-time = "2026-03-13T17:13:43.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/10/c437bd2ac41ef30d3019063e6ce537dc111e9214473b337ee88f7fa6359a/qdrant_client-1.18.0-py3-none-any.whl", hash = "sha256:093aa8cf8a420ee3ad2a68b007e1378d7992b2600e0b53c193fc172674f659cd", size = 398126, upload-time = "2026-05-11T14:12:36.998Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11547
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR bumps the version pin for the qdrant client up to v1.18.0

### How can this be tested?
There are no functional changes. Tests should pass


### Additional Context
Our qdrant clusters have been bumped to v1.18.0 so this client upgrade will let us take advantage of some newer functionality when we need to
