### PR TITLE
Retry embeddings tasks on Qdrant gRPC DEADLINE_EXCEEDED

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 
 import celery
+import grpc
 import sentry_sdk
 from celery.exceptions import Ignore
 from django.conf import settings
@@ -119,10 +120,10 @@ def generate_embeddings(ids, resource_type, overwrite):
         raise
     except SystemExit as err:
         raise RetryError(SystemExit.__name__) from err
-    except:  # noqa: E722
-        error = "generate_embeddings threw an error"
-        log.exception(error)
-        return error
+    except grpc.RpcError as err:
+        if err.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+            raise RetryError(str(err)) from err
+        raise
 
 
 @app.task(
@@ -148,10 +149,10 @@ def remove_embeddings(ids, resource_type):
         raise
     except SystemExit as err:
         raise RetryError(SystemExit.__name__) from err
-    except:  # noqa: E722
-        error = "generate_embeddings threw an error"
-        log.exception(error)
-        return error
+    except grpc.RpcError as err:
+        if err.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
+            raise RetryError(str(err)) from err
+        raise
 
 
 @app.task(bind=True)

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -833,6 +833,16 @@ def test_remove_embeddings_raises_retryerror_on_grpc_deadline(mocker):
         remove_embeddings([1], COURSE_TYPE)
 
 
+def test_remove_embeddings_reraises_other_grpc_errors(mocker):
+    """Non-transient gRPC errors propagate (task fails) rather than retrying."""
+    mocker.patch(
+        "vector_search.tasks.remove_qdrant_records",
+        side_effect=_rpc_error(grpc.StatusCode.INVALID_ARGUMENT),
+    )
+    with pytest.raises(grpc.RpcError):
+        remove_embeddings([1], COURSE_TYPE)
+
+
 def test_remove_embeddings_does_not_swallow_errors(mocker):
     """Unhandled errors propagate so the task fails instead of reporting success."""
     mocker.patch(

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -1,6 +1,7 @@
 import datetime
 import random
 
+import grpc
 import pytest
 from django.conf import settings
 
@@ -24,6 +25,7 @@ from learning_resources_search.constants import (
     LEARNING_RESOURCE_TYPES,
     PROGRAM_TYPE,
 )
+from learning_resources_search.exceptions import RetryError
 from main.utils import now_in_utc
 from vector_search.tasks import (
     embed_learning_resources_by_id,
@@ -31,6 +33,8 @@ from vector_search.tasks import (
     embed_new_learning_resources,
     embed_run_content_files,
     embeddings_healthcheck,
+    generate_embeddings,
+    remove_embeddings,
     remove_run_content_files,
     remove_unpublished_run_content_files,
     start_embed_resources,
@@ -38,6 +42,13 @@ from vector_search.tasks import (
 from vector_search.utils import vector_point_id
 
 pytestmark = pytest.mark.django_db
+
+
+def _rpc_error(code):
+    """Build a grpc.RpcError carrying a status code, like qdrant's gRPC failures."""
+    err = grpc.RpcError()
+    err.code = lambda: code
+    return err
 
 
 @pytest.mark.parametrize("index", list(LEARNING_RESOURCE_TYPES))
@@ -780,3 +791,53 @@ def test_embeddings_healthcheck_missing_summaries(mocker):
         mock_sentry.mock_calls[0].args[0]
         == "Warning: 1 missing content file summaries detected"
     )
+
+
+def test_generate_embeddings_raises_retryerror_on_grpc_deadline(mocker):
+    """A DEADLINE_EXCEEDED gRPC error becomes a RetryError (autoretry_for picks it up)."""
+    mocker.patch(
+        "vector_search.tasks.embed_learning_resources",
+        side_effect=_rpc_error(grpc.StatusCode.DEADLINE_EXCEEDED),
+    )
+    with pytest.raises(RetryError):
+        generate_embeddings([1], COURSE_TYPE, overwrite=False)
+
+
+def test_generate_embeddings_reraises_other_grpc_errors(mocker):
+    """Non-transient gRPC errors propagate (task fails) rather than retrying."""
+    mocker.patch(
+        "vector_search.tasks.embed_learning_resources",
+        side_effect=_rpc_error(grpc.StatusCode.INVALID_ARGUMENT),
+    )
+    with pytest.raises(grpc.RpcError):
+        generate_embeddings([1], COURSE_TYPE, overwrite=False)
+
+
+def test_generate_embeddings_does_not_swallow_errors(mocker):
+    """Unhandled errors propagate so the task fails instead of reporting success."""
+    mocker.patch(
+        "vector_search.tasks.embed_learning_resources",
+        side_effect=ValueError("boom"),
+    )
+    with pytest.raises(ValueError, match="boom"):
+        generate_embeddings([1], COURSE_TYPE, overwrite=False)
+
+
+def test_remove_embeddings_raises_retryerror_on_grpc_deadline(mocker):
+    """remove_embeddings retries on DEADLINE_EXCEEDED rather than swallowing it."""
+    mocker.patch(
+        "vector_search.tasks.remove_qdrant_records",
+        side_effect=_rpc_error(grpc.StatusCode.DEADLINE_EXCEEDED),
+    )
+    with pytest.raises(RetryError):
+        remove_embeddings([1], COURSE_TYPE)
+
+
+def test_remove_embeddings_does_not_swallow_errors(mocker):
+    """Unhandled errors propagate so the task fails instead of reporting success."""
+    mocker.patch(
+        "vector_search.tasks.remove_qdrant_records",
+        side_effect=ValueError("boom"),
+    )
+    with pytest.raises(ValueError, match="boom"):
+        remove_embeddings([1], COURSE_TYPE)


### PR DESCRIPTION
### What are the relevant tickets?
mitodl/hq#11987

### Description (What does it do?)
The `generate_embeddings` and `remove_embeddings` Celery tasks talk to Qdrant over gRPC (`prefer_grpc=True`). A Qdrant timeout surfaces as a `grpc.RpcError` with code `DEADLINE_EXCEEDED`, which was being caught by a bare `except` that logged it and **returned an error string** — so Celery marked the task SUCCESS, the embeddings were silently never written, and nothing retried (the data loss seen in Sentry).

This change:
- Converts a `DEADLINE_EXCEEDED` gRPC error into `RetryError`, so the existing `autoretry_for=(RetryError,)` + `retry_backoff` retries it. Other gRPC codes re-raise.
- Removes the bare `except ... return error` from both tasks. Unhandled exceptions now propagate, so the task records FAILURE (still captured by Sentry) instead of a false success.

### How can this be tested?
**Unit tests** (handler + propagation for both tasks):
```
docker compose run --rm web uv run pytest vector_search/tasks_test.py -k embeddings
```

**Manual — confirm a real Qdrant timeout is the exception the handler keys on** (what the mocked tests can't prove). In `manage.py shell`, force a sub-millisecond gRPC deadline against a populated collection:
```python
import grpc
from django.conf import settings
from qdrant_client import QdrantClient
c = QdrantClient(url=settings.QDRANT_HOST, api_key=settings.QDRANT_API_KEY,
                 grpc_port=6334, prefer_grpc=True, timeout=0.001)
try:
    c.scroll("resource_embeddings.content_files", limit=20000,
             with_payload=True, with_vectors=True)
except grpc.RpcError as e:
    print(e.code(), e.code() == grpc.StatusCode.DEADLINE_EXCEEDED)
# -> StatusCode.DEADLINE_EXCEEDED True
```
That `(grpc.RpcError, code() == DEADLINE_EXCEEDED)` is exactly what the new handler matches before raising `RetryError`.

**End-to-end (retry/backoff in worker logs):** set `QDRANT_CLIENT_TIMEOUT=0.001` and enqueue a bulk embed against a loaded/remote Qdrant — the worker logs show `Retry ... in Ns` (backoff) instead of a SUCCESS-with-error-string. Note: against a local single-node Qdrant, per-resource calls finish in under a millisecond and won't reliably trip the deadline; only heavy reads (like the scroll above) do.
