### PR TITLE
update elipses css

### DIFF
--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -8,7 +8,6 @@ import {
   Container,
   Typography,
   SimpleSelect,
-  truncateText,
   css,
   Drawer,
   Stack,
@@ -150,11 +149,16 @@ const FacetStyles = styled.div`
     justify-content: space-between;
     display: flex;
     flex-direction: row;
-    width: 100%;
-    align-items: baseline;
+    flex: 1;
+    min-width: 0;
+    align-items: center;
 
     .facet-text {
-      ${truncateText(1)};
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
       color: ${({ theme }) => theme.custom.colors.silverGrayDark};
     }
   }
@@ -211,9 +215,11 @@ const FacetStyles = styled.div`
 
       .facet-count {
         font-size: 12px;
-        padding-left: 3px;
+        padding-left: 8px;
         color: ${({ theme }) => theme.custom.colors.silverGrayDark};
-        float: right;
+        flex-shrink: 0;
+        font-variant-numeric: tabular-nums;
+        text-align: right;
       }
 
       &.checked,


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5113


### Description (What does it do?)
This pr updates facet text truncation to show as much text as possible instead of cutting off at word boundries 

### Screenshots (if appropriate):
<img width="303" height="524" alt="Screenshot 2026-06-26 at 4 13 22 PM" src="https://github.com/user-attachments/assets/fa069bef-a8cb-4c83-a7d3-e0f19534660a" />
<img width="303" height="532" alt="Screenshot 2026-06-26 at 4 12 29 PM" src="https://github.com/user-attachments/assets/32a6ff26-93ab-47fa-b406-adaad83f1840" />

Before: 
<img width="304" height="530" alt="Screenshot 2026-06-26 at 4 28 22 PM" src="https://github.com/user-attachments/assets/f9d8c999-0bf9-432f-8439-35b4aeb317ed" />


### How can this be tested?
Go to the search. Verify that the facet text looks good at different screen sizes