### PR TITLE
make uai heading navigable

### DIFF
--- a/frontends/main/src/page-components/SearchDisplay/UniversalAIBanner.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/UniversalAIBanner.tsx
@@ -60,7 +60,7 @@ const BannerTitle = styled(Typography)(({ theme }) => ({
   fontWeight: theme.typography.fontWeightBold,
   fontSize: "16px",
   lineHeight: "20px",
-}))
+})) as typeof Typography
 
 const BannerLink = styled(Link)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
@@ -126,7 +126,7 @@ const UniversalAIBanner: React.FC<UniversalAIBannerProps> = ({
     <BannerContainer>
       <BannerContent>
         <BannerLabel>New on MIT Learn</BannerLabel>
-        <BannerTitle>Universal AI</BannerTitle>
+        <BannerTitle component="h2">Universal AI</BannerTitle>
         <BannerDescription>
           A self-paced program that takes learners from AI fundamentals to
           practical, industry-relevant applications. No technical background


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/11319

### Description (What does it do?)
Adds a header tag to the UAI banner to make it screen reader navigable


### How can this be tested?
On Mac, VoiceOver is the built-in screen reader:

Turn on VoiceOver: Cmd + F5 (or Fn + Cmd + F5 on newer Macs)
Open Chrome/Safari and navigate to the search page with a term like "AI"
Open the Rotor (VoiceOver's heading navigator): Ctrl + Option + U, then use arrow keys to select "Headings"
Arrow through the headings — you should now see "Universal AI" listed at level 2 alongside "Search Results"
To turn VoiceOver off: Cmd + F5 again.

I'm not sure how to test this with other operating systems