### PR TITLE
fix for remove_run_content_files task

### DIFF
--- a/main/celery.py
+++ b/main/celery.py
@@ -20,6 +20,7 @@ app.conf.task_routes = {
     "vector_search.tasks.generate_embeddings": {"queue": "embeddings"},
     "vector_search.tasks.embed_run_content_files": {"queue": "embeddings"},
     "vector_search.tasks.remove_run_content_files": {"queue": "embeddings"},
+    "vector_search.tasks.remove_unpublished_run_content_files": {"queue": "embeddings"},
     "vector_search.tasks.remove_embeddings": {"queue": "embeddings"},
     "vector_search.tasks.embed_learning_resources_by_id": {"queue": "embeddings"},
     "vector_search.tasks.embed_new_learning_resources": {"queue": "embeddings"},

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -407,24 +407,28 @@ def embed_run_content_files(self, run_id):
     )
 
 
-@app.task
-def remove_run_content_files(run_id):
+@app.task(bind=True)
+def remove_run_content_files(self, run_id):
     """
     Remove content files associated with a run from Qdrant
     """
     content_file_ids = list(
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
-    return celery.group(
-        [
-            remove_embeddings.si(ids, CONTENT_FILE_TYPE)
-            for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
-        ]
+    return self.replace(
+        celery.group(
+            [
+                remove_embeddings.si(ids, CONTENT_FILE_TYPE)
+                for ids in chunks(
+                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
+                )
+            ]
+        )
     )
 
 
-@app.task
-def remove_unpublished_run_content_files(run_id):
+@app.task(bind=True)
+def remove_unpublished_run_content_files(self, run_id):
     """
     Remove unpublished content files associated with a run from Qdrant
     """
@@ -433,11 +437,15 @@ def remove_unpublished_run_content_files(run_id):
             "id", flat=True
         )
     )
-    return celery.group(
-        [
-            remove_embeddings.si(ids, CONTENT_FILE_TYPE)
-            for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
-        ]
+    return self.replace(
+        celery.group(
+            [
+                remove_embeddings.si(ids, CONTENT_FILE_TYPE)
+                for ids in chunks(
+                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
+                )
+            ]
+        )
     )
 
 

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -30,6 +30,8 @@ from vector_search.tasks import (
     embed_new_content_files,
     embed_new_learning_resources,
     embeddings_healthcheck,
+    remove_run_content_files,
+    remove_unpublished_run_content_files,
     start_embed_resources,
 )
 from vector_search.utils import vector_point_id
@@ -214,6 +216,64 @@ def test_embed_new_content_files(mocker, mocked_celery):
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(new_content_file_ids) == sorted(embedded_ids)
+
+
+def test_remove_run_content_files(mocker, mocked_celery, settings):
+    """
+    remove_run_content_files should replace itself with removal tasks for all
+    content files associated with the run.
+    """
+    settings.QDRANT_CHUNK_SIZE = 2
+    run = LearningResourceRunFactory.create()
+    content_file_ids = [
+        content_file.id for content_file in ContentFileFactory.create_batch(3, run=run)
+    ]
+    ContentFileFactory.create()
+    remove_embeddings_mock = mocker.patch(
+        "vector_search.tasks.remove_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        remove_run_content_files.delay(run.id)
+
+    removed_ids = [
+        content_file_id
+        for mock_call in remove_embeddings_mock.si.mock_calls
+        for content_file_id in mock_call.args[0]
+    ]
+    assert sorted(removed_ids) == sorted(content_file_ids)
+    assert all(
+        mock_call.args[1] == CONTENT_FILE_TYPE
+        for mock_call in remove_embeddings_mock.si.mock_calls
+    )
+    assert mocked_celery.group.call_count == 1
+    assert mocked_celery.replace.call_count == 1
+    assert mocked_celery.replace.call_args[0][1] == mocked_celery.group.return_value
+
+
+def test_remove_unpublished_run_content_files(mocker, mocked_celery):
+    """
+    remove_unpublished_run_content_files should only remove unpublished content
+    files associated with the run.
+    """
+    run = LearningResourceRunFactory.create()
+    unpublished_content_file = ContentFileFactory.create(run=run, published=False)
+    ContentFileFactory.create(run=run, published=True)
+    ContentFileFactory.create(published=False)
+    remove_embeddings_mock = mocker.patch(
+        "vector_search.tasks.remove_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        remove_unpublished_run_content_files.delay(run.id)
+
+    remove_embeddings_mock.si.assert_called_once_with(
+        [unpublished_content_file.id],
+        CONTENT_FILE_TYPE,
+    )
+    assert mocked_celery.group.call_count == 1
+    assert mocked_celery.replace.call_count == 1
+    assert mocked_celery.replace.call_args[0][1] == mocked_celery.group.return_value
 
 
 def test_embed_learning_resources_by_id(mocker, mocked_celery):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/11799
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where the celery task to remove unpublished run contentfiles from qdrant is a no-op


### How can this be tested?
1. checkout main
2. make sure you have some resources embedded locally
3. find a learning resource run that has embedded contentfiles (find a run id  that doesnt have special characters so you can search for it in the qdrant dashboard)
4. go to your [local qdrant contentfiles collection](http://localhost:6333/dashboard#/collections/resource_embeddings.content_files) and search for run_readable_id:<your run id> - verify points exist for it
5. in django shell run the task that is supposed to remove embeddings for runs (replace run_id with the pk of the run):
```python
from vector_search.tasks import remove_run_content_files
remove_run_content_files.apply([run_id])
```
6. visit the [qdrant dashboard](http://localhost:6333/dashboard#/collections/resource_embeddings.content_files) and search for the run_id again - note that points still exist in qdrant
7. checkout this branch and perform the same - note that the points are removed
