### PR TITLE
hide courseware cards in b2b contracts when variant selected if no variant run

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1741,6 +1741,182 @@ describe("ContractContent", () => {
     })
   })
 
+  test("hides program section when selected variant has no matching runs", async () => {
+    const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
+    mitxOnlineUser.legal_address = { country: "US" }
+    mitxOnlineUser.user_profile = { year_of_birth: 1988 }
+
+    const program = factories.programs.program({ courses: [] })
+    const contracts = createTestContracts(orgX.id, 1, [program.id])
+    orgX.contracts = contracts
+    mitxOnlineUser.b2b_organizations[0].contracts = contracts
+    contracts[0].variant_options = [
+      {
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: true,
+      },
+      {
+        language: LanguageEnum.EsEs,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: false,
+      },
+    ]
+
+    // Course only has an English run — no Spanish variant run
+    const englishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      title: "English Only Module",
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+    })
+    const englishOnlyCourse = factories.courses.course({
+      courseruns: [englishRun],
+      next_run_id: englishRun.id,
+    })
+    program.courses = [englishOnlyCourse.id]
+
+    setupOrgDashboardMocks(
+      orgX,
+      userApiPath,
+      mitxOnlineUser,
+      [program],
+      [englishOnlyCourse],
+      contracts,
+    )
+    // Variant runs endpoint returns no matching runs for this course
+    setMockResponse.get(
+      urls.courses.courseVariantRuns({
+        contract: contracts[0].id,
+        course_id: [englishOnlyCourse.id],
+        language: LanguageEnum.EsEs,
+      }),
+      [],
+    )
+
+    renderWithProviders(
+      <ContractContent orgSlug={orgX.slug} contractSlug={contracts[0].slug} />,
+    )
+
+    await screen.findByTestId("org-program-root")
+    await screen.findAllByRole("radio")
+
+    // Default (English) shows the program
+    expect(screen.getByTestId("org-program-root")).toBeInTheDocument()
+
+    // Switch to Spanish — program has no Spanish run, section should disappear
+    await user.click(screen.getByText(/español/i))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("org-program-root")).not.toBeInTheDocument()
+    })
+  })
+
+  test("hides collection section when selected variant has no matching runs", async () => {
+    const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
+    mitxOnlineUser.legal_address = { country: "US" }
+    mitxOnlineUser.user_profile = { year_of_birth: 1988 }
+
+    const program = factories.programs.program({ courses: [] })
+    const contracts = createTestContracts(orgX.id, 1, [program.id])
+    orgX.contracts = contracts
+    mitxOnlineUser.b2b_organizations[0].contracts = contracts
+    contracts[0].variant_options = [
+      {
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: true,
+      },
+      {
+        language: LanguageEnum.EsEs,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: false,
+      },
+    ]
+
+    const englishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      title: "Collection English Only",
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+    })
+    const englishOnlyCourse = factories.courses.course({
+      courseruns: [englishRun],
+      next_run_id: englishRun.id,
+    })
+    program.courses = [englishOnlyCourse.id]
+
+    setupOrgDashboardMocks(
+      orgX,
+      userApiPath,
+      mitxOnlineUser,
+      [program],
+      [englishOnlyCourse],
+      contracts,
+    )
+    setMockResponse.get(
+      urls.courses.courseVariantRuns({
+        contract: contracts[0].id,
+        course_id: [englishOnlyCourse.id],
+        language: LanguageEnum.EsEs,
+      }),
+      [],
+    )
+
+    const programCollection = factories.programs.programCollection({
+      programs: [{ id: program.id, title: program.title, order: 1 }],
+    })
+    setMockResponse.get(urls.programCollections.programCollectionsList(), {
+      results: [programCollection],
+    })
+    setMockResponse.get(
+      urls.programs.programsList({
+        id: [program.id],
+        contract_id: contracts[0].id,
+        page_size: 1,
+      }),
+      { results: [program] },
+    )
+    setMockResponse.get(
+      urls.courses.coursesList({
+        id: [englishOnlyCourse.id],
+        contract_id: contracts[0].id,
+      }),
+      { results: [englishOnlyCourse] },
+    )
+
+    renderWithProviders(
+      <ContractContent orgSlug={orgX.slug} contractSlug={contracts[0].slug} />,
+    )
+
+    await screen.findByTestId("org-program-collection-root")
+    await screen.findAllByRole("radio")
+
+    expect(
+      screen.getByTestId("org-program-collection-root"),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByText(/español/i))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("org-program-collection-root"),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   test("shared contract variant picker is hidden when only one variant option is present", async () => {
     const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
     mitxOnlineUser.legal_address = { country: "US" }

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -291,6 +291,11 @@ const OrgProgramDisplay: React.FC<{
   programEnrollment?: V3UserProgramEnrollment
 }> = ({ program, entries, programEnrollment }) => {
   const hasValidCertificate = !!programEnrollment?.certificate
+
+  if (entries.length === 0) {
+    return null
+  }
+
   return (
     <ProgramRoot data-testid="org-program-root">
       <ProgramHeader>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
@@ -19,7 +19,6 @@ import type {
 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   buildCourseEntry,
-  entryMatchesVariant,
   getCollectionFirstCoursesInDisplayOrder,
   getProgramCoursesInContractOrder,
   getRenderableContractCollections,
@@ -136,8 +135,8 @@ const useContractDashboardData = (
   // query has not yet resolved (status = 'pending', i.e. no data yet).  Using
   // isPending (not isLoading) ensures this is true on the very first render
   // after the picker changes — before React Query has started the fetch and set
-  // isFetching.  Without this guard, entryMatchesVariant would filter away
-  // cards that haven't received their variant run data yet.
+  // isFetching.  While loading, we skip passing the variant to buildCourseEntry
+  // so that entries are not filtered out before the run data arrives.
   const variantRunsLoading =
     !isDefaultVariantSelection && variantRunsQuery.isPending
 
@@ -176,16 +175,16 @@ const useContractDashboardData = (
             ancestorContext: programEnrollment
               ? { programEnrollment }
               : undefined,
-            variant: selectedVariant ?? undefined,
-            variantCandidateRuns: isDefaultVariantSelection
+            variant: variantRunsLoading
               ? undefined
-              : variantRunsByCourseId[course.id],
+              : (selectedVariant ?? undefined),
+            variantCandidateRuns:
+              isDefaultVariantSelection || variantRunsLoading
+                ? undefined
+                : variantRunsByCourseId[course.id],
           }),
         )
-        .filter(
-          (entry) =>
-            variantRunsLoading || entryMatchesVariant(entry, selectedVariant),
-        ),
+        .filter((entry): entry is DashboardCourseEntry => entry !== null),
       programEnrollment,
     }
   })
@@ -202,16 +201,16 @@ const useContractDashboardData = (
         .map((course) =>
           buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
             contractId: contract.id,
-            variant: selectedVariant ?? undefined,
-            variantCandidateRuns: isDefaultVariantSelection
+            variant: variantRunsLoading
               ? undefined
-              : variantRunsByCourseId[course.id],
+              : (selectedVariant ?? undefined),
+            variantCandidateRuns:
+              isDefaultVariantSelection || variantRunsLoading
+                ? undefined
+                : variantRunsByCourseId[course.id],
           }),
         )
