### PR TITLE
dashboard refactor phase 7b

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -35,8 +35,9 @@ type StyledComponentBaseProps = {
 }
 
 /** Props for the default course / enrollment card display. */
-type CoursewareCardDefaultProps = CoursewareCardBaseProps & {
+type CoursewareCardDefaultProps = StyledComponentBaseProps & {
   layout?: "default" | "stacked"
+  entry: DashboardCourseEntry
   showNotComplete?: boolean
   offerUpgrade?: boolean
   isLoading?: boolean
@@ -52,14 +53,15 @@ type CoursewareCardDefaultProps = CoursewareCardBaseProps & {
  * `entry.ancestorContext` so callers only need to embed them there (via
  * `buildCourseEntry`).
  */
-type CoursewareCardModuleRowProps = CoursewareCardBaseProps & {
+type CoursewareCardModuleRowProps = StyledComponentBaseProps & {
   layout: "moduleRow"
+  entry: DashboardCourseEntry
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
 }
 
 /** Props for program card display. */
 type CoursewareCardProgramProps = StyledComponentBaseProps & {
-  variant: "program"
+  layout: "program"
   programEnrollment: V3UserProgramEnrollment
   showNotComplete?: boolean
 }
@@ -74,7 +76,7 @@ export type CoursewareCardProps =
 
 const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
   // ── program arm ──────────────────────────────────────────────────────────
-  if (props.variant === "program") {
+  if (props.layout === "program") {
     const { programEnrollment, Component, className } = props
     return (
       <DashboardCard

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -14,9 +14,13 @@
 import React from "react"
 import type { SimpleMenuItem } from "ol-components"
 import { adaptCourseEntryToLegacyDashboardCardProps } from "./model/dashboardAdapters"
-import type { DashboardCourseEntry } from "./model/dashboardViewModel"
+import {
+  DashboardType,
+  type DashboardCourseEntry,
+} from "./model/dashboardViewModel"
 import { DashboardCard } from "./DashboardCard"
 import { DashboardCard as ModuleCardInner } from "./ModuleCard"
+import { V3UserProgramEnrollment } from "@mitodl/mitxonline-api-axios/v2"
 
 // Re-export the card root so OrganizationCards.tsx can migrate in Phase 7c.
 export { DashboardCardRoot as CoursewareCardRoot } from "./DashboardCard"
@@ -25,8 +29,7 @@ export { DashboardCardRoot as CoursewareCardRoot } from "./DashboardCard"
 // Prop types
 // ---------------------------------------------------------------------------
 
-type CoursewareCardBaseProps = {
-  entry: DashboardCourseEntry
+type StyledComponentBaseProps = {
   className?: string
   Component?: React.ElementType
 }
@@ -54,17 +57,39 @@ type CoursewareCardModuleRowProps = CoursewareCardBaseProps & {
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
 }
 
+/** Props for program card display. */
+type CoursewareCardProgramProps = StyledComponentBaseProps & {
+  variant: "program"
+  programEnrollment: V3UserProgramEnrollment
+  showNotComplete?: boolean
+}
+
 export type CoursewareCardProps =
   | CoursewareCardDefaultProps
   | CoursewareCardModuleRowProps
-
+  | CoursewareCardProgramProps
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
-  const { entry, Component, className } = props
+  // ── program arm ──────────────────────────────────────────────────────────
+  if (props.variant === "program") {
+    const { programEnrollment, Component, className } = props
+    return (
+      <DashboardCard
+        resource={{
+          type: DashboardType.ProgramEnrollment,
+          data: programEnrollment,
+        }}
+        showNotComplete={props.showNotComplete}
+        Component={Component}
+        className={className}
+      />
+    )
+  }
 
+  const { entry, Component, className } = props
   // ── moduleRow arm ────────────────────────────────────────────────────────
   if (props.layout === "moduleRow") {
     const { headingLevel } = props

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -20,7 +20,7 @@ import {
 } from "./model/dashboardViewModel"
 import { DashboardCard } from "./DashboardCard"
 import { DashboardCard as ModuleCardInner } from "./ModuleCard"
-import { V3UserProgramEnrollment } from "@mitodl/mitxonline-api-axios/v2"
+import type { V3UserProgramEnrollment } from "@mitodl/mitxonline-api-axios/v2"
 
 // Re-export the card root so OrganizationCards.tsx can migrate in Phase 7c.
 export { DashboardCardRoot as CoursewareCardRoot } from "./DashboardCard"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -156,7 +156,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       resourceType: ResourceType.Program,
                       id: item.enrollment.program.id,
                     })}
-                    variant="program"
+                    layout="program"
                     programEnrollment={item.enrollment}
                     showNotComplete={false}
                   />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -149,7 +149,6 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                   )
                 }
 
-                // program-enrollment arm: still uses legacy DashboardCard until Phase 7b
                 return (
                   <ProgramEnrollmentCard
                     key={getKey({

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 import { Skeleton, Stack, Typography, styled, theme } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
-import { DashboardType, ResourceType, getKey } from "./model/dashboardViewModel"
+import { ResourceType, getKey } from "./model/dashboardViewModel"
 import { CoursewareCard } from "./CoursewareCard"
-import { DashboardCard } from "./DashboardCard"
 import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { RiAwardFill } from "@remixicon/react"
@@ -14,8 +13,7 @@ const CourseEntryCardStyled = styled(CoursewareCard)({
   boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
 })
 
-// Program-enrollment arm still uses DashboardCard directly (Phase 7b migration).
-const ProgramEnrollmentCard = styled(DashboardCard)({
+const ProgramEnrollmentCard = styled(CoursewareCard)({
   borderRadius: "8px",
   boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
 })
@@ -158,10 +156,8 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       resourceType: ResourceType.Program,
                       id: item.enrollment.program.id,
                     })}
-                    resource={{
-                      type: DashboardType.ProgramEnrollment,
-                      data: item.enrollment,
-                    }}
+                    variant="program"
+                    programEnrollment={item.enrollment}
                     showNotComplete={false}
                   />
                 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11205

### Description (What does it do?)
This PR migrates `ProgramEnrollmentDisplay` to use the new `CoursewareCard` display component. A "program" arm was added to `CoursewareCard`'s rendering method that handles constructing a `DashboardCard` (for now) component for the program.

### How can this be tested?
- Ensure that you have MITx Online and Learn connected as described in the readme with sufficient test data, which in this case is an enrollable B2C program. Your user should be enrolled in the program so it shows up in their My Learning section of the dashboard home page.
- Once enrolled, visit the dashboard home page. You should see a card there with "View Program" on it. Click the button and it should bring you to the program dashboard.