### PR TITLE
feat: implement PostHog tracking for video shorts interactions

### DIFF
--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
@@ -356,38 +356,7 @@ describe("VideoShortsModal", () => {
     afterEach(() => {
       delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
     })
-    test("captures VideoShortViewed without timeOnVideoMs for the initial slide", async () => {
-      const videoData = [
-        makeVideoResource({ title: "First Video" }),
-        makeVideoResource({ title: "Second Video" }),
-      ]
-
-      renderWithProviders(
-        <VideoShortsModal
-          startIndex={0}
-          videoData={videoData}
-          onClose={jest.fn()}
-        />,
-      )
-
-      act(() => {
-        triggerSlidesInView([0])
-      })
-
-      const call = mockedPostHogCapture.mock.calls.find(
-        ([event]) => event === "video_short_viewed",
-      )
-      expect(call?.[1]).toMatchObject({
-        videoId: videoData[0].id,
-        videoTitle: "First Video",
-        position: 0,
-      })
-      expect(call?.[1]).not.toHaveProperty("timeOnVideoMs")
-      expect(call?.[1]).not.toHaveProperty("videoDurationMs")
-      expect(call?.[1]).not.toHaveProperty("percentageWatched")
-    })
-
-    test("captures VideoShortViewed with timeOnVideoMs and videoDurationMs on subsequent slides", async () => {
+    test("captures VideoShortViewed with timeOnPrevVideoMs on every scroll", async () => {
       const videoData = [
         makeVideoResource({ title: "First Video" }),
         makeVideoResource({
@@ -410,10 +379,6 @@ describe("VideoShortsModal", () => {
         />,
       )
 
-      act(() => {
-        triggerSlidesInView([0])
-      })
-
       // Simulate player ready with a valid duration for slide 0
       await act(async () => {
         mockHandles[0]?.triggerReady()
@@ -424,18 +389,19 @@ describe("VideoShortsModal", () => {
         triggerSlidesInView([1])
       })
 
-      const calls = mockedPostHogCapture.mock.calls.filter(
+      const call = mockedPostHogCapture.mock.calls.find(
         ([event]) => event === "video_short_viewed",
       )
-      const secondCall = calls[1]
-      expect(secondCall?.[1]).toMatchObject({
+      expect(call?.[1]).toMatchObject({
         videoId: videoData[1].id,
         videoTitle: "Second Video",
         position: 0,
       })
-      expect(secondCall?.[1]).toHaveProperty("timeOnVideoMs")
-      expect(secondCall?.[1].videoDurationMs).toBe(30000)
-      expect(secondCall?.[1]).not.toHaveProperty("percentageWatched")
+      expect(call?.[1]).toHaveProperty("timeOnPrevVideoMs")
+      expect(call?.[1].prevVideoDurationMs).toBe(30000)
+      expect(call?.[1]).not.toHaveProperty("percentageWatched")
+      expect(call?.[1]).not.toHaveProperty("timeOnVideoMs")
+      expect(call?.[1]).not.toHaveProperty("videoDurationMs")
     })
 
     test("totalVideosViewed is 1 when closing without scrolling", async () => {

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
@@ -356,19 +356,10 @@ describe("VideoShortsModal", () => {
     afterEach(() => {
       delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
     })
-    test("captures VideoShortViewed with timeOnPrevVideoMs on every scroll", async () => {
+    test("captures VideoShortViewed for the video being left when scrolling", async () => {
       const videoData = [
         makeVideoResource({ title: "First Video" }),
-        makeVideoResource({
-          title: "Second Video",
-          video: {
-            id: 2,
-            streaming_url: "https://example.com/video2.mp4",
-            duration: "PT1M",
-            caption_urls: [],
-            cover_image_url: null,
-          },
-        }),
+        makeVideoResource({ title: "Second Video" }),
       ]
 
       renderWithProviders(
@@ -392,16 +383,29 @@ describe("VideoShortsModal", () => {
       const call = mockedPostHogCapture.mock.calls.find(
         ([event]) => event === "video_short_viewed",
       )
+      // Event describes the video being LEFT (slide 0), not the one arrived at
       expect(call?.[1]).toMatchObject({
-        videoId: videoData[1].id,
-        videoTitle: "Second Video",
-        position: 0,
+        videoId: videoData[0].id,
+        videoTitle: "First Video",
       })
-      expect(call?.[1]).toHaveProperty("timeOnPrevVideoMs")
-      expect(call?.[1].prevVideoDurationMs).toBe(30000)
+      expect(call?.[1]).toHaveProperty("timeOnVideoMs")
+      expect(call?.[1].videoDurationMs).toBe(30000)
       expect(call?.[1]).not.toHaveProperty("percentageWatched")
-      expect(call?.[1]).not.toHaveProperty("timeOnVideoMs")
-      expect(call?.[1]).not.toHaveProperty("videoDurationMs")
+    })
+
+    test("captures VideoShortViewed for the current video on close", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_short_viewed",
+      )
+      expect(call?.[1]).toMatchObject({
+        videoId: defaultProps.videoData[0].id,
+        videoTitle: "First Video",
+      })
+      expect(call?.[1]).toHaveProperty("timeOnVideoMs")
     })
 
     test("totalVideosViewed is 1 when closing without scrolling", async () => {
@@ -433,8 +437,7 @@ describe("VideoShortsModal", () => {
     test("totalVideosViewed does not double-count when scrolling back to a previous video", async () => {
       renderWithProviders(<VideoShortsModal {...defaultProps} />)
 
-      // Simulate scrolling away from the initial video then back (Embla never
-      // fires slidesInView on mount, so index 0 is seeded but not scroll-fired)
+      // Scroll away then back — neither should double-count
       act(() => {
         triggerSlidesInView([1])
       })
@@ -485,6 +488,113 @@ describe("VideoShortsModal", () => {
         ([event]) => event === "video_shorts_closed",
       )
       expect(call?.[1].sessionDurationMs).toBeGreaterThanOrEqual(0)
+    })
+
+    test("flushes session analytics on pagehide", () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      act(() => {
+        window.dispatchEvent(new Event("pagehide"))
+      })
+
+      expect(mockedPostHogCapture).toHaveBeenCalledWith(
+        "video_shorts_closed",
+        expect.objectContaining({
+          sessionDurationMs: expect.any(Number),
+          totalVideosViewed: 1,
+        }),
+      )
+    })
+
+    test("flushes session analytics when the page is hidden", () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      act(() => {
+        Object.defineProperty(document, "visibilityState", {
+          value: "hidden",
+          configurable: true,
+        })
+        document.dispatchEvent(new Event("visibilitychange"))
+      })
+
+      expect(mockedPostHogCapture).toHaveBeenCalledWith(
+        "video_shorts_closed",
+        expect.objectContaining({ sessionDurationMs: expect.any(Number) }),
+      )
+
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      })
+    })
+
+    test("does not emit duplicate close events when pagehide follows an explicit close", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+      act(() => {
+        window.dispatchEvent(new Event("pagehide"))
+      })
+
+      const closeCalls = mockedPostHogCapture.mock.calls.filter(
+        ([event]) => event === "video_shorts_closed",
+      )
+      expect(closeCalls).toHaveLength(1)
+    })
+  })
+
+  describe("playback", () => {
+    test("autoplays the selected video after Embla settles when startIndex > 0", async () => {
+      const videoData = [
+        makeVideoResource({ title: "First" }),
+        makeVideoResource({ title: "Second" }),
+        makeVideoResource({ title: "Third" }),
+      ]
+      renderWithProviders(
+        <VideoShortsModal
+          startIndex={2}
+          videoData={videoData}
+          onClose={jest.fn()}
+        />,
+      )
+
+      await act(async () => {
+        mockHandles.forEach((handle) => {
+          handle.triggerReady()
+          handle.player.paused.mockReturnValue(true)
+        })
+      })
+
+      // Embla animates from slide 0 to startIndex, firing intermediate events.
+      act(() => triggerSlidesInView([0]))
+      act(() => triggerSlidesInView([1]))
+      act(() => triggerSlidesInView([2]))
+
+      // The selected video should be playing (button reflects "Pause").
+      expect(
+        await screen.findByRole("button", { name: "Pause" }),
+      ).toBeInTheDocument()
+    })
+
+    test("keeps the playing state on same-slide re-emit", async () => {
+      const videoData = [makeVideoResource({ title: "Only" })]
+      renderWithProviders(
+        <VideoShortsModal
+          startIndex={0}
+          videoData={videoData}
+          onClose={jest.fn()}
+        />,
+      )
+
+      await act(async () => {
+        mockHandles[0]?.triggerReady()
+        mockHandles[0]?.player.paused.mockReturnValue(true)
+      })
+
+      act(() => triggerSlidesInView([0]))
+      act(() => triggerSlidesInView([0]))
+
+      expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument()
     })
   })
 })

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
@@ -431,7 +431,7 @@ describe("VideoShortsModal", () => {
       expect(secondCall?.[1]).toMatchObject({
         videoId: videoData[1].id,
         videoTitle: "Second Video",
-        position: 1,
+        position: 0,
       })
       expect(secondCall?.[1]).toHaveProperty("timeOnVideoMs")
       expect(secondCall?.[1].videoDurationMs).toBe(30000)

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.test.tsx
@@ -5,6 +5,14 @@ import { ResourceTypeEnum } from "api/v1"
 import { factories } from "api/test-utils"
 import { renderWithProviders, screen, user, fireEvent, act } from "@/test-utils"
 import type Player from "video.js/dist/types/player"
+import { usePostHog } from "posthog-js/react"
+import type { PostHog } from "posthog-js"
+
+jest.mock("posthog-js/react")
+const mockedPostHogCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue({
+  capture: mockedPostHogCapture,
+} as unknown as PostHog)
 
 // Stub VideoJsPlayer to avoid loading video.js in the test environment.
 // Captures the onReady callback so tests can simulate the player being ready,
@@ -63,6 +71,29 @@ jest.mock("@/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer", () => ({
   },
 }))
 
+// CarouselV2Vertical uses Embla scroll APIs unavailable in JSDOM; render
+// children directly and expose triggerSlidesInView so tests can simulate
+// scroll events on demand (matching Embla's behavior: no fire on initial mount).
+let triggerSlidesInView: (inView: number[]) => void = () => {}
+jest.mock("ol-components/CarouselV2Vertical", () => ({
+  CarouselV2Vertical: ({
+    children,
+    onSlidesInView,
+  }: {
+    children: React.ReactNode
+    onSlidesInView?: (inView: number[]) => void
+    initialSlide?: number
+  }) => {
+    React.useEffect(() => {
+      triggerSlidesInView = (inView) => onSlidesInView?.(inView)
+      return () => {
+        triggerSlidesInView = () => {}
+      }
+    }, [onSlidesInView])
+    return <div>{children}</div>
+  },
+}))
+
 const makeVideoResource = (
   overrides: Partial<VideoResource> = {},
 ): VideoResource =>
@@ -81,6 +112,7 @@ const makeVideoResource = (
 describe("VideoShortsModal", () => {
   beforeEach(() => {
     mockHandles.length = 0
+    mockedPostHogCapture.mockClear()
   })
 
   const defaultProps = {
@@ -315,5 +347,178 @@ describe("VideoShortsModal", () => {
 
     // No VideoJsPlayer rendered — no <video> element in the DOM
     expect(document.querySelector("video")).toBeNull()
+  })
+
+  describe("PostHog tracking", () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+    })
+    afterEach(() => {
+      delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+    })
+    test("captures VideoShortViewed without timeOnVideoMs for the initial slide", async () => {
+      const videoData = [
+        makeVideoResource({ title: "First Video" }),
+        makeVideoResource({ title: "Second Video" }),
+      ]
+
+      renderWithProviders(
+        <VideoShortsModal
+          startIndex={0}
+          videoData={videoData}
+          onClose={jest.fn()}
+        />,
+      )
+
+      act(() => {
+        triggerSlidesInView([0])
+      })
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_short_viewed",
+      )
+      expect(call?.[1]).toMatchObject({
+        videoId: videoData[0].id,
+        videoTitle: "First Video",
+        position: 0,
+      })
+      expect(call?.[1]).not.toHaveProperty("timeOnVideoMs")
+      expect(call?.[1]).not.toHaveProperty("videoDurationMs")
+      expect(call?.[1]).not.toHaveProperty("percentageWatched")
+    })
+
+    test("captures VideoShortViewed with timeOnVideoMs and videoDurationMs on subsequent slides", async () => {
+      const videoData = [
+        makeVideoResource({ title: "First Video" }),
+        makeVideoResource({
+          title: "Second Video",
+          video: {
+            id: 2,
+            streaming_url: "https://example.com/video2.mp4",
+            duration: "PT1M",
+            caption_urls: [],
+            cover_image_url: null,
+          },
+        }),
+      ]
+
+      renderWithProviders(
+        <VideoShortsModal
+          startIndex={0}
+          videoData={videoData}
+          onClose={jest.fn()}
+        />,
+      )
+
+      act(() => {
+        triggerSlidesInView([0])
+      })
+
+      // Simulate player ready with a valid duration for slide 0
+      await act(async () => {
+        mockHandles[0]?.triggerReady()
+        mockHandles[0]?.player.duration.mockReturnValue(30)
+      })
+
+      act(() => {
+        triggerSlidesInView([1])
+      })
+
+      const calls = mockedPostHogCapture.mock.calls.filter(
+        ([event]) => event === "video_short_viewed",
+      )
+      const secondCall = calls[1]
+      expect(secondCall?.[1]).toMatchObject({
+        videoId: videoData[1].id,
+        videoTitle: "Second Video",
+        position: 1,
+      })
+      expect(secondCall?.[1]).toHaveProperty("timeOnVideoMs")
+      expect(secondCall?.[1].videoDurationMs).toBe(30000)
+      expect(secondCall?.[1]).not.toHaveProperty("percentageWatched")
+    })
+
+    test("totalVideosViewed is 1 when closing without scrolling", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_shorts_closed",
+      )
+      expect(call?.[1].totalVideosViewed).toBe(1)
+    })
+
+    test("totalVideosViewed increments as user scrolls through videos", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      act(() => {
+        triggerSlidesInView([1])
+      })
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_shorts_closed",
+      )
+      expect(call?.[1].totalVideosViewed).toBe(2)
+    })
+
+    test("totalVideosViewed does not double-count when scrolling back to a previous video", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      // Simulate scrolling away from the initial video then back (Embla never
+      // fires slidesInView on mount, so index 0 is seeded but not scroll-fired)
+      act(() => {
+        triggerSlidesInView([1])
+      })
+      act(() => {
+        triggerSlidesInView([0]) // scroll back to initial video
+      })
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_shorts_closed",
+      )
+      expect(call?.[1].totalVideosViewed).toBe(2) // 2 unique videos, no double-count
+    })
+
+    test("captures VideoShortsClosed with sessionDurationMs when close button is clicked", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      expect(mockedPostHogCapture).toHaveBeenCalledWith(
+        "video_shorts_closed",
+        expect.objectContaining({
+          sessionDurationMs: expect.any(Number),
+        }),
+      )
+    })
+
+    test("captures VideoShortsClosed with sessionDurationMs when Escape key is pressed", () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      fireEvent.keyDown(document, { key: "Escape" })
+
+      expect(mockedPostHogCapture).toHaveBeenCalledWith(
+        "video_shorts_closed",
+        expect.objectContaining({
+          sessionDurationMs: expect.any(Number),
+        }),
+      )
+    })
+
+    test("sessionDurationMs is non-negative", async () => {
+      renderWithProviders(<VideoShortsModal {...defaultProps} />)
+
+      await user.click(screen.getByRole("button", { name: "Close" }))
+
+      const call = mockedPostHogCapture.mock.calls.find(
+        ([event]) => event === "video_shorts_closed",
+      )
+      expect(call?.[1].sessionDurationMs).toBeGreaterThanOrEqual(0)
+    })
   })
 })

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -257,7 +257,6 @@ const VideoShortsModal = ({
   const muteButtonRef = useRef<HTMLButtonElement>(null)
   const sessionStartedAtRef = useRef<number>(Date.now())
   const currentVideoStartedAtRef = useRef<number>(Date.now())
-  const isInitialSlideRef = useRef<boolean>(true)
   const sessionPositionRef = useRef<number>(0)
   const viewedIndicesRef = useRef<Set<number>>(new Set([startIndex]))
   const selectedIndexRef = useRef<number | null>(startIndex)
@@ -325,16 +324,14 @@ const VideoShortsModal = ({
       setAnnouncement(
         `${inView[0] + 1} of ${videoData.length}: ${videoData[inView[0]].title}`,
       )
-      const isInitial = isInitialSlideRef.current
-
       const prevIndex = selectedIndexRef.current
       const prevPlayer =
         prevIndex !== null ? playersRef.current[prevIndex] : null
-      let videoDurationMs: number | undefined
-      if (!isInitial && prevPlayer) {
+      let prevVideoDurationMs: number | undefined
+      if (prevPlayer) {
         const duration = prevPlayer.duration()
         if (duration && isFinite(duration) && duration > 0) {
-          videoDurationMs = Math.round(duration * 1000)
+          prevVideoDurationMs = Math.round(duration * 1000)
         }
       }
 
@@ -343,14 +340,9 @@ const VideoShortsModal = ({
         videoTitle: videoData[inView[0]].title,
         position: sessionPositionRef.current,
         totalVideos: videoData.length,
-        ...(isInitial
-          ? {}
-          : {
-              timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
-              ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
-            }),
+        timeOnPrevVideoMs: Date.now() - currentVideoStartedAtRef.current,
+        ...(prevVideoDurationMs !== undefined ? { prevVideoDurationMs } : {}),
       })
-      isInitialSlideRef.current = false
       if (!viewedIndicesRef.current.has(inView[0])) {
         viewedIndicesRef.current.add(inView[0])
         sessionPositionRef.current += 1

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -16,6 +16,9 @@ import MITOpenLearningLogo from "@/public/images/mit-open-learning-logo.svg"
 import VideoJsPlayer from "@/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer"
 import type Player from "video.js/dist/types/player"
 import { FocusTrap } from "@mui/base/FocusTrap"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+import { env } from "@/env"
 
 const MODAL_VERTICAL_PADDING = 60
 const PORTRAIT_ASPECT_RATIO = 9 / 16
@@ -252,6 +255,21 @@ const VideoShortsModal = ({
 
   const playersRef = useRef<(Player | null)[]>([])
   const muteButtonRef = useRef<HTMLButtonElement>(null)
+  const sessionStartedAtRef = useRef<number>(Date.now())
+  const currentVideoStartedAtRef = useRef<number>(Date.now())
+  const isInitialSlideRef = useRef<boolean>(true)
+  const sessionPositionRef = useRef<number>(0)
+  const viewedIndicesRef = useRef<Set<number>>(new Set([startIndex]))
+  const selectedIndexRef = useRef<number | null>(startIndex)
+  const posthog = usePostHog()
+  const capture = useCallback(
+    (event: string, properties?: Record<string, unknown>) => {
+      if (env("NEXT_PUBLIC_POSTHOG_API_KEY")) {
+        posthog.capture(event, properties)
+      }
+    },
+    [posthog],
+  )
 
   useEffect(() => {
     const id = requestAnimationFrame(() => {
@@ -268,11 +286,19 @@ const VideoShortsModal = ({
     playersRef.current = playersRef.current.slice(0, videoData.length)
   }, [videoData])
 
+  const handleClose = useCallback(() => {
+    capture(PostHogEvents.VideoShortsClosed, {
+      sessionDurationMs: Date.now() - sessionStartedAtRef.current,
+      totalVideosViewed: viewedIndicesRef.current.size,
+    })
+    onClose()
+  }, [onClose, capture])
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && onClose) {
+      if (event.key === "Escape") {
         event.preventDefault()
-        onClose()
+        handleClose()
       }
     }
 
@@ -280,10 +306,14 @@ const VideoShortsModal = ({
     return () => {
       document.removeEventListener("keydown", handleKeyDown)
     }
-  }, [onClose])
+  }, [handleClose])
 
-  const onSlidesInView = (inView: number[]) => {
-    if (inView.length === 1) {
+  // Keep a ref to the latest implementation so the stable wrapper below never
+  // changes identity, preventing CarouselV2Vertical from stacking duplicate
+  // Embla listeners on every mute/interaction state change.
+  const onSlidesInViewRef = useRef<(inView: number[]) => void>(() => {})
+  onSlidesInViewRef.current = (inView: number[]) => {
+    if (inView.length === 1 && videoData[inView[0]]) {
       playersRef.current
         .filter(
           (player, index): player is Player =>
@@ -295,6 +325,38 @@ const VideoShortsModal = ({
       setAnnouncement(
         `${inView[0] + 1} of ${videoData.length}: ${videoData[inView[0]].title}`,
       )
+      const isInitial = isInitialSlideRef.current
+
+      const prevIndex = selectedIndexRef.current
+      const prevPlayer =
+        prevIndex !== null ? playersRef.current[prevIndex] : null
+      let videoDurationMs: number | undefined
+      if (!isInitial && prevPlayer) {
+        const duration = prevPlayer.duration()
+        if (duration && isFinite(duration) && duration > 0) {
+          videoDurationMs = Math.round(duration * 1000)
+        }
+      }
+
+      capture(PostHogEvents.VideoShortViewed, {
+        videoId: videoData[inView[0]].id,
+        videoTitle: videoData[inView[0]].title,
+        position: sessionPositionRef.current,
+        totalVideos: videoData.length,
+        ...(isInitial
+          ? {}
+          : {
+              timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
+              ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
+            }),
+      })
+      isInitialSlideRef.current = false
+      if (!viewedIndicesRef.current.has(inView[0])) {
+        viewedIndicesRef.current.add(inView[0])
+        sessionPositionRef.current += 1
+      }
+      selectedIndexRef.current = inView[0]
+      currentVideoStartedAtRef.current = Date.now()
       const player = playersRef.current[inView[0]]
       if (player) {
         player.muted(muted)
@@ -308,6 +370,11 @@ const VideoShortsModal = ({
       }
     }
   }
+
+  const onSlidesInView = useCallback(
+    (inView: number[]) => onSlidesInViewRef.current(inView),
+    [],
+  )
 
   const onClickMute = () => {
     if (selectedIndex !== null && playersRef.current[selectedIndex]) {
@@ -356,7 +423,7 @@ const VideoShortsModal = ({
           size="large"
           edge="rounded"
           variant="text"
-          onClick={onClose}
+          onClick={handleClose}
           aria-label="Close"
         >
           <RiCloseLine />

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -363,69 +363,76 @@ const VideoShortsModal = ({
   // can be added/removed without touching existing behavior. The prevIndex
   // guard also makes it safe against CarouselV2Vertical firing the same event
   // on duplicate listeners.
-  const trackSlideViewed = (newIndex: number) => {
-    const prevIndex = selectedIndexRef.current
-    // During Embla's init animation, slidesInView fires for each intermediate
-    // slide; suppress analytics until it settles on startIndex.
-    if (!hasSettledRef.current) {
-      if (newIndex === startIndex) {
-        hasSettledRef.current = true
-        currentVideoStartedAtRef.current = Date.now()
+  const trackSlideViewed = useCallback(
+    (newIndex: number) => {
+      if (sessionEndedRef.current) return
+      const prevIndex = selectedIndexRef.current
+      // During Embla's init animation, slidesInView fires for each intermediate
+      // slide; suppress analytics until it settles on startIndex.
+      if (!hasSettledRef.current) {
+        if (newIndex === startIndex) {
+          hasSettledRef.current = true
+          currentVideoStartedAtRef.current = Date.now()
+        }
+        selectedIndexRef.current = newIndex
+        return
+      }
+      if (prevIndex === newIndex) return
+      // Fire an event for the video being left.
+      if (prevIndex !== null && videoData[prevIndex]) {
+        const prevPlayer = playersRef.current[prevIndex]
+        let videoDurationMs: number | undefined
+        if (prevPlayer) {
+          const duration = prevPlayer.duration()
+          if (duration && isFinite(duration) && duration > 0) {
+            videoDurationMs = Math.round(duration * 1000)
+          }
+        }
+        capture(PostHogEvents.VideoShortViewed, {
+          videoId: videoData[prevIndex].id,
+          videoTitle: videoData[prevIndex].title,
+          timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
+          ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
+        })
+        viewedIndicesRef.current.add(prevIndex)
       }
       selectedIndexRef.current = newIndex
-      return
-    }
-    if (prevIndex === newIndex) return
-    // Fire an event for the video being left.
-    if (prevIndex !== null && videoData[prevIndex]) {
-      const prevPlayer = playersRef.current[prevIndex]
-      let videoDurationMs: number | undefined
-      if (prevPlayer) {
-        const duration = prevPlayer.duration()
-        if (duration && isFinite(duration) && duration > 0) {
-          videoDurationMs = Math.round(duration * 1000)
-        }
-      }
-      capture(PostHogEvents.VideoShortViewed, {
-        videoId: videoData[prevIndex].id,
-        videoTitle: videoData[prevIndex].title,
-        timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
-        ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
-      })
-      viewedIndicesRef.current.add(prevIndex)
-    }
-    selectedIndexRef.current = newIndex
-    currentVideoStartedAtRef.current = Date.now()
-  }
+      currentVideoStartedAtRef.current = Date.now()
+    },
+    [videoData, startIndex, capture],
+  )
 
-  const onSlidesInView = (inView: number[]) => {
-    if (inView.length === 1 && videoData[inView[0]]) {
-      playersRef.current
-        .filter(
-          (player, index): player is Player =>
-            player !== null && index !== inView[0],
+  const onSlidesInView = useCallback(
+    (inView: number[]) => {
+      if (inView.length === 1 && videoData[inView[0]]) {
+        playersRef.current
+          .filter(
+            (player, index): player is Player =>
+              player !== null && index !== inView[0],
+          )
+          .forEach((player) => player.pause())
+        setSelectedIndex(inView[0])
+        setPlaying(false)
+        setAnnouncement(
+          `${inView[0] + 1} of ${videoData.length}: ${videoData[inView[0]].title}`,
         )
-        .forEach((player) => player.pause())
-      setSelectedIndex(inView[0])
-      setPlaying(false)
-      setAnnouncement(
-        `${inView[0] + 1} of ${videoData.length}: ${videoData[inView[0]].title}`,
-      )
-      const player = playersRef.current[inView[0]]
-      if (player) {
-        player.muted(muted)
-        // On iOS, only autoplay if muted or if user has interacted
-        if (!isIOS() || muted || hasUserInteracted) {
-          player.play()?.catch(() => {
-            setPlaying(false)
-          })
-          setPlaying(true)
+        const player = playersRef.current[inView[0]]
+        if (player) {
+          player.muted(muted)
+          // On iOS, only autoplay if muted or if user has interacted
+          if (!isIOS() || muted || hasUserInteracted) {
+            player.play()?.catch(() => {
+              setPlaying(false)
+            })
+            setPlaying(true)
+          }
         }
-      }
 
-      trackSlideViewed(inView[0])
-    }
-  }
+        trackSlideViewed(inView[0])
+      }
+    },
+    [videoData, muted, hasUserInteracted, trackSlideViewed],
+  )
 
   const onClickMute = () => {
     if (selectedIndex !== null && playersRef.current[selectedIndex]) {

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -257,9 +257,13 @@ const VideoShortsModal = ({
   const muteButtonRef = useRef<HTMLButtonElement>(null)
   const sessionStartedAtRef = useRef<number>(Date.now())
   const currentVideoStartedAtRef = useRef<number>(Date.now())
-  const sessionPositionRef = useRef<number>(0)
-  const viewedIndicesRef = useRef<Set<number>>(new Set([startIndex]))
+  const viewedIndicesRef = useRef<Set<number>>(new Set())
   const selectedIndexRef = useRef<number | null>(startIndex)
+  // For startIndex > 0, Embla animates from slide 0 to startIndex on mount,
+  // firing slidesInView for each intermediate slide. hasSettledRef suppresses
+  // all analytics until Embla fires for startIndex itself.
+  const hasSettledRef = useRef<boolean>(startIndex === 0)
+  const sessionEndedRef = useRef<boolean>(false)
   const posthog = usePostHog()
   const capture = useCallback(
     (event: string, properties?: Record<string, unknown>) => {
@@ -285,13 +289,40 @@ const VideoShortsModal = ({
     playersRef.current = playersRef.current.slice(0, videoData.length)
   }, [videoData])
 
-  const handleClose = useCallback(() => {
+  // Fires the final analytics for the session. Guarded so it only runs once,
+  // since it can be triggered by an explicit close, the tab being hidden, or
+  // the page being unloaded — whichever happens first.
+  const captureSessionEnd = useCallback(() => {
+    if (sessionEndedRef.current) return
+    sessionEndedRef.current = true
+    const currentIndex = selectedIndexRef.current
+    if (currentIndex !== null && videoData[currentIndex]) {
+      const player = playersRef.current[currentIndex]
+      let videoDurationMs: number | undefined
+      if (player) {
+        const duration = player.duration()
+        if (duration && isFinite(duration) && duration > 0) {
+          videoDurationMs = Math.round(duration * 1000)
+        }
+      }
+      capture(PostHogEvents.VideoShortViewed, {
+        videoId: videoData[currentIndex].id,
+        videoTitle: videoData[currentIndex].title,
+        timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
+        ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
+      })
+      viewedIndicesRef.current.add(currentIndex)
+    }
     capture(PostHogEvents.VideoShortsClosed, {
       sessionDurationMs: Date.now() - sessionStartedAtRef.current,
       totalVideosViewed: viewedIndicesRef.current.size,
     })
+  }, [capture, videoData])
+
+  const handleClose = useCallback(() => {
+    captureSessionEnd()
     onClose()
-  }, [onClose, capture])
+  }, [onClose, captureSessionEnd])
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -307,11 +338,63 @@ const VideoShortsModal = ({
     }
   }, [handleClose])
 
-  // Keep a ref to the latest implementation so the stable wrapper below never
-  // changes identity, preventing CarouselV2Vertical from stacking duplicate
-  // Embla listeners on every mute/interaction state change.
-  const onSlidesInViewRef = useRef<(inView: number[]) => void>(() => {})
-  onSlidesInViewRef.current = (inView: number[]) => {
+  // Flush session analytics when the user leaves without an explicit close
+  // (closing/refreshing the tab, navigating away, or backgrounding the page),
+  // otherwise the final video_short_viewed and video_shorts_closed events would
+  // be lost — which is the most common way a session actually ends.
+  useEffect(() => {
+    const handlePageHide = () => captureSessionEnd()
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") captureSessionEnd()
+    }
+    window.addEventListener("pagehide", handlePageHide)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [captureSessionEnd])
+
+  // Analytics only; intentionally separate from the playback logic below so it
+  // can be added/removed without touching existing behavior. The prevIndex
+  // guard also makes it safe against CarouselV2Vertical firing the same event
+  // on duplicate listeners.
+  const trackSlideViewed = (newIndex: number) => {
+    const prevIndex = selectedIndexRef.current
+    // During Embla's init animation, slidesInView fires for each intermediate
+    // slide; suppress analytics until it settles on startIndex.
+    if (!hasSettledRef.current) {
+      if (newIndex === startIndex) {
+        hasSettledRef.current = true
+        currentVideoStartedAtRef.current = Date.now()
+      }
+      selectedIndexRef.current = newIndex
+      return
+    }
+    if (prevIndex === newIndex) return
+    // Fire an event for the video being left.
+    if (prevIndex !== null && videoData[prevIndex]) {
+      const prevPlayer = playersRef.current[prevIndex]
+      let videoDurationMs: number | undefined
+      if (prevPlayer) {
+        const duration = prevPlayer.duration()
+        if (duration && isFinite(duration) && duration > 0) {
+          videoDurationMs = Math.round(duration * 1000)
+        }
+      }
+      capture(PostHogEvents.VideoShortViewed, {
+        videoId: videoData[prevIndex].id,
+        videoTitle: videoData[prevIndex].title,
+        timeOnVideoMs: Date.now() - currentVideoStartedAtRef.current,
+        ...(videoDurationMs !== undefined ? { videoDurationMs } : {}),
+      })
+      viewedIndicesRef.current.add(prevIndex)
+    }
+    selectedIndexRef.current = newIndex
+    currentVideoStartedAtRef.current = Date.now()
+  }
+
+  const onSlidesInView = (inView: number[]) => {
     if (inView.length === 1 && videoData[inView[0]]) {
       playersRef.current
         .filter(
@@ -324,31 +407,6 @@ const VideoShortsModal = ({
       setAnnouncement(
         `${inView[0] + 1} of ${videoData.length}: ${videoData[inView[0]].title}`,
       )
-      const prevIndex = selectedIndexRef.current
-      const prevPlayer =
-        prevIndex !== null ? playersRef.current[prevIndex] : null
-      let prevVideoDurationMs: number | undefined
-      if (prevPlayer) {
-        const duration = prevPlayer.duration()
-        if (duration && isFinite(duration) && duration > 0) {
-          prevVideoDurationMs = Math.round(duration * 1000)
-        }
-      }
-
-      capture(PostHogEvents.VideoShortViewed, {
-        videoId: videoData[inView[0]].id,
-        videoTitle: videoData[inView[0]].title,
-        position: sessionPositionRef.current,
-        totalVideos: videoData.length,
-        timeOnPrevVideoMs: Date.now() - currentVideoStartedAtRef.current,
-        ...(prevVideoDurationMs !== undefined ? { prevVideoDurationMs } : {}),
-      })
-      if (!viewedIndicesRef.current.has(inView[0])) {
-        viewedIndicesRef.current.add(inView[0])
-        sessionPositionRef.current += 1
-      }
-      selectedIndexRef.current = inView[0]
-      currentVideoStartedAtRef.current = Date.now()
       const player = playersRef.current[inView[0]]
       if (player) {
         player.muted(muted)
@@ -360,13 +418,10 @@ const VideoShortsModal = ({
           setPlaying(true)
         }
       }
+
+      trackSlideViewed(inView[0])
     }
   }
-
-  const onSlidesInView = useCallback(
-    (inView: number[]) => onSlidesInViewRef.current(inView),
-    [],
-  )
 
   const onClickMute = () => {
     if (selectedIndex !== null && playersRef.current[selectedIndex]) {

--- a/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsModal.tsx
@@ -296,7 +296,11 @@ const VideoShortsModal = ({
     if (sessionEndedRef.current) return
     sessionEndedRef.current = true
     const currentIndex = selectedIndexRef.current
-    if (currentIndex !== null && videoData[currentIndex]) {
+    if (
+      hasSettledRef.current &&
+      currentIndex !== null &&
+      videoData[currentIndex]
+    ) {
       const player = playersRef.current[currentIndex]
       let videoDurationMs: number | undefined
       if (player) {

--- a/frontends/main/src/app-pages/HomePage/VideoShortsSection.test.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsSection.test.tsx
@@ -1,0 +1,91 @@
+import React from "react"
+import { setMockResponse, urls, factories } from "api/test-utils"
+import { renderWithProviders, screen, user } from "@/test-utils"
+import { usePostHog } from "posthog-js/react"
+import type { PostHog } from "posthog-js"
+import VideoShortsSection from "./VideoShortsSection"
+
+jest.mock("posthog-js/react")
+const mockedPostHogCapture = jest.fn()
+jest.mocked(usePostHog).mockReturnValue({
+  capture: mockedPostHogCapture,
+} as unknown as PostHog)
+
+// Stub VideoShortsModal to avoid rendering the full player stack
+jest.mock("./VideoShortsModal", () => ({
+  __esModule: true,
+  default: () => <div data-testid="video-shorts-modal" />,
+}))
+
+// CarouselV2 uses scroll APIs unavailable in JSDOM; render children directly
+jest.mock("ol-components/CarouselV2", () => ({
+  CarouselV2: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+
+const setupApis = () => {
+  const videos = [
+    factories.learningResources.video({ title: "First Short" }),
+    factories.learningResources.video({ title: "Second Short" }),
+  ]
+
+  setMockResponse.get(expect.stringContaining(urls.search.resources()), {
+    count: videos.length,
+    next: null,
+    previous: null,
+    results: videos,
+  })
+
+  return { videos }
+}
+
+describe("VideoShortsSection", () => {
+  beforeEach(() => {
+    mockedPostHogCapture.mockClear()
+    process.env.NEXT_PUBLIC_POSTHOG_API_KEY = "test-key"
+  })
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_POSTHOG_API_KEY
+  })
+
+  test("captures VideoShortsOpened with videoId, videoTitle, and position when a thumbnail is clicked", async () => {
+    const { videos } = setupApis()
+
+    renderWithProviders(<VideoShortsSection />)
+
+    const button = await screen.findByRole("button", {
+      name: `Play ${videos[0].title}`,
+    })
+    await user.click(button)
+
+    expect(mockedPostHogCapture).toHaveBeenCalledWith(
+      "video_shorts_opened",
+      expect.objectContaining({
+        videoId: videos[0].id,
+        videoTitle: videos[0].title,
+        position: 0,
+      }),
+    )
+  })
+
+  test("captures VideoShortsOpened with correct position for non-first thumbnail", async () => {
+    const { videos } = setupApis()
+
+    renderWithProviders(<VideoShortsSection />)
+
+    const button = await screen.findByRole("button", {
+      name: `Play ${videos[1].title}`,
+    })
+    await user.click(button)
+
+    expect(mockedPostHogCapture).toHaveBeenCalledWith(
+      "video_shorts_opened",
+      expect.objectContaining({
+        videoId: videos[1].id,
+        videoTitle: videos[1].title,
+        position: 1,
+      }),
+    )
+  })
+})

--- a/frontends/main/src/app-pages/HomePage/VideoShortsSection.tsx
+++ b/frontends/main/src/app-pages/HomePage/VideoShortsSection.tsx
@@ -9,6 +9,9 @@ import { ResourceTypeEnum } from "api"
 import VideoShortsModal from "./VideoShortsModal"
 import MITOpenLearningLogo from "@/public/images/mit-open-learning-logo.svg"
 import type { VideoResource } from "api/v1"
+import { usePostHog } from "posthog-js/react"
+import { PostHogEvents } from "@/common/constants"
+import { env } from "@/env"
 
 const Section = styled.section(({ theme }) => ({
   padding: "80px 0",
@@ -105,8 +108,21 @@ const VideoShortsSection = () => {
   const [videoIndex, setVideoIndex] = useState(0)
   const [announcement, setAnnouncement] = useState("")
   const [visibleSlides, setVisibleSlides] = useState<number[]>([])
+  const posthog = usePostHog()
 
   if (isLoading || !data?.length) return null
+
+  const openModal = (video: VideoResource, index: number) => {
+    setShowModal(true)
+    setVideoIndex(index)
+    if (env("NEXT_PUBLIC_POSTHOG_API_KEY")) {
+      posthog.capture(PostHogEvents.VideoShortsOpened, {
+        videoId: video.id,
+        videoTitle: video.title,
+        position: index,
+      })
+    }
+  }
 
   return (
     <Section>
@@ -152,14 +168,12 @@ const VideoShortsSection = () => {
               }
               aria-label={`Play ${video.title}`}
               onClick={() => {
-                setShowModal(true)
-                setVideoIndex(index)
+                openModal(video, index)
               }}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault()
-                  setShowModal(true)
-                  setVideoIndex(index)
+                  openModal(video, index)
                 }
               }}
             >

--- a/frontends/main/src/common/constants.ts
+++ b/frontends/main/src/common/constants.ts
@@ -27,6 +27,9 @@ export const PostHogEvents = {
   ClickedNavBrowsePopular: "clicked_nav_browse_popular",
   ClickedNavBrowseFree: "clicked_nav_browse_free",
   ClickedNavBrowseCertificate: "clicked_nav_browse_certificate",
+  VideoShortsOpened: "video_shorts_opened",
+  VideoShortViewed: "video_short_viewed",
+  VideoShortsClosed: "video_shorts_closed",
 } as const
 
 export const DigitalCredentialsFAQLink =

--- a/frontends/ol-components/src/components/CarouselV2/CarouselV2Vertical.tsx
+++ b/frontends/ol-components/src/components/CarouselV2/CarouselV2Vertical.tsx
@@ -139,14 +139,21 @@ const CarouselV2Vertical: React.FC<CarouselV2VerticalProps> = ({
   }, [emblaApi])
 
   useEffect(() => {
-    emblaApi?.on("slidesInView", (event) => {
-      const inView = event.slidesInView()
+    if (!emblaApi) {
+      return
+    }
+    const handleSlidesInView = () => {
+      const inView = emblaApi.slidesInView()
       if (inView.length === 1) {
         setCanScrollPrev(emblaApi.canScrollPrev())
         setCanScrollNext(emblaApi.canScrollNext())
       }
       onSlidesInView?.(inView)
-    })
+    }
+    emblaApi.on("slidesInView", handleSlidesInView)
+    return () => {
+      emblaApi.off("slidesInView", handleSlidesInView)
+    }
   }, [emblaApi, onSlidesInView])
 
   const handleWheelGesture = useCallback(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10916

### Description (What does it do?)
<!--- Describe your changes in detail -->
adds PostHog tracking for video shorts interactions
- video_shorts_opened — fires when a thumbnail is clicked. Captures the video ID, title, and its position in the carousel.
- video_short_viewed — fires each time the user scrolls to a new video. Captures video ID, title, session position, and (for non-first videos) how long they spent on the previous video and its total duration.
- video_shorts_closed — fires when the modal is closed. Captures total session duration and how many videos were viewed.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

frontend.local.env
```
NEXT_PUBLIC_FEATURE_VIDEO_SHORTS=True
```
backend.local.env 
```
OVS_API_BASE_URL=https://video.odl.mit.edu/
```

Run `docker compose run --rm web python manage.py backpopulate_ovs_data` to populate some video shorts locally

Click on one of these video shorts on the homepage, and verified these events are captured

video_shorts_opened
<img width="1404" height="126" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/a178caa2-abbe-46bd-a3d3-14b40296fe6f" />

video_shorts_viewed
<img width="1315" height="198" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/6d6dfc71-5786-4804-8f3d-3658084b202e" />

video_shorts_closed
<img width="949" height="72" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/05b6354e-5996-40be-aedd-564724fb78bf" />


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
