### PR TITLE
Add wait=False to relevant qdrant sdk calls

### DIFF
--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -507,6 +507,7 @@ def update_learning_resource_payload(serialized_document):
         collection_name=RESOURCES_COLLECTION_NAME,
         payload=serialized_document,
         points=[point_id],
+        wait=False,
     )
 
 
@@ -558,6 +559,7 @@ def _set_payload(points, document, param_map, collection_name):
             collection_name=collection_name,
             payload=payload,
             points=point_batch,
+            wait=False,
         )
 
 
@@ -1311,6 +1313,7 @@ def remove_points_matching_params(
             points_selector=models.FilterSelector(
                 filter=qdrant_conditions,
             ),
+            wait=False,
         )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12008?issue=mitodl%7Chq%7C12018
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR simply adds wait=False to the relevant qdrant sdk calls ass suggested by qdrant:

>with prevent_unoptimized: true enabled on your collections, any write operation using wait=True (the SDK default) will block until the optimizer finishes processing the segment. This may be why you are seeing in the Deferred points wait interrupted: caller timed out log warnings. I do not see overwrite_payload, set_payload, and delete in your codebase containing wait=False. We recommend explicitly add wait=False to all three and see how this affects your performance. 

this should resolve the following in qdrant cluster logs:
```
2026-06-26T14:55:32.421298Z  WARN collection::update_workers::update_worker: Failed to await for deferred points: Operation Cancelled: Deferred points wait interrupted: caller timed out
```

### How can this be tested?
1. checkout this branch - restart celery
2. run this snippet which should work:
```python
from learning_resources.models import ContentFile
from vector_search.tasks import embed_learning_resources_by_id

content_file = (
    ContentFile.objects.filter(
        published=True,
        run__learning_resource__published=True,
    )
    .exclude(content__isnull=True)
    .exclude(content="")
    .first()
)
assert content_file, "Need at least one published content file with content"

resource = content_file.run.learning_resource
result = embed_learning_resources_by_id.delay(
    [resource.id],
    skip_content_files=False,
    overwrite=True,
)

print("Queued embedding task:", result.id)
print("Resource:", resource.id, resource.title)
```
4. confirm embeddings work as intended via management commands:
```./manage.py generate_embeddings --courses --skip-contentfiles```
monitor the celery container logs and see embeddings are generating as expected

