### PR TITLE
fix: add article model to Django Admin

### DIFF
--- a/website_content/admin.py
+++ b/website_content/admin.py
@@ -1,1 +1,33 @@
-# Register your models here.
+"""Admin configuration for website_content app."""
+
+from django.contrib import admin
+
+from website_content.models import WebsiteContent, WebsiteContentImageUpload
+
+
+@admin.register(WebsiteContent)
+class WebsiteContentAdmin(admin.ModelAdmin):
+    """Admin for WebsiteContent."""
+
+    list_display = (
+        "title",
+        "content_type",
+        "is_published",
+        "publish_date",
+        "user",
+        "created_on",
+    )
+    list_filter = ("content_type", "is_published")
+    search_fields = ("title", "slug", "author_name")
+    readonly_fields = ("slug", "cover_image", "created_on", "updated_on")
+    list_select_related = ("user",)
+    ordering = ("-created_on",)
+
+
+@admin.register(WebsiteContentImageUpload)
+class WebsiteContentImageUploadAdmin(admin.ModelAdmin):
+    """Admin for WebsiteContentImageUpload."""
+
+    list_display = ("user", "created_at")
+    list_select_related = ("user",)
+    ordering = ("-created_at",)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10359

### Description (What does it do?)
It would be nice if the Article model showed up in Django Admin, for when/if we need to handle things there.

### Screenshots (if appropriate):
<img width="1552" height="904" alt="Screenshot 2026-06-12 at 4 09 22 PM" src="https://github.com/user-attachments/assets/8f354a6c-b296-421c-b611-c94d374dbcf9" />

### How can this be tested?
Just visit the django admin page and see the tables for `Website contents` and `Website content image uploads` locally.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
