### PR TITLE
remove langchain-openai

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ dependencies = [
     "jedi>=0.19.0,<0.20",
     "langchain>=1.3.9,<1.4",
     "langchain-experimental>=0.4,<0.5",
-    "langchain-openai>=0.3.2,<0.4",
     "litellm==1.84.0",
     "llama-index>=0.14.0,<0.15",
     "llama-index-llms-openai>=0.6.0,<0.7",

--- a/uv.lock
+++ b/uv.lock
@@ -2062,20 +2062,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langchain-openai"
-version = "0.3.34"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-core" },
-    { name = "openai" },
-    { name = "tiktoken" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/75/23/91461c6c2b1c8ceeadd6fefe453a03b1537afeff4ace3c118d7e7659f5a7/langchain_openai-0.3.34.tar.gz", hash = "sha256:57916d462be5b8fd19e5cb2f00d4e5cf0465266a292d583de2fc693a55ba190e", size = 785924, upload-time = "2025-10-01T15:18:40.635Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/94/132aff5a1ed4ebfe7b4d3e4dbf30b9f70ce2bd2ac3470d0c0e742845afb1/langchain_openai-0.3.34-py3-none-any.whl", hash = "sha256:08d61d68a6d869c70d542171e149b9065668dedfc4fafcd4de8aeb5b933030a9", size = 75605, upload-time = "2025-10-01T15:18:39.415Z" },
-]
-
-[[package]]
 name = "langchain-protocol"
 version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
@@ -2620,7 +2606,6 @@ dependencies = [
     { name = "langchain" },
     { name = "langchain-experimental" },
     { name = "langchain-litellm" },
-    { name = "langchain-openai" },
     { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-llms-openai" },
@@ -2760,7 +2745,6 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.3.9,<1.4" },
     { name = "langchain-experimental", specifier = ">=0.4,<0.5" },
     { name = "langchain-litellm", specifier = ">=0.5.1" },
-    { name = "langchain-openai", specifier = ">=0.3.2,<0.4" },
     { name = "litellm", specifier = "==1.84.0" },
     { name = "llama-index", specifier = ">=0.14.0,<0.15" },
     { name = "llama-index-llms-openai", specifier = ">=0.6.0,<0.7" },


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
renovate has a pr to update langchain-openai: https://github.com/mitodl/mit-learn/pull/3497

I believe we can remove it instead. We don't call openai through langchain-openai but through litellm


### How can this be tested?
tests should pass
Verify that learn can access open ai. 
set OPENAI_API_KEY

Run


```
from  learning_resources.models import *
from learning_resources.content_summarizer import ContentSummarizer

ContentSummarizerConfiguration.objects.get_or_create(
	allowed_content_types=["file"],
	allowed_extensions=[".srt", ".vtt"],
	is_active=True,
	llm_model="gpt-4o-mini",
	defaults={
		"platform": LearningResourcePlatform.objects.get(code="mitxonline")
	}
)
summarizer = ContentSummarizer()
cf = LearningResource.objects.filter(require_summaries=True).first().runs.first().content_files.filter(file_extension=".srt").first()

```
verify that cf.content is not blank

Then run
```
summarizer.summarize_content_files_by_ids([cf.id], overwrite=True)
```
