### PR TITLE
add s-maxage=0, fastly ignores no-store

### DIFF
--- a/frontends/main/src/app/healthcheck/route.ts
+++ b/frontends/main/src/app/healthcheck/route.ts
@@ -7,6 +7,6 @@ export async function GET() {
       version: VERSION,
       timestamp: new Date().toISOString(), // easily tell if response is cached
     },
-    { status: 200, headers: { "Cache-Control": "no-store" } },
+    { status: 200, headers: { "Cache-Control": "no-store, s-maxage=0" } },
   )
 }


### PR DESCRIPTION
### What are the relevant tickets?
Followup to #3413 

### Description (What does it do?)
Gives healthcheck route `s-maxage=0`. Turns out fastly ignores `no-store`:

>  Directives ignored by Fastly include, but are not limited to, Cache-Control: no-cache, Cache-Control: no-store, and Cache-Control: must-revalidate.
> – https://www.fastly.com/documentation/guides/full-site-delivery/caching/about-cache-control-headers/

### How can this be tested?
Visit http://open.odl.local:8062/healthcheck and check the header.