### PR TITLE
fix ordering of course runs when none of them are enrollable

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -121,14 +121,16 @@ describe("helpers", () => {
       expect(result).toBeUndefined()
     })
 
-    test("returns first run if no next_run_id specified", () => {
+    test("returns run with most recent start date when no next_run_id specified", () => {
       const run1 = factories.courses.courseRun({
         id: 1,
         is_enrollable: true,
+        start_date: "2025-01-01T00:00:00Z",
       })
       const run2 = factories.courses.courseRun({
         id: 2,
         is_enrollable: true,
+        start_date: "2026-01-01T00:00:00Z",
       })
       const course = factories.courses.course({
         courseruns: [run1, run2],
@@ -136,7 +138,7 @@ describe("helpers", () => {
       })
 
       const result = getBestRun(course)
-      expect(result).toEqual(run1)
+      expect(result).toEqual(run2)
     })
 
     test("returns next_run_id run when specified", () => {
@@ -163,24 +165,29 @@ describe("helpers", () => {
         id: 1,
         b2b_contract: null,
         is_enrollable: true,
+        start_date: "2026-06-01T00:00:00Z",
       })
       const run2 = factories.courses.courseRun({
         id: 2,
         b2b_contract: contractId,
         is_enrollable: true,
+        start_date: "2025-01-01T00:00:00Z",
       })
       const run3 = factories.courses.courseRun({
         id: 3,
         b2b_contract: contractId,
         is_enrollable: true,
+        start_date: "2026-01-01T00:00:00Z",
       })
       const course = factories.courses.course({
         courseruns: [run1, run2, run3],
         next_run_id: null,
       })
 
+      // run1 is filtered out (wrong contract); run3 has the most recent start
+      // date among contract runs, so it wins.
       const result = getBestRun(course, { contractId })
-      expect(result).toEqual(run2)
+      expect(result).toEqual(run3)
     })
 
     test("prefers next_run_id within contract runs", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1605,6 +1605,34 @@ describe("dashboardViewModel", () => {
       expect(resolved.displayedEnrollment).toBeNull()
       expect(resolved.displayedRun?.id).toBe(englishRun.id)
     })
+
+    test("non-enrollable fallback: picks the run with the most recent start_date when no runs are enrollable and next_run_id is null", () => {
+      // Regression: capstone exams have next_run_id=null and is_enrollable=false
+      // on all runs. The stale (older) run must NOT be picked just because it
+      // appears first in the courseruns array.
+      const staleRun = factories.courses.courseRun({
+        id: 563,
+        title: "[WRONG] Supply Chain Exam - Stale 2023 Run",
+        is_enrollable: false,
+        start_date: "2023-09-01T00:00:00Z",
+      })
+      const currentRun = factories.courses.courseRun({
+        id: 564,
+        title: "[CORRECT] Supply Chain Exam - Current 2026 Run",
+        is_enrollable: false,
+        start_date: "2026-03-01T00:00:00Z",
+      })
+      const course = factories.courses.course({
+        // API returns stale run first — our fix must ignore array order
+        courseruns: [staleRun, currentRun],
+        next_run_id: null,
+      })
+
+      const resolved = resolveDisplayedRunAndEnrollment(course, [])
+
+      expect(resolved.displayedEnrollment).toBeNull()
+      expect(resolved.displayedRun?.id).toBe(currentRun.id)
+    })
   })
 })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -560,7 +560,7 @@ const resolveDisplayedRunAndEnrollment = (
       enrollableOnly: true,
       contractId: opts?.contractId,
     }) ??
-    course.courseruns[0] ??
+    getBestRun(course, { contractId: opts?.contractId }) ??
     null
   const isNonDefaultVariant = opts?.variant && !opts.variant.default_variant
   const displayedRun = isNonDefaultVariant

