### PR TITLE
Canvas-AI: resolve orphaned files

### DIFF
--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -18,6 +18,7 @@ from learning_resources.etl.canvas_utils import (
     _compact_element,
     get_published_items,
     is_file_published,
+    parse_canvas_files,
     parse_canvas_settings,
     parse_files_meta,
     parse_module_meta,
@@ -1746,6 +1747,141 @@ def test_get_published_items_for_attachment_module(mocker, tmp_path):
     }
     published = get_published_items(zip_path, url_config)
     assert Path("web_resources/visible_attachment_module.txt").resolve() in published
+
+
+def test_get_published_items_ingests_file_absent_from_files_meta(tmp_path):
+    """
+    An ordinary published file that Canvas omits from files_meta.xml (because it
+    has no non-default metadata) is still ingested via the manifest inventory.
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="web_resources/Syllabus/syllabus.docx">
+          <file href="web_resources/Syllabus/syllabus.docx"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    # no module_meta.xml and no files_meta.xml: the file is reachable only via
+    # the manifest, exactly like the orphaned syllabus docx in course 2198.
+    zip_path = make_canvas_zip(
+        tmp_path,
+        module_xml=None,
+        manifest_xml=manifest_xml,
+        files=[("web_resources/Syllabus/syllabus.docx", "syllabus body")],
+    )
+    published = get_published_items(zip_path, {})
+    assert Path("web_resources/Syllabus/syllabus.docx").resolve() in published
+
+
+def test_get_published_items_excludes_file_in_locked_folder(tmp_path):
+    """
+    A file that is not individually locked but lives in a locked (or hidden)
+    folder is not ingested, even when it is absent from files_meta.xml.
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="web_resources/secret/hidden.pdf">
+          <file href="web_resources/secret/hidden.pdf"/>
+        </resource>
+        <resource identifier="RES2" type="webcontent" href="web_resources/open/shown.pdf">
+          <file href="web_resources/open/shown.pdf"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    files_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <fileMeta xmlns="http://canvas.instructure.com/xsd/cccv1p0">
+      <folders>
+        <folder path="secret">
+          <locked>true</locked>
+        </folder>
+      </folders>
+    </fileMeta>
+    """
+    zip_path = make_canvas_zip(
+        tmp_path,
+        module_xml=None,
+        manifest_xml=manifest_xml,
+        files=[
+            ("course_settings/files_meta.xml", files_xml),
+            ("web_resources/secret/hidden.pdf", "hidden"),
+            ("web_resources/open/shown.pdf", "shown"),
+        ],
+    )
+    published = get_published_items(zip_path, {})
+    assert Path("web_resources/open/shown.pdf").resolve() in published
+    assert Path("web_resources/secret/hidden.pdf").resolve() not in published
+
+
+def test_get_published_items_subfolder_file_respects_hidden_file_section(tmp_path):
+    """
+    A file in a web_resources subfolder is excluded when the Files navigation
+    section is hidden (it would not be reachable by students).
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="web_resources/materials/notes.pdf">
+          <file href="web_resources/materials/notes.pdf"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    files = [("web_resources/materials/notes.pdf", "notes")]
+    notes_path = Path("web_resources/materials/notes.pdf").resolve()
+
+    # files section visible (default settings) -> ingested
+    visible_zip = make_canvas_zip(
+        tmp_path, module_xml=None, manifest_xml=manifest_xml, files=files
+    )
+    assert notes_path in get_published_items(visible_zip, {})
+
+    # files section hidden -> excluded (re-uses tmp_path, overwriting the zip)
+    settings_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+        <course xmlns="http://canvas.instructure.com/xsd/cccv1p0">
+            <title>Test Course Title</title>
+            <tab_configuration>[{"id":0},{"id":11, "hidden":true}]</tab_configuration>
+            <course_code>TEST-101</course_code>
+        </course>
+    """
+    hidden_zip = make_canvas_zip(
+        tmp_path,
+        settings_xml=settings_xml,
+        module_xml=None,
+        manifest_xml=manifest_xml,
+        files=files,
+    )
+    assert notes_path not in get_published_items(hidden_zip, {})
+
+
+def test_parse_canvas_files_skips_html_and_tutor_files(tmp_path, settings):
+    """
+    parse_canvas_files enumerates webcontent files but skips HTML pages (handled
+    by parse_web_content) and tutor problem files (ingested separately).
+    """
+    settings.CANVAS_TUTORBOT_FOLDER = "web_resources/ai/tutor/"
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES1" type="webcontent" href="web_resources/doc.pdf">
+          <file href="web_resources/doc.pdf"/>
+        </resource>
+        <resource identifier="RES2" type="webcontent" href="web_resources/page.html">
+          <file href="web_resources/page.html"/>
+        </resource>
+        <resource identifier="RES3" type="webcontent" href="web_resources/ai/tutor/Unit1/problem.docx">
+          <file href="web_resources/ai/tutor/Unit1/problem.docx"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    zip_path = make_canvas_zip(tmp_path, module_xml=None, manifest_xml=manifest_xml)
+    result = parse_canvas_files(zip_path)
+    active_paths = {str(item["path"]) for item in result["active"]}
+    assert active_paths == {"web_resources/doc.pdf"}
 
 
 def test_ingestion_finishes_with_missing_xml_files(

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -1543,6 +1543,11 @@ def test_get_published_items_with_hidden_file_section(mocker, tmp_path):
 
 
 def test_get_published_items_for_unpublshed_but_embedded(mocker, tmp_path):
+    """
+    An embedded file that is unpublished (locked) is excluded, but one that is
+    only "available with link" (hidden, not locked) is still ingested because a
+    student can reach it through the linking page.
+    """
     html_content = """
     <html>
     <head><meta name="workflow_state" content="active"/></head>