-        .filter(
-          (entry) =>
-            variantRunsLoading || entryMatchesVariant(entry, selectedVariant),
-        ),
+        .filter((entry): entry is DashboardCourseEntry => entry !== null),
     }
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
@@ -19,6 +19,7 @@ import type {
 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   buildCourseEntry,
+  entryMatchesVariant,
   getCollectionFirstCoursesInDisplayOrder,
   getProgramCoursesInContractOrder,
   getRenderableContractCollections,
@@ -131,6 +132,15 @@ const useContractDashboardData = (
     return map
   }, [isDefaultVariantSelection, variantRunsQuery.data])
 
+  // True while a non-default variant is selected but the lazy variant-runs
+  // query has not yet resolved (status = 'pending', i.e. no data yet).  Using
+  // isPending (not isLoading) ensures this is true on the very first render
+  // after the picker changes — before React Query has started the fetch and set
+  // isFetching.  Without this guard, entryMatchesVariant would filter away
+  // cards that haven't received their variant run data yet.
+  const variantRunsLoading =
+    !isDefaultVariantSelection && variantRunsQuery.isPending
+
   const programs = programsQuery.data?.results ?? []
   const collections = programCollectionsQuery.data?.results ?? []
   const sortedPrograms = getSortedStandaloneContractPrograms(
@@ -159,18 +169,23 @@ const useContractDashboardData = (
     const programEnrollment = programEnrollmentsById[program.id]
     return {
       program,
-      entries: courses.map((course) =>
-        buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
-          contractId: contract.id,
-          ancestorContext: programEnrollment
-            ? { programEnrollment }
-            : undefined,
-          variant: selectedVariant ?? undefined,
-          variantCandidateRuns: isDefaultVariantSelection
-            ? undefined
-            : variantRunsByCourseId[course.id],
-        }),
-      ),
+      entries: courses
+        .map((course) =>
+          buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
+            contractId: contract.id,
+            ancestorContext: programEnrollment
+              ? { programEnrollment }
+              : undefined,
+            variant: selectedVariant ?? undefined,
+            variantCandidateRuns: isDefaultVariantSelection
+              ? undefined
+              : variantRunsByCourseId[course.id],
+          }),
+        )
+        .filter(
+          (entry) =>
+            variantRunsLoading || entryMatchesVariant(entry, selectedVariant),
+        ),
       programEnrollment,
     }
   })
