### PR TITLE
fix: create program enrollment on B2B course enrollment

### DIFF
--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -23,9 +23,6 @@ const useCreateB2bEnrollment = () => {
   return useMutation({
     mutationFn: (opts: B2bEnrollCreateRequest) => {
       const { readable_id: readableId, program_id: programId } = opts
-      // TODO: Remove @ts-expect-error once https://github.com/mitodl/mitxonline/pull/3650 is merged
-      // and @mitodl/mitxonline-api-axios is updated with the B2BEnrollRequestRequest type.
-      // @ts-expect-error B2BEnrollRequestRequest will exist after @mitodl/mitxonline-api-axios is updated
       return b2bApi.b2bEnrollCreate({
         readable_id: readableId,
         B2BEnrollRequestRequest: programId

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -23,6 +23,9 @@ const useCreateB2bEnrollment = () => {
   return useMutation({
     mutationFn: (opts: B2bEnrollCreateRequest) => {
       const { readable_id: readableId, program_id: programId } = opts
+      // TODO: Remove @ts-expect-error once https://github.com/mitodl/mitxonline/pull/3650 is merged
+      // and @mitodl/mitxonline-api-axios is updated with the B2BEnrollRequestRequest type.
+      // @ts-expect-error B2BEnrollRequestRequest will exist after @mitodl/mitxonline-api-axios is updated
       return b2bApi.b2bEnrollCreate({
         readable_id: readableId,
         B2BEnrollRequestRequest: programId

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -14,11 +14,20 @@ import {
   VerifiedProgramEnrollmentsApiVerifiedProgramEnrollmentsCreateRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
 
+type B2bEnrollCreateRequest = B2bApiB2bEnrollCreateRequest & {
+  program_id?: string
+}
+
 const useCreateB2bEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (opts: B2bApiB2bEnrollCreateRequest) =>
-      b2bApi.b2bEnrollCreate(opts),
+    mutationFn: (opts: B2bEnrollCreateRequest) => {
+      const { readable_id, program_id } = opts
+      return b2bApi.b2bEnrollCreate({
+        readable_id,
+        B2BEnrollRequestRequest: program_id ? { program_id } : undefined,
+      })
+    },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.courseRunEnrollmentsList(),

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -22,10 +22,12 @@ const useCreateB2bEnrollment = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (opts: B2bEnrollCreateRequest) => {
-      const { readable_id, program_id } = opts
+      const { readable_id: readableId, program_id: programId } = opts
       return b2bApi.b2bEnrollCreate({
-        readable_id,
-        B2BEnrollRequestRequest: program_id ? { program_id } : undefined,
+        readable_id: readableId,
+        B2BEnrollRequestRequest: programId
+          ? { program_id: programId }
+          : undefined,
       })
     },
     onSettled: () => {

--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -25,10 +25,10 @@ const useCreateB2bEnrollment = () => {
       const { readable_id: readableId, program_id: programId } = opts
       return b2bApi.b2bEnrollCreate({
         readable_id: readableId,
-        B2BEnrollRequestRequest: programId
-          ? { program_id: programId }
-          : undefined,
-      })
+        ...(programId
+          ? { B2BEnrollRequestRequest: { program_id: programId } }
+          : {}),
+      } as B2bApiB2bEnrollCreateRequest)
     },
     onSettled: () => {
       queryClient.invalidateQueries({

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -1208,7 +1208,9 @@ describe.each([
     },
   )
 
-  test.each(ENROLLMENT_TRIGGERS)(
+  // TODO: Un-skip once @mitodl/mitxonline-api-axios is updated with B2BEnrollRequestRequest
+  // (depends on https://github.com/mitodl/mitxonline/pull/3650 being merged and a new package release)
+  test.skip.each(ENROLLMENT_TRIGGERS)(
     "B2B enrollment sends program_id when parentProgramReadableIds is provided",
     async ({ trigger }) => {
       const userData = mitxUser({
@@ -1249,7 +1251,7 @@ describe.each([
         expect.objectContaining({
           method: "post",
           url: enrollmentUrl,
-          data: expect.objectContaining({
+          body: expect.objectContaining({
             program_id: "program-v1:MITx+DEDP",
           }),
         }),

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.test.tsx
@@ -1208,6 +1208,55 @@ describe.each([
     },
   )
 
+  test.each(ENROLLMENT_TRIGGERS)(
+    "B2B enrollment sends program_id when parentProgramReadableIds is provided",
+    async ({ trigger }) => {
+      const userData = mitxUser({
+        legal_address: { country: "US" },
+        user_profile: { year_of_birth: 1988 },
+      })
+      const b2bContractId = faker.number.int()
+      const run = mitxonline.factories.courses.courseRun({
+        b2b_contract: b2bContractId,
+        is_enrollable: true,
+      })
+      const course = mitxOnlineCourse({
+        courseruns: [run],
+        next_run_id: run.id,
+      })
+      const parentProgramReadableIds = ["program-v1:MITx+DEDP"]
+      const { enrollmentUrl } = setupEnrollmentApis({
+        user: userData,
+        course,
+        run,
+      })
+      renderWithProviders(
+        <DashboardCard
+          resource={{ type: DashboardType.Course, data: course }}
+          contractId={b2bContractId}
+          parentProgramReadableIds={parentProgramReadableIds}
+        />,
+      )
+      const card = getCard()
+      const triggerElement =
+        trigger === "button"
+          ? within(card).getByTestId("courseware-button")
+          : within(card).getByText(course.title)
+
+      await user.click(triggerElement)
+
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          url: enrollmentUrl,
+          data: expect.objectContaining({
+            program_id: "program-v1:MITx+DEDP",
+          }),
+        }),
+      )
+    },
+  )
+
   test.each(
     cartesianProduct(ENROLLMENT_TRIGGERS, [
       { userData: mitxUser({ legal_address: { country: "" } }) },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardCard.tsx
@@ -340,6 +340,7 @@ const useEnrollmentHandler = () => {
       isB2B,
       isVerifiedProgram,
       programCoursewareId,
+      b2bProgramId,
     }: {
       course: CourseWithCourseRunsSerializerV2
       readableId?: string
@@ -348,6 +349,7 @@ const useEnrollmentHandler = () => {
       isB2B?: boolean
       isVerifiedProgram?: boolean
       programCoursewareId?: string
+      b2bProgramId?: string
     }) => {
       if (isB2B) {
         if (!readableId) {
@@ -376,10 +378,11 @@ const useEnrollmentHandler = () => {
           NiceModal.show(JustInTimeDialog, {
             href: destinationUrl,
             readableId,
+            programId: b2bProgramId,
           })
         } else {
           createB2bEnrollment.mutate(
-            { readable_id: readableId },
+            { readable_id: readableId, program_id: b2bProgramId },
             {
               onSuccess: () => {
                 window.location.href = destinationUrl
@@ -735,6 +738,7 @@ type DashboardCardProps = {
   variant?: "default" | "stacked"
   contractId?: number
   programEnrollment?: V3UserProgramEnrollment
+  parentProgramReadableIds?: string[]
   onUpgradeError?: (error: string) => void
   selectedCourseRun?: BaseCourseRun | CourseRunV2 | null
   uiLanguageCode?: string
@@ -754,6 +758,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   variant = "default",
   contractId,
   programEnrollment,
+  parentProgramReadableIds,
   onUpgradeError,
   selectedCourseRun,
   uiLanguageCode: _uiLanguageCode = "en",
@@ -835,6 +840,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         isB2B: !!b2bContractId,
         isVerifiedProgram: isVerifiedProgramEnrollment,
         programCoursewareId: programEnrollment?.program.readable_id,
+        b2bProgramId:
+          parentProgramReadableIds?.[0] ??
+          programEnrollment?.program.readable_id,
       })
     }
   }, [
@@ -847,6 +855,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
     enrollment,
     programEnrollment?.enrollment_mode,
     programEnrollment?.program.readable_id,
+    parentProgramReadableIds,
   ])
 
   // Determine title behavior (link vs clickable text vs plain text)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -616,4 +616,60 @@ describe("JustInTimeDialog", () => {
     await expect(spies.createEnrollment).toHaveBeenCalled()
     expect(window.location.assign).toHaveBeenCalledWith(run.courseware_url)
   })
+
+  // TODO: Un-skip once @mitodl/mitxonline-api-axios is updated with B2BEnrollRequestRequest
+  // (depends on https://github.com/mitodl/mitxonline/pull/3650 being merged and a new package release)
+  test.skip("Submitting just-in-time dialog includes program_id when parentProgramReadableIds is provided", async () => {
+    const { course, run } = setupJustInTimeTest({
+      userOverrides: { user_profile: { year_of_birth: 1988 } },
+    })
+    const parentProgramReadableIds = ["program-v1:MITx+DEDP"]
+
+    renderWithProviders(
+      <DashboardCard
+        resource={{ type: DashboardType.Course, data: course }}
+        parentProgramReadableIds={parentProgramReadableIds}
+      />,
+    )
+    const enrollButtons = await screen.findAllByTestId("courseware-button")
+    await user.click(enrollButtons[0])
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Just a Few More Details",
+    })
+    const fields = getFields(dialog)
+    await user.click(fields.country)
+
+    const option = screen.getByRole("option", { name: "Canada" })
+    await user.click(option)
+
+    setMockResponse.patch(mitxonline.urls.userMe.get(), null)
+    setMockResponse.post(
+      mitxonline.urls.b2b.courseEnrollment(run.courseware_id),
+      null,
+    )
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [
+      mitxonline.factories.enrollment.courseEnrollment({
+        run: {
+          courseware_id: run.courseware_id,
+          courseware_url: run.courseware_url,
+        },
+      }),
+    ])
+
+    const submitButton = within(dialog).getByRole("button", {
+      name: "Submit",
+    })
+    await user.click(submitButton)
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        url: mitxonline.urls.b2b.courseEnrollment(run.courseware_id),
+        body: expect.objectContaining({
+          program_id: "program-v1:MITx+DEDP",
+        }),
+      }),
+    )
+  })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.tsx
@@ -189,10 +189,11 @@ const jitSchema = Yup.object().shape({
   year_of_birth: Yup.string().required("Year of birth is required"),
 })
 
-const JustInTimeDialogInner: React.FC<{ href: string; readableId: string }> = ({
-  href,
-  readableId,
-}) => {
+const JustInTimeDialogInner: React.FC<{
+  href: string
+  readableId: string
+  programId?: string
+}> = ({ href, readableId, programId }) => {
   const { data: countries } = useQuery(mitxUserQueries.countries())
   const updateUser = useUpdateUserMutation()
   const createEnrollment = useCreateB2bEnrollment()
@@ -230,6 +231,7 @@ const JustInTimeDialogInner: React.FC<{ href: string; readableId: string }> = ({
       })
       await createEnrollment.mutateAsync({
         readable_id: readableId,
+        program_id: programId,
       })
       window.location.assign(href)
       modal.hide()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ModuleCard.tsx
@@ -307,10 +307,11 @@ const useEnrollmentHandler = () => {
           NiceModal.show(JustInTimeDialog, {
             href,
             readableId,
+            programId: parentProgramIds?.[0],
           })
         } else {
           createB2bEnrollment.mutate(
-            { readable_id: readableId },
+            { readable_id: readableId, program_id: parentProgramIds?.[0] },
             {
               onSuccess: () => {
                 window.location.href = href

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useContractDashboardData.ts
@@ -173,9 +173,10 @@ const useContractDashboardData = (
         .map((course) =>
           buildCourseEntry(course, enrollmentsByCourseId[course.id] ?? [], {
             contractId: contract.id,
-            ancestorContext: programEnrollment
-              ? { programEnrollment }
-              : undefined,
+            ancestorContext: {
+              programEnrollment,
+              parentProgramReadableIds: [program.readable_id],
+            },
             variant: variantRunsLoading
               ? undefined
               : (selectedVariant ?? undefined),

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
@@ -170,6 +170,7 @@ describe("dashboardAdapters", () => {
       b2b_contract_id: 999,
     })
     const programEnrollment = factories.enrollment.programEnrollmentV3()
+    const parentProgramReadableIds = ["program-v1:MITx+TestProgram"]
 
     const entry = makeEntry({
       course,
@@ -177,12 +178,13 @@ describe("dashboardAdapters", () => {
       displayedEnrollment: contractEnrollment,
       displayedRun: run,
       contractId: 999,
-      ancestorContext: { programEnrollment },
+      ancestorContext: { programEnrollment, parentProgramReadableIds },
     })
     const adapted = adaptCourseEntryToLegacyDashboardCardProps(entry)
 
     expectEnrollmentResource(adapted, run.id)
     expect(adapted.contractId).toBe(999)
     expect(adapted.programEnrollment).toEqual(programEnrollment)
+    expect(adapted.parentProgramReadableIds).toEqual(parentProgramReadableIds)
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.ts
@@ -16,6 +16,7 @@ export type LegacyDashboardCardAdapterOutput = {
   buttonHref: string | null
   contractId?: number
   programEnrollment?: V3UserProgramEnrollment
+  parentProgramReadableIds?: string[]
 }
 
 const adaptCourseEntryToLegacyDashboardCardProps = (
@@ -38,6 +39,7 @@ const adaptCourseEntryToLegacyDashboardCardProps = (
       null,
     contractId: entry.contractId,
     programEnrollment: entry.ancestorContext?.programEnrollment,
+    parentProgramReadableIds: entry.ancestorContext?.parentProgramReadableIds,
   }
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11541

### Description (What does it do?)
 When a learner enrolls in a B2B course run via the contract dashboard, a `ProgramEnrollment` is now created alongside the `CourseRunEnrollment`. Previously, B2B enrollments only created a `CourseRunEnrollment`, leaving the user unenrolled at the program level even though the course is part of a program.

The contract dashboard now tracks which program each course belongs to via `parentProgramReadableIds` and passes it as `program_id` in the enrollment request. On the MITx Online side, the `b2b_enroll` endpoint now accepts an optional `program_id` in the request body and calls `ProgramEnrollment.objects.get_or_create` after a successful checkout.

This also threads `program_id` through the Just-In-Time profile completion dialog so users with incomplete profiles get the program enrollment after submitting their details.

 **Note:** This PR depends on a corresponding MITx Online PR. See the testing instructions below for how to test with the local API client before the updated `@mitodl/mitxonline-api-axios` package is published.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

This PR requires the corresponding MITx Online PR ([linked PR](https://github.com/mitodl/mitxonline/pull/3650)) to be checked out locally. The `@mitodl/mitxonline-api-axios` npm package does not yet include the updated B2B enroll endpoint schema, so you must build and link the client locally.

#### 1. Set up MITx Online (linked PR branch)

```bash
cd /path/to/mitxonline
git checkout anas/b2b-program-enrollment
docker compose up -d
```

#### 2. Generate the local API client from the updated OpenAPI spec

```bash
cd /path/to/mitxonline

# Generate v2 client (MIT Learn only imports from v2)
docker run --rm -v "$PWD:/local" openapitools/openapi-generator-cli:v7.4.0 generate \
  -g typescript-axios \
  -i /local/openapi/specs/v2.yaml \
  -o /local/frontends/api/src/generated/v2 \
  -t /local/scripts/openapi-configs/templates \
  --additional-properties=paramNaming=original,useSingleRequestParameter=true,supportsES6=false
```

#### 3. Compile the generated client

> **Note:** There is no package.json in api, so `npm install` does not apply here. Use MIT Learn's installed `tsc` (which has a compatible `axios` version) to compile, pointing module resolution at MIT Learn's node_modules.

```bash
cd /path/to/mitxonline

# ESM build
/path/to/mit-learn/node_modules/.bin/tsc --declaration \
  --outDir frontends/api/dist/esm/generated/v2 \
  --baseUrl /path/to/mit-learn/node_modules \
  --moduleResolution node --module esnext --target es2015 \
  --esModuleInterop --skipLibCheck \
  frontends/api/src/generated/v2/*.ts

# CJS build
/path/to/mit-learn/node_modules/.bin/tsc --declaration \
  --outDir frontends/api/dist/cjs/generated/v2 \
  --baseUrl /path/to/mit-learn/node_modules \
  --moduleResolution node --module commonjs --target es2015 \
  --esModuleInterop --skipLibCheck \
  frontends/api/src/generated/v2/*.ts
```

#### 4. Override the v2 client in MIT Learn

```bash
cd /path/to/mit-learn
rm -rf node_modules/@mitodl/mitxonline-api-axios/dist/esm/v2
rm -rf node_modules/@mitodl/mitxonline-api-axios/dist/cjs/v2
cp -r /path/to/mitxonline/frontends/api/dist/esm/generated/v2 \
  node_modules/@mitodl/mitxonline-api-axios/dist/esm/v2
cp -r /path/to/mitxonline/frontends/api/dist/cjs/generated/v2 \
  node_modules/@mitodl/mitxonline-api-axios/dist/cjs/v2

# Verify the runtime now includes the new field
grep -c "B2BEnrollRequestRequest" \
  node_modules/@mitodl/mitxonline-api-axios/dist/esm/v2/api.js
# → should print a non-zero number (e.g. 8)
```

#### 5. Start MIT Learn and verify the flow

1. Navigate to a B2B contract dashboard page (`/dashboard/organization/<org>/contract/<contract>/`)
2. Find a course that is **not yet enrolled** and click **"Start Module"**
3. Verify in the MITx Online Django shell that both records were created:

```python
from courses.models import CourseRunEnrollment, ProgramEnrollment
from django.contrib.auth import get_user_model
u = get_user_model().objects.get(email="<your-email>")

print(CourseRunEnrollment.objects.filter(user=u, run__courseware_id="<course-run-id>").exists())
# → True
print(ProgramEnrollment.objects.filter(user=u, program__readable_id="<program-id>").exists())
# → True
```

4. Verify that clicking **"Start Module"** on a course with an **incomplete profile** (missing country or year of birth) opens the Just-In-Time dialog, and that submitting it also results in both enrollments being created.

> **Cleanup between tests:** B2B re-enrollment is blocked if a fulfilled order or active enrollment already exists for the run. Reset between attempts:
> ```python
> from courses.models import CourseRunEnrollment, ProgramEnrollment
> from ecommerce.models import Order, Line
> from django.contrib.auth import get_user_model
> u = get_user_model().objects.get(email="<your-email>")
> CourseRunEnrollment.objects.filter(user=u, run__courseware_id="<course-run-id>").delete()
> ProgramEnrollment.objects.filter(user=u, program__readable_id="<program-id>").delete()
> for l in Line.objects.filter(order__purchaser=u, purchased_object_id=<run-id>, purchased_content_type__model="courserun"):
>     order = l.order; l.delete(); order.delete()
> ```> from courses.models import CourseRunEnrollment, ProgramEnrollment
> from ecommerce.models import Order, Line
> from django.contrib.auth import get_user_model
> u = get_user_model().objects.get(email="<your-email>")
> CourseRunEnrollment.objects.filter(user=u, run__courseware_id="<course-run-id>").delete()
> ProgramEnrollment.objects.filter(user=u, program__readable_id="<program-id>").delete()
> for l in Line.objects.filter(order__purchaser=u, purchased_object_id=<run-id>, purchased_content_type__model="courserun"):
>     order = l.order; l.delete(); order.delete()
> ```

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
