### PR TITLE
Sort variants + Variant Picker UI Updates

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1704,9 +1704,11 @@ describe("ContractContent", () => {
       expect(screen.queryByText(programDescription)).not.toBeInTheDocument()
     })
 
-    // Switch back to default — description reappears
+    // Switch back to default — description reappears. The default card is
+    // identified by its "Certificate Eligible" badge (its title is the
+    // contract-specific defaultVariantLabel, not the computed variant label).
     await user.click(
-      screen.getByRole("radio", { name: /English.*General.*Full/ }),
+      screen.getByRole("radio", { name: /Certificate Eligible/ }),
     )
 
     await screen.findByText(programDescription)
@@ -1814,9 +1816,11 @@ describe("ContractContent", () => {
       expect(screen.queryByText(collectionDescription)).not.toBeInTheDocument()
     })
 
-    // Switch back to default — description reappears
+    // Switch back to default — description reappears. The default card is
+    // identified by its "Certificate Eligible" badge (its title is the
+    // contract-specific defaultVariantLabel, not the computed variant label).
     await user.click(
-      screen.getByRole("radio", { name: /English.*General.*Full/ }),
+      screen.getByRole("radio", { name: /Certificate Eligible/ }),
     )
 
     await screen.findByText(collectionDescription)

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -465,6 +465,7 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
             selectedVariant={selectedVariant}
             setSelectedVariant={setSelectedVariant}
             defaultVariantLabel={`${contract.name} Program`}
+            customizedVariantLabel={`Customized ${contract.name}`}
             description={`${org.name} provides multiple ways to learn this material. Choose the version that best fits your goals.`}
           />
         )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
@@ -28,128 +28,60 @@ const esVariant = makeVariant({
   default_variant: false,
 })
 
-describe("VariantPicker", () => {
-  describe("defaultVariantLabel", () => {
-    test("uses defaultVariantLabel for the default variant card title instead of the computed label", () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={enDefault}
-          setSelectedVariant={jest.fn()}
-          defaultVariantLabel="Universal AI Program"
-        />,
-      )
+const DEFAULT_LABEL = "Universal AI Program"
+const CUSTOMIZED_LABEL = "Customized Universal AI"
 
-      expect(
-        screen.getByRole("radio", { name: /Universal AI Program/ }),
-      ).toBeInTheDocument()
+// defaultVariantLabel and customizedVariantLabel are required props; provide
+// them here so each test only specifies what it actually exercises.
+const renderPicker = (
+  props: Partial<React.ComponentProps<typeof VariantPicker>> = {},
+) =>
+  renderWithProviders(
+    <VariantPicker
+      variantOptions={[enDefault, esVariant]}
+      selectedVariant={null}
+      setSelectedVariant={jest.fn()}
+      defaultVariantLabel={DEFAULT_LABEL}
+      customizedVariantLabel={CUSTOMIZED_LABEL}
+      {...props}
+    />,
+  )
+
+describe("VariantPicker labels", () => {
+  test("the default variant card title is defaultVariantLabel, not the computed label", () => {
+    renderPicker({ selectedVariant: enDefault })
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: /Universal AI Program/,
     })
-
-    test("uses the computed label for the default variant card when defaultVariantLabel is not provided", () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={enDefault}
-          setSelectedVariant={jest.fn()}
-        />,
-      )
-
-      // The computed label for (en, "", "") is "English • General • Full"
-      expect(
-        screen.getByRole("radio", { name: /English.*General.*Full/ }),
-      ).toBeInTheDocument()
-    })
-
-    test("does not apply defaultVariantLabel to non-default variant cards", () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={esVariant}
-          setSelectedVariant={jest.fn()}
-          defaultVariantLabel="Universal AI Program"
-        />,
-      )
-
-      // Spanish card should still use computed label, not the default label
-      expect(
-        screen.getByRole("radio", { name: /español.*General.*Full/ }),
-      ).toBeInTheDocument()
-    })
-
-    test("shows defaultVariantLabel in the Viewing indicator when the default variant is selected", async () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={enDefault}
-          setSelectedVariant={jest.fn()}
-          defaultVariantLabel="Universal AI Program"
-        />,
-      )
-
-      // Label appears in both the card title and the Viewing indicator
-      expect(screen.getAllByText("Universal AI Program")).toHaveLength(2)
-      // Confirm the "Viewing:" prefix is present
-      expect(screen.getByText("Viewing:")).toBeInTheDocument()
-    })
-
-    test("shows computed label in Viewing indicator when defaultVariantLabel not provided", () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={enDefault}
-          setSelectedVariant={jest.fn()}
-        />,
-      )
-
-      // Label appears in both the card title and the Viewing indicator
-      expect(screen.getAllByText("English • General • Full")).toHaveLength(2)
-    })
-
-    test("shows the computed label for a non-default variant in the Viewing indicator", () => {
-      renderWithProviders(
-        <VariantPicker
-          variantOptions={[enDefault, esVariant]}
-          selectedVariant={esVariant}
-          setSelectedVariant={jest.fn()}
-          defaultVariantLabel="Universal AI Program"
-        />,
-      )
-
-      // Spanish label in JSDOM uses Intl.DisplayNames form; appears in card + Viewing indicator
-      expect(screen.getAllByText(/español.*General.*Full/)).toHaveLength(2)
-    })
+    expect(defaultRadio).toHaveAccessibleName(/Certificate Eligible/)
+    expect(defaultRadio).not.toHaveAccessibleName(/Customized/)
   })
