### PR TITLE
add scm as synonym to search

### DIFF
--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -513,4 +513,5 @@ SYNONYMS = [
     "natural language processing, nlp",
     "large language model, llm",
     "micromasters, micro masters",
+    "scm, supply chain management",
 ]


### PR DESCRIPTION
### What are the relevant tickets?
None

People complained that searching for "scm" does not bring up much

### Description (What does it do?)
This pr sets scm as a synonym for supply chain management in learn search

### How can this be tested?
If you don't have the scm program in your local search already run
`docker compose run --rm web python manage.py backpopulate_mitxonline_data`

search for scm
http://open.odl.local:8062/search?q=scm

You will not see the micromasters scm program in the results

Run 
`docker-compose run web ./manage.py recreate_index --programs`


search for scm
http://open.odl.local:8062/search?q=scm again

You should see the micromasters program in the results