### PR TITLE
fix: add link to the creation page of article and news

### DIFF
--- a/frontends/main/src/app-pages/Articles/ArticleListingPage.tsx
+++ b/frontends/main/src/app-pages/Articles/ArticleListingPage.tsx
@@ -17,7 +17,6 @@ import {
   Breadcrumbs,
 } from "ol-components"
 import Link from "next/link"
-import { useRouter } from "next-nprogress-bar"
 import { RiArrowLeftLine, RiArrowRightLine } from "@remixicon/react"
 import type { WebsiteContent } from "api/v1"
 import { LocalDate } from "ol-utilities"
@@ -25,7 +24,7 @@ import { useWebsiteContentList } from "api/hooks/website_content"
 import { extractArticleContent } from "@/common/websiteContentUtils"
 import { articleView, websiteContentCreateView } from "@/common/urls"
 import { Permission, useUserHasPermission } from "api/hooks/user"
-import { Button } from "@mitodl/smoot-design"
+import { ButtonLink } from "@mitodl/smoot-design"
 
 const PAGE_SIZE = 10
 const MAX_PAGE = 50
@@ -306,7 +305,7 @@ const BannerSection = styled.div`
   background: ${theme.custom.colors.white};
   border-bottom: 1px solid ${theme.custom.colors.lightGray2};
 `
