### PR TITLE
Use CMS Certificate Title for program LinkedIn "Add to Profile"

### DIFF
--- a/frontends/main/src/common/certificateUtils.test.ts
+++ b/frontends/main/src/common/certificateUtils.test.ts
@@ -1,9 +1,12 @@
 import {
+  CertificateType,
   getCertificateBadgeLines,
   getCertificateBadgeTypography,
   getCertificateInfo,
+  getCertificateLinkedInUrl,
   getCertificateTitle,
 } from "./certificateUtils"
+import { factories } from "api/test-utils"
 
 describe("getCertificateInfo", () => {
   it("returns default certificate label when no program type is provided", () => {
@@ -146,5 +149,46 @@ describe("getCertificateBadgeTypography", () => {
     expect(getCertificateBadgeTypography("  MicroMasters®  ")).toEqual(
       micromastersTypography,
     )
+  })
+})
+
+describe("getCertificateLinkedInUrl", () => {
+  const pageUrl = "https://example.com/certificate/program/abc"
+
+  it("uses the CMS product name for program certificates", () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.certificate_page.product_name = "Universal AI"
+    certificate.program.title = "Fundamentals of Programming and ML"
+
+    const url = new URL(
+      getCertificateLinkedInUrl(CertificateType.Program, certificate, pageUrl),
+    )
+
+    expect(url.searchParams.get("name")).toBe("Universal AI")
+  })
+
+  it("falls back to the program title when product name is empty", () => {
+    const certificate = factories.mitxonline.programCertificate()
+    certificate.certificate_page.product_name = ""
+    certificate.program.title = "Fundamentals of Programming and ML"
+
+    const url = new URL(
+      getCertificateLinkedInUrl(CertificateType.Program, certificate, pageUrl),
+    )
+
+    expect(url.searchParams.get("name")).toBe(
+      "Fundamentals of Programming and ML",
+    )
+  })
+
+  it("uses the course title for course certificates", () => {
+    const certificate = factories.mitxonline.courseCertificate()
+    certificate.course_run.course.title = "Intro to Python"
+
+    const url = new URL(
+      getCertificateLinkedInUrl(CertificateType.Course, certificate, pageUrl),
+    )
+
+    expect(url.searchParams.get("name")).toBe("Intro to Python")
   })
 })

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -253,14 +253,17 @@ export const getCertificateLinkedInUrl = (
   certificateData: V2ProgramCertificate | V2CourseRunCertificate,
   pageUrl: string,
 ): string => {
-  const credentialName =
-    certificateType === CertificateType.Course
-      ? (certificateData as V2CourseRunCertificate).course_run.course.title
-      : getCertificateTitle(
-          (certificateData as V2ProgramCertificate).certificate_page
-            ?.product_name,
-          (certificateData as V2ProgramCertificate).program.title,
-        )
+  let credentialName: string
+  if (certificateType === CertificateType.Course) {
+    credentialName = (certificateData as V2CourseRunCertificate).course_run
+      .course.title
+  } else {
+    const programCert = certificateData as V2ProgramCertificate
+    credentialName = getCertificateTitle(
+      programCert.certificate_page?.product_name,
+      programCert.program.title,
+    )
+  }
   const certId = certificateData.uuid
   const linkedinUrl = new URL(LINKEDIN_ADD_TO_PROFILE_BASE_URL)
   linkedinUrl.searchParams.set("startTask", "CERTIFICATION_NAME")

--- a/frontends/main/src/common/certificateUtils.ts
+++ b/frontends/main/src/common/certificateUtils.ts
@@ -256,7 +256,11 @@ export const getCertificateLinkedInUrl = (
   const credentialName =
     certificateType === CertificateType.Course
       ? (certificateData as V2CourseRunCertificate).course_run.course.title
-      : (certificateData as V2ProgramCertificate).program.title
+      : getCertificateTitle(
+          (certificateData as V2ProgramCertificate).certificate_page
+            ?.product_name,
+          (certificateData as V2ProgramCertificate).program.title,
+        )
   const certId = certificateData.uuid
   const linkedinUrl = new URL(LINKEDIN_ADD_TO_PROFILE_BASE_URL)
   linkedinUrl.searchParams.set("startTask", "CERTIFICATION_NAME")


### PR DESCRIPTION
### What are the relevant tickets?


Follow-up to the certificate-title work ([hq#11907](https://github.com/mitodl/hq/issues/11907), tracked in [hq#11938](https://github.com/mitodl/hq/issues/11938)).

### Description


The LinkedIn **"Add to Profile"** link for a **program** certificate currently sends the **program title** as the credential `name`. This changes it to the CMS **"Certificate Title"** (`CertificatePage.product_name`), so the certification a learner adds to LinkedIn matches the title printed on the certificate and shown on the certificate page. Falls back to the program title when `product_name` is unset.

Reuses the `getCertificateTitle` helper (added in #3512) — the same resolver the certificate page heading, PDF, and metadata already use — so the LinkedIn name stays consistent with the displayed title.

- **Programs only.** The course branch of `getCertificateLinkedInUrl` is unchanged.
- This is the **unsigned** LinkedIn path, used when the viewer is not the cert owner, or when the certificate has no verifiable credential. When the owner has a signed verifiable credential, the LinkedIn name comes from the VC via `getVerifiableCredentialLinkedInURL` — which mitxonline [#3698](https://github.com/mitodl/mitxonline/pull/3698) updates to carry the same Certificate Title. Both paths therefore converge on the Certificate Title.

## Change

`frontends/main/src/common/certificateUtils.ts` — `getCertificateLinkedInUrl`, program branch:

```ts
getCertificateTitle(
  (certificateData as V2ProgramCertificate).certificate_page?.product_name,
  (certificateData as V2ProgramCertificate).program.title,
)
```

## How to test

Automated:

```
yarn test frontends/main/src/common/certificateUtils.test.ts
```

New `getCertificateLinkedInUrl` tests assert:
- program cert with a CMS `product_name` distinct from `program.title` → LinkedIn `name` param is the `product_name`;
- empty `product_name` → falls back to `program.title`;
- course cert → still uses the course title.

Manual:
1. Pick a **program certificate** whose CMS "Certificate Title" (`product_name`) differs from the program title (e.g. program title `… MicroMasters`, Certificate Title `… MicroMasters Certificate`).
2. Open its certificate page at `/certificate/program/<uuid>` and confirm the heading shows the **Certificate Title**.
3. Click **Share → LinkedIn / Add to profile**.
4. Inspect the LinkedIn "Add to Profile" URL (address bar, or right-click the option → copy link): the **`name=`** param should be the **Certificate Title**, not the bare program title.
5. _(Most convincing)_ Change the "Certificate Title" in the MITx Online Wagtail admin to a distinct value, publish, reload the page, and confirm the LinkedIn `name=` follows the new title — proving it reads the CMS field live.
