### PR TITLE
feat: type-aware certificate descriptor badges on Learn certificate pages

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -117,6 +117,29 @@ describe("CertificatePage", () => {
     await screen.findAllByText(certificate.uuid)
   })
 
+  it("renders a MicroMasters program certificate badge with the registered mark", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "MicroMasters®"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        cert_uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+    renderWithProviders(
+      <CertificatePage
+        certificateType={CertificateType.Program}
+        uuid={certificate.uuid}
+        pageUrl={`https://${process.env.NEXT_PUBLIC_ORIGIN}/certificate/program/${certificate.uuid}`}
+      />,
+    )
+
+    const badge = await screen.findByTestId("certificate-badge-label")
+    expect(within(badge).getByText("MicroMasters")).toBeInTheDocument()
+    expect(within(badge).getByText("®")).toBeInTheDocument()
+    expect(within(badge).getByText("Certificate")).toBeInTheDocument()
+  })
+
   it("does not display buttons when certificate belongs to a different user", async () => {
     const certificateOwner = mitxonline.factories.user.user({ id: 1 })
     const loggedInUser = mitxonline.factories.user.user({ id: 2 })

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -86,6 +86,7 @@ describe("CertificatePage", () => {
 
   it("renders a program certificate", async () => {
     const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
         cert_uuid: certificate.uuid,
@@ -101,7 +102,7 @@ describe("CertificatePage", () => {
     )
 
     await screen.findAllByText(certificate.program.title)
-    await screen.findAllByText("Certificate")
+    await screen.findAllByText("Program Certificate")
     await screen.findAllByText(certificate.user.name!)
 
     await screen.findAllByText(

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import moment from "moment"
 import { factories, setMockResponse } from "api/test-utils"
-import { screen, renderWithProviders, user } from "@/test-utils"
+import { screen, renderWithProviders, user, within } from "@/test-utils"
 import CertificatePage from "./CertificatePage"
 import { CertificateType } from "@/common/certificateUtils"
 import SharePopover from "@/components/SharePopover/SharePopover"
@@ -102,7 +102,9 @@ describe("CertificatePage", () => {
     )
 
     await screen.findAllByText(certificate.program.title)
-    await screen.findAllByText("Program Certificate")
+    const badge = await screen.findByTestId("certificate-badge-label")
+    expect(within(badge).getByText("Program")).toBeInTheDocument()
+    expect(within(badge).getByText("Certificate")).toBeInTheDocument()
     await screen.findAllByText(certificate.user.name!)
 
     await screen.findAllByText(

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -25,6 +25,7 @@ import { DigitalCredentialDialog } from "./DigitalCredentialDialog"
 import {
   getCertificateInfo,
   getCertificateBadgeLines,
+  getCertificateBadgeTypography,
   getVerifiableCredentialLinkedInURL,
   getCertificateLinkedInUrl,
   getVerifiableCredentialDownloadAPIURL,
@@ -192,7 +193,10 @@ const Badge = styled.div(({ theme }) => ({
   },
 }))
 
-const BadgeLabelRoot = styled.div(({ theme }) => ({
+const BadgeLabelRoot = styled.div<{
+  $fontSizePx: number
+  $lineHeightPx: number
+}>(({ theme, $fontSizePx, $lineHeightPx }) => ({
   color: theme.custom.colors.white,
   position: "absolute",
   left: "50%",
@@ -201,8 +205,8 @@ const BadgeLabelRoot = styled.div(({ theme }) => ({
   width: "175px",
   textAlign: "center",
   fontWeight: theme.typography.fontWeightBold,
-  fontSize: theme.typography.pxToRem(18),
-  lineHeight: theme.typography.pxToRem(26),
+  fontSize: theme.typography.pxToRem($fontSizePx),
+  lineHeight: theme.typography.pxToRem($lineHeightPx),
   "@media screen": {
     [theme.breakpoints.down("lg")]: {
       fontSize: theme.typography.pxToRem(16),
@@ -216,11 +220,11 @@ const BadgeLabelRoot = styled.div(({ theme }) => ({
   },
 }))
 
-const BadgeRegisteredMark = styled.span({
-  fontSize: "0.645em",
+const BadgeRegisteredMark = styled.span<{ $scale: number }>(({ $scale }) => ({
+  fontSize: `${$scale}em`,
   lineHeight: 1,
   verticalAlign: "super",
-})
+}))
 
 const CertificateBadgeLabel = ({
   programType,
@@ -228,13 +232,20 @@ const CertificateBadgeLabel = ({
   programType?: string | null
 }) => {
   const lines = getCertificateBadgeLines(programType)
+  const typography = getCertificateBadgeTypography(programType)
 
   return (
-    <BadgeLabelRoot data-testid="certificate-badge-label">
+    <BadgeLabelRoot
+      data-testid="certificate-badge-label"
+      $fontSizePx={typography.fontSizePx}
+      $lineHeightPx={typography.lineHeightPx}
+    >
       <div>
         {lines.primary}
         {lines.registeredMark ? (
-          <BadgeRegisteredMark>®</BadgeRegisteredMark>
+          <BadgeRegisteredMark $scale={typography.registeredMarkScale}>
+            ®
+          </BadgeRegisteredMark>
         ) : null}
       </div>
       {lines.secondary ? <div>{lines.secondary}</div> : null}

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -620,7 +620,7 @@ const ProgramCertificate = ({
 }) => {
   const title = certificate.program.title
 
-  const { displayType } = getCertificateInfo()
+  const { displayType } = getCertificateInfo(certificate.program.program_type)
 
   const userName = certificate.user.name
 
@@ -736,7 +736,9 @@ const CertificatePage: React.FC<{
       ? courseCertificateData?.course_run.course.title
       : programCertificateData?.program.title
 
-  const { displayType } = getCertificateInfo()
+  const { displayType } = getCertificateInfo(
+    programCertificateData?.program?.program_type,
+  )
 
   const certificateData =
     certificateType === CertificateType.Course

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -654,7 +654,7 @@ const ProgramCertificate = ({
   return (
     <Certificate
       title={title}
-      badgeProgramType={certificate.program.program_type}
+      badgeProgramType={certificate?.program?.program_type}
       userName={userName}
       ceus={ceus}
       signatories={signatories}

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -24,6 +24,7 @@ import SharePopover from "@/components/SharePopover/SharePopover"
 import { DigitalCredentialDialog } from "./DigitalCredentialDialog"
 import {
   getCertificateInfo,
+  getCertificateBadgeLines,
   getVerifiableCredentialLinkedInURL,
   getCertificateLinkedInUrl,
   getVerifiableCredentialDownloadAPIURL,
@@ -191,31 +192,55 @@ const Badge = styled.div(({ theme }) => ({
   },
 }))
 
-const BadgeText = styled(Typography)(({ theme }) => ({
+const BadgeLabelRoot = styled.div(({ theme }) => ({
   color: theme.custom.colors.white,
   position: "absolute",
-  top: "185px",
-  right: "26px",
+  left: "50%",
+  top: "203px",
+  transform: "translate(-50%, -50%)",
   width: "175px",
   textAlign: "center",
+  fontWeight: theme.typography.fontWeightBold,
+  fontSize: theme.typography.pxToRem(18),
+  lineHeight: theme.typography.pxToRem(26),
   "@media screen": {
     [theme.breakpoints.down("lg")]: {
       fontSize: theme.typography.pxToRem(16),
-      lineHeight: "150%",
-      fontWeight: theme.typography.fontWeightMedium,
-      top: "53px",
-      right: "18px",
+      lineHeight: theme.typography.pxToRem(24),
+      top: "77px",
       width: "119px",
     },
     [theme.breakpoints.down("md")]: {
       width: "130px",
-      position: "absolute",
-      top: "50px",
-      right: "50%",
-      transform: "translateX(50%)",
     },
   },
 }))
+
+const BadgeRegisteredMark = styled.span({
+  fontSize: "0.645em",
+  lineHeight: 1,
+  verticalAlign: "super",
+})
+
+const CertificateBadgeLabel = ({
+  programType,
+}: {
+  programType?: string | null
+}) => {
+  const lines = getCertificateBadgeLines(programType)
+
+  return (
+    <BadgeLabelRoot data-testid="certificate-badge-label">
+      <div>
+        {lines.primary}
+        {lines.registeredMark ? (
+          <BadgeRegisteredMark>®</BadgeRegisteredMark>
+        ) : null}
+      </div>
+      {lines.secondary ? <div>{lines.secondary}</div> : null}
+    </BadgeLabelRoot>
+  )
+}
 
 const Certification = styled.div(({ theme }) => ({
   display: "flex",
@@ -506,7 +531,7 @@ const PrintContainer = styled.div({
 
 const Certificate = ({
   title,
-  displayType,
+  badgeProgramType,
   userName,
   ceus,
   signatories,
@@ -514,7 +539,7 @@ const Certificate = ({
   uuid,
 }: {
   title: string
-  displayType: string
+  badgeProgramType?: string | null
   userName?: string
   ceus?: string
   signatories: SignatoryItem[]
@@ -526,8 +551,8 @@ const Certificate = ({
       <Inner>
         <Logo src={OpenLearningLogo} alt="MIT Open Learning" />
         <PrintLogo src={OpenLearningLogo.src} alt="MIT Open Learning" />
-        <Badge>
-          <BadgeText variant="h4">{displayType}</BadgeText>
+        <Badge data-testid="certificate-badge">
+          <CertificateBadgeLabel programType={badgeProgramType} />
         </Badge>
         <Certification>
           <Typography variant="h4">This is to certify that</Typography>
@@ -597,14 +622,12 @@ const CourseCertificate = ({
 
   const userName = certificate.user.name
 
-  const { displayType } = getCertificateInfo()
   const signatories = certificate.certificate_page.signatory_items
   const issueDate = certificate?.issue_date
 
   return (
     <Certificate
       title={title}
-      displayType={displayType}
       userName={userName}
       signatories={signatories}
       issueDate={issueDate}
@@ -620,8 +643,6 @@ const ProgramCertificate = ({
 }) => {
   const title = certificate.program.title
 
-  const { displayType } = getCertificateInfo(certificate.program.program_type)
-
   const userName = certificate.user.name
 
   const ceus = certificate.certificate_page.CEUs
@@ -633,7 +654,7 @@ const ProgramCertificate = ({
   return (
     <Certificate
       title={title}
-      displayType={displayType}
+      badgeProgramType={certificate.program.program_type}
       userName={userName}
       ceus={ceus}
       signatories={signatories}

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
@@ -1,0 +1,68 @@
+import { generateMetadata } from "./page"
+import { factories, setMockResponse } from "api/test-utils"
+import * as mitxonline from "api/mitxonline-test-utils"
+
+type GenerateMetadataArgs = Parameters<typeof generateMetadata>[0]
+
+const callGenerateMetadata = (certificateType: string, uuid: string) =>
+  generateMetadata({
+    params: Promise.resolve({ certificateType, uuid }),
+    searchParams: Promise.resolve({}),
+  } as GenerateMetadataArgs)
+
+describe("Certificate page generateMetadata", () => {
+  it("includes the MicroMasters descriptor for a MicroMasters program certificate", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "MicroMasters®"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        cert_uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+
+    const metadata = await callGenerateMetadata("program", certificate.uuid)
+
+    expect(metadata.title).toContain(
+      `${certificate.user.name}'s MicroMasters® Certificate`,
+    )
+    expect(metadata.description).toBe(
+      `${certificate.user.name} has successfully completed: ${certificate.program.title}`,
+    )
+  })
+
+  it("uses the plain Program descriptor for a Program certificate", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        cert_uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+
+    const metadata = await callGenerateMetadata("program", certificate.uuid)
+
+    expect(metadata.title).toContain(
+      `${certificate.user.name}'s Program Certificate`,
+    )
+  })
+
+  it("omits a program descriptor for a course certificate", async () => {
+    const certificate = factories.mitxonline.courseCertificate()
+    setMockResponse.get(
+      mitxonline.urls.certificates.courseCertificatesRetrieve({
+        cert_uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+
+    const metadata = await callGenerateMetadata("course", certificate.uuid)
+
+    expect(metadata.title).toContain(`${certificate.user.name}'s Certificate`)
+    expect(metadata.title).not.toContain("MicroMasters")
+    expect(metadata.description).toBe(
+      `${certificate.user.name} has successfully completed: ${certificate.course_run.course.title}`,
+    )
+  })
+})

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
@@ -23,8 +23,7 @@ export async function generateMetadata({
   const { certificateType, uuid } = await params
 
   return safeGenerateMetadata(async () => {
-    let title, userName
-    const { displayType } = getCertificateInfo()
+    let title, userName, displayType
 
     const queryClient = getQueryClient()
 
@@ -38,6 +37,7 @@ export async function generateMetadata({
       title = data.course_run.course.title
 
       userName = data?.user?.name
+      displayType = getCertificateInfo().displayType
     } else {
       const data = await queryClient.fetchQueryOr404(
         certificateQueries.programCertificatesRetrieve({
@@ -48,6 +48,7 @@ export async function generateMetadata({
       title = data.program.title
 
       userName = data.user.name
+      displayType = getCertificateInfo(data.program.program_type).displayType
     }
 
     return standardizeMetadata({

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -26,7 +26,7 @@ import {
 } from "@react-pdf/renderer"
 import { redirect } from "next/navigation"
 import { pxToPt, getNameStyles } from "./utils"
-import { getCertificateInfo } from "@/common/certificateUtils"
+import { getCertificateBadgeLines } from "@/common/certificateUtils"
 
 // https://use.typekit.net/lbk1xay.css
 Font.register({
@@ -87,6 +87,14 @@ const typography = {
     fontFamily: "Neue Haas Grotesk Text 400",
     fontSize: pxToPt(16),
     lineHeight: pxToPt(2),
+  },
+  badge: {
+    fontFamily: "Neue Haas Grotesk Text 700",
+    fontSize: pxToPt(18),
+    lineHeight: pxToPt(26),
+  },
+  badgeMark: {
+    fontSize: pxToPt(11.61),
   },
 }
 
@@ -162,65 +170,88 @@ const OpenLearningLogo = () => (
   </Svg>
 )
 
-const Badge = ({ displayType }: { displayType: string }) => (
-  <View
-    style={{
-      position: "absolute",
-      top: pxToPt(0),
-      right: pxToPt(67),
-    }}
-  >
-    <Svg
-      viewBox="0 0 230 391"
-      fill="none"
+const Badge = ({ programType }: { programType?: string | null }) => {
+  const lines = getCertificateBadgeLines(programType)
+
+  return (
+    <View
       style={{
-        width: pxToPt(230),
-        height: pxToPt(391),
-      }}
-    >
-      <Path
-        d="M183.001 391L114.501 349.587L46.0015 391V0H183.001V391Z"
-        fill="#DDE1E6"
-      />
-      <Path
-        d="M230.001 198.963C230.001 211.203 221.176 221.735 217.476 232.552C214.06 243.938 214.914 257.886 208.082 267.28C201.251 276.673 188.156 280.089 178.763 286.921C169.369 293.752 162.253 305.708 151.152 309.408C140.335 313.109 127.525 307.701 115.855 307.701C103.899 307.701 91.0897 313.109 80.5575 309.408C69.1714 305.708 62.055 293.752 52.9461 286.921C43.5525 280.089 30.1739 276.673 23.3422 267.28C16.5105 257.886 17.6491 243.938 13.9486 232.552C10.5328 221.735 1.42383 211.203 1.42383 198.963C1.42383 186.723 10.5328 176.191 13.9486 165.374C17.6491 153.988 16.5105 140.04 23.3422 130.646C30.1739 121.253 43.5525 117.837 52.9461 111.005C62.055 104.173 69.1714 92.2178 80.5575 88.5173C91.0897 84.8168 103.899 90.2253 115.855 90.2253C127.525 90.2253 140.335 84.8168 151.152 88.5173C162.253 92.2178 169.369 104.173 178.763 111.005C188.156 117.837 201.251 121.253 208.082 130.646C214.914 140.04 214.06 153.988 217.476 165.374C221.176 176.191 230.001 186.723 230.001 198.963Z"
-        fill="#750014"
-      />
-      <Path
-        d="M228.578 200.102C228.578 212.057 219.753 222.589 216.053 233.406C212.352 244.507 213.491 258.171 206.659 267.28C199.828 276.673 186.449 280.089 177.34 286.921C167.947 293.468 160.83 305.139 149.729 308.839C138.912 312.255 126.102 307.131 114.147 307.131C102.476 307.131 89.6668 312.255 78.85 308.839C67.7485 305.139 60.6321 293.468 51.2386 286.921C41.845 280.089 28.751 276.673 21.9193 267.28C15.0876 258.171 15.9416 244.507 12.5258 233.406C8.8253 222.589 0.000976562 212.057 0.000976562 200.102C0.000976562 188.146 8.8253 177.899 12.5258 167.082C15.9416 155.98 15.0876 142.317 21.9193 132.923C28.751 123.814 41.845 120.399 51.2386 113.567C60.6321 106.735 67.7485 95.0644 78.85 91.6486C89.6668 87.9481 102.476 93.0718 114.147 93.0718C126.102 93.0718 138.912 87.9481 149.729 91.6486C160.83 95.0644 167.947 106.735 177.34 113.567C186.449 120.399 199.828 123.814 206.659 132.923C213.491 142.317 212.352 155.98 216.053 167.082C219.753 177.899 228.578 188.146 228.578 200.102Z"
-        fill="#750014"
-      />
-      <Path
-        d="M200.967 197.255C200.967 246.785 160.547 287.206 111.017 287.206C61.4871 287.206 21.0664 246.785 21.0664 197.255C21.0664 147.725 61.4871 107.305 111.017 107.305C160.547 107.305 200.967 147.725 200.967 197.255Z"
-        fill="#212326"
-        fillOpacity="0.2"
-      />
-      <Path
-        d="M205.806 203.233C205.806 252.763 165.67 292.899 116.14 292.899C66.3256 292.899 26.1895 252.763 26.1895 203.233C26.1895 153.419 66.3256 113.283 116.14 113.283C165.67 113.283 205.806 153.419 205.806 203.233Z"
-        fill="#212326"
-        fillOpacity="0.2"
-      />
-      <Path
-        d="M204.098 200.387C204.098 250.201 163.962 290.337 114.147 290.337C64.6176 290.337 24.4814 250.201 24.4814 200.387C24.4814 150.857 64.6176 110.721 114.147 110.721C163.962 110.721 204.098 150.857 204.098 200.387Z"
-        fill="#83192A"
-      />
-    </Svg>
-    <Text
-      style={{
-        color: colors.white,
         position: "absolute",
-        top: pxToPt(185),
-        right: pxToPt(26),
-        width: pxToPt(175),
-        textAlign: "center",
-        ...typography.h4,
-        fontFamily: "Neue Haas Grotesk Text 700",
+        top: pxToPt(0),
+        right: pxToPt(67),
       }}
     >
-      {displayType}
-    </Text>
-  </View>
-)
+      <Svg
+        viewBox="0 0 230 391"
+        fill="none"
+        style={{
+          width: pxToPt(230),
+          height: pxToPt(391),
+        }}
+      >
+        <Path
+          d="M183.001 391L114.501 349.587L46.0015 391V0H183.001V391Z"
+          fill="#DDE1E6"
+        />
+        <Path
+          d="M230.001 198.963C230.001 211.203 221.176 221.735 217.476 232.552C214.06 243.938 214.914 257.886 208.082 267.28C201.251 276.673 188.156 280.089 178.763 286.921C169.369 293.752 162.253 305.708 151.152 309.408C140.335 313.109 127.525 307.701 115.855 307.701C103.899 307.701 91.0897 313.109 80.5575 309.408C69.1714 305.708 62.055 293.752 52.9461 286.921C43.5525 280.089 30.1739 276.673 23.3422 267.28C16.5105 257.886 17.6491 243.938 13.9486 232.552C10.5328 221.735 1.42383 211.203 1.42383 198.963C1.42383 186.723 10.5328 176.191 13.9486 165.374C17.6491 153.988 16.5105 140.04 23.3422 130.646C30.1739 121.253 43.5525 117.837 52.9461 111.005C62.055 104.173 69.1714 92.2178 80.5575 88.5173C91.0897 84.8168 103.899 90.2253 115.855 90.2253C127.525 90.2253 140.335 84.8168 151.152 88.5173C162.253 92.2178 169.369 104.173 178.763 111.005C188.156 117.837 201.251 121.253 208.082 130.646C214.914 140.04 214.06 153.988 217.476 165.374C221.176 176.191 230.001 186.723 230.001 198.963Z"
+          fill="#750014"
+        />
+        <Path
+          d="M228.578 200.102C228.578 212.057 219.753 222.589 216.053 233.406C212.352 244.507 213.491 258.171 206.659 267.28C199.828 276.673 186.449 280.089 177.34 286.921C167.947 293.468 160.83 305.139 149.729 308.839C138.912 312.255 126.102 307.131 114.147 307.131C102.476 307.131 89.6668 312.255 78.85 308.839C67.7485 305.139 60.6321 293.468 51.2386 286.921C41.845 280.089 28.751 276.673 21.9193 267.28C15.0876 258.171 15.9416 244.507 12.5258 233.406C8.8253 222.589 0.000976562 212.057 0.000976562 200.102C0.000976562 188.146 8.8253 177.899 12.5258 167.082C15.9416 155.98 15.0876 142.317 21.9193 132.923C28.751 123.814 41.845 120.399 51.2386 113.567C60.6321 106.735 67.7485 95.0644 78.85 91.6486C89.6668 87.9481 102.476 93.0718 114.147 93.0718C126.102 93.0718 138.912 87.9481 149.729 91.6486C160.83 95.0644 167.947 106.735 177.34 113.567C186.449 120.399 199.828 123.814 206.659 132.923C213.491 142.317 212.352 155.98 216.053 167.082C219.753 177.899 228.578 188.146 228.578 200.102Z"
+          fill="#750014"
+        />
+        <Path
+          d="M200.967 197.255C200.967 246.785 160.547 287.206 111.017 287.206C61.4871 287.206 21.0664 246.785 21.0664 197.255C21.0664 147.725 61.4871 107.305 111.017 107.305C160.547 107.305 200.967 147.725 200.967 197.255Z"
+          fill="#212326"
+          fillOpacity="0.2"
+        />
+        <Path
+          d="M205.806 203.233C205.806 252.763 165.67 292.899 116.14 292.899C66.3256 292.899 26.1895 252.763 26.1895 203.233C26.1895 153.419 66.3256 113.283 116.14 113.283C165.67 113.283 205.806 153.419 205.806 203.233Z"
+          fill="#212326"
+          fillOpacity="0.2"
+        />
+        <Path
+          d="M204.098 200.387C204.098 250.201 163.962 290.337 114.147 290.337C64.6176 290.337 24.4814 250.201 24.4814 200.387C24.4814 150.857 64.6176 110.721 114.147 110.721C163.962 110.721 204.098 150.857 204.098 200.387Z"
+          fill="#83192A"
+        />
+      </Svg>
+      <View
+        style={{
+          position: "absolute",
+          top: pxToPt(177),
+          left: pxToPt(0),
+          width: pxToPt(230),
+          alignItems: "center",
+        }}
+      >
+        <Text
+          style={{
+            ...typography.badge,
+            color: colors.white,
+            textAlign: "center",
+          }}
+        >
+          {lines.primary}
+          {lines.registeredMark ? (
+            <Text style={typography.badgeMark}>®</Text>
+          ) : null}
+        </Text>
+        {lines.secondary ? (
+          <Text
+            style={{
+              ...typography.badge,
+              color: colors.white,
+              textAlign: "center",
+            }}
+          >
+            {lines.secondary}
+          </Text>
+        ) : null}
+      </View>
+    </View>
+  )
+}
 
 enum CertificateType {
   Course = "course",
@@ -230,7 +261,7 @@ enum CertificateType {
 const CertificateDoc = ({
   uuid,
   title,
-  displayType,
+  badgeProgramType,
   userName,
   ceus,
   signatories,
@@ -238,7 +269,7 @@ const CertificateDoc = ({
 }: {
   uuid: string
   title: string
-  displayType: string
+  badgeProgramType?: string | null
   userName: string
   ceus?: string | null
   signatories: SignatoryItem[]
@@ -282,7 +313,7 @@ const CertificateDoc = ({
             }}
           >
             <OpenLearningLogo />
-            <Badge displayType={displayType} />
+            <Badge programType={badgeProgramType} />
 
             <Text
               style={{
@@ -468,7 +499,6 @@ const CourseCertificate = ({
 }: {
   certificate: V2CourseRunCertificate
 }) => {
-  const { displayType } = getCertificateInfo()
   const title = certificate?.course_run?.course?.title
 
   const userName = certificate?.user?.name
@@ -482,7 +512,6 @@ const CourseCertificate = ({
   return (
     <CertificateDoc
       title={title}
-      displayType={displayType}
       userName={userName!}
       ceus={ceus}
       signatories={signatories}
@@ -499,8 +528,6 @@ const ProgramCertificate = ({
 }) => {
   const title = certificate?.program?.title
 
-  const { displayType } = getCertificateInfo(certificate.program.program_type)
-
   const userName = certificate?.user?.name
 
   const ceus = certificate?.certificate_page?.CEUs
@@ -513,7 +540,7 @@ const ProgramCertificate = ({
     <CertificateDoc
       uuid={certificate.uuid}
       title={title}
-      displayType={displayType}
+      badgeProgramType={certificate.program.program_type}
       userName={userName!}
       ceus={ceus}
       signatories={signatories}

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -26,7 +26,10 @@ import {
 } from "@react-pdf/renderer"
 import { redirect } from "next/navigation"
 import { pxToPt, getNameStyles } from "./utils"
-import { getCertificateBadgeLines } from "@/common/certificateUtils"
+import {
+  getCertificateBadgeLines,
+  getCertificateBadgeTypography,
+} from "@/common/certificateUtils"
 
 // https://use.typekit.net/lbk1xay.css
 Font.register({
@@ -87,14 +90,6 @@ const typography = {
     fontFamily: "Neue Haas Grotesk Text 400",
     fontSize: pxToPt(16),
     lineHeight: pxToPt(2),
-  },
-  badge: {
-    fontFamily: "Neue Haas Grotesk Text 700",
-    fontSize: pxToPt(18),
-    lineHeight: pxToPt(26),
-  },
-  badgeMark: {
-    fontSize: pxToPt(11.61),
   },
 }
 
@@ -172,6 +167,16 @@ const OpenLearningLogo = () => (
 
 const Badge = ({ programType }: { programType?: string | null }) => {
   const lines = getCertificateBadgeLines(programType)
+  const { fontSizePx, lineHeightPx, registeredMarkScale } =
+    getCertificateBadgeTypography(programType)
+  const badgeStyle = {
+    fontFamily: "Neue Haas Grotesk Text 700",
+    fontSize: pxToPt(fontSizePx),
+    lineHeight: pxToPt(lineHeightPx),
+  }
+  const badgeMarkStyle = {
+    fontSize: pxToPt(fontSizePx * registeredMarkScale),
+  }
 
   return (
     <View
@@ -227,20 +232,18 @@ const Badge = ({ programType }: { programType?: string | null }) => {
       >
         <Text
           style={{
-            ...typography.badge,
+            ...badgeStyle,
             color: colors.white,
             textAlign: "center",
           }}
         >
           {lines.primary}
-          {lines.registeredMark ? (
-            <Text style={typography.badgeMark}>®</Text>
-          ) : null}
+          {lines.registeredMark ? <Text style={badgeMarkStyle}>®</Text> : null}
         </Text>
         {lines.secondary ? (
           <Text
             style={{
-              ...typography.badge,
+              ...badgeStyle,
               color: colors.white,
               textAlign: "center",
             }}
@@ -540,7 +543,7 @@ const ProgramCertificate = ({
     <CertificateDoc
       uuid={certificate.uuid}
       title={title}
-      badgeProgramType={certificate.program.program_type}
+      badgeProgramType={certificate?.program?.program_type}
       userName={userName!}
       ceus={ceus}
       signatories={signatories}

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -499,7 +499,7 @@ const ProgramCertificate = ({
 }) => {
   const title = certificate?.program?.title
 
-  const { displayType } = getCertificateInfo()
+  const { displayType } = getCertificateInfo(certificate.program.program_type)
 
   const userName = certificate?.user?.name
 

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -1,4 +1,7 @@
-import { getCertificateInfo } from "./certificateUtils"
+import {
+  getCertificateBadgeLines,
+  getCertificateInfo,
+} from "./certificateUtils"
 
 describe("getCertificateInfo", () => {
   it("returns default certificate label when no program type is provided", () => {
@@ -23,5 +26,30 @@ describe("getCertificateInfo", () => {
 
   it("falls back to default label for unrecognized program types", () => {
     expect(getCertificateInfo("Degree").displayType).toBe("Certificate")
+  })
+})
+
+describe("getCertificateBadgeLines", () => {
+  it("returns a single line for course certificates", () => {
+    expect(getCertificateBadgeLines()).toEqual({ primary: "Certificate" })
+  })
+
+  it("splits MicroMasters into two lines with a registered mark", () => {
+    expect(getCertificateBadgeLines("MicroMasters®")).toEqual({
+      primary: "MicroMasters",
+      secondary: "Certificate",
+      registeredMark: true,
+    })
+  })
+
+  it("splits series and program descriptors across two lines", () => {
+    expect(getCertificateBadgeLines("Series")).toEqual({
+      primary: "Series",
+      secondary: "Certificate",
+    })
+    expect(getCertificateBadgeLines("Program")).toEqual({
+      primary: "Program",
+      secondary: "Certificate",
+    })
   })
 })

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   getCertificateBadgeLines,
+  getCertificateBadgeTypography,
   getCertificateInfo,
 } from "./certificateUtils"
 
@@ -75,5 +76,39 @@ describe("getCertificateBadgeLines", () => {
       secondary: "Certificate",
       registeredMark: true,
     })
+  })
+})
+
+describe("getCertificateBadgeTypography", () => {
+  const defaultTypography = {
+    fontSizePx: 24,
+    lineHeightPx: 30,
+    registeredMarkScale: 0.645,
+  }
+
+  const micromastersTypography = {
+    fontSizePx: 18,
+    lineHeightPx: 26,
+    registeredMarkScale: 0.645,
+  }
+
+  it("returns 24px typography for course certificates and unrecognized types", () => {
+    expect(getCertificateBadgeTypography()).toEqual(defaultTypography)
+    expect(getCertificateBadgeTypography(null)).toEqual(defaultTypography)
+    expect(getCertificateBadgeTypography("Degree")).toEqual(defaultTypography)
+  })
+
+  it("returns 24px typography for program and series descriptors", () => {
+    expect(getCertificateBadgeTypography("Program")).toEqual(defaultTypography)
+    expect(getCertificateBadgeTypography("Series")).toEqual(defaultTypography)
+  })
+
+  it("returns 18px typography for micromasters descriptors", () => {
+    expect(getCertificateBadgeTypography("MicroMasters®")).toEqual(
+      micromastersTypography,
+    )
+    expect(getCertificateBadgeTypography("  MicroMasters®  ")).toEqual(
+      micromastersTypography,
+    )
   })
 })

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -12,6 +12,18 @@ describe("getCertificateInfo", () => {
     expect(getCertificateInfo("MicroMasters®").displayType).toBe(
       "MicroMasters® Certificate",
     )
+    expect(getCertificateInfo("  MicroMasters®  ").displayType).toBe(
+      "MicroMasters® Certificate",
+    )
+    expect(getCertificateInfo("MicroMasters Credential").displayType).toBe(
+      "MicroMasters® Certificate",
+    )
+  })
+
+  it("does not match unrelated program types containing micro and master substrings", () => {
+    expect(getCertificateInfo("Microbiology Masters").displayType).toBe(
+      "Certificate",
+    )
   })
 
   it("returns series badge label for series program types", () => {
@@ -50,6 +62,18 @@ describe("getCertificateBadgeLines", () => {
     expect(getCertificateBadgeLines("Program")).toEqual({
       primary: "Program",
       secondary: "Certificate",
+    })
+  })
+
+  it("keeps display type and badge lines in sync for the same program type", () => {
+    const programType = "MicroMasters®"
+    expect(getCertificateInfo(programType).displayType).toBe(
+      "MicroMasters® Certificate",
+    )
+    expect(getCertificateBadgeLines(programType)).toEqual({
+      primary: "MicroMasters",
+      secondary: "Certificate",
+      registeredMark: true,
     })
   })
 })

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -16,12 +16,15 @@ describe("getCertificateInfo", () => {
     expect(getCertificateInfo("  MicroMasters®  ").displayType).toBe(
       "MicroMasters® Certificate",
     )
-    expect(getCertificateInfo("MicroMasters Credential").displayType).toBe(
+    expect(getCertificateInfo("MicroMasters").displayType).toBe(
       "MicroMasters® Certificate",
     )
   })
 
-  it("does not match unrelated program types containing micro and master substrings", () => {
+  it("falls back to default for micromasters-prefixed values that are not the exact descriptor", () => {
+    expect(getCertificateInfo("MicroMasters Professional").displayType).toBe(
+      "Certificate",
+    )
     expect(getCertificateInfo("Microbiology Masters").displayType).toBe(
       "Certificate",
     )

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -1,0 +1,27 @@
+import { getCertificateInfo } from "./certificateUtils"
+
+describe("getCertificateInfo", () => {
+  it("returns default certificate label when no program type is provided", () => {
+    expect(getCertificateInfo().displayType).toBe("Certificate")
+  })
+
+  it("returns MicroMasters badge label for micromasters program types", () => {
+    expect(getCertificateInfo("MicroMasters®").displayType).toBe(
+      "MicroMasters® Certificate",
+    )
+  })
+
+  it("returns series badge label for series program types", () => {
+    expect(getCertificateInfo("Series").displayType).toBe("Series Certificate")
+  })
+
+  it("returns program badge label for program program types", () => {
+    expect(getCertificateInfo("Program").displayType).toBe(
+      "Program Certificate",
+    )
+  })
+
+  it("falls back to default label for unrecognized program types", () => {
+    expect(getCertificateInfo("Degree").displayType).toBe("Certificate")
+  })
+})

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -12,63 +12,81 @@ export type CertificateBadgeLines = {
   registeredMark?: boolean
 }
 
+type ProgramTypeLabelKey = "micromasters" | "series" | "program"
+
+type CertificateLabel = {
+  displayType: string
+  badgeLines: CertificateBadgeLines
+}
+
+const PROGRAM_TYPE_LABELS: Record<ProgramTypeLabelKey, CertificateLabel> = {
+  micromasters: {
+    displayType: "MicroMasters\u00ae Certificate",
+    badgeLines: {
+      primary: "MicroMasters",
+      secondary: "Certificate",
+      registeredMark: true,
+    },
+  },
+  series: {
+    displayType: "Series Certificate",
+    badgeLines: { primary: "Series", secondary: "Certificate" },
+  },
+  program: {
+    displayType: "Program Certificate",
+    badgeLines: { primary: "Program", secondary: "Certificate" },
+  },
+}
+
+const DEFAULT_LABEL: CertificateLabel = {
+  displayType: "Certificate",
+  badgeLines: { primary: "Certificate" },
+}
+
+const normalizeProgramType = (programType?: string | null): string =>
+  (programType ?? "").trim().toLowerCase().replace(/®/g, "").replace(/\s+/g, "")
+
+const resolveKey = (
+  programType?: string | null,
+): ProgramTypeLabelKey | undefined => {
+  const normalized = normalizeProgramType(programType)
+  if (!normalized) {
+    return undefined
+  }
+  if (normalized === "series") {
+    return "series"
+  }
+  if (normalized === "program") {
+    return "program"
+  }
+  if (normalized === "micromasters" || normalized.startsWith("micromasters")) {
+    return "micromasters"
+  }
+  return undefined
+}
+
+const resolveCertificateLabel = (
+  programType?: string | null,
+): CertificateLabel => {
+  const key = resolveKey(programType)
+  return key ? PROGRAM_TYPE_LABELS[key] : DEFAULT_LABEL
+}
+
 /**
  * Returns common display info for a certificate.
  */
 export const getCertificateInfo = (
   programType?: string | null,
-): { displayType: string } => {
-  const normalizedProgramType = (programType ?? "").trim().toLowerCase()
-  if (
-    normalizedProgramType.includes("micro") &&
-    normalizedProgramType.includes("master")
-  ) {
-    return {
-      displayType: "MicroMasters\u00ae Certificate",
-    }
-  }
-  if (normalizedProgramType === "series") {
-    return {
-      displayType: "Series Certificate",
-    }
-  }
-  if (normalizedProgramType === "program") {
-    return {
-      displayType: "Program Certificate",
-    }
-  }
-  return {
-    displayType: "Certificate",
-  }
-}
+): { displayType: string } => ({
+  displayType: resolveCertificateLabel(programType).displayType,
+})
 
+/**
+ * Badge label lines for the certificate seal (Figma: 18px bold, two lines).
+ */
 export const getCertificateBadgeLines = (
   programType?: string | null,
-): CertificateBadgeLines => {
-  const { displayType } = getCertificateInfo(programType)
-
-  if (displayType === "Certificate") {
-    return { primary: "Certificate" }
-  }
-
-  if (displayType === "MicroMasters\u00ae Certificate") {
-    return {
-      primary: "MicroMasters",
-      secondary: "Certificate",
-      registeredMark: true,
-    }
-  }
-
-  const descriptorMatch = /^(.+) Certificate$/.exec(displayType)
-  if (descriptorMatch) {
-    return {
-      primary: descriptorMatch[1],
-      secondary: "Certificate",
-    }
-  }
-
-  return { primary: displayType }
-}
+): CertificateBadgeLines => resolveCertificateLabel(programType).badgeLines
 
 export enum CertificateType {
   Course = "course",

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -50,23 +50,20 @@ const normalizeProgramType = (programType?: string | null): string =>
     .replace(/®/g, "")
     .replace(/\s+/g, "")
 
+/*
+ * program_type is a free-form string on the client (`string | null`); the
+ * canonical enum is owned by MITx Online. Match the normalized value exactly
+ * against the known descriptors so unexpected values fall back to the plain
+ * "Certificate" label instead of being silently coerced (e.g. a prefix match
+ * on "micromasters" would swallow data issues).
+ */
 const resolveKey = (
   programType?: string | null,
 ): ProgramTypeLabelKey | undefined => {
   const normalized = normalizeProgramType(programType)
-  if (!normalized) {
-    return undefined
-  }
-  if (normalized === "series") {
-    return "series"
-  }
-  if (normalized === "program") {
-    return "program"
-  }
-  if (normalized === "micromasters" || normalized.startsWith("micromasters")) {
-    return "micromasters"
-  }
-  return undefined
+  return Object.hasOwn(PROGRAM_TYPE_LABELS, normalized)
+    ? (normalized as ProgramTypeLabelKey)
+    : undefined
 }
 
 const resolveCertificateLabel = (

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -85,12 +85,39 @@ export const getCertificateInfo = (
   displayType: resolveCertificateLabel(programType).displayType,
 })
 
-/**
- * Badge label lines for the certificate seal (Figma: 18px bold, two lines).
- */
+const BADGE_REGISTERED_MARK_SCALE = 0.645
+
+export type CertificateBadgeTypography = {
+  fontSizePx: number
+  lineHeightPx: number
+  registeredMarkScale: number
+}
+
+const MICROMASTERS_BADGE_TYPOGRAPHY: CertificateBadgeTypography = {
+  fontSizePx: 18,
+  lineHeightPx: 26,
+  registeredMarkScale: BADGE_REGISTERED_MARK_SCALE,
+}
+
+const DEFAULT_BADGE_TYPOGRAPHY: CertificateBadgeTypography = {
+  fontSizePx: 24,
+  lineHeightPx: 30,
+  registeredMarkScale: BADGE_REGISTERED_MARK_SCALE,
+}
+
 export const getCertificateBadgeLines = (
   programType?: string | null,
 ): CertificateBadgeLines => resolveCertificateLabel(programType).badgeLines
+
+/**
+ * Badge typography for the certificate seal (Figma: 24px bold; MicroMasters 18px).
+ */
+export const getCertificateBadgeTypography = (
+  programType?: string | null,
+): CertificateBadgeTypography =>
+  resolveKey(programType) === "micromasters"
+    ? MICROMASTERS_BADGE_TYPOGRAPHY
+    : DEFAULT_BADGE_TYPOGRAPHY
 
 export enum CertificateType {
   Course = "course",

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -44,7 +44,11 @@ const DEFAULT_LABEL: CertificateLabel = {
 }
 
 const normalizeProgramType = (programType?: string | null): string =>
-  (programType ?? "").trim().toLowerCase().replace(/®/g, "").replace(/\s+/g, "")
+  (programType ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/®/g, "")
+    .replace(/\s+/g, "")
 
 const resolveKey = (
   programType?: string | null,

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -5,6 +5,13 @@ import type {
 } from "@mitodl/mitxonline-api-axios/v2"
 
 import { LINKEDIN_ADD_TO_PROFILE_BASE_URL } from "@/common/urls"
+
+export type CertificateBadgeLines = {
+  primary: string
+  secondary?: string
+  registeredMark?: boolean
+}
+
 /**
  * Returns common display info for a certificate.
  */
@@ -33,6 +40,34 @@ export const getCertificateInfo = (
   return {
     displayType: "Certificate",
   }
+}
+
+export const getCertificateBadgeLines = (
+  programType?: string | null,
+): CertificateBadgeLines => {
+  const { displayType } = getCertificateInfo(programType)
+
+  if (displayType === "Certificate") {
+    return { primary: "Certificate" }
+  }
+
+  if (displayType === "MicroMasters\u00ae Certificate") {
+    return {
+      primary: "MicroMasters",
+      secondary: "Certificate",
+      registeredMark: true,
+    }
+  }
+
+  const descriptorMatch = /^(.+) Certificate$/.exec(displayType)
+  if (descriptorMatch) {
+    return {
+      primary: descriptorMatch[1],
+      secondary: "Certificate",
+    }
+  }
+
+  return { primary: displayType }
 }
 
 export enum CertificateType {

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -8,7 +8,28 @@ import { LINKEDIN_ADD_TO_PROFILE_BASE_URL } from "@/common/urls"
 /**
  * Returns common display info for a certificate.
  */
-export const getCertificateInfo = (): { displayType: string } => {
+export const getCertificateInfo = (
+  programType?: string | null,
+): { displayType: string } => {
+  const normalizedProgramType = (programType ?? "").trim().toLowerCase()
+  if (
+    normalizedProgramType.includes("micro") &&
+    normalizedProgramType.includes("master")
+  ) {
+    return {
+      displayType: "MicroMasters\u00ae Certificate",
+    }
+  }
+  if (normalizedProgramType === "series") {
+    return {
+      displayType: "Series Certificate",
+    }
+  }
+  if (normalizedProgramType === "program") {
+    return {
+      displayType: "Program Certificate",
+    }
+  }
   return {
     displayType: "Certificate",
   }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11559#event-26188616589

### Description (What does it do?)

- Program certificates on MIT Learn show the correct upper-right badge from MITx Online program.program_type (MicroMasters®, Series, Program).
- Course and module certificates stay Certificate (no descriptor).
- Same badge text on the public certificate page, PDF route, page metadata, and share UI.

### Screenshots (if appropriate):
**Certificate:**

<img width="1772" height="936" alt="Screenshot 2026-06-03 at 7 50 21 PM" src="https://github.com/user-attachments/assets/88cea1c2-8413-4700-8155-9fa2e16916aa" />

**MicroMasters Certificate:**

<img width="1792" height="935" alt="Screenshot 2026-06-03 at 7 51 15 PM" src="https://github.com/user-attachments/assets/05c6b0d8-c1cd-4801-bf3e-78e3c98566f8" />

**Series Certificate:**

<img width="1902" height="934" alt="Screenshot 2026-06-03 at 7 51 38 PM" src="https://github.com/user-attachments/assets/cf3a7bb6-0379-4dbd-b3ae-ed55d8145561" />

**Program Certificate:**

<img width="1810" height="936" alt="Screenshot 2026-06-03 at 7 52 07 PM" src="https://github.com/user-attachments/assets/1660e3be-179a-4398-9a7e-f2ca88d4e791" />

Mobile:
<img width="1544" height="848" alt="Screenshot 2026-06-03 at 8 10 01 PM" src="https://github.com/user-attachments/assets/44613f23-6fa7-48c8-ab67-88c989d41d76" />



### How can this be tested?

**Install the seed command (from GitHub):**

Copy the script into your local mitxonline checkout:

`cd /path/to/mitxonline`
```
curl -o courses/management/commands/ensure_certificate_descriptor_test_data.py \
  https://raw.githubusercontent.com/zamanafzal/mitxonline-scripts/main/courses/management/commands/ensure_certificate_descriptor_test_data.py
```
Or clone https://github.com/zamanafzal/mitxonline-scripts and copy:

```
cp /path/to/mitxonline-scripts/courses/management/commands/ensure_certificate_descriptor_test_data.py \
   courses/management/commands/
```
 **Run the seed command:**

Currently, it has default test users (zamanafzal@gmail.com, test1@gmail.com):

`docker compose exec web python manage.py ensure_certificate_descriptor_test_data
`
Use your own email/user like this:

```
docker compose exec web python manage.py ensure_certificate_descriptor_test_data \
  --email your.email@example.com
```
If you see no user with email — sign up once on local Learn, then re-run.

MITx Online on port 9080 (if not 8013):

```
docker compose exec web python manage.py ensure_certificate_descriptor_test_data \
  --mitxonline-base-url http://mitxonline.odl.local:9080
```
The command prints MIT Learn URLs — use those (UUIDs differ per machine/user).

**Verify each printed URL**


For each program URL (/certificate/program/<uuid>):


-  Badge line 1 / line 2 match the table (MicroMasters®, Series, or Program).

- Text looks centred in the seal.

 - Same URL + /pdf shows the same badge.

For the course URL (/certificate/course/<uuid>, Walmart SPOC fixture):


 - Badge is only Certificate (no program descriptor).
