### PR TITLE
Program certificate title from CMS "Certificate Title" (behind flag)

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -6,14 +6,23 @@ import CertificatePage from "./CertificatePage"
 import { CertificateType } from "@/common/certificateUtils"
 import SharePopover from "@/components/SharePopover/SharePopover"
 import * as mitxonline from "api/mitxonline-test-utils"
+import { useFeatureFlagEnabled } from "posthog-js/react"
 import {
   FACEBOOK_SHARE_BASE_URL,
   TWITTER_SHARE_BASE_URL,
   LINKEDIN_SHARE_BASE_URL,
 } from "@/common/urls"
 
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  useFeatureFlagEnabled: jest.fn(),
+}))
+const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+
 describe("CertificatePage", () => {
   beforeEach(() => {
+    // Default the CMS-title flag ON; individual tests override as needed.
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
     const mitxUser = mitxonline.factories.user.user()
     setMockResponse.get(mitxonline.urls.userMe.get(), mitxUser)
   })
@@ -84,9 +93,45 @@ describe("CertificatePage", () => {
     await screen.findAllByText(certificate.uuid)
   })
 
-  it("renders a program certificate", async () => {
+  it("renders a program certificate with the CMS product name as the title", async () => {
     const certificate = factories.mitxonline.programCertificate()
     certificate.program.program_type = "Program"
+    certificate.certificate_page.product_name =
+      "Custom Program Certificate Title"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+    renderWithProviders(
+      <CertificatePage
+        certificateType={CertificateType.Program}
+        uuid={certificate.uuid}
+        pageUrl={`https://${process.env.NEXT_PUBLIC_ORIGIN}/certificate/program/${certificate.uuid}`}
+      />,
+    )
+
+    await screen.findAllByText("Custom Program Certificate Title")
+    const badge = await screen.findByTestId("certificate-badge-label")
+    expect(within(badge).getByText("Program")).toBeInTheDocument()
+    expect(within(badge).getByText("Certificate")).toBeInTheDocument()
+    await screen.findAllByText(certificate.user.name!)
+
+    await screen.findAllByText(
+      `Awarded ${certificate.certificate_page.CEUs} Continuing Education Units (CEUs)`,
+    )
+    await screen.findAllByText(
+      moment(certificate.issue_date).format("MMM D, YYYY"),
+    )
+
+    await screen.findAllByText(certificate.uuid)
+  })
+
+  it("falls back to the program title when the certificate page has no product name", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
+    certificate.certificate_page.product_name = ""
     setMockResponse.get(
       mitxonline.urls.certificates.programCertificatesRetrieve({
         uuid: certificate.uuid,
@@ -102,19 +147,29 @@ describe("CertificatePage", () => {
     )
 
     await screen.findAllByText(certificate.program.title)
-    const badge = await screen.findByTestId("certificate-badge-label")
-    expect(within(badge).getByText("Program")).toBeInTheDocument()
-    expect(within(badge).getByText("Certificate")).toBeInTheDocument()
-    await screen.findAllByText(certificate.user.name!)
+  })
 
-    await screen.findAllByText(
-      `Awarded ${certificate.certificate_page.CEUs} Continuing Education Units (CEUs)`,
+  it("shows the program title (not the CMS title) when the flag is off", async () => {
+    mockedUseFeatureFlagEnabled.mockReturnValue(false)
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
+    certificate.certificate_page.product_name = "Custom CMS Title"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        uuid: certificate.uuid,
+      }),
+      certificate,
     )
-    await screen.findAllByText(
-      moment(certificate.issue_date).format("MMM D, YYYY"),
+    renderWithProviders(
+      <CertificatePage
+        certificateType={CertificateType.Program}
+        uuid={certificate.uuid}
+        pageUrl={`https://${process.env.NEXT_PUBLIC_ORIGIN}/certificate/program/${certificate.uuid}`}
+      />,
     )
 
-    await screen.findAllByText(certificate.uuid)
+    await screen.findAllByText(certificate.program.title)
+    expect(screen.queryByText("Custom CMS Title")).not.toBeInTheDocument()
   })
 
   it("renders a MicroMasters program certificate badge with the registered mark", async () => {
@@ -166,7 +221,7 @@ describe("CertificatePage", () => {
       />,
     )
 
-    await screen.findAllByText(certificate.program.title)
+    await screen.findAllByText(certificate.user.name!)
 
     expect(
       screen.queryByRole("button", { name: "Download PDF" }),
@@ -204,7 +259,7 @@ describe("CertificatePage", () => {
       />,
     )
 
-    await screen.findAllByText(certificate.program.title)
+    await screen.findAllByText(certificate.user.name!)
 
     await screen.findByRole("button", { name: "Download PDF" })
     await screen.findByRole("button", { name: "Share" })

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -24,6 +24,7 @@ import SharePopover from "@/components/SharePopover/SharePopover"
 import { DigitalCredentialDialog } from "./DigitalCredentialDialog"
 import {
   getCertificateInfo,
+  getCertificateTitle,
   getCertificateBadgeLines,
   getCertificateBadgeTypography,
   getVerifiableCredentialLinkedInURL,
@@ -31,6 +32,8 @@ import {
   getVerifiableCredentialDownloadAPIURL,
   CertificateType,
 } from "@/common/certificateUtils"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { FeatureFlags } from "@/common/feature_flags"
 
 const Page = styled.div(({ theme }) => ({
   backgroundImage: `url(${backgroundImage.src})`,
@@ -626,11 +629,11 @@ const Certificate = ({
 
 const CourseCertificate = ({
   certificate,
+  title,
 }: {
   certificate: V2CourseRunCertificate
+  title: string
 }) => {
-  const title = certificate.course_run.course.title
-
   const userName = certificate.user.name
 
   const signatories = certificate.certificate_page.signatory_items
@@ -649,11 +652,11 @@ const CourseCertificate = ({
 
 const ProgramCertificate = ({
   certificate,
+  title,
 }: {
   certificate: V2ProgramCertificate
+  title: string
 }) => {
-  const title = certificate.program.title
-
   const userName = certificate.user.name
 
   const ceus = certificate.certificate_page.CEUs
@@ -684,6 +687,11 @@ const CertificatePage: React.FC<{
     useState(false)
 
   const { data: userData } = useQuery(mitxUserQueries.me())
+
+  // Gates whether the certificate title comes from the CMS "Certificate Title"
+  // (product_name) field or the program/course title. Defaults to the
+  // program/course title until the flag loads / is enabled.
+  const useCmsTitle = !!useFeatureFlagEnabled(FeatureFlags.CmsCertificateTitle)
 
   const {
     data: courseCertificateData,
@@ -750,6 +758,18 @@ const CertificatePage: React.FC<{
     return notFound()
   }
 
+  let title = ""
+  if (certificateType === CertificateType.Course) {
+    title = courseCertificateData?.course_run.course.title ?? ""
+  } else if (useCmsTitle) {
+    title = getCertificateTitle(
+      programCertificateData?.certificate_page?.product_name,
+      programCertificateData?.program.title ?? "",
+    )
+  } else {
+    title = programCertificateData?.program.title ?? ""
+  }
+
   const download = async () => {
     const res = await fetch(`/certificate/${certificateType}/${uuid}/pdf`)
     const blob = await res.blob()
@@ -762,11 +782,6 @@ const CertificatePage: React.FC<{
     document.body.removeChild(a)
     window.URL.revokeObjectURL(url)
   }
-
-  const title =
-    certificateType === CertificateType.Course
-      ? courseCertificateData?.course_run.course.title
-      : programCertificateData?.program.title
 
   const { displayType } = getCertificateInfo(
     programCertificateData?.program?.program_type,
@@ -849,9 +864,15 @@ const CertificatePage: React.FC<{
       ) : null}
       <PrintContainer ref={contentRef}>
         {certificateType === CertificateType.Course ? (
-          <CourseCertificate certificate={courseCertificateData!} />
+          <CourseCertificate
+            certificate={courseCertificateData!}
+            title={title}
+          />
         ) : (
-          <ProgramCertificate certificate={programCertificateData!} />
+          <ProgramCertificate
+            certificate={programCertificateData!}
+            title={title}
+          />
         )}
       </PrintContainer>
       <Note>

--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -2,6 +2,7 @@ import {
   getCertificateBadgeLines,
   getCertificateBadgeTypography,
   getCertificateInfo,
+  getCertificateTitle,
 } from "./certificateUtils"
 
 describe("getCertificateInfo", () => {
@@ -42,6 +43,38 @@ describe("getCertificateInfo", () => {
 
   it("falls back to default label for unrecognized program types", () => {
     expect(getCertificateInfo("Degree").displayType).toBe("Certificate")
+  })
+})
+
+describe("getCertificateTitle", () => {
+  it("prefers the CMS product name when present", () => {
+    expect(getCertificateTitle("Universal AI", "Fundamentals of ML")).toBe(
+      "Universal AI",
+    )
+  })
+
+  it("falls back to the program/course title when product name is missing", () => {
+    expect(getCertificateTitle(null, "Fundamentals of ML")).toBe(
+      "Fundamentals of ML",
+    )
+    expect(getCertificateTitle(undefined, "Fundamentals of ML")).toBe(
+      "Fundamentals of ML",
+    )
+  })
+
+  it("falls back when product name is empty or whitespace only", () => {
+    expect(getCertificateTitle("", "Fundamentals of ML")).toBe(
+      "Fundamentals of ML",
+    )
+    expect(getCertificateTitle("   ", "Fundamentals of ML")).toBe(
+      "Fundamentals of ML",
+    )
+  })
+
+  it("trims surrounding whitespace from the product name", () => {
+    expect(getCertificateTitle("  Universal AI  ", "fallback")).toBe(
+      "Universal AI",
+    )
   })
 })
 

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -82,6 +82,11 @@ export const getCertificateInfo = (
   displayType: resolveCertificateLabel(programType).displayType,
 })
 
+export const getCertificateTitle = (
+  productName: string | null | undefined,
+  fallbackTitle: string,
+): string => productName?.trim() || fallbackTitle
+
 const BADGE_REGISTERED_MARK_SCALE = 0.645
 
 export type CertificateBadgeTypography = {

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -17,6 +17,7 @@ export enum FeatureFlags {
   PodcastDetailPage = "podcast-detail-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
   Arithmix = "arithmix",
+  CmsCertificateTitle = "cms-certificate-title",
 }
 
 /**


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11907

### Description (What does it do?)

- Program certificates on MIT Learn now show the CMS certificate page's `product_name` ("Certificate Title") as the displayed title, instead of the program title.
- Gated behind the **`cms-certificate-title`** PostHog flag. Flag **off** (default) or empty `product_name` → falls back to the program title (today's behaviour).
- **Course** certificates are unchanged. **PDF + SEO metadata** intentionally stay on the program title for now (they run server-side where we don't yet evaluate PostHog) — gated in a follow-up.
- Adds a `getCertificateTitle(productName, fallbackTitle)` helper + unit tests, and flag on/off + fallback coverage. The title is resolved once in `CertificatePage` and passed to the sub-components (printed cert, page heading, share text, download filename all use the same value).

> **Rollout note:** keep the flag **off in production** until #11938 (server-side gating of the PDF + share/SEO metadata) lands; otherwise an enabled flag shows the CMS title on the page and share text but the program title in the downloaded PDF and the link-preview card.

### Screenshots (if appropriate):
With Flag On

<img width="1239" height="669" alt="Screenshot 2026-06-23 at 5 08 45 PM" src="https://github.com/user-attachments/assets/f6df8fb4-1a18-411e-a4b4-8c6e0298a5a9" />

With Flag OFF
<img width="1262" height="668" alt="Screenshot 2026-06-23 at 5 08 05 PM" src="https://github.com/user-attachments/assets/e98122e8-925c-4c45-9506-f6fde3360cf7" />

<img width="510" height="298" alt="Screenshot 2026-06-23 at 5 06 42 PM" src="https://github.com/user-attachments/assets/8e1f9194-216e-4290-9d78-96530d1c1569" />



### How can this be tested?

**Need (a) a **program** certificate whose CMS "Certificate Title" differs from its program title, and (b) enable the cms-certificate-title.

1. **Get a certificate whose CMS "Certificate Title" ≠ program title** — either use an existing one (e.g. a UAI program cert; confirm the value in the CMS → Certificate page), **or create one** (set a distinct "Certificate Title" in the CMS + publish, then issue a cert for that program via MITx Online Django admin — no custom scripts).

3. **Toggle the cms-certificate-title flag
4. **Verify** — flag ON → CMS title; OFF → program title; course unchanged; PDF/metadata still program title.


