### PR TITLE
fix: Run Typegen before Typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,21 +107,6 @@ jobs:
       - name: Lints
         run: yarn run lint-check
 
-      - name: Build Next.js frontend
-        run: yarn workspace main build
-        env:
-          # Build env-agnostically, exactly like the standalone Docker image.
-          # NEXT_BUILD_CI=1 skips validateEnv() because NEXT_PUBLIC_* values are
-          # injected at runtime (via PublicEnvScript), not baked in at build.
-          # No NEXT_PUBLIC_* vars are set here on purpose: with them unset, any
-          # code that reads one at module scope (e.g. a module-level
-          # requiredEnv(), which throws on the undefined value) fails the build.
-          # This gates such build-time env dependencies in CI rather than letting
-          # them surface only at container startup.
-          NODE_ENV: production
-          NEXT_BUILD_CI: "1"
-        # do this before typecheck. See https://github.com/vercel/next.js/issues/53959#issuecomment-1735563224
-
       - name: Typecheck
         run: yarn run typecheck
 

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -6,7 +6,8 @@
     "dev": "PORT=${PORT:-8062} TZ=UTC next dev",
     "build": "next build",
     "start": "TZ=UTC next start",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "typegen": "NEXT_BUILD_CI=1 next typegen"
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",

--- a/frontends/package.json
+++ b/frontends/package.json
@@ -22,7 +22,7 @@
     "test-watch": "yarn global:test-watch",
     "style-lint": "yarn in-workspaces run global:style-lint",
     "style-lint-fix": "yarn in-workspaces run global:style-lint-fix",
-    "typecheck": "yarn in-workspaces run global:typecheck",
+    "typecheck": "yarn workspace main run typegen && yarn in-workspaces run global:typecheck",
     "global:style-lint": "cd $INIT_CWD && stylelint '**/*.{css,scss,ts,tsx}' --allow-empty-input",
     "global:style-lint-fix": "cd $INIT_CWD && stylelint '**/*.{css,scss,ts,tsx}' --allow-empty-input --fix",
     "global:test": "cd $INIT_CWD && NODE_ENV=test jest",


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
NextJS generate some types based on our files, and typechecking won't pass unless those types are generated. For humans, this isn't usually a problem, because the dev server generates them. However for LLMs, they don't have the dev server running. So now:

- `yarn typecheck` now build nextjs types BEFORE running `typecheck`.
- I removed the `yarn build` step in `ci.yaml`. This is the how we were generating NextJS types prior to typechecking before.
    - typegen is faster
    - `yarn build` was redundant, since we still build the production docker image in the `build-nextjs-container` step of `ci.yml`



### How can this be tested?
1. `yarn typecheck` should pass
2. CI should pass