### PR TITLE
make healthcheck route nocache

### DIFF
--- a/frontends/main/src/app/healthcheck/route.ts
+++ b/frontends/main/src/app/healthcheck/route.ts
@@ -7,6 +7,6 @@ export async function GET() {
       version: VERSION,
       timestamp: new Date().toISOString(), // easily tell if response is cached
     },
-    { status: 200 },
+    { status: 200, headers: { "Cache-Control": "no-store" } },
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
None, followup to #3364 

### Description (What does it do?)
Makes https://learn.mit.edu/healthcheck have `Cache-Control: no store`

### How can this be tested?
View http://open.odl.local:8062/healthcheck and check that it has the Cache-Control: no-store header in dev tools.
