### PR TITLE
Fix error pages after swap to runtime env vars

### DIFF
--- a/frontends/main/src/app/(site)/page.tsx
+++ b/frontends/main/src/app/(site)/page.tsx
@@ -28,10 +28,6 @@ export async function generateMetadata({
 const Page: React.FC<PageProps<"/">> = async () => {
   const queryClient = getQueryClient()
 
-  if (process.env.PAGE_ERROR === "true") {
-    throw new Error("This is a test error on home page.")
-  }
-
   await Promise.all([
     // Featured Courses carousel "All"
     queryClient.prefetchQuery(

--- a/frontends/main/src/app/(site)/page.tsx
+++ b/frontends/main/src/app/(site)/page.tsx
@@ -28,6 +28,10 @@ export async function generateMetadata({
 const Page: React.FC<PageProps<"/">> = async () => {
   const queryClient = getQueryClient()
 
+  if (process.env.PAGE_ERROR === "true") {
+    throw new Error("This is a test error on home page.")
+  }
+
   await Promise.all([
     // Featured Courses carousel "All"
     queryClient.prefetchQuery(

--- a/frontends/main/src/app/components/PublicEnvScript.tsx
+++ b/frontends/main/src/app/components/PublicEnvScript.tsx
@@ -18,19 +18,16 @@
  */
 import React from "react"
 import { connection } from "next/server"
+import { publicEnvObject } from "@/env"
 
 export async function PublicEnvScript() {
   // `connection()` opts this route out of static prerendering so that
   // process.env is read fresh on every request (not baked at build time).
   await connection()
 
-  const publicEnv = Object.fromEntries(
-    Object.entries(process.env).filter(([k]) => k.startsWith("NEXT_PUBLIC_")),
-  )
-
   // Escape `<` to prevent a value like `</script><script>...` from breaking
   // out of the script tag.
-  const json = JSON.stringify(publicEnv).replace(/</g, "\\u003c")
+  const json = JSON.stringify(publicEnvObject()).replace(/</g, "\\u003c")
 
   return (
     <script dangerouslySetInnerHTML={{ __html: `window.__ENV=${json};` }} />

--- a/frontends/main/src/app/global-error.tsx
+++ b/frontends/main/src/app/global-error.tsx
@@ -8,6 +8,9 @@
  *  - does NOT use root layout (since error occurred there!)
  *  - therefore, must define its own HTML tags and providers
  *    Must define its own HTML tag
+ *  - root layout metadata still emits here, so the x-public-env <meta> and env()
+ *    usually work (also how Sentry inits) — but prefer env() over requiredEnv()
+ *    in this subtree; there's no boundary below to catch a throw.
  *  - NOT used in development mode
  *
  * https://nextjs.org/docs/app/building-your-application/routing/error-handling#handling-errors-in-root-layouts

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -1,17 +1,29 @@
 import React from "react"
 import Providers from "./providers"
 import { PublicEnvScript } from "./components/PublicEnvScript"
-import { env } from "@/env"
+import { env, publicEnvObject } from "@/env"
 
 import "./GlobalStyles"
+import { Metadata } from "next"
 
 const NEXT_PUBLIC_ORIGIN = env("NEXT_PUBLIC_ORIGIN")
 
 /**
- * As part of the root layout, this metadata object is site-wide defaults
+ * Site-wide metadata defaults plus an x-public-env meta tag carrying all
+ * NEXT_PUBLIC_* values as JSON. NOTES:
+ *  1. This delivery mechanism for NEXT_PUBLIC_* facilitates runtime env vars (not buildtime)
+ *  2. Delivery via metadata works even when errors are thrown server-side,
+ *     in which case React SSR is aborted and rendering falls back to a client-side render
+ *  3. Available to synchronous scripts below <meta x-public-env> or async scripts
+ *     above it, as long as this tag is delivered in the same HTML chunk as the async
+ *     scripts above it. (In practice, this is true for metadata + HTML content
+ *     down to the first suspense boundary.)
  */
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: NEXT_PUBLIC_ORIGIN ? new URL(NEXT_PUBLIC_ORIGIN) : null,
+  // raw JSON is fine: the attribute is HTML-escaped when rendered and
+  // getAttribute() returns it decoded, so JSON.parse round-trips.
+  other: { "x-public-env": JSON.stringify(publicEnvObject()) },
 }
 
 /**

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -41,6 +41,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  if (process.env.GLOBAL_ERROR === "true") {
+    throw new Error("This is a test error on root layout")
+  }
   return (
     <html lang="en">
       <head>

--- a/frontends/main/src/app/layout.tsx
+++ b/frontends/main/src/app/layout.tsx
@@ -41,9 +41,6 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  if (process.env.GLOBAL_ERROR === "true") {
-    throw new Error("This is a test error on root layout")
-  }
   return (
     <html lang="en">
       <head>

--- a/frontends/main/src/env.test.ts
+++ b/frontends/main/src/env.test.ts
@@ -1,8 +1,60 @@
-import { env, requiredEnv } from "@/env"
+import { env, requiredEnv, fullEnv } from "@/env"
 
 test("env() reads from window.__ENV", () => {
   window.__ENV = { NEXT_PUBLIC_ORIGIN: "https://example.test" }
   expect(env("NEXT_PUBLIC_ORIGIN")).toBe("https://example.test")
+  delete window.__ENV
+})
+
+test("env() falls back to the x-public-env <meta> when window.__ENV is unset", () => {
+  // Error/not-found pages are client-rendered shells where PublicEnvScript never
+  // runs; env() must read the value from the <meta> the root layout emits.
+  const meta = document.createElement("meta")
+  meta.setAttribute("name", "x-public-env")
+  meta.setAttribute(
+    "content",
+    JSON.stringify({ NEXT_PUBLIC_ORIGIN: "https://meta.test" }),
+  )
+  document.head.appendChild(meta)
+
+  expect(env("NEXT_PUBLIC_ORIGIN")).toBe("https://meta.test")
+  // cached so later reads skip the DOM query
+  expect(window.__ENV).toEqual({ NEXT_PUBLIC_ORIGIN: "https://meta.test" })
+
+  meta.remove()
+  delete window.__ENV
+})
+
+test("env() ignores a malformed x-public-env <meta> and does not throw", () => {
+  const meta = document.createElement("meta")
+  meta.setAttribute("name", "x-public-env")
+  meta.setAttribute("content", "{not valid json")
+  document.head.appendChild(meta)
+
+  expect(() => env("NEXT_PUBLIC_ORIGIN")).not.toThrow()
+  expect(window.__ENV).toBeUndefined()
+
+  meta.remove()
+})
+
+test("fullEnv() returns the full map, bootstrapping from the <meta> like env()", () => {
+  const meta = document.createElement("meta")
+  meta.setAttribute("name", "x-public-env")
+  meta.setAttribute(
+    "content",
+    JSON.stringify({
+      NEXT_PUBLIC_ORIGIN: "https://meta.test",
+      NEXT_PUBLIC_FEATURE_demo: "True",
+    }),
+  )
+  document.head.appendChild(meta)
+
+  expect(fullEnv()).toEqual({
+    NEXT_PUBLIC_ORIGIN: "https://meta.test",
+    NEXT_PUBLIC_FEATURE_demo: "True",
+  })
+
+  meta.remove()
   delete window.__ENV
 })
 

--- a/frontends/main/src/env.ts
+++ b/frontends/main/src/env.ts
@@ -45,6 +45,23 @@ type RequiredPublicEnvVar = Extract<
   `NEXT_PUBLIC_${string}`
 >
 
+// Populate window.__ENV from the x-public-env <meta> on first read. Error/
+// not-found pages are a client-rendered shell where PublicEnvScript never runs,
+// so window.__ENV is otherwise unset there. Shared by env() and fullEnv().
+const bootstrapClientEnv = (): void => {
+  if (window.__ENV) return
+  const content = document
+    .querySelector('meta[name="x-public-env"]')
+    ?.getAttribute("content")
+  if (content) {
+    try {
+      window.__ENV = JSON.parse(content)
+    } catch {
+      /* malformed; leave unset and fall through to process.env */
+    }
+  }
+}
+
 /**
  * Get the value of an environment variable at runtime.
  * NOTES:
@@ -54,12 +71,11 @@ type RequiredPublicEnvVar = Extract<
  */
 export const env = (key: PublicEnvVar): string | undefined => {
   if (typeof window !== "undefined") {
-    // Browser: read from server-injected window.__ENV. Fall back to process.env
-    // only when a `process` global actually exists (jsdom/test environments that
-    // set process.env directly). Webpack provides no `process` global for
-    // dynamic `process.env[key]` access, so an unguarded read would throw
-    // `ReferenceError: process is not defined` for any key absent from __ENV
-    // (e.g. an optional NEXT_PUBLIC_* var unset in the pod).
+    bootstrapClientEnv()
+    // Fall back to process.env only when a `process` global exists (jsdom/test
+    // environments that set it directly). Webpack provides no `process` global,
+    // so an unguarded read would throw ReferenceError for any key absent from
+    // __ENV (e.g. an optional NEXT_PUBLIC_* var unset in the pod).
     return (
       window.__ENV?.[key] ??
       (typeof process !== "undefined" ? process.env[key] : undefined)
@@ -68,6 +84,19 @@ export const env = (key: PublicEnvVar): string | undefined => {
   // Server: dynamic bracket access is NOT replaced by DefinePlugin, so this
   // reads the actual Kubernetes env var at request time.
   return process.env[key]
+}
+
+/**
+ * The full { NEXT_PUBLIC_*: value } map (vs env()'s single key). Uses the same
+ * client bootstrap as env() — window.__ENV, populated from the x-public-env
+ * <meta> if needed; on the server reads process.env.
+ */
+export const fullEnv = (): Record<string, string | undefined> => {
+  if (typeof window !== "undefined") {
+    bootstrapClientEnv()
+    return window.__ENV ?? {}
+  }
+  return publicEnvObject()
 }
 
 /**
@@ -82,3 +111,12 @@ export const requiredEnv = (key: RequiredPublicEnvVar): string => {
   invariant(value, `${key} must be defined`)
   return value
 }
+
+/**
+ * Server-side { NEXT_PUBLIC_*: value } map from process.env. Shared by
+ * PublicEnvScript and the x-public-env <meta> so the two can't drift.
+ */
+export const publicEnvObject = (): Record<string, string | undefined> =>
+  Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => k.startsWith("NEXT_PUBLIC_")),
+  )

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -3,22 +3,20 @@ import posthog from "posthog-js"
 import { PostHogProvider, usePostHog } from "posthog-js/react"
 import { useUserMe } from "api/hooks/user"
 import { INTERNAL_BOOTSTRAPPING_FLAG } from "@/common/feature_flags"
-import { env } from "@/env"
+import { env, fullEnv } from "@/env"
 
 /**
- * Compute PostHog bootstrap feature flags from window.__ENV at runtime.
- * Previously this was computed at build time from process.env in next.config.js
- * (as FEATURE_FLAGS), but that approach bakes empty values when the Docker
- * image is built in CI without per-environment values. Reading from
- * window.__ENV gives the correct per-env flags injected by PublicEnvScript.
+ * Compute PostHog bootstrap feature flags from the runtime env (fullEnv()).
+ * Previously computed at build time from process.env in next.config.js, which
+ * bakes empty values when the image is built in CI without per-env values.
  */
 const getBootstrapFeatureFlags = (): Record<
   string,
   boolean | string
 > | null => {
   if (typeof window === "undefined") return null
-  const envSource = window.__ENV ?? {}
-  const prefix = envSource["NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX"] ?? "FEATURE_"
+  const prefix = env("NEXT_PUBLIC_POSTHOG_FEATURE_PREFIX") ?? "FEATURE_"
+  const envSource = fullEnv()
   const fullPrefix = `NEXT_PUBLIC_${prefix}`
   const flags: Record<string, boolean | string> = {}
 


### PR DESCRIPTION
### What are the relevant tickets?

- Closes https://github.com/mitodl/hq/issues/11679

### Description (What does it do?)
This PR changes how we provide env variables on the frontend. Originally, we baked env variables into the NextJS assets at build time (the usual approach). Following https://github.com/mitodl/mit-learn/pull/3364, we switched to runtime env vars. The mechanism for runtime env vars was:
1. Runtime env vars are always available on server—normal NextJS behavior.
2. By NextJS SSR, the root `layout.tsx` render function included a `<script>window.__ENV= { /* env values*/ }` script into document head.
3. The build-time static assets included a `env(...)` helper that read from the SSR-injected script tag's window assignment.

This works well for normal NextJS pages. Cool.

**However:** It did not work for many error pages. When an error is thrown server-side (unintentionally, or intentionally via `notFound()`):
1. NextJS starts server-rendering  HTML from render functions (like `layout.tsx`) before error
2. The error is thrown
3. The server-rendered HTML is thrown away, the error page renders client side

That resulted in the server-rendered `<script>window.__ENV={...}</script>` tag being thrown away. (The env vars are still encoded in the HTML , but not as a regular script tag, and not as a way that is available to the static assets on load: they're included as a RSC payload that you can see [here](https://gist.github.com/ChristopherChudzicki/398da195b2a8458e2dd5f788e864a112#file-response-does-not-exist-2026-06-09-L1047).)

**What this does:** This PR moves the env var delivery mechanism out of a layout function and into a `<meta name="x-public-env" value="env values here">` tag.

This is included whether the NextJS server responds 200 or whether an error is thrown during request handling.

### How to test this
I recommend you test this using a production build.

1. To orient yourself, visit `courses/does-not-exist` on production or on `main`. The page is blank. Uh-oh.
2. `git checkout cc/runtime-env-on-error-pages~1` t checkout the penultimate commit on this branch. This commit includes some debugging code to help you throw server errors at runtime. (The final commit just removes that code.)
3.  Build the docker image: `docker build -f frontends/main/Dockerfile.web --target runner -t mit-learn-nextjs:test .`
4. Then run the docker image, see script below. First with `PAGE_ERROR` and `GLOBAL_ERROR` env vars false.
    - View server-rendered HTML in network tab. You should see a `<meta x-public-env>` tag.
    - Page should load, everything should work.
5. Visit `courses/does-not-exist`. You should get the regular 404 page and the header should correctly reflect whether you are logged in or not. If you're logged out, the login link should be correct.
6. Restart container with `PAGE_ERROR=true`. This will make the homepage return a 500. You should see the correct error page, `window.__ENV` should be defined, and the header should correctly reflect your auth status.
7. Restart the container with `GLOBAL_ERROR=true`. This emulates an error in our root layout (extremely rare), so you won't see a header/footer (those come from root layout). But it should render, and you should see `window.__ENV` defined.

Running the container (set `PAGE_ERROR` and `GLOBAL_ERROR` as desired) ... Will need to replace `$NEXT_PUBLIC_ORIGIN` if they aren't in your host env
```sh
# Then run with your local env vars:
echo 'docker run --rm --name mln-test -p 8062:3000 \
    --add-host=api.open.odl.local:host-gateway \
    -e NEXT_PUBLIC_ORIGIN=$NEXT_PUBLIC_ORIGIN \
    -e NEXT_PUBLIC_MITOL_API_BASE_URL=$NEXT_PUBLIC_MITOL_API_BASE_URL \
    -e NEXT_PUBLIC_SITE_NAME=$NEXT_PUBLIC_SITE_NAME \
    -e NEXT_PUBLIC_MITOL_SUPPORT_EMAIL=$NEXT_PUBLIC_MITOL_SUPPORT_EMAIL \
    -e NEXT_PUBLIC_CSRF_COOKIE_NAME=$NEXT_PUBLIC_CSRF_COOKIE_NAME \
    -e NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL=$NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL \
    -e NEXT_PUBLIC_MITX_ONLINE_BASE_URL=https://api.learn.mit.edu/mitxonline \
    -e NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME=$NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME \
    -e NEXT_CACHE_S_MAXAGE_SECONDS=7200 \
    -e NEXT_PUBLIC_POSTHOG_API_KEY=phc_k26arhw0Wafe79ZDBTqeN3v4Y7dzNS7os9naQPxJhr5 \
    -e NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS=$NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS \
    -e PAGE_ERROR=false \
    -e GLOBAL_ERROR=false \
    mit-learn-nextjs:test'
```

