### PR TITLE
set default variant label

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -458,6 +458,7 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
             variantOptions={variantOptions}
             selectedVariant={selectedVariant}
             setSelectedVariant={setSelectedVariant}
+            defaultVariantLabel={`${contract.name} Program`}
             description={`${org.name} provides multiple ways to learn this material. Choose the version that best fits your goals.`}
           />
         )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
@@ -105,13 +105,12 @@ describe("VariantPicker", () => {
       expect(screen.getAllByText("English • General • Full")).toHaveLength(2)
     })
 
-    test("selecting a non-default variant shows its computed label in the Viewing indicator", async () => {
-      const setSelectedVariant = jest.fn()
+    test("shows the computed label for a non-default variant in the Viewing indicator", () => {
       renderWithProviders(
         <VariantPicker
           variantOptions={[enDefault, esVariant]}
           selectedVariant={esVariant}
-          setSelectedVariant={setSelectedVariant}
+          setSelectedVariant={jest.fn()}
           defaultVariantLabel="Universal AI Program"
         />,
       )
@@ -273,12 +272,9 @@ describe("VariantPicker selection", () => {
       />,
     )
 
-    const viewingLabel = screen
-      .getByText("Viewing:")
-      .closest("div")!
-      .querySelector("p:last-child")!
+    const indicator = screen.getByText("Viewing:").closest("div")!
     expect(
-      within(viewingLabel as HTMLElement).getByText(/español.*General.*Full/),
+      within(indicator as HTMLElement).getByText(/español.*General.*Full/),
     ).toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
@@ -1,0 +1,284 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import { renderWithProviders, user, within } from "@/test-utils"
+import {
+  LanguageEnum,
+  type SupportedVariant,
+} from "@mitodl/mitxonline-api-axios/v2"
+import { VariantPicker } from "./VariantPicker"
+
+const makeVariant = (
+  overrides: Partial<SupportedVariant> = {},
+): SupportedVariant => ({
+  language: LanguageEnum.En,
+  variant_industry: "",
+  variant_length: "",
+  active: true,
+  b2b_only: true,
+  default_variant: false,
+  ...overrides,
+})
+
+const enDefault = makeVariant({
+  language: LanguageEnum.En,
+  default_variant: true,
+})
+const esVariant = makeVariant({
+  language: LanguageEnum.EsEs,
+  default_variant: false,
+})
+
+describe("VariantPicker", () => {
+  describe("defaultVariantLabel", () => {
+    test("uses defaultVariantLabel for the default variant card title instead of the computed label", () => {
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={enDefault}
+          setSelectedVariant={jest.fn()}
+          defaultVariantLabel="Universal AI Program"
+        />,
+      )
+
+      expect(
+        screen.getByRole("radio", { name: /Universal AI Program/ }),
+      ).toBeInTheDocument()
+    })
+
+    test("uses the computed label for the default variant card when defaultVariantLabel is not provided", () => {
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={enDefault}
+          setSelectedVariant={jest.fn()}
+        />,
+      )
+
+      // The computed label for (en, "", "") is "English • General • Full"
+      expect(
+        screen.getByRole("radio", { name: /English.*General.*Full/ }),
+      ).toBeInTheDocument()
+    })
+
+    test("does not apply defaultVariantLabel to non-default variant cards", () => {
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={esVariant}
+          setSelectedVariant={jest.fn()}
+          defaultVariantLabel="Universal AI Program"
+        />,
+      )
+
+      // Spanish card should still use computed label, not the default label
+      expect(
+        screen.getByRole("radio", { name: /español.*General.*Full/ }),
+      ).toBeInTheDocument()
+    })
+
+    test("shows defaultVariantLabel in the Viewing indicator when the default variant is selected", async () => {
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={enDefault}
+          setSelectedVariant={jest.fn()}
+          defaultVariantLabel="Universal AI Program"
+        />,
+      )
+
+      // Label appears in both the card title and the Viewing indicator
+      expect(screen.getAllByText("Universal AI Program")).toHaveLength(2)
+      // Confirm the "Viewing:" prefix is present
+      expect(screen.getByText("Viewing:")).toBeInTheDocument()
+    })
+
+    test("shows computed label in Viewing indicator when defaultVariantLabel not provided", () => {
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={enDefault}
+          setSelectedVariant={jest.fn()}
+        />,
+      )
+
+      // Label appears in both the card title and the Viewing indicator
+      expect(screen.getAllByText("English • General • Full")).toHaveLength(2)
+    })
+
+    test("selecting a non-default variant shows its computed label in the Viewing indicator", async () => {
+      const setSelectedVariant = jest.fn()
+      renderWithProviders(
+        <VariantPicker
+          variantOptions={[enDefault, esVariant]}
+          selectedVariant={esVariant}
+          setSelectedVariant={setSelectedVariant}
+          defaultVariantLabel="Universal AI Program"
+        />,
+      )
+
+      // Spanish label in JSDOM uses Intl.DisplayNames form; appears in card + Viewing indicator
+      expect(screen.getAllByText(/español.*General.*Full/)).toHaveLength(2)
+    })
+  })
+})
+
+describe("VariantPicker rendering", () => {
+  test("renders the default title 'Available Versions'", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    screen.getByRole("heading", { name: "Available Versions" })
+  })
+
+  test("renders a custom title when the title prop is provided", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+        title="Choose Your Path"
+      />,
+    )
+
+    screen.getByRole("heading", { name: "Choose Your Path" })
+    expect(
+      screen.queryByRole("heading", { name: "Available Versions" }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("renders the description when provided", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+        description="Pick the version that fits your goals."
+      />,
+    )
+
+    screen.getByText("Pick the version that fits your goals.")
+  })
+
+  test("does not render a description element when description is not provided", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    expect(
+      screen.queryByText("Pick the version that fits your goals."),
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe("VariantPicker certificate badge", () => {
+  test("the default variant card includes 'Certificate Eligible' in its accessible name", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    // Only the default_variant radio should include "Certificate Eligible"
+    const certEligibleRadios = screen.getAllByRole("radio", {
+      name: /Certificate Eligible/,
+    })
+    expect(certEligibleRadios).toHaveLength(1)
+  })
+
+  test("non-default variant cards do not include 'Certificate Eligible' in their accessible name", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={esVariant}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    const esRadio = screen.getByRole("radio", {
+      name: /español.*General.*Full/,
+    })
+    expect(esRadio).not.toHaveAccessibleName(/Certificate Eligible/)
+  })
+})
+
+describe("VariantPicker selection", () => {
+  test("the radio for the selected variant is checked", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={esVariant}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    const esRadio = screen.getByRole("radio", {
+      name: /español.*General.*Full/,
+    })
+    const enRadio = screen.getByRole("radio", {
+      name: /English.*General.*Full/,
+    })
+    expect(esRadio).toBeChecked()
+    expect(enRadio).not.toBeChecked()
+  })
+
+  test("clicking a card calls setSelectedVariant with the correct variant", async () => {
+    const setSelectedVariant = jest.fn()
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={setSelectedVariant}
+      />,
+    )
+
+    const esRadio = screen.getByRole("radio", {
+      name: /español.*General.*Full/,
+    })
+    await user.click(esRadio)
+    expect(setSelectedVariant).toHaveBeenCalledWith(esVariant)
+    expect(setSelectedVariant).toHaveBeenCalledTimes(1)
+  })
+
+  test("shows empty Viewing indicator when selectedVariant is null", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={null}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    screen.getByText("Viewing:")
+    // Variant labels appear only in the cards (once each), not also in the indicator
+    expect(screen.getAllByText(/English.*General.*Full/)).toHaveLength(1)
+  })
+
+  test("the Viewing indicator shows the label of the currently selected variant", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={esVariant}
+        setSelectedVariant={jest.fn()}
+      />,
+    )
+
+    const viewingLabel = screen
+      .getByText("Viewing:")
+      .closest("div")!
+      .querySelector("p:last-child")!
+    expect(
+      within(viewingLabel as HTMLElement).getByText(/español.*General.*Full/),
+    ).toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
@@ -90,6 +90,7 @@ type VariantChoiceBoxesProps = {
   variantOptions: SupportedVariant[]
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
+  defaultVariantLabel?: string
   "aria-label"?: string
   "aria-labelledby"?: string
 }
