### PR TITLE
Hybrid Search: Fix "resource type" filter

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -10822,6 +10822,7 @@ export const VectorLearningResourcesSearchApiAxiosParamCreator = function (
      * @param {boolean} [published] If the resource is published. We default to True unless passed in
      * @param {string} [q] The search text
      * @param {string} [readable_id] The readable id of the resource
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<VectorLearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<VectorLearningResourcesSearchRetrieveResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {number} [score_cutoff] The minimum score a result must have to be returned. Defaults to 0.0 when omitted, but the server clamps the effective cutoff to the minimum allowed for the selected search mode (dense or hybrid).
@@ -10851,6 +10852,7 @@ export const VectorLearningResourcesSearchApiAxiosParamCreator = function (
       published?: boolean,
       q?: string,
       readable_id?: string,
+      resource_category?: Array<string>,
       resource_type?: Array<VectorLearningResourcesSearchRetrieveResourceTypeEnum>,
       resource_type_group?: Array<VectorLearningResourcesSearchRetrieveResourceTypeGroupEnum>,
       score_cutoff?: number,
@@ -10948,6 +10950,10 @@ export const VectorLearningResourcesSearchApiAxiosParamCreator = function (
         localVarQueryParameter["readable_id"] = readable_id
       }
 
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
+      }
+
       if (resource_type) {
         localVarQueryParameter["resource_type"] = resource_type
       }
@@ -11024,6 +11030,7 @@ export const VectorLearningResourcesSearchApiFp = function (
      * @param {boolean} [published] If the resource is published. We default to True unless passed in
      * @param {string} [q] The search text
      * @param {string} [readable_id] The readable id of the resource
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<VectorLearningResourcesSearchRetrieveResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<VectorLearningResourcesSearchRetrieveResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {number} [score_cutoff] The minimum score a result must have to be returned. Defaults to 0.0 when omitted, but the server clamps the effective cutoff to the minimum allowed for the selected search mode (dense or hybrid).
@@ -11053,6 +11060,7 @@ export const VectorLearningResourcesSearchApiFp = function (
       published?: boolean,
       q?: string,
       readable_id?: string,
+      resource_category?: Array<string>,
       resource_type?: Array<VectorLearningResourcesSearchRetrieveResourceTypeEnum>,
       resource_type_group?: Array<VectorLearningResourcesSearchRetrieveResourceTypeGroupEnum>,
       score_cutoff?: number,
@@ -11087,6 +11095,7 @@ export const VectorLearningResourcesSearchApiFp = function (
           published,
           q,
           readable_id,
+          resource_category,
           resource_type,
           resource_type_group,
           score_cutoff,
@@ -11154,6 +11163,7 @@ export const VectorLearningResourcesSearchApiFactory = function (
           requestParameters.published,
           requestParameters.q,
           requestParameters.readable_id,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
           requestParameters.score_cutoff,
@@ -11301,6 +11311,13 @@ export interface VectorLearningResourcesSearchApiVectorLearningResourcesSearchRe
   readonly readable_id?: string
 
   /**
+   * The resource category for the resource
+   * @type {Array<string>}
+   * @memberof VectorLearningResourcesSearchApiVectorLearningResourcesSearchRetrieve
+   */
+  readonly resource_category?: Array<string>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof VectorLearningResourcesSearchApiVectorLearningResourcesSearchRetrieve
@@ -11389,6 +11406,7 @@ export class VectorLearningResourcesSearchApi extends BaseAPI {
         requestParameters.published,
         requestParameters.q,
         requestParameters.readable_id,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
         requestParameters.score_cutoff,

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -16586,6 +16586,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -16606,6 +16607,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       offered_by?: Array<LearningResourcesSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesSimilarListPlatformEnum>,
       professional?: boolean | null,
+      resource_category?: Array<string>,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
       topic?: Array<string>,
@@ -16678,6 +16680,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
 
       if (professional !== undefined) {
         localVarQueryParameter["professional"] = professional
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -16930,6 +16936,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -16950,6 +16957,7 @@ export const LearningResourcesApiAxiosParamCreator = function (
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
+      resource_category?: Array<string>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
       topic?: Array<string>,
@@ -17023,6 +17031,10 @@ export const LearningResourcesApiAxiosParamCreator = function (
 
       if (professional !== undefined) {
         localVarQueryParameter["professional"] = professional
+      }
+
+      if (resource_category) {
+        localVarQueryParameter["resource_category"] = resource_category
       }
 
       if (resource_type) {
@@ -17406,6 +17418,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningResourcesSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<LearningResourcesSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -17426,6 +17439,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       offered_by?: Array<LearningResourcesSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesSimilarListPlatformEnum>,
       professional?: boolean | null,
+      resource_category?: Array<string>,
       resource_type?: Array<LearningResourcesSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesSimilarListResourceTypeGroupEnum>,
       topic?: Array<string>,
@@ -17451,6 +17465,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           offered_by,
           platform,
           professional,
+          resource_category,
           resource_type,
           resource_type_group,
           topic,
@@ -17610,6 +17625,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
      * @param {Array<LearningResourcesVectorSimilarListOfferedByEnum>} [offered_by] The organization that offers the learning resource               * &#x60;mitx&#x60; - MITx * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;climate&#x60; - MIT Climate
      * @param {Array<LearningResourcesVectorSimilarListPlatformEnum>} [platform] The platform on which the learning resource is offered               * &#x60;edx&#x60; - edX * &#x60;ocw&#x60; - MIT OpenCourseWare * &#x60;oll&#x60; - Open Learning Library * &#x60;mitxonline&#x60; - MITx Online * &#x60;bootcamps&#x60; - Bootcamps * &#x60;xpro&#x60; - MIT xPRO * &#x60;csail&#x60; - CSAIL * &#x60;mitpe&#x60; - MIT Professional Education * &#x60;see&#x60; - MIT Sloan Executive Education * &#x60;scc&#x60; - Schwarzman College of Computing * &#x60;ctl&#x60; - Center for Transportation &amp; Logistics * &#x60;whu&#x60; - WHU * &#x60;susskind&#x60; - Susskind * &#x60;globalalumni&#x60; - Global Alumni * &#x60;simplilearn&#x60; - Simplilearn * &#x60;emeritus&#x60; - Emeritus * &#x60;podcast&#x60; - Podcast * &#x60;youtube&#x60; - YouTube * &#x60;canvas&#x60; - Canvas * &#x60;climate&#x60; - MIT Climate * &#x60;ovs&#x60; - ODL Video Service
      * @param {boolean | null} [professional]
+     * @param {Array<string>} [resource_category] The resource category for the resource
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeEnum>} [resource_type] The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
      * @param {Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>} [resource_type_group] The category of learning resource               * &#x60;course&#x60; - Course * &#x60;program&#x60; - Program * &#x60;learning_material&#x60; - Learning Material
      * @param {Array<string>} [topic] The topic name. To see a list of options go to api/v1/topics/
@@ -17630,6 +17646,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
       offered_by?: Array<LearningResourcesVectorSimilarListOfferedByEnum>,
       platform?: Array<LearningResourcesVectorSimilarListPlatformEnum>,
       professional?: boolean | null,
+      resource_category?: Array<string>,
       resource_type?: Array<LearningResourcesVectorSimilarListResourceTypeEnum>,
       resource_type_group?: Array<LearningResourcesVectorSimilarListResourceTypeGroupEnum>,
       topic?: Array<string>,
@@ -17655,6 +17672,7 @@ export const LearningResourcesApiFp = function (configuration?: Configuration) {
           offered_by,
           platform,
           professional,
+          resource_category,
           resource_type,
           resource_type_group,
           topic,
@@ -17868,6 +17886,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.offered_by,
           requestParameters.platform,
           requestParameters.professional,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
           requestParameters.topic,
@@ -17956,6 +17975,7 @@ export const LearningResourcesApiFactory = function (
           requestParameters.offered_by,
           requestParameters.platform,
           requestParameters.professional,
+          requestParameters.resource_category,
           requestParameters.resource_type,
           requestParameters.resource_type_group,
           requestParameters.topic,
@@ -18386,6 +18406,13 @@ export interface LearningResourcesApiLearningResourcesSimilarListRequest {
   readonly professional?: boolean | null
 
   /**
+   * The resource category for the resource
+   * @type {Array<string>}
+   * @memberof LearningResourcesApiLearningResourcesSimilarList
+   */
+  readonly resource_category?: Array<string>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof LearningResourcesApiLearningResourcesSimilarList
@@ -18666,6 +18693,13 @@ export interface LearningResourcesApiLearningResourcesVectorSimilarListRequest {
   readonly professional?: boolean | null
 
   /**
+   * The resource category for the resource
+   * @type {Array<string>}
+   * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
+   */
+  readonly resource_category?: Array<string>
+
+  /**
    * The type of learning resource               * &#x60;course&#x60; - course * &#x60;program&#x60; - program * &#x60;learning_path&#x60; - learning path * &#x60;podcast&#x60; - podcast * &#x60;podcast_episode&#x60; - podcast episode * &#x60;video&#x60; - video * &#x60;video_playlist&#x60; - video playlist * &#x60;document&#x60; - document
    * @type {Array<'course' | 'program' | 'learning_path' | 'podcast' | 'podcast_episode' | 'video' | 'video_playlist' | 'document'>}
    * @memberof LearningResourcesApiLearningResourcesVectorSimilarList
@@ -18890,6 +18924,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.offered_by,
         requestParameters.platform,
         requestParameters.professional,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
         requestParameters.topic,
@@ -18984,6 +19019,7 @@ export class LearningResourcesApi extends BaseAPI {
         requestParameters.offered_by,
         requestParameters.platform,
         requestParameters.professional,
+        requestParameters.resource_category,
         requestParameters.resource_type,
         requestParameters.resource_type_group,
         requestParameters.topic,

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -85,6 +85,16 @@ const getLastApiSearchParams = () => {
   return fullUrl.searchParams
 }
 
+const getLastVectorApiSearchParams = () => {
+  const call = makeRequest.mock.calls.find(([args]) => {
+    if (args.method !== "get") return false
+    return args.url.startsWith(urls.search.vectorResources())
+  })
+  invariant(call)
+  const fullUrl = new URL(call[0].url, "http://mit.edu")
+  return fullUrl.searchParams
+}
+
 describe("SearchPage", () => {
   test("Renders search results", async () => {
     const resources = factories.learningResources.resources({
@@ -1078,6 +1088,39 @@ describe("UniversalAIBanner", () => {
         "LearningMaterials(0)",
       ])
     })
+  })
+
+  test("Vector Hybrid Search passes resource category filters without a text query", async () => {
+    setMockApiResponses({
+      search: {
+        count: 1,
+        metadata: {
+          aggregations: {
+            resource_type_group: [{ key: "learning_material", doc_count: 1 }],
+            resource_category: [{ key: "Video", doc_count: 1 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+
+    renderWithProviders(<SearchPage />, {
+      url: "?vector_search=true&resource_type_group=learning_material&resource_category=Video&topic=Systems%20Engineering",
+    })
+
+    await waitFor(() => {
+      expect(
+        makeRequest.mock.calls.some(([args]) =>
+          args.url.startsWith(urls.search.vectorResources()),
+        ),
+      ).toBe(true)
+    })
+
+    const apiSearchParams = getLastVectorApiSearchParams()
+    expect(apiSearchParams.get("hybrid_search")).toBe("true")
+    expect(apiSearchParams.get("resource_type_group")).toBe("learning_material")
+    expect(apiSearchParams.get("resource_category")).toBe("Video")
+    expect(apiSearchParams.get("topic")).toBe("Systems Engineering")
   })
 
   test("Vector Hybrid Search with a query hides pagination and filters results locally", async () => {

--- a/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
@@ -54,6 +54,8 @@ const toVectorSearchParams = (
   platform: params.platform as VectorSearchRequest["platform"],
   professional: params.professional,
   q: params.q,
+  resource_category:
+    params.resource_category as VectorSearchRequest["resource_category"],
   resource_type: params.resource_type as VectorSearchRequest["resource_type"],
   resource_type_group:
     params.resource_type_group as VectorSearchRequest["resource_type_group"],

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1227,6 +1227,14 @@ paths:
           minLength: 1
         description: The readable id of the resource
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        description: The resource category for the resource
+      - in: query
         name: resource_type
         schema:
           type: array

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -2994,6 +2994,14 @@ paths:
           type: boolean
           nullable: true
       - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        description: The resource category for the resource
+      - in: query
         name: resource_type
         schema:
           type: array
@@ -3354,6 +3362,14 @@ paths:
         schema:
           type: boolean
           nullable: true
+      - in: query
+        name: resource_category
+        schema:
+          type: array
+          items:
+            type: string
+            minLength: 1
+        description: The resource category for the resource
       - in: query
         name: resource_type
         schema:

--- a/vector_search/serializers.py
+++ b/vector_search/serializers.py
@@ -88,6 +88,11 @@ class LearningResourcesSearchFiltersSerializer(serializers.Serializer):
             \n\n{build_choice_description_list(resource_choices)}"
         ),
     )
+    resource_category = serializers.ListField(
+        required=False,
+        child=serializers.CharField(),
+        help_text="The resource category for the resource",
+    )
     free = ArrayWrappedBoolean(
         required=False,
         allow_null=True,

--- a/vector_search/serializers_test.py
+++ b/vector_search/serializers_test.py
@@ -14,6 +14,18 @@ def test_filter_serializer_accepts_resource_type():
     assert s.validated_data["resource_type"] == ["video_playlist"]
 
 
+def test_filter_serializer_accepts_resource_category():
+    """Resource category is a shared learning resource search filter."""
+    s = LearningResourcesSearchFiltersSerializer(
+        data={"resource_category": ["Course", "Practice & Assignment"]}
+    )
+    assert s.is_valid(), s.errors
+    assert s.validated_data["resource_category"] == [
+        "Course",
+        "Practice & Assignment",
+    ]
+
+
 def test_filter_serializer_rejects_invalid_resource_type():
     s = LearningResourcesSearchFiltersSerializer(data={"resource_type": ["not_a_type"]})
     assert not s.is_valid()
@@ -36,6 +48,7 @@ def test_filter_serializer_has_no_search_fields():
 def test_vector_search_request_serializer_inherits_filter_fields():
     fields = LearningResourcesVectorSearchRequestSerializer().fields
     assert "resource_type" in fields
+    assert "resource_category" in fields
     assert "platform" in fields
     assert "q" in fields
     assert "hybrid_search" in fields

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -38,6 +38,7 @@ def test_vector_search_filters(mocker, client):
         "offered_by": ["ocw"],
         "platform": ["edx"],
         "resource_type": ["course"],
+        "resource_category": ["Course", "Practice & Assignment"],
         "free": True,
         "department": ["6", "7"],
     }
@@ -57,6 +58,10 @@ def test_vector_search_filters(mocker, client):
             ),
             models.FieldCondition(
                 key="resource_type", match=models.MatchAny(any=["course"])
+            ),
+            models.FieldCondition(
+                key="resource_category",
+                match=models.MatchAny(any=["Course", "Practice & Assignment"]),
             ),
             models.FieldCondition(key="free", match=models.MatchValue(value=True)),
             models.FieldCondition(
@@ -88,6 +93,7 @@ def test_vector_search_filters_empty_query(mocker, client):
         "offered_by": ["ocw"],
         "platform": ["edx"],
         "resource_type": ["course"],
+        "resource_category": ["Course", "Practice & Assignment"],
         "free": True,
         "department": ["6", "7"],
     }
@@ -107,6 +113,10 @@ def test_vector_search_filters_empty_query(mocker, client):
             ),
             models.FieldCondition(
                 key="resource_type", match=models.MatchAny(any=["course"])
+            ),
+            models.FieldCondition(
+                key="resource_category",
+                match=models.MatchAny(any=["Course", "Practice & Assignment"]),
             ),
             models.FieldCondition(key="free", match=models.MatchValue(value=True)),
             models.FieldCondition(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes  https://github.com/mitodl/hq/issues/11858
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue where in the hybrid search interface (topic pages which is live) the "resource category" filter does not work when looking at learning materials.

### Screenshots (if appropriate):
<img width="854" height="393" alt="Screenshot 2026-06-26 at 10 37 00 AM" src="https://github.com/user-attachments/assets/ae384ad3-a4ea-4141-b748-e1337b731f17" />


### How can this be tested?
1. checkout this branch
2. make sure you have a variety of learning materials embedded locally - otherwise run ```./manage.py generate_embeddings --videos --video_playlists --documents --podcasts --skip-contentfiles```
3. go to a [topic channel page](http://open.odl.local:8062/c/topic/biology) - select "learning materials"
4. try to filter by different resource categories and confirm it works as intended
5. login as an admin and go to the [main search interface](http://open.odl.local:8062/search) and enable "hybrid search" from the admin options ~ try the same filtering and it should work.
