### PR TITLE
feat: show duplicate emails and stats summary in B2B seat assignment modal

### DIFF
--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -10,7 +10,6 @@ const baseProps = {
   availableSeats: 10,
   invalidEmails: [],
   duplicateEmails: [],
-  duplicateCount: 0,
   skippedCount: 0,
 }
 
@@ -52,7 +51,7 @@ describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
 
     expect(screen.getByText("7")).toBeInTheDocument()
     expect(
-      screen.getByText(/seats remaining after sending/i),
+      screen.getByRole("group", { name: /7 seats remaining after sending/i }),
     ).toBeInTheDocument()
   })
 
@@ -73,6 +72,26 @@ describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
     await user.click(screen.getByRole("button", { name: /cancel/i }))
 
     expect(baseProps.onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test("shows 'Sending…' on the Send button while submitting", async () => {
+    let resolve!: () => void
+    const promise = new Promise<void>((res) => {
+      resolve = res
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} onConfirm={() => promise} />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /send 3 invitations/i }),
+    )
+
+    expect(
+      screen.getByRole("button", { name: /sending…/i }),
+    ).toBeInTheDocument()
+
+    resolve()
   })
 })
 
@@ -98,7 +117,6 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     renderWithTheme(
       <AssignSeatsConfirmModal
         {...baseProps}
-        duplicateCount={2}
         duplicateEmails={["dup@example.com", "dup2@example.com"]}
       />,
     )
@@ -127,7 +145,6 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     renderWithTheme(
       <AssignSeatsConfirmModal
         {...baseProps}
-        duplicateCount={1}
         duplicateEmails={["dup@example.com"]}
       />,
     )
@@ -147,7 +164,7 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     expect(screen.getByText("a@x.com")).toBeInTheDocument()
     expect(screen.queryByText("d@x.com")).not.toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: /\+ 2 more/i }),
+      screen.getByRole("button", { name: /show 2 more email addresses/i }),
     ).toBeInTheDocument()
   })
 
@@ -157,7 +174,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
       <AssignSeatsConfirmModal {...baseProps} invalidEmails={emails} />,
     )
 
-    await user.click(screen.getByRole("button", { name: /\+ 2 more/i }))
+    await user.click(
+      screen.getByRole("button", { name: /show 2 more email addresses/i }),
+    )
 
     expect(screen.getByText("e@x.com")).toBeInTheDocument()
     expect(
@@ -174,7 +193,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
       />,
     )
 
-    expect(screen.getByText(/4 rows skipped/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/4 rows skipped/i, { selector: "strong" }),
+    ).toBeInTheDocument()
   })
 
   test("advancing from review step shows confirm step", async () => {
@@ -187,6 +208,15 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     expect(
       screen.getByRole("heading", { name: /ready to send invitations/i }),
     ).toBeInTheDocument()
+  })
+
+  test("shows review step when only skippedCount > 0 (no invalid or duplicate)", () => {
+    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} skippedCount={3} />)
+
+    expect(
+      screen.getByRole("heading", { name: /some rows were skipped/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByText(/3 rows skipped/i)).toBeInTheDocument()
   })
 })
 
@@ -205,11 +235,10 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
     expect(
       screen.getByRole("heading", { name: /not enough seats available/i }),
     ).toBeInTheDocument()
-    expect(
-      screen.getByRole("alertdialog", {
-        name: /not enough seats available/i,
-      }),
-    ).toHaveAccessibleDescription(
+    // MUI places role="alertdialog" on the outer modal root; aria-labelledby and
+    // aria-describedby are on the inner role="dialog" paper.
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument()
+    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
       /15 learners were imported, but only 10 seats remain/i,
     )
   })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { act } from "react"
 import { renderWithTheme, screen, user } from "@/test-utils"
 import { AssignSeatsConfirmModal } from "./AssignSeatsConfirmModal"
 
@@ -91,7 +91,9 @@ describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
       screen.getByRole("button", { name: /sending…/i }),
     ).toBeInTheDocument()
 
-    resolve()
+    await act(async () => {
+      resolve()
+    })
   })
 })
 
@@ -216,7 +218,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     expect(
       screen.getByRole("heading", { name: /some rows were skipped/i }),
     ).toBeInTheDocument()
-    expect(screen.getByText(/3 rows skipped/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/3 rows skipped/i, { selector: "strong" }),
+    ).toBeInTheDocument()
   })
 })
 
@@ -235,10 +239,11 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
     expect(
       screen.getByRole("heading", { name: /not enough seats available/i }),
     ).toBeInTheDocument()
-    // MUI places role="alertdialog" on the outer modal root; aria-labelledby and
-    // aria-describedby are on the inner role="dialog" paper.
+    // role="alertdialog" is applied to the MUI paper via PaperProps, which also
+    // carries aria-describedby. alertdialog is a subtype of dialog per ARIA, so
+    // getByRole("dialog") matches the same element.
     expect(screen.getByRole("alertdialog")).toBeInTheDocument()
-    expect(screen.getByRole("dialog")).toHaveAccessibleDescription(
+    expect(screen.getByRole("alertdialog")).toHaveAccessibleDescription(
       /15 learners were imported, but only 10 seats remain/i,
     )
   })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -205,6 +205,13 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
     expect(
       screen.getByRole("heading", { name: /not enough seats available/i }),
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole("alertdialog", {
+        name: /not enough seats available/i,
+      }),
+    ).toHaveAccessibleDescription(
+      /15 learners were imported, but only 10 seats remain/i,
+    )
   })
 
   test("shows imported, available, and over-limit stats", () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -75,10 +75,7 @@ describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
   })
 
   test("shows 'Sending…' on the Send button while submitting", async () => {
-    let resolve!: () => void
-    const promise = new Promise<void>((res) => {
-      resolve = res
-    })
+    const { promise, resolve } = Promise.withResolvers<void>()
     renderWithTheme(
       <AssignSeatsConfirmModal {...baseProps} onConfirm={() => promise} />,
     )

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -299,3 +299,156 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
     expect(baseProps.onConfirm).not.toHaveBeenCalled()
   })
 })
+
+describe("AssignSeatsConfirmModal — copy buttons", () => {
+  afterEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    })
+  })
+
+  test("copies invalid emails to clipboard and shows Copied! feedback", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        invalidEmails={["bad@", "alsobad@"]}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all invalid emails/i }),
+    )
+
+    expect(writeText).toHaveBeenCalledWith("bad@\nalsobad@")
+    expect(
+      await screen.findByRole("button", { name: /copied!/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("copies duplicate emails to clipboard and shows Copied! feedback", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        duplicateEmails={["dup@example.com", "dup2@example.com"]}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all duplicate emails/i }),
+    )
+
+    expect(writeText).toHaveBeenCalledWith("dup@example.com\ndup2@example.com")
+    expect(
+      await screen.findByRole("button", { name: /copied!/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("announces copy success to screen readers via aria-live region", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+      configurable: true,
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={["bad@"]} />,
+    )
+
+    const liveRegion = document.querySelector("[aria-live='polite']")
+    expect(liveRegion).toHaveTextContent("")
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all invalid emails/i }),
+    )
+
+    await screen.findByRole("button", { name: /copied!/i })
+    expect(liveRegion).toHaveTextContent("Copied invalid emails to clipboard.")
+  })
+
+  test("falls back to execCommand when clipboard API is unavailable (invalid emails)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    })
+    document.execCommand = jest.fn().mockImplementation((cmd: string) => {
+      if (cmd === "copy") {
+        document.dispatchEvent(
+          new Event("copy", { bubbles: true, cancelable: true }),
+        )
+        return true
+      }
+      return false
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={["bad@"]} />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all invalid emails/i }),
+    )
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy")
+    expect(
+      await screen.findByRole("button", { name: /copied!/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("falls back to execCommand when clipboard API is unavailable (duplicate emails)", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    })
+    document.execCommand = jest.fn().mockImplementation((cmd: string) => {
+      if (cmd === "copy") {
+        document.dispatchEvent(
+          new Event("copy", { bubbles: true, cancelable: true }),
+        )
+        return true
+      }
+      return false
+    })
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        duplicateEmails={["dup@example.com"]}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all duplicate emails/i }),
+    )
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy")
+    expect(
+      await screen.findByRole("button", { name: /copied!/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("does not show Copied! when both clipboard and execCommand fail", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    })
+    document.execCommand = jest.fn().mockReturnValue(false)
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={["bad@"]} />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /copy all invalid emails/i }),
+    )
+
+    expect(
+      screen.queryByRole("button", { name: /copied!/i }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -43,11 +43,17 @@ describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
 
   test("shows seats-remaining stat", () => {
     renderWithTheme(
-      <AssignSeatsConfirmModal {...baseProps} validCount={3} availableSeats={10} />,
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        validCount={3}
+        availableSeats={10}
+      />,
     )
 
     expect(screen.getByText("7")).toBeInTheDocument()
-    expect(screen.getByText(/seats remaining after sending/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/seats remaining after sending/i),
+    ).toBeInTheDocument()
   })
 
   test("calls onConfirm and then onClose when Send is clicked", async () => {
@@ -82,7 +88,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     )
 
     expect(
-      screen.getByRole("heading", { name: /some learners could not be added/i }),
+      screen.getByRole("heading", {
+        name: /some learners could not be added/i,
+      }),
     ).toBeInTheDocument()
   })
 
@@ -138,7 +146,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
 
     expect(screen.getByText("a@x.com")).toBeInTheDocument()
     expect(screen.queryByText("d@x.com")).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /\+ 2 more/i })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /\+ 2 more/i }),
+    ).toBeInTheDocument()
   })
 
   test("expands full list when show more is clicked", async () => {
@@ -150,7 +160,9 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
     await user.click(screen.getByRole("button", { name: /\+ 2 more/i }))
 
     expect(screen.getByText("e@x.com")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /more/i })).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /more/i }),
+    ).not.toBeInTheDocument()
   })
 
   test("shows skipped count in description when rows were skipped", () => {
@@ -167,15 +179,10 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
 
   test("advancing from review step shows confirm step", async () => {
     renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        invalidEmails={["bad@"]}
-      />,
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={["bad@"]} />,
     )
 
-    await user.click(
-      screen.getByRole("button", { name: /review & confirm/i }),
-    )
+    await user.click(screen.getByRole("button", { name: /review & confirm/i }))
 
     expect(
       screen.getByRole("heading", { name: /ready to send invitations/i }),
@@ -243,7 +250,9 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
       />,
     )
 
-    await user.click(screen.getByRole("button", { name: /close & update csv/i }))
+    await user.click(
+      screen.getByRole("button", { name: /close & update csv/i }),
+    )
 
     expect(baseProps.onClose).toHaveBeenCalledTimes(1)
     expect(baseProps.onConfirm).not.toHaveBeenCalled()

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -9,214 +9,56 @@ const baseProps = {
   validCount: 3,
   availableSeats: 10,
   invalidEmails: [],
+  duplicateEmails: [],
   duplicateCount: 0,
   skippedCount: 0,
 }
 
-describe("AssignSeatsConfirmModal", () => {
+describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
   beforeEach(() => jest.clearAllMocks())
 
-  test("shows valid count in title and confirm button", () => {
+  test("shows 'Ready to send invitations' title when there are no issues", () => {
     renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
 
     expect(
-      screen.getByRole("heading", { name: /3 emails ready to assign/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: /send 3 emails/i }),
+      screen.getByRole("heading", { name: /ready to send invitations/i }),
     ).toBeInTheDocument()
   })
 
-  test("shows singular form for a single email", () => {
+  test("shows invitation count in the send button", () => {
+    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
+
+    expect(
+      screen.getByRole("button", { name: /send 3 invitations/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("shows singular form for one invitation", () => {
     renderWithTheme(<AssignSeatsConfirmModal {...baseProps} validCount={1} />)
 
     expect(
-      screen.getByRole("heading", { name: /1 email ready to assign/i }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: /send 1 email/i }),
+      screen.getByRole("button", { name: /send 1 invitation$/i }),
     ).toBeInTheDocument()
   })
 
-  test("shows confirmation copy when there are no issues", () => {
+  test("shows seats-remaining stat", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} validCount={3} availableSeats={10} />,
+    )
+
+    expect(screen.getByText("7")).toBeInTheDocument()
+    expect(screen.getByText(/seats remaining after sending/i)).toBeInTheDocument()
+  })
+
+  test("calls onConfirm and then onClose when Send is clicked", async () => {
     renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
 
-    expect(
-      screen.getAllByText(/are you sure you want to send/i)[0],
-    ).toBeInTheDocument()
-  })
-
-  test("shows imported copy when there are issues", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        invalidEmails={["bad@example"]}
-      />,
+    await user.click(
+      screen.getByRole("button", { name: /send 3 invitations/i }),
     )
 
-    expect(
-      screen.getAllByText(/imported and ready to assign/i)[0],
-    ).toBeInTheDocument()
-  })
-
-  test("shows duplicate count when duplicates were removed", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal {...baseProps} duplicateCount={2} />,
-    )
-
-    expect(screen.getAllByText(/2 duplicates removed/i)[0]).toBeInTheDocument()
-  })
-
-  test("does not show duplicate section when duplicateCount is 0", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal {...baseProps} duplicateCount={0} />,
-    )
-
-    expect(screen.queryByText(/duplicate/i)).not.toBeInTheDocument()
-  })
-
-  test("shows skipped row count when rows were skipped", () => {
-    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} skippedCount={3} />)
-
-    expect(screen.getAllByText(/3 rows skipped/i)[0]).toBeInTheDocument()
-    expect(
-      screen.getAllByText(/no email address found/i)[0],
-    ).toBeInTheDocument()
-  })
-
-  test("does not show skipped section when skippedCount is 0", () => {
-    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} skippedCount={0} />)
-
-    expect(screen.queryByText(/skipped/i)).not.toBeInTheDocument()
-  })
-
-  test("lists invalid emails", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        invalidEmails={["bad@", "also-bad@"]}
-      />,
-    )
-
-    expect(screen.getByText("bad@")).toBeInTheDocument()
-    expect(screen.getByText("also-bad@")).toBeInTheDocument()
-    expect(
-      screen.getByText(/these addresses were not valid/i),
-    ).toBeInTheDocument()
-  })
-
-  test("does not show invalid section when invalidEmails is empty", () => {
-    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
-
-    expect(
-      screen.queryByText(/these addresses were not valid/i),
-    ).not.toBeInTheDocument()
-  })
-
-  test("collapses long invalid list beyond 10 items", () => {
-    const manyEmails = Array.from({ length: 15 }, (_, i) => `bad${i}@`)
-    renderWithTheme(
-      <AssignSeatsConfirmModal {...baseProps} invalidEmails={manyEmails} />,
-    )
-
-    // First 10 visible, rest hidden behind show more
-    expect(screen.getByText("bad0@")).toBeInTheDocument()
-    expect(screen.queryByText("bad10@")).not.toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: /\+5 more/i }),
-    ).toBeInTheDocument()
-  })
-
-  test("expands full list when show more is clicked", async () => {
-    const manyEmails = Array.from({ length: 15 }, (_, i) => `bad${i}@`)
-    renderWithTheme(
-      <AssignSeatsConfirmModal {...baseProps} invalidEmails={manyEmails} />,
-    )
-
-    await user.click(screen.getByRole("button", { name: /\+5 more/i }))
-
-    expect(screen.getByText("bad14@")).toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: /more/i }),
-    ).not.toBeInTheDocument()
-  })
-
-  test("shows over-capacity dialog when validCount exceeds availableSeats", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        validCount={15}
-        availableSeats={10}
-      />,
-    )
-
-    expect(
-      screen.getAllByText(
-        /15 emails entered, only 10 seats remaining\. Please enter fewer emails\./i,
-      ).length,
-    ).toBeGreaterThan(0)
-    expect(
-      screen.getByRole("heading", { name: /too many invitees/i }),
-    ).toBeInTheDocument()
-  })
-
-  test("does not show over-capacity dialog when validCount is within availableSeats", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        validCount={3}
-        availableSeats={10}
-      />,
-    )
-
-    expect(
-      screen.queryByText(/emails entered, only \d+ seats remaining/i),
-    ).not.toBeInTheDocument()
-  })
-
-  test("over-capacity: shows Ok button and no Cancel button", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        validCount={15}
-        availableSeats={10}
-      />,
-    )
-
-    expect(screen.getByRole("button", { name: "Ok" })).toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: /cancel/i }),
-    ).not.toBeInTheDocument()
-  })
-
-  test("over-capacity: Ok button closes the dialog", async () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        validCount={15}
-        availableSeats={10}
-      />,
-    )
-
-    await user.click(screen.getByRole("button", { name: "Ok" }))
-
+    expect(baseProps.onConfirm).toHaveBeenCalledTimes(1)
     expect(baseProps.onClose).toHaveBeenCalledTimes(1)
