### PR TITLE
fix ocw routing for playlist parent

### DIFF
--- a/frontends/main/src/common/urls.test.ts
+++ b/frontends/main/src/common/urls.test.ts
@@ -1,5 +1,5 @@
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
-import { auth, coursePageView, programPageView } from "./urls"
+import { auth, coursePageView, ocwLearnPageView, programPageView } from "./urls"
 
 const MITOL_API_BASE_URL = process.env.NEXT_PUBLIC_MITOL_API_BASE_URL
 
@@ -112,4 +112,28 @@ test("programPageView falls back to /programs/ for unknown display_mode values",
       display_mode: "unknown-future-value" as never,
     }),
   ).toBe("/programs/some-slug")
+})
+
+test.each([
+  "https://example.com/courses/some-course",
+  "https://mit.edu/courses/some-course",
+])("ocwLearnPageView returns original URL for non-OCW hostnames", (url) => {
+  expect(ocwLearnPageView(url)).toBe(url)
+})
+
+test.each([
+  {
+    input: "https://ocw.mit.edu/courses/some-course",
+    expected: "/courses/o/some-course",
+  },
+  {
+    input: "https://ocw.mit.edu/courses/physics-101/",
+    expected: "/courses/o/physics-101/",
+  },
+  {
+    input: "https://ocw.mit.edu/search",
+    expected: "/search",
+  },
+])("ocwLearnPageView transforms OCW URLs correctly", ({ input, expected }) => {
+  expect(ocwLearnPageView(input)).toBe(expected)
 })

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -290,7 +290,10 @@ export const programPageView = (program: {
       : PROGRAM_PAGE_VIEW
   return generatePath(pattern, { readableId: program.readable_id })
 }
-export const ocwLearnPageView = (ocwUrl: string) => {
-  const url = new URL(ocwUrl)
+export const ocwLearnPageView = (originalUrl: string) => {
+  const url = new URL(originalUrl)
+  if (!url.hostname.includes("ocw.mit.edu")) {
+    return originalUrl
+  }
   return url.pathname.replace(/^\/courses/, "/courses/o")
 }

--- a/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/InfoSection.tsx
@@ -544,10 +544,7 @@ const INFO_ITEMS: InfoItemConfig = [
           : resource.url
       if (!url) return name
 
-      const href =
-        ocwProductPages && resource.platform?.code === PlatformEnum.Ocw
-          ? ocwLearnPageView(url)
-          : url
+      const href = ocwProductPages ? ocwLearnPageView(url) : url
 
       return (
         <Link href={href} color="red" hovercolor="red" size="small">


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
The link for ocw playlist parents currently ignores the new ocw routing even when the `ocw-product-pages` flag is set to true
https://rc.learn.mit.edu/search?offered_by=ocw&resource_category=Video+Playlist&resource_type_group=learning_material&resource=129015


This fixes the issue

### How can this be tested?
Run
```
docker-compose run web ./manage.py
backpopulate_ocw_data --course-name 14-12-economic-applications-of-game-theory-fall-2025

Run

docker-compose run web ./manage.py
backpopulate_youtube_data
```
to populate an ocw course, videos with a parent course and a video playlist with a parent course

set
ocw-product-pages to enabled in posthog

The links for ocw videos, playlists and courses should go to http://open.odl.local:8062/courses/o/ domains. The playlist and course should go to the base course url and the video will go to a specific video


set
ocw-product-pages to disabled in posthog

The links for ocw videos, playlists and courses  should go the ocw site