@@ -183,15 +198,20 @@ const useContractDashboardData = (
     )
     return {
       collection,
-      entries: firstCourses.map((course) =>
-        buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
-          contractId: contract.id,
-          variant: selectedVariant ?? undefined,
-          variantCandidateRuns: isDefaultVariantSelection
-            ? undefined
-            : variantRunsByCourseId[course.id],
-        }),
-      ),
+      entries: firstCourses
+        .map((course) =>
+          buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
+            contractId: contract.id,
+            variant: selectedVariant ?? undefined,
+            variantCandidateRuns: isDefaultVariantSelection
+              ? undefined
+              : variantRunsByCourseId[course.id],
+          }),
+        )
+        .filter(
+          (entry) =>
+            variantRunsLoading || entryMatchesVariant(entry, selectedVariant),
+        ),
     }
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -15,7 +15,6 @@ import {
   buildVariantKey,
   buildVariantLabel,
   enrollmentCourseIsInPrograms,
-  entryMatchesVariant,
   getCollectionFirstCoursesInDisplayOrder,
   getModuleCourseIdsFromPrograms,
   getNonContractProgramEnrollments,
@@ -1639,92 +1638,6 @@ const makeRun = (overrides: Partial<BaseCourseRun> = {}): BaseCourseRun => ({
   is_enrollable: true,
   is_archived: false,
   ...overrides,
-})
-
-describe("entryMatchesVariant", () => {
-  const esVariant: SupportedVariant = {
-    language: LanguageEnum.EsEs,
-    variant_industry: "",
-    variant_length: "",
-    active: true,
-    b2b_only: true,
-    default_variant: false,
-  }
-  const enDefaultVariant: SupportedVariant = {
-    language: LanguageEnum.En,
-    variant_industry: "",
-    variant_length: "",
-    active: true,
-    b2b_only: true,
-    default_variant: true,
-  }
-
-  const makeEntry = (
-    displayedRun: BaseCourseRun | null,
-  ): ReturnType<typeof buildCourseEntry> => {
-    const course = factories.courses.course({ courseruns: [] })
-    return {
-      course,
-      enrollments: [],
-      displayedEnrollment: null,
-      displayedRun,
-    }
-  }
-
-  test("returns true when variant is null", () => {
-    expect(entryMatchesVariant(makeEntry(null), null)).toBe(true)
-  })
-
-  test("returns true when variant is the default variant", () => {
-    expect(entryMatchesVariant(makeEntry(null), enDefaultVariant)).toBe(true)
-  })
-
-  test("returns true when displayedRun matches the variant", () => {
-    const run = makeRun({
-      language: LanguageEnum.EsEs,
-      variant_industry: "",
-      variant_length: "",
-    })
-    expect(entryMatchesVariant(makeEntry(run), esVariant)).toBe(true)
-  })
-
-  test("returns false when displayedRun does not match the variant", () => {
-    // English run shown as fallback when no Spanish variant run exists
-    const englishFallback = makeRun({
-      language: LanguageEnum.En,
-      variant_industry: "",
-      variant_length: "",
-    })
-    expect(entryMatchesVariant(makeEntry(englishFallback), esVariant)).toBe(
-      false,
-    )
-  })
-
-  test("returns false when displayedRun is null and variant is non-default", () => {
-    expect(entryMatchesVariant(makeEntry(null), esVariant)).toBe(false)
-  })
-
-  test("returns true when displayedEnrollment run matches the variant", () => {
-    const course = factories.courses.course({ courseruns: [] })
-    const enrolledRun = makeRun({
-      language: LanguageEnum.EsEs,
-      variant_industry: "",
-      variant_length: "",
-    })
-    const enrollment = factories.enrollment.courseEnrollment({
-      run: {
-        ...enrolledRun,
-        course: { id: course.id, title: course.title },
-      },
-    })
-    const entry: ReturnType<typeof buildCourseEntry> = {
-      course,
-      enrollments: [enrollment],
-      displayedEnrollment: enrollment,
-      displayedRun: enrolledRun,
-    }
-    expect(entryMatchesVariant(entry, esVariant)).toBe(true)
-  })
 })
 
 describe("buildVariantKey", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -15,6 +15,7 @@ import {
   buildVariantKey,
   buildVariantLabel,
   enrollmentCourseIsInPrograms,
+  entryMatchesVariant,
   getCollectionFirstCoursesInDisplayOrder,
   getModuleCourseIdsFromPrograms,
   getNonContractProgramEnrollments,
@@ -1638,6 +1639,92 @@ const makeRun = (overrides: Partial<BaseCourseRun> = {}): BaseCourseRun => ({
   is_enrollable: true,
   is_archived: false,
   ...overrides,
+})
+
+describe("entryMatchesVariant", () => {
+  const esVariant: SupportedVariant = {
+    language: LanguageEnum.EsEs,
+    variant_industry: "",
+    variant_length: "",
+    active: true,
+    b2b_only: true,
+    default_variant: false,
+  }
+  const enDefaultVariant: SupportedVariant = {
+    language: LanguageEnum.En,
+    variant_industry: "",
+    variant_length: "",
+    active: true,
+    b2b_only: true,
+    default_variant: true,
+  }
+
+  const makeEntry = (
+    displayedRun: BaseCourseRun | null,
+  ): ReturnType<typeof buildCourseEntry> => {
+    const course = factories.courses.course({ courseruns: [] })
+    return {
+      course,
+      enrollments: [],
+      displayedEnrollment: null,
+      displayedRun,
+    }
+  }
+
+  test("returns true when variant is null", () => {
+    expect(entryMatchesVariant(makeEntry(null), null)).toBe(true)
+  })
+
+  test("returns true when variant is the default variant", () => {
+    expect(entryMatchesVariant(makeEntry(null), enDefaultVariant)).toBe(true)
+  })
+
+  test("returns true when displayedRun matches the variant", () => {
+    const run = makeRun({
+      language: LanguageEnum.EsEs,
+      variant_industry: "",
+      variant_length: "",
+    })
+    expect(entryMatchesVariant(makeEntry(run), esVariant)).toBe(true)
+  })
+
+  test("returns false when displayedRun does not match the variant", () => {
+    // English run shown as fallback when no Spanish variant run exists
+    const englishFallback = makeRun({
+      language: LanguageEnum.En,
+      variant_industry: "",
+      variant_length: "",
+    })
+    expect(entryMatchesVariant(makeEntry(englishFallback), esVariant)).toBe(
+      false,
+    )
+  })
+
+  test("returns false when displayedRun is null and variant is non-default", () => {
+    expect(entryMatchesVariant(makeEntry(null), esVariant)).toBe(false)
+  })
+
+  test("returns true when displayedEnrollment run matches the variant", () => {
+    const course = factories.courses.course({ courseruns: [] })
+    const enrolledRun = makeRun({
+      language: LanguageEnum.EsEs,
+      variant_industry: "",
+      variant_length: "",
+    })
+    const enrollment = factories.enrollment.courseEnrollment({
+      run: {
+        ...enrolledRun,
+        course: { id: course.id, title: course.title },
+      },
+    })
+    const entry: ReturnType<typeof buildCourseEntry> = {
+      course,
+      enrollments: [enrollment],
+      displayedEnrollment: enrollment,
+      displayedRun: enrolledRun,
+    }
+    expect(entryMatchesVariant(entry, esVariant)).toBe(true)
+  })
 })
 
 describe("buildVariantKey", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -768,7 +768,7 @@ describe("dashboardViewModel", () => {
         courseruns: [run],
         next_run_id: run.id,
       })
-      const entry = buildCourseEntry(course, [], {})
+      const entry = buildCourseEntry(course, [], {})!
 
       expect(entry.displayedEnrollment).toBeNull()
       expect(entry.displayedRun).not.toBeNull()
@@ -799,7 +799,7 @@ describe("dashboardViewModel", () => {
         },
       })
 
-      const entry = buildCourseEntry(course, [enrollment], {})
+      const entry = buildCourseEntry(course, [enrollment], {})!
 
       expect(entry.displayedEnrollment).toBe(enrollment)
       expect(entry.displayedRun?.id).toBe(run.id)
@@ -820,7 +820,7 @@ describe("dashboardViewModel", () => {
       })
 
       // no selectedLanguageKey → legacy path
-      const entry = buildCourseEntry(course, [noCert, withCert], {})
+      const entry = buildCourseEntry(course, [noCert, withCert], {})!
 
       expect(entry.displayedEnrollment).toBe(withCert)
     })
@@ -859,7 +859,7 @@ describe("dashboardViewModel", () => {
 
       const entry = buildCourseEntry(course, [otherContractEnrollment], {
         contractId: 10,
-      })
+      })!
 
       expect(entry.displayedEnrollment).toBeNull()
     })
