### PR TITLE
switch to celery.chain for certain vector_search tasks

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -382,7 +382,9 @@ def embed_new_content_files(self):
             chunk_size=settings.QDRANT_CHUNK_SIZE,
         )
     ]
-    embed_tasks = celery.chain(tasks)
+    if not tasks:
+        return None
+    embed_tasks = celery.chain(*tasks)
     return self.replace(embed_tasks)
 
 

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -51,6 +51,15 @@ from vector_search.utils import (
 log = logging.getLogger(__name__)
 
 
+def _replace_with_chain(task, task_signatures):
+    """
+    Replace a task with a chain only when there is work to do.
+    """
+    if not task_signatures:
+        return None
+    return task.replace(celery.chain(*task_signatures))
+
+
 def _queue_program_content_file_embedding_tasks(index_tasks, program_ids, overwrite):
     """Queue content file embedding tasks for programs using a single bulk query."""
     if not program_ids:
@@ -243,7 +252,7 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):  # noqa
 
     # Use self.replace so that code waiting on this task will also wait on the embedding
     #  and finish tasks
-    return self.replace(celery.chain(*index_tasks))
+    return _replace_with_chain(self, index_tasks)
 
 
 @app.task(bind=True)
@@ -321,7 +330,7 @@ def embed_learning_resources_by_id(self, ids, skip_content_files, overwrite):
     # Use self.replace so that code waiting on this task will also wait on the embedding
     #  and finish tasks
 
-    return self.replace(celery.chain(*index_tasks))
+    return _replace_with_chain(self, index_tasks)
 
 
 @app.task(bind=True)
@@ -382,10 +391,7 @@ def embed_new_content_files(self):
             chunk_size=settings.QDRANT_CHUNK_SIZE,
         )
     ]
-    if not tasks:
-        return None
-    embed_tasks = celery.chain(*tasks)
-    return self.replace(embed_tasks)
+    return _replace_with_chain(self, tasks)
 
 
 @app.task(bind=True)
@@ -401,10 +407,7 @@ def embed_run_content_files(self, run_id):
         generate_embeddings.si(ids, CONTENT_FILE_TYPE, overwrite=True)
         for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
     ]
-    if not tasks:
-        return None
-
-    return self.replace(celery.chain(*tasks))
+    return _replace_with_chain(self, tasks)
 
 
 @app.task(bind=True)
@@ -415,16 +418,11 @@ def remove_run_content_files(self, run_id):
     content_file_ids = list(
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
-    return self.replace(
-        celery.chain(
-            [
-                remove_embeddings.si(ids, CONTENT_FILE_TYPE)
-                for ids in chunks(
-                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
-                )
-            ]
-        )
-    )
+    tasks = [
+        remove_embeddings.si(ids, CONTENT_FILE_TYPE)
+        for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
+    ]
+    return _replace_with_chain(self, tasks)
 
 
 @app.task(bind=True)
@@ -437,16 +435,11 @@ def remove_unpublished_run_content_files(self, run_id):
             "id", flat=True
         )
     )
-    return self.replace(
-        celery.chain(
-            [
-                remove_embeddings.si(ids, CONTENT_FILE_TYPE)
-                for ids in chunks(
-                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
-                )
-            ]
-        )
-    )
+    tasks = [
+        remove_embeddings.si(ids, CONTENT_FILE_TYPE)
+        for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
+    ]
+    return _replace_with_chain(self, tasks)
 
 
 @app.task

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -397,16 +397,14 @@ def embed_run_content_files(self, run_id):
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
 
