### PR TITLE
adding fix for topic page search

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
@@ -175,6 +175,32 @@ describe("ChannelSearch", () => {
     const apiSearchParams = getLastApiSearchParams()
     expect(apiSearchParams.get("hybrid_search")).toBe("true")
   })
+
+  test("Topic channel page with search term preserves constant search parameters in API request", async () => {
+    const { channel } = setMockApiResponses({
+      channelPatch: {
+        channel_type: ChannelTypeEnum.Topic,
+        search_filter: "topic=Economics",
+      },
+    })
+
+    renderWithProviders(<ChannelPage />, {
+      url: `/c/${channel.channel_type}/${channel.name}?q=python`,
+    })
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "get",
+          url: expect.stringContaining(urls.search.vectorResources()),
+        }),
+      )
+    })
+
+    const apiSearchParams = getLastApiSearchParams()
+    expect(apiSearchParams.get("q")).toBe("python")
+    expect(apiSearchParams.get("topic")).toBe("Economics")
+  })
   test.each([
     {
       searchFilter: "offered_by=ocw",

--- a/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
@@ -88,7 +88,7 @@ const toUnfacetedVectorSearchParams = (
     limit: _limit,
     ...vectorParams
   } = toVectorSearchParams(params, cutoffScore)
-  console.log(constantSearchParams)
+
   return Object.fromEntries(
     Object.entries(vectorParams).filter(
       ([key]) =>

--- a/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react"
 import { learningResourceQueries } from "api/hooks/learningResources"
 import type { LearningResource } from "api"
+import type { Facets, BooleanFacets } from "@mitodl/course-search-utils"
 import type {
   LearningResourcesVectorSearchResponse,
   VectorLearningResourcesSearchApiVectorLearningResourcesSearchRetrieveRequest as VectorSearchRequest,
@@ -79,6 +80,7 @@ type VectorClientFilterFacet = (typeof VECTOR_CLIENT_FILTER_FACETS)[number]
 
 const toUnfacetedVectorSearchParams = (
   params: ReturnType<typeof getSearchParams> & { sortby?: string },
+  constantSearchParams: Facets & BooleanFacets = {},
   cutoffScore?: number,
 ): VectorSearchRequest => {
   const {
@@ -86,11 +88,12 @@ const toUnfacetedVectorSearchParams = (
     limit: _limit,
     ...vectorParams
   } = toVectorSearchParams(params, cutoffScore)
-
+  console.log(constantSearchParams)
   return Object.fromEntries(
     Object.entries(vectorParams).filter(
       ([key]) =>
-        !VECTOR_CLIENT_FILTER_FACETS.includes(key as VectorClientFilterFacet),
+        !VECTOR_CLIENT_FILTER_FACETS.includes(key as VectorClientFilterFacet) ||
+        key in constantSearchParams,
     ),
   ) as VectorSearchRequest
 }
@@ -208,11 +211,15 @@ const HybridSearchDisplay: React.FC<HybridSearchDisplayProps> = ({
         typeof params.q === "string" && params.q.trim() !== ""
       return learningResourceQueries.vectorSearch(
         hasSearchTerm
-          ? toUnfacetedVectorSearchParams(params, cutoffScore)
+          ? toUnfacetedVectorSearchParams(
+              params,
+              props.constantSearchParams,
+              cutoffScore,
+            )
           : toVectorSearchParams(params, cutoffScore),
       )
     },
-    [cutoffScore],
+    [cutoffScore, props.constantSearchParams],
   )
 
   const getDisplayData = useMemo(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related/Follow fix for https://github.com/mitodl/hq/issues/11167
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR ensures that the hybrid search component preserves/passes along pre-existing filters when performing a search with a query (in this case the pre-existing filter associated with each channel/topic page)


### How can this be tested?
1. on the current rc - open web inspector and go to a topic page. https://rc.learn.mit.edu/c/topic/business-analytics
2. note the vector search endpoint that gets hit which by default includes the topic=Business+Analytics query param
3. search for something and note that the vector endpoint does not have the topic filter/param
4. on this branch perform the same and note that the "topic" parameter is carried over when searching

