### PR TITLE
Fix sitemap pagination

### DIFF
--- a/frontends/main/src/app/getQueryClient.ts
+++ b/frontends/main/src/app/getQueryClient.ts
@@ -4,6 +4,7 @@ import { QueryClient, isServer, focusManager } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
 import { cache } from "react"
 import { notFound } from "next/navigation"
+import { bootstrapApiClients } from "@/bootstrap/api"
 
 /** Max retries after first failure */
 const MAX_RETRIES = 3
@@ -73,6 +74,10 @@ class AugmentedQueryClient extends QueryClient {
  * readiness for the dehydrated state to be sent to the client.
  */
 export const getServerQueryClient = cache(() => {
+  // Bootstrap client here, in addition to instrumentation.ts
+  // At least in development, sitemaps run in a separate worker process that
+  // doesn't execute instrumentation.ts. This seems NOT to be true in production.
+  bootstrapApiClients()
   return new AugmentedQueryClient({
     defaultOptions: {
       queries: {

--- a/frontends/main/src/app/sitemaps/channels/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/channels/sitemap.test.ts
@@ -39,7 +39,7 @@ describe("Resource Sitemaps", () => {
     )
 
     const sitemapPage = await sitemap({
-      id: String(page),
+      id: Promise.resolve(String(page)),
     })
     expect(sitemapPage).toEqual(
       channels.results.map((channel) => ({

--- a/frontends/main/src/app/sitemaps/channels/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/channels/sitemap.ts
@@ -1,6 +1,6 @@
 import { requiredEnv } from "@/env"
 import type { MetadataRoute } from "next"
-import type { GenerateSitemapResult } from "../types"
+import type { GenerateSitemapResult, GeneratedSitemapArgs } from "../types"
 import { dangerouslyDetectProductionBuildPhase } from "../util"
 import { getQueryClient } from "@/app/getQueryClient"
 import { channelQueries } from "api/hooks/channels"
@@ -35,14 +35,13 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
 export default async function sitemap({
   id,
-}: {
-  id: string
-}): Promise<MetadataRoute.Sitemap> {
+}: GeneratedSitemapArgs): Promise<MetadataRoute.Sitemap> {
+  const page = +(await id)
   const queryClient = getQueryClient()
   const data = await queryClient.fetchQuery(
     channelQueries.list({
       limit: PAGE_SIZE,
-      offset: +id * PAGE_SIZE,
+      offset: page * PAGE_SIZE,
     }),
   )
 

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.test.ts
@@ -50,7 +50,7 @@ describe("Podcast Sitemaps", () => {
       podcastList,
     )
 
-    const sitemapPage = await sitemap({ id: String(page) })
+    const sitemapPage = await sitemap({ id: Promise.resolve(String(page)) })
     expect(sitemapPage).toEqual(
       podcastList.results.map((resource) => ({
         url: `http://test.learn.odl.local:8062/podcast/${resource.id}`,
@@ -90,7 +90,7 @@ describe("Podcast Sitemaps", () => {
       { count: results.length, next: null, previous: null, results },
     )
 
-    const sitemapPage = await sitemap({ id: String(page) })
+    const sitemapPage = await sitemap({ id: Promise.resolve(String(page)) })
     // episodeWithoutParent should be excluded; episodeWithMultipleParents emits one entry per parent
     expect(sitemapPage).toEqual([
       {

--- a/frontends/main/src/app/sitemaps/podcast/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/podcast/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next"
 import { getQueryClient } from "@/app/getQueryClient"
 import { learningResourceQueries } from "api/hooks/learningResources"
 import { ResourceTypeEnum } from "api"
-import type { GenerateSitemapResult } from "../types"
+import type { GenerateSitemapResult, GeneratedSitemapArgs } from "../types"
 import { dangerouslyDetectProductionBuildPhase } from "../util"
 
 const PAGE_SIZE = 1_000
@@ -46,15 +46,14 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
 export default async function sitemap({
   id,
-}: {
-  id: string
-}): Promise<MetadataRoute.Sitemap> {
+}: GeneratedSitemapArgs): Promise<MetadataRoute.Sitemap> {
+  const page = +(await id)
   const BASE_URL = requiredEnv("NEXT_PUBLIC_ORIGIN")
   const queryClient = getQueryClient()
   const data = await queryClient.fetchQuery(
     learningResourceQueries.list({
       limit: PAGE_SIZE,
-      offset: +id * PAGE_SIZE,
+      offset: page * PAGE_SIZE,
       resource_type: RESOURCE_TYPES,
     }),
   )

--- a/frontends/main/src/app/sitemaps/products/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/products/sitemap.test.ts
@@ -52,7 +52,7 @@ describe("Product Sitemaps", () => {
       summaries,
     )
 
-    const sitemapPage = await sitemap({ id: String(page) })
+    const sitemapPage = await sitemap({ id: Promise.resolve(String(page)) })
     expect(sitemapPage).toEqual(
       summaries.results
         .filter((resource) => Boolean(resource.url))

--- a/frontends/main/src/app/sitemaps/products/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/products/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next"
 import { getQueryClient } from "@/app/getQueryClient"
 import { learningResourceQueries } from "api/hooks/learningResources"
 import { PlatformEnum, ResourceTypeEnum } from "api"
-import type { GenerateSitemapResult } from "../types"
+import type { GenerateSitemapResult, GeneratedSitemapArgs } from "../types"
 import { dangerouslyDetectProductionBuildPhase } from "../util"
 
 const PAGE_SIZE = 1_000
@@ -33,14 +33,13 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
 export default async function sitemap({
   id,
-}: {
-  id: string
-}): Promise<MetadataRoute.Sitemap> {
+}: GeneratedSitemapArgs): Promise<MetadataRoute.Sitemap> {
+  const page = +(await id)
   const queryClient = getQueryClient()
   const data = await queryClient.fetchQuery(
     learningResourceQueries.summaryList({
       limit: PAGE_SIZE,
-      offset: +id * PAGE_SIZE,
+      offset: page * PAGE_SIZE,
       platform: [PlatformEnum.Mitxonline],
       resource_type: [ResourceTypeEnum.Course, ResourceTypeEnum.Program],
     }),

--- a/frontends/main/src/app/sitemaps/resources/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/resources/sitemap.test.ts
@@ -44,7 +44,7 @@ describe("Resource Sitemaps", () => {
       summaries,
     )
 
-    const sitemapPage = await sitemap({ id: String(page) })
+    const sitemapPage = await sitemap({ id: Promise.resolve(String(page)) })
     expect(sitemapPage).toEqual(
       summaries.results.map((resource) => ({
         url: `http://test.learn.odl.local:8062/search?resource=${resource.id}`,

--- a/frontends/main/src/app/sitemaps/resources/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/resources/sitemap.ts
@@ -2,7 +2,7 @@ import { requiredEnv } from "@/env"
 import type { MetadataRoute } from "next"
 import { getQueryClient } from "@/app/getQueryClient"
 import { learningResourceQueries } from "api/hooks/learningResources"
-import type { GenerateSitemapResult } from "../types"
+import type { GenerateSitemapResult, GeneratedSitemapArgs } from "../types"
 import { dangerouslyDetectProductionBuildPhase } from "../util"
 
 const PAGE_SIZE = 1_000
@@ -39,15 +39,14 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
 export default async function sitemap({
   id,
-}: {
-  id: string
-}): Promise<MetadataRoute.Sitemap> {
+}: GeneratedSitemapArgs): Promise<MetadataRoute.Sitemap> {
+  const page = +(await id)
   const BASE_URL = requiredEnv("NEXT_PUBLIC_ORIGIN")
   const queryClient = getQueryClient()
   const data = await queryClient.fetchQuery(
     learningResourceQueries.summaryList({
       limit: PAGE_SIZE,
-      offset: +id * PAGE_SIZE,
+      offset: page * PAGE_SIZE,
     }),
   )
 

--- a/frontends/main/src/app/sitemaps/types.ts
+++ b/frontends/main/src/app/sitemaps/types.ts
@@ -14,3 +14,19 @@ export type GenerateSitemapResult = {
    */
   location: string
 }
+
+/**
+ * The argument NextJS passes to a metadata route's default `sitemap()` export
+ * when the route also exports `generateSitemaps()`.
+ *
+ * `id` is the stringified `id` from a {@link GenerateSitemapResult}, and in
+ * Next 15.5+/16 it arrives as a Promise (part of the async request-API change),
+ * so it MUST be awaited before use. NextJS does not type the `sitemap()`
+ * argument itself — only the return value (`MetadataRoute.Sitemap`) — so this
+ * type is hand-maintained to keep the await contract explicit and consistent
+ * across every sitemap route. Not awaiting `id` silently makes `+id` NaN, which
+ * collapses every shard to offset 0.
+ */
+export type GeneratedSitemapArgs = {
+  id: Promise<string>
+}

--- a/frontends/main/src/app/sitemaps/video/sitemap.test.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.test.ts
@@ -52,7 +52,7 @@ describe("Video Sitemaps", () => {
       { count: results.length, next: null, previous: null, results },
     )
 
-    const sitemapPage = await sitemap({ id: String(page) })
+    const sitemapPage = await sitemap({ id: Promise.resolve(String(page)) })
     expect(sitemapPage).toEqual(
       results.map((resource) => {
         if (resource.resource_type === ResourceTypeEnum.VideoPlaylist) {

--- a/frontends/main/src/app/sitemaps/video/sitemap.ts
+++ b/frontends/main/src/app/sitemaps/video/sitemap.ts
@@ -3,7 +3,7 @@ import type { MetadataRoute } from "next"
 import { getQueryClient } from "@/app/getQueryClient"
 import { learningResourceQueries } from "api/hooks/learningResources"
 import { ResourceTypeEnum } from "api"
-import type { GenerateSitemapResult } from "../types"
+import type { GenerateSitemapResult, GeneratedSitemapArgs } from "../types"
 import { dangerouslyDetectProductionBuildPhase } from "../util"
 
 const PAGE_SIZE = 1_000
@@ -43,15 +43,14 @@ export async function generateSitemaps(): Promise<GenerateSitemapResult[]> {
 
 export default async function sitemap({
   id,
-}: {
-  id: string
-}): Promise<MetadataRoute.Sitemap> {
+}: GeneratedSitemapArgs): Promise<MetadataRoute.Sitemap> {
+  const page = +(await id)
   const BASE_URL = requiredEnv("NEXT_PUBLIC_ORIGIN")
   const queryClient = getQueryClient()
   const data = await queryClient.fetchQuery(
     learningResourceQueries.list({
       limit: PAGE_SIZE,
-      offset: +id * PAGE_SIZE,
+      offset: page * PAGE_SIZE,
       resource_type: RESOURCE_TYPES,
     }),
   )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11775

### Description (What does it do?)
Fixes sitemap pagination.


### How can this be tested?
1. Visit. http://open.odl.local:8062/sitemaps/sitemap-index.xml ... If you don't have enough entries in your local db to get multiple pages of sitemaps, change PAGE_SIZE in frontends/main/src/app/sitemaps/resources/sitemap.ts
2. View the linked sitemaps, e.g., http://open.odl.local:8062/sitemaps/resources/sitemap/0.xml, http://open.odl.local:8062/sitemaps/resources/sitemap/1.xml etc; they should be different and match pages of `/api/v1/learning_resources/summary/`
