### PR TITLE
fix: fix the caption controls breaking on video player & banner's heading placeholder text color change

### DIFF
--- a/frontends/main/src/page-components/TiptapEditor/TiptapEditor.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/TiptapEditor.tsx
@@ -119,17 +119,40 @@ const Container = styled.div<{
     a: {
       color: theme.custom.colors.darkGray2,
     },
-    ul: {
+    "ul:not([data-style-boundary] *)": {
       ...theme.typography.body1,
     },
-    ol: {
+    "ol:not([data-style-boundary] *)": {
       ...theme.typography.body1,
     },
-    li: {
+    "li:not([data-style-boundary] *)": {
       ...theme.typography.body1,
       lineHeight: pxToRem(54),
       p: {
         marginBottom: 0,
+      },
+    },
+    // [data-style-boundary] marks embedded third-party components (e.g. video player)
+    // that must not inherit editor typography.
+    "& [data-style-boundary] ul, & [data-style-boundary] ol": {
+      marginTop: "revert",
+      marginBottom: "unset",
+      paddingLeft: "unset",
+      listStyle: "revert",
+      fontFamily: "revert",
+      fontSize: "revert",
+      fontWeight: "revert",
+      lineHeight: "revert",
+      letterSpacing: "revert",
+    },
+    "& [data-style-boundary] li": {
+      lineHeight: "revert",
+      fontFamily: "revert",
+      fontSize: "revert",
+      fontWeight: "revert",
+      letterSpacing: "revert",
+      p: {
+        marginTop: "revert",
       },
     },
     blockquote: {

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/Banner/ArticleBannerNode.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/Banner/ArticleBannerNode.tsx
@@ -106,7 +106,7 @@ const StyledNodeViewContent = styled(NodeViewContent)(({ theme }) => ({
   },
   ".is-empty:not(.with-slash)[data-placeholder]:has(> .ProseMirror-trailingBreak:only-child)::before":
     {
-      color: theme.custom.colors.silverGrayLight,
+      color: theme.custom.colors.darkGray2,
       opacity: 0.4,
     },
   '[contenteditable="true"] &': {

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/MediaEmbed/MediaEmbedNodeView.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/MediaEmbed/MediaEmbedNodeView.tsx
@@ -159,13 +159,15 @@ const OVSVideoPlayer = ({
   const video: VideoResource | undefined =
     resource?.resource_type === "video" ? resource : undefined
   return (
-    <VideoResourcePlayer
-      video={video}
-      videoId={videoId}
-      isLoading={isLoading}
-      videoTitleLabel={title || "Video"}
-      videoThumbnailAlt={title || "Video thumbnail"}
-    />
+    <div data-style-boundary>
+      <VideoResourcePlayer
+        video={video}
+        videoId={videoId}
+        isLoading={isLoading}
+        videoTitleLabel={title || "Video"}
+        videoThumbnailAlt={title || "Video thumbnail"}
+      />
+    </div>
   )
 }
 

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/MediaEmbed/MediaEmbedViewer.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/MediaEmbed/MediaEmbedViewer.tsx
@@ -60,13 +60,15 @@ const OVSVideoPlayer = ({
   const video: VideoResource | undefined =
     resource?.resource_type === "video" ? resource : undefined
   return (
-    <VideoResourcePlayer
-      video={video}
-      videoId={videoId}
-      isLoading={isLoading}
-      videoTitleLabel={title || "Video"}
-      videoThumbnailAlt={title || "Video thumbnail"}
-    />
+    <div data-style-boundary>
+      <VideoResourcePlayer
+        video={video}
+        videoId={videoId}
+        isLoading={isLoading}
+        videoTitleLabel={title || "Video"}
+        videoThumbnailAlt={title || "Video thumbnail"}
+      />
+    </div>
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11721

### Description (What does it do?)
 - As a content editor, I want Video.js player menus and caption settings to display correctly inside the Tiptap editor, so I can read and interact with caption/subtitle labels without visual distortion.
 - We also changed the banner's headings placeholder text color for article only

### Screenshots (if appropriate):
### Before
<img width="2154" height="1318" alt="image" src="https://github.com/user-attachments/assets/c3886abd-a969-4e7b-a977-73daa958e975" />

### After

<img width="1898" height="1166" alt="image" src="https://github.com/user-attachments/assets/2fec9d31-d75b-4aef-8849-0681b708ed3c" />




### How can this be tested?
For testing you need to embed any video inside the editor and check the caption in editor view and as well as in reader view

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
