### PR TITLE
Fix flaky test

### DIFF
--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -98,7 +98,9 @@ describe("LearningResourceDrawer", () => {
   ])(
     "Renders drawer content when resource=id is in the URL and captures the view if PostHog $descriptor",
     async ({ enablePostHog }) => {
-      const { resource } = setupApis()
+      const { resource } = setupApis({
+        resource: { resource_type: ResourceTypeEnum.Course },
+      })
       process.env.NEXT_PUBLIC_POSTHOG_API_KEY = enablePostHog
         ? "12345abcdef" // pragma: allowlist secret
         : ""


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12044

### Description (What does it do?)
<!--- Describe your changes in detail -->
Sets up the test resource so that it is always a course instead of potentially something else.


### How can this be tested?
Run this inside the watch container, it should succeed 10x:

```bash
for i in $(seq 1 10); do yarn test src/page-components/LearningResourceDrawer/LearningResourceDrawer.test
.tsx --silent >/dev/null 2>&1 && echo "run $i: PASS" || { echo "run $i: FAIL"; break; }; done
```
