### PR TITLE
fix: remove event section if no event data available

### DIFF
--- a/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/HomePage.test.tsx
@@ -328,6 +328,36 @@ describe("Home Page News and Events", () => {
     expect(links[5]).toHaveAttribute("href", events.results[5].url)
     within(links[5]).getByText(events.results[5].title)
   })
+  test("Hides Events section when events list is empty", async () => {
+    const news = newsEvents.newsItems({ count: 6 })
+    setMockResponse.get(
+      urls.newsEvents.list({
+        feed_type: ["news"],
+        limit: 6,
+        sortby: "-news_date",
+      }),
+      news,
+    )
+
+    setMockResponse.get(
+      urls.newsEvents.list({
+        feed_type: ["events"],
+        limit: 6,
+        sortby: "event_date",
+      }),
+      newsEvents.eventItems({ count: 0 }),
+    )
+
+    renderWithProviders(<NewsEventsSection />)
+
+    await waitFor(() => {
+      screen.getAllByRole("heading", { name: "News" })
+    })
+
+    expect(
+      screen.queryByRole("heading", { name: "Events" }),
+    ).not.toBeInTheDocument()
+  })
 })
 
 describe("Home Page personalize section", () => {

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -52,12 +52,13 @@ const MobileContent = styled.div`
   margin: 40px 0;
 `
 
-const NewsContainer = styled.section`
+const NewsContainer = styled.section<{ fullWidth?: boolean }>`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
   flex: 1 0 0;
+  ${({ fullWidth }) => fullWidth && "flex-basis: 100%;"}
 `
 
 const MobileContainer = styled.section`
@@ -305,11 +306,16 @@ const NewsEventsSection: React.FC = () => {
       <AboveMdOnly>
         <Container>
           <Content>
-            <NewsContainer>
+            <NewsContainer fullWidth={events.results.length === 0}>
               <Typography component="h3" variant="h4">
                 News
               </Typography>
-              <Grid2 container columnSpacing="24px" rowSpacing="28px">
+              <Grid2
+                container
+                columnSpacing="24px"
+                rowSpacing="28px"
+                sx={{ width: "100%" }}
+              >
                 {newsList.map((item, index) => (
                   <Grid2
                     key={item.id}
@@ -331,12 +337,14 @@ const NewsEventsSection: React.FC = () => {
                 </SeeAllButton>
               </HeadingContainer>
             </NewsContainer>
-            <EventsContainer>
-              <Typography component="h3" variant="h4">
-                Events
-              </Typography>
-              <Events>{EventCards}</Events>
-            </EventsContainer>
+            {events.results.length > 0 && (
+              <EventsContainer>
+                <Typography component="h3" variant="h4">
+                  Events
+                </Typography>
+                <Events>{EventCards}</Events>
+              </EventsContainer>
+            )}
           </Content>
         </Container>
       </AboveMdOnly>

--- a/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/NewsEventsSection.tsx
@@ -295,12 +295,14 @@ const NewsEventsSection: React.FC = () => {
               </SeeAllButton>
             </HeadingContainer>
           </MobileContainer>
-          <MobileContainer>
-            <Typography component="h3" variant="h4">
-              Events
-            </Typography>
-            <MobileEvents>{EventCards}</MobileEvents>
-          </MobileContainer>
+          {events.results.length > 0 && (
+            <MobileContainer>
+              <Typography component="h3" variant="h4">
+                Events
+              </Typography>
+              <MobileEvents>{EventCards}</MobileEvents>
+            </MobileContainer>
+          )}
         </MobileContent>
       </BelowMdOnly>
       <AboveMdOnly>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11614

### Description (What does it do?)
 - Hide the event section if no event data is available 

### Screenshots (if appropriate):
### Before
<img width="2880" height="6932" alt="image" src="https://github.com/user-attachments/assets/e2773a71-b5e2-40e7-b340-15eac51c6145" />

### After
<img width="2880" height="6932" alt="image" src="https://github.com/user-attachments/assets/cee60033-a4a6-467d-acad-26aa53d9492b" />


### How can this be tested?
For testing you need to just return 0 event in apis response and you will see the News section will stretch to whole available space and event section will be hide

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
