### PR TITLE
Fix bug in vector resource metadata updates

### DIFF
--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -483,12 +483,14 @@ def _process_resource_embeddings(serialized_resources):
 
 
 def update_learning_resource_payload(serialized_document):
-    points = [vector_point_id(vector_point_key(serialized_document))]
-    _set_payload(
-        points,
-        serialized_document,
-        param_map=QDRANT_RESOURCE_PARAM_MAP,
+    """
+    Refresh a resource's Qdrant payload without re-embedding.
+    """
+    point_id = vector_point_id(vector_point_key(serialized_document))
+    qdrant_client().overwrite_payload(
         collection_name=RESOURCES_COLLECTION_NAME,
+        payload=serialized_document,
+        points=[point_id],
     )
 
 

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -74,6 +74,7 @@ from vector_search.utils import (
     update_learning_resource_payload,
     update_qdrant_indexes,
     vector_point_id,
+    vector_point_key,
 )
 from vector_search.utils import qdrant_client as vector_qdrant_client
 
@@ -912,9 +913,7 @@ def test_update_payload_learning_resource(mocker):
     mock_qdrant.overwrite_payload.assert_called_once()
     call_args = mock_qdrant.overwrite_payload.call_args[1]
     assert call_args["collection_name"] == RESOURCES_COLLECTION_NAME
-    assert call_args["points"] == [
-        vector_point_id(f"{doc['platform']['code']}.{doc['readable_id']}")
-    ]
+    assert call_args["points"] == [vector_point_id(vector_point_key(doc))]
     # The whole serialized doc is written. Topics in particular must propagate;
     # the old param-map projection keyed on `topic` (not `topics`) silently
     # dropped them, hiding resources from topic filters (mitodl/hq#11786).

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -903,25 +903,24 @@ def test_should_not_generate_for_unchanged_content_file(mocker):
 
 
 def test_update_payload_learning_resource(mocker):
-    """Should update payload for learning resources"""
+    """Should overwrite the point payload with the full serialized document"""
     resource = LearningResourceFactory.create()
-    serialized_resources = list(serialize_bulk_learning_resources([resource.id]))
+    doc = next(iter(serialize_bulk_learning_resources([resource.id])))
     mock_qdrant = mocker.MagicMock()
     mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
-    update_learning_resource_payload(serialized_resources[0])
-    mock_qdrant.set_payload.assert_called_once()
-    call_args = mock_qdrant.set_payload.call_args[1]
+    update_learning_resource_payload(doc)
+    mock_qdrant.overwrite_payload.assert_called_once()
+    call_args = mock_qdrant.overwrite_payload.call_args[1]
     assert call_args["collection_name"] == RESOURCES_COLLECTION_NAME
     assert call_args["points"] == [
-        vector_point_id(
-            f"{serialized_resources[0]['platform']['code']}.{serialized_resources[0]['readable_id']}"
-        )
+        vector_point_id(f"{doc['platform']['code']}.{doc['readable_id']}")
     ]
-    # Verify payload contains the mapped values
-    for src_key, dest_key in QDRANT_RESOURCE_PARAM_MAP.items():
-        if src_key in serialized_resources[0]:
-            assert dest_key in call_args["payload"]
-            assert call_args["payload"][dest_key] == serialized_resources[0][src_key]
+    # The whole serialized doc is written. Topics in particular must propagate;
+    # the old param-map projection keyed on `topic` (not `topics`) silently
+    # dropped them, hiding resources from topic filters (mitodl/hq#11786).
+    assert call_args["payload"] == doc
+    assert doc["topics"]
+    assert call_args["payload"]["topics"] == doc["topics"]
 
 
 def test_update_payload_content_file(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11786

### Description (What does it do?)
Refreshes a resource's full Qdrant payload (topics, etc.) when metadata changes without the embedding text changing. The old skip-path update projected through a filter-param map keyed on the wrong names (`topic` vs `topics`), so those fields silently never got written.

### How can this be tested?
- Pick an already-embedded resource, note its `id`, change its topics in admin, and save.
-  Reprocess the existing point: `docker compose run --rm web python manage.py generate_embeddings --resource-ids <id> --overwrite`
- Confirm the payload topics now match:
   ```python
   from vector_search.utils import qdrant_client, vector_point_id, vector_point_key
   from learning_resources_search.serializers import serialize_bulk_learning_resources
   from vector_search.constants import RESOURCES_COLLECTION_NAME

   doc = next(iter(serialize_bulk_learning_resources([<id>])))
   pid = vector_point_id(vector_point_key(doc))
   print(qdrant_client().retrieve(RESOURCES_COLLECTION_NAME, ids=[pid])[0].payload["topics"])
   ```

With QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS enabled (as it is on RC and prod), every ETL create/update re-embeds on a text change and refreshes the payload otherwise, so changes should reconcile automatically.