### PR TITLE
feat: wire up B2B seat management write actions

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -31,7 +31,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2026.6.10",
+    "@mitodl/mitxonline-api-axios": "2026.6.17",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/src/mitxonline/hooks/certificates/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/certificates/queries.ts
@@ -28,7 +28,7 @@ const certificateQueries = {
           .courseCertificatesRetrieve(opts)
           .then((res) => res.data)
       },
-      enabled: !!opts.cert_uuid,
+      enabled: !!opts.uuid,
     }),
   programCertificatesRetrieve: (
     opts: ProgramCertificatesApiProgramCertificatesRetrieveRequest,

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -7,7 +7,11 @@ import {
   B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
   B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
-import { organizationQueries, managerOrganizationQueries } from "./queries"
+import {
+  organizationQueries,
+  managerOrganizationQueries,
+  managerOrganizationKeys,
+} from "./queries"
 
 const useB2BAttachMutation = (opts: B2bApiB2bAttachCreateRequest) => {
   const queryClient = useQueryClient()
@@ -33,15 +37,12 @@ const useBulkAssignSeats = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesBulkAssignCreateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
-    onSettled: () => {
+    onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: [
-          "mitxonline",
-          "manager",
-          "organizations",
-          "contracts",
-          "codes",
-        ],
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
       })
     },
   })
@@ -54,15 +55,12 @@ const useRemindCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
-    onSettled: () => {
+    onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: [
-          "mitxonline",
-          "manager",
-          "organizations",
-          "contracts",
-          "codes",
-        ],
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
       })
     },
   })
@@ -75,15 +73,12 @@ const useRevokeCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
-    onSettled: () => {
+    onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: [
-          "mitxonline",
-          "manager",
-          "organizations",
-          "contracts",
-          "codes",
-        ],
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
       })
     },
   })
@@ -100,15 +95,12 @@ const useReassignCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesReassignUpdateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
-    onSettled: () => {
+    onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: [
-          "mitxonline",
-          "manager",
-          "organizations",
-          "contracts",
-          "codes",
-        ],
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -7,11 +7,7 @@ import {
   B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
   B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
-import {
-  organizationQueries,
-  managerOrganizationQueries,
-  managerOrganizationKeys,
-} from "./queries"
+import { organizationQueries, managerOrganizationQueries } from "./queries"
 
 const useB2BAttachMutation = (opts: B2bApiB2bAttachCreateRequest) => {
   const queryClient = useQueryClient()
@@ -37,7 +33,7 @@ const useBulkAssignSeats = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesBulkAssignCreateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
-    onSettled: (_data, _err, vars) => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [
           "mitxonline",
@@ -58,7 +54,7 @@ const useRemindCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
-    onSettled: (_data, _err, vars) => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [
           "mitxonline",
@@ -79,7 +75,7 @@ const useRevokeCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
-    onSettled: (_data, _err, vars) => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [
           "mitxonline",
@@ -104,7 +100,7 @@ const useReassignCode = () => {
     mutationFn: (
       opts: B2bApiB2bManagerOrganizationsContractsCodesReassignUpdateRequest,
     ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
-    onSettled: (_data, _err, vars) => {
+    onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: [
           "mitxonline",

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -69,10 +69,7 @@ const useRevokeCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -1,7 +1,17 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { b2bApi } from "../../clients"
-import { B2bApiB2bAttachCreateRequest } from "@mitodl/mitxonline-api-axios/v2"
-import { organizationQueries, managerOrganizationQueries } from "./queries"
+import {
+  B2bApiB2bAttachCreateRequest,
+  B2bApiB2bManagerOrganizationsContractsCodesBulkAssignCreateRequest,
+  B2bApiB2bManagerOrganizationsContractsCodesReassignUpdateRequest,
+  B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
+  B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
+} from "@mitodl/mitxonline-api-axios/v2"
+import {
+  organizationQueries,
+  managerOrganizationQueries,
+  managerOrganizationKeys,
+} from "./queries"
 
 const useB2BAttachMutation = (opts: B2bApiB2bAttachCreateRequest) => {
   const queryClient = useQueryClient()
@@ -16,5 +26,93 @@ const useB2BAttachMutation = (opts: B2bApiB2bAttachCreateRequest) => {
   })
 }
 
-export { organizationQueries, managerOrganizationQueries, useB2BAttachMutation }
+/**
+ * Bulk-assign available enrollment codes to a list of email addresses. Codes are
+ * auto-allocated by the backend (one per record); the response reports which
+ * addresses were assigned and which failed.
+ */
+const useBulkAssignSeats = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (
+      opts: B2bApiB2bManagerOrganizationsContractsCodesBulkAssignCreateRequest,
+    ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
+    onSettled: (_data, _err, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
+      })
+    },
+  })
+}
+
+/** Resend the claim email for an assigned-but-unredeemed enrollment code. */
+const useRemindCode = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (
+      opts: B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
+    ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
+    onSettled: (_data, _err, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
+      })
+    },
+  })
+}
+
+/** Revoke a code assignment, returning the code to the unassigned pool. */
+const useRevokeCode = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (
+      opts: B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
+    ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
+    onSettled: (_data, _err, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
+      })
+    },
+  })
+}
+
+/**
+ * Reassign an assigned-but-unredeemed enrollment code to a new email address.
+ * The backend updates the existing assignment in place and re-sends the claim
+ * email. Returns 409 if the code has already been redeemed.
+ */
+const useReassignCode = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (
+      opts: B2bApiB2bManagerOrganizationsContractsCodesReassignUpdateRequest,
+    ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
+    onSettled: (_data, _err, vars) => {
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractCodes({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
+      })
+    },
+  })
+}
+
+export {
+  organizationQueries,
+  managerOrganizationQueries,
+  useB2BAttachMutation,
+  useBulkAssignSeats,
+  useReassignCode,
+  useRemindCode,
+  useRevokeCode,
+}
 export type { ContractCode } from "./queries"

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -54,10 +54,7 @@ const useRemindCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -39,10 +39,7 @@ const useBulkAssignSeats = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -39,7 +39,13 @@ const useBulkAssignSeats = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
+        queryKey: [
+          "mitxonline",
+          "manager",
+          "organizations",
+          "contracts",
+          "codes",
+        ],
       })
     },
   })
@@ -54,7 +60,13 @@ const useRemindCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
+        queryKey: [
+          "mitxonline",
+          "manager",
+          "organizations",
+          "contracts",
+          "codes",
+        ],
       })
     },
   })
@@ -69,7 +81,13 @@ const useRevokeCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
+        queryKey: [
+          "mitxonline",
+          "manager",
+          "organizations",
+          "contracts",
+          "codes",
+        ],
       })
     },
   })
@@ -88,7 +106,13 @@ const useReassignCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
+        queryKey: [
+          "mitxonline",
+          "manager",
+          "organizations",
+          "contracts",
+          "codes",
+        ],
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -88,10 +88,7 @@ const useReassignCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: ["mitxonline", "manager", "organizations", "contracts", "codes"],
       })
     },
   })

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -45,17 +45,11 @@ const managerOrganizationKeys = {
       "detail",
       opts,
     ] as const,