-    expect(baseProps.onConfirm).not.toHaveBeenCalled()
-  })
-
-  test("CSV within capacity: shows normal Send button and Cancel button", () => {
-    renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        validCount={5}
-        availableSeats={10}
-      />,
-    )
-
-    expect(
-      screen.getByRole("button", { name: /send 5 emails/i }),
-    ).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument()
   })
 
   test("calls onClose when Cancel is clicked", async () => {
@@ -226,12 +68,184 @@ describe("AssignSeatsConfirmModal", () => {
 
     expect(baseProps.onClose).toHaveBeenCalledTimes(1)
   })
+})
 
-  test("calls onConfirm when Send is clicked", async () => {
-    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
+describe("AssignSeatsConfirmModal — review step (has issues)", () => {
+  beforeEach(() => jest.clearAllMocks())
 
-    await user.click(screen.getByRole("button", { name: /send 3 emails/i }))
+  test("shows review step when there are invalid emails", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        invalidEmails={["bad@", "alsabad@"]}
+      />,
+    )
 
-    expect(baseProps.onConfirm).toHaveBeenCalledTimes(1)
+    expect(
+      screen.getByRole("heading", { name: /some learners could not be added/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("shows 'Duplicate emails removed' title when only duplicates exist", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        duplicateCount={2}
+        duplicateEmails={["dup@example.com", "dup2@example.com"]}
+      />,
+    )
+
+    expect(
+      screen.getByRole("heading", { name: /duplicate emails removed/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("shows invalid email addresses in an alert box", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        invalidEmails={["bad@", "alsabad@"]}
+      />,
+    )
+
+    expect(screen.getByText("bad@")).toBeInTheDocument()
+    expect(screen.getByText("alsabad@")).toBeInTheDocument()
+    expect(
+      screen.getByText(/invalid email addresses \(2\)/i),
+    ).toBeInTheDocument()
+  })
+
+  test("shows duplicate emails in an alert box", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        duplicateCount={1}
+        duplicateEmails={["dup@example.com"]}
+      />,
+    )
+
+    expect(screen.getByText("dup@example.com")).toBeInTheDocument()
+    expect(
+      screen.getByText(/duplicate email addresses \(1\)/i),
+    ).toBeInTheDocument()
+  })
+
+  test("collapses email list beyond 3 items with show-more button", () => {
+    const emails = ["a@x.com", "b@x.com", "c@x.com", "d@x.com", "e@x.com"]
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={emails} />,
+    )
+
+    expect(screen.getByText("a@x.com")).toBeInTheDocument()
+    expect(screen.queryByText("d@x.com")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /\+ 2 more/i })).toBeInTheDocument()
+  })
+
+  test("expands full list when show more is clicked", async () => {
+    const emails = ["a@x.com", "b@x.com", "c@x.com", "d@x.com", "e@x.com"]
+    renderWithTheme(
+      <AssignSeatsConfirmModal {...baseProps} invalidEmails={emails} />,
+    )
+
+    await user.click(screen.getByRole("button", { name: /\+ 2 more/i }))
+
+    expect(screen.getByText("e@x.com")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /more/i })).not.toBeInTheDocument()
+  })
+
+  test("shows skipped count in description when rows were skipped", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        invalidEmails={["bad@"]}
+        skippedCount={4}
+      />,
+    )
+
+    expect(screen.getByText(/4 rows skipped/i)).toBeInTheDocument()
+  })
+
+  test("advancing from review step shows confirm step", async () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        invalidEmails={["bad@"]}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /review & confirm/i }),
+    )
+
+    expect(
+      screen.getByRole("heading", { name: /ready to send invitations/i }),
+    ).toBeInTheDocument()
+  })
+})
+
+describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test("shows 'Not enough seats available' title when over capacity", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        validCount={15}
+        availableSeats={10}
+      />,
+    )
+
+    expect(
+      screen.getByRole("heading", { name: /not enough seats available/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("shows imported, available, and over-limit stats", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        validCount={15}
+        availableSeats={10}
+      />,
+    )
+
+    expect(screen.getAllByText("15")[0]).toBeInTheDocument()
+    expect(screen.getByText("10")).toBeInTheDocument()
+    expect(screen.getByText("5")).toBeInTheDocument()
+    expect(screen.getByText("Imported")).toBeInTheDocument()
+    expect(screen.getByText("Seats available")).toBeInTheDocument()
+    expect(screen.getByText("Over the limit")).toBeInTheDocument()
+  })
+
+  test("shows only 'Close & Update CSV' button with no Cancel", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        validCount={15}
+        availableSeats={10}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", { name: /close & update csv/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /cancel/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("'Close & Update CSV' calls onClose and not onConfirm", async () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        validCount={15}
+        availableSeats={10}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: /close & update csv/i }))
+
+    expect(baseProps.onClose).toHaveBeenCalledTimes(1)
+    expect(baseProps.onConfirm).not.toHaveBeenCalled()
   })
 })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -1,75 +1,199 @@
 "use client"
 
-import React, { useId, useState } from "react"
-import { Dialog, Stack, Typography, styled } from "ol-components"
-import { VisuallyHidden } from "@mitodl/smoot-design"
+import React, { useEffect, useId, useRef, useState } from "react"
+import { Dialog, DialogActions, Stack, Typography, alpha, styled } from "ol-components"
+import { Button, VisuallyHidden } from "@mitodl/smoot-design"
 import { pluralize } from "ol-utilities"
+import {
+  RiAlertFill,
+  RiFileCopyLine,
+  RiInformationLine,
+  RiMailLine,
+} from "@remixicon/react"
 
-const SHOW_MORE_THRESHOLD = 10
+// ─── Icon badges ─────────────────────────────────────────────────────────────
 
-const SectionLabel = styled(Typography)(({ theme }) => ({
-  ...theme.typography.subtitle2,
+const IconBadge = styled("span")<{ $variant: "warning" | "error" }>(
+  ({ theme, $variant }) => ({
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "28px",
+    height: "28px",
+    borderRadius: "50%",
+    backgroundColor:
+      $variant === "error"
+        ? theme.custom.colors.red
+        : theme.custom.colors.orange,
+    color: theme.custom.colors.white,
+    flexShrink: 0,
+    "& svg": { width: "20px", height: "20px" },
+  }),
+)
+
+// ─── Email alert box (invalid / duplicate list) ───────────────────────────────
+
+const EmailAlertBox = styled("div")(({ theme }) => ({
+  backgroundColor: alpha(theme.custom.colors.orange, 0.15),
+  border: `1px solid ${alpha(theme.custom.colors.orange, 0.5)}`,
+  borderRadius: "4px",
+  padding: "11px 16px",
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+  width: "100%",
+}))
+
+const AlertBoxTitle = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle3,
   color: theme.custom.colors.darkGray2,
 })) as typeof Typography
 
