### PR TITLE
remove semantic chunker and dependance on langchain-experimental

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -871,32 +871,6 @@ CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = get_int(
     name="CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP",
     default=0,  # default that the tokenizer uses
 )
-CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED = get_bool(
-    name="CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED", default=False
-)
-
-SEMANTIC_CHUNKING_CONFIG = {
-    "buffer_size": get_int(
-        # Number of sentences to combine.
-        name="SEMANTIC_CHUNKING_BUFFER_SIZE",
-        default=1,
-    ),
-    "breakpoint_threshold_type": get_string(
-        # 'percentile', 'standard_deviation', 'interquartile', or 'gradient'
-        name="SEMANTIC_CHUNKING_BREAKPOINT_THRESHOLD_TYPE",
-        default="percentile",
-    ),
-    "breakpoint_threshold_amount": get_float(
-        # value we use for breakpoint_threshold_type to filter outliers
-        name="SEMANTIC_CHUNKING_BREAKPOINT_THRESHOLD_AMOUNT",
-        default=None,
-    ),
-    "number_of_chunks": get_int(
-        # number of chunks to consider for merging
-        name="SEMANTIC_CHUNKING_NUMBER_OF_CHUNKS",
-        default=None,
-    ),
-}
 
 CONTENT_FILE_SUMMARIZER_BATCH_SIZE = get_int("CONTENT_FILE_SUMMARIZER_BATCH_SIZE", 20)
 # number of flashcards to generate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
     "isodate>=0.7.2,<0.8",
     "jedi>=0.19.0,<0.20",
     "langchain>=1.3.9,<1.4",
-    "langchain-experimental>=0.4,<0.5",
     "litellm==1.84.0",
     "llama-index>=0.14.0,<0.15",
     "llama-index-llms-openai>=0.6.0,<0.7",