+  contractCodesRoot: () =>
+    ["mitxonline", "manager", "organizations", "contracts", "codes"] as const,
   contractCodes: (
     opts: B2bApiB2bManagerOrganizationsContractsCodesListRequest,
-  ) =>
-    [
-      "mitxonline",
-      "manager",
-      "organizations",
-      "contracts",
-      "codes",
-      opts,
-    ] as const,
+  ) => [...managerOrganizationKeys.contractCodesRoot(), opts] as const,
 }
 
 const managerOrganizationQueries = {

--- a/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
@@ -1,5 +1,9 @@
 import { faker } from "@faker-js/faker/locale/en"
-import type { ContractPage } from "@mitodl/mitxonline-api-axios/v2"
+import type {
+  BulkAssignError,
+  BulkAssignResult,
+  ContractPage,
+} from "@mitodl/mitxonline-api-axios/v2"
 import { makePaginatedFactory } from "ol-test-utilities"
 import type { ContractCode } from "../../hooks/organizations"
 
@@ -40,4 +44,21 @@ const contractCode = (overrides: Partial<ContractCode> = {}): ContractCode => {
   }
 }
 
-export { contract, contracts, contractCode }
+const bulkAssignError = (
+  overrides: Partial<BulkAssignError> = {},
+): BulkAssignError => ({
+  email: faker.internet.email(),
+  name: faker.person.fullName(),
+  detail: "Code has already been assigned or redeemed.",
+  ...overrides,
+})
+
+const bulkAssignResult = (
+  overrides: Partial<BulkAssignResult> = {},
+): BulkAssignResult => ({
+  assigned: [contractCode({ redemption_status: "assigned" })],
+  errors: [],
+  ...overrides,
+})
+
+export { contract, contracts, contractCode, bulkAssignError, bulkAssignResult }

--- a/frontends/api/src/mitxonline/test-utils/factories/courses.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/courses.ts
@@ -176,7 +176,7 @@ const course: PartialFactory<CourseWithCourseRunsSerializerV2> = (
         bio: faker.lorem.paragraph(),
       })),
     },