-const EmailList = styled.ul(({ theme }) => ({
-  margin: "4px 0 0",
-  paddingLeft: "20px",
-  ...theme.typography.body2,
+const EmailListUl = styled("ul")(({ theme }) => ({
+  margin: 0,
+  paddingLeft: "18px",
+  ...theme.typography.body3,
   color: theme.custom.colors.darkGray2,
+  "& li": { marginBottom: 0 },
 }))
 
-const ShowMoreButton = styled.button(({ theme }) => ({
+const ShowMoreButton = styled("button")(({ theme }) => ({
   background: "none",
   border: "none",
   padding: 0,
   cursor: "pointer",
-  ...theme.typography.body2,
-  color: theme.custom.colors.darkRed,
-  textDecoration: "underline",
+  ...theme.typography.body3,
+  color: theme.custom.colors.darkGray2,
+  textAlign: "left",
   "&:hover": { opacity: 0.8 },
 }))
 
-const DuplicateNotice = styled(Typography)(({ theme }) => ({
+const CopyLink = styled("button")(({ theme }) => ({
+  background: "none",
+  border: "none",
+  padding: "8px 0",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  textDecoration: "underline",
+  ...theme.typography.body3,
+  color: theme.custom.colors.darkGray2,
+  "& svg": { width: "16px", height: "16px", flexShrink: 0 },
+  "&:hover": { opacity: 0.8 },
+}))
+
+// ─── Info note ────────────────────────────────────────────────────────────────
+
+const InfoNote = styled("div")(({ theme }) => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "4px",
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+  "& svg": { width: "16px", height: "16px", marginTop: "1px", flexShrink: 0 },
+}))
+
+// ─── Description text ─────────────────────────────────────────────────────────
+
+const DescriptionText = styled(Typography)(({ theme }) => ({
   ...theme.typography.body2,
   color: theme.custom.colors.darkGray2,
 })) as typeof Typography
 
-type InvalidEmailListProps = {
-  emails: string[]
-}
+// ─── Stats card ───────────────────────────────────────────────────────────────
 
-const InvalidEmailList: React.FC<InvalidEmailListProps> = ({ emails }) => {
+const StatsCard = styled("div")<{ $variant: "default" | "error" }>(
+  ({ theme, $variant }) => ({
+    backgroundColor:
+      $variant === "error" ? theme.custom.colors.white : theme.custom.colors.lightGray1,
+    border: `1px solid ${$variant === "error" ? theme.custom.colors.red : theme.custom.colors.lightGray2}`,
+    borderRadius: "4px",
+    padding: "16px",
+    display: "flex",
+    alignItems: "center",
+    gap: "16px",
+    width: "100%",
+  }),
+)
+
+const StatDivider = styled("div")(({ theme }) => ({
+  width: "1px",
+  alignSelf: "stretch",
+  backgroundColor: theme.custom.colors.lightGray2,
+  flexShrink: 0,
+}))
+
+const StatColumn = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  flex: "1 0 0",
+  minWidth: 0,
+  gap: "4px",
+})
+
+const StatValue = styled(Typography, {
+  shouldForwardProp: (prop) => prop !== "$error",
+})<{ $error?: boolean }>(({ theme, $error }) => ({
+  ...theme.typography.h3,
+  color: $error ? theme.custom.colors.red : theme.custom.colors.darkGray2,
+  lineHeight: "36px",
+  textAlign: "center",
+  width: "100%",
+}))
+
+const StatLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle3,
+  color: theme.custom.colors.silverGrayDark,
+  textAlign: "center",
+  width: "100%",
+})) as typeof Typography
+
+// ─── Small helpers ────────────────────────────────────────────────────────────
+
+const SHOW_MORE_THRESHOLD = 3
+
+const EmailListExpand: React.FC<{ emails: string[] }> = ({ emails }) => {
   const [expanded, setExpanded] = useState(false)
   const visible = expanded ? emails : emails.slice(0, SHOW_MORE_THRESHOLD)
   const hidden = emails.length - SHOW_MORE_THRESHOLD
 
   return (
     <div>
-      <EmailList>
+      <EmailListUl>
         {visible.map((email) => (
           <li key={email}>{email}</li>
         ))}
-      </EmailList>
+      </EmailListUl>
       {!expanded && hidden > 0 && (
         <ShowMoreButton onClick={() => setExpanded(true)}>
-          +{hidden} more
+          + {hidden} more
         </ShowMoreButton>
       )}
     </div>
   )
 }
 
+const copyToClipboard = (text: string) => {
+  navigator.clipboard.writeText(text).catch(() => undefined)
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
 type AssignSeatsConfirmModalProps = {
   open: boolean
   onClose: () => void
-  onConfirm: () => void
+  onConfirm: () => void | Promise<void>
   validCount: number
   availableSeats: number
   invalidEmails: string[]
+  duplicateEmails: string[]
   duplicateCount: number
   skippedCount: number
 }
+
+type Step = "review" | "confirm"
 
 const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   open,
@@ -78,73 +202,298 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   validCount,
   availableSeats,
   invalidEmails,
+  duplicateEmails,
   duplicateCount,
   skippedCount,
 }) => {
   const descriptionId = useId()
-  const hasIssues =
-    invalidEmails.length > 0 || duplicateCount > 0 || skippedCount > 0
+
+  const hasInvalid = invalidEmails.length > 0
+  const hasDuplicates = duplicateCount > 0
+  const hasIssues = hasInvalid || hasDuplicates
   const overCapacity = validCount > availableSeats
-  const confirmText = overCapacity
-    ? "Ok"
-    : `Send ${validCount} ${pluralize("email", validCount)}`
-  const overCapacityBody = overCapacity
-    ? `${validCount} ${pluralize("email", validCount)} entered, only ${availableSeats} ${pluralize("seat", availableSeats)} remaining. Please enter fewer emails.`
-    : ""
-  const descriptionText = overCapacity
-    ? overCapacityBody
-    : hasIssues
-      ? `${validCount} ${pluralize("email", validCount)} imported and ready to assign.${duplicateCount > 0 ? ` ${duplicateCount} ${pluralize("duplicate", duplicateCount)} removed — only 1 instance kept per address.` : ""}${skippedCount > 0 ? ` ${skippedCount} ${pluralize("row", skippedCount)} skipped — no email address found.` : ""}`
-      : `Are you sure you want to send invitations to ${validCount} ${pluralize("recipient", validCount)}?`
+
+  const [step, setStep] = useState<Step>(() =>
+    hasIssues && !overCapacity ? "review" : "confirm",
+  )
+  const [copiedInvalid, setCopiedInvalid] = useState(false)
+  const [copiedDuplicate, setCopiedDuplicate] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [sendError, setSendError] = useState<string | null>(null)
+  const copyInvalidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const copyDuplicateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setStep(hasIssues && !overCapacity ? "review" : "confirm")
+      setCopiedInvalid(false)
+      setCopiedDuplicate(false)
+      setSendError(null)
+    }
+  }, [open, hasIssues, overCapacity])
+
+  useEffect(() => {
+    return () => {
+      if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
+      if (copyDuplicateTimerRef.current) clearTimeout(copyDuplicateTimerRef.current)
+    }
+  }, [])
+
+  const handleCopyInvalid = () => {
+    copyToClipboard(invalidEmails.join("\n"))
+    setCopiedInvalid(true)
+    if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
+    copyInvalidTimerRef.current = setTimeout(() => setCopiedInvalid(false), 2000)
+  }
+
+  const handleCopyDuplicate = () => {
+    copyToClipboard(duplicateEmails.join("\n"))
+    setCopiedDuplicate(true)
+    if (copyDuplicateTimerRef.current) clearTimeout(copyDuplicateTimerRef.current)
+    copyDuplicateTimerRef.current = setTimeout(() => setCopiedDuplicate(false), 2000)
+  }
+
+  const handleSend = async () => {
+    setIsSubmitting(true)
+    setSendError(null)
+    try {
+      await onConfirm()
+      onClose()
+    } catch {
+      setSendError("Something went wrong. Please try again.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const seatsAfterSending = availableSeats - validCount
+  const overLimit = validCount - availableSeats
+
+  // ── Over-capacity state (CSV only) ────────────────────────────────────────
+
+  if (overCapacity) {
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="sm"
+        aria-describedby={descriptionId}
+        title={
+          <>
+            <IconBadge $variant="error" aria-hidden="true">
+              <RiAlertFill />
+            </IconBadge>
+            Not enough seats available
+          </>
+        }
+        actions={
+          <DialogActions>
+            <Button variant="primary" onClick={onClose}>
+              Close &amp; Update CSV
+            </Button>
+          </DialogActions>
+        }
+      >
+        <VisuallyHidden id={descriptionId}>
+          {`${validCount} learners were imported, but only ${availableSeats} seats remain. ${overLimit} learners exceed the remaining contract capacity and cannot be assigned.`}
+        </VisuallyHidden>
+        <Stack gap="24px">
+          <DescriptionText>
+            <strong>{validCount}</strong> learners were imported, but only{" "}
+            <strong>{availableSeats} seats</strong> remain.{" "}
+            <strong>{overLimit} learners</strong> exceed the remaining contract
+            capacity and cannot be assigned.
+          </DescriptionText>
+          <StatsCard $variant="error">
+            <StatColumn>
+              <StatValue>{validCount}</StatValue>
+              <StatLabel>Imported</StatLabel>
+            </StatColumn>
+            <StatDivider />
+            <StatColumn>
+              <StatValue $error>{availableSeats}</StatValue>
+              <StatLabel>Seats available</StatLabel>
+            </StatColumn>
+            <StatDivider />
+            <StatColumn>
+              <StatValue $error>{overLimit}</StatValue>
+              <StatLabel>Over the limit</StatLabel>
+            </StatColumn>
+          </StatsCard>
+          <InfoNote>
+            <RiInformationLine aria-hidden="true" />
+            Update your CSV to reduce the number of learners before continuing.
+          </InfoNote>
+        </Stack>
+      </Dialog>
+    )
+  }
+
+  // ── Review step (has invalid/duplicate emails) ────────────────────────────
+
+  if (step === "review") {
+    const reviewTitle = hasInvalid
+      ? "Some learners could not be added"
+      : "Duplicate emails removed"
+
+    return (
+      <Dialog
+        open={open}
+        onClose={onClose}
+        fullWidth
+        maxWidth="sm"
+        aria-describedby={descriptionId}
+        title={
+          <>
+            <IconBadge $variant="warning" aria-hidden="true">
+              <RiAlertFill />
+            </IconBadge>
+            {reviewTitle}
+          </>
+        }
+        actions={
+          <DialogActions>
+            <Button variant="bordered" color="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={() => setStep("confirm")}>
+              Review &amp; Confirm
+            </Button>
+          </DialogActions>
+        }
+      >
+        <VisuallyHidden id={descriptionId}>
+          {`${validCount} learners are ready to invite.${hasInvalid ? ` ${invalidEmails.length} email addresses were invalid.` : ""}${hasDuplicates ? ` ${duplicateCount} duplicate email addresses were removed.` : ""}`}
+        </VisuallyHidden>
+        <Stack gap="24px">
+          <DescriptionText>
+            <strong>{validCount} learners are ready</strong> to invite.{" "}
+            {hasInvalid && (
+              <>
+                <strong>{invalidEmails.length}</strong>{" "}
+                {pluralize("email address", invalidEmails.length, "email addresses")}{" "}
+                {hasInvalid && hasDuplicates
+                  ? "were invalid."
+                  : "were invalid and will be excluded."}
+              </>
+            )}
+            {hasInvalid && hasDuplicates && " "}
+            {hasDuplicates && (
+              <>
+                <strong>{duplicateCount}</strong> duplicate{" "}
+                {pluralize("email address", duplicateCount, "email addresses")}{" "}
+                {duplicateCount === 1 ? "was" : "were"} removed.
+                {!hasInvalid && " Only the first instance of each email was kept."}
+              </>
+            )}
+            {skippedCount > 0 && (
+              <>
+                {" "}
+                <strong>
+                  {skippedCount} {pluralize("row", skippedCount)} skipped
+                </strong>{" "}
+                — no email address found.
+              </>
+            )}
+          </DescriptionText>
+
+          {hasInvalid && (
+            <EmailAlertBox>
+              <AlertBoxTitle component="p">
+                Invalid email addresses ({invalidEmails.length})
+              </AlertBoxTitle>
+              <EmailListExpand emails={invalidEmails} />
+              <CopyLink onClick={handleCopyInvalid} type="button">
+                <RiFileCopyLine aria-hidden="true" />
+                {copiedInvalid ? "Copied!" : "Copy all invalid emails"}
+              </CopyLink>
+            </EmailAlertBox>
+          )}
+
+          {hasDuplicates && (
+            <EmailAlertBox>
+              <AlertBoxTitle component="p">
+                Duplicate email addresses ({duplicateCount})
+              </AlertBoxTitle>
+              <EmailListExpand emails={duplicateEmails} />
+              <CopyLink onClick={handleCopyDuplicate} type="button">
+                <RiFileCopyLine aria-hidden="true" />
+                {copiedDuplicate ? "Copied!" : "Copy all duplicate emails"}
+              </CopyLink>
+            </EmailAlertBox>
+          )}
+
+          <InfoNote>
+            <RiInformationLine aria-hidden="true" />
+            Only valid, unique emails will be assigned.
+          </InfoNote>
+        </Stack>
+      </Dialog>
+    )
+  }
+
+  // ── Confirm step ("Ready to send invitations") ────────────────────────────
 
   return (
     <Dialog
       open={open}
       onClose={onClose}
-      onConfirm={overCapacity ? () => {} : onConfirm}
-      title={
-        overCapacity
-          ? "Too many invitees"
-          : `${validCount} ${pluralize("email", validCount)} ready to assign`
-      }
-      confirmText={confirmText}
-      cancelText={overCapacity ? null : "Cancel"}
       fullWidth
       maxWidth="sm"
       aria-describedby={descriptionId}
+      title="Ready to send invitations"
+      actions={
+        <DialogActions>
+          <Button variant="bordered" color="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSend}
+            disabled={isSubmitting}
+          >
+            Send {validCount} {pluralize("Invitation", validCount)}
+          </Button>
+        </DialogActions>
+      }
     >
-      <VisuallyHidden id={descriptionId}>{descriptionText}</VisuallyHidden>
-      {overCapacity ? (
-        <Typography variant="body1">{overCapacityBody}</Typography>
-      ) : (
-        <Stack gap="16px">
-          <Typography variant="body1">
-            {hasIssues
-              ? `${validCount} ${pluralize("email", validCount)} imported and ready to assign.`
-              : `Are you sure you want to send invitations to ${validCount} ${pluralize("recipient", validCount)}?`}
+      <VisuallyHidden id={descriptionId}>
+        {`You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials.`}
+      </VisuallyHidden>
+      <Stack gap="24px">
+        <DescriptionText>
+          You are about to send <strong>{validCount}</strong> invitation{" "}
+          {pluralize("email", validCount)} from MIT Learn. Learners will receive
+          an email with secure link to claim their seat and access the materials.
+        </DescriptionText>
+        <StatsCard $variant="default">
+          <StatColumn>
+            <StatValue>{validCount}</StatValue>
+            <StatLabel>Invitations</StatLabel>
+          </StatColumn>
+          <StatDivider />
+          <StatColumn>
+            <StatValue>{seatsAfterSending}</StatValue>
+            <StatLabel>Seats remaining after sending</StatLabel>
+          </StatColumn>
+          <StatDivider />
+          <StatColumn>
+            <RiMailLine
+              aria-hidden="true"
+              style={{ width: "28px", height: "28px" }}
+            />
+            <StatLabel>
+              Emails will be sent immediately and cannot be recalled.
+            </StatLabel>
+          </StatColumn>
+        </StatsCard>
+        {sendError && (
+          <Typography variant="body2" component="p" color="error">
+            {sendError}
           </Typography>
-          {duplicateCount > 0 && (
-            <DuplicateNotice>
-              {duplicateCount} {pluralize("duplicate", duplicateCount)} removed
-              — only 1 instance kept per address.
-            </DuplicateNotice>
-          )}
-          {skippedCount > 0 && (
-            <DuplicateNotice>
-              {skippedCount} {pluralize("row", skippedCount)} skipped — no email
-              address found.
-            </DuplicateNotice>
-          )}
-          {invalidEmails.length > 0 && (
-            <Stack gap="4px">
-              <SectionLabel component="p">
-                These addresses were not valid and were not added:
-              </SectionLabel>
-              <InvalidEmailList emails={invalidEmails} />
-            </Stack>
-          )}
-        </Stack>
-      )}
+        )}
+      </Stack>
     </Dialog>
   )
 }

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -185,8 +185,31 @@ const EmailListExpand: React.FC<{ emails: string[] }> = ({ emails }) => {
   )
 }
 
-const copyToClipboard = (text: string) => {
-  navigator.clipboard?.writeText(text).catch(() => undefined)
+const copyToClipboard = async (text: string): Promise<boolean> => {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+  // execCommand fallback for non-secure contexts (HTTP dev environments).
+  // Sets clipboard data via the copy event directly, bypassing focus trap
+  // issues caused by MUI Dialog.
+  return new Promise<boolean>((resolve) => {
+    const handler = (e: ClipboardEvent) => {
+      e.clipboardData?.setData("text/plain", text)
+      e.preventDefault()
+      resolve(true)
+    }
+    document.addEventListener("copy", handler, { once: true })
+    const success = document.execCommand("copy")
+    if (!success) {
+      document.removeEventListener("copy", handler)
+      resolve(false)
+    }
+  })
 }
 
 // ─── Main component ───────────────────────────────────────────────────────────
@@ -275,8 +298,9 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
     }
   }, [])
 
-  const handleCopyInvalid = () => {
-    copyToClipboard(invalidEmails.join("\n"))
+  const handleCopyInvalid = async () => {
+    const ok = await copyToClipboard(invalidEmails.join("\n"))
+    if (!ok) return
     setCopiedInvalid(true)
     if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
     copyInvalidTimerRef.current = setTimeout(
@@ -285,8 +309,9 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
     )
   }
 
-  const handleCopyDuplicate = () => {
-    copyToClipboard(duplicateEmails.join("\n"))
+  const handleCopyDuplicate = async () => {
+    const ok = await copyToClipboard(duplicateEmails.join("\n"))
+    if (!ok) return
     setCopiedDuplicate(true)
     if (copyDuplicateTimerRef.current)
       clearTimeout(copyDuplicateTimerRef.current)

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -23,21 +23,18 @@ import {
 const IconBadge = styled("span", {
   shouldForwardProp: (prop) => prop !== "$variant",
 })<{ $variant: "warning" | "error" }>(({ theme, $variant }) => ({
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-    width: "28px",
-    height: "28px",
-    borderRadius: "50%",
-    backgroundColor:
-      $variant === "error"
-        ? theme.custom.colors.red
-        : theme.custom.colors.orange,
-    color: theme.custom.colors.white,
-    flexShrink: 0,
-    "& svg": { width: "20px", height: "20px" },
-  }),
-)
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "28px",
+  height: "28px",
+  borderRadius: "50%",
+  backgroundColor:
+    $variant === "error" ? theme.custom.colors.red : theme.custom.colors.orange,
+  color: theme.custom.colors.white,
+  flexShrink: 0,
+  "& svg": { width: "20px", height: "20px" },
+}))
 
 // ─── Email alert box (invalid / duplicate list) ───────────────────────────────
 
@@ -114,19 +111,18 @@ const DescriptionText = styled(Typography)(({ theme }) => ({
 const StatsCard = styled("div", {
   shouldForwardProp: (prop) => prop !== "$variant",
 })<{ $variant: "default" | "error" }>(({ theme, $variant }) => ({
-    backgroundColor:
-      $variant === "error"
-        ? theme.custom.colors.white
-        : theme.custom.colors.lightGray1,
-    border: `1px solid ${$variant === "error" ? theme.custom.colors.red : theme.custom.colors.lightGray2}`,
-    borderRadius: "4px",
-    padding: "16px",
-    display: "flex",
-    alignItems: "center",
-    gap: "16px",
-    width: "100%",
-  }),
-)
+  backgroundColor:
+    $variant === "error"
+      ? theme.custom.colors.white
+      : theme.custom.colors.lightGray1,
+  border: `1px solid ${$variant === "error" ? theme.custom.colors.red : theme.custom.colors.lightGray2}`,
+  borderRadius: "4px",
+  padding: "16px",
+  display: "flex",
+  alignItems: "center",
+  gap: "16px",
+  width: "100%",
+}))
 
 const StatDivider = styled("div")(({ theme }) => ({
   width: "1px",

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -219,6 +219,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   skippedCount,
 }) => {
   const descriptionId = useId()
+  const overCapacitySummaryId = `${descriptionId}-summary`
 
   const hasInvalid = invalidEmails.length > 0
   const hasDuplicates = duplicateCount > 0
@@ -232,8 +233,15 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const [copiedDuplicate, setCopiedDuplicate] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
+  // Assertive live region text for step transitions. Using reset-then-set (100ms
+  // delay) so NVDA picks up the content change cleanly after focus settles on the
+  // new step's first focusable element inside the same persistent dialog.
+  const [stepAnnouncement, setStepAnnouncement] = useState("")
   const copyInvalidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const copyDuplicateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
+  const stepAnnouncementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
 
@@ -243,6 +251,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       setCopiedInvalid(false)
       setCopiedDuplicate(false)
       setSendError(null)
+      setStepAnnouncement("")
     }
   }, [open, hasIssues, overCapacity])
 
