### PR TITLE
fix issues with multiple summarizer config instances

### DIFF
--- a/learning_resources/content_summarizer.py
+++ b/learning_resources/content_summarizer.py
@@ -127,7 +127,7 @@ class ContentSummarizer:
                 )
 
             unprocessed_content_file_ids.extend(
-                list(unprocessed_content.values_list("id", flat=True))
+                unprocessed_content.values_list("id", flat=True)
             )
 
         return unprocessed_content_file_ids

--- a/learning_resources/content_summarizer.py
+++ b/learning_resources/content_summarizer.py
@@ -126,8 +126,8 @@ class ContentSummarizer:
                     run__learning_resource__id__in=learning_resource_ids
                 )
 
-            unprocessed_content_file_ids = list(
-                unprocessed_content.values_list("id", flat=True)
+            unprocessed_content_file_ids.extend(
+                list(unprocessed_content.values_list("id", flat=True))
             )
 
         return unprocessed_content_file_ids

--- a/learning_resources/content_summarizer_test.py
+++ b/learning_resources/content_summarizer_test.py
@@ -248,6 +248,59 @@ def test_get_unprocessed_content_files_with_platform_and_config(
     )
 
 
+def test_get_unprocessed_content_file_ids_with_multiple_configs():
+    """Test that get_unprocessed_content_file_ids returns IDs from multiple active configurations"""
+    from learning_resources.models import ContentSummarizerConfiguration
+
+    ContentFile.objects.all().delete()
+    ContentSummarizerConfiguration.objects.all().delete()
+
+    summarizer = ContentSummarizer()
+    allowed_types = [CONTENT_TYPE_FILE]
+    allowed_extensions = [".srt"]
+
+    config1 = ContentSummarizerConfigurationFactory.create(
+        allowed_extensions=allowed_extensions,
+        allowed_content_types=allowed_types,
+        is_active=True,
+        llm_model="test",
+        platform__code=PlatformType.edx.name,
+    )
+    config2 = ContentSummarizerConfigurationFactory.create(
+        allowed_extensions=allowed_extensions,
+        allowed_content_types=allowed_types,
+        is_active=True,
+        llm_model="test",
+        platform__code=PlatformType.xpro.name,
+    )
+
+    run1 = LearningResourceRunFactory.create(
+        learning_resource__platform=config1.platform
+    )
+    file1 = ContentFileFactory.create(
+        content="Test content 1",
+        file_extension=allowed_extensions[0],
+        content_type=allowed_types[0],
+        run=run1,
+    )
+
+    run2 = LearningResourceRunFactory.create(
+        learning_resource__platform=config2.platform
+    )
+    file2 = ContentFileFactory.create(
+        content="Test content 2",
+        file_extension=allowed_extensions[0],
+        content_type=allowed_types[0],
+        run=run2,
+    )
+
+    unprocessed_file_ids = summarizer.get_unprocessed_content_file_ids(overwrite=False)
+
+    assert len(unprocessed_file_ids) == 2
+    assert file1.id in unprocessed_file_ids
+    assert file2.id in unprocessed_file_ids
+
+
 def test_summarize_content_files_by_ids(
     processable_content_files, mock_summarize_single_content_file
 ):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11806
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where if you have multiple contentsummarizerconfiguration objects - only one of them has their contentfiles processed

### How can this be tested?
1. checkout main
2. create a contentfilesummarizer config for mitxonline (reference rc: https://api.rc.learn.mit.edu/admin/learning_resources/contentsummarizerconfiguration/1/change/)
3. create another summarizer config instance except make the platform ocw
4. try to get a list of unprocessed contentfiles - it should come up empty:
```python

from learning_resources.content_summarizer import ContentSummarizer
summarizer = ContentSummarizer()
ContentFile.objects.filter(run__learning_resource__platform__code="ocw").values_list("id",flat=True)
```
5. checkout this branch and it should come back with a populated list