-    return self.replace(
-        celery.chain(
-            [
-                generate_embeddings.si(ids, CONTENT_FILE_TYPE, overwrite=True)
-                for ids in chunks(
-                    content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE
-                )
-            ]
-        )
-    )
+    tasks = [
+        generate_embeddings.si(ids, CONTENT_FILE_TYPE, overwrite=True)
+        for ids in chunks(content_file_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
+    ]
+    if not tasks:
+        return None
+
+    return self.replace(celery.chain(*tasks))
 
 
 @app.task(bind=True)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -80,7 +80,7 @@ def _queue_program_content_file_embedding_tasks(index_tasks, program_ids, overwr
     reject_on_worker_lost=True,
     autoretry_for=(RetryError,),
     retry_backoff=True,
-    rate_limit="300/m",
+    rate_limit="200/m",
 )
 def generate_embeddings(ids, resource_type, overwrite):
     """
@@ -382,7 +382,7 @@ def embed_new_content_files(self):
             chunk_size=settings.QDRANT_CHUNK_SIZE,
         )
     ]
-    embed_tasks = celery.group(tasks)
+    embed_tasks = celery.chain(tasks)
     return self.replace(embed_tasks)
 
 
@@ -396,7 +396,7 @@ def embed_run_content_files(self, run_id):
     )
 
     return self.replace(
-        celery.group(
+        celery.chain(
             [
                 generate_embeddings.si(ids, CONTENT_FILE_TYPE, overwrite=True)
                 for ids in chunks(
@@ -416,7 +416,7 @@ def remove_run_content_files(self, run_id):
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
     return self.replace(
-        celery.group(
+        celery.chain(
             [
                 remove_embeddings.si(ids, CONTENT_FILE_TYPE)
                 for ids in chunks(
@@ -438,7 +438,7 @@ def remove_unpublished_run_content_files(self, run_id):
         )
     )
     return self.replace(
-        celery.group(
+        celery.chain(
             [
                 remove_embeddings.si(ids, CONTENT_FILE_TYPE)
                 for ids in chunks(

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -255,6 +255,22 @@ def test_remove_run_content_files(mocker, mocked_celery, settings):
     assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
 
 
+def test_remove_run_content_files_no_content_files(mocker, mocked_celery):
+    """
+    remove_run_content_files should short-circuit when there is nothing to remove.
+    """
+    run = LearningResourceRunFactory.create()
+    remove_embeddings_mock = mocker.patch(
+        "vector_search.tasks.remove_embeddings", autospec=True
+    )
+
+    remove_run_content_files.delay(run.id)
+
+    remove_embeddings_mock.si.assert_not_called()
+    mocked_celery.chain.assert_not_called()
+    mocked_celery.replace.assert_not_called()
+
+
 def test_remove_unpublished_run_content_files(mocker, mocked_celery):
     """
     remove_unpublished_run_content_files should only remove unpublished content

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -578,7 +578,7 @@ def test_embed_new_content_files_without_runs(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.chain.call_args[0][0])
+    list(mocked_celery.chain.call_args[0])
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     for contentfile_id in content_files_without_run:
         assert contentfile_id in embedded_ids

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -29,6 +29,7 @@ from vector_search.tasks import (
     embed_learning_resources_by_id,
     embed_new_content_files,
     embed_new_learning_resources,
+    embed_run_content_files,
     embeddings_healthcheck,
     remove_run_content_files,
     remove_unpublished_run_content_files,
@@ -212,10 +213,13 @@ def test_embed_new_content_files(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.chain.call_args[0])
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(new_content_file_ids) == sorted(embedded_ids)
+    assert mocked_celery.chain.call_args.args == tuple(
+        generate_embeddings_mock.si.return_value
+        for _ in generate_embeddings_mock.si.mock_calls
+    )
 
 
 def test_remove_run_content_files(mocker, mocked_celery, settings):
@@ -578,10 +582,61 @@ def test_embed_new_content_files_without_runs(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.chain.call_args[0])
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     for contentfile_id in content_files_without_run:
         assert contentfile_id in embedded_ids
+
+
+def test_embed_run_content_files(mocker, mocked_celery, settings):
+    """
+    embed_run_content_files should replace itself with embedding tasks for all
+    content files associated with the run.
+    """
+    settings.QDRANT_CHUNK_SIZE = 2
+    run = LearningResourceRunFactory.create()
+    content_file_ids = [
+        content_file.id for content_file in ContentFileFactory.create_batch(3, run=run)
+    ]
+    ContentFileFactory.create()
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        embed_run_content_files.delay(run.id)
+
+    embedded_ids = [
+        content_file_id
+        for mock_call in generate_embeddings_mock.si.mock_calls
+        for content_file_id in mock_call.args[0]
+    ]
+    assert sorted(embedded_ids) == sorted(content_file_ids)
+    assert all(
+        mock_call.args[1:] == (CONTENT_FILE_TYPE,)
+        and mock_call.kwargs == {"overwrite": True}
+        for mock_call in generate_embeddings_mock.si.mock_calls
+    )
+    assert mocked_celery.chain.call_args.args == tuple(
+        generate_embeddings_mock.si.return_value
+        for _ in generate_embeddings_mock.si.mock_calls
+    )
+    assert mocked_celery.replace.call_count == 1
+
+
+def test_embed_run_content_files_no_content_files(mocker, mocked_celery):
+    """
+    embed_run_content_files should short-circuit when there is nothing to embed.
+    """
+    run = LearningResourceRunFactory.create()
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    embed_run_content_files.delay(run.id)
+
+    generate_embeddings_mock.si.assert_not_called()
+    mocked_celery.chain.assert_not_called()
+    mocked_celery.replace.assert_not_called()
 
 
 def test_embeddings_healthcheck_no_missing_embeddings(mocker):

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -212,7 +212,7 @@ def test_embed_new_content_files(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.chain.call_args[0][0])
+    list(mocked_celery.chain.call_args[0])
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(new_content_file_ids) == sorted(embedded_ids)

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -212,7 +212,7 @@ def test_embed_new_content_files(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.group.call_args[0][0])
+    list(mocked_celery.chain.call_args[0][0])
 
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(new_content_file_ids) == sorted(embedded_ids)
@@ -246,9 +246,9 @@ def test_remove_run_content_files(mocker, mocked_celery, settings):
         mock_call.args[1] == CONTENT_FILE_TYPE
         for mock_call in remove_embeddings_mock.si.mock_calls
     )
-    assert mocked_celery.group.call_count == 1
+    assert mocked_celery.chain.call_count == 1
     assert mocked_celery.replace.call_count == 1
-    assert mocked_celery.replace.call_args[0][1] == mocked_celery.group.return_value
+    assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
 
 
 def test_remove_unpublished_run_content_files(mocker, mocked_celery):
@@ -271,9 +271,9 @@ def test_remove_unpublished_run_content_files(mocker, mocked_celery):
         [unpublished_content_file.id],
         CONTENT_FILE_TYPE,
     )
