### PR TITLE
Route /ai/* through the APISIX gateway to local learn-ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,6 @@ Run [learn-ai](https://github.com/mitodl/learn-ai) locally, then point the Learn
 # MIT Learn, frontend.local.env
 NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
 NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
-NEXT_PUBLIC_LEARN_AI_LOGIN_ENDPOINT=http://open.odl.local:8065/ai/http/login/
 ```
 
 On the learn-ai side, add the Learn gateway origin to its trusted origins so

--- a/README.md
+++ b/README.md
@@ -301,6 +301,35 @@ MITX_ONLINE_COURSES_API_URL=http://mitxonline.odl.local:8013/api/v2/courses/
 MITX_ONLINE_PROGRAMS_API_URL=http://mitxonline.odl.local:8013/api/v2/programs/
 ```
 
+### Connecting with learn-ai
+
+The [learn-ai](https://github.com/mitodl/learn-ai) service (AI recommendation/syllabus
+agents) integrates the same way as MITxOnline: a single shared Keycloak realm, with
+MIT Learn's APISIX acting as the gateway. MIT Learn's APISIX proxies `/ai/*` to the
+local learn-ai service, performing the Keycloak login and forwarding the user identity,
+so a user logged into Learn is automatically authenticated in learn-ai.
+
+> [!TIP]
+> Log in via the Learn frontend. The shared APISIX session is reused for `/ai/*`, so
+> learn-ai sees your user without a separate login.
+
+Run [learn-ai](https://github.com/mitodl/learn-ai) locally, then point the Learn frontend at the gateway path:
+
+```env
+# MIT Learn, frontend.local.env
+NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
+NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
+NEXT_PUBLIC_LEARN_AI_LOGIN_ENDPOINT=http://open.odl.local:8065/ai/http/login/
+```
+
+On the learn-ai side, add the Learn gateway origin to its trusted origins so
+CSRF-protected requests routed through the gateway are accepted:
+
+```env
+# learn-ai, env/backend.env (add http://open.odl.local:8065 to the existing list)
+CSRF_TRUSTED_ORIGINS=["http://open.odl.local:8062", "http://open.odl.local:8065", ...]
+```
+
 ## GitHub Pages Storybook
 
 Demos and documentation of reusable UI components in this repo are published as a [storybook](https://storybook.js.org/) at https://mitodl.github.io/mit-learn/.

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -216,6 +216,7 @@ routes:
           - "^/ai/(.*)"
           - "/$1"
     uris:
+      - "/ai/http/login"
       - "/ai/http/login/"
       - "/ai/admin/login/*"
     hosts:

--- a/config/apisix/apisix.yaml
+++ b/config/apisix/apisix.yaml
@@ -7,6 +7,10 @@ upstreams:
     nodes:
       "${{MITX_ONLINE_UPSTREAM}}": 1
     type: roundrobin
+  - id: 3
+    nodes:
+      "${{AI_UPSTREAM}}": 1
+    type: roundrobin
 
 routes:
   - id: 1
@@ -136,4 +140,84 @@ routes:
     uri: "/mitxonline/*"
     hosts:
       - ${{MITOL_API_DOMAIN}}
+  - id: 5
+    name: "learn-ai-passauth"
+    desc: "Proxy /ai/* to learn-ai, includes user data if any."
+    priority: 20
+    upstream_id: 3
+    plugins:
+      openid-connect:
+        client_id: ${{KEYCLOAK_CLIENT_ID}}
+        client_secret: ${{KEYCLOAK_CLIENT_SECRET}}
+        discovery: ${{KEYCLOAK_DISCOVERY_URL}}
+        realm: ${{KEYCLOAK_REALM_NAME}}
+        scope: ${{KEYCLOAK_SCOPES}}
+        bearer_only: false
+        introspection_endpoint_auth_method: "client_secret_post"
+        ssl_verify: false
+        session:
+          secret: ${{APISIX_SESSION_SECRET_KEY}}
+          cookie:
+            lifetime: 1209600
+            domain: ${{CSRF_COOKIE_DOMAIN}}
+        logout_path: "/logout/oidc"
+        post_logout_redirect_uri: ${{APISIX_LOGOUT_URL}}
+        unauth_action: "pass"
+      cors:
+        allow_origins: "**"
+        allow_methods: "**"
+        allow_headers: "**"
+        allow_credential: true
+      response-rewrite:
+        headers:
+          set:
+            Referrer-Policy: "origin"
+      proxy-rewrite:
+        regex_uri:
+          - "^/ai/(.*)"
+          - "/$1"
+    uri: "/ai/*"
+    hosts:
+      - open.odl.local
+  - id: 6
+    name: "learn-ai-reqauth"
+    desc: "learn-ai routes that require authentication."
+    priority: 30
+    upstream_id: 3
+    plugins:
+      openid-connect:
+        client_id: ${{KEYCLOAK_CLIENT_ID}}
+        client_secret: ${{KEYCLOAK_CLIENT_SECRET}}
+        discovery: ${{KEYCLOAK_DISCOVERY_URL}}
+        realm: ${{KEYCLOAK_REALM_NAME}}
+        scope: ${{KEYCLOAK_SCOPES}}
+        bearer_only: false
+        introspection_endpoint_auth_method: "client_secret_post"
+        ssl_verify: false
+        session:
+          secret: ${{APISIX_SESSION_SECRET_KEY}}
+          cookie:
+            lifetime: 1209600
+            domain: ${{CSRF_COOKIE_DOMAIN}}
+        logout_path: "/logout/oidc"
+        post_logout_redirect_uri: ${{APISIX_LOGOUT_URL}}
+        unauth_action: "auth"
+      cors:
+        allow_origins: "**"
+        allow_methods: "**"
+        allow_headers: "**"
+        allow_credential: true
+      response-rewrite:
+        headers:
+          set:
+            Referrer-Policy: "origin"
+      proxy-rewrite:
+        regex_uri:
+          - "^/ai/(.*)"
+          - "/$1"
+    uris:
+      - "/ai/http/login/"
+      - "/ai/admin/login/*"
+    hosts:
+      - open.odl.local
 #END

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -5,6 +5,7 @@ include:
 x-extra-hosts: &default-extra-hosts
   extra_hosts:
     - "mitxonline.odl.local:host-gateway"
+    - "ai.open.odl.local:host-gateway"
 
 services:
   db:
@@ -137,6 +138,7 @@ services:
       - MITOL_API_DOMAIN=${MITOL_API_DOMAIN:-api.open.odl.local}
       - MITX_ONLINE_UPSTREAM=${MITX_ONLINE_UPSTREAM:-mitxonline.odl.local:8013}
       - MITX_ONLINE_DOMAIN=${MITX_ONLINE_DOMAIN:-mitxonline.odl.local}
+      - AI_UPSTREAM=${AI_UPSTREAM:-ai.open.odl.local:8002}
       - NGINX_PORT=${NGINX_PORT:-8062}
     ports:
       - ${APISIX_PORT}:${APISIX_PORT}

--- a/env/frontend.local.example.env
+++ b/env/frontend.local.example.env
@@ -11,4 +11,3 @@ NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=""
 # in the README. Requires learn-ai running locally.
 # NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
 # NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
-# NEXT_PUBLIC_LEARN_AI_LOGIN_ENDPOINT=http://open.odl.local:8065/ai/http/login/

--- a/env/frontend.local.example.env
+++ b/env/frontend.local.example.env
@@ -5,3 +5,10 @@ NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=""
 # GTM_AUTH=
 # GTM_PREVIEW=
 # GTM_COOKIES_WIN=
+
+# learn-ai integration: route the AI agents through MIT Learn's APISIX gateway
+# (/ai/* is proxied to the local learn-ai service). See "Connecting with learn-ai"
+# in the README. Requires learn-ai running locally.
+# NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
+# NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
+# NEXT_PUBLIC_LEARN_AI_LOGIN_ENDPOINT=http://open.odl.local:8065/ai/http/login/


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#11716

### Description (What does it do?)

Mirrors the existing MITxOnline local-integration pattern for `learn-ai`. MIT Learn's APISIX gateway now proxies `http://open.odl.local:8065/ai/*` to the local learn-ai service, performing the Keycloak/openid-connect auth itself and forwarding the user identity (`X-Userinfo`). As a result, a user logged into MIT Learn is automatically authenticated in learn-ai through a single shared session.


Changes:

- **`config/apisix/apisix.yaml`** — add a learn-ai upstream (id 3) and two routes: a `/ai/*` pass-auth route that strips the `/ai` prefix and injects `X-Userinfo`, and an auth-required `/ai/http/login` route (mirrors the `mitxonline-api` route).
- **`docker-compose.services.yml`** — add `ai.open.odl.local` to the gateway `extra_hosts` and pass `AI_UPSTREAM` (defaults to learn-ai's nginx on `:8002`).
- **`README.md` / `env/frontend.local.example.env`** — document the integration: the gateway-path `NEXT_PUBLIC_LEARN_AI_*` endpoints and the learn-ai-side `CSRF_TRUSTED_ORIGINS` addition.

This is local-development plumbing only; production already routes AI under `/ai/`. A matching one-line `CSRF_TRUSTED_ORIGINS` change is needed in the learn-ai repo (documented in the README).

### How can this be tested?

With both stacks running locally (and learn-ai branch set to ):

#### learn-ai
- Switch to the `mb/apisix_improvements` branch of learn-ai and start containers for it.

#### mit-learn
- Populate POSTHOG env values so that AskTIM will be enabled locally (in `shared.local.env`)
- Assign the NEXT_PUBLIC_LEARN_AI_* values to your `frontend.local.env` file as suggested in the modified example file.
- Start containers
- Log in to mit-learn
- Click "AskTIM" from the home page
- Ask a question and wait for a response, you should get one
- Check your cookies, you should now have a populated auth cookie for the recommendation bot

### Additional Context

The `/ai/*` routes reuse the existing `openid-connect` plugin config from the other routes (same session secret and `.odl.local` cookie domain), which is what lets the MIT Learn login session carry over. The `ssl_verify: false` / `cors: **` values are copied verbatim from the existing local-dev routes in this file and are not new.