--- a/frontends/main/src/common/mitxonline/index.ts
+++ b/frontends/main/src/common/mitxonline/index.ts
@@ -320,18 +320,21 @@ const getBestRun = (
   let runs = course.courseruns ?? []
   if (enrollableOnly) runs = runs.filter((run) => run.is_enrollable)
   if (contractId) runs = runs.filter((run) => run.b2b_contract === contractId)
-  const byStartDateDesc = [...runs].sort((a, b) => {
-    const aMs = a.start_date ? new Date(a.start_date).getTime() : null
-    const bMs = b.start_date ? new Date(b.start_date).getTime() : null
-    if (aMs !== null && bMs !== null) return bMs - aMs
-    if (aMs !== null) return -1
-    if (bMs !== null) return 1
-    return 0
-  })
-  return (
-    byStartDateDesc.find((run) => run.id === course.next_run_id) ??
-    byStartDateDesc[0]
-  )
+
+  if (course.next_run_id !== null && course.next_run_id !== undefined) {
+    const next = runs.find((run) => run.id === course.next_run_id)
+    if (next) return next
+  }
+
+  return runs.reduce<CourseRunV2 | undefined>((best, run) => {
+    if (!best) return run
+    const bestMs = best.start_date ? new Date(best.start_date).getTime() : NaN
+    const runMs = run.start_date ? new Date(run.start_date).getTime() : NaN
+    // Prefer a run with a valid date over one without; among valid dates prefer later.
+    if (isNaN(bestMs) && !isNaN(runMs)) return run
+    if (!isNaN(bestMs) && isNaN(runMs)) return best
+    return runMs > bestMs ? run : best
+  }, undefined)
 }
 
 const isVerifiedEnrollmentMode = (mode?: string | null) => {

--- a/frontends/main/src/common/mitxonline/index.ts
+++ b/frontends/main/src/common/mitxonline/index.ts
@@ -304,7 +304,9 @@ export * from "./enrollmentAlert"
  * Returns the best run for a course.
  *
  * Prefers the run matching `next_run_id` among candidates; falls back to the
- * first candidate.
+ * candidate with the most recent start date (runs without a start date sort
+ * last). This ensures that when `next_run_id` is unset (e.g. non-enrollable
+ * capstone exams), the newest run is shown rather than an arbitrary one.
  *
  * @param opts.enrollableOnly - only consider runs where `is_enrollable` is true
  *   (use this on the dashboard where enrollment is the goal)
@@ -318,7 +320,18 @@ const getBestRun = (
   let runs = course.courseruns ?? []
   if (enrollableOnly) runs = runs.filter((run) => run.is_enrollable)
   if (contractId) runs = runs.filter((run) => run.b2b_contract === contractId)
-  return runs.find((run) => run.id === course.next_run_id) ?? runs[0]
+  const byStartDateDesc = [...runs].sort((a, b) => {
+    const aMs = a.start_date ? new Date(a.start_date).getTime() : null
+    const bMs = b.start_date ? new Date(b.start_date).getTime() : null
+    if (aMs !== null && bMs !== null) return bMs - aMs
+    if (aMs !== null) return -1
+    if (bMs !== null) return 1
+    return 0
+  })
+  return (
+    byStartDateDesc.find((run) => run.id === course.next_run_id) ??
+    byStartDateDesc[0]
+  )
 }
 
 const isVerifiedEnrollmentMode = (mode?: string | null) => {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11604

### Description (What does it do?)
This PR fixes an issue where the course run that is chosen to be associated with a card is incorrect when all runs are unenrollable. The `courseruns` property on a course returned from the courses API endpoint in MITx Online is a list of course runs that come back in database order. There are no API arguments you can send to change the order. Therefore, they must be sorted on the frontend. Normally, `next_run_id` is used to pick the course run. In the above issue, you'll see that the problem with that is that sometimes it's intentionally null because it isn't enrollable yet but still needs to be shown.

### How can this be tested?
- Make sure your local Learn is connected with an instance of MITx Online as described in the readme.
- Make sure you have sufficient test data created in your MITx Online database. Here is a script you can use that will create a program that can be enrolled in to test this scenario:
```
"""
One-shot script to create local test data for the next_run_id=null stale-title
scenario (Supply Chain CFx capstone exam).

Run with:
  docker compose exec web python manage.py shell -c \
      "exec(open('localdev/create_capstone_testdata.py').read())"
"""

from datetime import datetime, timedelta
from zoneinfo import ZoneInfo

from django.utils import timezone

from cms.models import CoursePage, CourseIndexPage, ProgramPage, ProgramIndexPage
from courses.models import Course, CourseRun, Program

UTC = ZoneInfo("UTC")


def dt(*args):
    return datetime(*args, tzinfo=UTC)


# ── 1. Capstone exam course ───────────────────────────────────────────────────
CAPSTONE_READABLE_ID = "course-v1:MITxDEMO+SCCFx"

capstone_course, created = Course.objects.get_or_create(
    readable_id=CAPSTONE_READABLE_ID,
    defaults={
        "title": "Supply Chain Comprehensive Exam",
        "live": True,
    },
)
print(
    f"{'Created' if created else 'Found'} capstone course: "
    f"id={capstone_course.id}  readable_id={capstone_course.readable_id!r}"
)

# ── 2. Older run (2023) – enrollment window closed, "stale" title ─────────────
older_run, _ = CourseRun.objects.update_or_create(
    courseware_id="course-v1:MITxDEMO+SCCFx+2023_R1",
    defaults={
        "course": capstone_course,
        "title": "[WRONG] Supply Chain Exam - Stale 2023 Run",
        "run_tag": "2023_R1",
        "start_date": dt(2023, 9, 1),
        "end_date": dt(2023, 12, 31),
        "enrollment_start": dt(2023, 8, 1),
        "enrollment_end": dt(2023, 9, 5),  # closed
        "live": True,
    },
)
print(
    f"Older run  id={older_run.id}"
    f"  start={older_run.start_date.date()}"
    f"  title={older_run.title!r}"
    f"  is_enrollable={older_run.is_enrollable}"
)

# ── 3. Newer run (2026) – enrollment window closed, "correct" title ───────────
newer_run, _ = CourseRun.objects.update_or_create(
    courseware_id="course-v1:MITxDEMO+SCCFx+2026_R1",
    defaults={
        "course": capstone_course,
        "title": "[CORRECT] Supply Chain Exam - Current 2026 Run",
        "run_tag": "2026_R1",
        "start_date": dt(2026, 3, 1),
        "end_date": dt(2026, 6, 30),
        "enrollment_start": dt(2026, 2, 1),
        "enrollment_end": dt(2026, 3, 5),  # closed (past)
        "live": True,
    },
)
print(
    f"Newer run  id={newer_run.id}"
    f"  start={newer_run.start_date.date()}"
    f"  title={newer_run.title!r}"
    f"  is_enrollable={newer_run.is_enrollable}"
)

# Confirm next_run_id will be None (clear cached_property)
capstone_course.__dict__.pop("first_unexpired_run", None)
print(
    f"next_run_id (should be None): "
    f"{getattr(capstone_course.first_unexpired_run, 'id', None)}"
)

# ── 4. Enrollable companion course ────────────────────────────────────────────
ENROLLABLE_READABLE_ID = "course-v1:MITxDEMO+SCx001"

enrollable_course, _ = Course.objects.get_or_create(
    readable_id=ENROLLABLE_READABLE_ID,
    defaults={
        "title": "Supply Chain Fundamentals",
        "live": True,
    },
)
now = timezone.now()
enrollable_run, _ = CourseRun.objects.update_or_create(
    courseware_id="course-v1:MITxDEMO+SCx001+2026_R1",
    defaults={
        "course": enrollable_course,
        "title": "Supply Chain Fundamentals",
        "run_tag": "2026_R1",
        "start_date": now + timedelta(days=30),
        "end_date": now + timedelta(days=120),
        "enrollment_start": now - timedelta(days=5),
        "enrollment_end": now + timedelta(days=60),
        "live": True,
    },
)
print(
    f"Enrollable run  id={enrollable_run.id}"
    f"  is_enrollable={enrollable_run.is_enrollable}"
)

# ── 5. Program containing both courses ────────────────────────────────────────
PROGRAM_READABLE_ID = "program-v1:MITxDEMO+SCx"

program, _ = Program.objects.get_or_create(
    readable_id=PROGRAM_READABLE_ID,
    defaults={
        "title": "MITx Demo Supply Chain Program",
        "live": True,
        "enrollment_start": now - timedelta(days=30),
        "enrollment_end": now + timedelta(days=365),
    },
)
# Ensure enrollment window is open even if program already existed
if program.enrollment_start is None or program.enrollment_end is None:
    program.enrollment_start = now - timedelta(days=30)
    program.enrollment_end = now + timedelta(days=365)
    program.save(update_fields=["enrollment_start", "enrollment_end"])
print(f"\nProgram id={program.id}  readable_id={program.readable_id!r}")

from courses.models import ProgramRequirement, ProgramRequirementNodeType
from courses.models import EnrollmentMode
from openedx.constants import EDX_ENROLLMENT_AUDIT_MODE, EDX_ENROLLMENT_VERIFIED_MODE

for course in (enrollable_course, capstone_course):
    already = ProgramRequirement.objects.filter(
        program=program,
        node_type=ProgramRequirementNodeType.COURSE,
        course=course,
    ).exists()
    if not already:
        program.add_requirement(course)
        print(f"  Added {course.readable_id!r} to program requirements.")
    else:
        print(f"  {course.readable_id!r} already a requirement (skipped).")

# Enrollment modes (audit + verified so the program is enrollable)
audit = EnrollmentMode.objects.get(mode_slug=EDX_ENROLLMENT_AUDIT_MODE)
verified = EnrollmentMode.objects.get(mode_slug=EDX_ENROLLMENT_VERIFIED_MODE)
program.enrollment_modes.set([audit, verified])
print(f"Enrollment modes: {list(program.enrollment_modes.values_list('mode_slug', flat=True))}")


# ── 6. Wagtail pages + include_in_learn_catalog ───────────────────────────────

def _get_or_create_course_page(course, slug):
    """Attach a live CoursePage to a Course, creating it if absent."""
    existing = CoursePage.objects.filter(course=course).first()
    if existing:
        if not existing.include_in_learn_catalog or not existing.live:
            existing.include_in_learn_catalog = True
            existing.live = True
            existing.save()
        print(f"  CoursePage for {course.readable_id!r}: id={existing.id} (updated)")
        return existing

    parent = CourseIndexPage.objects.first()
    if parent is None:
        raise RuntimeError(
            "No CourseIndexPage found. Run `python manage.py configure_wagtail` first."
        )
    page = CoursePage(
        title=course.title,
        slug=slug,
        course=course,
        live=True,
        include_in_learn_catalog=True,
        description="<p>Test course created by localdev script.</p>",
        length="Self-paced",
        min_weekly_hours=1,
        max_weekly_hours=5,
    )
    parent.add_child(instance=page)
    print(f"  CoursePage for {course.readable_id!r}: id={page.id} (created)")
    return page


def _get_or_create_program_page(program, slug):
    """Attach a live ProgramPage to a Program, creating it if absent."""
    existing = ProgramPage.objects.filter(program=program).first()
    if existing:
        if not existing.include_in_learn_catalog or not existing.live:
            existing.include_in_learn_catalog = True
            existing.live = True
            existing.save()
        print(f"  ProgramPage for {program.readable_id!r}: id={existing.id} (updated)")
        return existing

    parent = ProgramIndexPage.objects.first()
    if parent is None:
        raise RuntimeError(
            "No ProgramIndexPage found. Run `python manage.py configure_wagtail` first."
        )
    page = ProgramPage(
        title=program.title,
        slug=slug,
        program=program,
        live=True,
        include_in_learn_catalog=True,
        description="<p>Test program created by localdev script.</p>",
        length="Self-paced",
        min_weekly_hours=1,
        max_weekly_hours=5,
    )
    parent.add_child(instance=page)
    print(f"  ProgramPage for {program.readable_id!r}: id={page.id} (created)")
    return page


print("\nCreating / updating Wagtail pages…")
_get_or_create_course_page(capstone_course, "supply-chain-comprehensive-exam")
_get_or_create_course_page(enrollable_course, "supply-chain-fundamentals")
_get_or_create_program_page(program, "mitx-demo-supply-chain-program")

# Verify include_in_learn_catalog is visible via the model property
capstone_course.__dict__.pop("page", None)  # clear cached_property if set
enrollable_course.__dict__.pop("page", None)
program.__dict__.pop("page", None)

# ── 7. Summary ────────────────────────────────────────────────────────────────
print()
print("=" * 60)
print("SUMMARY")
print("=" * 60)
print(f"Capstone course id  : {capstone_course.id}")
print(f"  readable_id       : {capstone_course.readable_id}")
print(
    f"  include_in_learn_catalog : {capstone_course.include_in_learn_catalog}"
)
print(
    f"  next_run_id       : "
    f"{getattr(capstone_course.first_unexpired_run, 'id', None)}"
    f"  ← should be None"
)
print(
    f"  run (older)  id={older_run.id}"
    f"  start={older_run.start_date.date()}"
    f"  title={older_run.title!r}"
)
print(
    f"  run (newer)  id={newer_run.id}"
    f"  start={newer_run.start_date.date()}"
    f"  title={newer_run.title!r}"
)
print(f"Enrollable course id: {enrollable_course.id}")
print(f"  readable_id       : {enrollable_course.readable_id}")
print(f"Program id          : {program.id}")
print(f"  readable_id       : {program.readable_id}")
print(f"  include_in_learn_catalog : {getattr(program.page, 'include_in_learn_catalog', None)}")
print()
print("Verify API response (before fix – older run first is the bug):")
print(f"  GET /api/v2/courses/?readable_id={capstone_course.readable_id}")
print(
    f"  After fix: courseruns[0].title should be {newer_run.title!r}"
    f" (newer, {newer_run.start_date.date()})"
)
print(
    f"             courseruns[1].title should be {older_run.title!r}"
    f" (older, {older_run.start_date.date()})"
)
print()
print("MIT Learn dashboard URL (once synced):")
print(f"  /dashboard/program/{program.id}")

```
- Enroll in the program by visiting `/programs/program-v1:MITxDEMO+SCx` and clicking the enroll button, then enrolling for free.
- You should be redirected to the program dashboard afterward. The Capstone Exam course should show the run labelled `[CORRECT]`