### PR TITLE
feat: server-side pagination and search for contract codes

### DIFF
--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -16,6 +16,7 @@
     "./test-utils/mockAxios": "./src/test-utils/mockAxios.ts",
     "./test-utils": "./src/test-utils/index.ts",
     "./mitxonline-hooks/*": "./src/mitxonline/hooks/*/index.ts",
+    "./mitxonline-clients": "./src/mitxonline/clients.ts",
     "./mitxonline-test-utils": "./src/mitxonline/test-utils/index.ts"
   },
   "peerDependencies": {
@@ -31,7 +32,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "2026.6.17",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -32,7 +32,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -31,7 +31,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "2026.6.30-1",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -32,7 +32,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",
     "tiny-invariant": "^1.3.3"

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -16,7 +16,6 @@
     "./test-utils/mockAxios": "./src/test-utils/mockAxios.ts",
     "./test-utils": "./src/test-utils/index.ts",
     "./mitxonline-hooks/*": "./src/mitxonline/hooks/*/index.ts",
-    "./mitxonline-clients": "./src/mitxonline/clients.ts",
     "./mitxonline-test-utils": "./src/mitxonline/test-utils/index.ts"
   },
   "peerDependencies": {

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -115,4 +115,7 @@ export {
   useRemindCode,
   useRevokeCode,
 }
-export type { ContractCode, PaginatedContractCodes } from "./queries"
+export type {
+  ManagerEnrollmentCode,
+  PaginatedManagerEnrollmentCodeList,
+} from "@mitodl/mitxonline-api-axios/v2"

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -39,10 +39,10 @@ const useBulkAssignSeats = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesBulkAssignCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: managerOrganizationKeys.contractCodesForContract(
+          vars.id,
+          vars.parent_lookup_organization,
+        ),
       })
     },
   })
@@ -57,10 +57,10 @@ const useRemindCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRemindCreate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: managerOrganizationKeys.contractCodesForContract(
+          vars.id,
+          vars.parent_lookup_organization,
+        ),
       })
     },
   })
@@ -75,10 +75,10 @@ const useRevokeCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesRevokeDestroy(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: managerOrganizationKeys.contractCodesForContract(
+          vars.id,
+          vars.parent_lookup_organization,
+        ),
       })
     },
   })
@@ -97,10 +97,10 @@ const useReassignCode = () => {
     ) => b2bApi.b2bManagerOrganizationsContractsCodesReassignUpdate(opts),
     onSettled: (_data, _err, vars) => {
       queryClient.invalidateQueries({
-        queryKey: managerOrganizationKeys.contractCodes({
-          id: vars.id,
-          parent_lookup_organization: vars.parent_lookup_organization,
-        }),
+        queryKey: managerOrganizationKeys.contractCodesForContract(
+          vars.id,
+          vars.parent_lookup_organization,
+        ),
       })
     },
   })
@@ -115,4 +115,4 @@ export {
   useRemindCode,
   useRevokeCode,
 }