-    assert mocked_celery.group.call_count == 1
+    assert mocked_celery.chain.call_count == 1
     assert mocked_celery.replace.call_count == 1
-    assert mocked_celery.replace.call_args[0][1] == mocked_celery.group.return_value
+    assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
 
 
 def test_embed_learning_resources_by_id(mocker, mocked_celery):
@@ -578,7 +578,7 @@ def test_embed_new_content_files_without_runs(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_content_files.delay()
-    list(mocked_celery.group.call_args[0][0])
+    list(mocked_celery.chain.call_args[0][0])
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     for contentfile_id in content_files_without_run:
         assert contentfile_id in embedded_ids


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/11848
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR makes the contentfile embeddings (and similar) tasks in the vector_search app to use a celery chain instead of a group in order to resolve an issue where qdrant gets overwhelmed when many (100's) of runs are processed at once.


### How can this be tested?
I have not found a simple way of seeing this overwhelming of qdrant locally but you can verify that the tasks continue to work as expected using celery.chain:
```python
from vector_search.tasks import *
from learning_resources.models import *

run = LearningResourceRun.objects.first()

remove_run_content_files.apply_async([run.id])
embed_run_content_files.apply_async([run.id])
remove_unpublished_run_content_files.apply_async([run.id])
```


### Additional Context
After this deploys I will try embedding the ~1300 runs we need to as part of the variant course workaround - If it continues being problematic we may need to adjust the throttle further
