### PR TITLE
fix: suppress 'Add some text' placeholder inside the list and task items in Tiptap editor

### DIFF
--- a/frontends/main/src/page-components/TiptapEditor/extensions/baseExtensions.ts
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/baseExtensions.ts
@@ -55,7 +55,7 @@ export const createBaseExtensions = (
     showOnlyCurrent: false,
     includeChildren: true,
     placeholder: ({ node, editor }): string => {
-      let parentNode: typeof node | null = null
+      let parentNode: ProseMirrorNode | null = null
 
       editor.state.doc.descendants((n: ProseMirrorNode) => {
         n.forEach((childNode: ProseMirrorNode) => {
@@ -70,8 +70,13 @@ export const createBaseExtensions = (
       })
 
       if (parentNode) {
+        const pn = parentNode as ProseMirrorNode
+        if (pn.type.name === "listItem" || pn.type.name === "taskItem") {
+          return ""
+        }
+
         const parentExtension = editor.extensionManager.extensions.find(
-          (ext) => ext.name === parentNode!.type.name,
+          (ext) => ext.name === pn.type.name,
         )
 
         if (

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/Banner/BannerNode.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/Banner/BannerNode.tsx
@@ -29,7 +29,7 @@ const InnerContainer = styled(Container)({
     maxWidth: "890px",
   },
 
-  "& span a, & span a:hover": {
+  "& a, & a:hover": {
     color: "#fff !important",
   },
 })


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11790

### Description (What does it do?)
- As a content editor, I want list and task list items to appear clean without a placeholder label, so the editor doesn't show distracting "Add some text" hints inside every bullet or task item.
- Links in subheading should be visible properly which are not currently.


### Screenshots (if appropriate):
### Before
<img width="2852" height="1258" alt="image" src="https://github.com/user-attachments/assets/ed85d66f-2d26-4031-ab62-d9d4da2b04f6" />

### After
<img width="2842" height="1246" alt="image" src="https://github.com/user-attachments/assets/36653096-57ce-425d-8021-0a98a153eaa2" />

## Links before 
<img width="2858" height="662" alt="image" src="https://github.com/user-attachments/assets/27ae7b32-a8c9-4887-b5d1-7dc58d62d915" />

## Links after
<img width="2848" height="664" alt="image" src="https://github.com/user-attachments/assets/96a4fa6a-3c71-4f18-a58e-545a3693e214" />



### How can this be tested?
- You just need to visit the following url `/website_content/news/new` and then play around the list controls and see if there is no placeholder when list is inserted 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
