### PR TITLE
refactor(CoursewareCard): dispatch on `kind`, make `layout` density-only

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -277,6 +277,8 @@ const OrgProgramCollectionDisplay: React.FC<{
                 id: entry.course.id,
                 runId: entry.displayedRun?.id,
               })}
+              Component="li"
+              kind="course"
               entry={entry}
             />
           )
@@ -331,6 +333,8 @@ const OrgProgramDisplay: React.FC<{
                 id: entry.course.id,
                 runId: entry.displayedRun?.id,
               })}
+              Component="li"
+              kind="course"
               entry={entry}
             />
           )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -1,20 +1,22 @@
 /**
- * CoursewareCard — unified dashboard course card (Phase 7).
+ * CoursewareCard — unified dashboard course card.
  *
- * Replaces the `DashboardCard`+adapter pattern for consumers that hold a
- * `DashboardCourseEntry` (program dashboard, contract content).  For the
- * `moduleRow` variant it also replaces the `ModuleCard` usage in
- * `ProgramAsCourseCard`.
- *
- * Internal delegation: this component remains a thin facade over the legacy
- * `DashboardCard` / `ModuleCard` implementations during Phase 7a–7c.  The
- * legacy card rendering logic is moved here in Phase 7d when those files are
- * deleted.
+ * A thin router that dispatches on `kind` (the resource identity) to one of
+ * three isolated cards. `layout` carries presentation density only and is
+ * always orthogonal to `kind`:
+ *   - "course"             → a course row from a program/contract dashboard;
+ *                            the entry's `displayedEnrollment` decides whether
+ *                            it renders as enrolled or unenrolled.
+ *   - "enrollment"         → a single course-run enrollment (home "My Learning"
+ *                            rows, which cannot build a full entry).
+ *   - "program-enrollment" → a program enrollment.
  */
 import React from "react"
-import type { SimpleMenuItem } from "ol-components"
 import { type DashboardCourseEntry } from "./model/dashboardViewModel"
-import type { V3UserProgramEnrollment } from "@mitodl/mitxonline-api-axios/v2"
+import type {
+  CourseRunEnrollmentV3,
+  V3UserProgramEnrollment,
+} from "@mitodl/mitxonline-api-axios/v2"
 import { ProgramEnrollmentCard } from "./ProgramEnrollmentCard"
 import { EnrolledCourseCard } from "./EnrolledCourseCard"
 import { UnenrolledCourseCard } from "./UnenrolledCourseCard"
@@ -28,115 +30,71 @@ type StyledComponentBaseProps = {
   Component?: React.ElementType
 }
 
-/** Props for the default course / enrollment card display. */
-type CoursewareCardDefaultProps = StyledComponentBaseProps & {
-  layout?: "default" | "compact"
-  entry: {
-    displayedEnrollment: DashboardCourseEntry["displayedEnrollment"]
-  } & Partial<DashboardCourseEntry>
-  showNotComplete?: boolean
-  offerUpgrade?: boolean
-  isLoading?: boolean
-  onUpgradeError?: (error: string) => void
-  contextMenuItems?: SimpleMenuItem[]
-  noun?: string
-}
-
 /**
- * Props for the `moduleRow` variant — a compact stacked card used as a row
- * inside a `ProgramAsCourseCard` module list.
- *
- * `useVerifiedEnrollment` and `parentProgramIds` are read from
- * `entry.ancestorContext` so callers only need to embed them there (via
- * `buildCourseEntry`).
+ * Presentation props shared by the two course-display arms. The program arm
+ * has no density/heading/upgrade concerns, so it does not include these.
  */