-})
 
-describe("customizedVariantLabel", () => {
   test("non-default variant cards use 'Customized <name>' as the title with the language/industry/length detail as subtext", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={esVariant}
-        setSelectedVariant={jest.fn()}
-        defaultVariantLabel="Universal AI Program"
-        customizedVariantLabel="Customized Universal AI"
-      />,
-    )
+    renderPicker({ selectedVariant: esVariant })
 
     const esRadio = screen.getByRole("radio", {
       name: /Customized Universal AI/,
     })
     // the language/industry/length detail moves to the card subtext
     expect(esRadio).toHaveAccessibleName(/español.*General.*Full/)
+    // the default label does not leak onto the variant card
+    expect(esRadio).not.toHaveAccessibleName(/Universal AI Program/)
+  })
+})
+
+describe("VariantPicker Viewing indicator", () => {
+  test("shows defaultVariantLabel when the default variant is selected", () => {
+    renderPicker({ selectedVariant: enDefault })
+
+    // Label appears in both the card title and the Viewing indicator
+    expect(screen.getAllByText("Universal AI Program")).toHaveLength(2)
+    expect(screen.getByText("Viewing:")).toBeInTheDocument()
   })
 
-  test("the Viewing indicator shows 'Customized <name> (detail)' for a selected non-default variant", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={esVariant}
-        setSelectedVariant={jest.fn()}
-        defaultVariantLabel="Universal AI Program"
-        customizedVariantLabel="Customized Universal AI"
-      />,
-    )
+  test("shows 'Customized <name> (detail)' for a selected non-default variant", () => {
+    renderPicker({ selectedVariant: esVariant })
 
     const indicator = screen.getByText("Viewing:").closest("div")!
     expect(
@@ -159,47 +91,24 @@ describe("customizedVariantLabel", () => {
     ).toBeInTheDocument()
   })
 
-  test("does not apply customizedVariantLabel to the default variant card", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-        defaultVariantLabel="Universal AI Program"
-        customizedVariantLabel="Customized Universal AI"
-      />,
-    )
+  test("is empty when no variant is selected", () => {
+    renderPicker({ selectedVariant: null })
 
-    const defaultRadio = screen.getByRole("radio", {
-      name: /Universal AI Program/,
-    })
-    expect(defaultRadio).toHaveAccessibleName(/Certificate Eligible/)
-    expect(defaultRadio).not.toHaveAccessibleName(/Customized/)
+    expect(screen.getByText("Viewing:")).toBeInTheDocument()
+    // The default label appears only in its card, not also in the indicator
+    expect(screen.getAllByText("Universal AI Program")).toHaveLength(1)
   })
 })
 
 describe("VariantPicker rendering", () => {
   test("renders the default title 'Available Versions'", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
+    renderPicker({ selectedVariant: enDefault })
 
     screen.getByRole("heading", { name: "Available Versions" })
   })
 
   test("renders a custom title when the title prop is provided", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-        title="Choose Your Path"
-      />,
-    )
+    renderPicker({ selectedVariant: enDefault, title: "Choose Your Path" })
 
     screen.getByRole("heading", { name: "Choose Your Path" })
     expect(
@@ -208,26 +117,16 @@ describe("VariantPicker rendering", () => {
   })
 
   test("renders the description when provided", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-        description="Pick the version that fits your goals."
-      />,
-    )
+    renderPicker({
+      selectedVariant: enDefault,
+      description: "Pick the version that fits your goals.",
+    })
 
     screen.getByText("Pick the version that fits your goals.")
   })
 
   test("does not render a description element when description is not provided", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
+    renderPicker({ selectedVariant: enDefault })
 
     expect(
       screen.queryByText("Pick the version that fits your goals."),
@@ -237,13 +136,7 @@ describe("VariantPicker rendering", () => {
 
 describe("VariantPicker certificate badge", () => {
   test("the default variant card includes 'Certificate Eligible' in its accessible name", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
+    renderPicker({ selectedVariant: enDefault })
 
     // Only the default_variant radio should include "Certificate Eligible"
     const certEligibleRadios = screen.getAllByRole("radio", {
@@ -253,13 +146,7 @@ describe("VariantPicker certificate badge", () => {
   })
 
   test("non-default variant cards do not include 'Certificate Eligible' in their accessible name", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={esVariant}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
+    renderPicker({ selectedVariant: esVariant })
 
     const esRadio = screen.getByRole("radio", {
       name: /español.*General.*Full/,
@@ -270,33 +157,19 @@ describe("VariantPicker certificate badge", () => {
 
 describe("VariantPicker selection", () => {
   test("the radio for the selected variant is checked", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={esVariant}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
+    renderPicker({ selectedVariant: esVariant })
 
     const esRadio = screen.getByRole("radio", {
       name: /español.*General.*Full/,
     })
-    const enRadio = screen.getByRole("radio", {
-      name: /English.*General.*Full/,
-    })
+    const enRadio = screen.getByRole("radio", { name: /Universal AI Program/ })
     expect(esRadio).toBeChecked()
     expect(enRadio).not.toBeChecked()
   })
 
   test("clicking a card calls setSelectedVariant with the correct variant", async () => {
     const setSelectedVariant = jest.fn()
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={enDefault}
-        setSelectedVariant={setSelectedVariant}
-      />,
-    )
+    renderPicker({ selectedVariant: enDefault, setSelectedVariant })
 
     const esRadio = screen.getByRole("radio", {
       name: /español.*General.*Full/,
@@ -304,34 +177,5 @@ describe("VariantPicker selection", () => {
     await user.click(esRadio)
     expect(setSelectedVariant).toHaveBeenCalledWith(esVariant)
     expect(setSelectedVariant).toHaveBeenCalledTimes(1)
-  })
-
-  test("shows empty Viewing indicator when selectedVariant is null", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={null}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
-
-    screen.getByText("Viewing:")
-    // Variant labels appear only in the cards (once each), not also in the indicator
-    expect(screen.getAllByText(/English.*General.*Full/)).toHaveLength(1)
-  })
-
-  test("the Viewing indicator shows the label of the currently selected variant", () => {
-    renderWithProviders(
-      <VariantPicker
-        variantOptions={[enDefault, esVariant]}
-        selectedVariant={esVariant}
-        setSelectedVariant={jest.fn()}
-      />,
-    )
-
-    const indicator = screen.getByText("Viewing:").closest("div")!
-    expect(
-      within(indicator as HTMLElement).getByText(/español.*General.*Full/),
-    ).toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
@@ -121,6 +121,63 @@ describe("VariantPicker", () => {
   })
 })
 
+describe("customizedVariantLabel", () => {
+  test("non-default variant cards use 'Customized <name>' as the title with the language/industry/length detail as subtext", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={esVariant}
+        setSelectedVariant={jest.fn()}
+        defaultVariantLabel="Universal AI Program"
+        customizedVariantLabel="Customized Universal AI"
+      />,
+    )
+
+    const esRadio = screen.getByRole("radio", {
+      name: /Customized Universal AI/,
+    })
+    // the language/industry/length detail moves to the card subtext
+    expect(esRadio).toHaveAccessibleName(/español.*General.*Full/)
+  })
+
+  test("the Viewing indicator shows 'Customized <name> (detail)' for a selected non-default variant", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={esVariant}
+        setSelectedVariant={jest.fn()}
+        defaultVariantLabel="Universal AI Program"
+        customizedVariantLabel="Customized Universal AI"
+      />,
+    )
+
+    const indicator = screen.getByText("Viewing:").closest("div")!
+    expect(
+      within(indicator).getByText(
+        /Customized Universal AI \(español.*General.*Full\)/,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  test("does not apply customizedVariantLabel to the default variant card", () => {
+    renderWithProviders(
+      <VariantPicker
+        variantOptions={[enDefault, esVariant]}
+        selectedVariant={enDefault}
+        setSelectedVariant={jest.fn()}
+        defaultVariantLabel="Universal AI Program"
+        customizedVariantLabel="Customized Universal AI"
+      />,
+    )
+
+    const defaultRadio = screen.getByRole("radio", {
+      name: /Universal AI Program/,
+    })
+    expect(defaultRadio).toHaveAccessibleName(/Certificate Eligible/)
+    expect(defaultRadio).not.toHaveAccessibleName(/Customized/)
+  })
+})
+
 describe("VariantPicker rendering", () => {
   test("renders the default title 'Available Versions'", () => {
     renderWithProviders(

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
@@ -37,15 +37,21 @@ const VariantChoiceBox = styled("label", {
   gap: "4px",
   borderRadius: "4px",
   backgroundColor: theme.custom.colors.white,
-  border: `${checked ? "2px" : "1px"} solid ${checked ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
+  // Keep the border width constant at 1px and thicken the selected/focused
+  // state with an inset box-shadow instead of a 2px border. box-shadow does not
+  // affect layout, so the card content no longer shifts when selected.
+  border: `1px solid ${checked ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
+  boxShadow: checked ? `inset 0 0 0 1px ${theme.custom.colors.red}` : "none",
   cursor: "pointer",
   "&:focus-within": {
-    border: `2px solid ${theme.custom.colors.red}`,
+    borderColor: theme.custom.colors.red,
+    boxShadow: `inset 0 0 0 1px ${theme.custom.colors.red}`,
   },
 }))
 
 type VariantCardProps = {
   title: string
+  subtitle?: string
   certEligible: boolean
   selected: boolean
   name: string
@@ -55,6 +61,7 @@ type VariantCardProps = {
 
 const VariantCard: React.FC<VariantCardProps> = ({
   title,
+  subtitle,
   certEligible,
   selected,
   name,
@@ -71,17 +78,17 @@ const VariantCard: React.FC<VariantCardProps> = ({
         onChange={onChange}
       />
       <Typography variant="subtitle1">{title}</Typography>
-      <Stack
-        direction="row"
-        alignItems="center"
-        visibility={certEligible ? "visible" : "hidden"}
-        gap="8px"
-      >
-        <RiCheckboxFill size={20} />
-        <Typography variant="body3" color="darkGray2">
-          Certificate Eligible
-        </Typography>
-      </Stack>
+      {(certEligible || subtitle) && (
+        // Keep both subtext kinds (the certificate badge and the variant
+        // detail) in the same 20px-tall centered row so they align vertically
+        // across cards regardless of whether the checkbox icon is present.
+        <Stack direction="row" alignItems="center" gap="8px" minHeight="20px">
+          {certEligible && <RiCheckboxFill size={20} />}
+          <Typography variant="body3" color="darkGray2">
+            {certEligible ? "Certificate Eligible" : subtitle}
+          </Typography>
+        </Stack>
+      )}
     </VariantChoiceBox>
   )
 }
@@ -91,6 +98,7 @@ type VariantChoiceBoxesProps = {
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
   defaultVariantLabel?: string
+  customizedVariantLabel?: string
   "aria-label"?: string
   "aria-labelledby"?: string
 }
@@ -100,6 +108,7 @@ const VariantChoiceBoxes: React.FC<VariantChoiceBoxesProps> = ({
   selectedVariant,
   setSelectedVariant,
   defaultVariantLabel,
+  customizedVariantLabel,
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledby,
 }) => {
@@ -125,16 +134,24 @@ const VariantChoiceBoxes: React.FC<VariantChoiceBoxesProps> = ({
     >
       {variantOptions.map((variant) => {
         const value = buildVariantKey(variant)
-        const label =
-          variant.default_variant && defaultVariantLabel
-            ? defaultVariantLabel
-            : buildVariantLabel(variant)
+        const detailLabel = buildVariantLabel(variant)
+        // Default card: large title from defaultVariantLabel, "Certificate
+        // Eligible" badge as subtext. Variant cards: "Customized <Contract>"
+        // title with the language • industry • length detail as subtext.
+        const title = variant.default_variant
+          ? (defaultVariantLabel ?? detailLabel)
+          : (customizedVariantLabel ?? detailLabel)
+        const subtitle =
+          !variant.default_variant && customizedVariantLabel
+            ? detailLabel
+            : undefined
         return (
           <VariantCard
             key={value}
             name={groupName}
             value={value}
-            title={label}
+            title={title}
+            subtitle={subtitle}
             certEligible={variant.default_variant}
             selected={value === selectedValue}
             onChange={() => handleSelectedVariantChange(value)}
@@ -162,6 +179,7 @@ type VariantPickerProps = {
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
   defaultVariantLabel?: string
+  customizedVariantLabel?: string
   title?: string
   description?: string
 }
@@ -171,15 +189,23 @@ const VariantPicker: React.FC<VariantPickerProps> = ({
   selectedVariant,
   setSelectedVariant,
   defaultVariantLabel,
+  customizedVariantLabel,
   title = "Available Versions",
   description,
 }) => {
   const titleId = React.useId()
-  const viewingLabel = selectedVariant
-    ? selectedVariant.default_variant && defaultVariantLabel
-      ? defaultVariantLabel
-      : buildVariantLabel(selectedVariant)
-    : ""
+  let viewingLabel = ""
+  if (selectedVariant) {
+    const detailLabel = buildVariantLabel(selectedVariant)
+    if (selectedVariant.default_variant) {
+      viewingLabel = defaultVariantLabel ?? detailLabel
+    } else if (customizedVariantLabel) {
+      // e.g. "Customized Universal AI (English • Healthcare • Short)"
+      viewingLabel = `${customizedVariantLabel} (${detailLabel})`
+    } else {
+      viewingLabel = detailLabel
+    }
+  }
   return (
     <VariantPickerRoot>
       <Typography id={titleId} variant="h5" component="h2">
@@ -192,6 +218,7 @@ const VariantPicker: React.FC<VariantPickerProps> = ({
         selectedVariant={selectedVariant}
         setSelectedVariant={setSelectedVariant}
         defaultVariantLabel={defaultVariantLabel}
+        customizedVariantLabel={customizedVariantLabel}
       />
       <SelectedVariantIndicator>
         <Typography variant="body2">Viewing:</Typography>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
@@ -97,8 +97,8 @@ type VariantChoiceBoxesProps = {
   variantOptions: SupportedVariant[]
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
-  defaultVariantLabel?: string
-  customizedVariantLabel?: string
+  defaultVariantLabel: string
+  customizedVariantLabel: string
   "aria-label"?: string
   "aria-labelledby"?: string
 }
@@ -134,17 +134,15 @@ const VariantChoiceBoxes: React.FC<VariantChoiceBoxesProps> = ({
     >
       {variantOptions.map((variant) => {
         const value = buildVariantKey(variant)
-        const detailLabel = buildVariantLabel(variant)
         // Default card: large title from defaultVariantLabel, "Certificate
         // Eligible" badge as subtext. Variant cards: "Customized <Contract>"
         // title with the language • industry • length detail as subtext.
         const title = variant.default_variant
-          ? (defaultVariantLabel ?? detailLabel)
-          : (customizedVariantLabel ?? detailLabel)
-        const subtitle =
-          !variant.default_variant && customizedVariantLabel
-            ? detailLabel
-            : undefined
+          ? defaultVariantLabel
+          : customizedVariantLabel
+        const subtitle = variant.default_variant
+          ? undefined
+          : buildVariantLabel(variant)
         return (
           <VariantCard
             key={value}
@@ -178,8 +176,8 @@ type VariantPickerProps = {
   variantOptions: SupportedVariant[]
   selectedVariant: SupportedVariant | null
   setSelectedVariant: (variant: SupportedVariant | null) => void
-  defaultVariantLabel?: string
-  customizedVariantLabel?: string
+  defaultVariantLabel: string
+  customizedVariantLabel: string
   title?: string
   description?: string
 }
@@ -196,15 +194,9 @@ const VariantPicker: React.FC<VariantPickerProps> = ({
   const titleId = React.useId()
   let viewingLabel = ""
   if (selectedVariant) {
-    const detailLabel = buildVariantLabel(selectedVariant)
-    if (selectedVariant.default_variant) {
-      viewingLabel = defaultVariantLabel ?? detailLabel
-    } else if (customizedVariantLabel) {
-      // e.g. "Customized Universal AI (English • Healthcare • Short)"
-      viewingLabel = `${customizedVariantLabel} (${detailLabel})`
-    } else {
-      viewingLabel = detailLabel
-    }
+    viewingLabel = selectedVariant.default_variant
+      ? defaultVariantLabel
+      : `${customizedVariantLabel} (${buildVariantLabel(selectedVariant)})`
   }
   return (
     <VariantPickerRoot>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.tsx
@@ -43,9 +43,13 @@ const VariantChoiceBox = styled("label", {
   border: `1px solid ${checked ? theme.custom.colors.red : theme.custom.colors.silverGrayLight}`,
   boxShadow: checked ? `inset 0 0 0 1px ${theme.custom.colors.red}` : "none",
   cursor: "pointer",
-  "&:focus-within": {
-    borderColor: theme.custom.colors.red,
-    boxShadow: `inset 0 0 0 1px ${theme.custom.colors.red}`,
+  // Focus is a distinct OUTER ring layered on top of the (inset) selected
+  // state, so "selected" and "selected + focused" look different. :has(
+  // :focus-visible) keeps it to keyboard focus — a mouse click to select
+  // won't draw the ring. outline (not box-shadow) also survives forced-colors.
+  "&:has(:focus-visible)": {
+    outline: `2px solid ${theme.custom.colors.red}`,
+    outlineOffset: "2px",
   },
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
@@ -25,6 +25,7 @@ import {
   getSortedStandaloneContractPrograms,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
+  sortVariants,
   type DashboardCourseEntry,
 } from "../model/dashboardViewModel"
 
@@ -89,7 +90,7 @@ const useContractDashboardData = (
   )
 
   const variantOptions = React.useMemo(
-    () => contract.variant_options ?? [],
+    () => sortVariants(contract.variant_options ?? []),
     [contract],
   )
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -31,6 +31,7 @@ import {
   programHasContractRuns,
   resolveDisplayedRunAndEnrollment,
   selectVariantRunForCourse,
+  sortVariants,
 } from "./dashboardViewModel"
 
 describe("dashboardViewModel", () => {
@@ -1727,6 +1728,58 @@ describe("buildVariantLabel", () => {
     expect(
       buildVariantLabel(makeVariant({ variant_length: "XZ" as never })),
     ).toBe("English • General • XZ")
+  })
+})
+
+describe("sortVariants", () => {
+  test("groups the default's language first, then orders other languages alphabetically", () => {
+    // French is the default. Its label "Français" sorts alphabetically AFTER
+    // "English" and "Español", so the only reason the French variants lead is
+    // the default-language grouping rule — not alphabetical order.
+    const def = makeVariant({
+      language: LanguageEnum.Fr,
+      default_variant: true,
+    })
+    const frEnergyFull = makeVariant({
+      language: LanguageEnum.Fr,
+      variant_industry: VariantIndustryEnum.E,
+      variant_length: VariantLengthEnum.F,
+    })
+    const frEnergyShort = makeVariant({
+      language: LanguageEnum.Fr,
+      variant_industry: VariantIndustryEnum.E,
+      variant_length: VariantLengthEnum.S,
+    })
+    const frFinance = makeVariant({
+      language: LanguageEnum.Fr,
+      variant_industry: VariantIndustryEnum.F,
+    })
+    const english = makeVariant({ language: LanguageEnum.En })
+    const spanish = makeVariant({ language: LanguageEnum.EsEs })
+
+    const input = [
+      spanish,
+      frFinance,
+      english,
+      def,
+      frEnergyShort,
+      frEnergyFull,
+    ]
+
+    expect(sortVariants(input)).toEqual([
+      // default always first
+      def,
+      // rest of the default's language (French), by industry then length:
+      // Energy < Finance, with Energy's Full < Short tie-break on length
+      frEnergyFull,
+      frEnergyShort,
+      frFinance,
+      // then the other languages alphabetically: English < Español
+      english,
+      spanish,
+    ])
+    // input is not mutated
+    expect(input[0]).toBe(spanish)
   })
 })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1781,6 +1781,21 @@ describe("sortVariants", () => {
     // input is not mutated
     expect(input[0]).toBe(spanish)
   })
+
+  test("with no default variant, orders purely alphabetically by language", () => {
+    // No variant has default_variant: true, so there is no language to hoist
+    // and ordering falls through to the alphabetical language comparison.
+    const french = makeVariant({ language: LanguageEnum.Fr })
+    const english = makeVariant({ language: LanguageEnum.En })
+    const spanish = makeVariant({ language: LanguageEnum.EsEs })
+
+    // English < Español < Français
+    expect(sortVariants([french, spanish, english])).toEqual([
+      english,
+      spanish,
+      french,
+    ])
+  })
 })
 
 describe("selectVariantRunForCourse", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -855,27 +855,62 @@ const getNativeLanguageName = (languageCode: string): string => {
 const buildVariantKey = (variant: SupportedVariant): string =>
   `language:${variant.language ?? ""}|industry:${variant.variant_industry ?? ""}|length:${variant.variant_length ?? ""}`
 
-const buildVariantLabel = (variant: SupportedVariant): string => {
-  const langLabel = variant.language
-    ? getNativeLanguageName(variant.language)
-    : ""
-  const modifiers: string[] = []
-  if (variant.variant_industry) {
-    modifiers.push(
-      VARIANT_INDUSTRY_LABELS[variant.variant_industry] ??
-        variant.variant_industry,
+// Per-dimension display labels. These are the single source of truth shared by
+// both buildVariantLabel (what the picker renders) and sortVariants (the order
+// it renders in) so the sort always matches the visible text.
+const getVariantLanguageLabel = (variant: SupportedVariant): string =>
+  variant.language ? getNativeLanguageName(variant.language) : ""
+
+const getVariantIndustryLabel = (variant: SupportedVariant): string =>
+  variant.variant_industry
+    ? (VARIANT_INDUSTRY_LABELS[variant.variant_industry] ??
+      variant.variant_industry)
+    : "General"
+
+const getVariantLengthLabel = (variant: SupportedVariant): string =>
+  variant.variant_length
+    ? (VARIANT_LENGTH_LABELS[variant.variant_length] ?? variant.variant_length)
+    : "Full"
+
+const buildVariantLabel = (variant: SupportedVariant): string =>
+  [
+    getVariantLanguageLabel(variant),
+    getVariantIndustryLabel(variant),
+    getVariantLengthLabel(variant),
+  ]
+    .filter(Boolean)
+    .join(" • ")
+
+/**
+ * Returns a new array of variants ordered for display in the picker:
+ *   1. the default variant always comes first
+ *   2. then the remaining variants that share the default's language
+ *   3. then the other languages, alphabetically by displayed language name
+ *   4. within a language, ties broken by displayed industry then length label
+ *
+ * Sorting uses the human-readable labels (the same strings buildVariantLabel
+ * renders) so the picker reads alphabetically as the user sees it. Empty
+ * industry/length render as "General"/"Full" and sort among the rest.
+ */
+const sortVariants = (variants: SupportedVariant[]): SupportedVariant[] => {
+  const defaultLanguage = variants.find((v) => v.default_variant)?.language
+  return [...variants].sort((a, b) => {
+    if (a.default_variant !== b.default_variant) {
+      return a.default_variant ? -1 : 1
+    }
+    // Keep the default's language grouped at the top, ahead of other
+    // languages, regardless of where it falls alphabetically.
+    const aIsDefaultLanguage = a.language === defaultLanguage
+    const bIsDefaultLanguage = b.language === defaultLanguage
+    if (aIsDefaultLanguage !== bIsDefaultLanguage) {
+      return aIsDefaultLanguage ? -1 : 1
+    }
+    return (
+      getVariantLanguageLabel(a).localeCompare(getVariantLanguageLabel(b)) ||
+      getVariantIndustryLabel(a).localeCompare(getVariantIndustryLabel(b)) ||
+      getVariantLengthLabel(a).localeCompare(getVariantLengthLabel(b))
     )
-  } else {
-    modifiers.push("General")
-  }
-  if (variant.variant_length) {
-    modifiers.push(
-      VARIANT_LENGTH_LABELS[variant.variant_length] ?? variant.variant_length,
-    )
-  } else {
-    modifiers.push("Full")
-  }
-  return [langLabel, ...modifiers].filter(Boolean).join(" • ")
+  })
 }
 
 /**
@@ -1006,6 +1041,7 @@ export {
   getCollectionFirstCoursesInDisplayOrder,
   buildVariantKey,
   buildVariantLabel,
+  sortVariants,
   selectVariantRunForCourse,
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR:
- Updates the variant picker UI a bit, see screenshot
- sorts variants by (language, industry, length), but ensures the group matching default is shown first
- fixes a test that was failing on main
- Adds a focus ring when `focus-visible` to distinguish between selected vs selected+focused-via-keyboard. (Only affects keyboard users).

### Screenshots (if appropriate):
<img width="975" height="420" alt="Screenshot 2026-06-04 at 1 00 32 PM" src="https://github.com/user-attachments/assets/e176df59-9816-4c72-b809-073a088fadcb" />

Keyboard-only focus ring:
<img width="720" height="304" alt="Screenshot 2026-06-04 at 2 32 56 PM" src="https://github.com/user-attachments/assets/ce7d4a6f-5b7a-47e0-abe7-4a69b8fbf64c" />


### How can this be tested?
1. View a contract with variants set up. It should look like above, and default should be sorted to first card.