@@ -900,7 +900,7 @@ describe("dashboardViewModel", () => {
         {
           contractId: 1,
         },
-      )
+      )!
 
       expect(entry.displayedEnrollment?.b2b_contract_id).toBe(1)
     })
@@ -917,7 +917,7 @@ describe("dashboardViewModel", () => {
         certificate: { uuid: "cert-xyz" },
       })
 
-      const entry = buildCourseEntry(course, [e1, e2], {})
+      const entry = buildCourseEntry(course, [e1, e2], {})!
 
       // displayedEnrollment picks best one (e2), but all remain on entry
       expect(entry.enrollments).toEqual([e1, e2])
@@ -933,7 +933,7 @@ describe("dashboardViewModel", () => {
       const entry = buildCourseEntry(course, [], {
         contractId: 42,
         ancestorContext,
-      })
+      })!
 
       expect(entry.course).toBe(course)
       expect(entry.contractId).toBe(42)
@@ -945,7 +945,7 @@ describe("dashboardViewModel", () => {
 
       const entry = buildCourseEntry(course, [], {
         isContractPageResource: true,
-      })
+      })!
 
       expect(entry.isContractPageResource).toBe(true)
     })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -977,6 +977,30 @@ const getCollectionFirstCoursesInDisplayOrder = (
   })
 }
 
