### PR TITLE
add mynumbers game

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -14,6 +14,7 @@
     "@emotion/cache": "^11.13.1",
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
+    "@mitodl/arithmix": "^0.2.2",
     "@mitodl/course-search-utils": "^3.5.2",
     "@mitodl/mitxonline-api-axios": "2026.6.10",
     "@mitodl/smoot-design": "^6.27.0",

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixClient.test.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixClient.test.tsx
@@ -1,0 +1,95 @@
+import React from "react"
+import { renderWithProviders, screen } from "@/test-utils"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { notFound } from "next/navigation"
+import { allowConsoleErrors } from "ol-test-utilities"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import ArithmixClient from "./ArithmixClient"
+
+jest.mock("@mitodl/arithmix", () => ({
+  __esModule: true,
+  Arithmix: () => <div data-testid="arithmix">Arithmix Game</div>,
+}))
+
+jest.mock("@/common/useFeatureFlagsLoaded", () => ({
+  useFeatureFlagsLoaded: jest.fn(),
+}))
+
+jest.mock("posthog-js/react")
+
+const mockUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+const mockUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
+const mockNotFound = jest.mocked(notFound)
+
+describe("ArithmixClient", () => {
+  test("renders the Arithmix component when the feature flag is enabled", async () => {
+    mockUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockUseFeatureFlagEnabled.mockReturnValue(true)
+    renderWithProviders(<ArithmixClient />)
+    expect(await screen.findByTestId("arithmix")).toBeInTheDocument()
+  })
+
+  test("renders nothing while the feature flag is loading", () => {
+    mockUseFeatureFlagsLoaded.mockReturnValue(false)
+    mockUseFeatureFlagEnabled.mockReturnValue(undefined)
+    renderWithProviders(<ArithmixClient />)
+    expect(screen.queryByTestId("arithmix")).not.toBeInTheDocument()
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("calls notFound when the feature flag is disabled", () => {
+    allowConsoleErrors()
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND")
+    })
+    mockUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockUseFeatureFlagEnabled.mockReturnValue(false)
+    expect(() => renderWithProviders(<ArithmixClient />)).toThrow(
+      "NEXT_NOT_FOUND",
+    )
+    expect(mockNotFound).toHaveBeenCalled()
+  })
+
+  test("calls notFound when the mynumbers package fails to load", async () => {
+    allowConsoleErrors()
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND")
+    })
+
+    jest.doMock("@mitodl/arithmix", () => ({
+      __esModule: true,
+      get Arithmix() {
+        throw new Error("Failed to load dynamically imported module")
+      },
+    }))
+    jest.doMock("posthog-js/react", () => ({
+      useFeatureFlagEnabled: () => true,
+    }))
+    jest.doMock("@/common/useFeatureFlagsLoaded", () => ({
+      useFeatureFlagsLoaded: () => true,
+    }))
+
+    await jest.isolateModulesAsync(async () => {
+      // Disable Testing Library's auto-cleanup so importing it here does not
+      // register an `afterEach` hook (hooks cannot be defined inside a test).
+      // Import `@testing-library/react` directly rather than `@/test-utils`,
+      // which also pulls in `user-event` and registers an `afterAll` hook.
+      process.env.RTL_SKIP_AUTO_CLEANUP = "true"
+      const { render, act: isolatedAct } = await import(
+        "@testing-library/react"
+      )
+      delete process.env.RTL_SKIP_AUTO_CLEANUP
+
+      const { default: ArithmixClientWithFailedImport } = await import(
+        "./ArithmixClient"
+      )
+
+      await expect(
+        isolatedAct(async () => {
+          render(<ArithmixClientWithFailedImport />)
+          await new Promise((resolve) => setTimeout(resolve, 0))
+        }),
+      ).rejects.toThrow("NEXT_NOT_FOUND")
+    })
+  })
+})

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixClient.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixClient.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import React from "react"
+import dynamic from "next/dynamic"
+import ArithmixFlagGate from "./ArithmixFlagGate"
+
+// The mynumbers package accesses `document` at module-evaluation time, so it
+// must be loaded client-side only (no SSR).
+const Arithmix = dynamic(
+  () => import("@mitodl/arithmix").then((mod) => mod.Arithmix),
+  {
+    ssr: false,
+  },
+)
+
+const ArithmixClient: React.FC = () => {
+  return (
+    <ArithmixFlagGate>
+      <Arithmix basename="/games/arithmix" />
+    </ArithmixFlagGate>
+  )
+}
+
+export default ArithmixClient

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixFlagGate.test.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixFlagGate.test.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { renderWithProviders, screen } from "@/test-utils"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { notFound } from "next/navigation"
+import { allowConsoleErrors } from "ol-test-utilities"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import ArithmixFlagGate from "./ArithmixFlagGate"
+
+jest.mock("@/common/useFeatureFlagsLoaded", () => ({
+  useFeatureFlagsLoaded: jest.fn(),
+}))
+
+jest.mock("posthog-js/react")
+
+const mockUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+const mockUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
+const mockNotFound = jest.mocked(notFound)
+
+describe("ArithmixFlagGate", () => {
+  test("renders children when the feature flag is enabled", () => {
+    mockUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockUseFeatureFlagEnabled.mockReturnValue(true)
+    renderWithProviders(
+      <ArithmixFlagGate>
+        <div data-testid="gated-content">Gated content</div>
+      </ArithmixFlagGate>,
+    )
+    expect(screen.getByTestId("gated-content")).toBeInTheDocument()
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("renders nothing while the feature flags have not loaded", () => {
+    mockUseFeatureFlagsLoaded.mockReturnValue(false)
+    mockUseFeatureFlagEnabled.mockReturnValue(undefined)
+    renderWithProviders(
+      <ArithmixFlagGate>
+        <div data-testid="gated-content">Gated content</div>
+      </ArithmixFlagGate>,
+    )
+    expect(screen.queryByTestId("gated-content")).not.toBeInTheDocument()
+    expect(mockNotFound).not.toHaveBeenCalled()
+  })
+
+  test("calls notFound when the flag is disabled and flags have loaded", () => {
+    allowConsoleErrors()
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND")
+    })
+    mockUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockUseFeatureFlagEnabled.mockReturnValue(false)
+    expect(() =>
+      renderWithProviders(
+        <ArithmixFlagGate>
+          <div data-testid="gated-content">Gated content</div>
+        </ArithmixFlagGate>,
+      ),
+    ).toThrow("NEXT_NOT_FOUND")
+    expect(mockNotFound).toHaveBeenCalled()
+    expect(screen.queryByTestId("gated-content")).not.toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixFlagGate.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/ArithmixFlagGate.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import React from "react"
+import { notFound } from "next/navigation"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { FeatureFlags } from "@/common/feature_flags"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+
+/**
+ * Gates Arithmix routes behind the `FeatureFlags.Arithmix` feature flag.
+ *
+ * While flags are still loading, renders nothing to avoid prematurely 404ing
+ * users whose flags are bootstrapped client-side. Once flags are loaded and the
+ * flag is disabled, triggers a `notFound()`. When enabled, renders `children`.
+ */
+const ArithmixFlagGate: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const arithmixEnabled = useFeatureFlagEnabled(FeatureFlags.Arithmix)
+  const flagsLoaded = useFeatureFlagsLoaded()
+
+  if (!arithmixEnabled) {
+    return flagsLoaded ? notFound() : null
+  }
+
+  return <>{children}</>
+}
+
+export default ArithmixFlagGate

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/page.test.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/page.test.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { renderWithProviders, screen } from "@/test-utils"
+import Page, { metadata } from "./page"
+
+jest.mock("./ArithmixClient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="arithmix-client">Arithmix Client</div>,
+}))
+
+describe("arithmix page.tsx", () => {
+  test("renders the ArithmixClient", () => {
+    renderWithProviders(
+      <Page params={Promise.resolve({})} searchParams={Promise.resolve({})} />,
+    )
+    expect(screen.getByTestId("arithmix-client")).toBeInTheDocument()
+  })
+
+  test("sets the page title metadata", () => {
+    expect(metadata.title).toContain("Arithmix")
+  })
+})

--- a/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/page.tsx
+++ b/frontends/main/src/app/(site)/games/arithmix/[[...rest]]/page.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { Metadata } from "next"
+import { standardizeMetadata } from "@/common/metadata"
+import ArithmixClient from "./ArithmixClient"
+
+export const metadata: Metadata = standardizeMetadata({
+  title: "Arithmix",
+})
+
+const Page: React.FC<PageProps<"/games/arithmix/[[...rest]]">> = () => {
+  return <ArithmixClient />
+}
+
+export default Page

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -16,6 +16,7 @@ export enum FeatureFlags {
   VideoPlaylistPage = "video-playlist-page",
   PodcastDetailPage = "podcast-detail-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
+  Arithmix = "arithmix",
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3296,6 +3296,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mitodl/arithmix@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "@mitodl/arithmix@npm:0.2.2"
+  peerDependencies:
+    "@emotion/react": ">=11"
+    "@emotion/styled": ">=11"
+    react: ">=18"
+    react-dom: ">=18"
+  checksum: 10/6e1d7f1a8306cc64e281934b94c29f387455f58bc56af6dfdc19ecbcafaef5614fb91e867dce0f392a80bf804fd32f2dfa81b3d21b7dd1cdf60f8dfe704a46d4
+  languageName: node
+  linkType: hard
+
 "@mitodl/course-search-utils@npm:^3.5.2":
   version: 3.5.2
   resolution: "@mitodl/course-search-utils@npm:3.5.2"
@@ -16166,6 +16178,7 @@ __metadata:
     "@faker-js/faker": "npm:^10.0.0"
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
+    "@mitodl/arithmix": "npm:^0.2.2"
     "@mitodl/course-search-utils": "npm:^3.5.2"
     "@mitodl/mitxonline-api-axios": "npm:2026.6.10"
     "@mitodl/smoot-design": "npm:^6.27.0"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11688

### Description (What does it do?)
This pr adds the password game/ hacksnack from 
https://www.dropbox.com/scl/fi/om7jj7nvyd0i3p003thjg/password_game.zip?rlkey=frntioog3h6pyvl2s4obdh1r1&st=ojchbpgl&dl=0 as game in learn behind a feature flag. The library is here 
https://github.com/mitodl/hacksnack/pull/1


### Screenshots (if appropriate):
<img width="1728" height="927" alt="Screenshot 2026-06-17 at 7 42 06 PM" src="https://github.com/user-attachments/assets/8b048b40-52e2-4e19-b273-3af8c75af620" />


### How can this be tested?
go to http://open.odl.local:8062/games/hacksnack you should get a 404

enable "hacksnack" as flag in posthog then go back to 
go to http://open.odl.local:8062/games/hacksnack

the game should load and work correctly

If you want the answers to see how the app responds to correct solutions you can get them in 
assets/puzzle_picker_list.json in https://github.com/mitodl/hacksnack/pull/1