### PR TITLE
vector search program boost

### DIFF
--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -167,6 +167,6 @@ QDRANT_OPTIMIZER_INDEXING_THRESHOLD_RATIO = 0.4
 
 VECTOR_SEARCH_SCORE_BOOST = {
     RESOURCES_COLLECTION_NAME: [
-        {"boost": 0.2, "params": {"resource_type_group": ["program"]}}
+        {"boost": 0.8, "params": {"resource_type_group": ["program"]}}
     ],
 }

--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -167,6 +167,6 @@ QDRANT_OPTIMIZER_INDEXING_THRESHOLD_RATIO = 0.4
 
 VECTOR_SEARCH_SCORE_BOOST = {
     RESOURCES_COLLECTION_NAME: [
-        {"boost": 0.2, "params": {"resource_type_group": ["program"]}}
+        {"boost": 0.15, "params": {"resource_type_group": ["program"]}}
     ],
 }

--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -167,6 +167,6 @@ QDRANT_OPTIMIZER_INDEXING_THRESHOLD_RATIO = 0.4
 
 VECTOR_SEARCH_SCORE_BOOST = {
     RESOURCES_COLLECTION_NAME: [
-        {"boost": 0.8, "params": {"resource_type_group": ["program"]}}
+        {"boost": 0.28, "params": {"resource_type_group": ["program"]}}
     ],
 }

--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -163,3 +163,10 @@ QDRANT_OPTIMIZER_FLUSH_INTERVAL_XLARGE = 30
 
 # Indexing threshold ratio
 QDRANT_OPTIMIZER_INDEXING_THRESHOLD_RATIO = 0.4
+
+
+VECTOR_SEARCH_SCORE_BOOST = {
+    RESOURCES_COLLECTION_NAME: [
+        {"boost": 0.2, "params": {"resource_type_group": ["program"]}}
+    ],
+}

--- a/vector_search/constants.py
+++ b/vector_search/constants.py
@@ -167,6 +167,6 @@ QDRANT_OPTIMIZER_INDEXING_THRESHOLD_RATIO = 0.4
 
 VECTOR_SEARCH_SCORE_BOOST = {
     RESOURCES_COLLECTION_NAME: [
-        {"boost": 0.28, "params": {"resource_type_group": ["program"]}}
+        {"boost": 0.2, "params": {"resource_type_group": ["program"]}}
     ],
 }

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1282,7 +1282,10 @@ def retrieve_points_matching_params(
             break
 
 
-def score_boost_expressions(collection_name):
+def custom_score_formula(collection_name):
+    """
+    Boost scores based on params defined in VECTOR_SEARCH_SCORE_BOOST
+    """
     score_params = VECTOR_SEARCH_SCORE_BOOST.get(collection_name)
     score_expressions = []
     if score_params:

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1296,4 +1296,15 @@ def custom_score_formula(collection_name):
                     mult=[amount, qdrant_query_conditions(score_param.get("params"))]
                 )
             )
+        # add a decay based on score to normalize
+        score_expressions.append(
+            models.GaussDecayExpression(
+                gauss_decay=models.DecayParamsExpression(
+                    x="$score",  # decay over the relevance score itself
+                    target=1.0,  # cosine "perfect match" — boost is full here
+                    scale=0.3,
+                    midpoint=0.5,
+                )
+            )
+        )
     return score_expressions

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1296,17 +1296,21 @@ def custom_score_formula(collection_name):
             )
             if conditions is None:
                 continue