-export type { ContractCode } from "./queries"
+export type { ContractCode, PaginatedContractCodes } from "./queries"

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -4,6 +4,8 @@ import {
   OrganizationPage,
   ManagerContractDetail,
   ManagerEnrollmentCode,
+  PaginatedManagerEnrollmentCodeList,
+  PaginatedOrganizationPageList,
   B2bApiB2bOrganizationsRetrieveRequest,
   B2bApiB2bManagerOrganizationsContractsRetrieveRequest,
   B2bApiB2bManagerOrganizationsContractsCodesListRequest,
@@ -11,6 +13,13 @@ import {
 
 type ContractCode = ManagerEnrollmentCode & {
   redemption_status: "unassigned" | "assigned" | "redeemed"
+}
+
+type PaginatedContractCodes = Omit<
+  PaginatedManagerEnrollmentCodeList,
+  "results"
+> & {
+  results: ContractCode[]
 }
 
 const organizationKeys = {
@@ -47,9 +56,20 @@ const managerOrganizationKeys = {
     ] as const,
   contractCodesRoot: () =>
     ["mitxonline", "manager", "organizations", "contracts", "codes"] as const,
+  // Prefix key used for invalidation — matches all pages/search states for one contract
+  contractCodesForContract: (id: number, orgId: number) =>
+    [...managerOrganizationKeys.contractCodesRoot(), id, orgId] as const,
   contractCodes: (
     opts: B2bApiB2bManagerOrganizationsContractsCodesListRequest,
-  ) => [...managerOrganizationKeys.contractCodesRoot(), opts] as const,
+  ) =>
+    [
+      ...managerOrganizationKeys.contractCodesForContract(
+        opts.id,
+        opts.parent_lookup_organization,
+      ),
+      opts.page,
+      opts.search_term,
+    ] as const,
 }
 
 const managerOrganizationQueries = {
@@ -57,7 +77,12 @@ const managerOrganizationQueries = {
     queryOptions({
       queryKey: managerOrganizationKeys.list(),
       queryFn: async (): Promise<OrganizationPage[]> =>
-        b2bApi.b2bManagerOrganizationsList().then((res) => res.data),
+        b2bApi.b2bManagerOrganizationsList().then((res) => {
+          const data = res.data as
+            | PaginatedOrganizationPageList
+            | OrganizationPage[]
+          return Array.isArray(data) ? data : data.results
+        }),
     }),
   managerContractDetail: (
     opts: B2bApiB2bManagerOrganizationsContractsRetrieveRequest,
@@ -74,10 +99,10 @@ const managerOrganizationQueries = {
   ) =>
     queryOptions({
       queryKey: managerOrganizationKeys.contractCodes(opts),
-      queryFn: async (): Promise<ContractCode[]> =>
+      queryFn: async (): Promise<PaginatedContractCodes> =>
         b2bApi
           .b2bManagerOrganizationsContractsCodesList(opts)
-          .then((res) => res.data as ContractCode[]),
+          .then((res) => res.data as PaginatedContractCodes),
     }),
 }
 
@@ -88,4 +113,4 @@ export {
   managerOrganizationKeys,
 }
 
-export type { ContractCode }
+export type { ContractCode, PaginatedContractCodes }

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -69,6 +69,7 @@ const managerOrganizationKeys = {
       ),
       opts.page,
       opts.search_term,
+      opts.status,
     ] as const,
 }
 

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -56,22 +56,15 @@ const managerOrganizationKeys = {
     ] as const,
   contractCodesRoot: () =>
     ["mitxonline", "manager", "organizations", "contracts", "codes"] as const,
-  // Prefix key used for invalidation — matches all pages/search states for one contract
-  contractCodesForContract: (id: number, orgId: number) =>
-    [...managerOrganizationKeys.contractCodesRoot(), id, orgId] as const,
   contractCodes: (
     opts: B2bApiB2bManagerOrganizationsContractsCodesListRequest,
-  ) =>
-    [
-      ...managerOrganizationKeys.contractCodesForContract(
-        opts.id,
-        opts.parent_lookup_organization,
-      ),
-      opts.page,
-      opts.page_size,
-      opts.search_term,
-      opts.status,
-    ] as const,
+  ) => [...managerOrganizationKeys.contractCodesRoot(), opts] as const,
+  // Prefix key used for invalidation — matches all pages/search states for one contract
+  contractCodesForContract: (id: number, orgId: number) =>
+    managerOrganizationKeys.contractCodes({
+      id,
+      parent_lookup_organization: orgId,
+    }),
 }
 
 const managerOrganizationQueries = {

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -3,24 +3,11 @@ import { b2bApi } from "../../clients"
 import {
   OrganizationPage,
   ManagerContractDetail,
-  ManagerEnrollmentCode,
   PaginatedManagerEnrollmentCodeList,
-  PaginatedOrganizationPageList,
   B2bApiB2bOrganizationsRetrieveRequest,
   B2bApiB2bManagerOrganizationsContractsRetrieveRequest,
   B2bApiB2bManagerOrganizationsContractsCodesListRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
-
-type ContractCode = ManagerEnrollmentCode & {
-  redemption_status: "unassigned" | "assigned" | "redeemed"
-}
-
-type PaginatedContractCodes = Omit<
-  PaginatedManagerEnrollmentCodeList,
-  "results"
-> & {
-  results: ContractCode[]
-}
 
 const organizationKeys = {
   root: ["mitxonline", "organizations"],
@@ -72,12 +59,7 @@ const managerOrganizationQueries = {
     queryOptions({
       queryKey: managerOrganizationKeys.list(),
       queryFn: async (): Promise<OrganizationPage[]> =>
-        b2bApi.b2bManagerOrganizationsList().then((res) => {
-          const data = res.data as
-            | PaginatedOrganizationPageList
-            | OrganizationPage[]
-          return Array.isArray(data) ? data : data.results
-        }),
+        b2bApi.b2bManagerOrganizationsList().then((res) => res.data.results),
     }),
   managerContractDetail: (
     opts: B2bApiB2bManagerOrganizationsContractsRetrieveRequest,
@@ -94,10 +76,10 @@ const managerOrganizationQueries = {
   ) =>
     queryOptions({
       queryKey: managerOrganizationKeys.contractCodes(opts),
-      queryFn: async (): Promise<PaginatedContractCodes> =>
+      queryFn: async (): Promise<PaginatedManagerEnrollmentCodeList> =>
         b2bApi
           .b2bManagerOrganizationsContractsCodesList(opts)
-          .then((res) => res.data as PaginatedContractCodes),
+          .then((res) => res.data),
     }),
 }
 
@@ -108,4 +90,3 @@ export {
   managerOrganizationKeys,
 }
 
-export type { ContractCode, PaginatedContractCodes }

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -68,6 +68,7 @@ const managerOrganizationKeys = {
         opts.parent_lookup_organization,
       ),
       opts.page,
+      opts.page_size,
       opts.search_term,
       opts.status,
     ] as const,

--- a/frontends/api/src/mitxonline/hooks/organizations/queries.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/queries.ts
@@ -89,4 +89,3 @@ export {
   managerOrganizationQueries,
   managerOrganizationKeys,
 }
-

--- a/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
@@ -5,7 +5,10 @@ import type {
   ContractPage,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { makePaginatedFactory } from "ol-test-utilities"
-import type { ContractCode } from "../../hooks/organizations"
+import type {
+  ContractCode,
+  PaginatedContractCodes,
+} from "../../hooks/organizations"
 
 const contract = (overrides: Partial<ContractPage> = {}): ContractPage => ({
   id: faker.number.int(),
@@ -25,6 +28,16 @@ const contract = (overrides: Partial<ContractPage> = {}): ContractPage => ({
 })
 
 const contracts = makePaginatedFactory(contract)
+
+const paginatedContractCodes = (
+  results: ContractCode[],
+  opts: { count?: number; next?: string | null; previous?: string | null } = {},
+): PaginatedContractCodes => ({
+  count: opts.count ?? results.length,
+  next: opts.next ?? null,
+  previous: opts.previous ?? null,
+  results,
+})
 
 const contractCode = (overrides: Partial<ContractCode> = {}): ContractCode => {
   const status = overrides.redemption_status ?? "assigned"
@@ -61,4 +74,11 @@ const bulkAssignResult = (
   ...overrides,
 })
 
-export { contract, contracts, contractCode, bulkAssignError, bulkAssignResult }
+export {
+  contract,
+  contracts,
+  contractCode,
+  paginatedContractCodes,
+  bulkAssignError,
+  bulkAssignResult,
+}

--- a/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
@@ -3,19 +3,16 @@ import type {
   BulkAssignError,
   BulkAssignResult,
   ContractPage,
+  ManagerEnrollmentCode,
+  PaginatedManagerEnrollmentCodeList,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { makePaginatedFactory } from "ol-test-utilities"
-import type {
-  ContractCode,
-  PaginatedContractCodes,
-} from "../../hooks/organizations"
 
 const contract = (overrides: Partial<ContractPage> = {}): ContractPage => ({
   id: faker.number.int(),
   contract_end: faker.date.future().toISOString(),
   contract_start: faker.date.past().toISOString(),
   description: faker.lorem.sentence(),
-  integration_type: "non-sso" as const,
   name: faker.company.name(),
   organization: faker.number.int(),
   slug: faker.lorem.slug(),
@@ -30,16 +27,16 @@ const contract = (overrides: Partial<ContractPage> = {}): ContractPage => ({
 const contracts = makePaginatedFactory(contract)
 
 const paginatedContractCodes = (
-  results: ContractCode[],
+  results: ManagerEnrollmentCode[],
   opts: { count?: number; next?: string | null; previous?: string | null } = {},
-): PaginatedContractCodes => ({
+): PaginatedManagerEnrollmentCodeList => ({
   count: opts.count ?? results.length,
   next: opts.next ?? null,
   previous: opts.previous ?? null,
   results,
 })
 
-const contractCode = (overrides: Partial<ContractCode> = {}): ContractCode => {
+const contractCode = (overrides: Partial<ManagerEnrollmentCode> = {}): ManagerEnrollmentCode => {
   const status = overrides.redemption_status ?? "assigned"
   const isAssigned = status !== "unassigned"
   const isRedeemed = status === "redeemed"

--- a/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/contracts.ts
@@ -36,7 +36,9 @@ const paginatedContractCodes = (
   results,
 })
 
-const contractCode = (overrides: Partial<ManagerEnrollmentCode> = {}): ManagerEnrollmentCode => {
+const contractCode = (
+  overrides: Partial<ManagerEnrollmentCode> = {},
+): ManagerEnrollmentCode => {
   const status = overrides.redemption_status ?? "assigned"
   const isAssigned = status !== "unassigned"
   const isRedeemed = status === "redeemed"

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -90,8 +90,19 @@ const contracts = {
   contractsList: () => `${getApiBaseUrl()}/api/v0/b2b/contracts/`,
   managerContractDetail: (orgId: number, contractId: number) =>
     `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/`,
-  managerContractCodes: (orgId: number, contractId: number) =>
-    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/`,
+  managerContractCodes: (
+    orgId: number,
+    contractId: number,
+    params?: { page?: number; page_size?: number; search_term?: string },
+  ) => {
+    // queryify does not filter undefined values, so strip them first to avoid e.g. search_term=undefined in the URL
+    const clean = params
+      ? Object.fromEntries(
+          Object.entries(params).filter(([, v]) => v !== undefined),
+        )
+      : undefined
+    return `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/${queryify(clean)}`
+  },
   managerContractBulkAssign: (orgId: number, contractId: number) =>
     `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/bulk_assign/`,
   managerContractCodeRemind: (

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -93,7 +93,12 @@ const contracts = {
   managerContractCodes: (
     orgId: number,
     contractId: number,
-    params?: { page?: number; page_size?: number; search_term?: string },
+    params?: {
+      page?: number
+      page_size?: number
+      search_term?: string
+      status?: string
+    },
   ) => {
     // queryify does not filter undefined values, so strip them first to avoid e.g. search_term=undefined in the URL
     const clean = params

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -16,7 +16,7 @@
     "@floating-ui/react": "^0.27.16",
     "@mitodl/arithmix": "^0.2.2",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "2026.6.30-1",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -16,7 +16,7 @@
     "@floating-ui/react": "^0.27.16",
     "@mitodl/arithmix": "^0.2.2",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "2026.6.17",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -16,7 +16,7 @@
     "@floating-ui/react": "^0.27.16",
     "@mitodl/arithmix": "^0.2.2",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -16,7 +16,7 @@
     "@floating-ui/react": "^0.27.16",
     "@mitodl/arithmix": "^0.2.2",
     "@mitodl/course-search-utils": "^3.5.2",
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz",
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz",
     "@mitodl/smoot-design": "^6.27.0",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",

--- a/frontends/main/public/sample-seat-assignments.csv
+++ b/frontends/main/public/sample-seat-assignments.csv
@@ -1,0 +1,6 @@
+id,name,email
+1,Test User One,testuser1@example.com
+2,Test User Two,testuser2@example.com
+3,Test User Three,testuser3@example.com
+4,Test User Four,testuser4@example.com
+5,Test User Five,testuser5@example.com

--- a/frontends/main/public/sample-seat-assignments.csv
+++ b/frontends/main/public/sample-seat-assignments.csv
@@ -1,6 +1,6 @@
-id,name,email
-1,Test User One,testuser1@example.com
-2,Test User Two,testuser2@example.com
-3,Test User Three,testuser3@example.com
-4,Test User Four,testuser4@example.com
-5,Test User Five,testuser5@example.com
+email
+testuser1@example.com
+testuser2@example.com
+testuser3@example.com
+testuser4@example.com
+testuser5@example.com

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -73,7 +73,7 @@ describe("AssignSeatsSection", () => {
     expect(screen.getByText("(download sample CSV)")).toBeInTheDocument()
   })
 
-  test("download sample CSV pseudo-link is in the tab order and disabled", () => {
+  test("download sample CSV link is rendered", () => {
     renderWithProviders(
       <AssignSeatsSection
         orgId={1}
@@ -83,12 +83,11 @@ describe("AssignSeatsSection", () => {
       />,
     )
 
-    // Only the download link is still disabled — import from CSV is now active
-    const downloadLink = screen.getByRole("button", {
+    // The download link is a real anchor — in the tab order and not disabled
+    const downloadLink = screen.getByRole("link", {
       name: "(download sample CSV)",
     })
-    expect(downloadLink).toHaveAttribute("tabindex", "0")
-    expect(downloadLink).toHaveAttribute("aria-disabled", "true")
+    expect(downloadLink).toBeInTheDocument()
   })
 
   test("import from CSV button is active and in the tab order", () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -51,7 +51,12 @@ describe("AssignSeatsSection", () => {
 
   test("renders section title and key UI elements", () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     expect(
@@ -70,7 +75,12 @@ describe("AssignSeatsSection", () => {
 
   test("download sample CSV pseudo-link is in the tab order and disabled", () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     // Only the download link is still disabled — import from CSV is now active
@@ -83,7 +93,12 @@ describe("AssignSeatsSection", () => {
 
   test("import from CSV button is active and in the tab order", () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const importButton = screen.getByRole("button", { name: "import from CSV" })
@@ -94,7 +109,12 @@ describe("AssignSeatsSection", () => {
 
   test("Assign Seats button is disabled when textarea is empty", () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     expect(screen.getByRole("button", { name: "Assign Seats" })).toBeDisabled()
@@ -102,7 +122,12 @@ describe("AssignSeatsSection", () => {
 
   test("Assign Seats button is disabled when valid email count exceeds available seats", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={1} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={1}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -113,7 +138,12 @@ describe("AssignSeatsSection", () => {
 
   test("Assign Seats button enables when at least one valid email is entered", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -126,7 +156,12 @@ describe("AssignSeatsSection", () => {
 
   test("Assign Seats button stays disabled when only invalid emails are entered", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -137,7 +172,12 @@ describe("AssignSeatsSection", () => {
 
   test("sole invalid token is not highlighted while focused (no preceding comma)", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -150,7 +190,12 @@ describe("AssignSeatsSection", () => {
 
   test("last invalid token is highlighted while focused when preceded by a comma", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -163,7 +208,12 @@ describe("AssignSeatsSection", () => {
 
   test("last invalid token is highlighted after blur (no trailing comma)", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -177,7 +227,12 @@ describe("AssignSeatsSection", () => {
 
   test("shows valid/invalid counts after entering emails", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -189,7 +244,12 @@ describe("AssignSeatsSection", () => {
 
   test("shows only valid count when all emails are valid", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -201,7 +261,12 @@ describe("AssignSeatsSection", () => {
 
   test("validation badge is not shown when textarea is empty", () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     expect(screen.queryByText(/valid/i)).not.toBeInTheDocument()
@@ -209,7 +274,12 @@ describe("AssignSeatsSection", () => {
 
   test("live region announces email validation summary after debounce", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -229,7 +299,12 @@ describe("AssignSeatsSection", () => {
 
   test("clicking Assign Seats opens the confirm modal", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -245,7 +320,12 @@ describe("AssignSeatsSection", () => {
 
   test("modal shows invalid emails when textarea has mixed input", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -258,7 +338,12 @@ describe("AssignSeatsSection", () => {
 
   test("modal shows duplicate count when textarea has repeated emails", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -273,7 +358,12 @@ describe("AssignSeatsSection", () => {
 
   test("closing the modal hides it", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -294,7 +384,12 @@ describe("AssignSeatsSection", () => {
 
   test("importing a valid CSV opens the modal without populating the textarea", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent = "email\nalice@example.com\nbob@example.com"
@@ -318,7 +413,12 @@ describe("AssignSeatsSection", () => {
 
   test("importing a CSV with invalid emails shows them in the modal", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent = "alice@example.com\nbad@\nnot-quite@.com"
@@ -336,7 +436,12 @@ describe("AssignSeatsSection", () => {
 
   test("importing a CSV with duplicates shows duplicate count in modal", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent = "alice@example.com\nbob@example.com\nalice@example.com"
@@ -355,7 +460,12 @@ describe("AssignSeatsSection", () => {
 
   test("importing a CSV with no-@ rows shows skipped count in modal", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent =
@@ -375,7 +485,12 @@ describe("AssignSeatsSection", () => {
 
   test("importing a CSV with no valid emails shows inline error", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent = "Email\nNot An Email\nbad@"
@@ -397,7 +512,12 @@ describe("AssignSeatsSection", () => {
 
   test("assertive live region announces CSV error text for screen readers", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const csvContent = "Email\nNot An Email\nbad@"
@@ -420,7 +540,12 @@ describe("AssignSeatsSection", () => {
 
   test("accepts newline-separated emails", async () => {
     renderWithProviders(
-      <AssignSeatsSection orgId={1} contractId={2} availableSeats={50} />,
+      <AssignSeatsSection
+        orgId={1}
+        contractId={2}
+        availableSeats={50}
+        isLoadingSeats={false}
+      />,
     )
 
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
@@ -462,6 +587,7 @@ describe("AssignSeatsSection", () => {
           orgId={ORG_ID}
           contractId={CONTRACT_ID}
           availableSeats={50}
+          isLoadingSeats={false}
         />,
       )
 
@@ -492,6 +618,7 @@ describe("AssignSeatsSection", () => {
           orgId={ORG_ID}
           contractId={CONTRACT_ID}
           availableSeats={50}
+          isLoadingSeats={false}
         />,
       )
 
@@ -514,6 +641,7 @@ describe("AssignSeatsSection", () => {
           orgId={ORG_ID}
           contractId={CONTRACT_ID}
           availableSeats={50}
+          isLoadingSeats={false}
         />,
       )
 

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -83,7 +83,6 @@ describe("AssignSeatsSection", () => {
       />,
     )
 
-    // The download link is a real anchor — in the tab order and not disabled
     const downloadLink = screen.getByRole("link", {
       name: "(download sample CSV)",
     })

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -540,8 +540,12 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
         >
           import from CSV
         </ActiveLink>
-        {/* TODO: replace href with a real sample CSV once we have one */}
-        <Link href="#" color="red" rel="noopener noreferrer" target="_blank">
+        <Link
+          href="/sample-seat-assignments.csv"
+          color="red"
+          download
+          target="_blank"
+        >
           (download sample CSV)
         </Link>
       </Stack>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useMemo, useRef, useState } from "react"
-import { Stack, Tooltip, Typography, styled } from "ol-components"
+import { Link, Stack, Typography, styled } from "ol-components"
 import { Alert, Button, VisuallyHidden } from "@mitodl/smoot-design"
 import {
   isValidEmail,
@@ -57,14 +57,6 @@ const ActiveLink = styled.span(({ theme }) => ({
   textDecoration: "underline",
   cursor: "pointer",
   "&:hover": { opacity: 0.8 },
-}))
-
-const DisabledLink = styled.span(({ theme }) => ({
-  ...theme.typography.subtitle2,
-  color: theme.custom.colors.darkRed,
-  textDecoration: "underline",
-  cursor: "not-allowed",
-  opacity: 0.5,
 }))
 
 const CountBadge = styled.div<{ $variant: "valid" | "warning" | "default" }>(
@@ -215,12 +207,14 @@ type AssignSeatsSectionProps = {
   orgId: number
   contractId: number
   availableSeats: number
+  isLoadingSeats: boolean
 }
 
 const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   orgId,
   contractId,
   availableSeats,
+  isLoadingSeats,
 }) => {
   const [emailInput, setEmailInput] = useState("")
   const [focused, setFocused] = useState(false)
@@ -514,7 +508,7 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
         <ButtonWrapper>
           <Button
             variant="primary"
-            disabled={!canSubmit || overCapacity}
+            disabled={!canSubmit || overCapacity || isLoadingSeats}
             onClick={handleAssignSeats}
           >
             Assign Seats
@@ -546,11 +540,10 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
         >
           import from CSV
         </ActiveLink>
-        <Tooltip title="Coming soon" describeChild>
-          <DisabledLink role="button" aria-disabled="true" tabIndex={0}>
-            (download sample CSV)
-          </DisabledLink>
-        </Tooltip>
+        {/* TODO: replace href with a real sample CSV once we have one */}
+        <Link href="#" color="red" rel="noopener noreferrer" target="_blank">
+          (download sample CSV)
+        </Link>
       </Stack>
       {!overCapacity && (invalidCount > 0 || duplicateCount > 0) && (
         <Alert severity="warning">

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -116,7 +116,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const otherOrg = factories.organizations.organization({})
-    setMockResponse.get(managerOrgsUrl, [otherOrg])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [otherOrg],
+    })
 
     renderWithProviders(
       <ContractAdminPage orgSlug="not-my-org" contractSlug="some-contract" />,
@@ -130,7 +135,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
 
     renderWithProviders(
       <ContractAdminPage
@@ -147,7 +157,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
     setMockResponse.get(
       managerContractDetailUrl(org.id, contract.id),
       makeContractDetail(contract),
@@ -173,7 +188,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
     setMockResponse.get(
       managerContractDetailUrl(org.id, contract.id),
       makeContractDetail(contract, { total_codes: 75, total_enrollments: 12 }),
@@ -198,7 +218,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
     setMockResponse.get(
       managerContractDetailUrl(org.id, contract.id),
       makeContractDetail(contract, {
@@ -241,7 +266,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
     setMockResponse.get(
       managerContractDetailUrl(org.id, contract.id),
       makeContractDetail(contract, {
@@ -297,7 +327,12 @@ describe("ContractAdminPage", () => {
       contract: ReturnType<typeof factories.contracts.contract>,
       overrides: Parameters<typeof makeContractDetail>[1] = {},
     ) => {
-      setMockResponse.get(managerOrgsUrl, [org])
+      setMockResponse.get(managerOrgsUrl, {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [org],
+      })
       setMockResponse.get(
         managerContractDetailUrl(org.id, contract.id),
         makeContractDetail(contract, overrides),
@@ -446,7 +481,12 @@ describe("ContractAdminPage", () => {
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
+    setMockResponse.get(managerOrgsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [org],
+    })
     setMockResponse.get(
       managerContractDetailUrl(org.id, contract.id),
       makeContractDetail(contract, {

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -154,7 +154,6 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
-        page_size: 20,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -180,7 +179,6 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
-        page_size: 20,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -210,7 +208,6 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
-        page_size: 20,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -265,7 +262,6 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
-        page_size: 20,
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
@@ -312,7 +308,6 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
-        page_size: 20,
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -303,23 +303,21 @@ describe("ContractAdminPage", () => {
       )
     }
 
-    let clickedAnchor: HTMLAnchorElement | null = null
+    const mockAnchorClick = jest.fn()
     const mockCreateObjectURL = jest.fn().mockReturnValue("blob:fake-url")
     const mockRevokeObjectURL = jest.fn()
 
     beforeEach(() => {
       mockedUseFeatureFlagsLoaded.mockReturnValue(true)
       mockedUseFeatureFlagEnabled.mockReturnValue(true)
-      clickedAnchor = null
+      mockAnchorClick.mockClear()
       mockCreateObjectURL.mockClear()
       mockRevokeObjectURL.mockClear()
       URL.createObjectURL = mockCreateObjectURL
       URL.revokeObjectURL = mockRevokeObjectURL
       jest
         .spyOn(HTMLAnchorElement.prototype, "click")
-        .mockImplementation(function (this: HTMLAnchorElement) {
-          clickedAnchor = this
-        })
+        .mockImplementation(mockAnchorClick)
     })
 
     afterEach(() => {
@@ -353,8 +351,9 @@ describe("ContractAdminPage", () => {
       await waitFor(() => {
         expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob))
       })
-      expect(clickedAnchor).not.toBeNull()
-      expect(clickedAnchor!.download).toBe("seat-assignments.csv")
+      expect(mockAnchorClick).toHaveBeenCalledTimes(1)
+      const clickedAnchor = mockAnchorClick.mock.instances[0] as HTMLAnchorElement
+      expect(clickedAnchor.download).toBe("seat-assignments.csv")
       expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:fake-url")
       await screen.findByText("CSV download started.")
     })

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { renderWithProviders, screen, user } from "@/test-utils"
+import { waitFor } from "@testing-library/react"
 import { setMockResponse } from "api/test-utils"
 import { factories, urls } from "api/mitxonline-test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -265,6 +266,13 @@ describe("ContractAdminPage", () => {
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
+    setMockResponse.get(
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        status: "redeemed",
+      }),
+      factories.contracts.paginatedContractCodes([redeemedCode]),
+    )
 
     renderWithProviders(
       <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
@@ -274,8 +282,155 @@ describe("ContractAdminPage", () => {
 
     await user.click(screen.getByRole("tab", { name: "Redeemed" }))
 
-    expect(screen.getByText("redeemed@example.com")).toBeInTheDocument()
+    await screen.findByText("redeemed@example.com")
     expect(screen.queryByText("pending@example.com")).not.toBeInTheDocument()
+  })
+
+  describe("CSV export", () => {
+    const setupPage = (
+      org: ReturnType<typeof factories.organizations.organization>,
+      contract: ReturnType<typeof factories.contracts.contract>,
+      overrides: Parameters<typeof makeContractDetail>[1] = {},
+    ) => {
+      setMockResponse.get(managerOrgsUrl, [org])
+      setMockResponse.get(
+        managerContractDetailUrl(org.id, contract.id),
+        makeContractDetail(contract, overrides),
+      )
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, { page: 1 }),
+        factories.contracts.paginatedContractCodes([]),
+      )
+    }
+
+    let clickedAnchor: HTMLAnchorElement | null = null
+    const mockCreateObjectURL = jest.fn().mockReturnValue("blob:fake-url")
+    const mockRevokeObjectURL = jest.fn()
+
+    beforeEach(() => {
+      mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+      clickedAnchor = null
+      mockCreateObjectURL.mockClear()
+      mockRevokeObjectURL.mockClear()
+      URL.createObjectURL = mockCreateObjectURL
+      URL.revokeObjectURL = mockRevokeObjectURL
+      jest
+        .spyOn(HTMLAnchorElement.prototype, "click")
+        .mockImplementation(function (this: HTMLAnchorElement) {
+          clickedAnchor = this
+        })
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    test("triggers download with correct filename for a single page of results", async () => {
+      const { org, contract } = makeOrgWithContract()
+      setupPage(org, contract, { total_codes: 2 })
+
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 500,
+        }),
+        factories.contracts.paginatedContractCodes([
+          factories.contracts.contractCode({
+            assigned_to: "alice@example.com",
+          }),
+          factories.contracts.contractCode({ assigned_to: "bob@example.com" }),
+        ]),
+      )
+
+      renderWithProviders(
+        <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+      )
+
+      await screen.findByRole("button", { name: "Export CSV" })
+      await user.click(screen.getByRole("button", { name: "Export CSV" }))
+
+      await waitFor(() => {
+        expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob))
+      })
+      expect(clickedAnchor).not.toBeNull()
+      expect(clickedAnchor!.download).toBe("seat-assignments.csv")
+      expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:fake-url")
+      await screen.findByText("CSV download started.")
+    })
+
+    test("fetches additional pages and includes all rows in the CSV", async () => {
+      const { org, contract } = makeOrgWithContract()
+      setupPage(org, contract, { total_codes: 2 })
+
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 500,
+        }),
+        factories.contracts.paginatedContractCodes(
+          [
+            factories.contracts.contractCode({
+              assigned_to: "alice@example.com",
+            }),
+          ],
+          { count: 2, next: "next-page" },
+        ),
+      )
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 2,
+          page_size: 500,
+        }),
+        factories.contracts.paginatedContractCodes([
+          factories.contracts.contractCode({ assigned_to: "bob@example.com" }),
+        ]),
+      )
+
+      renderWithProviders(
+        <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+      )
+
+      await screen.findByRole("button", { name: "Export CSV" })
+      await user.click(screen.getByRole("button", { name: "Export CSV" }))
+
+      await waitFor(() => {
+        expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob))
+      })
+      const blob = mockCreateObjectURL.mock.calls[0][0] as Blob
+      const csv = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(reader.result as string)
+        reader.onerror = reject
+        reader.readAsText(blob)
+      })
+      expect(csv).toContain("alice@example.com")
+      expect(csv).toContain("bob@example.com")
+    })
+
+    test("shows error alert when the export request fails", async () => {
+      allowConsoleErrors()
+      const { org, contract } = makeOrgWithContract()
+      setupPage(org, contract, { total_codes: 1 })
+
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 500,
+        }),
+        "Internal Server Error",
+        { code: 500 },
+      )
+
+      renderWithProviders(
+        <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+      )
+
+      await screen.findByRole("button", { name: "Export CSV" })
+      await user.click(screen.getByRole("button", { name: "Export CSV" }))
+
+      await screen.findByText("Could not export CSV. Please try again.")
+    })
   })
 
   test("Pending claim tab filters to assigned codes only", async () => {
@@ -311,6 +466,13 @@ describe("ContractAdminPage", () => {
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
+    setMockResponse.get(
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        status: "assigned",
+      }),
+      factories.contracts.paginatedContractCodes([assignedCode]),
+    )
 
     renderWithProviders(
       <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
@@ -320,7 +482,9 @@ describe("ContractAdminPage", () => {
 
     await user.click(screen.getByRole("tab", { name: "Pending claim" }))
 
+    await waitFor(() => {
+      expect(screen.queryByText("redeemed@example.com")).not.toBeInTheDocument()
+    })
     expect(screen.getByText("pending@example.com")).toBeInTheDocument()
-    expect(screen.queryByText("redeemed@example.com")).not.toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -352,7 +352,8 @@ describe("ContractAdminPage", () => {
         expect(mockCreateObjectURL).toHaveBeenCalledWith(expect.any(Blob))
       })
       expect(mockAnchorClick).toHaveBeenCalledTimes(1)
-      const clickedAnchor = mockAnchorClick.mock.instances[0] as HTMLAnchorElement
+      const clickedAnchor = mockAnchorClick.mock
+        .instances[0] as HTMLAnchorElement
       expect(clickedAnchor.download).toBe("seat-assignments.csv")
       expect(mockRevokeObjectURL).toHaveBeenCalledWith("blob:fake-url")
       await screen.findByText("CSV download started.")

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { renderWithProviders, screen, user, waitFor } from "@/test-utils"
+import { renderWithProviders, screen, user } from "@/test-utils"
 import { setMockResponse } from "api/test-utils"
 import { factories, urls } from "api/mitxonline-test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -26,6 +26,25 @@ const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
 
 const managerOrgsUrl = urls.organization.managerOrganizationsList()
 const managerContractDetailUrl = urls.contracts.managerContractDetail
+
+const makeContractDetail = (
+  contract: ReturnType<typeof factories.contracts.contract>,
+  overrides: {
+    total_codes?: number
+    assigned_codes?: number
+    unassigned_codes?: number
+    redeemed_codes?: number
+    total_enrollments?: number
+  } = {},
+) => ({
+  ...contract,
+  attachment_percentage: null,
+  total_enrollments: overrides.total_enrollments ?? 0,
+  total_codes: overrides.total_codes ?? 10,
+  assigned_codes: overrides.assigned_codes ?? 2,
+  unassigned_codes: overrides.unassigned_codes ?? 6,
+  redeemed_codes: overrides.redeemed_codes ?? 2,
+})
 
 const makeOrgWithContract = () => {
   const contract = factories.contracts.contract()
@@ -128,15 +147,16 @@ describe("ContractAdminPage", () => {
 
     const { org, contract } = makeOrgWithContract()
     setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 0,
-      total_codes: 50,
-    })
     setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      [],
+      managerContractDetailUrl(org.id, contract.id),
+      makeContractDetail(contract),
+    )
+    setMockResponse.get(
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        page_size: 20,
+      }),
+      factories.contracts.paginatedContractCodes([]),
     )
 
     renderWithProviders(
@@ -153,17 +173,16 @@ describe("ContractAdminPage", () => {
 
     const { org, contract } = makeOrgWithContract()
     setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 12,
-      total_codes: 75,
-    })
     setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      Array.from({ length: 75 }, () =>
-        factories.contracts.contractCode({ redemption_status: "unassigned" }),
-      ),
+      managerContractDetailUrl(org.id, contract.id),
+      makeContractDetail(contract, { total_codes: 75, total_enrollments: 12 }),
+    )
+    setMockResponse.get(
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        page_size: 20,
+      }),
+      factories.contracts.paginatedContractCodes([]),
     )
 
     renderWithProviders(
@@ -173,86 +192,47 @@ describe("ContractAdminPage", () => {
     await screen.findByText("75 seats")
   })
 
-  test("derives Unassigned and Pending claim summary stats from codes", async () => {
+  test("renders per-status stats from contract detail", async () => {
     mockedUseFeatureFlagsLoaded.mockReturnValue(true)
     mockedUseFeatureFlagEnabled.mockReturnValue(true)
 
     const { org, contract } = makeOrgWithContract()
     setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 1,
-      total_codes: 5,
-    })
     setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      [
-        factories.contracts.contractCode({ redemption_status: "unassigned" }),
-        factories.contracts.contractCode({ redemption_status: "unassigned" }),
-        factories.contracts.contractCode({ redemption_status: "assigned" }),
-        factories.contracts.contractCode({
-          redemption_status: "redeemed",
-          redeemed_by: "a@example.com",
-          redeemed_on: new Date().toISOString(),
-        }),
-      ],
+      managerContractDetailUrl(org.id, contract.id),
+      makeContractDetail(contract, {
+        total_codes: 30,
+        assigned_codes: 10,
+        unassigned_codes: 15,
+        redeemed_codes: 5,
+      }),
+    )
+    setMockResponse.get(
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        page_size: 20,
+      }),
+      factories.contracts.paginatedContractCodes([]),
     )
 
     renderWithProviders(
       <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
     )
 
-    // findByRole waits for the org to load; then waitFor waits for codes to load
-    const unassignedStat = await screen.findByRole("group", {
-      name: "Unassigned",
-    })
-    await waitFor(() => expect(unassignedStat).toHaveTextContent("2"))
-
-    const pendingStat = screen.getByRole("group", { name: "Pending claim" })
-    expect(pendingStat).toHaveTextContent("1")
-  })
-
-  test("hides unassigned codes from the table and shows assigned and redeemed", async () => {
-    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-
-    const { org, contract } = makeOrgWithContract()
-    setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 1,
-      total_codes: 3,
-    })
-
-    const assignedCode = factories.contracts.contractCode({
-      redemption_status: "assigned",
-      assigned_to: "pending@example.com",
-    })
-    const redeemedCode = factories.contracts.contractCode({
-      redemption_status: "redeemed",
-      assigned_to: "redeemed@example.com",
-      redeemed_by: "claimer@example.com",
-      redeemed_on: new Date().toISOString(),
-    })
-    const unassignedCode = factories.contracts.contractCode({
-      redemption_status: "unassigned",
-      assigned_to: null,
-    })
-
-    setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      [assignedCode, redeemedCode, unassignedCode],
+    // Wait for contract detail to finish loading (skeletons replaced by values)
+    await screen.findByText("30")
+    expect(
+      screen.getByRole("group", { name: "Total purchased" }),
+    ).toHaveTextContent("30")
+    expect(screen.getByRole("group", { name: "Unassigned" })).toHaveTextContent(
+      "15",
     )
-
-    renderWithProviders(
-      <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+    expect(
+      screen.getByRole("group", { name: "Pending claim" }),
+    ).toHaveTextContent("10")
+    expect(screen.getByRole("group", { name: "Redeemed" })).toHaveTextContent(
+      "5",
     )
-
-    await screen.findByText("pending@example.com")
-    expect(screen.getByText("redeemed@example.com")).toBeInTheDocument()
-    expect(screen.queryByText(unassignedCode.code)).not.toBeInTheDocument()
   })
 
   test("Redeemed tab filters to redeemed codes only", async () => {
@@ -261,12 +241,15 @@ describe("ContractAdminPage", () => {
 
     const { org, contract } = makeOrgWithContract()
     setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 1,
-      total_codes: 2,
-    })
+    setMockResponse.get(
+      managerContractDetailUrl(org.id, contract.id),
+      makeContractDetail(contract, {
+        total_codes: 2,
+        assigned_codes: 1,
+        redeemed_codes: 1,
+        unassigned_codes: 0,
+      }),
+    )
 
     const assignedCode = factories.contracts.contractCode({
       redemption_status: "assigned",
@@ -280,8 +263,11 @@ describe("ContractAdminPage", () => {
     })
 
     setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      [assignedCode, redeemedCode],
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        page_size: 20,
+      }),
+      factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
 
     renderWithProviders(
@@ -302,12 +288,15 @@ describe("ContractAdminPage", () => {
 
     const { org, contract } = makeOrgWithContract()
     setMockResponse.get(managerOrgsUrl, [org])
-    setMockResponse.get(managerContractDetailUrl(org.id, contract.id), {
-      ...contract,
-      attachment_percentage: null,
-      total_enrollments: 1,
-      total_codes: 2,
-    })
+    setMockResponse.get(
+      managerContractDetailUrl(org.id, contract.id),
+      makeContractDetail(contract, {
+        total_codes: 2,
+        assigned_codes: 1,
+        redeemed_codes: 1,
+        unassigned_codes: 0,
+      }),
+    )
 
     const assignedCode = factories.contracts.contractCode({
       redemption_status: "assigned",
@@ -321,8 +310,11 @@ describe("ContractAdminPage", () => {
     })
 
     setMockResponse.get(
-      urls.contracts.managerContractCodes(org.id, contract.id),
-      [assignedCode, redeemedCode],
+      urls.contracts.managerContractCodes(org.id, contract.id, {
+        page: 1,
+        page_size: 20,
+      }),
+      factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
 
     renderWithProviders(

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -155,6 +155,7 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -180,6 +181,7 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -209,6 +211,7 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
       }),
       factories.contracts.paginatedContractCodes([]),
     )
@@ -263,12 +266,14 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
         status: "redeemed",
       }),
       factories.contracts.paginatedContractCodes([redeemedCode]),
@@ -298,7 +303,10 @@ describe("ContractAdminPage", () => {
         makeContractDetail(contract, overrides),
       )
       setMockResponse.get(
-        urls.contracts.managerContractCodes(org.id, contract.id, { page: 1 }),
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 25,
+        }),
         factories.contracts.paginatedContractCodes([]),
       )
     }
@@ -463,12 +471,14 @@ describe("ContractAdminPage", () => {
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
       }),
       factories.contracts.paginatedContractCodes([assignedCode, redeemedCode]),
     )
     setMockResponse.get(
       urls.contracts.managerContractCodes(org.id, contract.id, {
         page: 1,
+        page_size: 25,
         status: "assigned",
       }),
       factories.contracts.paginatedContractCodes([assignedCode]),

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -31,7 +31,7 @@ import { AssignSeatsSection } from "./AssignSeatsSection"
 import { RowActionMenu } from "./RowActionMenu"
 import {
   managerOrganizationQueries,
-  type ContractCode,
+  type ManagerEnrollmentCode,
 } from "api/mitxonline-hooks/organizations"
 import type { AxiosError } from "axios"
 import { matchOrganizationBySlug } from "@/common/utils"
@@ -516,7 +516,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     if (!totalPurchased) return
     setIsExporting(true)
     try {
-      const allRows: ContractCode[] = []
+      const allRows: ManagerEnrollmentCode[] = []
       let page = 1
       let hasMore = true
       while (hasMore) {

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -2,7 +2,11 @@
 
 import React, { useEffect, useRef, useState } from "react"
 import Image from "next/image"
-import { useQuery } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import {
   alpha,
@@ -26,7 +30,6 @@ import {
 import { AssignSeatsSection } from "./AssignSeatsSection"
 import { RowActionMenu } from "./RowActionMenu"
 import { managerOrganizationQueries } from "api/mitxonline-hooks/organizations"
-import { b2bApi } from "api/mitxonline-clients"
 import type { AxiosError } from "axios"
 import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
@@ -338,10 +341,13 @@ type ContractAdminPageInternalProps = {
   contractSlug: string
 }
 
+const CODES_PAGE_SIZE = 25
+
 const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   orgSlug,
   contractSlug,
 }) => {
+  const queryClient = useQueryClient()
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
   const [searchQuery, setSearchQuery] = useState("")
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("")
@@ -413,6 +419,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
       id: contract?.id ?? 0,
       parent_lookup_organization: org?.id ?? 0,
       page,
+      page_size: CODES_PAGE_SIZE,
       search_term: debouncedSearchQuery || undefined,
       status:
         statusFilter === "redeemed"
@@ -422,6 +429,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
             : undefined,
     }),
     enabled: !!org && !!contract,
+    placeholderData: keepPreviousData,
   })
 
   // Announce the result count after the query settles following a search change.
@@ -489,13 +497,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   const pageResults = codes?.results ?? []
 
   const totalCount = codes?.count ?? 0
-  // Derive total pages from the response: if there's a next page we're on a
-  // full page so results.length equals the backend page size; otherwise this
-  // is the last page so totalPages equals the current page number.
-  const totalPages =
-    codes?.next && pageResults.length > 0
-      ? Math.ceil(totalCount / pageResults.length)
-      : page
+  const totalPages = Math.ceil(totalCount / CODES_PAGE_SIZE)
 
   const handleTabChange = (_: React.SyntheticEvent, val: StatusFilter) => {
     setStatusFilter(val)
@@ -510,25 +512,14 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     if (!totalPurchased) return
     setIsExporting(true)
     try {
-      const PAGE_SIZE = 500
-      let page = 1
-      let res = await b2bApi.b2bManagerOrganizationsContractsCodesList({
-        id: contract.id,
-        parent_lookup_organization: org.id,
-        page,
-        page_size: PAGE_SIZE,
-      })
-      const rows = [...res.data.results]
-      while (res.data.next) {
-        page += 1
-        res = await b2bApi.b2bManagerOrganizationsContractsCodesList({
+      const data = await queryClient.fetchQuery(
+        managerOrganizationQueries.managerContractCodes({
           id: contract.id,
           parent_lookup_organization: org.id,
-          page,
-          page_size: PAGE_SIZE,
-        })
-        rows.push(...res.data.results)
-      }
+          page_size: totalPurchased,
+        }),
+      )
+      const rows = data.results
       const header = buildCsvRow([
         "Assigned to",
         "Redeemed by",

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -470,6 +470,9 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
 
   // Tab filter is applied client-side on the current page of results.
   // Unassigned codes are excluded server-side (API only returns assigned/redeemed).
+  // TODO: pass statusFilter as a server-side query param once the API supports a
+  // redemption_status filter — client-side filtering against paginated results means
+  // pagination counts reflect all statuses, not the active tab's subset.
   const pageResults = codes?.results ?? []
   const tabFilteredCodes = pageResults.filter((code) => {
     return (
@@ -483,9 +486,10 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   // Derive total pages from the response: if there's a next page we're on a
   // full page so results.length equals the backend page size; otherwise this
   // is the last page so totalPages equals the current page number.
-  const totalPages = codes?.next
-    ? Math.ceil(totalCount / pageResults.length)
-    : page
+  const totalPages =
+    codes?.next && pageResults.length > 0
+      ? Math.ceil(totalCount / pageResults.length)
+      : page
 
   const handleTabChange = (_: React.SyntheticEvent, val: StatusFilter) => {
     setStatusFilter(val)
@@ -497,40 +501,48 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   }
 
   const handleExportCsv = async () => {
-    const response = await b2bApi.b2bManagerOrganizationsContractsCodesList({
-      id: contract.id,
-      parent_lookup_organization: org.id,
-      page_size: totalPurchased,
-    })
-    const rows = response.data.results
-    const header = buildCsvRow([
-      "Assigned to",
-      "Redeemed by",
-      "Status",
-      "Assigned on",
-      "Redeemed on",
-      "Last sent",
-    ])
-    const dataRows = rows.map((c) =>
-      buildCsvRow([
-        c.assigned_to,
-        c.redeemed_by,
-        c.redemption_status === "redeemed" ? "Redeemed" : "Pending claim",
-        formatDate(c.assigned_on),
-        formatDate(c.redeemed_on),
-        formatDate(c.last_sent),
-      ]),
-    )
-    const csv = [header, ...dataRows].join("\n")
-    const blob = new Blob([csv], { type: "text/csv" })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = "seat-assignments.csv"
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
+    if (!totalPurchased) return
+    try {
+      const response = await b2bApi.b2bManagerOrganizationsContractsCodesList({
+        id: contract.id,
+        parent_lookup_organization: org.id,
+        page_size: totalPurchased,
+      })
+      const rows = response.data.results
+      const header = buildCsvRow([
+        "Assigned to",
+        "Redeemed by",
+        "Status",
+        "Assigned on",
+        "Redeemed on",
+        "Last sent",
+      ])
+      const dataRows = rows.map((c) =>
+        buildCsvRow([
+          c.assigned_to,
+          c.redeemed_by,
+          c.redemption_status === "redeemed" ? "Redeemed" : "Pending claim",
+          formatDate(c.assigned_on),
+          formatDate(c.redeemed_on),
+          formatDate(c.last_sent),
+        ]),
+      )
+      const csv = [header, ...dataRows].join("\n")
+      const blob = new Blob([csv], { type: "text/csv" })
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement("a")
+      link.href = url
+      link.download = "seat-assignments.csv"
+      document.body.appendChild(link)
+      link.click()
+      document.body.removeChild(link)
+      URL.revokeObjectURL(url)
+    } catch {
+      setRowActionResult({
+        message: "Could not export CSV. Please try again.",
+        severity: "error",
+      })
+    }
   }
 
   return (
@@ -642,7 +654,11 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
               />
             </ControlsLeft>
             <ExportButtonWrapper>
-              <Button variant="bordered" onClick={handleExportCsv}>
+              <Button
+                variant="bordered"
+                onClick={handleExportCsv}
+                disabled={isLoadingContractDetail || !totalPurchased}
+              >
                 Export CSV
               </Button>
             </ExportButtonWrapper>

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import Image from "next/image"
 import { useQuery } from "@tanstack/react-query"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -13,7 +13,6 @@ import {
   Skeleton,
   Stack,
   TabContext,
-  Tooltip,
   Typography,
   styled,
 } from "ol-components"
@@ -27,6 +26,7 @@ import {
 import { AssignSeatsSection } from "./AssignSeatsSection"
 import { RowActionMenu } from "./RowActionMenu"
 import { managerOrganizationQueries } from "api/mitxonline-hooks/organizations"
+import { b2bApi } from "api/mitxonline-clients"
 import type { AxiosError } from "axios"
 import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
@@ -324,6 +324,17 @@ function formatDate(iso: string | null | undefined): string {
   })
 }
 
+function buildCsvRow(values: (string | null | undefined)[]): string {
+  return values
+    .map((v) => {
+      const s = v ?? ""
+      return s.includes(",") || s.includes('"') || s.includes("\n")
+        ? `"${s.replace(/"/g, '""')}"`
+        : s
+    })
+    .join(",")
+}
+
 type ContractAdminPageInternalProps = {
   orgSlug: string
   contractSlug: string
@@ -335,6 +346,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
 }) => {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
   const [searchQuery, setSearchQuery] = useState("")
+  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("")
   const [page, setPage] = useState(1)
   const [searchAnnouncement, setSearchAnnouncement] = useState("")
   const [rowActionResult, setRowActionResult] = useState<{
@@ -342,6 +354,15 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     severity: "success" | "error"
   } | null>(null)
   const [rowActionAnnouncement, setRowActionAnnouncement] = useState("")
+
+  // Debounce search query to avoid firing a new request on every keystroke.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setDebouncedSearchQuery(searchQuery)
+      setPage(1)
+    }, 300)
+    return () => clearTimeout(id)
+  }, [searchQuery])
 
   // Mirror row-action Alert text into an assertive live region — smoot-design
   // Alert announces only its aria-describedby ("success/error message") via NVDA
@@ -370,6 +391,16 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   const org = managerOrgs?.find(matchOrganizationBySlug(orgSlug))
   const contract = org?.contracts.find((c) => c.slug === contractSlug)
 
+  const { data: contractDetail, isLoading: isLoadingContractDetail } = useQuery(
+    {
+      ...managerOrganizationQueries.managerContractDetail({
+        id: contract?.id ?? 0,
+        parent_lookup_organization: org?.id ?? 0,
+      }),
+      enabled: !!org && !!contract,
+    },
+  )
+
   const {
     data: codes,
     isLoading: isLoadingCodes,
@@ -379,9 +410,29 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     ...managerOrganizationQueries.managerContractCodes({
       id: contract?.id ?? 0,
       parent_lookup_organization: org?.id ?? 0,
+      page,
+      page_size: PAGE_SIZE,
+      search_term: debouncedSearchQuery || undefined,
     }),
     enabled: !!org && !!contract,
   })
+
+  // Announce the result count after the query settles following a search change.
+  // Using a ref to track the last announced query so we only fire once per change,
+  // not on every re-render while loading.
+  const announcedQueryRef = useRef("")
+  useEffect(() => {
+    if (isLoadingCodes || announcedQueryRef.current === debouncedSearchQuery)
+      return
+    announcedQueryRef.current = debouncedSearchQuery
+    const count = codes?.count ?? 0
+    setSearchAnnouncement("")
+    const id = setTimeout(
+      () => setSearchAnnouncement(`${count} result${count !== 1 ? "s" : ""}`),
+      0,
+    )
+    return () => clearTimeout(id)
+  }, [isLoadingCodes, debouncedSearchQuery, codes?.count])
 
   if (isLoadingOrgs) {
     return (
@@ -415,23 +466,15 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     return <ErrorContent title="Contract not found" timSays="404" />
   }
 
-  const allCodes = codes ?? []
-  const totalPurchased = isLoadingCodes ? undefined : allCodes.length
-  const totalUnassigned = allCodes.filter(
-    (code) => code.redemption_status === "unassigned",
-  ).length
-  const totalPendingClaim = allCodes.filter(
-    (code) => code.redemption_status === "assigned",
-  ).length
-  const totalRedeemed = allCodes.filter(
-    (code) => code.redemption_status === "redeemed",
-  ).length
+  const totalPurchased = contractDetail?.total_codes
+  const unassignedCount = contractDetail?.unassigned_codes
+  const assignedCount = contractDetail?.assigned_codes
+  const redeemedCount = contractDetail?.redeemed_codes
 
-  const visibleCodes = (codes ?? []).filter(
-    (code) => code.redemption_status !== "unassigned",
-  )
-
-  const tabFilteredCodes = visibleCodes.filter((code) => {
+  // Tab filter is applied client-side on the current page of results.
+  // Unassigned codes are excluded server-side (API only returns assigned/redeemed).
+  const pageResults = codes?.results ?? []
+  const tabFilteredCodes = pageResults.filter((code) => {
     return (
       statusFilter === "all" ||
       (statusFilter === "redeemed" && code.redemption_status === "redeemed") ||
@@ -439,20 +482,8 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     )
   })
 
-  const filteredCodes = tabFilteredCodes.filter((code) => {
-    if (!searchQuery) return true
-    const q = searchQuery.toLowerCase()
-    return (
-      (code.assigned_to ?? "").toLowerCase().includes(q) ||
-      (code.assigned_name ?? "").toLowerCase().includes(q)
-    )
-  })
-
-  const totalPages = Math.ceil(filteredCodes.length / PAGE_SIZE)
-  const pagedCodes = filteredCodes.slice(
-    (page - 1) * PAGE_SIZE,
-    page * PAGE_SIZE,
-  )
+  const totalCount = codes?.count ?? 0
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE)
 
   const handleTabChange = (_: React.SyntheticEvent, val: StatusFilter) => {
     setStatusFilter(val)
@@ -461,14 +492,43 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchQuery(e.target.value)
-    setPage(1)
   }
 
-  const announceSearchCount = (count: number) => {
-    setSearchAnnouncement("")
-    setTimeout(() => {
-      setSearchAnnouncement(`${count} result${count !== 1 ? "s" : ""}`)
-    }, 0)
+  const handleExportCsv = async () => {
+    const response = await b2bApi.b2bManagerOrganizationsContractsCodesList({
+      id: contract.id,
+      parent_lookup_organization: org.id,
+      page_size: totalPurchased,
+    })
+    const rows = response.data.results
+    const header = buildCsvRow([
+      "Assigned to",
+      "Redeemed by",
+      "Status",
+      "Assigned on",
+      "Redeemed on",
+      "Last sent",
+    ])
+    const dataRows = rows.map((c) =>
+      buildCsvRow([
+        c.assigned_to,
+        c.redeemed_by,
+        c.redemption_status === "redeemed" ? "Redeemed" : "Pending claim",
+        formatDate(c.assigned_on),
+        formatDate(c.redeemed_on),
+        formatDate(c.last_sent),
+      ]),
+    )
+    const csv = [header, ...dataRows].join("\n")
+    const blob = new Blob([csv], { type: "text/csv" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = "seat-assignments.csv"
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
   }
 
   return (
@@ -489,7 +549,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
               <OrgName component="h1">{org.name}</OrgName>
               <ContractSubtitle>
                 <span>{contract.name}</span>
-                {!isLoadingCodes && totalPurchased !== undefined ? (
+                {!isLoadingContractDetail && totalPurchased !== undefined ? (
                   <>
                     {" "}
                     · <span>{totalPurchased} seats</span>
@@ -500,34 +560,34 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
           </OrgDetailsContainer>
           <StatsSide>
             <StatBlock role="group" aria-label="Total purchased">
-              {isLoadingCodes ? (
+              {isLoadingContractDetail ? (
                 <Skeleton width="48px" height="36px" />
               ) : (
-                <StatValue>{totalPurchased ?? STUB}</StatValue>
+                <StatValue>{totalPurchased}</StatValue>
               )}
               <StatLabel>Total purchased</StatLabel>
             </StatBlock>
             <StatBlock role="group" aria-label="Unassigned">
-              {isLoadingCodes ? (
+              {isLoadingContractDetail ? (
                 <Skeleton width="48px" height="36px" />
               ) : (
-                <StatValue>{totalUnassigned}</StatValue>
+                <StatValue>{unassignedCount}</StatValue>
               )}
               <StatLabel>Unassigned</StatLabel>
             </StatBlock>
             <StatBlock role="group" aria-label="Pending claim">
-              {isLoadingCodes ? (
+              {isLoadingContractDetail ? (
                 <Skeleton width="48px" height="36px" />
               ) : (
-                <StatValue>{totalPendingClaim}</StatValue>
+                <StatValue>{assignedCount}</StatValue>
               )}
               <StatLabel>Pending claim</StatLabel>
             </StatBlock>
             <StatBlock role="group" aria-label="Redeemed">
-              {isLoadingCodes ? (
+              {isLoadingContractDetail ? (
                 <Skeleton width="48px" height="36px" />
               ) : (
-                <StatValue>{totalRedeemed}</StatValue>
+                <StatValue>{redeemedCount}</StatValue>
               )}
               <StatLabel>Redeemed</StatLabel>
             </StatBlock>
@@ -537,7 +597,8 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
         <AssignSeatsSection
           orgId={org.id}
           contractId={contract.id}
-          availableSeats={totalUnassigned}
+          availableSeats={unassignedCount ?? 0}
+          isLoadingSeats={isLoadingContractDetail}
         />
 
         {/* Seat Assignments */}
@@ -574,25 +635,14 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                 onClear={() => {
                   setSearchQuery("")
                   setPage(1)
-                  announceSearchCount(tabFilteredCodes.length)
                 }}
-                onSubmit={() => announceSearchCount(filteredCodes.length)}
+                onSubmit={() => {}}
               />
             </ControlsLeft>
             <ExportButtonWrapper>
-              <Tooltip title="Coming soon" describeChild>
-                <Stack
-                  component="span"
-                  sx={{
-                    width: { xs: "100%", md: "auto" },
-                    "& > button": { width: { xs: "100%", md: "auto" } },
-                  }}
-                >
-                  <Button variant="bordered" disabled>
-                    Export CSV
-                  </Button>
-                </Stack>
-              </Tooltip>
+              <Button variant="bordered" onClick={handleExportCsv}>
+                Export CSV
+              </Button>
             </ExportButtonWrapper>
           </SeatAssignmentsControls>
           <VisuallyHidden aria-live="polite" aria-atomic="true">
@@ -645,9 +695,9 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                 <VisuallyHidden aria-live="polite" aria-atomic="true">
                   {isLoadingCodes
                     ? "Loading seat assignments"
-                    : filteredCodes.length === 0
+                    : tabFilteredCodes.length === 0
                       ? "No seat assignments found"
-                      : `Showing ${filteredCodes.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1}–${Math.min(page * PAGE_SIZE, filteredCodes.length)} of ${filteredCodes.length} assignment${filteredCodes.length !== 1 ? "s" : ""}`}
+                      : `Showing page ${page} of ${totalPages}`}
                 </VisuallyHidden>
                 {isLoadingCodes ? (
                   <>
@@ -659,7 +709,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                       </TableRow>
                     ))}
                   </>
-                ) : pagedCodes.length === 0 ? (
+                ) : tabFilteredCodes.length === 0 ? (
                   <TableRow role="row">
                     <EmptyTableMessage
                       role="cell"
@@ -670,7 +720,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                     </EmptyTableMessage>
                   </TableRow>
                 ) : (
-                  pagedCodes.map((code) => (
+                  tabFilteredCodes.map((code) => (
                     <TableRow role="row" key={code.id}>
                       <TableCell
                         role="cell"
@@ -727,11 +777,9 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
             </div>
             <TableFooter>
               <TableFootnote aria-hidden="true">
-                Showing{" "}
-                {filteredCodes.length === 0 ? 0 : (page - 1) * PAGE_SIZE + 1}–
-                {Math.min(page * PAGE_SIZE, filteredCodes.length)} of{" "}
-                {filteredCodes.length} assignment
-                {filteredCodes.length !== 1 ? "s" : ""}
+                {totalCount === 0
+                  ? "No assignments"
+                  : `Page ${page} of ${totalPages}`}
               </TableFootnote>
               {totalPages > 1 && (
                 <Pagination

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -35,8 +35,6 @@ import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { ErrorContent } from "../ErrorPage/ErrorPageTemplate"
 import graduateLogo from "@/public/images/dashboard/graduate.png"
 
-const PAGE_SIZE = 20
-
 const Page = styled(Container)(({ theme }) => ({
   maxWidth: "1400px",
   padding: "40px 24px",
@@ -411,7 +409,6 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
       id: contract?.id ?? 0,
       parent_lookup_organization: org?.id ?? 0,
       page,
-      page_size: PAGE_SIZE,
       search_term: debouncedSearchQuery || undefined,
     }),
     enabled: !!org && !!contract,
@@ -483,7 +480,12 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   })
 
   const totalCount = codes?.count ?? 0
-  const totalPages = Math.ceil(totalCount / PAGE_SIZE)
+  // Derive total pages from the response: if there's a next page we're on a
+  // full page so results.length equals the backend page size; otherwise this
+  // is the last page so totalPages equals the current page number.
+  const totalPages = codes?.next
+    ? Math.ceil(totalCount / pageResults.length)
+    : page
 
   const handleTabChange = (_: React.SyntheticEvent, val: StatusFilter) => {
     setStatusFilter(val)

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -29,7 +29,10 @@ import {
 } from "@mitodl/smoot-design"
 import { AssignSeatsSection } from "./AssignSeatsSection"
 import { RowActionMenu } from "./RowActionMenu"
-import { managerOrganizationQueries } from "api/mitxonline-hooks/organizations"
+import {
+  managerOrganizationQueries,
+  type ContractCode,
+} from "api/mitxonline-hooks/organizations"
 import type { AxiosError } from "axios"
 import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
@@ -342,6 +345,7 @@ type ContractAdminPageInternalProps = {
 }
 
 const CODES_PAGE_SIZE = 25
+const CSV_EXPORT_PAGE_SIZE = 500
 
 const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   orgSlug,
@@ -512,14 +516,23 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     if (!totalPurchased) return
     setIsExporting(true)
     try {
-      const data = await queryClient.fetchQuery(
-        managerOrganizationQueries.managerContractCodes({
-          id: contract.id,
-          parent_lookup_organization: org.id,
-          page_size: totalPurchased,
-        }),
-      )
-      const rows = data.results
+      const allRows: ContractCode[] = []
+      let page = 1
+      let hasMore = true
+      while (hasMore) {
+        const data = await queryClient.fetchQuery(
+          managerOrganizationQueries.managerContractCodes({
+            id: contract.id,
+            parent_lookup_organization: org.id,
+            page,
+            page_size: CSV_EXPORT_PAGE_SIZE,
+          }),
+        )
+        allRows.push(...data.results)
+        hasMore = !!data.next
+        page++
+      }
+      const rows = allRows
       const header = buildCsvRow([
         "Assigned to",
         "Redeemed by",

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -390,15 +390,18 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   const org = managerOrgs?.find(matchOrganizationBySlug(orgSlug))
   const contract = org?.contracts.find((c) => c.slug === contractSlug)
 
-  const { data: contractDetail, isLoading: isLoadingContractDetail } = useQuery(
-    {
-      ...managerOrganizationQueries.managerContractDetail({
-        id: contract?.id ?? 0,
-        parent_lookup_organization: org?.id ?? 0,
-      }),
-      enabled: !!org && !!contract,
-    },
-  )
+  const {
+    data: contractDetail,
+    isLoading: isLoadingContractDetail,
+    isError: isContractDetailError,
+    error: contractDetailError,
+  } = useQuery({
+    ...managerOrganizationQueries.managerContractDetail({
+      id: contract?.id ?? 0,
+      parent_lookup_organization: org?.id ?? 0,
+    }),
+    enabled: !!org && !!contract,
+  })
 
   const {
     data: codes,
@@ -457,6 +460,14 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   if (isCodesError) {
     const status = (codesError as AxiosError)?.response?.status
     if (status === 403 || status === 401 || status === 404) {
+      return <ErrorContent title="Access denied" timSays="403" />
+    }
+    return <ErrorContent title="Something went wrong" timSays="Oops!" />
+  }
+
+  if (isContractDetailError) {
+    const status = (contractDetailError as AxiosError)?.response?.status
+    if (status === 403 || status === 401) {
       return <ErrorContent title="Access denied" timSays="403" />
     }
     return <ErrorContent title="Something went wrong" timSays="Oops!" />
@@ -526,16 +537,18 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
         "Redeemed on",
         "Last sent",
       ])
-      const dataRows = rows.map((c) =>
-        buildCsvRow([
-          c.assigned_to,
-          c.redeemed_by,
-          c.redemption_status === "redeemed" ? "Redeemed" : "Pending claim",
-          formatDate(c.assigned_on),
-          formatDate(c.redeemed_on),
-          formatDate(c.last_sent),
-        ]),
-      )
+      const dataRows = rows
+        .filter((c) => c.redemption_status !== "unassigned")
+        .map((c) =>
+          buildCsvRow([
+            c.assigned_to,
+            c.redeemed_by,
+            c.redemption_status === "redeemed" ? "Redeemed" : "Pending claim",
+            formatDate(c.assigned_on),
+            formatDate(c.redeemed_on),
+            formatDate(c.last_sent),
+          ]),
+        )
       const csv = [header, ...dataRows].join("\n")
       const blob = new Blob([csv], { type: "text/csv" })
       const url = URL.createObjectURL(blob)

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -352,6 +352,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
     severity: "success" | "error"
   } | null>(null)
   const [rowActionAnnouncement, setRowActionAnnouncement] = useState("")
+  const [isExporting, setIsExporting] = useState(false)
 
   // Debounce search query to avoid firing a new request on every keystroke.
   useEffect(() => {
@@ -410,6 +411,12 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
       parent_lookup_organization: org?.id ?? 0,
       page,
       search_term: debouncedSearchQuery || undefined,
+      status:
+        statusFilter === "redeemed"
+          ? "redeemed"
+          : statusFilter === "pending"
+            ? "assigned"
+            : undefined,
     }),
     enabled: !!org && !!contract,
   })
@@ -468,19 +475,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   const assignedCount = contractDetail?.assigned_codes
   const redeemedCount = contractDetail?.redeemed_codes
 
-  // Tab filter is applied client-side on the current page of results.
-  // Unassigned codes are excluded server-side (API only returns assigned/redeemed).
-  // TODO: pass statusFilter as a server-side query param once the API supports a
-  // redemption_status filter — client-side filtering against paginated results means
-  // pagination counts reflect all statuses, not the active tab's subset.
   const pageResults = codes?.results ?? []
-  const tabFilteredCodes = pageResults.filter((code) => {
-    return (
-      statusFilter === "all" ||
-      (statusFilter === "redeemed" && code.redemption_status === "redeemed") ||
-      (statusFilter === "pending" && code.redemption_status === "assigned")
-    )
-  })
 
   const totalCount = codes?.count ?? 0
   // Derive total pages from the response: if there's a next page we're on a
@@ -502,13 +497,27 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
 
   const handleExportCsv = async () => {
     if (!totalPurchased) return
+    setIsExporting(true)
     try {
-      const response = await b2bApi.b2bManagerOrganizationsContractsCodesList({
+      const PAGE_SIZE = 500
+      let page = 1
+      let res = await b2bApi.b2bManagerOrganizationsContractsCodesList({
         id: contract.id,
         parent_lookup_organization: org.id,
-        page_size: totalPurchased,
+        page,
+        page_size: PAGE_SIZE,
       })
-      const rows = response.data.results
+      const rows = [...res.data.results]
+      while (res.data.next) {
+        page += 1
+        res = await b2bApi.b2bManagerOrganizationsContractsCodesList({
+          id: contract.id,
+          parent_lookup_organization: org.id,
+          page,
+          page_size: PAGE_SIZE,
+        })
+        rows.push(...res.data.results)
+      }
       const header = buildCsvRow([
         "Assigned to",
         "Redeemed by",
@@ -537,11 +546,17 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
       link.click()
       document.body.removeChild(link)
       URL.revokeObjectURL(url)
+      setRowActionResult({
+        message: "CSV download started.",
+        severity: "success",
+      })
     } catch {
       setRowActionResult({
         message: "Could not export CSV. Please try again.",
         severity: "error",
       })
+    } finally {
+      setIsExporting(false)
     }
   }
 
@@ -657,9 +672,12 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
               <Button
                 variant="bordered"
                 onClick={handleExportCsv}
-                disabled={isLoadingContractDetail || !totalPurchased}
+                disabled={
+                  isLoadingContractDetail || !totalPurchased || isExporting
+                }
+                aria-busy={isExporting}
               >
-                Export CSV
+                {isExporting ? "Exporting..." : "Export CSV"}
               </Button>
             </ExportButtonWrapper>
           </SeatAssignmentsControls>
@@ -713,7 +731,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                 <VisuallyHidden aria-live="polite" aria-atomic="true">
                   {isLoadingCodes
                     ? "Loading seat assignments"
-                    : tabFilteredCodes.length === 0
+                    : pageResults.length === 0
                       ? "No seat assignments found"
                       : `Showing page ${page} of ${totalPages}`}
                 </VisuallyHidden>
@@ -727,7 +745,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                       </TableRow>
                     ))}
                   </>
-                ) : tabFilteredCodes.length === 0 ? (
+                ) : pageResults.length === 0 ? (
                   <TableRow role="row">
                     <EmptyTableMessage
                       role="cell"
@@ -738,7 +756,7 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                     </EmptyTableMessage>
                   </TableRow>
                 ) : (
-                  tabFilteredCodes.map((code) => (
+                  pageResults.map((code) => (
                     <TableRow role="row" key={code.id}>
                       <TableCell
                         role="cell"

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -56,7 +56,7 @@ describe("RowActionMenu", () => {
   })
 
   describe("redeemed code", () => {
-    test("opens menu with only Uninvite item", async () => {
+    test("renders a disabled button with no menu for redeemed codes", async () => {
       const code = makeCode({
         redemption_status: "redeemed",
         redeemed_by: "user@example.com",
@@ -64,12 +64,14 @@ describe("RowActionMenu", () => {
       })
       renderMenu(code)
 
-      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      const button = screen.getByRole("button", {
+        name: /no actions available/i,
+      })
+      expect(button).toBeDisabled()
 
-      expect(
-        screen.getByRole("menuitem", { name: "Uninvite" }),
-      ).toBeInTheDocument()
-      expect(screen.queryByText("Copy claim link")).not.toBeInTheDocument()
+      // Clicking the disabled button should not open any menu
+      await user.click(button)
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument()
     })
   })
 
@@ -172,35 +174,6 @@ describe("RowActionMenu", () => {
 
       await waitFor(() => {
         expect(onResult).toHaveBeenCalledWith("Seat released.", "success")
-      })
-    })
-
-    test("surfaces the already-redeemed (409) error", async () => {
-      const code = makeCode({
-        redemption_status: "redeemed",
-        redeemed_by: "user@example.com",
-        redeemed_on: new Date().toISOString(),
-      })
-      setMockResponse.delete(
-        urls.contracts.managerContractCodeRevoke(
-          ORG_ID,
-          CONTRACT_ID,
-          code.code,
-        ),
-        { detail: "Cannot revoke a code that has already been redeemed." },
-        { code: 409 },
-      )
-      const { onResult } = renderMenu(code)
-
-      await user.click(screen.getByRole("button", { name: /more actions/i }))
-      await user.click(screen.getByRole("menuitem", { name: "Uninvite" }))
-      await user.click(screen.getByRole("button", { name: "Uninvite" }))
-
-      await waitFor(() => {
-        expect(onResult).toHaveBeenCalledWith(
-          expect.stringContaining("already been redeemed"),
-          "error",
-        )
       })
     })
   })

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -138,8 +138,14 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         parent_lookup_organization: orgId,
       })
       onResult("Seat released.", "success")
-    } catch {
-      onResult("Could not release the seat. Please try again.", "error")
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status
+      onResult(
+        status === 409
+          ? "This seat has already been redeemed and cannot be released."
+          : "Could not release the seat. Please try again.",
+        "error",
+      )
     }
     // Dialog closes itself once this resolves.
   }

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -75,10 +75,10 @@ type RowActionMenuProps = {
 /**
  * Three-dot row action menu for the contract admin codes table.
  *
- * Pending rows: Change assigned email (reassign, confirmed), Resend claim
- * email (remind), Copy claim link, Release seat (revoke, confirmed).
+ * Pending (assigned) rows: Change assigned email, Resend claim email, Copy
+ * claim link, Release seat.
  *
- * Redeemed rows: Uninvite (revoke, confirmed).
+ * Redeemed rows: button is disabled — no actions available.
  */
 const RowActionMenu: React.FC<RowActionMenuProps> = ({
   code,
@@ -137,15 +137,9 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult(isRedeemed ? "Learner uninvited." : "Seat released.", "success")
-    } catch (err) {
-      const status = (err as AxiosError)?.response?.status
-      onResult(
-        status === 409
-          ? "This code has already been redeemed and cannot be revoked."
-          : "Could not complete the action. Please try again.",
-        "error",
-      )
+      onResult("Seat released.", "success")
+    } catch {
+      onResult("Could not release the seat. Please try again.", "error")
     }
     // Dialog closes itself once this resolves.
   }
@@ -223,45 +217,19 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
     }
   }
 
-  const menuItems = isRedeemed ? (
-    <DestructiveMenuItem onClick={openRevokeConfirm}>
-      Uninvite
-    </DestructiveMenuItem>
-  ) : (
-    [
-      <ActionMenuItem key="change-email" onClick={openReassign}>
-        Change assigned email
-      </ActionMenuItem>,
-      hasAssignedEmail ? (
-        <ActionMenuItem key="resend-email" onClick={handleResend}>
-          Resend claim email
-        </ActionMenuItem>
-      ) : (
-        <Tooltip
-          key="resend-email"
-          title="No email is assigned to this seat yet."
-          describeChild
-        >
-          <ActionMenuItem disabled aria-label="Resend claim email">
-            Resend claim email
-          </ActionMenuItem>
-        </Tooltip>
-      ),
-      copied ? (
-        <CopiedMenuItem key="copy-link" disabled>
-          Link copied to clipboard
-        </CopiedMenuItem>
-      ) : (
-        <ActionMenuItem key="copy-link" onClick={handleCopyClaimLink}>
-          Copy claim link
-        </ActionMenuItem>
-      ),
-      <Divider component="li" role="separator" key="divider" />,
-      <DestructiveMenuItem key="release-seat" onClick={openRevokeConfirm}>
-        Release seat
-      </DestructiveMenuItem>,
-    ]
-  )
+  // Redeemed rows have no available actions — render a disabled button only.
+  if (isRedeemed) {
+    return (
+      <ActionButton
+        aria-label={`No actions available for ${assignedTo}`}
+        variant="text"
+        size="small"
+        disabled
+      >
+        <RiMoreLine size={16} />
+      </ActionButton>
+    )
+  }
 
   return (
     <>
@@ -287,21 +255,43 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         onClose={handleClose}
         MenuListProps={{ "aria-labelledby": `row-action-trigger-${code.id}` }}
       >
-        {menuItems}
+        <ActionMenuItem onClick={openReassign}>
+          Change assigned email
+        </ActionMenuItem>
+        {hasAssignedEmail ? (
+          <ActionMenuItem onClick={handleResend}>
+            Resend claim email
+          </ActionMenuItem>
+        ) : (
+          <Tooltip title="No email is assigned to this seat yet." describeChild>
+            <ActionMenuItem disabled aria-label="Resend claim email">
+              Resend claim email
+            </ActionMenuItem>
+          </Tooltip>
+        )}
+        {copied ? (
+          <CopiedMenuItem disabled>Link copied to clipboard</CopiedMenuItem>
+        ) : (
+          <ActionMenuItem onClick={handleCopyClaimLink}>
+            Copy claim link
+          </ActionMenuItem>
+        )}
+        <Divider component="li" role="separator" />
+        <DestructiveMenuItem onClick={openRevokeConfirm}>
+          Release seat
+        </DestructiveMenuItem>
       </Menu>
       <Dialog
         open={revokeConfirmOpen}
         onClose={() => setRevokeConfirmOpen(false)}
         onConfirm={handleRevokeConfirm}
-        title={isRedeemed ? "Uninvite learner" : "Release seat"}
-        confirmText={isRedeemed ? "Uninvite" : "Release seat"}
+        title="Release seat"
+        confirmText="Release seat"
         maxWidth="sm"
         aria-describedby={revokeDescId}
       >
         <p id={revokeDescId} style={{ margin: 0 }}>
-          {isRedeemed
-            ? `This will remove ${assignedTo}'s access to the program. This cannot be undone.`
-            : `This will revoke the invitation for ${assignedTo} and return the seat to the unassigned pool.`}
+          {`This will revoke the invitation for ${assignedTo} and return the seat to the unassigned pool.`}
         </p>
       </Dialog>
       <FormDialog

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -20,7 +20,7 @@ import {
   useRemindCode,
   useRevokeCode,
 } from "api/mitxonline-hooks/organizations"
-import type { ContractCode } from "api/mitxonline-hooks/organizations"
+import type { ManagerEnrollmentCode } from "api/mitxonline-hooks/organizations"
 import type { AxiosError } from "axios"
 
 const ActionMenuItem = styled(MenuItem)(({ theme }) => ({
@@ -65,7 +65,7 @@ const CopiedMenuItem = styled(ActionMenuItem)(({ theme }) => ({
 type ActionSeverity = "success" | "error"
 
 type RowActionMenuProps = {
-  code: ContractCode
+  code: ManagerEnrollmentCode
   orgId: number
   contractId: number
   /** Surfaces action outcomes in the page-level result Alert. */

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -1413,7 +1413,12 @@ describe("ContractContent", () => {
     mockedUseFeatureFlagEnabled.mockImplementation(() => false)
     const { orgX } = setupProgramsAndCourses()
 
-    setMockResponse.get(managerOrganizationsUrl, [orgX])
+    setMockResponse.get(managerOrganizationsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [orgX],
+    })
 
     renderWithProviders(
       <ContractContent
@@ -1436,7 +1441,12 @@ describe("ContractContent", () => {
 
     // Return a different org — user is a manager elsewhere, not for orgX
     const otherOrg = factories.organizations.organization({})
-    setMockResponse.get(managerOrganizationsUrl, [otherOrg])
+    setMockResponse.get(managerOrganizationsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [otherOrg],
+    })
 
     renderWithProviders(
       <ContractContent
@@ -1457,7 +1467,12 @@ describe("ContractContent", () => {
     )
     const { orgX } = setupProgramsAndCourses()
 
-    setMockResponse.get(managerOrganizationsUrl, [orgX])
+    setMockResponse.get(managerOrganizationsUrl, {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [orgX],
+    })
 
     renderWithProviders(
       <ContractContent

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,13 +3344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz":
-  version: 2026.6.24
-  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
+"@mitodl/mitxonline-api-axios@npm:2026.6.30-1":
+  version: 2026.6.30-1
+  resolution: "@mitodl/mitxonline-api-axios@npm:2026.6.30-1"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/231c1eacf79f382aad264b8c837431f564192babe26d2a823cee674c814965a771f3e5c06015c7ca3ddda67830b64bf574be0dbd96b468702d2cdf2fcd418039
+  checksum: 10/cb5ba8cabe66e9ace0902c96cba527052263b1599a9909d9a41a7e3cff5022c907bc2994712a9e6a055edc2307a19518fd606df91c70a8efc47457842ed5b4f8
   languageName: node
   linkType: hard
 
@@ -8953,7 +8953,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "npm:2026.6.30-1"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16180,7 +16180,7 @@ __metadata:
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/arithmix": "npm:^0.2.2"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "npm:2026.6.30-1"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,13 +3344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz":
+"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz":
   version: 2026.6.24
-  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
+  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/324d0b95622278848e99b7d60b73d204ef43a8043b9f7105682fc72372a6047980cb43cec7d36d2a0d4c544e4d2351814ffd49f20a4ab43a351d67fc03331e29
+  checksum: 10/231c1eacf79f382aad264b8c837431f564192babe26d2a823cee674c814965a771f3e5c06015c7ca3ddda67830b64bf574be0dbd96b468702d2cdf2fcd418039
   languageName: node
   linkType: hard
 
@@ -8953,7 +8953,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16180,7 +16180,7 @@ __metadata:
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/arithmix": "npm:^0.2.2"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes-client-443be46/src/typescript/mitxonline-api-axios/package.tgz"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,13 +3344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@npm:2026.6.17":
-  version: 2026.6.17
-  resolution: "@mitodl/mitxonline-api-axios@npm:2026.6.17"
+"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz":
+  version: 2026.6.24
+  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/8b6fbc67de43903b04fdb9c641f204ebc58ace1562cb35b86fdcf4b2fedf95edfb47f27c8e8c72bc02a0d90b6964a74033e0376a15150b0ce1348051c74a8d0f
+  checksum: 10/a7eeb3ffb9cf9d87669702c873901d2f56ec61e39d84e3eeaf0942662309cdaf446fb495e04b9e7674dc02478b6dcbabae87d2d7a1c74911847aa9aea2aebc6f
   languageName: node
   linkType: hard
 
@@ -8953,7 +8953,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "npm:2026.6.17"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16180,7 +16180,7 @@ __metadata:
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/arithmix": "npm:^0.2.2"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "npm:2026.6.17"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,13 +3344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz":
+"@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz":
   version: 2026.6.24
-  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
+  resolution: "@mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
   dependencies:
     "@types/node": "npm:^20.11.19"
     axios: "npm:^1.6.5"
-  checksum: 10/a7eeb3ffb9cf9d87669702c873901d2f56ec61e39d84e3eeaf0942662309cdaf446fb495e04b9e7674dc02478b6dcbabae87d2d7a1c74911847aa9aea2aebc6f
+  checksum: 10/324d0b95622278848e99b7d60b73d204ef43a8043b9f7105682fc72372a6047980cb43cec7d36d2a0d4c544e4d2351814ffd49f20a4ab43a351d67fc03331e29
   languageName: node
   linkType: hard
 
@@ -8953,7 +8953,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"
     axios: "npm:^1.12.2"
@@ -16180,7 +16180,7 @@ __metadata:
     "@happy-dom/jest-environment": "npm:^20.1.0"
     "@mitodl/arithmix": "npm:^0.2.2"
     "@mitodl/course-search-utils": "npm:^3.5.2"
-    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7af6a2c/src/typescript/mitxonline-api-axios/package.tgz"
+    "@mitodl/mitxonline-api-axios": "https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/dansubak/202606_paginated_codes_means_paginated_problems-client-7dbc25d/src/typescript/mitxonline-api-axios/package.tgz"
     "@mitodl/smoot-design": "npm:^6.27.0"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->


### Description (What does it do?)
<!--- Describe your changes in detail -->
#### Summary

- Migrates contract codes list from client-side to server-side with pagination and debounced search
- Adds a dedicated `contractDetail` API query for per-status seat counts (total, unassigned, assigned, redeemed) instead of deriving them by filtering the full codes list client-side
- Implements the CSV export button 
- Removes the "Uninvite" action for redeemed codes — redeemed rows now show a disabled button with no menu


### Screen Recording (if appropriate):
<!--- optional - delete if empty --->


https://github.com/user-attachments/assets/3a9ca69c-7b78-4c06-a567-4e3856baf857

Using NVDA

https://github.com/user-attachments/assets/799756a6-f534-4658-a4db-ee595f92c8b3



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- [ ] Load the Contract Admin page — verify the four stat blocks Total purchased, Unassigned, Pending claim, Redeemed
- [ ] Type in the search box — verify results filter server-side after a short debounce. Screen reader announcement reflects the correct total count after results load
- [ ] Clear the search — verify the full list is restored
- [ ] Tab between All / Pending claim / Redeemed — verify tab filtering works on the current page of results
- [ ] Paginate through results — verify the correct page loads and the footer shows the right page info
- [ ] Click "Export CSV" — verify a CSV downloads with all assigned/redeemed codes 
- [ ] Confirm redeemed rows show a disabled action button with no menu

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
