### PR TITLE
fix podcasts type

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3984,10 +3984,10 @@ export interface PodcastEpisode {
   id: number
   /**
    * Get the podcast id(s) the episode belongs to
-   * @type {Array<string>}
+   * @type {Array<number>}
    * @memberof PodcastEpisode
    */
-  podcasts: Array<string>
+  podcasts: Array<number>
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -6674,10 +6674,10 @@ export interface PodcastEpisode {
   id: number
   /**
    * Get the podcast id(s) the episode belongs to
-   * @type {Array<string>}
+   * @type {Array<number>}
    * @memberof PodcastEpisode
    */
-  podcasts: Array<string>
+  podcasts: Array<number>
   /**
    *
    * @type {string}

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
@@ -63,8 +63,8 @@ describe("Podcast Sitemaps", () => {
     // Use a non-overlapping range from the podcast test (which uses { min: 5, max: 10 })
     // to avoid query cache collisions on the same list URL.
     const page = faker.number.int({ min: 11, max: 20 })
-    const podcastId1 = String(faker.number.int())
-    const podcastId2 = String(faker.number.int())
+    const podcastId1 = faker.number.int()
+    const podcastId2 = faker.number.int()
     const episodeWithMultipleParents =
       factories.learningResources.podcastEpisode({
         podcast_episode: { podcasts: [podcastId1, podcastId2] },

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.tsx
@@ -197,7 +197,7 @@ const DrawerContent: React.FC<{
       bottomCarousels.push(
         itemsCarousel(
           "Other Episodes in this Podcast",
-          parseInt(resource.data.podcast_episode.podcasts[0]),
+          resource.data.podcast_episode.podcasts[0],
           resourceId,
         ),
       )

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -448,7 +448,7 @@ class PodcastEpisodeSerializer(serializers.ModelSerializer):
 
     podcasts = serializers.SerializerMethodField()
 
-    def get_podcasts(self, instance) -> list[str]:
+    def get_podcasts(self, instance) -> list[int]:
         """Get the podcast id(s) the episode belongs to"""
         return [podcast.parent_id for podcast in instance.learning_resource.podcasts]
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4433,7 +4433,7 @@ components:
         podcasts:
           type: array
           items:
-            type: string
+            type: integer
           description: Get the podcast id(s) the episode belongs to
           readOnly: true
         transcript:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -14718,7 +14718,7 @@ components:
         podcasts:
           type: array
           items:
-            type: string
+            type: integer
           description: Get the podcast id(s) the episode belongs to
           readOnly: true
         transcript:


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes `learning_resource.podcast_episode.podcasts` type. It was incorrectly `str[]` but should be `number[]`

### How can this be tested?
1. Check that the API results actually show `number[]` for the `podcast_episode.podcasts` property at https://api.learn.mit.edu/api/v1/podcast_episodes/
2. And now the spec does, too.

### Additional Context
<!-- Github supports: NOTE, TIP, IMPORTANT, WARNING, CAUTION -->
> [!NOTE]
> oasdiff will classify this as a breaking change. It's not. It's a spec bugfix.