+/**
+ * Returns true when the entry's resolved display run (or enrolled run) actually
+ * satisfies the selected variant — i.e. the course has a real matching run and
+ * the card should be shown.
+ *
+ * Returns true unconditionally when:
+ *  - `variant` is null/undefined (no variant picker active)
+ *  - `variant.default_variant === true` (all runs belong to the default set)
+ *
+ * This is the single predicate used by `useContractDashboardData` to hide cards
+ * for courses that have no runs in the selected variant.
+ */
+const entryMatchesVariant = (
+  entry: DashboardCourseEntry,
+  variant: SupportedVariant | null | undefined,
+): boolean => {
+  if (!variant || variant.default_variant) return true
+  const matches = runMatchesVariant(variant)
+  if (entry.displayedEnrollment && matches(entry.displayedEnrollment.run)) {
+    return true
+  }
+  return entry.displayedRun !== null && matches(entry.displayedRun)
+}
+
 export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
@@ -1001,6 +1025,7 @@ export {
   buildVariantKey,
   buildVariantLabel,
   selectVariantRunForCourse,
+  entryMatchesVariant,
 }
 
 export type { RequirementSectionItem, RequirementSection }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -393,11 +393,9 @@ const resolveDisplayedRunAndEnrollment = (
     }) ??
     course.courseruns[0] ??
     null
-  const displayedRun = opts?.variant
-    ? (selectVariantRunForCourse(
-        opts.variantCandidateRuns ?? [],
-        opts.variant,
-      ) ?? defaultRun)
+  const isNonDefaultVariant = opts?.variant && !opts.variant.default_variant
+  const displayedRun = isNonDefaultVariant
+    ? selectVariantRunForCourse(opts.variantCandidateRuns ?? [], opts.variant!)
     : defaultRun
   return { displayedEnrollment: null, displayedRun }
 }