@@ -251,6 +260,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
       if (copyDuplicateTimerRef.current)
         clearTimeout(copyDuplicateTimerRef.current)
+      if (stepAnnouncementTimerRef.current)
+        clearTimeout(stepAnnouncementTimerRef.current)
     }
   }, [])
 
@@ -291,43 +302,130 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const seatsAfterSending = availableSeats - validCount
   const overLimit = validCount - availableSeats
 
-  // ── Over-capacity state (CSV only) ────────────────────────────────────────
+  const reviewTitle = hasInvalid
+    ? "Some learners could not be added"
+    : "Duplicate emails removed"
 
-  if (overCapacity) {
-    return (
-      <Dialog
-        open={open}
-        onClose={onClose}
-        fullWidth
-        maxWidth="sm"
-        aria-describedby={descriptionId}
-        title={
-          <>
-            <IconBadge $variant="error" aria-hidden="true">
-              <RiAlertFill />
-            </IconBadge>
-            Not enough seats available
-          </>
-        }
-        actions={
-          <DialogActions>
-            <Button variant="primary" onClick={onClose}>
-              Close &amp; Update CSV
-            </Button>
-          </DialogActions>
-        }
-      >
-        <VisuallyHidden id={descriptionId}>
-          {`${validCount} learners were imported, but only ${availableSeats} seats remain. ${overLimit} learners exceed the remaining contract capacity and cannot be assigned. Update your CSV to reduce the number of learners before continuing.`}
-        </VisuallyHidden>
+  // Advance from the review step to the confirm step within the same dialog
+  // instance. Using an assertive live region (reset-then-set) rather than
+  // mounting a new Dialog so that focus stays trapped and NVDA doesn't have
+  // to re-discover a new role="dialog" element.
+  const handleReviewAndConfirm = () => {
+    setStep("confirm")
+    const confirmText = `Ready to send invitations. You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with a secure link to claim their seat and access the materials. ${seatsAfterSending} seats remaining after sending. Emails will be sent immediately and cannot be recalled.`
+    setStepAnnouncement("")
+    if (stepAnnouncementTimerRef.current)
+      clearTimeout(stepAnnouncementTimerRef.current)
+    stepAnnouncementTimerRef.current = setTimeout(
+      () => setStepAnnouncement(confirmText),
+      100,
+    )
+  }
+
+  // ── Derived title / actions / description (single Dialog, step-based) ──────
+
+  const dialogTitle = overCapacity ? (
+    <>
+      <IconBadge $variant="error" aria-hidden="true">
+        <RiAlertFill />
+      </IconBadge>
+      Not enough seats available
+    </>
+  ) : step === "review" ? (
+    <>
+      <IconBadge $variant="warning" aria-hidden="true">
+        <RiAlertFill />
+      </IconBadge>
+      {reviewTitle}
+    </>
+  ) : (
+    "Ready to send invitations"
+  )
+
+  const dialogActions = overCapacity ? (
+    <DialogActions>
+      <Button variant="primary" onClick={onClose}>
+        Close &amp; Update CSV
+      </Button>
+    </DialogActions>
+  ) : step === "review" ? (
+    <DialogActions>
+      <Button variant="bordered" color="secondary" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button variant="primary" onClick={handleReviewAndConfirm}>
+        Review &amp; Confirm
+      </Button>
+    </DialogActions>
+  ) : (
+    <DialogActions>
+      <Button variant="bordered" color="secondary" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button variant="primary" onClick={handleSend} disabled={isSubmitting}>
+        Send {validCount} {pluralize("Invitation", validCount)}
+      </Button>
+    </DialogActions>
+  )
+
+  const dialogDescription = overCapacity
+    ? `${validCount} learners were imported, but only ${availableSeats} seats remain. ${overLimit} learners exceed the remaining contract capacity and cannot be assigned. Update your CSV to reduce the number of learners before continuing.`
+    : step === "review"
+      ? [
+          `${validCount} learners are ready to invite.`,
+          hasInvalid
+            ? ` ${invalidEmails.length} ${pluralize("email address", invalidEmails.length, "email addresses")} were invalid and will be excluded.`
+            : "",
+          hasDuplicates
+            ? ` ${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")} ${duplicateCount === 1 ? "was" : "were"} removed.`
+            : "",
+          skippedCount > 0
+            ? ` ${skippedCount} ${pluralize("row", skippedCount)} skipped — no email address found.`
+            : "",
+          " Only valid, unique emails will be assigned.",
+        ].join("")
+      : `You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSending} seats remaining after sending. Emails will be sent immediately and cannot be recalled.`
+
+  // For overCapacity we point aria-describedby at the visible paragraph so
+  // role="alertdialog" reads it exactly once on open. We do NOT programmatically
+  // focus that paragraph — focus goes to the first interactive element (close
+  // button) so NVDA enters forms mode, preventing browse-mode mouse-hover reads.
+  const dialogDescribedBy = overCapacity ? overCapacitySummaryId : descriptionId
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullWidth
+      maxWidth="sm"
+      aria-describedby={dialogDescribedBy}
+      role={overCapacity ? "alertdialog" : undefined}
+      title={dialogTitle}
+      actions={dialogActions}
+    >
+      {/* Static description read when focus first enters the dialog.
+          Not rendered for overCapacity — focus on the visible paragraph handles
+          that announcement to avoid a double-read. */}
+      {!overCapacity && (
+        <VisuallyHidden id={descriptionId}>{dialogDescription}</VisuallyHidden>
+      )}
+      {/* Step-transition announcement — fires after focus settles on the new
+          step's content within the same dialog, so NVDA doesn't re-read the
+          previous step or miss the new one */}
+      <VisuallyHidden aria-live="assertive" aria-atomic="true">
+        {stepAnnouncement}
+      </VisuallyHidden>
+
+      {/* ── Over-capacity content ──────────────────────────────────────────── */}
+      {overCapacity && (
         <Stack gap="24px">
-          <DescriptionText>
+          <DescriptionText id={overCapacitySummaryId}>
             <strong>{validCount}</strong> learners were imported, but only{" "}
             <strong>{availableSeats} seats</strong> remain.{" "}
             <strong>{overLimit} learners</strong> exceed the remaining contract
             capacity and cannot be assigned.
           </DescriptionText>
-          <StatsCard $variant="error">
+          <StatsCard $variant="error" aria-hidden="true">
             <StatColumn role="group" aria-label={`${validCount} imported`}>
               <StatValue aria-hidden="true">{validCount}</StatValue>
               <StatLabel aria-hidden="true">Imported</StatLabel>
@@ -355,58 +453,10 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             Update your CSV to reduce the number of learners before continuing.
           </InfoNote>
         </Stack>
-      </Dialog>
-    )
-  }
+      )}
 
-  // ── Review step (has invalid/duplicate emails) ────────────────────────────
-
-  if (step === "review") {
-    const reviewTitle = hasInvalid
-      ? "Some learners could not be added"
-      : "Duplicate emails removed"
-
-    return (
-      <Dialog
-        open={open}
-        onClose={onClose}
-        fullWidth
-        maxWidth="sm"
-        aria-describedby={descriptionId}
-        title={
-          <>
-            <IconBadge $variant="warning" aria-hidden="true">
-              <RiAlertFill />
-            </IconBadge>
-            {reviewTitle}
-          </>
-        }
-        actions={
-          <DialogActions>
-            <Button variant="bordered" color="secondary" onClick={onClose}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={() => setStep("confirm")}>
-              Review &amp; Confirm
-            </Button>
-          </DialogActions>
-        }
-      >
-        <VisuallyHidden id={descriptionId}>
-          {[
-            `${validCount} learners are ready to invite.`,
-            hasInvalid
-              ? ` ${invalidEmails.length} ${pluralize("email address", invalidEmails.length, "email addresses")} were invalid and will be excluded.`
-              : "",
-            hasDuplicates
-              ? ` ${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")} ${duplicateCount === 1 ? "was" : "were"} removed.`
-              : "",
-            skippedCount > 0
-              ? ` ${skippedCount} ${pluralize("row", skippedCount)} skipped — no email address found.`
-              : "",
-            " Only valid, unique emails will be assigned.",
-          ].join("")}
-        </VisuallyHidden>
+      {/* ── Review step content ────────────────────────────────────────────── */}
+      {!overCapacity && step === "review" && (
         <Stack gap="24px">
           <DescriptionText>
             <strong>{validCount} learners are ready</strong> to invite.{" "}
@@ -475,80 +525,58 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             Only valid, unique emails will be assigned.
           </InfoNote>
         </Stack>
-      </Dialog>
-    )
-  }
+      )}
 
-  // ── Confirm step ("Ready to send invitations") ────────────────────────────
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      fullWidth
-      maxWidth="sm"
-      aria-describedby={descriptionId}
-      title="Ready to send invitations"
-      actions={
-        <DialogActions>
-          <Button variant="bordered" color="secondary" onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            onClick={handleSend}
-            disabled={isSubmitting}
-          >
-            Send {validCount} {pluralize("Invitation", validCount)}
-          </Button>
-        </DialogActions>
-      }
-    >
-      <VisuallyHidden id={descriptionId}>
-        {`You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSending} seats remaining after sending. Emails will be sent immediately and cannot be recalled.`}
-      </VisuallyHidden>
-      <Stack gap="24px">
-        <DescriptionText>
-          You are about to send <strong>{validCount}</strong> invitation{" "}
-          {pluralize("email", validCount)} from MIT Learn. Learners will receive
-          an email with secure link to claim their seat and access the
-          materials.
-        </DescriptionText>
-        <StatsCard $variant="default">
-          <StatColumn
-            role="group"
-            aria-label={`${validCount} ${pluralize("invitation", validCount)}`}
-          >
-            <StatValue aria-hidden="true">{validCount}</StatValue>
-            <StatLabel aria-hidden="true">Invitations</StatLabel>
-          </StatColumn>
-          <StatDivider aria-hidden="true" />
-          <StatColumn
-            role="group"
-            aria-label={`${seatsAfterSending} seats remaining after sending`}
-          >
-            <StatValue aria-hidden="true">{seatsAfterSending}</StatValue>
-            <StatLabel aria-hidden="true">
-              Seats remaining after sending
-            </StatLabel>
-          </StatColumn>
-          <StatDivider aria-hidden="true" />
-          <StatColumn>
-            <RiMailLine
-              aria-hidden="true"
-              style={{ width: "28px", height: "28px" }}
-            />
-            <StatLabel>
-              Emails will be sent immediately and cannot be recalled.
-            </StatLabel>
-          </StatColumn>
-        </StatsCard>
-        {sendError && (
-          <Typography variant="body2" component="p" color="error" role="alert">
-            {sendError}
-          </Typography>
-        )}
-      </Stack>
+      {/* ── Confirm step content ───────────────────────────────────────────── */}
+      {!overCapacity && step === "confirm" && (
+        <Stack gap="24px">
+          <DescriptionText>
+            You are about to send <strong>{validCount}</strong> invitation{" "}
+            {pluralize("email", validCount)} from MIT Learn. Learners will
+            receive an email with secure link to claim their seat and access the
+            materials.
+          </DescriptionText>
+          <StatsCard $variant="default">
+            <StatColumn
+              role="group"
+              aria-label={`${validCount} ${pluralize("invitation", validCount)}`}
+            >
+              <StatValue aria-hidden="true">{validCount}</StatValue>
+              <StatLabel aria-hidden="true">Invitations</StatLabel>
+            </StatColumn>
+            <StatDivider aria-hidden="true" />
+            <StatColumn
+              role="group"
+              aria-label={`${seatsAfterSending} seats remaining after sending`}
+            >
+              <StatValue aria-hidden="true">{seatsAfterSending}</StatValue>
+              <StatLabel aria-hidden="true">
+                Seats remaining after sending
+              </StatLabel>
+            </StatColumn>
+            <StatDivider aria-hidden="true" />
+            <StatColumn>
+              <RiMailLine
+                aria-hidden="true"
+                style={{ width: "28px", height: "28px" }}
+              />
+              <StatLabel>
+                Emails will be sent immediately and cannot be recalled.
+              </StatLabel>
+            </StatColumn>
+          </StatsCard>
+          {sendError && (
+            <Typography
+              variant="body2"
+              component="p"
+              color="error"
+              role="alert"
+            >
+              {sendError}
+            </Typography>
+          )}
+        </Stack>
+      )}
     </Dialog>
   )
 }

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -201,7 +201,6 @@ type AssignSeatsConfirmModalProps = {
   availableSeats: number
   invalidEmails: string[]
   duplicateEmails: string[]
-  duplicateCount: number
   skippedCount: number
 }
 
@@ -215,15 +214,14 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   availableSeats,
   invalidEmails,
   duplicateEmails,