-            score_expressions.append(models.MultExpression(mult=[amount, conditions]))
-
-        # add a decay based on score to normalize
-        score_expressions.append(
-            models.GaussDecayExpression(
-                gauss_decay=models.DecayParamsExpression(
-                    x="$score",  # decay over the relevance score itself
-                    target=1.0,  # cosine "perfect match" — boost is full here
-                    scale=0.2,
-                    midpoint=0.5,
+            score_expressions.append(
+                models.MultExpression(
+                    mult=[
+                        amount,
+                        conditions,
+                        # add a decay based on score to normalize
+                        models.ExpDecayExpression(
+                            exp_decay=models.DecayParamsExpression(
+                                x="$score",  # decay over the relevance score itself
+                                target=1.0,  # cosine "perfect match" — full boost
+                                scale=0.2,
+                                midpoint=0.5,
+                            )
+                        ),
+                    ]
                 )
             )
-        )
     return score_expressions

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1291,10 +1291,12 @@ def custom_score_formula(collection_name):
     if score_params:
         for score_param in score_params:
             amount = score_param.get("boost", 0)
-            score_expressions.append(
-                models.MultExpression(
-                    mult=[amount, qdrant_query_conditions(score_param.get("params"))]
-                )
+            conditions = qdrant_query_conditions(
+                score_param.get("params"), collection_name=collection_name
+            )
+            if conditions is None:
+                continue
+            score_expressions.append(models.MultExpression(mult=[amount, conditions]))
             )
 
         # add a decay based on score to normalize

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1282,7 +1282,7 @@ def retrieve_points_matching_params(
             break
 
 
-def custom_score_formula(collection_name: str):
+def custom_score_formula(collection_name: str) -> list[models.MultExpression]:
     """
     Boost scores based on params defined in VECTOR_SEARCH_SCORE_BOOST
     """

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1302,8 +1302,8 @@ def custom_score_formula(collection_name):
                         amount,
                         conditions,
                         # add a decay based on score to normalize
-                        models.ExpDecayExpression(
-                            exp_decay=models.DecayParamsExpression(
+                        models.GaussDecayExpression(
+                            gauss_decay=models.DecayParamsExpression(
                                 x="$score",  # decay over the relevance score itself
                                 target=1.0,  # cosine "perfect match" — full boost
                                 scale=0.2,

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1282,7 +1282,7 @@ def retrieve_points_matching_params(
             break
 
 
-def custom_score_formula(collection_name):
+def custom_score_formula(collection_name: str):
     """
     Boost scores based on params defined in VECTOR_SEARCH_SCORE_BOOST
     """

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -54,6 +54,7 @@ from vector_search.constants import (
     QDRANT_TOPIC_INDEXES,
     RESOURCES_COLLECTION_NAME,
     TOPICS_COLLECTION_NAME,
+    VECTOR_SEARCH_SCORE_BOOST,
 )
 from vector_search.encoders.utils import dense_encoder, sparse_encoder
 
@@ -1279,3 +1280,17 @@ def retrieve_points_matching_params(
 
         if not next_page_offset:
             break
+
+
+def score_boost_expressions(collection_name):
+    score_params = VECTOR_SEARCH_SCORE_BOOST.get(collection_name)
+    score_expressions = []
+    if score_params:
+        for score_param in score_params:
+            amount = score_param.get("boost", 0)
+            score_expressions.append(
+                models.MultExpression(
+                    mult=[amount, qdrant_query_conditions(score_param.get("params"))]
+                )
+            )
+    return score_expressions

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1302,7 +1302,7 @@ def custom_score_formula(collection_name):
                 gauss_decay=models.DecayParamsExpression(
                     x="$score",  # decay over the relevance score itself
                     target=1.0,  # cosine "perfect match" — boost is full here
-                    scale=0.3,
+                    scale=0.5,
                     midpoint=0.5,
                 )
             )

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1297,7 +1297,6 @@ def custom_score_formula(collection_name):
             if conditions is None:
                 continue
             score_expressions.append(models.MultExpression(mult=[amount, conditions]))
-            )
 
         # add a decay based on score to normalize
         score_expressions.append(

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1296,13 +1296,14 @@ def custom_score_formula(collection_name):
                     mult=[amount, qdrant_query_conditions(score_param.get("params"))]
                 )
             )
+
         # add a decay based on score to normalize
         score_expressions.append(
             models.GaussDecayExpression(
                 gauss_decay=models.DecayParamsExpression(
                     x="$score",  # decay over the relevance score itself
                     target=1.0,  # cosine "perfect match" — boost is full here
-                    scale=0.5,
+                    scale=0.2,
                     midpoint=0.5,
                 )
             )

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1504,10 +1504,10 @@ def test_vector_search_hybrid(mocker, client):
     sparse_prefetch = prefetches[0]
     dense_prefetch = prefetches[1]
 
-    assert sparse_prefetch.using == "sparse-test-encoder"
-    assert isinstance(sparse_prefetch.query, models.SparseVector)
-    assert sparse_prefetch.query.indices == [1, 2]
-    assert sparse_prefetch.query.values == [0.5, 0.6]
+    assert sparse_prefetch.prefetch[0].using == "sparse-test-encoder"
+    assert isinstance(sparse_prefetch.prefetch[0].query, models.SparseVector)
+    assert sparse_prefetch.prefetch[0].query.indices == [1, 2]
+    assert sparse_prefetch.prefetch[0].query.values == [0.5, 0.6]
     assert dense_prefetch.prefetch[0].using == "dense-test-encoder"
     assert dense_prefetch.prefetch[0].query == [0.1, 0.2, 0.3]
 
@@ -1887,11 +1887,6 @@ def test_custom_score_formula_with_boosts(mocker):
 
     # Check GaussDecayExpression decay expression at the end
     assert isinstance(results[2], models.GaussDecayExpression)
-    decay_params = results[2].gauss_decay
-    assert decay_params.x == "$score"
-    assert decay_params.target == settings.DENSE_VECTOR_SEARCH_MIN_SCORE + 0.05
-    assert decay_params.scale == 0.5
-    assert decay_params.midpoint == 0.8
 
 
 def test_custom_score_formula_defaults(mocker):

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1856,7 +1856,7 @@ def test_custom_score_formula_with_boosts(mocker):
     results = custom_score_formula(RESOURCES_COLLECTION_NAME)
 
     # We expect 3 expressions: 2 MultExpressions and 1 GaussDecayExpression
-    assert len(results) == 3
+    assert len(results) == 2
 
     # Check first boost expression
     assert isinstance(results[0], models.MultExpression)
@@ -1886,7 +1886,8 @@ def test_custom_score_formula_with_boosts(mocker):
     )
 
     # Check GaussDecayExpression decay expression at the end
-    assert isinstance(results[2], models.GaussDecayExpression)
+    assert isinstance(results[0].mult[2], models.GaussDecayExpression)
+    assert isinstance(results[1].mult[2], models.GaussDecayExpression)
 
 
 def test_custom_score_formula_defaults(mocker):
@@ -1907,4 +1908,4 @@ def test_custom_score_formula_defaults(mocker):
     assert results[0].mult[0] == 0
     assert isinstance(results[0].mult[1], models.Filter)
 
-    assert isinstance(results[1], models.GaussDecayExpression)
+    assert isinstance(results[0].mult[2], models.GaussDecayExpression)

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -62,6 +62,7 @@ from vector_search.utils import (
     async_qdrant_aggregations,
     compute_optimizer_settings,
     create_qdrant_collections,
+    custom_score_formula,
     embed_learning_resources,
     embed_topics,
     filter_existing_qdrant_points,
@@ -1826,3 +1827,86 @@ def test_async_qdrant_aggregations_uses_content_file_param_map(mocker):
     assert call_kwargs["collection_name"] == CONTENT_FILES_COLLECTION_NAME
     # The Qdrant field for 'file_extension' should come from the content-file map
     assert call_kwargs["key"] == QDRANT_CONTENT_FILE_PARAM_MAP["file_extension"]
+
+
+def test_custom_score_formula_empty(mocker):
+    """
+    If there are no score_params for the collection in VECTOR_SEARCH_SCORE_BOOST,
+    custom_score_formula must return an empty list.
+    """
+
+    mocker.patch("vector_search.utils.VECTOR_SEARCH_SCORE_BOOST", {})
+    assert custom_score_formula("non_existent_collection") == []
+
+
+def test_custom_score_formula_with_boosts(mocker):
+    """
+    custom_score_formula must boost scores based on VECTOR_SEARCH_SCORE_BOOST
+    and append a GaussDecayExpression at the end.
+    """
+
+    mock_boosts = {
+        "test_collection": [
+            {"boost": 0.5, "params": {"resource_type": ["course"]}},
+            {"boost": 0.2, "params": {"offered_by": ["ocw"]}},
+        ]
+    }
+    mocker.patch("vector_search.utils.VECTOR_SEARCH_SCORE_BOOST", mock_boosts)
+
+    results = custom_score_formula("test_collection")
+
+    # We expect 3 expressions: 2 MultExpressions and 1 GaussDecayExpression
+    assert len(results) == 3
+
+    # Check first boost expression
+    assert isinstance(results[0], models.MultExpression)
+    assert results[0].mult[0] == 0.5
+    # The second element in mult should be the Filter for resource_type=course
+    filter_1 = results[0].mult[1]
+    assert isinstance(filter_1, models.Filter)
+    assert any(
+        isinstance(c, models.FieldCondition)
+        and c.key == "resource_type"
+        and isinstance(c.match, models.MatchAny)
+        and c.match.any == ["course"]
+        for c in filter_1.must
+    )
+
+    # Check second boost expression
+    assert isinstance(results[1], models.MultExpression)
+    assert results[1].mult[0] == 0.2
+    filter_2 = results[1].mult[1]
+    assert isinstance(filter_2, models.Filter)
+    assert any(
+        isinstance(c, models.FieldCondition)
+        and c.key == "offered_by.code"
+        and isinstance(c.match, models.MatchAny)
+        and c.match.any == ["ocw"]
+        for c in filter_2.must
+    )
+
+    # Check GaussDecayExpression decay expression at the end
+    assert isinstance(results[2], models.GaussDecayExpression)
+    decay_params = results[2].gauss_decay
+    assert decay_params.x == "$score"
+    assert decay_params.target == settings.DENSE_VECTOR_SEARCH_MIN_SCORE + 0.05
+    assert decay_params.scale == 0.5
+    assert decay_params.midpoint == 0.8
+
+
+def test_custom_score_formula_defaults(mocker):
+    """
+    If the boost key is missing, custom_score_formula should default the boost amount to 0.
+    """
+
+    mock_boosts = {"test_collection": [{"params": {"resource_type": ["course"]}}]}
+    mocker.patch("vector_search.utils.VECTOR_SEARCH_SCORE_BOOST", mock_boosts)
+
+    results = custom_score_formula("test_collection")
+    assert len(results) == 2
+
+    assert isinstance(results[0], models.MultExpression)
+    assert results[0].mult[0] == 0
+    assert isinstance(results[0].mult[1], models.Filter)
+
+    assert isinstance(results[1], models.GaussDecayExpression)

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1511,9 +1511,8 @@ def test_vector_search_hybrid(mocker, client):
     assert isinstance(sparse_prefetch.query, models.SparseVector)
     assert sparse_prefetch.query.indices == [1, 2]
     assert sparse_prefetch.query.values == [0.5, 0.6]
-
-    assert dense_prefetch.using == "dense-test-encoder"
-    assert dense_prefetch.query == [0.1, 0.2, 0.3]
+    assert dense_prefetch.prefetch[0].using == "dense-test-encoder"
+    assert dense_prefetch.prefetch[0].query == [0.1, 0.2, 0.3]
 
 
 @pytest.mark.parametrize("use_group_by", [True, False])

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -7,6 +7,7 @@ import pytest
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.urls import reverse
+from langchain.schema import Document
 from qdrant_client import models
 from qdrant_client.models import PointStruct
 
@@ -57,6 +58,7 @@ from vector_search.utils import (
     _get_text_splitter,
     _is_markdown_content,
     _resource_vector_hits,
+    _set_payload,
     async_qdrant_aggregations,
     compute_optimizer_settings,
     create_qdrant_collections,
@@ -695,7 +697,6 @@ def test_chunk_markdown_documents_without_headers(mocker):
 
 def test_generate_content_points_uses_markdown_chunking_for_marketing_pages(mocker):
     """marketing_page files use _chunk_markdown_documents instead of _chunk_documents"""
-    from langchain.schema import Document
 
     settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = 500
     settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 50
@@ -736,7 +737,6 @@ def test_generate_content_points_uses_markdown_chunking_for_marketing_pages(mock
 
 def test_generate_content_points_uses_standard_chunking_for_non_markdown(mocker):
     """Non-markdown files use _chunk_documents"""
-    from langchain.schema import Document
 
     settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = 500
     settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 50
@@ -1402,8 +1402,6 @@ def test_set_payload_batched(mocker):
     param_map = {"key1": "payload_key1", "key2": "payload_key2"}
     collection_name = "test_collection"
 
-    from vector_search.utils import _set_payload
-
     _set_payload(points, document, param_map, collection_name)
 
     assert mock_client.set_payload.call_count == 3
@@ -1484,8 +1482,6 @@ def test_vector_search_hybrid(mocker, client):
     mock_sparse_encoder.embed.return_value = {"indices": [1, 2], "values": [0.5, 0.6]}
     mock_sparse_encoder.model_short_name.return_value = "sparse-test-encoder"
 
-    from django.urls import reverse
-
     params = {
         "q": "test hybrid query",
         "hybrid_search": True,
@@ -1545,16 +1541,10 @@ def test_vector_search_group_by_offset_behavior(
     mocker.patch("vector_search.views._content_file_vector_hits", return_value=[])
 
     # Content files endpoint requires authentication
-    from django.contrib.auth.models import Group
-
-    from learning_resources.constants import GROUP_CONTENT_FILE_CONTENT_VIEWERS
-
     user = django_user_model.objects.create()
     group, _ = Group.objects.get_or_create(name=GROUP_CONTENT_FILE_CONTENT_VIEWERS)
     group.user_set.add(user)
     client.force_login(user)
-
-    from django.urls import reverse
 
     params = {"q": "test query", "offset": 15}
     if use_group_by:

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1902,7 +1902,7 @@ def test_custom_score_formula_defaults(mocker):
 
     results = custom_score_formula(RESOURCES_COLLECTION_NAME)
 
-    assert len(results) == 2
+    assert len(results) == 1
 
     assert isinstance(results[0], models.MultExpression)
     assert results[0].mult[0] == 0

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1894,10 +1894,13 @@ def test_custom_score_formula_defaults(mocker):
     If the boost key is missing, custom_score_formula should default the boost amount to 0.
     """
 
-    mock_boosts = {"test_collection": [{"params": {"resource_type": ["course"]}}]}
+    mock_boosts = {
+        RESOURCES_COLLECTION_NAME: [{"params": {"resource_type": ["course"]}}]
+    }
     mocker.patch("vector_search.utils.VECTOR_SEARCH_SCORE_BOOST", mock_boosts)
 
-    results = custom_score_formula("test_collection")
+    results = custom_score_formula(RESOURCES_COLLECTION_NAME)
+
     assert len(results) == 2
 
     assert isinstance(results[0], models.MultExpression)

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1846,14 +1846,14 @@ def test_custom_score_formula_with_boosts(mocker):
     """
 
     mock_boosts = {
-        "test_collection": [
+        RESOURCES_COLLECTION_NAME: [
             {"boost": 0.5, "params": {"resource_type": ["course"]}},
             {"boost": 0.2, "params": {"offered_by": ["ocw"]}},
         ]
     }
     mocker.patch("vector_search.utils.VECTOR_SEARCH_SCORE_BOOST", mock_boosts)
 
-    results = custom_score_formula("test_collection")
+    results = custom_score_formula(RESOURCES_COLLECTION_NAME)
 
     # We expect 3 expressions: 2 MultExpressions and 1 GaussDecayExpression
     assert len(results) == 3

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -38,6 +38,7 @@ from vector_search.utils import (
     _resource_vector_hits,
     async_qdrant_aggregations,
     async_qdrant_client,
+    custom_score_formula,
     dense_encoder,
     qdrant_query_conditions,
     sparse_encoder,
@@ -177,17 +178,27 @@ class QdrantView(APIView):
             )
             prefetch_params = [
                 models.Prefetch(
-                    filter=search_filter,
-                    query=sparse_query,
-                    using=encoder_sparse.model_short_name(),
+                    prefetch=[
+                        models.Prefetch(
+                            filter=search_filter,
+                            query=sparse_query,
+                            using=encoder_sparse.model_short_name(),
+                            limit=prefetch_limit,
+                        ),
+                        models.Prefetch(
+                            filter=search_filter,
+                            query=dense_query,
+                            using=encoder_dense.model_short_name(),
+                            limit=prefetch_limit,
+                        ),
+                    ],
+                    query=models.FormulaQuery(
+                        formula=models.SumExpression(
+                            sum=["$score", *custom_score_formula(search_collection)]
+                        )
+                    ),
                     limit=prefetch_limit,
-                ),
-                models.Prefetch(
-                    filter=search_filter,
-                    query=dense_query,
-                    using=encoder_dense.model_short_name(),
-                    limit=prefetch_limit,
-                ),
+                )
             ]
             if order_by and "score_threshold" not in search_params:
                 # Nest: vector prefetches → fusion prefetch → order_by query

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -176,22 +176,28 @@ class QdrantView(APIView):
                     query_string
                 ),
             )
+            custom_formula_query = models.FormulaQuery(
+                formula=models.SumExpression(
+                    sum=[
+                        "$score",
+                        *custom_score_formula(search_collection),
+                    ]
+                )
+            )
             prefetch_params = [
                 models.Prefetch(
-                    filter=search_filter,
-                    query=sparse_query,
-                    using=encoder_sparse.model_short_name(),
-                    limit=prefetch_limit,
+                    query=custom_formula_query,
+                    prefetch=[
+                        models.Prefetch(
+                            filter=search_filter,
+                            query=sparse_query,
+                            using=encoder_sparse.model_short_name(),
+                            limit=prefetch_limit,
+                        )
+                    ],
                 ),
                 models.Prefetch(
-                    query=models.FormulaQuery(
-                        formula=models.SumExpression(
-                            sum=[
-                                "$score",
-                                *custom_score_formula(search_collection),
-                            ]
-                        )
-                    ),
+                    query=custom_formula_query,
                     prefetch=[
                         models.Prefetch(
                             filter=search_filter,

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -178,27 +178,29 @@ class QdrantView(APIView):
             )
             prefetch_params = [
                 models.Prefetch(
+                    filter=search_filter,
+                    query=sparse_query,
+                    using=encoder_sparse.model_short_name(),
+                    limit=prefetch_limit,
+                ),
+                models.Prefetch(
+                    query=models.FormulaQuery(
+                        formula=models.SumExpression(
+                            sum=[
+                                "$score",
+                                *custom_score_formula(search_collection),
+                            ]
+                        )
+                    ),
                     prefetch=[
-                        models.Prefetch(
-                            filter=search_filter,
-                            query=sparse_query,
-                            using=encoder_sparse.model_short_name(),
-                            limit=prefetch_limit,
-                        ),
                         models.Prefetch(
                             filter=search_filter,
                             query=dense_query,
                             using=encoder_dense.model_short_name(),
                             limit=prefetch_limit,
-                        ),
-                    ],
-                    query=models.FormulaQuery(
-                        formula=models.SumExpression(
-                            sum=["$score", *custom_score_formula(search_collection)]
                         )
-                    ),
-                    limit=prefetch_limit,
-                )
+                    ],
+                ),
             ]
             if order_by and "score_threshold" not in search_params:
                 # Nest: vector prefetches → fusion prefetch → order_by query


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/mit-learn/issues/3440

related https://github.com/mitodl/mit-learn/pull/3428
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR gives programs a modest boost in hybrid search results for the learning resources endpoint while still maintaining overall search relevance.

### Screenshots
<img width="200" alt="Screenshot 2026-06-09 at 3 57 22 PM" src="https://github.com/user-attachments/assets/efa1f073-8234-49d2-a977-a940341d8ef5" />
<img width="200" alt="Screenshot 2026-06-09 at 3 57 17 PM" src="https://github.com/user-attachments/assets/cb7d8c3d-1f45-4eaf-abd1-3e058e238f19" />


### How can this be tested?
1. Make sure you have learning resources embedded locally (otherwise run ```python manage.py generate_embeddings --all --skip-contentfiles```
2. checkout main
3. login as an admin user - enable the vector search admin toggle 
4. go to the search interface and search for "ai" and other terms "scm" etc and view the results list (programs are not at the top).
5. checkout this branch and perform the same searches. programs should be appearing at the top of the results

### Additional Context
- The settings in this PR will need to be tested on our deployed environments since we use bm25 and the text-embed-large model (we may need to make slight adjustments to the values after deploying this). 