@@ -1626,15 +1631,64 @@ def test_get_published_items_for_unpublshed_but_embedded(mocker, tmp_path):
             ("web_resources/html_page.html", html_content),
         ],
     )
-    url_config = {
+    # unpublished (locked) embedded file -> excluded even though it is linked
+    # from an active page: a student cannot open a locked file
+    locked_config = {
         "/file1.pdf": {
             "url": "https://cdn.example.com/file1.pdf",
             "locked": True,
             "hidden": True,
         },
     }
-    published = get_published_items(zip_path, url_config)
+    published = get_published_items(zip_path, locked_config)
+    assert Path("web_resources/file1.pdf").resolve() not in published
+
+    # "available with link" (hidden but not locked) embedded file -> ingested,
+    # since the linking page makes it reachable
+    hidden_config = {
+        "/file1.pdf": {
+            "url": "https://cdn.example.com/file1.pdf",
+            "hidden": True,
+        },
+    }
+    published = get_published_items(zip_path, hidden_config)
     assert Path("web_resources/file1.pdf").resolve() in published
+
+
+def test_get_published_items_excludes_embedded_tutor_files(tmp_path, settings):
+    """
+    A tutor problem file embedded in an active page is not ingested as a content
+    file - tutor files are ingested separately as problem files.
+    """
+    settings.CANVAS_TUTORBOT_FOLDER = "web_resources/ai/tutor/"
+    html_content = """
+    <html>
+    <head><meta name="workflow_state" content="active"/></head>
+        <body>
+            <a href="$IMS-CC-FILEBASE$/ai/tutor/problem.pdf">Embedded problem</a>
+        </body>
+    </html>
+    """
+    manifest_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+      <resources>
+        <resource identifier="RES3" type="webcontent" href="web_resources/html_page.html">
+          <file href="web_resources/html_page.html"/>
+        </resource>
+      </resources>
+    </manifest>
+    """
+    zip_path = make_canvas_zip(
+        tmp_path,
+        module_xml=None,
+        manifest_xml=manifest_xml,
+        files=[
+            ("web_resources/html_page.html", html_content),
+            ("web_resources/ai/tutor/problem.pdf", "problem"),
+        ],
+    )
+    published = get_published_items(zip_path, {})
+    assert Path("web_resources/ai/tutor/problem.pdf").resolve() not in published
 
 
 def test_get_published_items_for_attachment_module(mocker, tmp_path):

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -691,7 +691,7 @@ def get_published_items(zipfile_path, url_config):
                 "title": "",
             }
             all_embedded_items.append(embedded)
-            if embedded_path in all_published_items:
+            if embedded_path in published_items:
                 continue
             # tutor problem files are ingested separately as problem files
             if str(embedded_file).startswith(settings.CANVAS_TUTORBOT_FOLDER):

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -674,8 +674,9 @@ def get_published_items(zipfile_path, url_config):
         item_configuration = url_config.get(_url_config_key(item))
         item_visible = _url_config_item_visible(item_configuration)
 
-        # Items stored under web_resources are generally only reachable via the Files UI,
-        # which is gated by the Files navigation tab (unless the file is surfaced
+        # Items stored under web_resources are generally only
+        # reachable via the Files UI, which is gated by the Files
+        # navigation tab (unless the file is surfaced
         # through a module). Embedded files are handled separately and can bypass
         # the Files-tab gating.
         in_files_area = "web_resources" in Path(item["path"]).parts

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -674,10 +674,10 @@ def get_published_items(zipfile_path, url_config):
         item_configuration = url_config.get(_url_config_key(item))
         item_visible = _url_config_item_visible(item_configuration)
 
-        # files in the "Files" area are only visible to students when the Files
-        # section is shown in the course navigation (unless the file is surfaced
-        # through a module). Content outside web_resources (pages, assignments)
-        # and embedded files are not gated by this.
+        # Items stored under web_resources are generally only reachable via the Files UI,
+        # which is gated by the Files navigation tab (unless the file is surfaced
+        # through a module). Embedded files are handled separately and can bypass
+        # the Files-tab gating.
         in_files_area = "web_resources" in Path(item["path"]).parts
         if item_visible and (
             not in_files_area or files_section_is_visible or item.get("module")

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -525,30 +525,37 @@ def _url_config_key(item):
     return item.get("title")
 
 
-def _url_config_item_visible(item_configuration):
+def _url_config_item_visible(item_configuration, *, allow_hidden=False):
     """
     Determine if an item is visible based on its configuration
-    from the metadata json file
+    from the metadata json file.
+
+    When allow_hidden is True, items that are merely "available with link" (the
+    file or its folder is hidden) are still treated as visible. This is used for
+    files embedded in published content: students reach them through the linking
+    page even though they are not browsable in the Files area. Items that are
+    genuinely inaccessible (unpublished/locked, date-locked, or in a locked
+    folder) are excluded regardless.
     """
     if item_configuration:
         # check if explicitely unpublished
         unpublished = not item_configuration.get("published", True)
         lock_at = item_configuration.get("lock_at")
         unlock_at = item_configuration.get("unlock_at")
-        return not any(
-            [
-                unpublished,
-                is_date_locked(lock_at, unlock_at),
-                item_configuration.get("hidden"),  # file hidden
-                item_configuration.get("locked"),  # file locked
+        checks = [
+            unpublished,
+            is_date_locked(lock_at, unlock_at),
+            item_configuration.get("locked"),  # file locked (unpublished)
+            item_configuration.get("folder", {}).get("locked"),  # parent folder locked
+        ]
+        if not allow_hidden:
+            checks.append(item_configuration.get("hidden"))  # file hidden
+            checks.append(
                 item_configuration.get("folder", {}).get(
                     "hidden"
-                ),  # parent folder hidden
-                item_configuration.get("folder", {}).get(
-                    "locked"
-                ),  # parent folder locked
-            ]
-        )
+                )  # parent folder hidden
+            )
+        return not any(checks)
     return True
 
 
@@ -684,6 +691,16 @@ def get_published_items(zipfile_path, url_config):
             }
             all_embedded_items.append(embedded)
             if embedded_path in all_published_items:
+                continue
+            # tutor problem files are ingested separately as problem files
+            if str(embedded_file).startswith(settings.CANVAS_TUTORBOT_FOLDER):
+                continue
+            # Embedded files bypass the Files-section and "available with link"
+            # (hidden) checks because students reach them through the linking
+            # page. They are still excluded when the file itself is
+            # unpublished/locked or date-locked (genuinely inaccessible).
+            embedded_config = url_config.get(_url_config_key(embedded))
+            if not _url_config_item_visible(embedded_config, allow_hidden=True):
                 continue
             published_items[embedded_path] = embedded
 

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -552,6 +552,94 @@ def _url_config_item_visible(item_configuration):
     return True
 
 
+def parse_canvas_folders(course_archive_path: str) -> set[str]:
+    """
+    Return the set of folder paths (relative to the course files root) that are
+    hidden or locked according to course_settings/files_meta.xml. Any file in
+    one of these folders (or a descendant of one) is not visible to students.
+    """
+    restricted: set[str] = set()
+    with zipfile.ZipFile(course_archive_path, "r") as course_archive:
+        files_meta_path = "course_settings/files_meta.xml"
+        if files_meta_path not in course_archive.namelist():
+            return restricted
+        files_xml = course_archive.read(files_meta_path)
+    try:
+        root = ElementTree.fromstring(files_xml)
+    except Exception:
+        log.exception("Error parsing files_meta.xml folders")
+        return restricted
+    for folder_elem in root.findall(".//cccv1p0:folder", NAMESPACES):
+        path = folder_elem.get("path")
+        if not path:
+            continue
+        hidden = (
+            folder_elem.findtext("cccv1p0:hidden", "", NAMESPACES) or ""
+        ).strip().lower() == "true"
+        locked = (
+            folder_elem.findtext("cccv1p0:locked", "", NAMESPACES) or ""
+        ).strip().lower() == "true"
+        if hidden or locked:
+            restricted.add(path)
+    return restricted
+
+
+def parse_canvas_files(course_archive_path: str) -> dict:
+    """
+    Resolve publish/visibility status for course files present in the archive.
+
+    Canvas only writes a course_settings/files_meta.xml <file> entry for files
+    with non-default metadata (restricted, renamed, usage rights, icon-maker
+    icons), so ordinary published files are absent from files_meta.xml and are
+    only represented as webcontent resources in imsmanifest.xml. This enumerates
+    those webcontent files (the complete inventory) and marks each active unless
+    it is itself hidden/locked or it lives in a hidden/locked folder.
+
+    HTML pages are skipped here because parse_web_content already resolves them
+    (applying workflow_state, intended-role and syllabus rules). Tutor problem
+    files are skipped because they are ingested separately as problem files.
+    """
+    publish_status = {"active": [], "unpublished": []}
+    with zipfile.ZipFile(course_archive_path, "r") as course_archive:
+        manifest_path = "imsmanifest.xml"
+        if manifest_path not in course_archive.namelist():
+            return publish_status
+        manifest_xml = course_archive.read(manifest_path)
+    resource_map = extract_resources_by_identifier(manifest_xml)
+    restricted_folders = parse_canvas_folders(course_archive_path)
+    # files that files_meta.xml explicitly marks unpublished (hidden/locked/dated)
+    files_meta_unpublished = {
+        str(item["path"])
+        for item in (parse_files_meta(course_archive_path) or {}).get("unpublished", [])
+    }
+    seen = set()
+    for resource in resource_map.values():
+        if resource.get("type") != "webcontent":
+            continue
+        for file in resource.get("files", []):
+            if not file or not file.startswith("web_resources/") or file in seen:
+                continue
+            seen.add(file)
+            # HTML pages are resolved by parse_web_content
+            if file.endswith(".html"):
+                continue
+            # tutor problem files are ingested separately as problem files
+            if file.startswith(settings.CANVAS_TUTORBOT_FOLDER):
+                continue
+            relpath = file[len("web_resources/") :]
+            ancestors = Path(relpath).parts[:-1]
+            in_restricted_folder = any(
+                "/".join(ancestors[: i + 1]) in restricted_folders
+                for i in range(len(ancestors))
+            )
+            item = {"title": Path(file).name, "path": Path(file)}
+            if in_restricted_folder or file in files_meta_unpublished:
+                publish_status["unpublished"].append(item)
+            else:
+                publish_status["active"].append(item)
+    return publish_status
+
+
 def get_published_items(zipfile_path, url_config):
     """
     Get all published items from a Canvas course archive
@@ -564,8 +652,12 @@ def get_published_items(zipfile_path, url_config):
     # https://developerdocs.instructure.com/services/dap/dataset/dataset-additional-notes
     """
     files_section_is_visible = not tab_configuration.get(11, {}).get("hidden", False)
+    # parse_canvas_files is listed first so that the more specific sources
+    # (modules, files_meta, web content) override its generic entries with their
+    # richer metadata (Canvas display_name, module membership) for shared paths.
     all_published_items = (
-        parse_module_meta(zipfile_path)["active"]
+        parse_canvas_files(zipfile_path)["active"]
+        + parse_module_meta(zipfile_path)["active"]
         + parse_files_meta(zipfile_path)["active"]
         + parse_web_content(zipfile_path)["active"]
     )
@@ -575,11 +667,13 @@ def get_published_items(zipfile_path, url_config):
         item_configuration = url_config.get(_url_config_key(item))
         item_visible = _url_config_item_visible(item_configuration)
 
-        # if the item is not explicitely hidden and global files section is visible
+        # files in the "Files" area are only visible to students when the Files
+        # section is shown in the course navigation (unless the file is surfaced
+        # through a module). Content outside web_resources (pages, assignments)
+        # and embedded files are not gated by this.
+        in_files_area = "web_resources" in Path(item["path"]).parts
         if item_visible and (
-            str(Path(item["path"]).parent) != "web_resources"
-            or files_section_is_visible
-            or item.get("module")
+            not in_files_area or files_section_is_visible or item.get("module")
         ):
             published_items[path] = item
         for embedded_file in item.get("embedded_files", []):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11940
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue for the canvas etl where we incorrectly skip files that: 
- are uploaded with no explicit "published"/visible state, are not changed or modified (so it never shows up in the files_meta.xml) and are not embedded on any page or module (so will not show up in modules_meta.xml)


### How can this be tested?
- Check out main
- restart celery, fetch canvas course [2198](https://canvas.mit.edu/courses/2198) course via:`./manage.py backpopulate_canvas_courses --canvas-ids 2198`
- once done, view the contentfiles that were created in django shell:
```python
from learning_resources.models import *
list(LearningResource.objects.get(readable_id__icontains="2198").runs.first().content_files.all().values_list("source_path",flat=True))
```
- make note of the list of files - "21G.515-Syllabus-Fall2025.docx" which is a file visible to students is missing from the list
- checkout this branch - restart celery and do the same - note that there are more files and 21G.515-Syllabus-Fall2025.docx is in the list



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
