### PR TITLE
Fix for empty "Other videos in this Series" section

### DIFF
--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -298,6 +298,31 @@ describe("ResourceCarousel", () => {
     expect(screen.queryByText(resources.list.results[1].title)).toBeNull()
   })
 
+  it("Does not render if all resources are excluded by excludeResourceId", async () => {
+    const config: ResourceCarouselProps["config"] = [
+      {
+        label: "Resources",
+        data: {
+          type: "resources",
+          params: { resource_type: ["course", "program"], professional: true },
+        },
+      },
+    ]
+    const { resources } = setupApis({ count: 1 })
+    const { view } = renderWithProviders(
+      <ResourceCarousel
+        titleComponent="h1"
+        title="My Carousel"
+        config={config}
+        excludeResourceId={resources.list.results[0].id}
+      />,
+    )
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(view.container.firstChild).toBeNull()
+  })
+
   it.each([
     { titleComponent: "h1", expectedLevel: 2 },
     { titleComponent: "h2", expectedLevel: 3 },

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.test.tsx
@@ -317,10 +317,9 @@ describe("ResourceCarousel", () => {
         excludeResourceId={resources.list.results[0].id}
       />,
     )
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
+    await waitFor(() => {
+      expect(view.container.firstChild).toBeNull()
     })
-    expect(view.container.firstChild).toBeNull()
   })
 
   it.each([

--- a/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
+++ b/frontends/main/src/page-components/ResourceCarousel/ResourceCarousel.tsx
@@ -235,20 +235,22 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
     }),
   })
 
-  const getCount = (
+  const getVisibleCount = (
     data: PaginatedLearningResourceList | LearningResource[] | undefined,
   ) => {
     if (!data) {
       return 0
     }
-    if ("count" in data) {
-      return data.count
+    const resources = "results" in data ? data.results : data
+    if (excludeResourceId !== undefined) {
+      return resources.filter((resource) => resource.id !== excludeResourceId)
+        .length
     }
-    return data.length
+    return resources.length
   }
 
   const allChildrenLoaded = queries.every(({ isLoading }) => !isLoading)
-  const allChildrenEmpty = queries.every(({ data }) => !getCount(data))
+  const allChildrenEmpty = queries.every(({ data }) => !getVisibleCount(data))
   if (!isLoading && allChildrenLoaded && allChildrenEmpty) {
     return null
   }
@@ -277,7 +279,7 @@ const ResourceCarousel: React.FC<ResourceCarouselProps> = ({
                     shouldShow:
                       isLoading ||
                       queries[index].isLoading ||
-                      getCount(queries[index].data) > 0,
+                      getVisibleCount(queries[index].data) > 0,
                   }))
                   .filter(({ shouldShow }) => shouldShow)
                   .map(({ tabConfig, index }) => (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10681
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue where a section displays even if there are no visible items in it

### How can this be tested?
1. checkout this branch
2. make sure you have learning resources loaded locally and indexed
3.  to replicate this -  find some video resource. look at the resources in "Other Videos in this Series" (its easiest if you find one with just one video there). alternatively "[How to Speak](https://learn.mit.edu/search?q=mit+stories&resource=7645)" is a resource that currently has this issue
4.  delete the other videos manually via django shell
5. re-index videos via ```python manage.py update_index --videos```
6. visit the resource drawer for that original video and note that the "Other Videos in this Series" no longer renders since there are no other videos in that series.

