### PR TITLE
chore: Remove podcast-detail-page feature flag

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
@@ -3,15 +3,7 @@ import { factories, setMockResponse, urls } from "api/test-utils"
 import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource, PodcastEpisodeResource } from "api/v1"
 import { renderWithProviders, screen, user } from "@/test-utils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { PodcastDetailPage } from "./PodcastDetailPage"
-
-jest.mock("posthog-js/react")
-jest.mock("@/common/useFeatureFlagsLoaded")
-
-const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
-const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
 jest.mock(
   "@/page-components/LearningResourceDrawer/LearningResourceDrawer",
@@ -94,15 +86,6 @@ const setupApis = ({
 }
 
 describe("PodcastDetailPage", () => {
-  beforeEach(() => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   test("renders initial episode list", async () => {
     const episodes = makePodcastEpisodes(3)
     const { podcast } = setupApis({ episodesPage1: episodes })

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import React, { useState, useEffect, useRef } from "react"
-import { notFound } from "next/navigation"
 import Link from "next/link"
 import { Breadcrumbs, Typography, styled, useMediaQuery } from "ol-components"
 import type { Theme } from "ol-components"
@@ -19,9 +18,6 @@ import moment from "moment"
 import { formatDate } from "ol-utilities"
 import { HOME, podcastEpisodePageView } from "@/common/urls"
 import PodcastContainer from "./PodcastContainer"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 
 const HeaderSection = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
@@ -404,10 +400,6 @@ const EPISODES_PAGE_SIZE = 5
 export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
   podcastId,
 }) => {
-  const showPodcastDetailPage = useFeatureFlagEnabled(
-    FeatureFlags.PodcastDetailPage,
-  )
-  const flagsLoaded = useFeatureFlagsLoaded()
   const id = Number(podcastId)
   const isMobile = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"))
   const [playingEpisode, setPlayingEpisode] = useState<LearningResource | null>(
@@ -510,10 +502,6 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
       root.style.removeProperty("--mit-player-height")
     }
   }, [currentTrack, isMobile])
-
-  if (!showPodcastDetailPage) {
-    return flagsLoaded ? notFound() : null
-  }
 
   return (
     <>

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
@@ -3,15 +3,7 @@ import { factories, setMockResponse, urls } from "api/test-utils"
 import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource, PodcastEpisodeResource } from "api/v1"
 import { renderWithProviders, screen, user } from "@/test-utils"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import { PodcastEpisodeDetailPage } from "./PodcastEpisodeDetailPage"
-
-jest.mock("posthog-js/react")
-jest.mock("@/common/useFeatureFlagsLoaded")
-
-const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
-const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
 
 jest.mock("./PodcastPlayer", () => ({
   __esModule: true,
@@ -90,15 +82,6 @@ const setupApis = ({
 }
 
 describe("PodcastEpisodeDetailPage", () => {
-  beforeEach(() => {
-    mockedUseFeatureFlagEnabled.mockReturnValue(true)
-    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   test("renders episode title and podcast name on the page", async () => {
     const { episode, podcast } = setupApis({ moreEpisodes: [] })
 
@@ -274,35 +257,5 @@ describe("PodcastEpisodeDetailPage", () => {
     expect(screen.getByTestId("player-track-title")).toHaveTextContent(
       moreEpisode.title!,
     )
-  })
-
-  test("returns null (not found) when feature flag is not loaded yet", () => {
-    mockedUseFeatureFlagsLoaded.mockReturnValue(false)
-    mockedUseFeatureFlagEnabled.mockReturnValue(false)
-
-    const episode = makePodcastEpisode()
-    const podcast = makePodcast()
-
-    setMockResponse.get(
-      urls.learningResources.details({ id: episode.id }),
-      episode,
-    )
-    setMockResponse.get(
-      urls.learningResources.details({ id: podcast.id }),
-      podcast,
-    )
-    setMockResponse.get(
-      `${urls.learningResources.items({ id: podcast.id })}?limit=${EPISODES_PAGE_SIZE}`,
-      makeItemsResponse([]),
-    )
-
-    const { view } = renderWithProviders(
-      <PodcastEpisodeDetailPage
-        episodeId={String(episode.id)}
-        podcastId={String(podcast.id)}
-      />,
-    )
-
-    expect(view.container).toBeEmptyDOMElement()
   })
 })

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -11,9 +11,6 @@ import {
 import type { Theme } from "ol-components"
 import { Button } from "@mitodl/smoot-design"
 import { RiPlayFill, RiPauseFill } from "@remixicon/react"
-import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
-import { useFeatureFlagEnabled } from "posthog-js/react"
-import { FeatureFlags } from "@/common/feature_flags"
 import PodcastPlayer, { PLAYER_HEIGHT } from "./PodcastPlayer"
 import type { PodcastTrack, PodcastPlayerHandle } from "./PodcastPlayer"
 import {
@@ -29,7 +26,6 @@ import { HOME, podcastPageView, podcastEpisodePageView } from "@/common/urls"
 import DOMPurify from "isomorphic-dompurify"
 import { EpisodeItem } from "./PodcastDetailPage"
 import PodcastContainer from "./PodcastContainer"
-import { notFound } from "next/navigation"
 import Link from "next/link"
 
 /* ── Layout ── */
@@ -202,10 +198,6 @@ export const PodcastEpisodeDetailPage: React.FC<
   const [isAudioPlaying, setIsAudioPlaying] = useState(false)
   const playerRef = useRef<PodcastPlayerHandle>(null)
 
-  const showPodcastDetailPage = useFeatureFlagEnabled(
-    FeatureFlags.PodcastDetailPage,
-  )
-  const flagsLoaded = useFeatureFlagsLoaded()
   const { data: episode } = useLearningResourcesDetail(Number(episodeId))
   const { data: podcast } = useLearningResourcesDetail(Number(podcastId))
 
@@ -293,9 +285,6 @@ export const PodcastEpisodeDetailPage: React.FC<
     ? podcastPageView(podcastId, podcast?.title)
     : "/"
 
-  if (!showPodcastDetailPage) {
-    return flagsLoaded ? notFound() : null
-  }
   return (
     <>
       <PageSection>

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -13,7 +13,6 @@ export enum FeatureFlags {
   CourseOutlineSection = "course-outline-section",
   OcwProductPages = "ocw-product-pages",
   VideoPlaylistPage = "video-playlist-page",
-  PodcastDetailPage = "podcast-detail-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
   Arithmix = "arithmix",
 }

--- a/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/CallToActionSection.tsx
@@ -317,9 +317,7 @@ const getResourceUrl = (
   resource: LearningResource,
   {
     ocwProductPages,
-    showPodcastPage,
   }: {
-    showPodcastPage?: boolean
     ocwProductPages?: boolean
   },
 ) => {
@@ -333,19 +331,17 @@ const getResourceUrl = (
     }
   }
 
-  if (showPodcastPage) {
-    if (resource.resource_type === ResourceTypeEnum.Podcast) {
-      return podcastPageView(resource.id.toString(), resource.title)
-    }
-    if (resource.resource_type === ResourceTypeEnum.PodcastEpisode) {
-      const [parentPodcastId] = parentPodcastIds(resource)
-      if (parentPodcastId !== undefined) {
-        return podcastEpisodePageView(
-          resource.id.toString(),
-          String(parentPodcastId),
-          resource.title,
-        )
-      }
+  if (resource.resource_type === ResourceTypeEnum.Podcast) {
+    return podcastPageView(resource.id.toString(), resource.title)
+  }
+  if (resource.resource_type === ResourceTypeEnum.PodcastEpisode) {
+    const [parentPodcastId] = parentPodcastIds(resource)
+    if (parentPodcastId !== undefined) {
+      return podcastEpisodePageView(
+        resource.id.toString(),
+        String(parentPodcastId),
+        resource.title,
+      )
     }
   }
 
@@ -385,7 +381,6 @@ const CallToActionSection = ({
   const [shareExpanded, setShareExpanded] = useState(false)
   const [copyText, setCopyText] = useState("Copy Link")
   const ocwProductPages = useFeatureFlagEnabled(FeatureFlags.OcwProductPages)
-  const showPodcastPage = useFeatureFlagEnabled(FeatureFlags.PodcastDetailPage)
 
   if (hide) {
     return null
@@ -413,7 +408,6 @@ const CallToActionSection = ({
   const socialIconSize = 18
   const url = appendUtmParams(
     getResourceUrl(resource, {
-      showPodcastPage,
       ocwProductPages,
     }),
     resource.title,

--- a/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
+++ b/frontends/main/src/page-components/LearningResourceExpanded/LearningResourceExpanded.test.tsx
@@ -12,6 +12,8 @@ import { renderWithProviders } from "@/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { kebabCase } from "lodash"
 import { faker } from "@faker-js/faker/locale/en"
+import { podcastEpisodePageView } from "@/common/urls"
+import { parentPodcastIds } from "@/common/slugs"
 
 jest.mock("posthog-js/react")
 const mockedUseFeatureFlagEnabled = jest
@@ -96,10 +98,19 @@ describe("Learning Resource Expanded", () => {
         const link = screen.getByRole("link", {
           name: linkName,
         }) as HTMLAnchorElement
-        expect(link.target).toBe("_blank")
-        expect(link.href).toBe(
-          `${resource.url?.replace(/\/$/, "")}/?utm_source=mit-learn&utm_medium=referral&utm_content=${kebabCase(resource.title)}`,
-        )
+
+        const isPodcast =
+          resourceType === ResourceTypeEnum.Podcast ||
+          resourceType === ResourceTypeEnum.PodcastEpisode
+
+        if (isPodcast) {
+          expect(link.target).toBe("")
+        } else {
+          expect(link.target).toBe("_blank")
+          expect(link.href).toBe(
+            `${resource.url?.replace(/\/$/, "")}/?utm_source=mit-learn&utm_medium=referral&utm_content=${kebabCase(resource.title)}`,
+          )
+        }
       }
     },
   )
@@ -163,7 +174,18 @@ describe("Learning Resource Expanded", () => {
         name: "Listen to Podcast",
       }) as HTMLAnchorElement
 
-      expect(link.href).toMatch(resource.url || "")
+      const [parentPodcastId] = parentPodcastIds(
+        resource as Parameters<typeof parentPodcastIds>[0],
+      )
+      const expectedHref =
+        parentPodcastId !== undefined
+          ? podcastEpisodePageView(
+              String(resource.id),
+              String(parentPodcastId),
+              resource.title,
+            )
+          : resource.url
+      expect(link.href).toContain(expectedHref || "")
     },
   )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11286 
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Removes the `podcast-detail-page` PostHog feature flag, replacing it with always-on behavior
- Podcast and podcast episode detail pages now always render (no `notFound()` guard)
- The resource drawer CTA always links to internal podcast/episode detail pages

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Use RC for real data. Point your local frontend at RC by setting `NEXT_PUBLIC_MITOPEN_API_BASE_URL` to the RC API base URL.
- [ ] Visit a podcast episode page (e.g. http://open.odl.local:8062/podcast/15122/podcast_episode/137321/announcing-building-32-from-mit-csail-alliances) — page renders normally
- [ ] Visit a podcast page — page renders normally
- [ ] Open a podcast or podcast episode in the resource drawer — the CTA links to the detail page (not an external URL)

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
