### PR TITLE
hide program descriptions when variant is selected

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1624,6 +1624,208 @@ describe("ContractContent", () => {
     })
   })
 
+  test("hides program description when a non-default variant is selected", async () => {
+    const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
+    mitxOnlineUser.legal_address = { country: "US" }
+    mitxOnlineUser.user_profile = { year_of_birth: 1988 }
+
+    const program = factories.programs.program({ courses: [] })
+    const programDescription = program.page!.description!
+    const contracts = createTestContracts(orgX.id, 1, [program.id])
+    orgX.contracts = contracts
+    mitxOnlineUser.b2b_organizations[0].contracts = contracts
+    contracts[0].variant_options = [
+      {
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: true,
+      },
+      {
+        language: LanguageEnum.EsEs,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: false,
+      },
+    ]
+
+    const englishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+    })
+    const spanishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+      language: LanguageEnum.EsEs,
+    })
+    const localizedCourse = factories.courses.course({
+      courseruns: [englishRun, spanishRun],
+      next_run_id: englishRun.id,
+    })
+    program.courses = [localizedCourse.id]
+
+    setupOrgDashboardMocks(
+      orgX,
+      userApiPath,
+      mitxOnlineUser,
+      [program],
+      [localizedCourse],
+      contracts,
+    )
+    setMockResponse.get(
+      urls.courses.courseVariantRuns({
+        contract: contracts[0].id,
+        course_id: [localizedCourse.id],
+        language: LanguageEnum.EsEs,
+      }),
+      [{ id: localizedCourse.id, courseruns: [spanishRun] }],
+    )
+
+    renderWithProviders(
+      <ContractContent orgSlug={orgX.slug} contractSlug={contracts[0].slug} />,
+    )
+
+    await screen.findByTestId("org-program-root")
+    await screen.findAllByRole("radio")
+
+    // Description is visible for the default (English) variant
+    expect(screen.getByText(programDescription)).toBeInTheDocument()
+
+    // Switch to the non-default (Spanish) variant
+    await user.click(screen.getByText(/español/i))
+
+    await waitFor(() => {
+      expect(screen.queryByText(programDescription)).not.toBeInTheDocument()
+    })
+
+    // Switch back to default — description reappears
+    await user.click(
+      screen.getByRole("radio", { name: /English.*General.*Full/ }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(programDescription)).toBeInTheDocument()
+    })
+  })
+
+  test("hides collection description when a non-default variant is selected", async () => {
+    const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
+    mitxOnlineUser.legal_address = { country: "US" }
+    mitxOnlineUser.user_profile = { year_of_birth: 1988 }
+
+    const program = factories.programs.program({ courses: [] })
+    const contracts = createTestContracts(orgX.id, 1, [program.id])
+    orgX.contracts = contracts
+    mitxOnlineUser.b2b_organizations[0].contracts = contracts
+    contracts[0].variant_options = [
+      {
+        language: LanguageEnum.En,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: true,
+      },
+      {
+        language: LanguageEnum.EsEs,
+        variant_industry: "",
+        variant_length: "",
+        active: true,
+        b2b_only: true,
+        default_variant: false,
+      },
+    ]
+
+    const englishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+    })
+    const spanishRun = factories.courses.courseRun({
+      id: faker.number.int(),
+      b2b_contract: contracts[0].id,
+      is_enrollable: true,
+      language: LanguageEnum.EsEs,
+    })
+    const localizedCourse = factories.courses.course({
+      courseruns: [englishRun, spanishRun],
+      next_run_id: englishRun.id,
+    })
+    program.courses = [localizedCourse.id]
+
+    setupOrgDashboardMocks(
+      orgX,
+      userApiPath,
+      mitxOnlineUser,
+      [program],
+      [localizedCourse],
+      contracts,
+    )
+    setMockResponse.get(
+      urls.courses.courseVariantRuns({
+        contract: contracts[0].id,
+        course_id: [localizedCourse.id],
+        language: LanguageEnum.EsEs,
+      }),
+      [{ id: localizedCourse.id, courseruns: [spanishRun] }],
+    )
+
+    const programCollection = factories.programs.programCollection({
+      programs: [{ id: program.id, title: program.title, order: 1 }],
+    })
+    const collectionDescription = programCollection.description!
+    setMockResponse.get(urls.programCollections.programCollectionsList(), {
+      results: [programCollection],
+    })
+    setMockResponse.get(
+      urls.programs.programsList({
+        id: [program.id],
+        contract_id: contracts[0].id,
+        page_size: 1,
+      }),
+      { results: [program] },
+    )
+    setMockResponse.get(
+      urls.courses.coursesList({
+        id: [localizedCourse.id],
+        contract_id: contracts[0].id,
+      }),
+      { results: [localizedCourse] },
+    )
+
+    renderWithProviders(
+      <ContractContent orgSlug={orgX.slug} contractSlug={contracts[0].slug} />,
+    )
+
+    await screen.findByTestId("org-program-collection-root")
+    await screen.findAllByRole("radio")
+
+    // Description is visible for the default (English) variant
+    expect(screen.getByText(collectionDescription)).toBeInTheDocument()
+
+    // Switch to the non-default (Spanish) variant
+    await user.click(screen.getByText(/español/i))
+
+    await waitFor(() => {
+      expect(screen.queryByText(collectionDescription)).not.toBeInTheDocument()
+    })
+
+    // Switch back to default — description reappears
+    await user.click(
+      screen.getByRole("radio", { name: /English.*General.*Full/ }),
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(collectionDescription)).toBeInTheDocument()
+    })
+  })
+
   test("shared contract variant picker switches program collection card title", async () => {
     const { orgX, user: userApiPath, mitxOnlineUser } = setupOrgAndUser()
     mitxOnlineUser.legal_address = { country: "US" }

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1709,9 +1709,7 @@ describe("ContractContent", () => {
       screen.getByRole("radio", { name: /English.*General.*Full/ }),
     )
 
-    await waitFor(() => {
-      expect(screen.getByText(programDescription)).toBeInTheDocument()
-    })
+    await screen.findByText(programDescription)
   })
 
   test("hides collection description when a non-default variant is selected", async () => {
@@ -1821,9 +1819,7 @@ describe("ContractContent", () => {
       screen.getByRole("radio", { name: /English.*General.*Full/ }),
     )
 
-    await waitFor(() => {
-      expect(screen.getByText(collectionDescription)).toBeInTheDocument()
-    })
+    await screen.findByText(collectionDescription)
   })
 
   test("shared contract variant picker switches program collection card title", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -246,14 +246,17 @@ const ProgramControls = styled.div(({ theme }) => ({
 const OrgProgramCollectionDisplay: React.FC<{
   collection: V2ProgramCollection
   entries: DashboardCourseEntry[]
-}> = ({ collection, entries }) => {
+  hideDescription?: boolean
+}> = ({ collection, entries, hideDescription }) => {
   const header = (
     <ProgramHeader>
       <ProgramHeaderText>
         <Typography variant="subtitle1" component="h2">
           {collection.title}
         </Typography>
-        <ProgramDescription html={collection.description ?? ""} />
+        {!hideDescription && (
+          <ProgramDescription html={collection.description ?? ""} />
+        )}
       </ProgramHeaderText>
     </ProgramHeader>
   )
@@ -289,7 +292,8 @@ const OrgProgramDisplay: React.FC<{
   program: V2Program
   entries: DashboardCourseEntry[]
   programEnrollment?: V3UserProgramEnrollment
-}> = ({ program, entries, programEnrollment }) => {
+  hideDescription?: boolean
+}> = ({ program, entries, programEnrollment, hideDescription }) => {
   const hasValidCertificate = !!programEnrollment?.certificate
 
   if (entries.length === 0) {
@@ -303,7 +307,9 @@ const OrgProgramDisplay: React.FC<{
           <Typography variant="subtitle1" component="h2">
             {program.title}
           </Typography>
-          <ProgramDescription html={program.page?.description ?? ""} />
+          {!hideDescription && (
+            <ProgramDescription html={program.page?.description ?? ""} />
+          )}
         </ProgramHeaderText>
         {hasValidCertificate && (
           <ProgramControls>
@@ -473,6 +479,9 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
             program={program}
             entries={entries}
             programEnrollment={programEnrollment}
+            hideDescription={
+              selectedVariant !== null && !selectedVariant.default_variant
+            }
           />
         ))}
         <ProgramCollectionsList>
@@ -484,6 +493,9 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
               })}
               collection={collection}
               entries={entries}
+              hideDescription={
+                selectedVariant !== null && !selectedVariant.default_variant
+              }
             />
           ))}
         </ProgramCollectionsList>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11621

### Description (What does it do?)
This PR hides program (and program collection) descriptions when a variant is actively selected through `VariantPicker`. These often contain language specific to the certificate you can earn with the base program, and you can't earn a certificate with the variant runs.

### How can this be tested?
1. Ensure the `mitxonline` backend is running with the merged variant options changes
2. Follow the instructions in this PR to create proper test data in `mitxonline`: https://github.com/mitodl/mitxonline/pull/3618
3. Ensure that at least one of your program pages has a description set on it in `mitxonline` Wagtail
4. Load the B2B dashboard for that contract — the variant picker should appear if there are 2+ variant options
5. Switch to a variant and verify that the program description is hidden