### PR TITLE
feat: implement podcast embed page

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
@@ -1,0 +1,329 @@
+import React from "react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { ThemeProvider } from "ol-components"
+import { factories } from "api/test-utils"
+import type { LearningResource, PodcastEpisodeResource } from "api/v1"
+import PodcastEmbedPlayer from "./PodcastEmbedPlayer"
+
+// JSDOM does not implement HTMLMediaElement methods; provide minimal stubs.
+beforeAll(() => {
+  window.HTMLMediaElement.prototype.load = jest.fn()
+  window.HTMLMediaElement.prototype.play = jest
+    .fn()
+    .mockResolvedValue(undefined)
+  window.HTMLMediaElement.prototype.pause = jest.fn()
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+const makeEpisode = (
+  overrides: Partial<PodcastEpisodeResource> = {},
+): PodcastEpisodeResource =>
+  factories.learningResources.podcastEpisode(overrides)
+
+const renderPlayer = async (
+  resource: LearningResource = makeEpisode(),
+  options: { waitForAutoPlay?: boolean } = {},
+) => {
+  const { waitForAutoPlay = true } = options
+  const view = render(
+    <ThemeProvider>
+      <PodcastEmbedPlayer resource={resource} />
+    </ThemeProvider>,
+  )
+  if (waitForAutoPlay) {
+    await waitFor(() =>
+      expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled(),
+    )
+  }
+  const audio = document.querySelector("audio") as HTMLAudioElement
+  const simulateCanPlay = () => fireEvent.canPlay(audio)
+  const simulateLoadedMetadata = (duration: number) => {
+    Object.defineProperty(audio, "duration", {
+      value: duration,
+      configurable: true,
+    })
+    fireEvent.loadedMetadata(audio)
+  }
+  return { ...view, audio, simulateCanPlay, simulateLoadedMetadata }
+}
+
+describe("PodcastEmbedPlayer", () => {
+  describe("metadata display", () => {
+    test("renders episode title", async () => {
+      const resource = makeEpisode({ title: "Deep Dive Episode" })
+      await renderPlayer(resource)
+      expect(screen.getByText("Deep Dive Episode")).toBeInTheDocument()
+    })
+
+    test("renders offered_by name as podcast label", async () => {
+      const resource = makeEpisode({
+        offered_by: {
+          channel_url: "https://example.com/channel",
+          code: "mitx",
+          name: "MITx",
+        },
+      })
+      await renderPlayer(resource)
+      expect(screen.getByText("MITx")).toBeInTheDocument()
+    })
+
+    test('falls back to "Podcast" when offered_by is null', async () => {
+      const resource = makeEpisode({ offered_by: null })
+      await renderPlayer(resource)
+      expect(screen.getByText("Podcast")).toBeInTheDocument()
+    })
+
+    test("renders cover art when image URL is present", async () => {
+      const resource = makeEpisode({
+        image: {
+          id: 1,
+          url: "https://example.com/cover.jpg",
+          alt: "Cover art",
+        },
+      })
+      await renderPlayer(resource)
+      const img = screen.getByRole("img", { name: /cover art/i })
+      expect(img).toHaveAttribute("src", "https://example.com/cover.jpg")
+    })
+
+    test("renders placeholder when image URL is absent", async () => {
+      const resource = makeEpisode({ image: null })
+      await renderPlayer(resource)
+      expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("audio source", () => {
+    test("audio element src uses audio_url", async () => {
+      const resource = makeEpisode({
+        podcast_episode: {
+          ...makeEpisode().podcast_episode!,
+          audio_url: "https://cdn.example.com/ep.mp3",
+          episode_link: "https://example.com/episode",
+        },
+      })
+      const { audio } = await renderPlayer(resource)
+      expect(audio).toHaveAttribute("src", "https://cdn.example.com/ep.mp3")
+    })
+
+    test("falls back to episode_link when audio_url is absent", async () => {
+      const resource = makeEpisode({
+        podcast_episode: {
+          ...makeEpisode().podcast_episode!,
+          audio_url: null as unknown as string,
+          episode_link: "https://example.com/fallback.mp3",
+        },
+      })
+      const { audio } = await renderPlayer(resource)
+      expect(audio).toHaveAttribute("src", "https://example.com/fallback.mp3")
+    })
+
+    test("audio element has no src when resource is not a podcast episode", async () => {
+      const resource = factories.learningResources.course() as LearningResource
+      const { audio } = await renderPlayer(resource, {
+        waitForAutoPlay: false,
+      })
+      expect(audio).not.toHaveAttribute("src")
+    })
+  })
+
+  describe("play/pause", () => {
+    test("auto-plays on mount", async () => {
+      await renderPlayer()
+      expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled()
+    })
+
+    test("shows loading state initially", async () => {
+      await renderPlayer()
+      // canPlay has not fired yet — still buffering
+      expect(screen.getByRole("button", { name: /^loading$/i })).toBeDisabled()
+    })
+
+    test("enables play/pause button after canPlay fires", async () => {
+      const { simulateCanPlay } = await renderPlayer()
+      simulateCanPlay()
+      expect(
+        screen.getByRole("button", { name: /^pause$/i }),
+      ).not.toBeDisabled()
+    })
+
+    test("clicking Pause calls audio.pause() and shows Play", async () => {
+      const { simulateCanPlay } = await renderPlayer()
+      simulateCanPlay()
+      fireEvent.click(screen.getByRole("button", { name: /^pause$/i }))
+      expect(window.HTMLMediaElement.prototype.pause).toHaveBeenCalled()
+      expect(
+        screen.getByRole("button", { name: /^play$/i }),
+      ).toBeInTheDocument()
+    })
+
+    test("clicking Play after pause calls audio.play()", async () => {
+      const { simulateCanPlay } = await renderPlayer()
+      simulateCanPlay()
+      fireEvent.click(screen.getByRole("button", { name: /^pause$/i }))
+      jest.clearAllMocks()
+      fireEvent.click(screen.getByRole("button", { name: /^play$/i }))
+      await waitFor(() =>
+        expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled(),
+      )
+    })
+
+    test("shows Play unavailable and is disabled when there is no audio source", async () => {
+      const resource = makeEpisode({
+        podcast_episode: {
+          ...makeEpisode().podcast_episode!,
+          audio_url: null as unknown as string,
+          episode_link: null,
+        },
+      })
+      await renderPlayer(resource, { waitForAutoPlay: false })
+      expect(window.HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
+      expect(
+        screen.getByRole("button", { name: /play unavailable/i }),
+      ).toBeDisabled()
+    })
+
+    test("prevents duplicate play calls while play is pending", async () => {
+      const { simulateCanPlay } = await renderPlayer()
+      simulateCanPlay()
+      fireEvent.click(screen.getByRole("button", { name: /^pause$/i }))
+      jest.clearAllMocks()
+
+      let resolvePlay: (() => void) | undefined
+      const pendingPlay = new Promise<void>((resolve) => {
+        resolvePlay = resolve
+      })
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockImplementation(
+        () => pendingPlay,
+      )
+
+      const playBtn = screen.getByRole("button", { name: /^play$/i })
+      fireEvent.click(playBtn)
+      fireEvent.click(playBtn)
+
+      expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(1)
+      expect(screen.getByRole("button", { name: /^loading$/i })).toBeDisabled()
+
+      resolvePlay?.()
+      await screen.findByRole("button", { name: /^pause$/i })
+    })
+  })
+
+  describe("skip controls", () => {
+    test("rewind button subtracts 10s from currentTime", async () => {
+      const { audio, simulateCanPlay, simulateLoadedMetadata } =
+        await renderPlayer()
+      simulateLoadedMetadata(120)
+      simulateCanPlay()
+      Object.defineProperty(audio, "currentTime", {
+        value: 60,
+        configurable: true,
+        writable: true,
+      })
+      fireEvent.click(
+        screen.getByRole("button", { name: /rewind 10 seconds/i }),
+      )
+      expect(audio.currentTime).toBe(50)
+    })
+
+    test("forward button adds 30s to currentTime", async () => {
+      const { audio, simulateCanPlay, simulateLoadedMetadata } =
+        await renderPlayer()
+      simulateLoadedMetadata(120)
+      simulateCanPlay()
+      Object.defineProperty(audio, "currentTime", {
+        value: 60,
+        configurable: true,
+        writable: true,
+      })
+      fireEvent.click(
+        screen.getByRole("button", { name: /forward 30 seconds/i }),
+      )
+      expect(audio.currentTime).toBe(90)
+    })
+
+    test("rewind clamps to 0", async () => {
+      const { audio, simulateCanPlay, simulateLoadedMetadata } =
+        await renderPlayer()
+      simulateLoadedMetadata(120)
+      simulateCanPlay()
+      Object.defineProperty(audio, "currentTime", {
+        value: 5,
+        configurable: true,
+        writable: true,
+      })
+      fireEvent.click(
+        screen.getByRole("button", { name: /rewind 10 seconds/i }),
+      )
+      expect(audio.currentTime).toBe(0)
+    })
+
+    test("forward clamps to duration", async () => {
+      const { audio, simulateCanPlay, simulateLoadedMetadata } =
+        await renderPlayer()
+      simulateLoadedMetadata(120)
+      simulateCanPlay()
+      Object.defineProperty(audio, "currentTime", {
+        value: 110,
+        configurable: true,
+        writable: true,
+      })
+      fireEvent.click(
+        screen.getByRole("button", { name: /forward 30 seconds/i }),
+      )
+      expect(audio.currentTime).toBe(120)
+    })
+  })
+
+  describe("speed control", () => {
+    test("initial speed label is 1x", async () => {
+      await renderPlayer()
+      expect(
+        screen.getByRole("button", { name: /playback speed/i }),
+      ).toHaveTextContent("1x")
+    })
+
+    test("cycles through speed options on click", async () => {
+      await renderPlayer()
+      const btn = screen.getByRole("button", { name: /playback speed/i })
+      fireEvent.click(btn)
+      expect(btn).toHaveTextContent("1.25x")
+      fireEvent.click(btn)
+      expect(btn).toHaveTextContent("1.5x")
+      fireEvent.click(btn)
+      expect(btn).toHaveTextContent("2x")
+      fireEvent.click(btn)
+      expect(btn).toHaveTextContent("0.75x")
+    })
+
+    test("cycling speed applies playbackRate to audio element", async () => {
+      const { audio } = await renderPlayer()
+      fireEvent.click(screen.getByRole("button", { name: /playback speed/i }))
+      expect(audio.playbackRate).toBe(1.25)
+    })
+  })
+
+  describe("seek slider", () => {
+    test("dragging the slider updates audio currentTime", async () => {
+      const { audio, simulateCanPlay, simulateLoadedMetadata } =
+        await renderPlayer()
+      simulateLoadedMetadata(200)
+      simulateCanPlay()
+      const slider = screen.getByRole("slider", { name: /seek/i })
+      fireEvent.change(slider, { target: { value: "90" } })
+      expect(audio.currentTime).toBe(90)
+    })
+  })
+
+  describe("no close button", () => {
+    test("does not render a close button", async () => {
+      await renderPlayer()
+      expect(
+        screen.queryByRole("button", { name: /close/i }),
+      ).not.toBeInTheDocument()
+    })
+  })
+})

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
@@ -109,16 +109,16 @@ describe("PodcastEmbedPlayer", () => {
       expect(audio).toHaveAttribute("src", "https://cdn.example.com/ep.mp3")
     })
 
-    test("falls back to episode_link when audio_url is absent", async () => {
+    test("does not use episode_link as audio src when audio_url is absent", async () => {
       const resource = makeEpisode({
         podcast_episode: {
           ...makeEpisode().podcast_episode!,
           audio_url: null as unknown as string,
-          episode_link: "https://example.com/fallback.mp3",
+          episode_link: "https://example.com/webpage",
         },
       })
-      const { audio } = await renderPlayer(resource)
-      expect(audio).toHaveAttribute("src", "https://example.com/fallback.mp3")
+      const { audio } = await renderPlayer(resource, { waitForAutoPlay: false })
+      expect(audio).not.toHaveAttribute("src")
     })
 
     test("audio element has no src when resource is not a podcast episode", async () => {
@@ -303,6 +303,20 @@ describe("PodcastEmbedPlayer", () => {
       const { audio } = await renderPlayer()
       fireEvent.click(screen.getByRole("button", { name: /playback speed/i }))
       expect(audio.playbackRate).toBe(1.25)
+    })
+  })
+
+  describe("time display", () => {
+    test("formats duration under 60 minutes as MM:SS", async () => {
+      const { simulateLoadedMetadata } = await renderPlayer()
+      simulateLoadedMetadata(125) // 2:05
+      expect(screen.getAllByText("02:05")[0]).toBeInTheDocument()
+    })
+
+    test("formats duration of 60 minutes or more as H:MM:SS", async () => {
+      const { simulateLoadedMetadata } = await renderPlayer()
+      simulateLoadedMetadata(3661) // 1:01:01
+      expect(screen.getAllByText("1:01:01")[0]).toBeInTheDocument()
     })
   })
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
@@ -1,0 +1,403 @@
+"use client"
+
+import React, { useRef, useState, useEffect, useCallback } from "react"
+import { styled, Typography, LoadingSpinner } from "ol-components"
+import {
+  RiPlayCircleLine,
+  RiPauseCircleLine,
+  RiReplay10Line,
+  RiForward30Line,
+} from "@remixicon/react"
+import type { LearningResource } from "api/v1"
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SPEED_OPTIONS = [0.75, 1, 1.25, 1.5, 2]
+
+const formatTime = (seconds: number): string => {
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+}
+
+function getAudioUrl(resource: LearningResource): string {
+  if (resource.resource_type !== "podcast_episode") return ""
+  return (
+    resource.podcast_episode?.audio_url ??
+    resource.podcast_episode?.episode_link ??
+    ""
+  )
+}
+
+// ─── Styled components ────────────────────────────────────────────────────────
+
+const Shell = styled.div(({ theme }) => ({
+  width: "100vw",
+  height: "100vh",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  backgroundColor: theme.custom.colors.white,
+  padding: "24px",
+  boxSizing: "border-box",
+}))
+
+const PlayerCard = styled.div(({ theme }) => ({
+  display: "grid",
+  gridTemplateColumns: "auto 1fr",
+  gridTemplateAreas: '"art info" "art controls" "art progress"',
+  gap: "12px 24px",
+  width: "100%",
+  maxWidth: "80%",
+  alignItems: "start",
+  [theme.breakpoints.down("sm")]: {
+    gridTemplateColumns: "1fr",
+    gridTemplateAreas: '"art" "info" "controls" "progress"',
+  },
+}))
+
+const CoverArt = styled.img(({ theme }) => ({
+  gridArea: "art",
+  width: "200px",
+  height: "200px",
+  objectFit: "cover",
+  borderRadius: "8px",
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  alignSelf: "center",
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+    height: "auto",
+  },
+}))
+
+const CoverArtPlaceholder = styled.div(({ theme }) => ({
+  gridArea: "art",
+  width: "120px",
+  height: "120px",
+  borderRadius: "8px",
+  backgroundColor: theme.custom.colors.lightGray2,
+  alignSelf: "center",
+  [theme.breakpoints.down("sm")]: {
+    width: "80px",
+    height: "80px",
+  },
+}))
+
+const TrackInfo = styled.div({
+  gridArea: "info",
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+  minWidth: 0,
+})
+
+const TrackTitle = styled(Typography)(({ theme }) => ({
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  color: theme.custom.colors.black,
+}))
+
+const PodcastName = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+}))
+
+const Controls = styled.div({
+  gridArea: "controls",
+  display: "flex",
+  alignItems: "center",
+  gap: "12px",
+})
+
+const IconButton = styled.button(({ theme }) => ({
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: 0,
+  display: "flex",
+  alignItems: "center",
+  color: theme.custom.colors.silverGray,
+  "&:hover": { color: theme.custom.colors.red },
+  "& svg": { width: "24px", height: "24px" },
+}))
+
+const PlayPauseButton = styled.button(({ theme }) => ({
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: 0,
+  position: "relative",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "48px",
+  height: "48px",
+  flexShrink: 0,
+  overflow: "hidden",
+  color: theme.custom.colors.red,
+  "&:hover": { opacity: 0.8 },
+  "& > svg": { width: "48px", height: "48px" },
+}))
+
+const PlayerLoader = styled(LoadingSpinner)({
+  position: "absolute",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+})
+
+const ProgressWrapper = styled.div({
+  gridArea: "progress",
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+})
+
+const ProgressRange = styled.input<{ percent: number }>(
+  ({ theme, percent }) => ({
+    appearance: "none",
+    WebkitAppearance: "none",
+    flex: 1,
+    height: "8px",
+    borderRadius: "4px",
+    cursor: "pointer",
+    outline: "none",
+    border: "none",
+    padding: 0,
+    background: `linear-gradient(to right, ${theme.custom.colors.red} ${percent}%, ${theme.custom.colors.lightGray2} ${percent}%)`,
+    "&::-webkit-slider-thumb": {
+      WebkitAppearance: "none",
+      width: "12px",
+      height: "12px",
+      borderRadius: "50%",
+      background: theme.custom.colors.red,
+      cursor: "pointer",
+    },
+    "&::-moz-range-thumb": {
+      width: "12px",
+      height: "12px",
+      borderRadius: "50%",
+      background: theme.custom.colors.red,
+      border: "none",
+      cursor: "pointer",
+    },
+  }),
+)
+
+const TimeLabel = styled(Typography)(({ theme }) => ({
+  color: theme.custom.colors.darkGray2,
+  whiteSpace: "nowrap",
+  flexShrink: 0,
+  minWidth: "38px",
+  textAlign: "center",
+}))
+
+const SpeedButton = styled.button(({ theme }) => ({
+  background: theme.custom.colors.lightGray1,
+  border: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  borderRadius: "4px",
+  padding: "4px 10px",
+  cursor: "pointer",
+  ...theme.typography.body3,
+  color: theme.custom.colors.darkGray2,
+  flexShrink: 0,
+  "&:hover": {
+    borderColor: theme.custom.colors.red,
+    color: theme.custom.colors.red,
+  },
+}))
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+type PodcastEmbedPlayerProps = {
+  resource: LearningResource
+}
+
+const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
+  resource,
+}) => {
+  const audioUrl = getAudioUrl(resource)
+  const hasAudioSource = Boolean(audioUrl.trim())
+  const audioRef = useRef<HTMLAudioElement>(null)
+  const isPlayPendingRef = useRef(false)
+  const playAttemptIdRef = useRef(0)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const [isBuffering, setIsBuffering] = useState(hasAudioSource)
+  const [isPlayPending, setIsPlayPending] = useState(false)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [speedIndex, setSpeedIndex] = useState(1)
+  const speedIndexRef = useRef(1)
+
+  const startPlayback = useCallback(async () => {
+    if (!hasAudioSource || isPlayPendingRef.current) return
+    const audio = audioRef.current
+    if (!audio) return
+
+    const attemptId = ++playAttemptIdRef.current
+    isPlayPendingRef.current = true
+    setIsPlayPending(true)
+
+    try {
+      await audio.play()
+      if (playAttemptIdRef.current === attemptId) setIsPlaying(true)
+    } catch {
+      if (playAttemptIdRef.current === attemptId) setIsPlaying(false)
+    } finally {
+      if (playAttemptIdRef.current === attemptId) {
+        isPlayPendingRef.current = false
+        setIsPlayPending(false)
+      }
+    }
+  }, [hasAudioSource])
+
+  useEffect(() => {
+    playAttemptIdRef.current += 1
+    isPlayPendingRef.current = false
+    setIsPlayPending(false)
+    setCurrentTime(0)
+    setDuration(0)
+    setIsPlaying(false)
+    setIsBuffering(hasAudioSource)
+
+    if (!hasAudioSource) return
+
+    const audio = audioRef.current
+    if (!audio) return
+    audio.load()
+    audio.playbackRate = SPEED_OPTIONS[speedIndexRef.current]
+    void startPlayback()
+  }, [audioUrl, hasAudioSource, startPlayback])
+
+  const handlePlayPause = () => {
+    if (!hasAudioSource) return
+    const audio = audioRef.current
+    if (!audio) return
+
+    if (isPlaying) {
+      audio.pause()
+      setIsPlaying(false)
+    } else {
+      void startPlayback()
+    }
+  }
+
+  const handleSkip = (seconds: number) => {
+    const audio = audioRef.current
+    if (!audio) return
+    audio.currentTime = Math.max(
+      0,
+      Math.min(audio.currentTime + seconds, duration),
+    )
+  }
+
+  const handleSpeedCycle = () => {
+    const nextIndex = (speedIndex + 1) % SPEED_OPTIONS.length
+    speedIndexRef.current = nextIndex
+    setSpeedIndex(nextIndex)
+    if (audioRef.current)
+      audioRef.current.playbackRate = SPEED_OPTIONS[nextIndex]
+  }
+
+  const percent = duration ? (currentTime / duration) * 100 : 0
+
+  return (
+    <Shell>
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <audio
+        ref={audioRef}
+        src={hasAudioSource ? audioUrl : undefined}
+        onWaiting={() => setIsBuffering(true)}
+        onCanPlay={() => setIsBuffering(false)}
+        onError={() => {
+          setIsBuffering(false)
+          setIsPlaying(false)
+        }}
+        onTimeUpdate={() => setCurrentTime(audioRef.current?.currentTime ?? 0)}
+        onLoadedMetadata={() => setDuration(audioRef.current?.duration ?? 0)}
+        onEnded={() => setIsPlaying(false)}
+      />
+
+      <PlayerCard>
+        {resource.image?.url ? (
+          <CoverArt
+            src={resource.image.url}
+            alt={resource.image.alt ?? resource.title ?? "Episode cover"}
+          />
+        ) : (
+          <CoverArtPlaceholder />
+        )}
+
+        <TrackInfo>
+          <PodcastName variant="body2">
+            {resource.offered_by?.name ?? "Podcast"}
+          </PodcastName>
+          <TrackTitle variant="subtitle2">{resource.title}</TrackTitle>
+        </TrackInfo>
+
+        <Controls>
+          <IconButton
+            onClick={() => handleSkip(-10)}
+            aria-label="Rewind 10 seconds"
+          >
+            <RiReplay10Line />
+          </IconButton>
+
+          <PlayPauseButton
+            onClick={handlePlayPause}
+            aria-label={
+              !hasAudioSource
+                ? "Play unavailable"
+                : isBuffering || isPlayPending
+                  ? "Loading"
+                  : isPlaying
+                    ? "Pause"
+                    : "Play"
+            }
+            disabled={isBuffering || isPlayPending || !hasAudioSource}
+          >
+            {isBuffering || isPlayPending ? (
+              <PlayerLoader loading size={32} color="inherit" />
+            ) : isPlaying ? (
+              <RiPauseCircleLine />
+            ) : (
+              <RiPlayCircleLine />
+            )}
+          </PlayPauseButton>
+
+          <IconButton
+            onClick={() => handleSkip(30)}
+            aria-label="Forward 30 seconds"
+          >
+            <RiForward30Line />
+          </IconButton>
+
+          <SpeedButton onClick={handleSpeedCycle} aria-label="Playback speed">
+            {SPEED_OPTIONS[speedIndex]}x
+          </SpeedButton>
+        </Controls>
+
+        <ProgressWrapper>
+          <TimeLabel variant="body3">{formatTime(currentTime)}</TimeLabel>
+          <ProgressRange
+            type="range"
+            min={0}
+            max={duration || 1}
+            value={currentTime}
+            step={1}
+            percent={percent}
+            aria-label="Seek"
+            onChange={(e) => {
+              const audio = audioRef.current
+              if (!audio) return
+              audio.currentTime = Number(e.target.value)
+            }}
+          />
+          <TimeLabel variant="body3">{formatTime(duration)}</TimeLabel>
+        </ProgressWrapper>
+      </PlayerCard>
+    </Shell>
+  )
+}
+
+export default PodcastEmbedPlayer

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
@@ -15,18 +15,17 @@ import type { LearningResource } from "api/v1"
 const SPEED_OPTIONS = [0.75, 1, 1.25, 1.5, 2]
 
 const formatTime = (seconds: number): string => {
-  const m = Math.floor(seconds / 60)
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds % 3600) / 60)
   const s = Math.floor(seconds % 60)
-  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+  const mm = String(m).padStart(2, "0")
+  const ss = String(s).padStart(2, "0")
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
 }
 
 function getAudioUrl(resource: LearningResource): string {
   if (resource.resource_type !== "podcast_episode") return ""
-  return (
-    resource.podcast_episode?.audio_url ??
-    resource.podcast_episode?.episode_link ??
-    ""
-  )
+  return resource.podcast_episode?.audio_url ?? ""
 }
 
 // ─── Styled components ────────────────────────────────────────────────────────
@@ -72,8 +71,8 @@ const CoverArt = styled.img(({ theme }) => ({
 
 const CoverArtPlaceholder = styled.div(({ theme }) => ({
   gridArea: "art",
-  width: "120px",
-  height: "120px",
+  width: "200px",
+  height: "200px",
   borderRadius: "8px",
   backgroundColor: theme.custom.colors.lightGray2,
   alignSelf: "center",
@@ -88,6 +87,7 @@ const TrackInfo = styled.div({
   display: "flex",
   flexDirection: "column",
   gap: "4px",
+  marginTop: "16px",
   minWidth: 0,
 })
 
@@ -372,7 +372,10 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
             <RiForward30Line />
           </IconButton>
 
-          <SpeedButton onClick={handleSpeedCycle} aria-label="Playback speed">
+          <SpeedButton
+            onClick={handleSpeedCycle}
+            aria-label={`Playback speed: ${SPEED_OPTIONS[speedIndex]}x`}
+          >
             {SPEED_OPTIONS[speedIndex]}x
           </SpeedButton>
         </Controls>
@@ -386,6 +389,7 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
             value={currentTime}
             step={1}
             percent={percent}
+            aria-valuetext={formatTime(currentTime)}
             aria-label="Seek"
             onChange={(e) => {
               const audio = audioRef.current

--- a/frontends/main/src/app/(embed)/podcast/embed/[id]/page.test.tsx
+++ b/frontends/main/src/app/(embed)/podcast/embed/[id]/page.test.tsx
@@ -1,0 +1,77 @@
+import { notFound } from "next/navigation"
+import { factories, setMockResponse, urls } from "api/test-utils"
+import type { PodcastEpisodeResource } from "api/v1"
+import Page from "./page"
+
+jest.mock("@/app/getQueryClient", () => {
+  const { makeBrowserQueryClient } = jest.requireActual("@/app/getQueryClient")
+  return {
+    getQueryClient: () => makeBrowserQueryClient({ maxRetries: 0 }),
+  }
+})
+
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  dehydrate: jest.fn().mockReturnValue({}),
+}))
+
+jest.mock("@/app-pages/PodcastPage/PodcastEmbedPlayer", () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+const mockNotFound = jest.mocked(notFound)
+
+describe("podcast embed page.tsx server component", () => {
+  beforeEach(() => {
+    mockNotFound.mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND")
+    })
+  })
+
+  test("calls notFound for a non-integer id", async () => {
+    await expect(
+      Page({ params: Promise.resolve({ id: "abc" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+
+  test("calls notFound for id of zero", async () => {
+    await expect(
+      Page({ params: Promise.resolve({ id: "0" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+
+  test("calls notFound for a negative id", async () => {
+    await expect(
+      Page({ params: Promise.resolve({ id: "-1" }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+
+  test("calls notFound when the resource is not a podcast episode", async () => {
+    const course = factories.learningResources.course()
+    setMockResponse.get(
+      urls.learningResources.details({ id: course.id }),
+      course,
+    )
+
+    await expect(
+      Page({ params: Promise.resolve({ id: String(course.id) }) }),
+    ).rejects.toThrow("NEXT_NOT_FOUND")
+    expect(notFound).toHaveBeenCalled()
+  })
+
+  test("does not call notFound for a valid podcast episode", async () => {
+    const episode =
+      factories.learningResources.podcastEpisode() as PodcastEpisodeResource
+    setMockResponse.get(
+      urls.learningResources.details({ id: episode.id }),
+      episode,
+    )
+
+    await Page({ params: Promise.resolve({ id: String(episode.id) }) })
+    expect(notFound).not.toHaveBeenCalled()
+  })
+})

--- a/frontends/main/src/app/(embed)/podcast/embed/[id]/page.tsx
+++ b/frontends/main/src/app/(embed)/podcast/embed/[id]/page.tsx
@@ -1,0 +1,66 @@
+import React from "react"
+import { HydrationBoundary, dehydrate } from "@tanstack/react-query"
+import { learningResourceQueries } from "api/hooks/learningResources"
+import { getQueryClient } from "@/app/getQueryClient"
+import { notFound } from "next/navigation"
+import PodcastEmbedPlayer from "@/app-pages/PodcastPage/PodcastEmbedPlayer"
+import { ResourceTypeEnum } from "api/v1"
+import {
+  safeGenerateMetadata,
+  standardizeMetadata,
+  MetadataNotFound,
+} from "@/common/metadata"
+
+export const generateMetadata = ({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) =>
+  safeGenerateMetadata(async () => {
+    const { id } = await params
+    const episodeId = Number(id)
+    if (!Number.isInteger(episodeId) || episodeId <= 0) {
+      throw new MetadataNotFound()
+    }
+    const queryClient = getQueryClient()
+    const resource = await queryClient
+      .fetchQuery(learningResourceQueries.detail(episodeId))
+      .catch(() => {
+        throw new MetadataNotFound()
+      })
+
+    if (resource?.resource_type !== ResourceTypeEnum.PodcastEpisode) {
+      throw new MetadataNotFound()
+    }
+
+    return standardizeMetadata({
+      title: resource.title,
+      robots: "noindex, nofollow",
+      social: false,
+    })
+  })
+
+const Page = async ({ params }: { params: Promise<{ id: string }> }) => {
+  const { id } = await params
+  const episodeId = Number(id)
+  if (!Number.isInteger(episodeId) || episodeId <= 0) {
+    notFound()
+  }
+
+  const queryClient = getQueryClient()
+  const resource = await queryClient.fetchQueryOr404(
+    learningResourceQueries.detail(episodeId),
+  )
+
+  if (resource.resource_type !== ResourceTypeEnum.PodcastEpisode) {
+    notFound()
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PodcastEmbedPlayer resource={resource} />
+    </HydrationBoundary>
+  )
+}
+
+export default Page


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11789

### Description (What does it do?)
- Implement the podcast episode embed page

### Screenshots (if appropriate):
### Desktop
<img width="2880" height="1410" alt="image" src="https://github.com/user-attachments/assets/99b4dcff-b366-4d41-8c91-79aa4fea9091" />

### Mobile 
<img width="850" height="1218" alt="image" src="https://github.com/user-attachments/assets/57b69a35-3f82-49c4-b2bd-afdd87569100" />


### How can this be tested?
For testing you need to follow this url `http://open.odl.local:8062/podcast/embed/[id]` and see episode embedding 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
