### PR TITLE
Ignore both SCM and DEDP micromasters programs

### DIFF
--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -90,6 +90,8 @@ def transform(programs_data):
     programs = []
     for program in programs_data:
         url = program.get("programpage_url")
+        if not url or IGNORE_URLS.search(url):
+            continue
         # need positioning of courses by course_id for course data
         courses = [
             {
@@ -111,51 +113,48 @@ def transform(programs_data):
                 key=lambda course: course["position_in_program"],
             )
         ]
-        if url and not IGNORE_URLS.search(url):
-            pace = sorted(
-                {
-                    pace
-                    for course in courses
-                    for pace in course["pace"]
-                    if course["published"]
-                }
-            )
-            programs.append(
-                {
-                    "readable_id": f"{READABLE_ID_PREFIX}{program['id']}",
-                    "etl_source": ETLSource.micromasters.name,
-                    "title": program["title"],
-                    "platform": PlatformType.edx.name,
-                    "offered_by": OFFERED_BY,
-                    "url": program.get("programpage_url"),
-                    "image": _transform_image(program),
-                    "certification": True,
-                    "certification_type": CertificationType.micromasters.name,
-                    "runs": [
-                        {
-                            "run_id": f"{READABLE_ID_PREFIX}{program['id']}",
-                            "title": program["title"],
-                            "instructors": [
-                                {"full_name": instructor["name"]}
-                                for instructor in program["instructors"]
-                            ],
-                            "prices": [
-                                transform_price(Decimal(program["total_price"]))
-                            ],
-                            "start_date": program["start_date"]
-                            or program["enrollment_start"],
-                            "end_date": program["end_date"],
-                            "enrollment_start": program["enrollment_start"],
-                            "availability": Availability.dated.name,
-                            "pace": pace,
-                            "format": [Format.asynchronous.name],
-                        }
-                    ],
-                    "topics": program["topics"],
-                    "availability": Availability.dated.name,
-                    "pace": pace,
-                    "format": [Format.asynchronous.name],
-                    "courses": courses,
-                }
-            )
+        pace = sorted(
+            {
+                pace
+                for course in courses
+                for pace in course["pace"]
+                if course["published"]
+            }
+        )
+        programs.append(
+            {
+                "readable_id": f"{READABLE_ID_PREFIX}{program['id']}",
+                "etl_source": ETLSource.micromasters.name,
+                "title": program["title"],
+                "platform": PlatformType.edx.name,
+                "offered_by": OFFERED_BY,
+                "url": program.get("programpage_url"),
+                "image": _transform_image(program),
+                "certification": True,
+                "certification_type": CertificationType.micromasters.name,
+                "runs": [
+                    {
+                        "run_id": f"{READABLE_ID_PREFIX}{program['id']}",
+                        "title": program["title"],
+                        "instructors": [
+                            {"full_name": instructor["name"]}
+                            for instructor in program["instructors"]
+                        ],
+                        "prices": [transform_price(Decimal(program["total_price"]))],
+                        "start_date": program["start_date"]
+                        or program["enrollment_start"],
+                        "end_date": program["end_date"],
+                        "enrollment_start": program["enrollment_start"],
+                        "availability": Availability.dated.name,
+                        "pace": pace,
+                        "format": [Format.asynchronous.name],
+                    }
+                ],
+                "topics": program["topics"],
+                "availability": Availability.dated.name,
+                "pace": pace,
+                "format": [Format.asynchronous.name],
+                "courses": courses,
+            }
+        )
     return programs

--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -1,6 +1,7 @@
 """MicroMasters ETL"""
 
 import logging
+import re
 from decimal import Decimal
 
 import requests
@@ -20,7 +21,7 @@ from learning_resources.models import LearningResource, default_pace
 
 OFFERED_BY = {"code": OfferedBy.mitx.name}
 READABLE_ID_PREFIX = "micromasters-program-"
-DEDP = "/dedp/"
+IGNORE_URLS = re.compile(r"/(dedp|scm)/")
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +111,7 @@ def transform(programs_data):
                 key=lambda course: course["position_in_program"],
             )
         ]
-        if url and DEDP not in url:
+        if url and not IGNORE_URLS.search(url):
             pace = sorted(
                 {
                     pace

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -186,6 +186,26 @@ def test_micromasters_transform(mock_micromasters_data, missing_url):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
+    ("url", "expected_excluded"),
+    [
+        ("http://example.com/program/1/url", False),
+        ("http://example.com/dedp/program/1/url", True),
+        ("http://example.com/scm/program/1/url", True),
+    ],
+)
+def test_micromasters_transform_ignores_urls(
+    mock_micromasters_data, url, expected_excluded
+):
+    """Programs whose URL contains /dedp/ or /scm/ should be excluded"""
+    # Drop the second program so only the program under test is considered
+    mock_micromasters_data = mock_micromasters_data[:1]
+    mock_micromasters_data[0]["programpage_url"] = url
+    transformed = micromasters.transform(mock_micromasters_data)
+    assert (len(transformed) == 0) is expected_excluded
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
     ("start_dt", "enrollment_dt", "expected_dt"),
     [
         (None, "2019-02-20T15:00:00Z", "2019-02-20T15:00:00Z"),

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -201,7 +201,7 @@ def test_micromasters_transform_ignores_urls(
     mock_micromasters_data = mock_micromasters_data[:1]
     mock_micromasters_data[0]["programpage_url"] = url
     transformed = micromasters.transform(mock_micromasters_data)
-    assert (len(transformed) == 0) is expected_excluded
+    assert (len(transformed) == 0) == expected_excluded
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Tweaks the micromasters ETL to ignore both `/dedp/` and `/scm/` programs.


### How can this be tested?
- Set `MICROMASTERS_CATALOG_API_URL=https://micromasters.mit.edu/api/v0/catalog/` in your `backend.local.env` file
- On the main branch, run `./manage.py backpopulate_micromasters_data`.  Then go to django admin url http://open.odl.local:8065/admin/learning_resources/learningresource/?etl_source=micromasters&resource_type__exact=program.  You should see a "Supply Chain Management" program there, and it should be published.
- Switch to this branch, restart containers, run the command again.
- Go back to django admin. The "Supply Chain Management" program should now be unpublished.

### Additional Context
<!--- optional - delete if empty --->
Using a env variable / django setting for IGNORE_URLS was considered but ultimatedly decided to leave as a constant and update as necessary.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