@@ -117,6 +116,8 @@ dependencies = [
     "langchain-litellm>=0.5.1",
     "scikit-learn>=1.8.0",
     "gensim>=4.4.0",
+    "langchain-community>=0.4.2",
+    "langchain-text-splitters>=1.1.2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2035,19 +2035,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langchain-experimental"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "langchain-community" },
-    { name = "langchain-core" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/1c/8240195c1b27f2c45b2ee93a07b2a5a466c92dec8881fc1213ec8e3cb6a8/langchain_experimental-0.4.2.tar.gz", hash = "sha256:1130fa7ecad5959e687295b2f7850ae3e5d8eeee6796bf9e99910806475d8acc", size = 172068, upload-time = "2026-05-22T20:38:42.184Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/ce/5c56f08407648ab897b119a4add46391560a144285cf89e060091bc793e9/langchain_experimental-0.4.2-py3-none-any.whl", hash = "sha256:fd98b9948cb6f991e0f632ea3d5fb839bcfe21e6d5a190a51126a76270a66d40", size = 211226, upload-time = "2026-05-22T20:38:40.678Z" },
-]
-
-[[package]]
 name = "langchain-litellm"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2604,8 +2591,9 @@ dependencies = [
     { name = "isodate" },
     { name = "jedi" },
     { name = "langchain" },
-    { name = "langchain-experimental" },
+    { name = "langchain-community" },
     { name = "langchain-litellm" },
+    { name = "langchain-text-splitters" },
     { name = "litellm" },
     { name = "llama-index" },
     { name = "llama-index-llms-openai" },
@@ -2743,8 +2731,9 @@ requires-dist = [
     { name = "isodate", specifier = ">=0.7.2,<0.8" },
     { name = "jedi", specifier = ">=0.19.0,<0.20" },
     { name = "langchain", specifier = ">=1.3.9,<1.4" },
-    { name = "langchain-experimental", specifier = ">=0.4,<0.5" },
+    { name = "langchain-community", specifier = ">=0.4.2" },
     { name = "langchain-litellm", specifier = ">=0.5.1" },
+    { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "litellm", specifier = "==1.84.0" },
     { name = "llama-index", specifier = ">=0.14.0,<0.15" },
     { name = "llama-index-llms-openai", specifier = ">=0.6.0,<0.7" },

--- a/vector_search/conftest.py
+++ b/vector_search/conftest.py
@@ -33,7 +33,6 @@ def _use_test_qdrant_settings(settings, mocker):
     settings.LITELLM_API_BASE = "https://test/api/"
     settings.LITELLM_TOKEN_ENCODING_NAME = None
     settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 0
-    settings.CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED = False
     settings.QDRANT_SPARSE_MODEL = "sklearn/hashing_vectorizer_sparse_model"
     settings.QDRANT_SPARSE_ENCODER = (
         "vector_search.encoders.sparse_hash.SparseHashEncoder"

--- a/vector_search/conftest.py
+++ b/vector_search/conftest.py
@@ -39,7 +39,6 @@ def _use_test_qdrant_settings(settings, mocker):
         "vector_search.encoders.sparse_hash.SparseHashEncoder"
     )
     mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
-    mocker.patch("vector_search.utils.SemanticChunker")
     mocker.patch(
         "vector_search.utils.compute_optimizer_settings",
         return_value={

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -360,7 +360,7 @@ def _get_text_splitter(**kwargs):
 
 
 def _chunk_documents(texts, metadatas):
-    # chunk the documents. use semantic chunking if enabled
+    # chunk the documents
     chunk_params = {
         "chunk_overlap": settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP,
     }

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -6,7 +6,6 @@ from functools import cache
 
 from django.conf import settings
 from django.db.models import Q
-from langchain_experimental.text_splitter import SemanticChunker
 from langchain_text_splitters import (
     MarkdownHeaderTextSplitter,
     RecursiveCharacterTextSplitter,
@@ -360,7 +359,7 @@ def _get_text_splitter(**kwargs):
     return RecursiveCharacterTextSplitter(**kwargs)
 
 
-def _chunk_documents(encoder, texts, metadatas):
+def _chunk_documents(texts, metadatas):
     # chunk the documents. use semantic chunking if enabled
     chunk_params = {
         "chunk_overlap": settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP,
@@ -370,18 +369,6 @@ def _chunk_documents(encoder, texts, metadatas):
         chunk_params["chunk_size"] = settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE
 
     recursive_splitter = _get_text_splitter(**chunk_params)
-
-    if settings.CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED:
-        """
-        If semantic chunking is enabled,
-        use the semantic chunker then recursive splitter
-        to stay within chunk size limits
-        """
-        return recursive_splitter.split_documents(
-            SemanticChunker(
-                encoder, **settings.SEMANTIC_CHUNKING_CONFIG
-            ).create_documents(texts=texts, metadatas=metadatas)
-        )
     return recursive_splitter.create_documents(texts=texts, metadatas=metadatas)
 
 
@@ -719,7 +706,7 @@ def _generate_content_file_points(serialized_content):
         if _is_markdown_content(doc):
             split_docs = _chunk_markdown_documents(embedding_context, doc)
         else:
-            split_docs = _chunk_documents(encoder_dense, [embedding_context], [doc])
+            split_docs = _chunk_documents([embedding_context], [doc])
 
         # Identify non-empty chunks and their original indices
         valid_chunks = [(i, d) for i, d in enumerate(split_docs) if d.page_content]

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -470,32 +470,6 @@ def test_complex_qdrant_query_conditions():
     )
 
 
-def test_document_chunker(mocker):
-    """
-    Test that the correct splitter is returned based on encoder
-    """
-    settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = None
-    settings.CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED = True
-    settings.LITELLM_TOKEN_ENCODING_NAME = None
-    encoder = dense_encoder()
-    encoder.token_encoding_name = None
-    mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
-    mocked_chunker = mocker.patch("vector_search.utils.SemanticChunker")
-    _chunk_documents(encoder, ["this is a test document"], [{}])
-
-    mocked_chunker.assert_called()
-    mocked_splitter.assert_called()
-
-    settings.CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED = False
-    _get_text_splitter.cache_clear()
-    mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
-    mocked_chunker = mocker.patch("vector_search.utils.SemanticChunker")
-
-    _chunk_documents(encoder, ["this is a test document"], [{}])
-    mocked_chunker.assert_not_called()
-    mocked_splitter.assert_called()
-
-
 def test_expected_document_chunks(mocker):
     """
     Test that the expected number of chunks are uploaded
@@ -505,7 +479,6 @@ def test_expected_document_chunks(mocker):
     settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = random.randrange(  # noqa: S311
         1, settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE
     )
-    settings.CONTENT_FILE_EMBEDDING_SEMANTIC_CHUNKING_ENABLED = False
 
     encoder = dense_encoder()
     mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
@@ -520,7 +493,6 @@ def test_expected_document_chunks(mocker):
         content="this is a.  test: document. " * 1000
     )
     chunked = _chunk_documents(
-        encoder,
         [content_file.content],
         list(serialize_bulk_content_files([content_file.id])),
     )
@@ -549,13 +521,13 @@ def test_document_chunker_tiktoken(mocker):
         "vector_search.utils.RecursiveCharacterTextSplitter.from_tiktoken_encoder"
     )
 
-    _chunk_documents(encoder, ["this is a test document"], [{}])
+    _chunk_documents(["this is a test document"], [{}])
     mocked_splitter.assert_not_called()
 
     # work around cache for testing
     _get_text_splitter.cache_clear()
     settings.LITELLM_TOKEN_ENCODING_NAME = "test"  # noqa: S105
-    _chunk_documents(encoder, ["this is a test document"], [{}])
+    _chunk_documents(["this is a test document"], [{}])
     mocked_splitter.assert_called()
 
 
@@ -569,11 +541,11 @@ def test_text_splitter_chunk_size_override(mocker):
     encoder = dense_encoder()
     mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
     encoder.token_encoding_name = "cl100k_base"  # noqa: S105
-    _chunk_documents(encoder, ["this is a test document"], [{}])
+    _chunk_documents(["this is a test document"], [{}])
     assert mocked_splitter.mock_calls[0].kwargs["chunk_size"] == 100
     mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
     settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = None
-    _chunk_documents(encoder, ["this is a test document"], [{}])
+    _chunk_documents(["this is a test document"], [{}])
     assert "chunk_size" not in mocked_splitter.mock_calls[0].kwargs
 
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/11945
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR removes the Semantic chunking functionality which is currently unused and also depends on the [deprecated langchain-experimental library](https://github.com/langchain-ai/langchain-experimental/issues/87). the SemanticChunker is also not something that appears to be ported to a now supported library.

### How can this be tested?
Tests should pass. Also verify nothing else depends or imports from the langchain-experimental library
