### PR TITLE
Exclude MicroMasters Finance program from ETL ingestion

### DIFF
--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -21,7 +21,7 @@ from learning_resources.models import LearningResource, default_pace
 
 OFFERED_BY = {"code": OfferedBy.mitx.name}
 READABLE_ID_PREFIX = "micromasters-program-"
-IGNORE_URLS = re.compile(r"/(dedp|scm)/")
+IGNORE_URLS = re.compile(r"/(dedp|scm|fin)/")
 
 log = logging.getLogger(__name__)
 

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -191,6 +191,8 @@ def test_micromasters_transform(mock_micromasters_data, missing_url):
         ("http://example.com/program/1/url", False),
         ("http://example.com/dedp/program/1/url", True),
         ("http://example.com/scm/program/1/url", True),
+        ("http://example.com/fin/program/1/url", True),
+        ("http://example.com/finis/program/1/url", False),
     ],
 )
 def test_micromasters_transform_ignores_urls(


### PR DESCRIPTION
### What are the relevant tickets?
Similar to https://github.com/mitodl/mit-learn/pull/3411

### Description (What does it do?)
<!--- Describe your changes in detail -->
Excludes the Micromasters Finance program from being ingested via the MM API


### How can this be tested?
- Set `MICROMASTERS_CATALOG_API_URL=https://micromasters.mit.edu/api/v0/catalog/` in your `backend.local.env` file
- On the main branch, run `./manage.py backpopulate_micromasters_data`.  Then go to django admin url http://open.odl.local:8065/admin/learning_resources/learningresource/?etl_source=micromasters&resource_type__exact=program.  You should see a "Finance" program there, and it should be published.
- Switch to this branch, restart containers, run the command again.
- Go back to django admin. The "Finance" program should now be unpublished.
