### PR TITLE
dashboard refactor phase 7c

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -32,6 +32,18 @@ jest.mock("posthog-js/react", () => ({
 }))
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
 
+// The generated b2bEnrollCreate client does not yet accept a request body, so
+// program_id never reaches the network layer (see the skipped DashboardCard
+// test). Spy on the hook's mutate to assert program_id is forwarded.
+const mockB2bEnrollMutate = jest.fn()
+jest.mock("api/mitxonline-hooks/enrollment", () => ({
+  ...jest.requireActual("api/mitxonline-hooks/enrollment"),
+  useCreateB2bEnrollment: () => ({
+    mutate: mockB2bEnrollMutate,
+    isPending: false,
+  }),
+}))
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL
 const managerOrganizationsUrl = `${API_BASE_URL}/api/v0/b2b/manager/organizations/`
 
@@ -2419,5 +2431,62 @@ describe("ContractContent", () => {
 
     await screen.findByText(programA.title)
     await screen.findByText(programB.title)
+  })
+
+  test("unenrolled B2B course row forwards the program's readable_id when enrolling", async () => {
+    const { orgX, mitxOnlineUser, programA, coursesA, coursesB } =
+      setupProgramsAndCourses()
+
+    // Normalize first course so it has a single run with a known courseware_id
+    // and next_run_id is set. Override BOTH the per-program and the all-courses
+    // queries so that useContractDashboardData builds the entry from the same data.
+    const normalizedCourse = normalizeCourseForCardAssertions(coursesA[0])
+    const normalizedCoursesA = [normalizedCourse, ...coursesA.slice(1)]
+    setMockResponse.get(
+      urls.courses.coursesList({
+        org_id: orgX.id,
+        contract_id: orgX.contracts[0].id,
+        page_size: 200,
+      }),
+      { results: [...normalizedCoursesA, ...coursesB] },
+    )
+    setMockResponse.get(
+      urls.courses.coursesList({
+        id: programA.courses,
+        contract_id: orgX.contracts[0].id,
+        page_size: 30,
+      }),
+      { results: normalizedCoursesA },
+    )
+
+    // Complete profile so enrollment bypasses the JustInTimeDialog
+    setMockResponse.get(urls.userMe.get(), {
+      ...mitxOnlineUser,
+      legal_address: { country: "US" },
+      user_profile: { year_of_birth: 1988 },
+    })
+
+    renderWithProviders(
+      <ContractContent
+        orgSlug={orgX.slug}
+        contractSlug={orgX.contracts[0].slug}
+      />,
+    )
+
+    const [programAEl] = await screen.findAllByTestId("org-program-root")
+    const cards = await within(programAEl).findAllByTestId(
+      "enrollment-card-desktop",
+    )
+    await user.click(within(cards[0]).getByTestId("courseware-button"))
+
+    await waitFor(() =>
+      expect(mockB2bEnrollMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          readable_id: normalizedCourse.courseruns[0].courseware_id,
+          program_id: programA.readable_id,
+        }),
+        expect.anything(),
+      ),
+    )
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -3,8 +3,7 @@
 import React, { useEffect } from "react"
 import Image from "next/image"
 import { useQuery } from "@tanstack/react-query"
