### PR TITLE
fix(dashboard): enroll in the displayed variant run, not getBestRun's…

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -126,6 +126,24 @@ describe.each([
     expect(within(card).getByTestId("courseware-button")).toBeDisabled()
   })
 
+  test("CTA is disabled when the displayed run is not enrollable", () => {
+    setupUserApis()
+    // A selected variant run can resolve to a non-enrollable run. The CTA must
+    // disable (the diff's `!courseRun?.is_enrollable` guard) rather than fall
+    // back to enrolling in some other run. courseware_url/id are present via
+    // factory defaults, so is_enrollable is the sole reason it's disabled.
+    const nonEnrollableRun = mitxonline.factories.courses.courseRun({
+      is_enrollable: false,
+    })
+    const course = mitxOnlineCourse()
+
+    renderWithProviders(
+      <UnenrolledCourseCard course={course} displayedRun={nonEnrollableRun} />,
+    )
+
+    expect(within(getCard()).getByTestId("courseware-button")).toBeDisabled()
+  })
+
   test("uses displayedRun title when provided", () => {
     setupUserApis()
     const defaultRun = mitxonline.factories.courses.courseRun({
@@ -301,8 +319,9 @@ describe.each([
       user_profile: { year_of_birth: 1988 },
     })
     const b2bContractId = faker.number.int()
-    // getBestRun returns next_run_id (the default variant), but the card is
-    // showing — and must enroll in — the selected variant run (displayedRun).
+    // Pre-fix, the card enrolled in getBestRun's pick (defaultRun, the canonical
+    // "next run") instead of the run it displays. The selected variant run is
+    // what must be enrolled in.
     const defaultRun = mitxonline.factories.courses.courseRun({
       b2b_contract: b2bContractId,
       is_enrollable: true,
@@ -311,10 +330,19 @@ describe.each([
       b2b_contract: b2bContractId,
       is_enrollable: true,
     })
+    // The variant run is intentionally NOT in course.courseruns: variant runs
+    // come from a separate endpoint and are often absent from the course
+    // payload. The card must still enroll in it (via displayedRun), and the
+    // handler must resolve its URL from the explicitly-passed href — not a
+    // course.courseruns lookup. Keeping it out of the array makes this test
+    // fail if that explicit-href path is ever dropped.
     const course = mitxOnlineCourse({
-      courseruns: [defaultRun, variantRun],
+      courseruns: [defaultRun],
       next_run_id: defaultRun.id,
     })
+    expect(course.courseruns.map((run) => run.courseware_id)).not.toContain(
+      variantRun.courseware_id,
+    )
     const { enrollmentUrl: variantEnrollUrl } = setupEnrollmentApis({
       user: userData,
       course,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -295,6 +295,59 @@ describe.each([
     },
   )
 
+  test("B2B enrollment targets the displayed (variant) run, not getBestRun's default pick", async () => {
+    const userData = mitxUser({
+      legal_address: { country: "US" },
+      user_profile: { year_of_birth: 1988 },
+    })
+    const b2bContractId = faker.number.int()
+    // getBestRun returns next_run_id (the default variant), but the card is
+    // showing — and must enroll in — the selected variant run (displayedRun).
+    const defaultRun = mitxonline.factories.courses.courseRun({
+      b2b_contract: b2bContractId,
+      is_enrollable: true,
+    })
+    const variantRun = mitxonline.factories.courses.courseRun({
+      b2b_contract: b2bContractId,
+      is_enrollable: true,
+    })
+    const course = mitxOnlineCourse({
+      courseruns: [defaultRun, variantRun],
+      next_run_id: defaultRun.id,
+    })
+    const { enrollmentUrl: variantEnrollUrl } = setupEnrollmentApis({
+      user: userData,
+      course,
+      run: variantRun,
+    })
+    // The default run must NOT be enrolled in. Mock it (rather than leaving it
+    // unhandled) so a buggy call resolves and the failure surfaces as a clear
+    // assertion; the sentinel body documents that reaching it is the bug.
+    const defaultEnrollUrl = mitxonline.urls.b2b.courseEnrollment(
+      defaultRun.courseware_id,
+    )
+    setMockResponse.post(defaultEnrollUrl, { result: "SHOULD_NOT_BE_CALLED" })
+
+    renderWithProviders(
+      <UnenrolledCourseCard
+        course={course}
+        contractId={b2bContractId}
+        displayedRun={variantRun}
+      />,
+    )
+
+    await user.click(within(getCard()).getByTestId("courseware-button"))
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "post", url: variantEnrollUrl }),
+      )
+    })
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "post", url: defaultEnrollUrl }),
+    )
+  })
+
   // ---------------------------------------------------------------------------
   // B2C (non-B2B) enrollment flows
   // ---------------------------------------------------------------------------

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -47,10 +47,9 @@ export const UnenrolledCourseCard = ({
   const isPending = enrollment.isPending
   const courseRun =
     displayedRunProp ?? getBestRun(course, { enrollableOnly: true, contractId })
-  const enrollableRun = getBestRun(course, { enrollableOnly: true, contractId })
-  const coursewareUrl = enrollableRun?.courseware_url || undefined
-  const readableId = enrollableRun?.courseware_id
-  const isDisabled = !enrollableRun || !coursewareUrl || !readableId
+  const coursewareUrl = courseRun?.courseware_url || undefined
+  const readableId = courseRun?.courseware_id
+  const isDisabled = !courseRun?.is_enrollable || !coursewareUrl || !readableId
   const title =
     layout === "compact" ? course.title : courseRun?.title || course.title
   const isContractPageResource = Boolean(contractId)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useEnrollmentHandler.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useEnrollmentHandler.ts
@@ -54,6 +54,11 @@ export const useEnrollmentHandler = () => {
           })
           return
         }
+        // A selected variant run may not be present in `course.courseruns`
+        // (variant runs come from a separate endpoint and aren't always in the
+        // course payload), so this find() can miss. `href` is the displayed
+        // run's URL, passed explicitly by the card for exactly this reason — it
+        // must take precedence, or variant enrollment redirects silently break.
         const matchedRun = (course.courseruns ?? []).find(
           (run) => run.courseware_id === readableId,
         )
@@ -102,6 +107,9 @@ export const useEnrollmentHandler = () => {
           )
           return
         }
+        // See the B2B note above: the displayed run may be absent from
+        // course.courseruns, so selectedCoursewareUrl/href must take precedence
+        // over this find().
         const verifiedDestination =
           selectedCoursewareUrl ??
           (course.courseruns ?? []).find(


### PR DESCRIPTION
### What are the relevant tickets?
none

### Description (What does it do?)
Fixes a contract bug where contract page was displaying the variant card but enrolling people in the non-variant (aka default variant) run.

### How can this be tested?
1. Set up a contract with variants
2. Try enrolling in default variant vs non-default variant. It should enroll you correctly.
3. The enrollment button should be correctly disabled if a run is not enrollable.