@@ -480,6 +478,10 @@ type RequirementSection = {
  * When `opts.variant` and `opts.variantCandidateRuns` are provided,
  * `resolveDisplayedRunAndEnrollment` will prefer any existing enrollment that
  * already matches the variant before falling back to the candidate runs.
+ *
+ * Returns `null` when a non-default variant is active and neither a matching
+ * run nor a matching enrollment could be found for this course. Callers should
+ * filter out null entries to hide courses that have no runs in the variant.
  */
 const buildCourseEntry = (
   course: CourseWithCourseRunsSerializerV2,
@@ -493,13 +495,18 @@ const buildCourseEntry = (
     /** Candidate runs from the variant-runs API for this course. */
     variantCandidateRuns?: BaseCourseRun[]
   },
-): DashboardCourseEntry => {
+): DashboardCourseEntry | null => {
   const { displayedRun, displayedEnrollment } =
     resolveDisplayedRunAndEnrollment(course, enrollments, {
       contractId: opts.contractId,
       variant: opts.variant,
       variantCandidateRuns: opts.variantCandidateRuns,
     })
+
+  const isNonDefaultVariant = opts.variant && !opts.variant.default_variant
+  if (isNonDefaultVariant && !displayedRun && !displayedEnrollment) {
+    return null
+  }
 
   return {
     course,
@@ -587,18 +594,17 @@ const buildRequirementSections = ({
           if (resource.type === "course") {
             const course = coursesById.get(resource.id)
             if (!course) return null
-            return {
-              kind: "course",
-              entry: buildCourseEntry(
-                course,
-                enrollmentsByCourseId[course.id] ?? [],
-                {
-                  ancestorContext: ancestorProgramEnrollment
-                    ? { programEnrollment: ancestorProgramEnrollment }
-                    : undefined,
-                },
-              ),
-            }
+            const entry = buildCourseEntry(
+              course,
+              enrollmentsByCourseId[course.id] ?? [],
+              {
+                ancestorContext: ancestorProgramEnrollment
+                  ? { programEnrollment: ancestorProgramEnrollment }
+                  : undefined,
+              },
+            )
+            if (!entry) return null
+            return { kind: "course", entry }
           }
 
           // resource.type === "program"
@@ -977,30 +983,6 @@ const getCollectionFirstCoursesInDisplayOrder = (
   })
 }
 
-/**
- * Returns true when the entry's resolved display run (or enrolled run) actually
- * satisfies the selected variant — i.e. the course has a real matching run and
- * the card should be shown.
- *
- * Returns true unconditionally when:
- *  - `variant` is null/undefined (no variant picker active)
- *  - `variant.default_variant === true` (all runs belong to the default set)
- *
- * This is the single predicate used by `useContractDashboardData` to hide cards
- * for courses that have no runs in the selected variant.
- */
-const entryMatchesVariant = (
-  entry: DashboardCourseEntry,
-  variant: SupportedVariant | null | undefined,
-): boolean => {
-  if (!variant || variant.default_variant) return true
-  const matches = runMatchesVariant(variant)
-  if (entry.displayedEnrollment && matches(entry.displayedEnrollment.run)) {
-    return true
-  }
-  return entry.displayedRun !== null && matches(entry.displayedRun)
-}
-
 export {
   pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
@@ -1025,7 +1007,6 @@ export {
   buildVariantKey,
   buildVariantLabel,
   selectVariantRunForCourse,
-  entryMatchesVariant,
 }
 
 export type { RequirementSectionItem, RequirementSection }


### PR DESCRIPTION
### What are the relevant tickets?
n/a

### Description (What does it do?)
This PR sets up the frontend to completely hide courseware cards in the situation where the user has selected a variant but there are no variant runs available for that course.

### How can this be tested?
Requires a local mitxonline instance running the code from mitxonline PR #3618 (now merged to main).

1. Ensure the `mitxonline` backend is running with the merged variant options changes
2. Follow the instructions in this PR to create proper test data in `mitxonline`, but make sure that for one of the courses you do *not* create a variant run in one of the variants: https://github.com/mitodl/mitxonline/pull/3618
4. Load the B2B dashboard for that contract — the variant picker should appear if there are 2+ variant options
5. Select the variant with the missing course run and verify that the card is hidden