-import { DashboardCard } from "./CoursewareDisplay/DashboardCard"
-import { adaptCourseEntryToLegacyDashboardCardProps } from "./CoursewareDisplay/model/dashboardAdapters"
+import { CoursewareCard } from "./CoursewareDisplay/CoursewareCard"
 import {
   alpha,
   Link,
@@ -170,7 +169,7 @@ const WelcomeMessage: React.FC<{ contract?: ContractPage }> = ({
   )
 }
 
-const DashboardCardStyled = styled(DashboardCard)({
+const DashboardCardStyled = styled(CoursewareCard)({
   borderRadius: "0px",
   borderTop: "none",
   "&:last-of-type": {
@@ -279,7 +278,7 @@ const OrgProgramCollectionDisplay: React.FC<{
               runId:
                 entry.displayedEnrollment?.run.id ?? entry.displayedRun?.id,
             })}
-            {...adaptCourseEntryToLegacyDashboardCardProps(entry)}
+            entry={entry}
             noun="Module"
             offerUpgrade={false}
           />
@@ -335,7 +334,7 @@ const OrgProgramDisplay: React.FC<{
               runId:
                 entry.displayedEnrollment?.run.id ?? entry.displayedRun?.id,
             })}
-            {...adaptCourseEntryToLegacyDashboardCardProps(entry)}
+            entry={entry}
             noun="Module"
             offerUpgrade={false}
           />

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -169,7 +169,7 @@ const WelcomeMessage: React.FC<{ contract?: ContractPage }> = ({
   )
 }
 
-const DashboardCardStyled = styled(CoursewareCard)({
+const CoursewareCardStyled = styled(CoursewareCard)({
   borderRadius: "0px",
   borderTop: "none",
   "&:last-of-type": {
@@ -270,7 +270,7 @@ const OrgProgramCollectionDisplay: React.FC<{
       {header}
       <PlainList>
         {entries.map((entry) => (
-          <DashboardCardStyled
+          <CoursewareCardStyled
             Component="li"
             key={getKey({
               resourceType: ResourceType.Course,
@@ -326,7 +326,7 @@ const OrgProgramDisplay: React.FC<{
       </ProgramHeader>
       <PlainList>
         {entries.map((entry) => (
-          <DashboardCardStyled
+          <CoursewareCardStyled
             Component="li"
             key={getKey({
               resourceType: ResourceType.Course,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -131,10 +131,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
 
   return (
     <DashboardCard
-      resource={adapted.resource}
-      selectedCourseRun={adapted.selectedCourseRun}
-      contractId={adapted.contractId}
-      programEnrollment={adapted.programEnrollment}
+      {...adapted}
       showNotComplete={showNotComplete}
       offerUpgrade={offerUpgrade}
       isLoading={isLoading}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -43,6 +43,7 @@ type CoursewareCardDefaultProps = StyledComponentBaseProps & {
   isLoading?: boolean
   onUpgradeError?: (error: string) => void
   contextMenuItems?: SimpleMenuItem[]
+  noun?: string
 }
 
 /**
@@ -140,6 +141,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
       onUpgradeError={onUpgradeError}
       contextMenuItems={contextMenuItems}
       variant={layout}
+      noun={props.noun}
       Component={Component}
       className={className}
     />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.tsx
@@ -3,7 +3,7 @@ import Image from "next/image"
 import graduateLogo from "@/public/images/dashboard/graduate.png"
 import { Stack, Typography, styled, theme, Link } from "ol-components"
 import { useQuery } from "@tanstack/react-query"
-import { DashboardCardRoot } from "./DashboardCard"
+import { CoursewareCardRoot } from "./CoursewareCard"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { ButtonLink } from "@mitodl/smoot-design"
 import { contractView } from "@/common/urls"
@@ -43,7 +43,7 @@ const ContractCard = styled.div({
   },
 })
 
-const CardRootStyled = styled(DashboardCardRoot)({
+const CardRootStyled = styled(CoursewareCardRoot)({
   display: "flex",
   flexDirection: "column",
   padding: 0,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11205

### Description (What does it do?)
This PR migrates `ContractContent` to use the new `CoursewareCard` display component. The `noun` optional string property was added to support how the B2B contract dashboard pages override the noun to say "Module" instead of "Course." Really this just sets the stage for the final part of the conversion.

### How can this be tested?
- Ensure that you have MITx Online and Learn connected as described in the readme with sufficient test data, which in this case is a B2B contract with several programs and program collections. Also make sure your user is enrolled in said contract.
- Browse to the dashboard and open the contract. Ensure that everything looks the same as it does when running Learn on `main`