-type CoursewareCardModuleRowProps = StyledComponentBaseProps & {
-  layout: "moduleRow"
-  entry: DashboardCourseEntry
+type CourseDisplayProps = {
+  /** Visual density only. Identity is carried by `kind`, never by `layout`. */
+  layout?: "default" | "compact"
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
   onUpgradeError?: (error: string) => void
 }
 
-/** Props for program card display. */
-type CoursewareCardProgramProps = StyledComponentBaseProps & {
-  layout: "program"
+/** A course row from a program/contract dashboard (full entry available). */
+type CoursewareCardCourseProps = StyledComponentBaseProps &
+  CourseDisplayProps & {
+    kind: "course"
+    entry: DashboardCourseEntry
+  }
+
+/**
+ * A single course-run enrollment — home "My Learning" rows. Home cannot build
+ * an honest `DashboardCourseEntry` (its V3 payload embeds only a thin course,
+ * not the full course-with-courseruns), so the enrollment is passed directly.
+ */
+type CoursewareCardEnrollmentProps = StyledComponentBaseProps &
+  CourseDisplayProps & {
+    kind: "enrollment"
+    enrollment: CourseRunEnrollmentV3
+  }
+
+/** A program enrollment. */
+type CoursewareCardProgramEnrollmentProps = StyledComponentBaseProps & {
+  kind: "program-enrollment"
   programEnrollment: V3UserProgramEnrollment
-  showNotComplete?: boolean
 }
 
 export type CoursewareCardProps =
-  | CoursewareCardDefaultProps
-  | CoursewareCardModuleRowProps
-  | CoursewareCardProgramProps
+  | CoursewareCardCourseProps
+  | CoursewareCardEnrollmentProps
+  | CoursewareCardProgramEnrollmentProps
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
 
 const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
-  // ── program arm ──────────────────────────────────────────────────────────
-  if (props.layout === "program") {
-    const { programEnrollment, Component, className } = props
+  const { Component, className } = props
+
+  if (props.kind === "program-enrollment") {
     return (
       <ProgramEnrollmentCard
-        programEnrollment={programEnrollment}
+        programEnrollment={props.programEnrollment}
         Component={Component}
         className={className}
       />
     )
   }
 
-  const { entry, Component, className } = props
-  // ── moduleRow arm ────────────────────────────────────────────────────────
-  if (props.layout === "moduleRow") {
-    const { headingLevel } = props
+  const { layout, headingLevel, onUpgradeError } = props
 
-    const resource = entry.displayedEnrollment
-      ? {
-          type: "courserun-enrollment" as const,
-          data: entry.displayedEnrollment,
-        }
-      : entry.course
-        ? { type: "course" as const, data: entry.course }
-        : null
-
-    if (!resource) return null
-
-    if (resource.type === "course") {
-      return (
-        <UnenrolledCourseCard
-          course={resource.data}
-          displayedRun={entry.displayedRun ?? undefined}
-          contractId={entry.contractId}
-          ancestorContext={entry.ancestorContext}
-          layout="compact"
-          headingLevel={headingLevel}
-          Component={Component}
-          className={className}
-        />
-      )
-    } else if (resource.type === "courserun-enrollment") {
-      return (
-        <EnrolledCourseCard
-          enrollment={resource.data}
-          layout="compact"
-          headingLevel={headingLevel}
-          onUpgradeError={props.onUpgradeError}
-          Component={Component}
-          className={className}
-        />
-      )
-    }
-    return null
-  }
-
-  // ── default / stacked arm ────────────────────────────────────────────────
-  const { onUpgradeError, layout } = props
-
-  if (entry.displayedEnrollment) {
+  if (props.kind === "enrollment") {
     return (
       <EnrolledCourseCard
-        enrollment={entry.displayedEnrollment}
+        enrollment={props.enrollment}
         layout={layout}
+        headingLevel={headingLevel}
         onUpgradeError={onUpgradeError}
         Component={Component}
         className={className}
@@ -144,19 +102,30 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
     )
   }
 
-  if (!entry.displayedEnrollment && entry.course) {
-    return (
-      <UnenrolledCourseCard
-        course={entry.course}
-        displayedRun={entry.displayedRun ?? undefined}
-        contractId={entry.contractId}
-        ancestorContext={entry.ancestorContext}
-        layout={layout}
-        Component={Component}
-        className={className}
-      />
-    )
-  }
+  const { entry } = props
+  return entry.displayedEnrollment ? (
+    // Happens to be the same as the enrollment branch above, for now.
+    // Will likely diverge with multiple enrollment display.
+    <EnrolledCourseCard
+      enrollment={entry.displayedEnrollment}
+      layout={layout}
+      headingLevel={headingLevel}
+      onUpgradeError={onUpgradeError}
+      Component={Component}
+      className={className}
+    />
+  ) : (
+    <UnenrolledCourseCard
+      course={entry.course}
+      displayedRun={entry.displayedRun ?? undefined}
+      contractId={entry.contractId}
+      ancestorContext={entry.ancestorContext}
+      layout={layout}
+      headingLevel={headingLevel}
+      Component={Component}
+      className={className}
+    />
+  )
 }
 
 export { CoursewareCard }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/test-utils"
 import { HomeEnrollmentsDisplay } from "./HomeEnrollmentsDisplay"
 import { CoursewareCard } from "./CoursewareCard"
+import { buildCourseEntry } from "./model/dashboardViewModel"
 import { dashboardCourse, setupEnrollments } from "./test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import {
@@ -177,7 +178,10 @@ describe("UnenrollProgramDialog", () => {
     const { programEnrollment } = setupProgramCard("audit", null)
 
     renderWithProviders(
-      <CoursewareCard layout="program" programEnrollment={programEnrollment} />,
+      <CoursewareCard
+        kind="program-enrollment"
+        programEnrollment={programEnrollment}
+      />,
     )
 
     const desktopCard = await screen.findByTestId("enrollment-card-desktop")
@@ -193,7 +197,10 @@ describe("UnenrollProgramDialog", () => {
     const { programEnrollment } = setupProgramCard("verified", null)
 
     renderWithProviders(
-      <CoursewareCard layout="program" programEnrollment={programEnrollment} />,
+      <CoursewareCard
+        kind="program-enrollment"
+        programEnrollment={programEnrollment}
+      />,
     )
 
     const desktopCard = await screen.findByTestId("enrollment-card-desktop")
@@ -209,7 +216,10 @@ describe("UnenrollProgramDialog", () => {
     const { programEnrollment } = setupProgramCard("audit", "course")
 
     renderWithProviders(
-      <CoursewareCard layout="program" programEnrollment={programEnrollment} />,
+      <CoursewareCard
+        kind="program-enrollment"
+        programEnrollment={programEnrollment}
+      />,
     )
 
     const desktopCard = await screen.findByTestId("enrollment-card-desktop")
@@ -232,7 +242,10 @@ describe("UnenrollProgramDialog", () => {
     )
 
     renderWithProviders(
-      <CoursewareCard layout="program" programEnrollment={programEnrollment} />,
+      <CoursewareCard
+        kind="program-enrollment"
+        programEnrollment={programEnrollment}
+      />,
     )
 
     const desktopCard = await screen.findByTestId("enrollment-card-desktop")
@@ -277,7 +290,10 @@ describe("UnenrollProgramDialog", () => {
     const { programEnrollment } = setupProgramCard("audit", null)
 
     renderWithProviders(
-      <CoursewareCard layout="program" programEnrollment={programEnrollment} />,
+      <CoursewareCard
+        kind="program-enrollment"
+        programEnrollment={programEnrollment}
+      />,
     )
 
     const desktopCard = await screen.findByTestId("enrollment-card-desktop")
@@ -303,7 +319,7 @@ describe("UnenrollProgramDialog", () => {
 
       renderWithProviders(
         <CoursewareCard
-          layout="program"
+          kind="program-enrollment"
           programEnrollment={programEnrollment}
         />,
       )
@@ -383,15 +399,11 @@ describe("JustInTimeDialog", () => {
   test("Opens just-in-time dialog when enrolling with incomplete mitxonline user data", async () => {
     const { course, run } = setupJustInTimeTest()
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -426,15 +438,11 @@ describe("JustInTimeDialog", () => {
     "Dialog pre-populates with user data if available",
     async ({ userOverrides, expectCountry, expectYob }) => {
       const { course, run } = setupJustInTimeTest({ userOverrides })
-      renderWithProviders(
-        <CoursewareCard
-          entry={{
-            displayedEnrollment: null,
-            course,
-            contractId: run.b2b_contract ?? undefined,
-          }}
-        />,
-      )
+      const entry = buildCourseEntry(course, [], {
+        contractId: run.b2b_contract ?? undefined,
+      })
+      invariant(entry)
+      renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
       const enrollButtons = await screen.findAllByTestId("courseware-button")
       await user.click(enrollButtons[0]) // Use the first (desktop) button
       const dialog = await screen.findByRole("dialog", {
@@ -449,15 +457,11 @@ describe("JustInTimeDialog", () => {
   test("Validates required fields in just-in-time dialog", async () => {
     const { course, run } = setupJustInTimeTest()
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -488,15 +492,11 @@ describe("JustInTimeDialog", () => {
   test("Generates correct year of birth options (minimum age 13)", async () => {
     const { course, run } = setupJustInTimeTest()
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -521,15 +521,11 @@ describe("JustInTimeDialog", () => {
   test("Shows expected countries in country dropdown", async () => {
     const { course, countries, run } = setupJustInTimeTest()
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -552,15 +548,11 @@ describe("JustInTimeDialog", () => {
   test("Cancels just-in-time dialog without making API calls", async () => {
     const { course, run } = setupJustInTimeTest()
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
 
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
@@ -588,15 +580,11 @@ describe("JustInTimeDialog", () => {
       userOverrides: { user_profile: { year_of_birth: 1988 } },
     })
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0]) // Use the first (desktop) button
 
@@ -649,16 +637,12 @@ describe("JustInTimeDialog", () => {
     })
     const parentProgramReadableIds = ["program-v1:MITx+DEDP"]
 
-    renderWithProviders(
-      <CoursewareCard
-        entry={{
-          displayedEnrollment: null,
-          course,
-          contractId: run.b2b_contract ?? undefined,
-          ancestorContext: { parentProgramReadableIds },
-        }}
-      />,
-    )
+    const entry = buildCourseEntry(course, [], {
+      contractId: run.b2b_contract ?? undefined,
+      ancestorContext: { parentProgramReadableIds },
+    })
+    invariant(entry)
+    renderWithProviders(<CoursewareCard kind="course" entry={entry} />)
     const enrollButtons = await screen.findAllByTestId("courseware-button")
     await user.click(enrollButtons[0])
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
@@ -178,7 +178,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
         <CoursewareCardStyled
           key={getResourceKey(resource)}
           Component="li"
-          layout="program"
+          kind="program-enrollment"
           programEnrollment={resource.data}
         />
       )
@@ -187,7 +187,8 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
         <CoursewareCardStyled
           key={getResourceKey(resource)}
           Component="li"
-          entry={{ displayedEnrollment: resource.data }}
+          kind="enrollment"
+          enrollment={resource.data}
           onUpgradeError={onUpgradeError}
         />
       )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -604,8 +604,9 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
                 id: course.id,
                 runId: entry.displayedEnrollment?.run.id,
               })}
+              kind="course"
               entry={entry}
-              layout="moduleRow"
+              layout="compact"
               headingLevel="h4"
               onUpgradeError={onUpgradeError}
             />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -127,8 +127,8 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                           item.entry.displayedEnrollment?.run.id ??
                           item.entry.displayedRun?.id,
                       })}
+                      kind="course"
                       entry={item.entry}
-                      showNotComplete={false}
                     />
                   )
                 }
@@ -155,9 +155,8 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       resourceType: ResourceType.Program,
                       id: item.enrollment.program.id,
                     })}
-                    layout="program"
+                    kind="program-enrollment"
                     programEnrollment={item.enrollment}
-                    showNotComplete={false}
                   />
                 )
               })}


### PR DESCRIPTION
On base, `layout` has four values: `default | compact | moduleRow | program`. This mixes some concepts:
- `default | compact` is related to layout. Keep these.
- `program` is about what sort of data the card is receiving
- `moduleRow` is about the context in which the card is renering (child of ProgramAsCourse).

This switches to `layout + kind`, where kind ~ data and layout ~ how card appears.

Drop `moduleRow` entirely: It was just `compact`