### PR TITLE
chore: remove video-playlist-page feature flag

### DIFF
--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -12,7 +12,6 @@ export enum FeatureFlags {
   VideoShorts = "video-shorts",
   CourseOutlineSection = "course-outline-section",
   OcwProductPages = "ocw-product-pages",
-  VideoPlaylistPage = "video-playlist-page",
   PodcastDetailPage = "podcast-detail-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
   Arithmix = "arithmix",

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -98,9 +98,7 @@ describe("LearningResourceDrawer", () => {
   ])(
     "Renders drawer content when resource=id is in the URL and captures the view if PostHog $descriptor",
     async ({ enablePostHog }) => {
-      const { resource } = setupApis({
-        resource: { resource_type: ResourceTypeEnum.Course },
-      })
+      const { resource } = setupApis()
       process.env.NEXT_PUBLIC_POSTHOG_API_KEY = enablePostHog
         ? "12345abcdef" // pragma: allowlist secret
         : ""

--- a/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceDrawer/LearningResourceDrawer.test.tsx
@@ -98,7 +98,9 @@ describe("LearningResourceDrawer", () => {
   ])(
     "Renders drawer content when resource=id is in the URL and captures the view if PostHog $descriptor",
     async ({ enablePostHog }) => {
-      const { resource } = setupApis()
+      const { resource } = setupApis({
+        resource: { resource_type: ResourceTypeEnum.Course },
+      })
       process.env.NEXT_PUBLIC_POSTHOG_API_KEY = enablePostHog
         ? "12345abcdef" // pragma: allowlist secret
         : ""


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Removes the `video-playlist-page` feature flag from the `FeatureFlags` enum.

The flag guards were already stripped from all components in #3327 (video embed page / route restructure). This cleans up the now-unused enum entry.


Part of https://github.com/mitodl/hq/issues/11286.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Use RC for real data. Point your local frontend at RC by setting NEXT_PUBLIC_MITOPEN_API_BASE_URL to the RC API base URL.

- [ ] Visit http://open.odl.local:8062/video-playlist/136873/science-of-everyday-life — playlist page loads normally
- [ ] Click into a video from the playlist — video detail page loads with breadcrumb back to the playlist
- [ ] Open the resource drawer for any Video or VideoPlaylist resource → CTA link correctly routes to the video/playlist page
- [ ] Confirm no video-playlist-page flag is being evaluated in PostHog (you can disable it in PostHog and verify behavior is unchanged)

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