-const NewArticleLink = styled(Button)`
+const NewArticleLink = styled(ButtonLink)`
   display: flex;
   justify-content: end;
 `
@@ -418,7 +417,6 @@ const ArticleListingPage: React.FC = () => {
   const parsedPage = Number.parseInt(searchParams.get("page") ?? "1", 10)
   const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1
 
-  const router = useRouter()
   const isArticleEditor = useUserHasPermission(Permission.ArticleEditor)
 
   const { data: articles, isLoading } = useWebsiteContentList({
@@ -460,7 +458,7 @@ const ArticleListingPage: React.FC = () => {
             {isArticleEditor && (
               <NewArticleLink
                 variant="primary"
-                onClick={() => router.push(websiteContentCreateView("article"))}
+                href={websiteContentCreateView("article")}
               >
                 <Typography variant="body1" color="white">
                   New Article

--- a/frontends/main/src/app-pages/Articles/ArticleListingPage.tsx
+++ b/frontends/main/src/app-pages/Articles/ArticleListingPage.tsx
@@ -17,12 +17,15 @@ import {
   Breadcrumbs,
 } from "ol-components"
 import Link from "next/link"
+import { useRouter } from "next-nprogress-bar"
 import { RiArrowLeftLine, RiArrowRightLine } from "@remixicon/react"
 import type { WebsiteContent } from "api/v1"
 import { LocalDate } from "ol-utilities"
 import { useWebsiteContentList } from "api/hooks/website_content"
 import { extractArticleContent } from "@/common/websiteContentUtils"
-import { articleView } from "@/common/urls"
+import { articleView, websiteContentCreateView } from "@/common/urls"
+import { Permission, useUserHasPermission } from "api/hooks/user"
+import { Button } from "@mitodl/smoot-design"
 
 const PAGE_SIZE = 10
 const MAX_PAGE = 50
@@ -223,6 +226,10 @@ const BannerGridContainer = styled.div`
   max-width: 842px;
   margin: 0 auto;
   padding: 64px 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 
   ${theme.breakpoints.down("sm")} {
     max-width: 100%;
@@ -299,6 +306,10 @@ const BannerSection = styled.div`
   background: ${theme.custom.colors.white};
   border-bottom: 1px solid ${theme.custom.colors.lightGray2};
 `
+const NewArticleLink = styled(Button)`
+  display: flex;
+  justify-content: end;
+`
 
 const EmptyState = styled.div`
   display: flex;
@@ -319,7 +330,6 @@ const EmptyState = styled.div`
 
 const BannerTitle = styled(Typography)`
   color: ${theme.custom.colors.black};
-  margin-top: 8px;
   ${theme.breakpoints.down("md")} {
     ${{ ...theme.typography.h2 }}
   }
@@ -328,16 +338,6 @@ const BannerTitle = styled(Typography)`
     margin-top: 0;
   }
 ` as typeof Typography
-
-const BannerDescription = styled(Typography)`
-  color: ${theme.custom.colors.black};
-  margin-top: 16px;
-  font-size: 20px;
-  line-height: 32px;
-  ${theme.breakpoints.down("sm")} {
-    ${{ ...theme.typography.body2 }}
-  }
-`
 
 const BreadcrumbBar = styled.div(({ theme }) => ({
   width: "100%",
@@ -418,6 +418,9 @@ const ArticleListingPage: React.FC = () => {
   const parsedPage = Number.parseInt(searchParams.get("page") ?? "1", 10)
   const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1
 
+  const router = useRouter()
+  const isArticleEditor = useUserHasPermission(Permission.ArticleEditor)
+
   const { data: articles, isLoading } = useWebsiteContentList({
     limit: PAGE_SIZE,
     offset: (page - 1) * PAGE_SIZE,
@@ -454,11 +457,16 @@ const ArticleListingPage: React.FC = () => {
             <BannerTitle component="h1" variant="h1">
               Articles
             </BannerTitle>
-            <BannerDescription variant="body1">
-              Dive into articles covering emerging technologies, global
-              challenges, and creative thinking. Stay connected with the latest
-              insights and discoveries from MIT.
-            </BannerDescription>
+            {isArticleEditor && (
+              <NewArticleLink
+                variant="primary"
+                onClick={() => router.push(websiteContentCreateView("article"))}
+              >
+                <Typography variant="body1" color="white">
+                  New Article
+                </Typography>
+              </NewArticleLink>
+            )}
           </BannerGridContainer>
         </Container>
       </BannerSection>

--- a/frontends/main/src/app-pages/News/NewsBanner.tsx
+++ b/frontends/main/src/app-pages/News/NewsBanner.tsx
@@ -7,6 +7,10 @@ import {
   Breadcrumbs,
   BannerBackground,
 } from "ol-components"
+import { Button } from "@mitodl/smoot-design"
+import { useRouter } from "next-nprogress-bar"
+import { Permission, useUserHasPermission } from "api/hooks/user"
+import { websiteContentCreateView } from "@/common/urls"
 
 export const DEFAULT_BACKGROUND_IMAGE_URL =
   "/images/backgrounds/backgroung_steps.jpg"
@@ -30,7 +34,17 @@ const BannerSection = styled(BannerBackground)`
     z-index: 2;
   }
 `
-
+const NewArticleLink = styled(Button)`
+  display: flex;
+  justify-content: end;
+`
+const InfoContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+`
 const BannerTitle = styled(Typography)`
   color: ${theme.custom.colors.white};
   margin-top: 8px;
@@ -65,6 +79,8 @@ const NewsBanner: React.FC<NewsBannerProps> = ({
   backgroundUrl = DEFAULT_BACKGROUND_IMAGE_URL,
   className,
 }) => {
+  const router = useRouter()
+  const isArticleEditor = useUserHasPermission(Permission.ArticleEditor)
   return (
     <BannerSection
       className={className}
@@ -78,10 +94,22 @@ const NewsBanner: React.FC<NewsBannerProps> = ({
           ancestors={[{ href: "/", label: "Home" }]}
           current={currentBreadcrumb}
         />
-        <BannerTitle component="h1" variant="h1">
-          {title}
-        </BannerTitle>
-        <BannerDescription variant="body1">{description}</BannerDescription>
+        <InfoContainer>
+          <div>
+            <BannerTitle component="h1" variant="h1">
+              {title}
+            </BannerTitle>
+            <BannerDescription variant="body1">{description}</BannerDescription>
+          </div>
+          {isArticleEditor && (
+            <NewArticleLink
+              variant="tertiary"
+              onClick={() => router.push(websiteContentCreateView("news"))}
+            >
+              <Typography variant="body1">Add news</Typography>
+            </NewArticleLink>
+          )}
+        </InfoContainer>
       </Container>
     </BannerSection>
   )

--- a/frontends/main/src/app-pages/News/NewsBanner.tsx
+++ b/frontends/main/src/app-pages/News/NewsBanner.tsx
@@ -7,8 +7,7 @@ import {
   Breadcrumbs,
   BannerBackground,
 } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
-import { useRouter } from "next-nprogress-bar"
+import { ButtonLink } from "@mitodl/smoot-design"
 import { Permission, useUserHasPermission } from "api/hooks/user"
 import { websiteContentCreateView } from "@/common/urls"
 
@@ -34,7 +33,7 @@ const BannerSection = styled(BannerBackground)`
     z-index: 2;
   }
 `
-const NewArticleLink = styled(Button)`
+const NewArticleLink = styled(ButtonLink)`
   display: flex;
   justify-content: end;
 `
