### PR TITLE
chore: Remove product page feature flag

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -14,14 +14,10 @@ import { waitFor } from "@testing-library/react"
 import invariant from "tiny-invariant"
 import moment from "moment"
 import NiceModal from "@ebay/nice-modal-react"
-import { useFeatureFlagEnabled } from "posthog-js/react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 
 jest.mock("posthog-js/react")
-const mockedUseFeatureFlagEnabled = jest
-  .mocked(useFeatureFlagEnabled)
-  .mockImplementation(() => false)
 
 describe("ProgramAsCourseCard", () => {
   setupLocationMock()
@@ -431,47 +427,7 @@ describe("ProgramAsCourseCard", () => {
     expect(certButton).not.toBeInTheDocument()
   })
 
-  test("shows legacy details link in context menu when product pages flag is disabled", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
-    const cardData = setupCardData({ includeProgramEnrollment: true })
-
-    renderWithProviders(
-      <ProgramAsCourseCard
-        courseProgram={cardData.courseProgram}
-        moduleCourses={cardData.moduleCourses}
-        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
-        courseProgramEnrollment={cardData.courseProgramEnrollment}
-      />,
-    )
-
-    await screen.findByText(cardData.courseProgram.title)
-    const programCard = screen.getByTestId("program-as-course-card")
-    await user.click(within(programCard).getAllByLabelText("More options")[0])
-
-    const detailsLink = await screen.findByRole("menuitem", {
-      name: "View Course Details",
-    })
-    expect(detailsLink).toHaveAttribute(
-      "href",
-      expect.stringContaining(
-        `/programs/${cardData.courseProgram.readable_id}`,
-      ),
-    )
-    expect(detailsLink).toHaveAttribute(
-      "href",
-      expect.stringContaining("ecom-service=true"),
-    )
-
-    expect(
-      screen.getByRole("menuitem", { name: "Program Record" }),
-    ).toHaveAttribute(
-      "href",
-      mitxonlineLegacyUrl(`/records/${cardData.courseProgram.id}/`),
-    )
-  })
-
-  test("shows product-page details link in context menu when product pages flag is enabled", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+  test("shows product-page details link in context menu", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
 
     renderWithProviders(
@@ -504,7 +460,6 @@ describe("ProgramAsCourseCard", () => {
   })
 
   test("clicking Unenroll menu item opens UnenrollProgramDialog with readable_id", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)
     cardData.courseProgramEnrollment.enrollment_mode = "audit"
@@ -532,7 +487,6 @@ describe("ProgramAsCourseCard", () => {
   })
 
   test("does not show Unenroll option in context menu for verified enrollment", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)
     cardData.courseProgramEnrollment.enrollment_mode = "verified"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -37,8 +37,6 @@ import { RiAwardFill, RiMore2Line } from "@remixicon/react"
 import NiceModal from "@ebay/nice-modal-react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
 import { ProgramCertificateButton } from "./ProgramEnrollmentDisplay"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 import { programPageView } from "@/common/urls"
 
 const ProgramCardRoot = styled.div(({ theme }) => ({
@@ -284,15 +282,12 @@ const getContextMenuItems = (
   resource: ProgramAsCourse,
   enrollmentMode: string | null | undefined,
   additionalItems: SimpleMenuItem[] = [],
-  useProductPages = false,
 ) => {
   const menuItems = []
-  const detailsUrl = useProductPages
-    ? programPageView({
-        readable_id: resource.readable_id,
-        display_mode: "course",
-      })
-    : mitxonlineLegacyUrl(`/programs/${resource.readable_id}`)
+  const detailsUrl = programPageView({
+    readable_id: resource.readable_id,
+    display_mode: "course",
+  })
 
   const courseMenuItems = []
 
@@ -405,9 +400,6 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
   className,
   onUpgradeError,
 }) => {
-  const useProductPages = useFeatureFlagEnabled(
-    FeatureFlags.MitxOnlineProductPages,
-  )
   const moduleRequirementSection = courseProgram?.req_tree?.find(
     (node) => node.data.node_type === "operator",
   )
@@ -488,7 +480,6 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     courseProgram,
     courseProgramEnrollment?.enrollment_mode,
     contextMenuItems,
-    useProductPages ?? false,
   )
 
   const contextMenu = (

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -16,15 +16,12 @@ import { notFound } from "next/navigation"
 import { useStayUpdatedEnv } from "./test-utils/stayUpdated"
 
 import { useFeatureFlagEnabled } from "posthog-js/react"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import invariant from "tiny-invariant"
 import { getOutlineCoursewareId } from "./util"
 import { FeatureFlags } from "@/common/feature_flags"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
-jest.mock("@/common/useFeatureFlagsLoaded")
-const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
 const makeCourse = factories.courses.course
 const makePage = factories.pages.coursePageItem
@@ -107,34 +104,7 @@ const setupApis = ({
 describe("CoursePage", () => {
   beforeEach(() => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
-    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
   })
-
-  test.each([
-    { flagsLoaded: true, isEnabled: true, shouldNotFound: false },
-    { flagsLoaded: true, isEnabled: false, shouldNotFound: true },
-    { flagsLoaded: false, isEnabled: true, shouldNotFound: false },
-    { flagsLoaded: false, isEnabled: false, shouldNotFound: false },
-  ])(
-    "Calls noFound if and only the feature flag is disabled",
-    async ({ flagsLoaded, isEnabled, shouldNotFound }) => {
-      mockedUseFeatureFlagEnabled.mockReturnValue(isEnabled)
-      mockedUseFeatureFlagsLoaded.mockReturnValue(flagsLoaded)
-
-      const course = makeCourse()
-      const page = makePage({ course_details: course })
-      setupApis({ course, page })
-      renderWithProviders(<CoursePage readableId={course.readable_id} />, {
-        url: `/courses/${course.readable_id}/`,
-      })
-
-      if (shouldNotFound) {
-        expect(notFound).toHaveBeenCalled()
-      } else {
-        expect(notFound).not.toHaveBeenCalled()
-      }
-    },
-  )
 
   test("Page has expected headings", async () => {
     const course = makeCourse()

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -19,7 +19,6 @@ import WhatYoullLearnSection from "./WhatYoullLearnSection"
 import HowYoullLearnSection from "./HowYoullLearnSection"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import CourseInfoBox from "./InfoBoxCourse"
 import CourseEnrollmentButton from "./CourseEnrollmentButton"
 import CourseOutlineSection from "./CourseOutlineSection"
@@ -54,15 +53,9 @@ const CoursePage: React.FC<CoursePageProps> = ({ readableId }) => {
     ...coursesQueries.courseOutline(effectiveOutlineCoursewareId ?? ""),
     enabled: Boolean(effectiveOutlineCoursewareId),
   })
-  const enabled = useFeatureFlagEnabled(FeatureFlags.MitxOnlineProductPages)
   const showCourseOutline = useFeatureFlagEnabled(
     FeatureFlags.CourseOutlineSection,
   )
-  const flagsLoaded = useFeatureFlagsLoaded()
-
-  if (!enabled) {
-    return flagsLoaded ? notFound() : null
-  }
 
   const doneLoading = pages.isSuccess && courses.isSuccess
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -26,19 +26,14 @@ import {
 import { assertHeadings } from "ol-test-utilities"
 import ProgramAsCoursePage from "./ProgramAsCoursePage"
 import { notFound } from "next/navigation"
-import { useFeatureFlagEnabled } from "posthog-js/react"
 import {
   useStayUpdatedEnv,
   PROGRAM_HIDE_STAY_UPDATED_CASES,
 } from "./test-utils/stayUpdated"
 import invariant from "tiny-invariant"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { getIdsFromReqTree } from "@/common/mitxonline"
 
 jest.mock("posthog-js/react")
-const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
-jest.mock("@/common/useFeatureFlagsLoaded")
-const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
 const makeProgramAsCourse: typeof factories.programs.program = (
   overrides = {},
@@ -121,11 +116,6 @@ const setupApis = ({
 }
 
 describe("ProgramAsCoursePage", () => {
-  beforeEach(() => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
-  })
-
   test("Page has expected headings", async () => {
     const reqTree = new RequirementTreeBuilder()
     const op = reqTree.addOperator({ operator: "all_of" })

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.tsx
@@ -6,8 +6,6 @@ import { pagesQueries } from "api/mitxonline-hooks/pages"
 import { useQuery } from "@tanstack/react-query"
 import { styled } from "@mitodl/smoot-design"
 import { programsQueries } from "api/mitxonline-hooks/programs"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 import { notFound } from "next/navigation"
 import { HeadingIds, parseReqTree } from "./util"
 import type { RequirementItem } from "./util"
@@ -23,7 +21,6 @@ import ProductPageTemplate from "./ProductPageTemplate"
 import WhatYoullLearnSection from "./WhatYoullLearnSection"
 import HowYoullLearnSection from "./HowYoullLearnSection"
 import { DEFAULT_RESOURCE_IMG, pluralize } from "ol-utilities"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import ProgramAsCourseInfoBox from "./InfoBoxProgramAsCourse"
 import ProgramEnrollmentButton from "./ProgramEnrollmentButton"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
@@ -240,13 +237,6 @@ const ProgramAsCoursePage: React.FC<ProgramAsCoursePageProps> = ({
     }),
     enabled: programIds.length > 0,
   })
-
-  const enabled = useFeatureFlagEnabled(FeatureFlags.MitxOnlineProductPages)
-  const flagsLoaded = useFeatureFlagsLoaded()
-
-  if (!enabled) {
-    return flagsLoaded ? notFound() : null
-  }
 
   const isLoading = pages.isLoading || programs.isLoading
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.test.tsx
@@ -31,22 +31,18 @@ import {
   PROGRAM_HIDE_STAY_UPDATED_CASES,
 } from "./test-utils/stayUpdated"
 
-import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
+import { usePostHog } from "posthog-js/react"
 import invariant from "tiny-invariant"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { getIdsFromReqTree } from "@/common/mitxonline"
 import { faker } from "@faker-js/faker/locale/en"
 import { PostHogEvents } from "@/common/constants"
 
 jest.mock("posthog-js/react")
-const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
 const mockCapture = jest.fn()
 jest.mocked(usePostHog).mockReturnValue(
   // @ts-expect-error Not mocking all of posthog
   { capture: mockCapture },
 )
-jest.mock("@/common/useFeatureFlagsLoaded")
-const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
 const makeProgram = factories.programs.program
 const makePage = factories.pages.programPageItem
@@ -225,36 +221,6 @@ const setupApis = ({
 }
 
 describe("ProgramPage", () => {
-  beforeEach(() => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-  })
-
-  test.each([
-    { flagsLoaded: true, isEnabled: true, shouldNotFound: false },
-    { flagsLoaded: true, isEnabled: false, shouldNotFound: true },
-    { flagsLoaded: false, isEnabled: true, shouldNotFound: false },
-    { flagsLoaded: false, isEnabled: false, shouldNotFound: false },
-  ])(
-    "Calls notFound if and only if the feature flag is disabled",
-    async ({ flagsLoaded, isEnabled, shouldNotFound }) => {
-      mockedUseFeatureFlagEnabled.mockReturnValue(isEnabled)
-      mockedUseFeatureFlagsLoaded.mockReturnValue(flagsLoaded)
-
-      const program = makeProgram({ ...makeReqs() })
-      const page = makePage({ program_details: program })
-      setupApis({ program, page })
-      renderWithProviders(<ProgramPage readableId={program.readable_id} />, {
-        url: `/programs/${program.readable_id}/`,
-      })
-
-      if (shouldNotFound) {
-        expect(notFound).toHaveBeenCalled()
-      } else {
-        expect(notFound).not.toHaveBeenCalled()
-      }
-    },
-  )
-
   test("Page has expected headings", async () => {
     const program = makeProgram({
       ...makeReqs({

--- a/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramPage.tsx
@@ -7,8 +7,6 @@ import { pagesQueries } from "api/mitxonline-hooks/pages"
 import { useQuery } from "@tanstack/react-query"
 import { styled } from "@mitodl/smoot-design"
 import { programsQueries } from "api/mitxonline-hooks/programs"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 import { notFound } from "next/navigation"
 import { HeadingIds, parseReqTree, RequirementData } from "./util"
 import {
@@ -27,7 +25,6 @@ import type {
   CourseWithCourseRunsSerializerV2,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { DEFAULT_RESOURCE_IMG, pluralize } from "ol-utilities"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import ProgramInfoBox from "./InfoBoxProgram"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import MitxOnlineResourceCard from "./MitxOnlineResourceCard"
@@ -257,13 +254,6 @@ const ProgramPage: React.FC<ProgramPageProps> = ({ readableId }) => {
     }),
     enabled: programIds.length > 0,
   })
-
-  const enabled = useFeatureFlagEnabled(FeatureFlags.MitxOnlineProductPages)
-  const flagsLoaded = useFeatureFlagsLoaded()
-
-  if (!enabled) {
-    return flagsLoaded ? notFound() : null
-  }
 
   const isLoading = pages.isLoading || programs.isLoading
 

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -10,7 +10,6 @@ export enum FeatureFlags {
   UniversalAI = "universal-ai",
   UniversalAISearchBanner = "universal-ai-search-banner",
   VideoShorts = "video-shorts",
-  MitxOnlineProductPages = "mitxonline-product-pages",
   CourseOutlineSection = "course-outline-section",
   OcwProductPages = "ocw-product-pages",
   VideoPlaylistPage = "video-playlist-page",

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
@@ -4,15 +4,13 @@ import { renderWithProviders } from "@/test-utils"
 import { factories } from "api/test-utils"
 import { DEFAULT_RESOURCE_IMG } from "ol-utilities"
 import { getByImageSrc } from "ol-test-utilities"
-import { PlatformEnum, ResourceTypeEnum, ResourceTypeGroupEnum } from "api"
+import { PlatformEnum, ResourceTypeEnum } from "api"
 import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react"
 import type { PostHog } from "posthog-js"
 import { FeatureFlags } from "@/common/feature_flags"
-import { coursePageView, programPageView } from "@/common/urls"
 import CallToActionSection from "./CallToActionSection"
 import type { ImageConfig } from "ol-components"
 import { kebabCase } from "lodash"
-import { faker } from "@faker-js/faker/locale/en"
 
 jest.mock("posthog-js/react")
 
@@ -224,67 +222,18 @@ describe("CallToActionSection", () => {
   })
 
   describe("MITx Online product pages", () => {
-    const readableId = faker.lorem.slug()
-    const url = faker.internet.url()
-
-    const mitxOnlineResource: typeof factories.learningResources.resource = (
-      overrides,
-    ) => {
-      return factories.learningResources.resource({
+    it("links to the resource's Learn product URL without rewriting it", () => {
+      // MITx Online product-page URLs are supplied by the backend ETL in
+      // `resource.url`; the component links to them directly rather than
+      // deriving a path from readable_id. The URL is same-origin (internal),
+      // so it gets no UTM params.
+      const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
+      const productUrl = `${NEXT_PUBLIC_ORIGIN}/courses/product-page-slug`
+      const resource = factories.learningResources.resource({
         platform: { code: PlatformEnum.Mitxonline },
-        readable_id: readableId,
-        url,
-        ...overrides,
-      })
-    }
-
-    it.each([
-      {
-        resourceType: ResourceTypeEnum.Course,
-        expectedPath: coursePageView(readableId),
-      },
-      {
-        resourceType: ResourceTypeEnum.Program,
-        resourceTypeGroup: ResourceTypeGroupEnum.Program,
-        expectedPath: programPageView({
-          readable_id: readableId,
-          display_mode: "",
-        }),
-      },
-      {
-        resourceType: ResourceTypeEnum.Program,
-        resourceTypeGroup: ResourceTypeGroupEnum.Course,
-        expectedPath: programPageView({
-          readable_id: readableId,
-          display_mode: "course",
-        }),
-      },
-    ])(
-      "links to product page $expectedPath for MITx Online $resourceType",
-      ({ resourceType, resourceTypeGroup, expectedPath }) => {
-        const resource = mitxOnlineResource({
-          resource_type: resourceType,
-          resource_type_group: resourceTypeGroup,
-        })
-
-        renderWithProviders(
-          <CallToActionSection
-            imgConfig={IMG_CONFIG}
-            resource={resource}
-            shareUrl="https://learn.mit.edu/test"
-          />,
-        )
-
-        const link = screen.getByRole("link", { name: "Learn More" })
-        expect(link).toHaveAttribute("href", expectedPath)
-        expect(link.getAttribute("href")).not.toContain("utm_")
-      },
-    )
-
-    it("uses external URL with UTM params for non-MITx Online course", () => {
-      const resource = mitxOnlineResource({
         resource_type: ResourceTypeEnum.Course,
-        platform: { code: PlatformEnum.Ocw },
+        readable_id: "a-different-readable-id",
+        url: productUrl,
       })
 
       renderWithProviders(
@@ -295,13 +244,9 @@ describe("CallToActionSection", () => {
         />,
       )
 
-      const link = screen.getByRole("link", {
-        name: "Access Course Materials",
-      })
-      const href = link.getAttribute("href")
-      expect(href).toContain(url)
-      expect(href).toContain("utm_source=mit-learn")
-      expect(href).not.toContain("/courses/")
+      const link = screen.getByRole("link", { name: "Learn More" })
+      expect(link).toHaveAttribute("href", productUrl)
+      expect(link.getAttribute("href")).not.toContain("utm_")
     })
   })
 

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.test.tsx
@@ -129,6 +129,7 @@ describe("CallToActionSection", () => {
     it("adds UTM params to external URLs", () => {
       const resource = factories.learningResources.resource({
         resource_type: ResourceTypeEnum.Course,
+        platform: { code: PlatformEnum.Xpro },
         title: "Test Course Title",
         url: "https://external-site.com/course",
       })
@@ -151,6 +152,7 @@ describe("CallToActionSection", () => {
     it("adds UTM params to URLs with existing query params", () => {
       const resource = factories.learningResources.resource({
         resource_type: ResourceTypeEnum.Course,
+        platform: { code: PlatformEnum.Xpro },
         title: "Test Course",
         url: "https://external-site.com/course?existing=param",
       })
@@ -175,6 +177,7 @@ describe("CallToActionSection", () => {
       const NEXT_PUBLIC_ORIGIN = process.env.NEXT_PUBLIC_ORIGIN
       const resource = factories.learningResources.resource({
         resource_type: ResourceTypeEnum.Course,
+        platform: { code: PlatformEnum.Xpro },
         title: "Test Course",
         url: `${NEXT_PUBLIC_ORIGIN}/internal/page`,
       })
@@ -198,6 +201,7 @@ describe("CallToActionSection", () => {
     it("does NOT add UTM params to relative URLs", () => {
       const resource = factories.learningResources.resource({
         resource_type: ResourceTypeEnum.Course,
+        platform: { code: PlatformEnum.Xpro },
         title: "Test Course",
         url: "/relative/path",
       })
@@ -256,11 +260,8 @@ describe("CallToActionSection", () => {
         }),
       },
     ])(
-      "links to product page $expectedPath when flag is ON for MITx Online $resourceType",
+      "links to product page $expectedPath for MITx Online $resourceType",
       ({ resourceType, resourceTypeGroup, expectedPath }) => {
-        mockUseFeatureFlagEnabled.mockImplementation(
-          (flag) => flag === FeatureFlags.MitxOnlineProductPages,
-        )
         const resource = mitxOnlineResource({
           resource_type: resourceType,
           resource_type_group: resourceTypeGroup,
@@ -280,32 +281,7 @@ describe("CallToActionSection", () => {
       },
     )
 
-    it("uses external URL with UTM params when feature flag is OFF for MITx Online course/program", () => {
-      mockUseFeatureFlagEnabled.mockReturnValue(false)
-
-      const resource = mitxOnlineResource({
-        resource_type: ResourceTypeEnum.Course,
-      })
-      renderWithProviders(
-        <CallToActionSection
-          imgConfig={IMG_CONFIG}
-          resource={resource}
-          shareUrl="https://learn.mit.edu/test"
-        />,
-      )
-
-      const link = screen.getByRole("link", { name: "Learn More" })
-      const href = link.getAttribute("href")
-      expect(href).toContain(url)
-      expect(href).toContain("utm_source=mit-learn")
-      expect(href).toContain("utm_medium=referral")
-    })
-
-    it("uses external URL with UTM params for non-MITx Online course even when flag is ON", () => {
-      mockUseFeatureFlagEnabled.mockImplementation(
-        (flag) => flag === FeatureFlags.MitxOnlineProductPages,
-      )
-
+    it("uses external URL with UTM params for non-MITx Online course", () => {
       const resource = mitxOnlineResource({
         resource_type: ResourceTypeEnum.Course,
         platform: { code: PlatformEnum.Ocw },
@@ -430,9 +406,9 @@ describe("CallToActionSection", () => {
         (flag) => flag === FeatureFlags.OcwProductPages,
       )
       const resource = factories.learningResources.resource({
-        platform: { code: PlatformEnum.Mitxonline },
+        platform: { code: PlatformEnum.Xpro },
         resource_type: ResourceTypeEnum.Course,
-        url: "https://courses.mitxonline.mit.edu/learn/course/some-course/",
+        url: "https://xpro.mit.edu/courses/some-course/",
       })
 
       renderWithProviders(
@@ -445,7 +421,7 @@ describe("CallToActionSection", () => {
 
       const link = screen.getByRole("link", { name: "Learn More" })
       const href = link.getAttribute("href")
-      expect(href).toContain("mitxonline.mit.edu")
+      expect(href).toContain("xpro.mit.edu")
       expect(href).not.toContain("/courses/o/")
     })
 

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -17,7 +17,7 @@ import {
   resourceContentFilesImageSrc,
   useImageWithFallback,
 } from "ol-utilities"
-import { ResourceTypeEnum, ResourceTypeGroupEnum, PlatformEnum } from "api"
+import { ResourceTypeEnum, PlatformEnum } from "api"
 import {
   Button,
   ButtonLink,
@@ -43,8 +43,6 @@ import {
   FACEBOOK_SHARE_BASE_URL,
   TWITTER_SHARE_BASE_URL,
   LINKEDIN_SHARE_BASE_URL,
-  coursePageView,
-  programPageView,
   videoDetailPageView,
   videoPlaylistPageView,
   podcastPageView,
@@ -52,7 +50,6 @@ import {
   ocwLearnPageView,
 } from "@/common/urls"
 import { parentPodcastIds, videoPlaylistIds } from "@/common/slugs"
-import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { FeatureFlags } from "@/common/feature_flags"
 import { externalLinkProps } from "@/common/utils"
 
@@ -326,21 +323,6 @@ const getResourceUrl = (
     ocwProductPages?: boolean
   },
 ) => {
-  if (resource.platform?.code === PlatformEnum.Mitxonline) {
-    if (resource.resource_type === ResourceTypeEnum.Course) {
-      return coursePageView(resource.readable_id)
-    } else if (resource.resource_type === ResourceTypeEnum.Program) {
-      return programPageView({
-        readable_id: resource.readable_id,
-        // Learn program resources that have resource_type_group correspond to
-        // MITxOnline programs with display_mode="course"
-        display_mode:
-          resource.resource_type_group === ResourceTypeGroupEnum.Course
-            ? DisplayModeEnum.Course
-            : undefined,
-      })
-    }
-  }
   if (resource.resource_type === ResourceTypeEnum.VideoPlaylist) {
     return videoPlaylistPageView(resource.id.toString(), resource.title)
   }

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -320,22 +320,13 @@ const getResourceUrl = (
   resource: LearningResource,
   {
     ocwProductPages,
-    mitxonlineProductPages,
     showPodcastPage,
   }: {
-    mitxonlineProductPages?: boolean
     showPodcastPage?: boolean
     ocwProductPages?: boolean
   },
 ) => {
-  if (
-    mitxonlineProductPages &&
-    resource.platform?.code === PlatformEnum.Mitxonline
-  ) {
-    /**
-     * TODO: After mitxonlineProductPages feature flag is fully rolled out,
-     * this logic should be handled during ETL
-     */
+  if (resource.platform?.code === PlatformEnum.Mitxonline) {
     if (resource.resource_type === ResourceTypeEnum.Course) {
       return coursePageView(resource.readable_id)
     } else if (resource.resource_type === ResourceTypeEnum.Program) {
@@ -343,7 +334,6 @@ const getResourceUrl = (
         readable_id: resource.readable_id,
         // Learn program resources that have resource_type_group correspond to
         // MITxOnline programs with display_mode="course"
-        // This can be moved into backend ETL after feature flags are removed.
         display_mode:
           resource.resource_type_group === ResourceTypeGroupEnum.Course
             ? DisplayModeEnum.Course
@@ -413,9 +403,6 @@ const CallToActionSection = ({
   const [shareExpanded, setShareExpanded] = useState(false)
   const [copyText, setCopyText] = useState("Copy Link")
   const ocwProductPages = useFeatureFlagEnabled(FeatureFlags.OcwProductPages)
-  const mitxonlineProductPages = useFeatureFlagEnabled(
-    FeatureFlags.MitxOnlineProductPages,
-  )
   const showPodcastPage = useFeatureFlagEnabled(FeatureFlags.PodcastDetailPage)
 
   if (hide) {
@@ -444,7 +431,6 @@ const CallToActionSection = ({
   const socialIconSize = 18
   const url = appendUtmParams(
     getResourceUrl(resource, {
-      mitxonlineProductPages,
       showPodcastPage,
       ocwProductPages,
     }),


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/11286

### Description (What does it do?)
Removes product page feature flags

### How can this be tested?
1. Check product pages load
2. Check that MITxOnline resources in the resource drawer still point to the product pages