-    programs: null,
+    programs: [],
     topics: [
       {
         name: faker.lorem.word(),

--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -105,7 +105,7 @@ const v2Course: PartialFactory<V2Course> = (overrides = {}) => {
         name: faker.company.name(),
       },
     ],
-    programs: null,
+    programs: [],
     min_price: faker.number.int({ min: 0, max: 1000 }),
     max_price: faker.number.int({ min: 1000, max: 2000 }),
     include_in_learn_catalog: faker.datatype.boolean(),

--- a/frontends/api/src/mitxonline/test-utils/factories/programs.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/programs.ts
@@ -18,6 +18,7 @@ const baseProgram: Factory<BaseProgram> = (overrides = {}) => {
     id: uniqueProgramId.enforce(() => faker.number.int()),
     readable_id: faker.lorem.slug(),
     type: faker.lorem.words(),
+    display_mode: null,
   }
   return {
     ...defaults,

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -92,15 +92,35 @@ const contracts = {
     `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/`,
   managerContractCodes: (orgId: number, contractId: number) =>
     `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/`,
+  managerContractBulkAssign: (orgId: number, contractId: number) =>
+    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/bulk_assign/`,
+  managerContractCodeRemind: (
+    orgId: number,
+    contractId: number,
+    code: string,
+  ) =>
+    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/${code}/remind/`,
+  managerContractCodeRevoke: (
+    orgId: number,
+    contractId: number,
+    code: string,
+  ) =>
+    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/${code}/revoke/`,
+  managerContractCodeReassign: (
+    orgId: number,
+    contractId: number,
+    code: string,
+  ) =>
+    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/${code}/reassign/`,
 }
 
 const certificates = {
   courseCertificatesRetrieve: (
     params: CourseCertificatesApiCourseCertificatesRetrieveRequest,
-  ) => `${getApiBaseUrl()}/api/v2/course_certificates/${params.cert_uuid}/`,
+  ) => `${getApiBaseUrl()}/api/v2/course_certificates/${params.uuid}/`,
   programCertificatesRetrieve: (
     params: ProgramCertificatesApiProgramCertificatesRetrieveRequest,
-  ) => `${getApiBaseUrl()}/api/v2/program_certificates/${params.cert_uuid}/`,
+  ) => `${getApiBaseUrl()}/api/v2/program_certificates/${params.uuid}/`,
 }
 
 const products = {

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -15,7 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@floating-ui/react": "^0.27.16",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "2026.6.10",
+    "@mitodl/mitxonline-api-axios": "2026.6.17",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -22,7 +22,7 @@ describe("CertificatePage", () => {
     const certificate = factories.mitxonline.courseCertificate()
     setMockResponse.get(
       mitxonline.urls.certificates.courseCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -89,7 +89,7 @@ describe("CertificatePage", () => {
     certificate.program.program_type = "Program"
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -122,7 +122,7 @@ describe("CertificatePage", () => {
     certificate.program.program_type = "MicroMasters®"
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -152,7 +152,7 @@ describe("CertificatePage", () => {
 
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -190,7 +190,7 @@ describe("CertificatePage", () => {
 
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -691,7 +691,7 @@ const CertificatePage: React.FC<{
     isError: isCourseError,
   } = useQuery({
     ...certificateQueries.courseCertificatesRetrieve({
-      cert_uuid: uuid,
+      uuid,
     }),
     enabled: certificateType === CertificateType.Course,
   })
@@ -702,7 +702,7 @@ const CertificatePage: React.FC<{
     isError: isProgramError,
   } = useQuery({
     ...certificateQueries.programCertificatesRetrieve({
-      cert_uuid: uuid,
+      uuid,
     }),
     enabled: certificateType === CertificateType.Program,
   })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -1,5 +1,7 @@
 import React from "react"
-import { renderWithTheme, screen, user, waitFor } from "@/test-utils"
+import { renderWithProviders, screen, user, waitFor } from "@/test-utils"
+import { setMockResponse } from "api/test-utils"
+import { factories, urls } from "api/mitxonline-test-utils"
 import { AssignSeatsSection } from "./AssignSeatsSection"
 
 // jsdom's File/Blob has no .text() or .arrayBuffer(), so FileReader.readAsText
@@ -48,7 +50,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("renders section title and key UI elements", () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     expect(
       screen.getByRole("heading", { name: "Assign Seats" }),
@@ -65,7 +69,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("download sample CSV pseudo-link is in the tab order and disabled", () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     // Only the download link is still disabled — import from CSV is now active
     const downloadLink = screen.getByRole("button", {
@@ -76,7 +82,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("import from CSV button is active and in the tab order", () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const importButton = screen.getByRole("button", { name: "import from CSV" })
     expect(importButton).toBeInTheDocument()
@@ -85,13 +93,17 @@ describe("AssignSeatsSection", () => {
   })
 
   test("Assign Seats button is disabled when textarea is empty", () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     expect(screen.getByRole("button", { name: "Assign Seats" })).toBeDisabled()
   })
 
   test("Assign Seats button is disabled when valid email count exceeds available seats", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={1} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={1} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com, bob@example.com")
@@ -100,7 +112,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("Assign Seats button enables when at least one valid email is entered", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com")
@@ -111,7 +125,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("Assign Seats button stays disabled when only invalid emails are entered", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "notanemail")
@@ -120,7 +136,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("sole invalid token is not highlighted while focused (no preceding comma)", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "notvalid")
@@ -131,7 +149,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("last invalid token is highlighted while focused when preceded by a comma", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com, notvalid")
@@ -142,7 +162,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("last invalid token is highlighted after blur (no trailing comma)", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "notvalid")
@@ -154,7 +176,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("shows valid/invalid counts after entering emails", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com, bob@example.com, notvalid")
@@ -164,7 +188,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("shows only valid count when all emails are valid", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com, bob@example.com")
@@ -174,13 +200,17 @@ describe("AssignSeatsSection", () => {
   })
 
   test("validation badge is not shown when textarea is empty", () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     expect(screen.queryByText(/valid/i)).not.toBeInTheDocument()
   })
 
   test("live region announces email validation summary after debounce", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com, bad-email")
@@ -198,7 +228,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("clicking Assign Seats opens the confirm modal", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com")
@@ -210,7 +242,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("modal shows invalid emails when textarea has mixed input", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.click(textarea)
@@ -221,7 +255,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("modal shows duplicate count when textarea has repeated emails", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.click(textarea)
@@ -234,7 +270,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("closing the modal hides it", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com")
@@ -253,7 +291,9 @@ describe("AssignSeatsSection", () => {
   // CSV import tests
 
   test("importing a valid CSV opens the modal without populating the textarea", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const csvContent = "email\nalice@example.com\nbob@example.com"
     mockFileContent = csvContent
@@ -273,7 +313,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("importing a CSV with invalid emails shows them in the modal", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const csvContent = "alice@example.com\nbad@\nnot-quite@.com"
     mockFileContent = csvContent
@@ -289,7 +331,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("importing a CSV with duplicates shows duplicate count in modal", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const csvContent = "alice@example.com\nbob@example.com\nalice@example.com"
     mockFileContent = csvContent
@@ -306,7 +350,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("importing a CSV with no-@ rows shows skipped count in modal", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const csvContent =
       "alice@example.com\nnoatsymbol\nalso-no-at\nalice@example.com"
@@ -324,7 +370,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("importing a CSV with no valid emails shows inline error", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const csvContent = "Email\nNot An Email\nbad@"
     mockFileContent = csvContent
@@ -344,7 +392,9 @@ describe("AssignSeatsSection", () => {
   })
 
   test("accepts newline-separated emails", async () => {
-    renderWithTheme(<AssignSeatsSection availableSeats={50} />)
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     // Simulate pasting newline-separated emails
@@ -353,5 +403,96 @@ describe("AssignSeatsSection", () => {
 
     expect(screen.getByText("2 valid")).toBeInTheDocument()
     expect(screen.getByText("1 invalid")).toBeInTheDocument()
+  })
+
+  describe("submitting the assignment", () => {
+    const ORG_ID = 1
+    const CONTRACT_ID = 2
+
+    const enterEmailsAndConfirm = async (emails: string) => {
+      const textarea = screen.getByPlaceholderText(/enter employee emails/i)
+      await user.click(textarea)
+      await user.paste(emails)
+      await user.click(screen.getByRole("button", { name: "Assign Seats" }))
+      await user.click(screen.getByRole("button", { name: /send 2 emails/i }))
+    }
+
+    test("assigns seats and shows a success alert, clearing the input", async () => {
+      setMockResponse.post(
+        urls.contracts.managerContractBulkAssign(ORG_ID, CONTRACT_ID),
+        factories.contracts.bulkAssignResult({
+          assigned: [
+            factories.contracts.contractCode(),
+            factories.contracts.contractCode(),
+          ],
+          errors: [],
+        }),
+      )
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+        />,
+      )
+
+      await enterEmailsAndConfirm("alice@example.com\nbob@example.com")
+
+      const alert = await screen.findByRole("alert")
+      expect(alert).toHaveTextContent("2 seats assigned.")
+      expect(screen.getByPlaceholderText(/enter employee emails/i)).toHaveValue(
+        "",
+      )
+    })
+
+    test("surfaces partial failures with a warning alert and the failed addresses", async () => {
+      setMockResponse.post(
+        urls.contracts.managerContractBulkAssign(ORG_ID, CONTRACT_ID),
+        factories.contracts.bulkAssignResult({
+          assigned: [factories.contracts.contractCode()],
+          errors: [
+            factories.contracts.bulkAssignError({
+              email: "taken@example.com",
+              detail: "Code has already been assigned or redeemed.",
+            }),
+          ],
+        }),
+      )
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+        />,
+      )
+
+      await enterEmailsAndConfirm("alice@example.com\ntaken@example.com")
+
+      const alert = await screen.findByRole("alert")
+      expect(alert).toHaveTextContent("1 seat assigned.")
+      expect(alert).toHaveTextContent("1 could not be assigned:")
+      expect(alert).toHaveTextContent("taken@example.com")
+    })
+
+    test("shows an error alert when the request fails", async () => {
+      setMockResponse.post(
+        urls.contracts.managerContractBulkAssign(ORG_ID, CONTRACT_ID),
+        { detail: "boom" },
+        { code: 500 },
+      )
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+        />,
+      )
+
+      await enterEmailsAndConfirm("alice@example.com\nbob@example.com")
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /something went wrong/i,
+      )
+    })
   })
 })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -11,6 +11,8 @@ import {
 } from "ol-utilities"
 import Papa from "papaparse"
 import { AssignSeatsConfirmModal } from "./AssignSeatsConfirmModal"
+import { useBulkAssignSeats } from "api/mitxonline-hooks/organizations"
+import type { BulkAssignError } from "@mitodl/mitxonline-api-axios/v2"
 
 // Shared metrics — must be identical between EmailHighlightLayer and EmailTextarea
 // so the overlay and the real textarea render text in exactly the same position.
@@ -184,6 +186,12 @@ const tokenizeInput = (input: string, allCommitted: boolean) => {
   })
 }
 
+const ResultErrorList = styled.ul(({ theme }) => ({
+  margin: "8px 0 0",
+  paddingLeft: "20px",
+  ...theme.typography.body2,
+}))
+
 type ModalData = {
   validEmails: string[]
   invalidEmails: string[]
@@ -191,11 +199,25 @@ type ModalData = {
   skippedCount: number
 }
 
+/**
+ * Outcome of a bulk-assign request, surfaced in an inline Alert.
+ * `errors: null` means the request itself failed (network/server error);
+ * `errors: []` means every code was assigned successfully.
+ */
+type AssignResult = {
+  assignedCount: number
+  errors: BulkAssignError[] | null
+}
+
 type AssignSeatsSectionProps = {
+  orgId: number
+  contractId: number
   availableSeats: number
 }
 
 const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
+  orgId,
+  contractId,
   availableSeats,
 }) => {
   const [emailInput, setEmailInput] = useState("")
@@ -203,9 +225,13 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   const [csvReadError, setCsvReadError] = useState(false)
   const [csvNoValid, setCsvNoValid] = useState(false)
   const [modalData, setModalData] = useState<ModalData | null>(null)
+  const [result, setResult] = useState<AssignResult | null>(null)
   const [debouncedAnnouncement, setDebouncedAnnouncement] = useState("")
   const [errorAnnouncement, setErrorAnnouncement] = useState("")
+  const [resultAnnouncement, setResultAnnouncement] = useState("")
   const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const bulkAssign = useBulkAssignSeats()
 
   const submitResult = useMemo(
     () => parseEmailsForSubmit(emailInput),
@@ -243,6 +269,36 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       setErrorAnnouncement("")
     }
   }, [csvReadError, csvNoValid])
+
+  // Severity, headline message, and screen-reader announcement for the
+  // bulk-assign outcome, derived from the result shape.
+  const resultContent = useMemo(() => {
+    if (!result) return null
+    const { assignedCount, errors } = result
+    const assigned = `${assignedCount} ${pluralize("seat", assignedCount)} assigned.`
+    if (errors === null) {
+      return {
+        severity: "error" as const,
+        message: "Something went wrong assigning seats. Please try again.",
+      }
+    }
+    if (errors.length === 0) {
+      return { severity: "success" as const, message: assigned }
+    }
+    const failed = `${errors.length} could not be assigned:`
+    return {
+      severity: assignedCount > 0 ? ("warning" as const) : ("error" as const),
+      message:
+        assignedCount > 0
+          ? `${assigned} ${failed}`
+          : `No seats assigned. ${failed}`,
+      errors,
+    }
+  }, [result])
+
+  useEffect(() => {
+    setResultAnnouncement(resultContent?.message ?? "")
+  }, [resultContent])
 
   const handleCsvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -286,9 +342,25 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
 
   const handleModalClose = () => setModalData(null)
 
-  const handleModalConfirm = () => {
-    // TODO: implement send when API is available
-    setModalData(null)
+  const handleModalConfirm = async () => {
+    const emails = modalData?.validEmails ?? []
+    if (emails.length === 0) return
+    setResult(null)
+    try {
+      const { data } = await bulkAssign.mutateAsync({
+        id: contractId,
+        parent_lookup_organization: orgId,
+        AssignRevokeCodeRequestRequest: emails.map((email) => ({ email })),
+      })
+      setResult({ assignedCount: data.assigned.length, errors: data.errors })
+      // Clear the input only on a fully successful assignment.
+      if (data.errors.length === 0) {
+        setEmailInput("")
+      }
+    } catch {
+      setResult({ assignedCount: 0, errors: null })
+    }
+    // The Dialog closes itself once this resolves (see Dialog.handleConfirm).
   }
 
   return (
@@ -307,6 +379,10 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       {/* Always-mounted so NVDA reliably announces dynamically injected errors */}
       <VisuallyHidden aria-live="assertive" aria-atomic="true">
         {errorAnnouncement}
+      </VisuallyHidden>
+      {/* Always-mounted live region for the assignment outcome */}
+      <VisuallyHidden aria-live="assertive" aria-atomic="true">
+        {resultAnnouncement}
       </VisuallyHidden>
       <Stack
         direction={{ xs: "column", sm: "row" }}
@@ -426,6 +502,24 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       {csvNoValid && (
         <Alert severity="error" closable onClose={() => setCsvNoValid(false)}>
           No valid email addresses found in this file.
+        </Alert>
+      )}
+      {resultContent && (
+        <Alert
+          severity={resultContent.severity}
+          closable
+          onClose={() => setResult(null)}
+        >
+          {resultContent.message}
+          {resultContent.errors && resultContent.errors.length > 0 && (
+            <ResultErrorList>
+              {resultContent.errors.map((err) => (
+                <li key={err.email}>
+                  {err.email} — {err.detail}
+                </li>
+              ))}
+            </ResultErrorList>
+          )}
         </Alert>
       )}
       {modalData && (

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -260,6 +260,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
 
   // Severity and headline message for the bulk-assign outcome, derived from the
   // result shape (and surfaced via an inline Alert).
+  const resultContent = useMemo(() => {
     if (!result) return null
     const { assignedCount, errors } = result
     const assigned = `${assignedCount} ${pluralize("seat", assignedCount)} assigned.`

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -258,9 +258,8 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
     return () => clearTimeout(id)
   }, [announcement])
 
-  // Severity, headline message, and screen-reader announcement for the
-  // bulk-assign outcome, derived from the result shape.
-  const resultContent = useMemo(() => {
+  // Severity and headline message for the bulk-assign outcome, derived from the
+  // result shape (and surfaced via an inline Alert).
     if (!result) return null
     const { assignedCount, errors } = result
     const assigned = `${assignedCount} ${pluralize("seat", assignedCount)} assigned.`

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -227,8 +227,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   const [modalData, setModalData] = useState<ModalData | null>(null)
   const [result, setResult] = useState<AssignResult | null>(null)
   const [debouncedAnnouncement, setDebouncedAnnouncement] = useState("")
-  const [errorAnnouncement, setErrorAnnouncement] = useState("")
-  const [resultAnnouncement, setResultAnnouncement] = useState("")
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const bulkAssign = useBulkAssignSeats()
@@ -260,16 +258,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
     return () => clearTimeout(id)
   }, [announcement])
 
-  useEffect(() => {
-    if (csvReadError) {
-      setErrorAnnouncement("Could not read the file. Please try again.")
-    } else if (csvNoValid) {
-      setErrorAnnouncement("No valid email addresses found in this file.")
-    } else {
-      setErrorAnnouncement("")
-    }
-  }, [csvReadError, csvNoValid])
-
   // Severity, headline message, and screen-reader announcement for the
   // bulk-assign outcome, derived from the result shape.
   const resultContent = useMemo(() => {
@@ -295,10 +283,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       errors,
     }
   }, [result])
-
-  useEffect(() => {
-    setResultAnnouncement(resultContent?.message ?? "")
-  }, [resultContent])
 
   const handleCsvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -375,14 +359,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       {/* Always-mounted live region — debounced so screen readers aren't spammed on every keystroke */}
       <VisuallyHidden aria-live="polite" aria-atomic="true">
         {debouncedAnnouncement}
-      </VisuallyHidden>
-      {/* Always-mounted so NVDA reliably announces dynamically injected errors */}
-      <VisuallyHidden aria-live="assertive" aria-atomic="true">
-        {errorAnnouncement}
-      </VisuallyHidden>
-      {/* Always-mounted live region for the assignment outcome */}
-      <VisuallyHidden aria-live="assertive" aria-atomic="true">
-        {resultAnnouncement}
       </VisuallyHidden>
       <Stack
         direction={{ xs: "column", sm: "row" }}

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -18,6 +18,7 @@ import {
   styled,
 } from "ol-components"
 import {
+  Alert,
   Button,
   TabButton,
   TabButtonList,
@@ -336,6 +337,10 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   const [searchQuery, setSearchQuery] = useState("")
   const [page, setPage] = useState(1)
   const [searchAnnouncement, setSearchAnnouncement] = useState("")
+  const [rowActionResult, setRowActionResult] = useState<{
+    message: string
+    severity: "success" | "error"
+  } | null>(null)
 
   const {
     data: managerOrgs,
@@ -511,11 +516,24 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
           </StatsSide>
         </HeaderSection>
 
-        <AssignSeatsSection availableSeats={totalUnassigned} />
+        <AssignSeatsSection
+          orgId={org.id}
+          contractId={contract.id}
+          availableSeats={totalUnassigned}
+        />
 
         {/* Seat Assignments */}
         <SeatAssignmentsSection>
           <SectionTitle component="h2">Seat Assignments</SectionTitle>
+          {rowActionResult && (
+            <Alert
+              severity={rowActionResult.severity}
+              closable
+              onClose={() => setRowActionResult(null)}
+            >
+              {rowActionResult.message}
+            </Alert>
+          )}
           <SeatAssignmentsControls>
             <ControlsLeft>
               <TabContext value={statusFilter}>
@@ -670,7 +688,14 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                         {formatDate(code.last_sent)}
                       </TableCell>
                       <ActionCell role="cell">
-                        <RowActionMenu code={code} />
+                        <RowActionMenu
+                          code={code}
+                          orgId={org.id}
+                          contractId={contract.id}
+                          onResult={(message, severity) =>
+                            setRowActionResult({ message, severity })
+                          }
+                        />
                       </ActionCell>
                     </TableRow>
                   ))

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -102,6 +102,19 @@ describe("RowActionMenu", () => {
       })
     })
 
+    test("is disabled when the seat has no assigned email", async () => {
+      const code = makeCode({ redemption_status: "assigned", assigned_to: "" })
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+
+      const item = screen.getByRole("menuitem", { name: "Resend claim email" })
+      expect(item).toHaveAttribute("aria-disabled", "true")
+
+      await user.click(item)
+      expect(onResult).not.toHaveBeenCalled()
+    })
+
     test("reports an error when the remind endpoint fails", async () => {
       const code = makeCode({ redemption_status: "assigned" })
       setMockResponse.post(

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -1,9 +1,28 @@
 import React from "react"
-import { renderWithTheme, screen, user } from "@/test-utils"
-import { factories } from "api/mitxonline-test-utils"
+import { renderWithProviders, screen, user, waitFor } from "@/test-utils"
+import { setMockResponse } from "api/test-utils"
+import { factories, urls } from "api/mitxonline-test-utils"
 import { RowActionMenu } from "./RowActionMenu"
 
 const makeCode = factories.contracts.contractCode
+
+const ORG_ID = 1
+const CONTRACT_ID = 2
+
+const renderMenu = (
+  code: ReturnType<typeof makeCode>,
+  onResult = jest.fn(),
+) => {
+  renderWithProviders(
+    <RowActionMenu
+      code={code}
+      orgId={ORG_ID}
+      contractId={CONTRACT_ID}
+      onResult={onResult}
+    />,
+  )
+  return { onResult }
+}
 
 afterEach(() => {
   // Restore clipboard so Object.defineProperty calls don't leak between tests
@@ -17,7 +36,7 @@ describe("RowActionMenu", () => {
   describe("pending code", () => {
     test("opens menu with correct items on trigger click", async () => {
       const code = makeCode({ redemption_status: "assigned" })
-      renderWithTheme(<RowActionMenu code={code} />)
+      renderMenu(code)
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
 
@@ -43,7 +62,7 @@ describe("RowActionMenu", () => {
         redeemed_by: "user@example.com",
         redeemed_on: new Date().toISOString(),
       })
-      renderWithTheme(<RowActionMenu code={code} />)
+      renderMenu(code)
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
 
@@ -51,6 +70,233 @@ describe("RowActionMenu", () => {
         screen.getByRole("menuitem", { name: "Uninvite" }),
       ).toBeInTheDocument()
       expect(screen.queryByText("Copy claim link")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("Resend claim email", () => {
+    test("calls the remind endpoint and reports success", async () => {
+      const code = makeCode({
+        redemption_status: "assigned",
+        assigned_to: "learner@example.com",
+      })
+      setMockResponse.post(
+        urls.contracts.managerContractCodeRemind(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        code,
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Resend claim email" }),
+      )
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith(
+          expect.stringContaining("learner@example.com"),
+          "success",
+        )
+      })
+    })
+
+    test("reports an error when the remind endpoint fails", async () => {
+      const code = makeCode({ redemption_status: "assigned" })
+      setMockResponse.post(
+        urls.contracts.managerContractCodeRemind(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        { detail: "boom" },
+        { code: 404 },
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Resend claim email" }),
+      )
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith(expect.any(String), "error")
+      })
+    })
+  })
+
+  describe("Release seat / revoke", () => {
+    test("opens a confirmation dialog before revoking", async () => {
+      const code = makeCode({ redemption_status: "assigned" })
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(screen.getByRole("menuitem", { name: "Release seat" }))
+
+      // Dialog appears; nothing has been revoked yet.
+      expect(
+        screen.getByRole("heading", { name: "Release seat" }),
+      ).toBeInTheDocument()
+      expect(onResult).not.toHaveBeenCalled()
+    })
+
+    test("revokes on confirm and reports success", async () => {
+      const code = makeCode({ redemption_status: "assigned" })
+      setMockResponse.delete(
+        urls.contracts.managerContractCodeRevoke(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        code,
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(screen.getByRole("menuitem", { name: "Release seat" }))
+      await user.click(screen.getByRole("button", { name: "Release seat" }))
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith("Seat released.", "success")
+      })
+    })
+
+    test("surfaces the already-redeemed (409) error", async () => {
+      const code = makeCode({
+        redemption_status: "redeemed",
+        redeemed_by: "user@example.com",
+        redeemed_on: new Date().toISOString(),
+      })
+      setMockResponse.delete(
+        urls.contracts.managerContractCodeRevoke(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        { detail: "Cannot revoke a code that has already been redeemed." },
+        { code: 409 },
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(screen.getByRole("menuitem", { name: "Uninvite" }))
+      await user.click(screen.getByRole("button", { name: "Uninvite" }))
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith(
+          expect.stringContaining("already been redeemed"),
+          "error",
+        )
+      })
+    })
+  })
+
+  describe("Change assigned email / reassign", () => {
+    test("opens a dialog prefilled with the current assignee email", async () => {
+      const code = makeCode({
+        redemption_status: "assigned",
+        assigned_to: "old@example.com",
+      })
+      renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Change assigned email" }),
+      )
+
+      expect(
+        screen.getByRole("heading", { name: "Change assigned email" }),
+      ).toBeInTheDocument()
+      expect(screen.getByLabelText(/New email address/i)).toHaveValue(
+        "old@example.com",
+      )
+    })
+
+    test("reassigns on submit and reports success", async () => {
+      const code = makeCode({
+        redemption_status: "assigned",
+        assigned_to: "old@example.com",
+      })
+      setMockResponse.put(
+        urls.contracts.managerContractCodeReassign(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        code,
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Change assigned email" }),
+      )
+
+      const input = screen.getByLabelText(/New email address/i)
+      await user.clear(input)
+      await user.type(input, "new@example.com")
+      await user.click(screen.getByRole("button", { name: "Reassign seat" }))
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith(
+          expect.stringContaining("new@example.com"),
+          "success",
+        )
+      })
+    })
+
+    test("blocks submission and shows an error for an invalid email", async () => {
+      const code = makeCode({ redemption_status: "assigned", assigned_to: "" })
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Change assigned email" }),
+      )
+
+      const input = screen.getByLabelText(/New email address/i)
+      await user.type(input, "not-an-email")
+
+      // Confirm button is disabled while the email is invalid.
+      expect(screen.getByRole("button", { name: "Reassign seat" })).toBeDisabled()
+      expect(
+        screen.getByText("Enter a valid email address."),
+      ).toBeInTheDocument()
+      expect(onResult).not.toHaveBeenCalled()
+    })
+
+    test("surfaces the already-redeemed (409) error", async () => {
+      const code = makeCode({
+        redemption_status: "assigned",
+        assigned_to: "old@example.com",
+      })
+      setMockResponse.put(
+        urls.contracts.managerContractCodeReassign(
+          ORG_ID,
+          CONTRACT_ID,
+          code.code,
+        ),
+        { detail: "Cannot reassign a code that has already been redeemed." },
+        { code: 409 },
+      )
+      const { onResult } = renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(
+        screen.getByRole("menuitem", { name: "Change assigned email" }),
+      )
+      const input = screen.getByLabelText(/New email address/i)
+      await user.clear(input)
+      await user.type(input, "new@example.com")
+      await user.click(screen.getByRole("button", { name: "Reassign seat" }))
+
+      await waitFor(() => {
+        expect(onResult).toHaveBeenCalledWith(
+          expect.stringContaining("already been redeemed"),
+          "error",
+        )
+      })
     })
   })
 
@@ -63,7 +309,7 @@ describe("RowActionMenu", () => {
         configurable: true,
       })
 
-      renderWithTheme(<RowActionMenu code={code} />)
+      renderMenu(code)
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
       await user.click(
@@ -87,7 +333,7 @@ describe("RowActionMenu", () => {
         configurable: true,
       })
 
-      renderWithTheme(<RowActionMenu code={code} />)
+      renderMenu(code)
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
 
@@ -123,7 +369,7 @@ describe("RowActionMenu", () => {
         return false
       })
 
-      renderWithTheme(<RowActionMenu code={code} />)
+      renderMenu(code)
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
       await user.click(

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -259,7 +259,9 @@ describe("RowActionMenu", () => {
       await user.type(input, "not-an-email")
 
       // Confirm button is disabled while the email is invalid.
-      expect(screen.getByRole("button", { name: "Reassign seat" })).toBeDisabled()
+      expect(
+        screen.getByRole("button", { name: "Reassign seat" }),
+      ).toBeDisabled()
       expect(
         screen.getByText("Enter a valid email address."),
       ).toBeInTheDocument()

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -7,6 +7,7 @@ import {
   FormDialog,
   Menu,
   MenuItem,
+  Tooltip,
   Typography,
   styled,
 } from "ol-components"
@@ -98,6 +99,7 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
   const reassign = useReassignCode()
 
   const isRedeemed = code.redemption_status === "redeemed"
+  const hasAssignedEmail = Boolean(code.assigned_to?.trim())
 
   const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget)
@@ -111,16 +113,16 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
 
   const handleResend = async () => {
     handleClose()
+    // No recipient to remind — the menu item is disabled in this state, so this
+    // is a defensive guard against an already-redeemed or unassigned code.
+    if (isRedeemed || !hasAssignedEmail) return
     try {
       await remind.mutateAsync({
         code: code.code,
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult(
-        `Claim email resent${code.assigned_to ? ` to ${code.assigned_to}` : ""}.`,
-        "success",
-      )
+      onResult(`Claim email resent to ${code.assigned_to}.`, "success")
     } catch {
       onResult("Could not resend the claim email. Please try again.", "error")
     }
@@ -228,9 +230,21 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
       <ActionMenuItem key="change-email" onClick={openReassign}>
         Change assigned email
       </ActionMenuItem>,
-      <ActionMenuItem key="resend-email" onClick={handleResend}>
-        Resend claim email
-      </ActionMenuItem>,
+      hasAssignedEmail ? (
+        <ActionMenuItem key="resend-email" onClick={handleResend}>
+          Resend claim email
+        </ActionMenuItem>
+      ) : (
+        <Tooltip
+          key="resend-email"
+          title="No email is assigned to this seat yet."
+          describeChild
+        >
+          <ActionMenuItem disabled aria-label="Resend claim email">
+            Resend claim email
+          </ActionMenuItem>
+        </Tooltip>
+      ),
       copied ? (
         <CopiedMenuItem key="copy-link" disabled>
           Link copied to clipboard

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -1,11 +1,26 @@
 "use client"
 
 import React, { useState } from "react"
-import { Divider, Menu, MenuItem, Tooltip, styled } from "ol-components"
+import {
+  Dialog,
+  Divider,
+  FormDialog,
+  Menu,
+  MenuItem,
+  Typography,
+  styled,
+} from "ol-components"
 import { RiMoreLine } from "@remixicon/react"
-import { ActionButton, VisuallyHidden } from "@mitodl/smoot-design"
+import { ActionButton, TextField, VisuallyHidden } from "@mitodl/smoot-design"
+import { isValidEmail } from "ol-utilities"
 import { b2bAttachView } from "@/common/urls"
+import {
+  useReassignCode,
+  useRemindCode,
+  useRevokeCode,
+} from "api/mitxonline-hooks/organizations"
 import type { ContractCode } from "api/mitxonline-hooks/organizations"
+import type { AxiosError } from "axios"
 
 const ActionMenuItem = styled(MenuItem)(({ theme }) => ({
   ...theme.typography.body3,
@@ -46,27 +61,43 @@ const CopiedMenuItem = styled(ActionMenuItem)(({ theme }) => ({
   },
 }))
 
+type ActionSeverity = "success" | "error"
+
 type RowActionMenuProps = {
   code: ContractCode
+  orgId: number
+  contractId: number
+  /** Surfaces action outcomes in the page-level result Alert. */
+  onResult: (message: string, severity: ActionSeverity) => void
 }
-
-const COMING_SOON = "Coming soon"
 
 /**
  * Three-dot row action menu for the contract admin codes table.
  *
- * Pending rows: Change assigned email (disabled), Resend claim email
- * (disabled), Copy claim link (functional), Release seat (disabled).
+ * Pending rows: Change assigned email (reassign, confirmed), Resend claim
+ * email (remind), Copy claim link, Release seat (revoke, confirmed).
  *
- * Redeemed rows: Uninvite (disabled).
- *
- * NOTE: All actions except "Copy claim link" are disabled pending backend
- * write API availability.
+ * Redeemed rows: Uninvite (revoke, confirmed).
  */
-const RowActionMenu: React.FC<RowActionMenuProps> = ({ code }) => {
+const RowActionMenu: React.FC<RowActionMenuProps> = ({
+  code,
+  orgId,
+  contractId,
+  onResult,
+}) => {
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null)
   const [copied, setCopied] = useState(false)
+  const [revokeConfirmOpen, setRevokeConfirmOpen] = useState(false)
+  const [reassignOpen, setReassignOpen] = useState(false)
+  const [reassignEmail, setReassignEmail] = useState("")
+  const [reassignTouched, setReassignTouched] = useState(false)
   const open = Boolean(anchorEl)
+
+  const remind = useRemindCode()
+  const revoke = useRevokeCode()
+  const reassign = useReassignCode()
+
+  const isRedeemed = code.redemption_status === "redeemed"
 
   const handleOpen = (e: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(e.currentTarget)
@@ -76,6 +107,43 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({ code }) => {
   const handleClose = () => {
     setAnchorEl(null)
     setCopied(false)
+  }
+
+  const handleResend = async () => {
+    handleClose()
+    try {
+      await remind.mutateAsync({
+        code: code.code,
+        id: contractId,
+        parent_lookup_organization: orgId,
+      })
+      onResult(
+        `Claim email resent${code.assigned_to ? ` to ${code.assigned_to}` : ""}.`,
+        "success",
+      )
+    } catch {
+      onResult("Could not resend the claim email. Please try again.", "error")
+    }
+  }
+
+  const handleRevokeConfirm = async () => {
+    try {
+      await revoke.mutateAsync({
+        code: code.code,
+        id: contractId,
+        parent_lookup_organization: orgId,
+      })
+      onResult(isRedeemed ? "Learner uninvited." : "Seat released.", "success")
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status
+      onResult(
+        status === 409
+          ? "This code has already been redeemed and cannot be revoked."
+          : "Could not complete the action. Please try again.",
+        "error",
+      )
+    }
+    // Dialog closes itself once this resolves.
   }
 
   const handleCopyClaimLink = async () => {
@@ -109,49 +177,75 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({ code }) => {
 
   const assignedTo = code.assigned_to ?? "unassigned seat"
 
-  const menuItems =
-    code.redemption_status === "redeemed" ? (
-      <Tooltip title={COMING_SOON} placement="right" describeChild>
-        <DestructiveMenuItem disabled>Uninvite</DestructiveMenuItem>
-      </Tooltip>
-    ) : (
-      [
-        <Tooltip
-          key="change-email"
-          title={COMING_SOON}
-          placement="right"
-          describeChild
-        >
-          <ActionMenuItem disabled>Change assigned email</ActionMenuItem>
-        </Tooltip>,
-        <Tooltip
-          key="resend-email"
-          title={COMING_SOON}
-          placement="right"
-          describeChild
-        >
-          <ActionMenuItem disabled>Resend claim email</ActionMenuItem>
-        </Tooltip>,
-        copied ? (
-          <CopiedMenuItem key="copy-link" disabled>
-            Link copied to clipboard
-          </CopiedMenuItem>
-        ) : (
-          <ActionMenuItem key="copy-link" onClick={handleCopyClaimLink}>
-            Copy claim link
-          </ActionMenuItem>
-        ),
-        <Divider component="li" role="separator" key="divider" />,
-        <Tooltip
-          key="release-seat"
-          title={COMING_SOON}
-          placement="right"
-          describeChild
-        >
-          <DestructiveMenuItem disabled>Release seat</DestructiveMenuItem>
-        </Tooltip>,
-      ]
-    )
+  const openRevokeConfirm = () => {
+    handleClose()
+    setRevokeConfirmOpen(true)
+  }
+
+  const openReassign = () => {
+    handleClose()
+    setReassignEmail(code.assigned_to ?? "")
+    setReassignTouched(false)
+    setReassignOpen(true)
+  }
+
+  const emailValid = isValidEmail(reassignEmail.trim())
+
+  const handleReassignSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const email = reassignEmail.trim()
+    if (!emailValid) {
+      setReassignTouched(true)
+      return
+    }
+    try {
+      await reassign.mutateAsync({
+        code: code.code,
+        id: contractId,
+        parent_lookup_organization: orgId,
+        AssignRevokeCodeRequestRequest: { email },
+      })
+      onResult(`Invitation reassigned to ${email}.`, "success")
+      setReassignOpen(false)
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status
+      onResult(
+        status === 409
+          ? "This code has already been redeemed and cannot be reassigned."
+          : "Could not change the assigned email. Please try again.",
+        "error",
+      )
+      setReassignOpen(false)
+    }
+  }
+
+  const menuItems = isRedeemed ? (
+    <DestructiveMenuItem onClick={openRevokeConfirm}>
+      Uninvite
+    </DestructiveMenuItem>
+  ) : (
+    [
+      <ActionMenuItem key="change-email" onClick={openReassign}>
+        Change assigned email
+      </ActionMenuItem>,
+      <ActionMenuItem key="resend-email" onClick={handleResend}>
+        Resend claim email
+      </ActionMenuItem>,
+      copied ? (
+        <CopiedMenuItem key="copy-link" disabled>
+          Link copied to clipboard
+        </CopiedMenuItem>
+      ) : (
+        <ActionMenuItem key="copy-link" onClick={handleCopyClaimLink}>
+          Copy claim link
+        </ActionMenuItem>
+      ),
+      <Divider component="li" role="separator" key="divider" />,
+      <DestructiveMenuItem key="release-seat" onClick={openRevokeConfirm}>
+        Release seat
+      </DestructiveMenuItem>,
+    ]
+  )
 
   return (
     <>
@@ -179,6 +273,51 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({ code }) => {
       >
         {menuItems}
       </Menu>
+      <Dialog
+        open={revokeConfirmOpen}
+        onClose={() => setRevokeConfirmOpen(false)}
+        onConfirm={handleRevokeConfirm}
+        title={isRedeemed ? "Uninvite learner" : "Release seat"}
+        confirmText={isRedeemed ? "Uninvite" : "Release seat"}
+        maxWidth="sm"
+      >
+        {isRedeemed
+          ? `This will remove ${assignedTo}'s access to the program. This cannot be undone.`
+          : `This will revoke the invitation for ${assignedTo} and return the seat to the unassigned pool.`}
+      </Dialog>
+      <FormDialog
+        open={reassignOpen}
+        title="Change assigned email"
+        confirmText="Reassign seat"
+        onClose={() => setReassignOpen(false)}
+        onSubmit={handleReassignSubmit}
+        disabled={!emailValid}
+        maxWidth="sm"
+        noValidate
+      >
+        <Typography variant="body2">
+          The invitation for {assignedTo} will be reassigned to the new address
+          and a claim email sent there.
+        </Typography>
+        <TextField
+          name="email"
+          label="New email address"
+          type="email"
+          value={reassignEmail}
+          onChange={(e) => {
+            setReassignEmail(e.target.value)
+            setReassignTouched(true)
+          }}
+          error={reassignTouched && !emailValid}
+          errorText={
+            reassignTouched && !emailValid
+              ? "Enter a valid email address."
+              : undefined
+          }
+          required
+          fullWidth
+        />
+      </FormDialog>
     </>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -8,7 +8,7 @@
  */
 import type {
   BaseCourseRun,
-  BaseProgramDisplayMode,
+  V2ProgramDisplayMode,
   ContractPage,
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
@@ -306,7 +306,7 @@ const groupProgramEnrollmentsByProgramId = (
 }
 
 const isProgramAsCourse = (program: {
-  display_mode?: BaseProgramDisplayMode | null
+  display_mode?: V2ProgramDisplayMode | null
 }) => program.display_mode === DisplayModeEnum.Course
 
 const isNonContractEnrollment = (enrollment: CourseRunEnrollmentV3) =>

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
@@ -16,7 +16,7 @@ describe("Certificate page generateMetadata", () => {
     certificate.program.program_type = "MicroMasters®"
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -36,7 +36,7 @@ describe("Certificate page generateMetadata", () => {
     certificate.program.program_type = "Program"
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )
@@ -52,7 +52,7 @@ describe("Certificate page generateMetadata", () => {
     const certificate = factories.mitxonline.courseCertificate()
     setMockResponse.get(
       mitxonline.urls.certificates.courseCertificatesRetrieve({
-        cert_uuid: certificate.uuid,
+        uuid: certificate.uuid,
       }),
       certificate,
     )

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
     if (certificateType === CertificateType.Course) {
       const data = await queryClient.fetchQueryOr404(
         certificateQueries.courseCertificatesRetrieve({
-          cert_uuid: uuid,
+          uuid,
         }),
       )
 
@@ -41,7 +41,7 @@ export async function generateMetadata({
     } else {
       const data = await queryClient.fetchQueryOr404(
         certificateQueries.programCertificatesRetrieve({
-          cert_uuid: uuid,
+          uuid,
         }),
       )
 
@@ -73,13 +73,13 @@ const Page: React.FC<
   if (certificateType === CertificateType.Course) {
     await queryClient.fetchQueryOr404(
       certificateQueries.courseCertificatesRetrieve({
-        cert_uuid: uuid,
+        uuid,
       }),
     )
   } else {
     await queryClient.fetchQueryOr404(
       certificateQueries.programCertificatesRetrieve({
-        cert_uuid: uuid,
+        uuid,
       }),
     )
   }

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -567,7 +567,7 @@ export async function GET(req: NextRequest, ctx: RouteContext) {
     if (certificateType === CertificateType.Course) {
       const certificate = await queryClient.fetchQuery(
         certificateQueries.courseCertificatesRetrieve({
-          cert_uuid: uuid,
+          uuid,
         }),
       )
 
@@ -575,7 +575,7 @@ export async function GET(req: NextRequest, ctx: RouteContext) {
     } else {
       const certificate = await queryClient.fetchQuery(
         certificateQueries.programCertificatesRetrieve({
-          cert_uuid: uuid,
+          uuid,
         }),
       )
       pdfDoc = pdf(<ProgramCertificate certificate={certificate} />)

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -1,5 +1,5 @@
 import { env, requiredEnv } from "@/env"
-import type { BaseProgramDisplayMode } from "@mitodl/mitxonline-api-axios/v2"
+import type { V2ProgramDisplayMode } from "@mitodl/mitxonline-api-axios/v2"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 
 // matches ! $ & ' ( ) * + , ; = : @ ~
@@ -282,7 +282,7 @@ export const programPageView = (program: {
    * But require it (arg is not optional, i.e., not `display_mode?`) to
    * encourage callers to pass the value.
    */
-  display_mode: BaseProgramDisplayMode | null | undefined
+  display_mode: V2ProgramDisplayMode | null | undefined
 }) => {
   const pattern =
     program.display_mode === DisplayModeEnum.Course

--- a/yarn.lock
+++ b/yarn.lock
@@ -3332,13 +3332,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2026.6.10":
-  version: 2026.6.10
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.6.10"
+"@mitodl/mitxonline-api-axios@npm:2026.6.17":
+  version: 2026.6.17
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.6.17"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/4c782d17814e04a5a7c1170dec4551569170e1d7a89a447c91bc8fee19f4366bdfa75957b6edb3b5cc4d57f1930d9cf24213846fc6bf15abf8c5a057671ef75b
+  checksum: 10/8b6fbc67de43903b04fdb9c641f204ebc58ace1562cb35b86fdcf4b2fedf95edfb47f27c8e8c72bc02a0d90b6964a74033e0376a15150b0ce1348051c74a8d0f
   languageName: node
   linkType: hard
 
@@ -8941,7 +8941,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:2026.6.10"
+    "@mitodl/mitxonline-api-axios": "npm:2026.6.17"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16167,7 +16167,7 @@ __metadata:
     "@floating-ui/react": "npm:^0.27.16"
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:2026.6.10"
+    "@mitodl/mitxonline-api-axios": "npm:2026.6.17"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11450
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

#### B2B seat management write actions 
Wires up the Contract Admin seat-management UI to the mitxonline B2B write APIs. Previously these actions were stubbed/disabled ("Coming soon"); they are now functional. 

**Known limitation**

- **Uninvite** (redeemed-row action) currently fails: the B2B revoke endpoint returns **409** for already-redeemed codes.

⚠️ Note: Everything in this section is not part of the B2B feature work. These are unavoidable type changes as a result of regenerating the API client at the newer version: @mitodl/mitxonline-api-axios 2026.6.10 → 2026.6.17

This bump pulls in mitxonline [#3615](https://github.com/mitodl/mitxonline/pull/3615) ("Fix some N+1 errors around programs on courses API"), which reshaped how programs are serialized on the courses API. 

1. programs on course serializers is now a non-nullable array
CourseWithCourseRunsSerializerV2.programs and V2Course.programs changed from Program[] | null to Program[] now it serializes programs as a list (empty when there are none) rather than null. Updated the course and v2Course test factories to default programs: [] instead of programs: null.

2. display_mode moved onto the program serializers
BaseProgram now carries a display_mode field, so the baseProgram factory was updated to include display_mode: null by default.

3. BaseProgramDisplayMode → V2ProgramDisplayMode
The display-mode enum was renamed as it moved to the V2 program serializer. Updated the import and the isProgramAsCourse signature in dashboardViewModel.ts.

4. Certificate retrieve param cert_uuid → uuid
The bump also renamed this query param. Updated CertificatePage.tsx, the certificate page/PDF routes, and the certificate queries to match.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots
https://github.com/user-attachments/assets/dc9839f4-9fc2-496e-87de-6794678d1ddc

Email Sent:
<img width="1253" height="233" alt="Screenshot 2026-06-18 at 10 22 31 AM" src="https://github.com/user-attachments/assets/6c555608-5224-4b8a-9ce8-05088e1d4d97" />

Copy Claim link:
As daniellerichard1@gmail.com
<img width="1724" height="794" alt="Screenshot 2026-06-18 at 11 28 18 AM" src="https://github.com/user-attachments/assets/c81e7f03-c05a-4955-9914-c39dce044944" />

As the admin after link is claimed:
<img width="1294" height="142" alt="Screenshot 2026-06-18 at 11 29 41 AM" src="https://github.com/user-attachments/assets/fc2adac4-9dcc-41a2-913f-956270c4272d" />

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

**Verify email send through the browser**

1. Keep docker compose logs -f celery running.
2. In the B2B contract admin, do a assign or a reassign on a pending seat with a new email.
3.  In the celery logs, the email prints addressed to the new email 

**Copy claim link**
Setup: You need a B2B contract with at least one pending (assigned but not yet redeemed) seat. Navigate to the Contract Admin page for that contract and find the seat table.

1. On a pending seat row, click the ⋮ "More actions" button
2. Click Copy claim link.
3. Verify the menu item swaps to a disabled "Link copied to clipboard" state (it no longer says "Copy claim link").
4. Paste the clipboard contents somewhere (e.g. the URL bar or a text field). It should be: 
`<current origin>/enrollmentcode/<code>` e.g. http://open.odl.local:8062/enrollmentcode/ABC123 — using the same code shown for that row.
5. Log in as the learner the seat was assigned to (the email on that row).
6.  With that learner logged in, open the copied link in a fresh tab. It should land on the enrollment-code claim/attach view for that code 
7. Then log back in as your manager user and verify that the user now has the status of "redeemed" 


**Assign / reassign / remind / revoke**

1. On the Contract Admin page, use the Assign Seats box to assign one or more emails. Confirm the inline result Alert reports success.
2. On a pending row's ⋮ menu: use **Change assigned email** (validates the new email, then reassigns), **Resend claim email**, and **Release seat** (confirmation dialog). Each should succeed and refresh the seat table.
3. ⚠️ Known limitation: **Uninvite** on a redeemed row currently 409s (see Known limitation above)


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