@@ -79,7 +78,6 @@ const NewsBanner: React.FC<NewsBannerProps> = ({
   backgroundUrl = DEFAULT_BACKGROUND_IMAGE_URL,
   className,
 }) => {
-  const router = useRouter()
   const isArticleEditor = useUserHasPermission(Permission.ArticleEditor)
   return (
     <BannerSection
@@ -104,7 +102,7 @@ const NewsBanner: React.FC<NewsBannerProps> = ({
           {isArticleEditor && (
             <NewArticleLink
               variant="tertiary"
-              onClick={() => router.push(websiteContentCreateView("news"))}
+              href={websiteContentCreateView("news")}
             >
               <Typography variant="body1">Add news</Typography>
             </NewArticleLink>

--- a/frontends/main/src/app-pages/News/NewsListingPage.test.tsx
+++ b/frontends/main/src/app-pages/News/NewsListingPage.test.tsx
@@ -23,6 +23,7 @@ describe("NewsListingPage", () => {
   beforeEach(() => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
     mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+    setMockResponse.get(urls.userMe.get(), { is_authenticated: false })
   })
 
   afterEach(() => {

--- a/frontends/main/src/app-pages/News/NewsListingPage.test.tsx
+++ b/frontends/main/src/app-pages/News/NewsListingPage.test.tsx
@@ -83,6 +83,34 @@ describe("NewsListingPage", () => {
     })
   })
 
+  test("shows 'Add news' button in banner when user is an article editor", async () => {
+    setMockResponse.get(urls.userMe.get(), {
+      is_authenticated: true,
+      is_article_editor: true,
+    })
+    setupAPI(21)
+    renderWithProviders(<NewsListingPage />)
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", { name: /add news/i }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  test("hides 'Add news' button in banner when user is not an article editor", async () => {
+    setupAPI(21)
+    renderWithProviders(<NewsListingPage />)
+
+    await waitFor(() => {
+      expect(screen.queryByRole("progressbar")).not.toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole("link", { name: /add news/i }),
+    ).not.toBeInTheDocument()
+  })
+
   test("displays News images when available", async () => {
     const news = setupAPI(21)
     renderWithProviders(<NewsListingPage />)

--- a/frontends/main/src/page-components/Header/Header.test.tsx
+++ b/frontends/main/src/page-components/Header/Header.test.tsx
@@ -148,4 +148,31 @@ describe("UserMenu", () => {
     })
     expect(link).toBe(null)
   })
+
+  test("Article editors see 'Article' and 'News' links in the user menu", async () => {
+    setMockResponse.get(urls.userMe.get(), {
+      is_authenticated: true,
+      is_article_editor: true,
+    })
+    renderWithProviders(<Header />)
+    const menu = await findUserMenu()
+
+    const articleLink = within(menu).getByRole("menuitem", { name: "Article" })
+    expect(articleLink).toHaveAttribute("href", "/website_content/article/new")
+
+    const newsLink = within(menu).getByRole("menuitem", { name: "News" })
+    expect(newsLink).toHaveAttribute("href", "/website_content/news/new")
+  })
+
+  test("Users WITHOUT ArticleEditor permission do not see 'Article' or 'News' links", async () => {
+    setMockResponse.get(urls.userMe.get(), {
+      is_authenticated: true,
+      is_article_editor: false,
+    })
+    renderWithProviders(<Header />)
+    const menu = await findUserMenu()
+
+    expect(within(menu).queryByRole("menuitem", { name: "Article" })).toBe(null)
+    expect(within(menu).queryByRole("menuitem", { name: "News" })).toBe(null)
+  })
 })

--- a/frontends/main/src/page-components/Header/UserMenu.tsx
+++ b/frontends/main/src/page-components/Header/UserMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from "@remixicon/react"
 import { useUserMe, User } from "api/hooks/user"
 import MITLogoLink from "@/components/MITLogoLink/MITLogoLink"
+import { websiteContentCreateView } from "@/common/urls"
 
 const FlexContainer = styled.div({
   display: "flex",
@@ -157,6 +158,18 @@ const UserMenu: React.FC<UserMenuProps> = ({ variant }) => {
       key: "learningpaths",
       allow: !!user?.is_learning_path_editor,
       href: urls.LEARNINGPATH_LISTING,
+    },
+    {
+      label: "Article",
+      key: "articles",
+      allow: !!user?.is_article_editor,
+      href: websiteContentCreateView("article"),
+    },
+    {
+      label: "News",
+      key: "news",
+      allow: !!user?.is_article_editor,
+      href: websiteContentCreateView("news"),
     },
     {
       label: "Log Out",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
 - Add link to creation of article and news pages.

### Screenshots (if appropriate):

<img width="669" height="343" alt="Screenshot 2026-06-05 at 4 50 14 PM" src="https://github.com/user-attachments/assets/a1bcb380-aa84-45d7-88bc-74566f5321f6" />

<img width="2880" height="5070" alt="image" src="https://github.com/user-attachments/assets/d10a023e-f016-4095-885c-156ee75bc894" />

<img width="2880" height="10701" alt="image" src="https://github.com/user-attachments/assets/34a71d11-af6d-4b7e-ba7c-05552592b115" />


### How can this be tested?
For testing you need to go to following urls and see the button added for article and news creation pages
`/articles`
`/news`
and we have added the links inside the UserMenu as well

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
