### PR TITLE
Always show CMS "Certificate Title" on program certificates (page, PDF, metadata; no flag)

### DIFF
--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.test.tsx
@@ -6,23 +6,14 @@ import CertificatePage from "./CertificatePage"
 import { CertificateType } from "@/common/certificateUtils"
 import SharePopover from "@/components/SharePopover/SharePopover"
 import * as mitxonline from "api/mitxonline-test-utils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
 import {
   FACEBOOK_SHARE_BASE_URL,
   TWITTER_SHARE_BASE_URL,
   LINKEDIN_SHARE_BASE_URL,
 } from "@/common/urls"
 
-jest.mock("posthog-js/react", () => ({
-  ...jest.requireActual("posthog-js/react"),
-  useFeatureFlagEnabled: jest.fn(),
-}))
-const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
-
 describe("CertificatePage", () => {
   beforeEach(() => {
-    // Default the CMS-title flag ON; individual tests override as needed.
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
     const mitxUser = mitxonline.factories.user.user()
     setMockResponse.get(mitxonline.urls.userMe.get(), mitxUser)
   })
@@ -147,29 +138,6 @@ describe("CertificatePage", () => {
     )
 
     await screen.findAllByText(certificate.program.title)
-  })
-
-  it("shows the program title (not the CMS title) when the flag is off", async () => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
-    const certificate = factories.mitxonline.programCertificate()
-    certificate.program.program_type = "Program"
-    certificate.certificate_page.product_name = "Custom CMS Title"
-    setMockResponse.get(
-      mitxonline.urls.certificates.programCertificatesRetrieve({
-        uuid: certificate.uuid,
-      }),
-      certificate,
-    )
-    renderWithProviders(
-      <CertificatePage
-        certificateType={CertificateType.Program}
-        uuid={certificate.uuid}
-        pageUrl={`https://${process.env.NEXT_PUBLIC_ORIGIN}/certificate/program/${certificate.uuid}`}
-      />,
-    )
-
-    await screen.findAllByText(certificate.program.title)
-    expect(screen.queryByText("Custom CMS Title")).not.toBeInTheDocument()
   })
 
   it("renders a MicroMasters program certificate badge with the registered mark", async () => {

--- a/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
+++ b/frontends/main/src/app-pages/CertificatePage/CertificatePage.tsx
@@ -32,8 +32,6 @@ import {
   getVerifiableCredentialDownloadAPIURL,
   CertificateType,
 } from "@/common/certificateUtils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 
 const Page = styled.div(({ theme }) => ({
   backgroundImage: `url(${backgroundImage.src})`,
@@ -688,11 +686,6 @@ const CertificatePage: React.FC<{
 
   const { data: userData } = useQuery(mitxUserQueries.me())
 
-  // Gates whether the certificate title comes from the CMS "Certificate Title"
-  // (product_name) field or the program/course title. Defaults to the
-  // program/course title until the flag loads / is enabled.
-  const useCmsTitle = !!useFeatureFlagEnabled(FeatureFlags.CmsCertificateTitle)
-
   const {
     data: courseCertificateData,
     isLoading: isCourseLoading,
@@ -761,13 +754,11 @@ const CertificatePage: React.FC<{
   let title = ""
   if (certificateType === CertificateType.Course) {
     title = courseCertificateData?.course_run.course.title ?? ""
-  } else if (useCmsTitle) {
+  } else {
     title = getCertificateTitle(
       programCertificateData?.certificate_page?.product_name,
       programCertificateData?.program.title ?? "",
     )
-  } else {
-    title = programCertificateData?.program.title ?? ""
   }
 
   const download = async () => {

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.test.tsx
@@ -27,6 +27,42 @@ describe("Certificate page generateMetadata", () => {
       `${certificate.user.name}'s MicroMasters® Certificate`,
     )
     expect(metadata.description).toBe(
+      `${certificate.user.name} has successfully completed: ${certificate.certificate_page.product_name}`,
+    )
+  })
+
+  it("uses the CMS product name in the program description", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
+    certificate.certificate_page.product_name = "Universal AI"
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+
+    const metadata = await callGenerateMetadata("program", certificate.uuid)
+
+    expect(metadata.description).toBe(
+      `${certificate.user.name} has successfully completed: Universal AI`,
+    )
+  })
+
+  it("falls back to the program title in the description when no product name is set", async () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.program.program_type = "Program"
+    certificate.certificate_page.product_name = ""
+    setMockResponse.get(
+      mitxonline.urls.certificates.programCertificatesRetrieve({
+        uuid: certificate.uuid,
+      }),
+      certificate,
+    )
+
+    const metadata = await callGenerateMetadata("program", certificate.uuid)
+
+    expect(metadata.description).toBe(
       `${certificate.user.name} has successfully completed: ${certificate.program.title}`,
     )
   })

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/page.tsx
@@ -8,7 +8,10 @@ import { isInEnum } from "@/common/utils"
 import { notFound } from "next/navigation"
 import { safeGenerateMetadata, standardizeMetadata } from "@/common/metadata"
 import { getQueryClient } from "@/app/getQueryClient"
-import { getCertificateInfo } from "@/common/certificateUtils"
+import {
+  getCertificateInfo,
+  getCertificateTitle,
+} from "@/common/certificateUtils"
 
 const NEXT_PUBLIC_ORIGIN = env("NEXT_PUBLIC_ORIGIN")
 
@@ -45,7 +48,10 @@ export async function generateMetadata({
         }),
       )
 
-      title = data.program.title
+      title = getCertificateTitle(
+        data.certificate_page?.product_name,
+        data.program.title ?? "",
+      )
 
       userName = data.user.name
       displayType = getCertificateInfo(data.program.program_type).displayType

--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -29,6 +29,7 @@ import { pxToPt, getNameStyles } from "./utils"
 import {
   getCertificateBadgeLines,
   getCertificateBadgeTypography,
+  getCertificateTitle,
 } from "@/common/certificateUtils"
 
 // https://use.typekit.net/lbk1xay.css
@@ -529,7 +530,10 @@ const ProgramCertificate = ({
 }: {
   certificate: V2ProgramCertificate
 }) => {
-  const title = certificate?.program?.title
+  const title = getCertificateTitle(
+    certificate?.certificate_page?.product_name,
+    certificate?.program?.title ?? "",
+  )
 
   const userName = certificate?.user?.name
 

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -17,7 +17,6 @@ export enum FeatureFlags {
   PodcastDetailPage = "podcast-detail-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
   Arithmix = "arithmix",
-  CmsCertificateTitle = "cms-certificate-title",
 }
 
 /**


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11938

### Description (What does it do?)

Follow-up to #3512 (merged), which gated the on-screen program certificate title behind the `cms-certificate-title` flag.

- Makes it **always-on** — removes the `cms-certificate-title` feature flag.
- The program certificate title now comes from the CMS certificate page's `product_name` ("Certificate Title") across **every** surface — the on-screen certificate, page heading, share text, download filename, the **PDF** (and Print), and the **page/SEO + link-preview metadata** — falling back to the program title when `product_name` is empty.
- **Course** certificates are unchanged.

### Screenshots (if appropriate):

<img width="1058" height="421" alt="Screenshot 2026-06-24 at 2 40 13 PM" src="https://github.com/user-attachments/assets/32cd816c-2e10-466a-b0b9-30ad5b64a241" />



### How can this be tested?

You need a **program** certificate whose CMS "Certificate Title" differs from its program title (no scripts): set a distinct "Certificate Title" in the CMS → that program's **Certificate** page → publish, then issue a certificate for that program to your user via MITx Online **Django admin**. (Or use an existing program cert whose Certificate Title already differs, e.g. a UAI cert.)

Open `/certificate/program/<uuid>` (log in as the cert owner for the buttons) and confirm the CMS **"Certificate Title"** appears as the title on:
- the page heading **and** the rendered certificate
- the **Download PDF** (and **Print**, which uses the same PDF)
- the **Share** text and the **link-preview / OG metadata** (paste the link to check the preview card)

A **course** certificate still shows the course title (unchanged).