### PR TITLE
feat: add title to learning resource summary endpoint

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -4960,6 +4960,12 @@ export interface LearningResourceSummary {
    * @memberof LearningResourceSummary
    */
   url?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof LearningResourceSummary
+   */
+  title: string
 }
 /**
  * Serializer for LearningResourceTopic model

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -370,6 +370,7 @@ const learningResourceSummary: LearningResourceFactory<
     id: uniqueEnforcerId.enforce(() => faker.number.int()),
     last_modified: faker.date.recent().toISOString(),
     url: faker.internet.url(),
+    title: faker.lorem.words(3),
     ...overrides,
   }
 }

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1796,4 +1796,4 @@ class LearningResourceSummarySerializer(serializers.ModelSerializer):
         """Meta configuration for LearningResourceSummarySerializer"""
 
         model = models.LearningResource
-        fields = ("id", "last_modified", "url")
+        fields = ("id", "last_modified", "url", "title")

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -353,6 +353,9 @@ class LearningResourceViewSet(
             LearningResource.objects.filter(published=True)
             .only("id", "last_modified", "url", "title")
             .distinct()
+            # Deterministic order so offset pagination has stable page
+            # boundaries.
+            .order_by("id")
         )
         page = self.paginate_queryset(queryset)
 

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -351,7 +351,7 @@ class LearningResourceViewSet(
             # we don't use `self.get_queryset()` here because there are incomplatible
             # `select_related()` invocations and we don't need related data anyway
             LearningResource.objects.filter(published=True)
-            .only("id", "last_modified", "url")
+            .only("id", "last_modified", "url", "title")
             .distinct()
         )
         page = self.paginate_queryset(queryset)

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1539,6 +1539,7 @@ def test_learning_resources_summary_listing_endpoint(django_assert_num_queries, 
             "id": lr.id,
             "last_modified": lr.last_modified.isoformat().replace("+00:00", "Z"),
             "url": lr.url,
+            "title": lr.title,
         }
         for lr in published
     ] == sorted(resp.data.get("results"), key=lambda x: int(x["id"]))

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -13460,8 +13460,12 @@ components:
           format: uri
           nullable: true
           maxLength: 2048
+        title:
+          type: string
+          maxLength: 256
       required:
       - id
+      - title
     LearningResourceTopic:
       type: object
       description: Serializer for LearningResourceTopic model


### PR DESCRIPTION
### What are the relevant tickets?

Supports readable URLs:

- https://github.com/mitodl/hq/issues/11210

### Description (What does it do?)

Adds `title` to response of `GET /api/v1/learning_resources/summary/`

This is split out of the upcoming readable-URLs frontend PR, which builds human-readable (slugged) sitemap URLs from summary listings. Landing and deploying the backend half first means the summary endpoint already serves titles when the frontend feature arrives — otherwise sitemap URLs would temporarily degrade to their slug-less form.

(Split out so the backend requirement can be deployed first)

### How can this be tested?

`GET /api/v1/learning_resources/summary/` — each result should now include `title` alongside `id`, `last_modified`, and `url`.