### PR TITLE
fix a bug with filtering out variant runs when the default is selected

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
@@ -165,7 +165,7 @@ const useContractDashboardData = (
           ancestorContext: programEnrollment
             ? { programEnrollment }
             : undefined,
-          variant: isDefaultVariantSelection ? undefined : selectedVariant,
+          variant: selectedVariant ?? undefined,
           variantCandidateRuns: isDefaultVariantSelection
             ? undefined
             : variantRunsByCourseId[course.id],
@@ -186,7 +186,7 @@ const useContractDashboardData = (
       entries: firstCourses.map((course) =>
         buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
           contractId: contract.id,
-          variant: isDefaultVariantSelection ? undefined : selectedVariant!,
+          variant: selectedVariant ?? undefined,
           variantCandidateRuns: isDefaultVariantSelection
             ? undefined
             : variantRunsByCourseId[course.id],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1552,6 +1552,58 @@ describe("dashboardViewModel", () => {
       expect(resolved.displayedEnrollment).toBeNull()
       expect(resolved.displayedRun?.id).toBe(enrollableRun.id)
     })
+
+    test("does not surface a variant enrollment when the default variant is active", () => {
+      // Regression: user enrolls in Spanish run, then switches picker back to
+      // English default variant. The Spanish enrollment must be excluded and
+      // the English run must be the displayedRun.
+      const englishRun = factories.courses.courseRun({
+        id: 41,
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        is_enrollable: true,
+        b2b_contract: 5,
+      })
+      const spanishRun = factories.courses.courseRun({
+        id: 42,
+        language: LanguageEnum.EsEs,
+        variant_industry: "",
+        variant_length: "",
+        is_enrollable: true,
+        b2b_contract: 5,
+      })
+      const course = factories.courses.course({
+        id: 4,
+        courseruns: [englishRun, spanishRun],
+        next_run_id: englishRun.id,
+      })
+      const spanishEnrollment = factories.enrollment.courseEnrollment({
+        b2b_contract_id: 5,
+        run: {
+          ...spanishRun,
+          language: LanguageEnum.EsEs,
+          course: { id: course.id, title: course.title },
+        },
+      })
+      const defaultEnglishVariant: SupportedVariant = {
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: true,
+      }
+
+      const resolved = resolveDisplayedRunAndEnrollment(
+        course,
+        [spanishEnrollment],
+        { contractId: 5, variant: defaultEnglishVariant },
+      )
+
+      expect(resolved.displayedEnrollment).toBeNull()
+      expect(resolved.displayedRun?.id).toBe(englishRun.id)
+    })
   })
 })
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow up to https://github.com/mitodl/mit-learn/pull/3379

### Description (What does it do?)
This PR fixes a bug in the above PR that selects the improper run / enrollment when the default variant is selected. If you enroll in a variant first, then toggle back to the default run, the variant runs were not properly being filtered out resulting in the course cards getting the variant run you enrolled in as context.

### How can this be tested?
Requires a local mitxonline instance running the code from mitxonline PR #3618 (now merged to main).

1. Ensure the `mitxonline` backend is running with the merged variant options changes
2. Follow the instructions in this PR to create proper test data in `mitxonline`: https://github.com/mitodl/mitxonline/pull/3618
3. Load the B2B dashboard for that contract — the variant picker should appear if there are 2+ variant options
4. Select a non-default variant — course run titles should update to reflect the selected variant
5. When you enroll in a variant, you should be redirected to the courseware URL associated with that variant
6. Select the default variant again and confirm you can enroll in it and the variant enrollment you created is not used as the course card context