-  duplicateCount,
   skippedCount,
 }) => {
   const descriptionId = useId()
   const overCapacitySummaryId = `${descriptionId}-summary`
 
   const hasInvalid = invalidEmails.length > 0
-  const hasDuplicates = duplicateCount > 0
-  const hasIssues = hasInvalid || hasDuplicates
+  const hasDuplicates = duplicateEmails.length > 0
+  const hasIssues = hasInvalid || hasDuplicates || skippedCount > 0
   const overCapacity = validCount > availableSeats
 
   const [step, setStep] = useState<Step>(() =>
@@ -304,7 +302,9 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
 
   const reviewTitle = hasInvalid
     ? "Some learners could not be added"
-    : "Duplicate emails removed"
+    : hasDuplicates
+      ? "Duplicate emails removed"
+      : "Some rows were skipped"
 
   // Advance from the review step to the confirm step within the same dialog
   // instance. Using an assertive live region (reset-then-set) rather than
@@ -363,7 +363,9 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         Cancel
       </Button>
       <Button variant="primary" onClick={handleSend} disabled={isSubmitting}>
-        Send {validCount} {pluralize("Invitation", validCount)}
+        {isSubmitting
+          ? "Sending…"
+          : `Send ${validCount} ${pluralize("Invitation", validCount)}`}
       </Button>
     </DialogActions>
   )
@@ -377,7 +379,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             ? ` ${invalidEmails.length} ${pluralize("email address", invalidEmails.length, "email addresses")} were invalid and will be excluded.`
             : "",
           hasDuplicates
-            ? ` ${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")} ${duplicateCount === 1 ? "was" : "were"} removed.`
+            ? ` ${duplicateEmails.length} duplicate ${pluralize("email address", duplicateEmails.length, "email addresses")} ${duplicateEmails.length === 1 ? "was" : "were"} removed.`
             : "",
           skippedCount > 0
             ? ` ${skippedCount} ${pluralize("row", skippedCount)} skipped — no email address found.`
@@ -476,9 +478,13 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             {hasInvalid && hasDuplicates && " "}
             {hasDuplicates && (
               <>
-                <strong>{duplicateCount}</strong> duplicate{" "}
-                {pluralize("email address", duplicateCount, "email addresses")}{" "}
-                {duplicateCount === 1 ? "was" : "were"} removed.
+                <strong>{duplicateEmails.length}</strong> duplicate{" "}
+                {pluralize(
+                  "email address",
+                  duplicateEmails.length,
+                  "email addresses",
+                )}{" "}
+                {duplicateEmails.length === 1 ? "was" : "were"} removed.
                 {!hasInvalid &&
                   " Only the first instance of each email was kept."}
               </>
@@ -510,7 +516,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           {hasDuplicates && (
             <EmailAlertBox>
               <AlertBoxTitle component="p">
-                Duplicate email addresses ({duplicateCount})
+                Duplicate email addresses ({duplicateEmails.length})
               </AlertBoxTitle>
               <EmailListExpand emails={duplicateEmails} />
               <CopyLink onClick={handleCopyDuplicate} type="button">

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -169,8 +169,8 @@ const EmailListExpand: React.FC<{ emails: string[] }> = ({ emails }) => {
   return (
     <div>
       <EmailListUl>
-        {visible.map((email) => (
-          <li key={email}>{email}</li>
+        {visible.map((email, idx) => (
+          <li key={`${email}-${idx}`}>{email}</li>
         ))}
       </EmailListUl>
       {!expanded && hidden > 0 && (

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -20,8 +20,9 @@ import {
 
 // ─── Icon badges ─────────────────────────────────────────────────────────────
 
-const IconBadge = styled("span")<{ $variant: "warning" | "error" }>(
-  ({ theme, $variant }) => ({
+const IconBadge = styled("span", {
+  shouldForwardProp: (prop) => prop !== "$variant",
+})<{ $variant: "warning" | "error" }>(({ theme, $variant }) => ({
     display: "inline-flex",
     alignItems: "center",
     justifyContent: "center",
@@ -110,8 +111,9 @@ const DescriptionText = styled(Typography)(({ theme }) => ({
 
 // ─── Stats card ───────────────────────────────────────────────────────────────
 
-const StatsCard = styled("div")<{ $variant: "default" | "error" }>(
-  ({ theme, $variant }) => ({
+const StatsCard = styled("div", {
+  shouldForwardProp: (prop) => prop !== "$variant",
+})<{ $variant: "default" | "error" }>(({ theme, $variant }) => ({
     backgroundColor:
       $variant === "error"
         ? theme.custom.colors.white
@@ -188,7 +190,7 @@ const EmailListExpand: React.FC<{ emails: string[] }> = ({ emails }) => {
 }
 
 const copyToClipboard = (text: string) => {
-  navigator.clipboard.writeText(text).catch(() => undefined)
+  navigator.clipboard?.writeText(text).catch(() => undefined)
 }
 
 // ─── Main component ───────────────────────────────────────────────────────────
@@ -235,6 +237,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   // delay) so NVDA picks up the content change cleanly after focus settles on the
   // new step's first focusable element inside the same persistent dialog.
   const [stepAnnouncement, setStepAnnouncement] = useState("")
+  const [sendErrorAnnouncement, setSendErrorAnnouncement] = useState("")
+  const prevOpenRef = useRef(open)
   const copyInvalidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const copyDuplicateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -242,13 +246,23 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const stepAnnouncementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   )
+  const sendErrorAnnouncementTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
 
+  // Only reset step and copy state when the dialog transitions from closed to
+  // open. Without prevOpenRef the effect would also fire when hasIssues or
+  // overCapacity change while the dialog is already open (e.g. a parent
+  // re-render), resetting the user's progress mid-flow.
   useEffect(() => {
-    if (open) {
+    const wasOpen = prevOpenRef.current
+    prevOpenRef.current = open
+    if (open && !wasOpen) {
       setStep(hasIssues && !overCapacity ? "review" : "confirm")
       setCopiedInvalid(false)
       setCopiedDuplicate(false)
       setSendError(null)
+      setSendErrorAnnouncement("")
       setStepAnnouncement("")
     }
   }, [open, hasIssues, overCapacity])
@@ -260,6 +274,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         clearTimeout(copyDuplicateTimerRef.current)
       if (stepAnnouncementTimerRef.current)
         clearTimeout(stepAnnouncementTimerRef.current)
+      if (sendErrorAnnouncementTimerRef.current)
+        clearTimeout(sendErrorAnnouncementTimerRef.current)
     }
   }, [])
 
@@ -291,7 +307,18 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       await onConfirm()
       onClose()
     } catch {
-      setSendError("Something went wrong. Please try again.")
+      const msg = "Something went wrong. Please try again."
+      setSendError(msg)
+      // Announce via assertive live region — same reset-then-set pattern used
+      // elsewhere in this file, because dynamically-mounted role="alert" elements
+      // are not consistently picked up by NVDA when other live regions are active.
+      setSendErrorAnnouncement("")
+      if (sendErrorAnnouncementTimerRef.current)
+        clearTimeout(sendErrorAnnouncementTimerRef.current)
+      sendErrorAnnouncementTimerRef.current = setTimeout(
+        () => setSendErrorAnnouncement(msg),
+        100,
+      )
     } finally {
       setIsSubmitting(false)
     }
@@ -401,7 +428,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       fullWidth
       maxWidth="sm"
       aria-describedby={dialogDescribedBy}
-      role={overCapacity ? "alertdialog" : undefined}
+      PaperProps={overCapacity ? { role: "alertdialog" } : undefined}
       title={dialogTitle}
       actions={dialogActions}
     >
@@ -416,6 +443,19 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           previous step or miss the new one */}
       <VisuallyHidden aria-live="assertive" aria-atomic="true">
         {stepAnnouncement}
+      </VisuallyHidden>
+      {/* Send-error announcement — workaround for dynamically-mounted role="alert"
+          not being consistently picked up by NVDA when other live regions are active */}
+      <VisuallyHidden aria-live="assertive" aria-atomic="true">
+        {sendErrorAnnouncement}
+      </VisuallyHidden>
+      {/* Copy-success announcement — polite so it doesn't interrupt ongoing speech */}
+      <VisuallyHidden aria-live="polite" aria-atomic="true">
+        {copiedInvalid
+          ? "Copied invalid emails to clipboard."
+          : copiedDuplicate
+            ? "Copied duplicate emails to clipboard."
+            : ""}
       </VisuallyHidden>
 
       {/* ── Over-capacity content ──────────────────────────────────────────── */}

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import React, { useEffect, useId, useRef, useState } from "react"
-import { Dialog, DialogActions, Stack, Typography, alpha, styled } from "ol-components"
+import {
+  Dialog,
+  DialogActions,
+  Stack,
+  Typography,
+  alpha,
+  styled,
+} from "ol-components"
 import { Button, VisuallyHidden } from "@mitodl/smoot-design"
 import { pluralize } from "ol-utilities"
 import {
@@ -106,7 +113,9 @@ const DescriptionText = styled(Typography)(({ theme }) => ({
 const StatsCard = styled("div")<{ $variant: "default" | "error" }>(
   ({ theme, $variant }) => ({
     backgroundColor:
-      $variant === "error" ? theme.custom.colors.white : theme.custom.colors.lightGray1,
+      $variant === "error"
+        ? theme.custom.colors.white
+        : theme.custom.colors.lightGray1,
     border: `1px solid ${$variant === "error" ? theme.custom.colors.red : theme.custom.colors.lightGray2}`,
     borderRadius: "4px",
     padding: "16px",
@@ -221,7 +230,9 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
   const copyInvalidTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const copyDuplicateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const copyDuplicateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  )
 
   useEffect(() => {
     if (open) {
@@ -235,7 +246,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   useEffect(() => {
     return () => {
       if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
-      if (copyDuplicateTimerRef.current) clearTimeout(copyDuplicateTimerRef.current)
+      if (copyDuplicateTimerRef.current)
+        clearTimeout(copyDuplicateTimerRef.current)
     }
   }, [])
 
@@ -243,14 +255,21 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
     copyToClipboard(invalidEmails.join("\n"))
     setCopiedInvalid(true)
     if (copyInvalidTimerRef.current) clearTimeout(copyInvalidTimerRef.current)
-    copyInvalidTimerRef.current = setTimeout(() => setCopiedInvalid(false), 2000)
+    copyInvalidTimerRef.current = setTimeout(
+      () => setCopiedInvalid(false),
+      2000,
+    )
   }
 
   const handleCopyDuplicate = () => {
     copyToClipboard(duplicateEmails.join("\n"))
     setCopiedDuplicate(true)
-    if (copyDuplicateTimerRef.current) clearTimeout(copyDuplicateTimerRef.current)
-    copyDuplicateTimerRef.current = setTimeout(() => setCopiedDuplicate(false), 2000)
+    if (copyDuplicateTimerRef.current)
+      clearTimeout(copyDuplicateTimerRef.current)
+    copyDuplicateTimerRef.current = setTimeout(
+      () => setCopiedDuplicate(false),
+      2000,
+    )
   }
 
   const handleSend = async () => {
@@ -372,7 +391,11 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             {hasInvalid && (
               <>
                 <strong>{invalidEmails.length}</strong>{" "}
-                {pluralize("email address", invalidEmails.length, "email addresses")}{" "}
+                {pluralize(
+                  "email address",
+                  invalidEmails.length,
+                  "email addresses",
+                )}{" "}
                 {hasInvalid && hasDuplicates
                   ? "were invalid."
                   : "were invalid and will be excluded."}
@@ -384,7 +407,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
                 <strong>{duplicateCount}</strong> duplicate{" "}
                 {pluralize("email address", duplicateCount, "email addresses")}{" "}
                 {duplicateCount === 1 ? "was" : "were"} removed.
-                {!hasInvalid && " Only the first instance of each email was kept."}
+                {!hasInvalid &&
+                  " Only the first instance of each email was kept."}
               </>
             )}
             {skippedCount > 0 && (
@@ -465,7 +489,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         <DescriptionText>
           You are about to send <strong>{validCount}</strong> invitation{" "}
           {pluralize("email", validCount)} from MIT Learn. Learners will receive
-          an email with secure link to claim their seat and access the materials.
+          an email with secure link to claim their seat and access the
+          materials.
         </DescriptionText>
         <StatsCard $variant="default">
           <StatColumn>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -176,7 +176,10 @@ const EmailListExpand: React.FC<{ emails: string[] }> = ({ emails }) => {
         ))}
       </EmailListUl>
       {!expanded && hidden > 0 && (
-        <ShowMoreButton onClick={() => setExpanded(true)}>
+        <ShowMoreButton
+          onClick={() => setExpanded(true)}
+          aria-label={`Show ${hidden} more email addresses`}
+        >
           + {hidden} more
         </ShowMoreButton>
       )}
@@ -315,7 +318,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         }
       >
         <VisuallyHidden id={descriptionId}>
-          {`${validCount} learners were imported, but only ${availableSeats} seats remain. ${overLimit} learners exceed the remaining contract capacity and cannot be assigned.`}
+          {`${validCount} learners were imported, but only ${availableSeats} seats remain. ${overLimit} learners exceed the remaining contract capacity and cannot be assigned. Update your CSV to reduce the number of learners before continuing.`}
         </VisuallyHidden>
         <Stack gap="24px">
           <DescriptionText>
@@ -325,19 +328,26 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             capacity and cannot be assigned.
           </DescriptionText>
           <StatsCard $variant="error">
-            <StatColumn>
-              <StatValue>{validCount}</StatValue>
-              <StatLabel>Imported</StatLabel>
+            <StatColumn role="group" aria-label={`${validCount} imported`}>
+              <StatValue aria-hidden="true">{validCount}</StatValue>
+              <StatLabel aria-hidden="true">Imported</StatLabel>
             </StatColumn>
-            <StatDivider />
-            <StatColumn>
-              <StatValue $error>{availableSeats}</StatValue>
-              <StatLabel>Seats available</StatLabel>
+            <StatDivider aria-hidden="true" />
+            <StatColumn
+              role="group"
+              aria-label={`${availableSeats} seats available`}
+            >
+              <StatValue $error aria-hidden="true">
+                {availableSeats}
+              </StatValue>
+              <StatLabel aria-hidden="true">Seats available</StatLabel>
             </StatColumn>
-            <StatDivider />
-            <StatColumn>
-              <StatValue $error>{overLimit}</StatValue>
-              <StatLabel>Over the limit</StatLabel>
+            <StatDivider aria-hidden="true" />
+            <StatColumn role="group" aria-label={`${overLimit} over the limit`}>
+              <StatValue $error aria-hidden="true">
+                {overLimit}
+              </StatValue>
+              <StatLabel aria-hidden="true">Over the limit</StatLabel>
             </StatColumn>
           </StatsCard>
           <InfoNote>
@@ -383,7 +393,19 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         }
       >
         <VisuallyHidden id={descriptionId}>
-          {`${validCount} learners are ready to invite.${hasInvalid ? ` ${invalidEmails.length} email addresses were invalid.` : ""}${hasDuplicates ? ` ${duplicateCount} duplicate email addresses were removed.` : ""}`}
+          {[
+            `${validCount} learners are ready to invite.`,
+            hasInvalid
+              ? ` ${invalidEmails.length} ${pluralize("email address", invalidEmails.length, "email addresses")} were invalid and will be excluded.`
+              : "",
+            hasDuplicates
+              ? ` ${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")} ${duplicateCount === 1 ? "was" : "were"} removed.`
+              : "",
+            skippedCount > 0
+              ? ` ${skippedCount} ${pluralize("row", skippedCount)} skipped — no email address found.`
+              : "",
+            " Only valid, unique emails will be assigned.",
+          ].join("")}
         </VisuallyHidden>
         <Stack gap="24px">
           <DescriptionText>
@@ -483,7 +505,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       }
     >
       <VisuallyHidden id={descriptionId}>
-        {`You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials.`}
+        {`You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSending} seats remaining after sending. Emails will be sent immediately and cannot be recalled.`}
       </VisuallyHidden>
       <Stack gap="24px">
         <DescriptionText>
@@ -493,16 +515,24 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           materials.
         </DescriptionText>
         <StatsCard $variant="default">
-          <StatColumn>
-            <StatValue>{validCount}</StatValue>
-            <StatLabel>Invitations</StatLabel>
+          <StatColumn
+            role="group"
+            aria-label={`${validCount} ${pluralize("invitation", validCount)}`}
+          >
+            <StatValue aria-hidden="true">{validCount}</StatValue>
+            <StatLabel aria-hidden="true">Invitations</StatLabel>
           </StatColumn>
-          <StatDivider />
-          <StatColumn>
-            <StatValue>{seatsAfterSending}</StatValue>
-            <StatLabel>Seats remaining after sending</StatLabel>
+          <StatDivider aria-hidden="true" />
+          <StatColumn
+            role="group"
+            aria-label={`${seatsAfterSending} seats remaining after sending`}
+          >
+            <StatValue aria-hidden="true">{seatsAfterSending}</StatValue>
+            <StatLabel aria-hidden="true">
+              Seats remaining after sending
+            </StatLabel>
           </StatColumn>
-          <StatDivider />
+          <StatDivider aria-hidden="true" />
           <StatColumn>
             <RiMailLine
               aria-hidden="true"
@@ -514,7 +544,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           </StatColumn>
         </StatsCard>
         {sendError && (
-          <Typography variant="body2" component="p" color="error">
+          <Typography variant="body2" component="p" color="error" role="alert">
             {sendError}
           </Typography>
         )}

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -237,7 +237,7 @@ describe("AssignSeatsSection", () => {
     await user.click(screen.getByRole("button", { name: "Assign Seats" }))
 
     expect(
-      await screen.findByRole("heading", { name: /email.*ready to assign/i }),
+      await screen.findByRole("heading", { name: /ready to send invitations/i }),
     ).toBeInTheDocument()
   })
 
@@ -277,13 +277,13 @@ describe("AssignSeatsSection", () => {
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com")
     await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-    await screen.findByRole("heading", { name: /email.*ready to assign/i })
+    await screen.findByRole("heading", { name: /ready to send invitations/i })
 
     await user.click(screen.getByRole("button", { name: /cancel/i }))
 
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: /email.*ready to assign/i }),
+        screen.queryByRole("heading", { name: /ready to send invitations/i }),
       ).not.toBeInTheDocument(),
     )
   })
@@ -305,7 +305,7 @@ describe("AssignSeatsSection", () => {
     await user.upload(fileInput, file)
 
     expect(
-      await screen.findByRole("heading", { name: /2 emails ready to assign/i }),
+      await screen.findByRole("heading", { name: /ready to send invitations/i }),
     ).toBeInTheDocument()
     expect(screen.getByPlaceholderText(/enter employee emails/i)).toHaveValue(
       "",
@@ -414,7 +414,7 @@ describe("AssignSeatsSection", () => {
       await user.click(textarea)
       await user.paste(emails)
       await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-      await user.click(screen.getByRole("button", { name: /send 2 emails/i }))
+      await user.click(screen.getByRole("button", { name: /send 2 invitations/i }))
     }
 
     test("assigns seats and shows a success alert, clearing the input", async () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -410,10 +410,12 @@ describe("AssignSeatsSection", () => {
     await user.upload(fileInput, file)
 
     await screen.findByRole("alert")
-    const assertiveRegion = document.querySelector("[aria-live='assertive']")
-    expect(assertiveRegion).toHaveTextContent(
-      /no valid email addresses found in this file/i,
-    )
+    await waitFor(() => {
+      const assertiveRegion = document.querySelector("[aria-live='assertive']")
+      expect(assertiveRegion).toHaveTextContent(
+        /no valid email addresses found in this file/i,
+      )
+    })
   })
 
   test("accepts newline-separated emails", async () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -237,7 +237,9 @@ describe("AssignSeatsSection", () => {
     await user.click(screen.getByRole("button", { name: "Assign Seats" }))
 
     expect(
-      await screen.findByRole("heading", { name: /ready to send invitations/i }),
+      await screen.findByRole("heading", {
+        name: /ready to send invitations/i,
+      }),
     ).toBeInTheDocument()
   })
 
@@ -305,7 +307,9 @@ describe("AssignSeatsSection", () => {
     await user.upload(fileInput, file)
 
     expect(
-      await screen.findByRole("heading", { name: /ready to send invitations/i }),
+      await screen.findByRole("heading", {
+        name: /ready to send invitations/i,
+      }),
     ).toBeInTheDocument()
     expect(screen.getByPlaceholderText(/enter employee emails/i)).toHaveValue(
       "",
@@ -414,7 +418,9 @@ describe("AssignSeatsSection", () => {
       await user.click(textarea)
       await user.paste(emails)
       await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-      await user.click(screen.getByRole("button", { name: /send 2 invitations/i }))
+      await user.click(
+        screen.getByRole("button", { name: /send 2 invitations/i }),
+      )
     }
 
     test("assigns seats and shows a success alert, clearing the input", async () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -395,6 +395,27 @@ describe("AssignSeatsSection", () => {
     ).not.toBeInTheDocument()
   })
 
+  test("assertive live region announces CSV error text for screen readers", async () => {
+    renderWithProviders(
+      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+    )
+
+    const csvContent = "Email\nNot An Email\nbad@"
+    mockFileContent = csvContent
+    const file = new File([csvContent], "emails.csv", { type: "text/csv" })
+
+    const fileInput = document.querySelector(
+      "input[type='file']",
+    ) as HTMLInputElement
+    await user.upload(fileInput, file)
+
+    await screen.findByRole("alert")
+    const assertiveRegion = document.querySelector("[aria-live='assertive']")
+    expect(assertiveRegion).toHaveTextContent(
+      /no valid email addresses found in this file/i,
+    )
+  })
+
   test("accepts newline-separated emails", async () => {
     renderWithProviders(
       <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -285,6 +285,31 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
     }
   }, [result])
 
+  // Derive the assertive announcement from all error sources in one place so
+  // the two concerns can't clear each other. Two separate effects sharing one
+  // setState caused the second effect to wipe the first when resultContent
+  // went null (e.g. user closes the success Alert).
+  const errorAnnouncement = useMemo(() => {
+    if (csvReadError) return "Error: Could not read the file. Please try again."
+    if (csvNoValid) return "Error: No valid email addresses found in this file."
+    if (resultContent) {
+      const prefix =
+        resultContent.severity === "error" ||
+        resultContent.severity === "warning"
+          ? `${resultContent.severity}: `
+          : ""
+      const errorDetails = resultContent.errors
+        ?.map((e) => `${e.email} — ${e.detail}`)
+        .join(", ")
+      return (
+        prefix +
+        resultContent.message +
+        (errorDetails ? ` ${errorDetails}` : "")
+      )
+    }
+    return ""
+  }, [csvReadError, csvNoValid, resultContent])
+
   const handleCsvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -362,6 +387,11 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       {/* Always-mounted live region — debounced so screen readers aren't spammed on every keystroke */}
       <VisuallyHidden aria-live="polite" aria-atomic="true">
         {debouncedAnnouncement}
+      </VisuallyHidden>
+      {/* Assertive region for errors — workaround for smoot-design Alert announcing
+          only its aria-describedby ("error message") instead of the children text */}
+      <VisuallyHidden aria-live="assertive" aria-atomic="true">
+        {errorAnnouncement}
       </VisuallyHidden>
       <Stack
         direction={{ xs: "column", sm: "row" }}

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -341,11 +341,11 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       })
       const { valid, invalid, duplicateEmails, skippedCount } =
         extractEmailsFromCsvRows(data)
+      setEmailInput("")
       if (valid.length === 0) {
         setCsvNoValid(true)
         return
       }
-      setEmailInput("")
       setModalData({
         validEmails: valid,
         invalidEmails: invalid,
@@ -379,10 +379,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
         AssignRevokeCodeRequestRequest: emails.map((email) => ({ email })),
       })
       setResult({ assignedCount: data.assigned.length, errors: data.errors })
-      // Clear the input only on a fully successful assignment.
-      if (data.errors.length === 0) {
-        setEmailInput("")
-      }
+      setEmailInput("")
     } catch {
       setResult({ assignedCount: 0, errors: null })
     }

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -195,6 +195,7 @@ const ResultErrorList = styled.ul(({ theme }) => ({
 type ModalData = {
   validEmails: string[]
   invalidEmails: string[]
+  duplicateEmails: string[]
   duplicateCount: number
   skippedCount: number
 }
@@ -297,7 +298,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       const { data } = Papa.parse<string[]>(text, {
         skipEmptyLines: true,
       })
-      const { valid, invalid, duplicateCount, skippedCount } =
+      const { valid, invalid, duplicateEmails, duplicateCount, skippedCount } =
         extractEmailsFromCsvRows(data)
       if (valid.length === 0) {
         setCsvNoValid(true)
@@ -307,6 +308,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       setModalData({
         validEmails: valid,
         invalidEmails: invalid,
+        duplicateEmails,
         duplicateCount,
         skippedCount,
       })
@@ -319,6 +321,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
     setModalData({
       validEmails: submitResult.valid,
       invalidEmails: submitResult.invalid,
+      duplicateEmails: submitResult.duplicateEmails,
       duplicateCount: submitResult.duplicateCount,
       skippedCount: submitResult.skippedCount,
     })
@@ -506,6 +509,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
           validCount={modalData.validEmails.length}
           availableSeats={availableSeats}
           invalidEmails={modalData.invalidEmails}
+          duplicateEmails={modalData.duplicateEmails}
           duplicateCount={modalData.duplicateCount}
           skippedCount={modalData.skippedCount}
         />

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -266,9 +266,22 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
           .filter(Boolean)
           .join(" and ")} will be ignored`
       : ""
-  const announcement = hasEmails
-    ? `${validCount} valid ${pluralize("email", validCount)}${invalidCount > 0 ? `, ${invalidCount} invalid` : ""}${duplicateCount > 0 ? `, ${duplicateCount} ${pluralize("duplicate", duplicateCount)}` : ""}${ignoreWarning}${overCapacity ? `. Error: You entered ${validCount} ${pluralize("email", validCount)}, but only ${availableSeats} unassigned ${pluralize("seat", availableSeats)} are available. Remove ${validCount - availableSeats} more email ${pluralize("address", validCount - availableSeats, "addresses")} to continue.` : ""}`
-    : ""
+  let announcement = ""
+  if (hasEmails) {
+    const parts = [`${validCount} valid ${pluralize("email", validCount)}`]
+    if (invalidCount > 0) parts.push(`${invalidCount} invalid`)
+    if (duplicateCount > 0)
+      parts.push(`${duplicateCount} ${pluralize("duplicate", duplicateCount)}`)
+    announcement = parts.join(", ") + ignoreWarning
+    if (overCapacity) {
+      const excess = validCount - availableSeats
+      const seatsClause =
+        availableSeats > 1
+          ? `${availableSeats} unassigned ${pluralize("seat", availableSeats)} are available.`
+          : `${availableSeats} unassigned seat is available.`
+      announcement += `. Error: You entered ${validCount} ${pluralize("email", validCount)}, but only ${seatsClause} Remove ${excess} more email ${pluralize("address", excess, "addresses")} to continue.`
+    }
+  }
 
   // Debounce the live-region text so screen readers aren't spammed on every keystroke.
   useEffect(() => {
@@ -556,9 +569,10 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       )}
       {overCapacity && (
         <Alert severity="error">
-          You entered {validCount} {pluralize("email", validCount)}, but only{" "}
-          {availableSeats} unassigned {pluralize("seat", availableSeats)} are
-          available. Remove {validCount - availableSeats} more email{" "}
+          {availableSeats > 1
+            ? `You entered ${validCount} ${pluralize("email", validCount)}, but only ${availableSeats} unassigned ${pluralize("seat", availableSeats)} are available.`
+            : `You entered ${validCount} ${pluralize("email", validCount)}, but only ${availableSeats} unassigned seat is available.`}{" "}
+          Remove {validCount - availableSeats} more email{" "}
           {pluralize("address", validCount - availableSeats, "addresses")} to
           continue.
         </Alert>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -67,24 +67,26 @@ const DisabledLink = styled.span(({ theme }) => ({
   opacity: 0.5,
 }))
 
-const ValidationBadge = styled.div(({ theme }) => ({
-  display: "inline-flex",
-  gap: "24px",
-  backgroundColor: theme.custom.colors.lightGray1,
-  border: `1px solid ${theme.custom.colors.lightGray2}`,
-  borderRadius: "4px",
-  padding: "8px 16px",
-  ...theme.typography.subtitle3,
-  fontWeight: theme.typography.fontWeightMedium as number,
-}))
-
-const ValidCount = styled.span(({ theme }) => ({
-  color: theme.custom.colors.darkGreen,
-}))
-
-const InvalidCount = styled.span(({ theme }) => ({
-  color: theme.custom.colors.darkRed,
-}))
+const CountBadge = styled.div<{ $variant: "valid" | "warning" | "default" }>(
+  ({ theme, $variant }) => ({
+    display: "inline-flex",
+    backgroundColor:
+      $variant === "warning"
+        ? theme.custom.colors.white
+        : theme.custom.colors.lightGray1,
+    border: `1px solid ${$variant === "warning" ? theme.custom.colors.darkRed : theme.custom.colors.lightGray2}`,
+    borderRadius: "4px",
+    padding: "8px 16px",
+    ...theme.typography.subtitle3,
+    fontWeight: theme.typography.fontWeightMedium as number,
+    color:
+      $variant === "valid"
+        ? theme.custom.colors.darkGreen
+        : $variant === "warning"
+          ? theme.custom.colors.darkRed
+          : theme.custom.colors.darkGray2,
+  }),
+)
 
 /**
  * Wrapper for the textarea + highlight overlay. We use a custom textarea here
@@ -145,7 +147,7 @@ const EmailTextarea = styled("textarea")<{ $transparent: boolean }>(
     background: "transparent",
     border: "none",
     outline: "none",
-    resize: "none",
+    resize: "vertical",
     fontFamily: "inherit",
     fontSize: TA_FONT_SIZE,
     lineHeight: TA_LINE_HEIGHT,
@@ -238,6 +240,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   )
   const validCount = submitResult.valid.length
   const invalidCount = submitResult.invalid.length
+  const duplicateCount = submitResult.duplicateEmails.length
   const hasEmails = emailInput.trim().length > 0
   const canSubmit = validCount > 0
 
@@ -249,8 +252,22 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   )
   const showOverlay = hasEmails
 
+  const overCapacity = validCount > availableSeats
+  const ignoreWarning =
+    !overCapacity && (invalidCount > 0 || duplicateCount > 0)
+      ? `. ${[
+          duplicateCount > 0
+            ? `${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")}`
+            : "",
+          invalidCount > 0
+            ? `${invalidCount} invalid ${pluralize("email address", invalidCount, "email addresses")}`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" and ")} will be ignored`
+      : ""
   const announcement = hasEmails
-    ? `${validCount} valid ${pluralize("email", validCount)}${invalidCount > 0 ? `, ${invalidCount} invalid` : ""}`
+    ? `${validCount} valid ${pluralize("email", validCount)}${invalidCount > 0 ? `, ${invalidCount} invalid` : ""}${duplicateCount > 0 ? `, ${duplicateCount} ${pluralize("duplicate", duplicateCount)}` : ""}${ignoreWarning}${overCapacity ? `. Error: You entered ${validCount} ${pluralize("email", validCount)}, but only ${availableSeats} unassigned ${pluralize("seat", availableSeats)} are available. Remove ${validCount - availableSeats} more email ${pluralize("address", validCount - availableSeats, "addresses")} to continue.` : ""}`
     : ""
 
   // Debounce the live-region text so screen readers aren't spammed on every keystroke.
@@ -459,24 +476,34 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
             />
           </EmailInputRoot>
           {hasEmails && (
-            <ValidationBadge id="assign-seats-validation" aria-hidden="true">
-              <ValidCount>{validCount} valid</ValidCount>
-              {invalidCount > 0 && (
-                <InvalidCount>{invalidCount} invalid</InvalidCount>
-              )}
-            </ValidationBadge>
-          )}
-          {validCount > availableSeats && (
-            <InvalidCount>
-              Only {availableSeats} unassigned{" "}
-              {pluralize("seat", availableSeats)} available.
-            </InvalidCount>
+            <Stack
+              direction="row"
+              alignItems="center"
+              flexWrap="wrap"
+              gap="8px"
+            >
+              <CountBadge $variant="valid" aria-hidden="true">
+                {validCount} valid
+              </CountBadge>
+              <CountBadge
+                $variant={invalidCount > 0 ? "warning" : "default"}
+                aria-hidden="true"
+              >
+                {invalidCount} invalid
+              </CountBadge>
+              <CountBadge
+                $variant={duplicateCount > 0 ? "warning" : "default"}
+                aria-hidden="true"
+              >
+                {duplicateCount} {pluralize("duplicate", duplicateCount)}
+              </CountBadge>
+            </Stack>
           )}
         </Stack>
         <ButtonWrapper>
           <Button
             variant="primary"
-            disabled={!canSubmit || validCount > availableSeats}
+            disabled={!canSubmit || overCapacity}
             onClick={handleAssignSeats}
           >
             Assign Seats
@@ -514,6 +541,30 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
           </DisabledLink>
         </Tooltip>
       </Stack>
+      {!overCapacity && (invalidCount > 0 || duplicateCount > 0) && (
+        <Alert severity="warning">
+          {[
+            duplicateCount > 0
+              ? `${duplicateCount} duplicate ${pluralize("email address", duplicateCount, "email addresses")}`
+              : "",
+            invalidCount > 0
+              ? `${invalidCount} invalid ${pluralize("email address", invalidCount, "email addresses")}`
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" and ")}{" "}
+          will be ignored
+        </Alert>
+      )}
+      {overCapacity && (
+        <Alert severity="error">
+          You entered {validCount} {pluralize("email", validCount)}, but only{" "}
+          {availableSeats} unassigned {pluralize("seat", availableSeats)} are
+          available. Remove {validCount - availableSeats} more email{" "}
+          {pluralize("address", validCount - availableSeats, "addresses")} to
+          continue.
+        </Alert>
+      )}
       {csvReadError && (
         <Alert severity="error" closable onClose={() => setCsvReadError(false)}>
           Could not read the file. Please try again.

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -196,7 +196,6 @@ type ModalData = {
   validEmails: string[]
   invalidEmails: string[]
   duplicateEmails: string[]
-  duplicateCount: number
   skippedCount: number
 }
 
@@ -340,7 +339,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       const { data } = Papa.parse<string[]>(text, {
         skipEmptyLines: true,
       })
-      const { valid, invalid, duplicateEmails, duplicateCount, skippedCount } =
+      const { valid, invalid, duplicateEmails, skippedCount } =
         extractEmailsFromCsvRows(data)
       if (valid.length === 0) {
         setCsvNoValid(true)
@@ -351,7 +350,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
         validEmails: valid,
         invalidEmails: invalid,
         duplicateEmails,
-        duplicateCount,
         skippedCount,
       })
     }
@@ -364,7 +362,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       validEmails: submitResult.valid,
       invalidEmails: submitResult.invalid,
       duplicateEmails: submitResult.duplicateEmails,
-      duplicateCount: submitResult.duplicateCount,
       skippedCount: submitResult.skippedCount,
     })
   }
@@ -557,7 +554,6 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
           availableSeats={availableSeats}
           invalidEmails={modalData.invalidEmails}
           duplicateEmails={modalData.duplicateEmails}
-          duplicateCount={modalData.duplicateCount}
           skippedCount={modalData.skippedCount}
         />
       )}

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -485,18 +485,16 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
               <CountBadge $variant="valid" aria-hidden="true">
                 {validCount} valid
               </CountBadge>
-              <CountBadge
-                $variant={invalidCount > 0 ? "warning" : "default"}
-                aria-hidden="true"
-              >
-                {invalidCount} invalid
-              </CountBadge>
-              <CountBadge
-                $variant={duplicateCount > 0 ? "warning" : "default"}
-                aria-hidden="true"
-              >
-                {duplicateCount} {pluralize("duplicate", duplicateCount)}
-              </CountBadge>
+              {invalidCount > 0 && (
+                <CountBadge $variant="warning" aria-hidden="true">
+                  {invalidCount} invalid
+                </CountBadge>
+              )}
+              {duplicateCount > 0 && (
+                <CountBadge $variant="warning" aria-hidden="true">
+                  {duplicateCount} {pluralize("duplicate", duplicateCount)}
+                </CountBadge>
+              )}
             </Stack>
           )}
         </Stack>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -228,6 +228,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   const [modalData, setModalData] = useState<ModalData | null>(null)
   const [result, setResult] = useState<AssignResult | null>(null)
   const [debouncedAnnouncement, setDebouncedAnnouncement] = useState("")
+  const [errorAnnouncement, setErrorAnnouncement] = useState("")
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const bulkAssign = useBulkAssignSeats()
@@ -289,7 +290,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   // the two concerns can't clear each other. Two separate effects sharing one
   // setState caused the second effect to wipe the first when resultContent
   // went null (e.g. user closes the success Alert).
-  const errorAnnouncement = useMemo(() => {
+  const errorAnnouncementText = useMemo(() => {
     if (csvReadError) return "Error: Could not read the file. Please try again."
     if (csvNoValid) return "Error: No valid email addresses found in this file."
     if (resultContent) {
@@ -309,6 +310,22 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
     }
     return ""
   }, [csvReadError, csvNoValid, resultContent])
+
+  // Reset-then-set with a short delay so the assertive live region fires after
+  // smoot-design Alert's role="alert" has been processed by NVDA. Without the
+  // delay, both fire in the same frame and NVDA drops the live-region update.
+  useEffect(() => {
+    if (!errorAnnouncementText) {
+      setErrorAnnouncement("")
+      return
+    }
+    setErrorAnnouncement("")
+    const id = setTimeout(
+      () => setErrorAnnouncement(errorAnnouncementText),
+      100,
+    )
+    return () => clearTimeout(id)
+  }, [errorAnnouncementText])
 
   const handleCsvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import Image from "next/image"
 import { useQuery } from "@tanstack/react-query"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -341,6 +341,14 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     message: string
     severity: "success" | "error"
   } | null>(null)
+  const [rowActionAnnouncement, setRowActionAnnouncement] = useState("")
+
+  // Mirror row-action Alert text into an assertive live region — smoot-design
+  // Alert announces only its aria-describedby ("success/error message") via NVDA
+  // instead of the actual children text. Must be before early returns (Rules of Hooks).
+  useEffect(() => {
+    setRowActionAnnouncement(rowActionResult?.message ?? "")
+  }, [rowActionResult])
 
   const {
     data: managerOrgs,
@@ -525,6 +533,11 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
         {/* Seat Assignments */}
         <SeatAssignmentsSection>
           <SectionTitle component="h2">Seat Assignments</SectionTitle>
+          {/* Assertive live region — workaround for smoot-design Alert reading
+              only aria-describedby ("success/error message") instead of children */}
+          <VisuallyHidden aria-live="assertive" aria-atomic="true">
+            {rowActionAnnouncement}
+          </VisuallyHidden>
           {rowActionResult && (
             <Alert
               severity={rowActionResult.severity}

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -346,8 +346,18 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   // Mirror row-action Alert text into an assertive live region — smoot-design
   // Alert announces only its aria-describedby ("success/error message") via NVDA
   // instead of the actual children text. Must be before early returns (Rules of Hooks).
+  // Reset-then-set with a 100ms delay so the live region fires after the Alert's
+  // role="alert" has been processed by NVDA, preventing the update from being dropped.
   useEffect(() => {
-    setRowActionAnnouncement(rowActionResult?.message ?? "")
+    if (!rowActionResult?.message) {
+      setRowActionAnnouncement("")
+      return
+    }
+    const prefix = rowActionResult.severity === "error" ? "error: " : ""
+    const text = prefix + rowActionResult.message
+    setRowActionAnnouncement("")
+    const id = setTimeout(() => setRowActionAnnouncement(text), 100)
+    return () => clearTimeout(id)
   }, [rowActionResult])
 
   const {

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useId, useState } from "react"
 import {
   Dialog,
   Divider,
@@ -92,6 +92,8 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
   const [reassignOpen, setReassignOpen] = useState(false)
   const [reassignEmail, setReassignEmail] = useState("")
   const [reassignTouched, setReassignTouched] = useState(false)
+  const revokeDescId = useId()
+  const reassignDescId = useId()
   const open = Boolean(anchorEl)
 
   const remind = useRemindCode()
@@ -294,10 +296,13 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         title={isRedeemed ? "Uninvite learner" : "Release seat"}
         confirmText={isRedeemed ? "Uninvite" : "Release seat"}
         maxWidth="sm"
+        aria-describedby={revokeDescId}
       >
-        {isRedeemed
-          ? `This will remove ${assignedTo}'s access to the program. This cannot be undone.`
-          : `This will revoke the invitation for ${assignedTo} and return the seat to the unassigned pool.`}
+        <p id={revokeDescId} style={{ margin: 0 }}>
+          {isRedeemed
+            ? `This will remove ${assignedTo}'s access to the program. This cannot be undone.`
+            : `This will revoke the invitation for ${assignedTo} and return the seat to the unassigned pool.`}
+        </p>
       </Dialog>
       <FormDialog
         open={reassignOpen}
@@ -308,8 +313,9 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         disabled={!emailValid}
         maxWidth="sm"
         noValidate
+        aria-describedby={reassignDescId}
       >
-        <Typography variant="body2">
+        <Typography variant="body2" id={reassignDescId}>
           The invitation for {assignedTo} will be reassigned to the new address
           and a claim email sent there.
         </Typography>

--- a/frontends/ol-components/src/components/Dialog/Dialog.tsx
+++ b/frontends/ol-components/src/components/Dialog/Dialog.tsx
@@ -7,7 +7,7 @@ import type { DialogProps as MuiDialogProps } from "@mui/material/Dialog"
 import { Button, ActionButton } from "@mitodl/smoot-design"
 import MuiDialogActions from "@mui/material/DialogActions"
 import { RiCloseLine } from "@remixicon/react"
-import Typography from "@mui/material/Typography"
+import MuiTypography from "@mui/material/Typography"
 
 const Close = styled.div`
   position: absolute;
@@ -38,13 +38,19 @@ const DialogActions = styled(MuiDialogActions)`
   }
 `
 
+const HeaderTitle = styled(MuiTypography)`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+` as typeof MuiTypography
+
 type DialogProps = {
   className?: string
   contentCss?: CSSObject
   open: boolean
   onClose: () => void
   onConfirm?: () => void | Promise<void>
-  title?: string
+  title?: React.ReactNode
   message?: string
   children?: React.ReactNode
   /**
@@ -141,13 +147,13 @@ const Dialog: React.FC<DialogProps> = ({
       </Close>
       {title && (
         <Header>
-          <Typography id={titleId} component="h1" variant="h5">
+          <HeaderTitle id={titleId} component="h1" variant="h5">
             {title}
-          </Typography>
+          </HeaderTitle>
         </Header>
       )}
       <Content css={contentCss}>
-        {message && <Typography variant="body1">{message}</Typography>}
+        {message && <MuiTypography variant="body1">{message}</MuiTypography>}
         {children}
       </Content>
       {actions !== undefined ? (

--- a/frontends/ol-components/src/components/Dialog/Dialog.tsx
+++ b/frontends/ol-components/src/components/Dialog/Dialog.tsx
@@ -77,6 +77,7 @@ type DialogProps = {
   scroll?: MuiDialogProps["scroll"]
   TransitionProps?: NonNullable<MuiDialogProps["slotProps"]>["transition"]
   "aria-describedby"?: string
+  role?: MuiDialogProps["role"]
 }
 
 /**
@@ -107,6 +108,7 @@ const Dialog: React.FC<DialogProps> = ({
   scroll,
   TransitionProps,
   "aria-describedby": ariaDescribedBy,
+  role,
 }) => {
   const [confirming, setConfirming] = useState(isSubmitting)
   const titleId = useId()
@@ -136,6 +138,7 @@ const Dialog: React.FC<DialogProps> = ({
       }}
       aria-labelledby={titleId}
       aria-describedby={ariaDescribedBy}
+      role={role}
       transitionDuration={process.env.NODE_ENV === "test" ? 0 : undefined}
       maxWidth={maxWidth}
       scroll={scroll}

--- a/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
+++ b/frontends/ol-components/src/components/FormDialog/FormDialog.tsx
@@ -65,6 +65,7 @@ interface FormDialogProps {
   maxWidth?: DialogProps["maxWidth"]
   disabled?: boolean
   TransitionProps?: DialogProps["TransitionProps"]
+  "aria-describedby"?: string
 }
 
 /**
@@ -93,6 +94,7 @@ const FormDialog: React.FC<FormDialogProps> = ({
   maxWidth,
   disabled = false,
   TransitionProps,
+  "aria-describedby": ariaDescribedBy,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = useCallback(
@@ -140,6 +142,7 @@ const FormDialog: React.FC<FormDialogProps> = ({
       maxWidth={maxWidth}
       disabled={isSubmitting || disabled}
       TransitionProps={TransitionProps}
+      aria-describedby={ariaDescribedBy}
     >
       <FormContent>{children}</FormContent>
     </Dialog>

--- a/frontends/ol-utilities/src/string/utils.test.ts
+++ b/frontends/ol-utilities/src/string/utils.test.ts
@@ -38,13 +38,35 @@ describe("extractEmailsFromCsvRows", () => {
     },
   )
 
-  test("counts data rows with no @ as skipped (not header rows)", () => {
+  test("counts data rows with no @ as skipped (no header row — column unknown)", () => {
     const { valid, skippedCount } = extract([
       ["alice@example.com"],
       ["no-email-here"],
       ["bob@example.com"],
     ])
     expect(valid).toEqual(["alice@example.com", "bob@example.com"])
+    expect(skippedCount).toBe(1)
+  })
+
+  test("treats no-@ values as invalid when email column is identified via header", () => {
+    const { valid, invalid, skippedCount } = extract([
+      ["id", "name", "email"],
+      ["1", "Alice", "alice@example.com"],
+      ["2", "Bob", "notanemail"],
+      ["3", "Carol", "carol@example.com"],
+    ])
+    expect(valid).toEqual(["alice@example.com", "carol@example.com"])
+    expect(invalid).toEqual(["notanemail"])
+    expect(skippedCount).toBe(0)
+  })
+
+  test("skips rows with blank email column when header is present", () => {
+    const { valid, skippedCount } = extract([
+      ["id", "name", "email"],
+      ["1", "Alice", "alice@example.com"],
+      ["2", "Bob", ""],
+    ])
+    expect(valid).toEqual(["alice@example.com"])
     expect(skippedCount).toBe(1)
   })
 
@@ -77,13 +99,14 @@ describe("extractEmailsFromCsvRows", () => {
   })
 
   test("deduplicates emails case-insensitively and counts duplicates", () => {
-    const { valid, duplicateCount } = extract([
+    const { valid, duplicateCount, duplicateEmails } = extract([
       ["alice@example.com"],
       ["Alice@Example.COM"],
       ["bob@example.com"],
     ])
     expect(valid).toEqual(["alice@example.com", "bob@example.com"])
     expect(duplicateCount).toBe(1)
+    expect(duplicateEmails).toEqual(["Alice@Example.COM"])
   })
 
   test("returns clean result with empty arrays for valid input", () => {
@@ -91,6 +114,7 @@ describe("extractEmailsFromCsvRows", () => {
     expect(result).toEqual({
       valid: ["alice@example.com", "bob@example.com"],
       invalid: [],
+      duplicateEmails: [],
       duplicateCount: 0,
       skippedCount: 0,
     })
@@ -134,6 +158,7 @@ describe("parseEmailsForSubmit", () => {
     expect(result).toEqual({
       valid: ["alice@example.com", "bob@example.com"],
       invalid: [],
+      duplicateEmails: [],
       duplicateCount: 0,
       skippedCount: 0,
     })
@@ -146,11 +171,12 @@ describe("parseEmailsForSubmit", () => {
   })
 
   test("deduplicates valid emails case-insensitively", () => {
-    const { valid, duplicateCount } = parse(
+    const { valid, duplicateCount, duplicateEmails } = parse(
       "alice@example.com\nAlice@Example.COM\nbob@example.com",
     )
     expect(valid).toEqual(["alice@example.com", "bob@example.com"])
     expect(duplicateCount).toBe(1)
+    expect(duplicateEmails).toEqual(["Alice@Example.COM"])
   })
 
   test("handles newline-separated input", () => {
@@ -163,6 +189,7 @@ describe("parseEmailsForSubmit", () => {
     expect(result).toEqual({
       valid: [],
       invalid: [],
+      duplicateEmails: [],
       duplicateCount: 0,
       skippedCount: 0,
     })

--- a/frontends/ol-utilities/src/string/utils.test.ts
+++ b/frontends/ol-utilities/src/string/utils.test.ts
@@ -109,6 +109,18 @@ describe("extractEmailsFromCsvRows", () => {
     expect(duplicateEmails).toEqual(["Alice@Example.COM"])
   })
 
+  test("does not add repeated entries to duplicateEmails when same address appears 3+ times", () => {
+    const { valid, duplicateCount, duplicateEmails } = extract([
+      ["alice@example.com"],
+      ["alice@example.com"],
+      ["alice@example.com"],
+      ["bob@example.com"],
+    ])
+    expect(valid).toEqual(["alice@example.com", "bob@example.com"])
+    expect(duplicateCount).toBe(2)
+    expect(duplicateEmails).toEqual(["alice@example.com"])
+  })
+
   test("returns clean result with empty arrays for valid input", () => {
     const result = extract([["alice@example.com"], ["bob@example.com"]])
     expect(result).toEqual({

--- a/frontends/ol-utilities/src/string/utils.ts
+++ b/frontends/ol-utilities/src/string/utils.ts
@@ -17,6 +17,7 @@ export const parseEmails = (input: string) =>
 export type EmailParseResult = {
   valid: string[]
   invalid: string[]
+  duplicateEmails: string[]
   duplicateCount: number
   skippedCount: number
 }
@@ -47,29 +48,59 @@ export const extractEmailsFromCsvRows = (
   const invalid: string[] = []
   let skippedCount = 0
 
-  const dataRows =
-    rows.length > 0 && isHeaderRow(rows[0]) ? rows.slice(1) : rows
+  // When the CSV has an identifiable email column header, record its index so
+  // we can validate values in that column even when they contain no "@".
+  // Without a header we fall back to finding any column that contains "@".
+  let dataRows: string[][]
+  let emailColIndex = -1
+
+  if (rows.length > 0 && isHeaderRow(rows[0])) {
+    dataRows = rows.slice(1)
+    emailColIndex = rows[0].findIndex((c) => EMAIL_HEADER_RE.test(c.trim()))
+  } else {
+    dataRows = rows
+  }
 
   for (const cols of dataRows) {
-    const emailCol = cols.map((c) => c.trim()).find((c) => c.includes("@"))
-    if (!emailCol) {
-      skippedCount++
-      continue
-    }
-    if (EMAIL_REGEX.test(emailCol)) {
-      valid.push(emailCol)
+    const trimmed = cols.map((c) => c.trim())
+
+    if (emailColIndex >= 0) {
+      const emailValue = trimmed[emailColIndex] ?? ""
+      if (!emailValue) {
+        // Blank email column — truly no data provided, skip the row.
+        skippedCount++
+        continue
+      }
+      if (EMAIL_REGEX.test(emailValue)) {
+        valid.push(emailValue)
+      } else {
+        // Non-empty value in a known email column that fails validation is
+        // invalid, even if it has no "@" (e.g. "isabeltaylor").
+        invalid.push(emailValue)
+      }
     } else {
-      invalid.push(emailCol)
+      const emailCol = trimmed.find((c) => c.includes("@"))
+      if (!emailCol) {
+        skippedCount++
+        continue
+      }
+      if (EMAIL_REGEX.test(emailCol)) {
+        valid.push(emailCol)
+      } else {
+        invalid.push(emailCol)
+      }
     }
   }
 
   const seen = new Set<string>()
   const deduped: string[] = []
+  const duplicateEmails: string[] = []
   let duplicateCount = 0
 
   for (const email of valid) {
     const key = email.toLowerCase()
     if (seen.has(key)) {
+      duplicateEmails.push(email)
       duplicateCount++
     } else {
       seen.add(key)
@@ -77,7 +108,7 @@ export const extractEmailsFromCsvRows = (
     }
   }
 
-  return { valid: deduped, invalid, duplicateCount, skippedCount }
+  return { valid: deduped, invalid, duplicateEmails, duplicateCount, skippedCount }
 }
 
 /**
@@ -103,11 +134,13 @@ export const parseEmailsForSubmit = (input: string): EmailParseResult => {
 
   const seen = new Set<string>()
   const deduped: string[] = []
+  const duplicateEmails: string[] = []
   let duplicateCount = 0
 
   for (const email of valid) {
     const key = email.toLowerCase()
     if (seen.has(key)) {
+      duplicateEmails.push(email)
       duplicateCount++
     } else {
       seen.add(key)
@@ -115,7 +148,7 @@ export const parseEmailsForSubmit = (input: string): EmailParseResult => {
     }
   }
 
-  return { valid: deduped, invalid, duplicateCount, skippedCount: 0 }
+  return { valid: deduped, invalid, duplicateEmails, duplicateCount, skippedCount: 0 }
 }
 
 export const initials = (title: string): string => {

--- a/frontends/ol-utilities/src/string/utils.ts
+++ b/frontends/ol-utilities/src/string/utils.ts
@@ -108,7 +108,13 @@ export const extractEmailsFromCsvRows = (
     }
   }
 
-  return { valid: deduped, invalid, duplicateEmails, duplicateCount, skippedCount }
+  return {
+    valid: deduped,
+    invalid,
+    duplicateEmails,
+    duplicateCount,
+    skippedCount,
+  }
 }
 
 /**
@@ -148,7 +154,13 @@ export const parseEmailsForSubmit = (input: string): EmailParseResult => {
     }
   }
 
-  return { valid: deduped, invalid, duplicateEmails, duplicateCount, skippedCount: 0 }
+  return {
+    valid: deduped,
+    invalid,
+    duplicateEmails,
+    duplicateCount,
+    skippedCount: 0,
+  }
 }
 
 export const initials = (title: string): string => {

--- a/frontends/ol-utilities/src/string/utils.ts
+++ b/frontends/ol-utilities/src/string/utils.ts
@@ -95,13 +95,17 @@ export const extractEmailsFromCsvRows = (
   const seen = new Set<string>()
   const deduped: string[] = []
   const duplicateEmails: string[] = []
+  const duplicateSeen = new Set<string>()
   let duplicateCount = 0
 
   for (const email of valid) {
     const key = email.toLowerCase()
     if (seen.has(key)) {
-      duplicateEmails.push(email)
       duplicateCount++
+      if (!duplicateSeen.has(key)) {
+        duplicateEmails.push(email)
+        duplicateSeen.add(key)
+      }
     } else {
       seen.add(key)
       deduped.push(email)
@@ -141,13 +145,17 @@ export const parseEmailsForSubmit = (input: string): EmailParseResult => {
   const seen = new Set<string>()
   const deduped: string[] = []
   const duplicateEmails: string[] = []
+  const duplicateSeen = new Set<string>()
   let duplicateCount = 0
 
   for (const email of valid) {
     const key = email.toLowerCase()
     if (seen.has(key)) {
-      duplicateEmails.push(email)
       duplicateCount++
+      if (!duplicateSeen.has(key)) {
+        duplicateEmails.push(email)
+        duplicateSeen.add(key)
+      }
     } else {
       seen.add(key)
       deduped.push(email)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Adds duplicateEmails: string[] prop to AssignSeatsConfirmModal — duplicate addresses are now listed individually in the review step, not just counted
- Adds stats cards to the confirm step (invitations, seats remaining after sending) and the over-capacity state (imported, seats available, over the limit)
- Updates Dialog to accept React.ReactNode for the title prop, enabling icon badges alongside text in dialog headers
- Updates extractEmailsFromCsvRows and parseEmailsForSubmit in ol-utilities to return duplicateEmails[] alongside duplicateCount

### Screen Recording (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots



https://github.com/user-attachments/assets/2f7e2f28-e778-44b7-8172-2066dde9ec05

Using NVDA

https://github.com/user-attachments/assets/25f33436-94a8-4f4f-b3f0-290b952f92f8




### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Confirm step (no issues):

1. Upload a CSV with all valid, unique emails within seat capacity.
2. Confirm the stats card shows the correct invitation count and seats remaining after sending.
3. Click "Send N Invitations" — confirm the modal closes after submission.

Review step (duplicates):

1. Upload a CSV with duplicate emails.
2. Confirm the review step lists the duplicate addresses individually (not just a count).
3. Advance to confirm and send — confirm only deduplicated emails are submitted.

Review step (all invalid):

1. Upload a CSV with only invalid emails.
2. Confirm that an inline error appears and no dialog opens

Review step (invalid + duplicates):

1. Upload a CSV with both invalid and duplicate emails.
2. Confirm both categories render correctly in the review step.

Over-capacity (CSV):

1. Upload a CSV where valid email count exceeds available seats. 
2. Confirm the stats card shows Imported, Seats available, and Over the limit with correct values.

Over-capacity (manual entry):

1. Add valid email count exceeds available seats. 
2. Confirm that an inline error displays and the Assign Seats button is disabled 


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