@@ -98,6 +99,7 @@ const VariantChoiceBoxes: React.FC<VariantChoiceBoxesProps> = ({
   variantOptions,
   selectedVariant,
   setSelectedVariant,
+  defaultVariantLabel,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
 }) => {
@@ -123,7 +125,10 @@ const VariantChoiceBoxes: React.FC<VariantChoiceBoxesProps> = ({
     >
       {variantOptions.map((variant) => {
         const value = buildVariantKey(variant)
-        const label = buildVariantLabel(variant)
+        const label =
+          variant.default_variant && defaultVariantLabel
+            ? defaultVariantLabel
+            : buildVariantLabel(variant)
         return (
           <VariantCard
             key={value}
@@ -156,6 +161,7 @@ type VariantPickerProps = {
   variantOptions: SupportedVariant[]
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
+  defaultVariantLabel?: string
   title?: string
   description?: string
 }
@@ -164,10 +170,16 @@ const VariantPicker: React.FC<VariantPickerProps> = ({
   variantOptions,
   selectedVariant,
   setSelectedVariant,
+  defaultVariantLabel,
   title = "Available Versions",
   description,
 }) => {
   const titleId = React.useId()
+  const viewingLabel = selectedVariant
+    ? selectedVariant.default_variant && defaultVariantLabel
+      ? defaultVariantLabel
+      : buildVariantLabel(selectedVariant)
+    : ""
   return (
     <VariantPickerRoot>
       <Typography id={titleId} variant="h5" component="h2">
@@ -179,12 +191,11 @@ const VariantPicker: React.FC<VariantPickerProps> = ({
         variantOptions={variantOptions}
         selectedVariant={selectedVariant}
         setSelectedVariant={setSelectedVariant}
+        defaultVariantLabel={defaultVariantLabel}
       />
       <SelectedVariantIndicator>
         <Typography variant="body2">Viewing:</Typography>
-        <Typography variant="subtitle2">
-          {selectedVariant ? buildVariantLabel(selectedVariant) : ""}
-        </Typography>
+        <Typography variant="subtitle2">{viewingLabel}</Typography>
       </SelectedVariantIndicator>
     </VariantPickerRoot>
   )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11620

### Description (What does it do?)
This PR adds the `defaultVariantLabel` property to `VariantPicker`. In the only place where it's called currently, `ContractContent`, the value is set to `${contract.name} Program`. In the "Universal AI" contract, this will result in "Universal AI Program." The `VariantPicker` also did not have any unit tests, so those were added as part of this.

### How can this be tested?
1. Ensure the `mitxonline` backend is running with the merged variant options changes
2. Follow the instructions in this PR to create proper test data in `mitxonline`: https://github.com/mitodl/mitxonline/pull/3618
4. Load the B2B dashboard for that contract — the variant picker should appear if there are 2+ variant options
5. Verify that the default variant has a label of your contract's name followed by "Program"