### PR TITLE
Add posthog enrollment_cta_clicked event with enrollment-specific data

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.tsx
@@ -103,7 +103,7 @@ const CourseEnrollArea: React.FC<CourseEnrollAreaProps> = ({
 
   const { state, scenario, isStatusLoading, isPending, isError } =
     useCourseEnrollment(course, selectedRun, {
-      placement: "infobox",
+      tracking: { placement: "infobox" },
       onRequireSignup: (el) => setAnchor(el),
     })
 

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.tsx
@@ -103,6 +103,7 @@ const CourseEnrollArea: React.FC<CourseEnrollAreaProps> = ({
 
   const { state, scenario, isStatusLoading, isPending, isError } =
     useCourseEnrollment(course, selectedRun, {
+      placement: "infobox",
       onRequireSignup: (el) => setAnchor(el),
     })
 

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -66,7 +66,7 @@ const CourseHeaderEnrollButton: React.FC<{
   const { state, isStatusLoading, isPending } = useCourseEnrollment(
     course,
     selectedRun,
-    { onRequireSignup: (el) => setAnchor(el) },
+    { placement: "header", onRequireSignup: (el) => setAnchor(el) },
   )
 
   if (state.status === "enrolled") {

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.tsx
@@ -66,7 +66,10 @@ const CourseHeaderEnrollButton: React.FC<{
   const { state, isStatusLoading, isPending } = useCourseEnrollment(
     course,
     selectedRun,
-    { placement: "header", onRequireSignup: (el) => setAnchor(el) },
+    {
+      tracking: { placement: "header" },
+      onRequireSignup: (el) => setAnchor(el),
+    },
   )
 
   if (state.status === "enrolled") {

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
@@ -510,7 +510,11 @@ describe("useCourseEnrollment — actions", () => {
     const onRequireSignup = jest.fn()
 
     const { result } = renderHook(
-      () => useCourseEnrollment(course, run, { onRequireSignup }),
+      () =>
+        useCourseEnrollment(course, run, {
+          placement: "infobox",
+          onRequireSignup,
+        }),
       { wrapper },
     )
 
@@ -571,9 +575,9 @@ describe("useCourseEnrollment — actions", () => {
       PostHogEvents.EnrollCtaClicked,
       expect.objectContaining({
         placement: "infobox",
-        enrollment_mode: "verified",
-        resource_type: "course",
-        readable_id: course.readable_id,
+        enrollmentMode: "verified",
+        resourceType: "course",
+        readableId: course.readable_id,
       }),
     )
   })
@@ -612,9 +616,9 @@ describe("useCourseEnrollment — actions", () => {
       PostHogEvents.EnrollCtaClicked,
       expect.objectContaining({
         placement: "header",
-        enrollment_mode: "audit",
-        resource_type: "course",
-        readable_id: course.readable_id,
+        enrollmentMode: "audit",
+        resourceType: "course",
+        readableId: course.readable_id,
       }),
     )
   })

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
@@ -533,7 +533,7 @@ describe("useCourseEnrollment — actions", () => {
     expect(onRequireSignup).toHaveBeenCalledWith(anchorButton)
   })
 
-  test("fires PostHog cta_clicked on paid action click", async () => {
+  test("fires PostHog enroll_cta_clicked on paid action click", async () => {
     const product = makeProduct()
     const run = makeRun({
       is_enrollable: true,
@@ -550,9 +550,10 @@ describe("useCourseEnrollment — actions", () => {
       items: [],
     })
 
-    const { result } = renderHook(() => useCourseEnrollment(course, run), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useCourseEnrollment(course, run, { placement: "infobox" }),
+      { wrapper },
+    )
 
     await waitFor(() => expect(result.current.isStatusLoading).toBe(false))
 
@@ -567,10 +568,53 @@ describe("useCourseEnrollment — actions", () => {
     paidOption.onClick!(fakeEvent)
 
     expect(mockCapture).toHaveBeenCalledWith(
-      PostHogEvents.CallToActionClicked,
+      PostHogEvents.EnrollCtaClicked,
       expect.objectContaining({
-        readableId: course.readable_id,
-        resourceType: "course",
+        placement: "infobox",
+        enrollment_mode: "verified",
+        resource_type: "course",
+        readable_id: course.readable_id,
+      }),
+    )
+  })
+
+  test("fires PostHog enroll_cta_clicked with audit mode on free action click", async () => {
+    // Unauthenticated: the event fires before the auth gate, then we return to
+    // the signup flow — so the fire is observable without an enrollment mock.
+    setMockResponse.get(
+      urls.userMe.get(),
+      makeUser({ is_authenticated: false }),
+    )
+    const run = makeRun({
+      is_enrollable: true,
+      is_upgradable: false,
+      is_archived: false,
+      enrollment_modes: [makeMode({ requires_payment: false })],
+    })
+    const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
+
+    const { result } = renderHook(
+      () => useCourseEnrollment(course, run, { placement: "header" }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isStatusLoading).toBe(false))
+
+    const state = result.current.state
+    if (state.status !== "options") return
+    const freeOption = state.options.find((o) => o.kind === "free")!
+
+    freeOption.onClick!({
+      currentTarget: document.createElement("button"),
+    } as React.MouseEvent<HTMLButtonElement>)
+
+    expect(mockCapture).toHaveBeenCalledWith(
+      PostHogEvents.EnrollCtaClicked,
+      expect.objectContaining({
+        placement: "header",
+        enrollment_mode: "audit",
+        resource_type: "course",
+        readable_id: course.readable_id,
       }),
     )
   })

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
@@ -512,7 +512,7 @@ describe("useCourseEnrollment — actions", () => {
     const { result } = renderHook(
       () =>
         useCourseEnrollment(course, run, {
-          placement: "infobox",
+          tracking: { placement: "infobox" },
           onRequireSignup,
         }),
       { wrapper },
@@ -555,7 +555,10 @@ describe("useCourseEnrollment — actions", () => {
     })
 
     const { result } = renderHook(
-      () => useCourseEnrollment(course, run, { placement: "infobox" }),
+      () =>
+        useCourseEnrollment(course, run, {
+          tracking: { placement: "infobox" },
+        }),
       { wrapper },
     )
 
@@ -598,7 +601,8 @@ describe("useCourseEnrollment — actions", () => {
     const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
 
     const { result } = renderHook(
-      () => useCourseEnrollment(course, run, { placement: "header" }),
+      () =>
+        useCourseEnrollment(course, run, { tracking: { placement: "header" } }),
       { wrapper },
     )
 

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
@@ -45,7 +45,10 @@ export type UseCourseEnrollment = {
 export const useCourseEnrollment = (
   course: CourseWithCourseRunsSerializerV2,
   selectedRun: CourseRunV2 | undefined,
-  opts?: { onRequireSignup?: (anchor: HTMLButtonElement) => void },
+  opts?: {
+    placement?: "header" | "infobox"
+    onRequireSignup?: (anchor: HTMLButtonElement) => void
+  },
 ): UseCourseEnrollment => {
   const me = useQuery({
     ...userQueries.me(),
@@ -77,11 +80,17 @@ export const useCourseEnrollment = (
   // a misleading "problem processing your enrollment" message.
   const isError = replaceBasketItem.isError || createEnrollment.isError
 
-  const firePostHog = (label: string) => {
+  // Dedicated, semantically-named enrollment event (hq#11941). Replaces the
+  // generic cta_clicked for enroll CTAs so analytics can slice by placement /
+  // enrollment_mode instead of the drifting button copy. `label` is retained
+  // for human readability, not as the analytics key.
+  const firePostHog = (kind: EnrollActionKind, label: string) => {
     if (env("NEXT_PUBLIC_POSTHOG_API_KEY")) {
-      posthog.capture(PostHogEvents.CallToActionClicked, {
-        readableId: course.readable_id,
-        resourceType: "course",
+      posthog.capture(PostHogEvents.EnrollCtaClicked, {
+        placement: opts?.placement,
+        enrollment_mode: kind === "paid" ? "verified" : "audit",
+        resource_type: "course",
+        readable_id: course.readable_id,
         label,
       })
     }
@@ -90,7 +99,7 @@ export const useCourseEnrollment = (
   const makeOnClick =
     (kind: EnrollActionKind, label: string): EnrollAction["onClick"] =>
     (e) => {
-      firePostHog(label)
+      firePostHog(kind, label)
       if (!me.data?.is_authenticated) {
         opts?.onRequireSignup?.(e.currentTarget)
         return

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
@@ -43,13 +43,17 @@ export type UseCourseEnrollment = {
   isError: boolean
 }
 
+type UseCourseEnrollmentOptions = {
+  /** Analytics-only metadata for the `enroll_cta_clicked` event; no behavior. */
+  tracking: { placement: "header" | "infobox" }
+  /** Behavioral: called when an unauthenticated user clicks an enroll action. */
+  onRequireSignup?: (anchor: HTMLButtonElement) => void
+}
+
 export const useCourseEnrollment = (
   course: CourseWithCourseRunsSerializerV2,
   selectedRun: CourseRunV2 | undefined,
-  opts?: {
-    placement: "header" | "infobox"
-    onRequireSignup?: (anchor: HTMLButtonElement) => void
-  },
+  opts?: UseCourseEnrollmentOptions,
 ): UseCourseEnrollment => {
   const me = useQuery({
     ...userQueries.me(),
@@ -88,7 +92,7 @@ export const useCourseEnrollment = (
   const firePostHog = (kind: EnrollActionKind, label: string) => {
     if (env("NEXT_PUBLIC_POSTHOG_API_KEY")) {
       posthog.capture(PostHogEvents.EnrollCtaClicked, {
-        placement: opts?.placement,
+        placement: opts?.tracking.placement,
         enrollmentMode: kind === "paid" ? "verified" : "audit",
         resourceType: "course",
         readableId: course.readable_id,

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
@@ -4,6 +4,7 @@ import type {
   CourseRunV2,
   CourseWithCourseRunsSerializerV2,
 } from "@mitodl/mitxonline-api-axios/v2"
+import { PlatformEnum } from "api"
 import { userQueries } from "api/hooks/user"
 import { useCreateEnrollment } from "api/mitxonline-hooks/enrollment"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
@@ -46,7 +47,7 @@ export const useCourseEnrollment = (
   course: CourseWithCourseRunsSerializerV2,
   selectedRun: CourseRunV2 | undefined,
   opts?: {
-    placement?: "header" | "infobox"
+    placement: "header" | "infobox"
     onRequireSignup?: (anchor: HTMLButtonElement) => void
   },
 ): UseCourseEnrollment => {
@@ -88,9 +89,10 @@ export const useCourseEnrollment = (
     if (env("NEXT_PUBLIC_POSTHOG_API_KEY")) {
       posthog.capture(PostHogEvents.EnrollCtaClicked, {
         placement: opts?.placement,
-        enrollment_mode: kind === "paid" ? "verified" : "audit",
-        resource_type: "course",
-        readable_id: course.readable_id,
+        enrollmentMode: kind === "paid" ? "verified" : "audit",
+        resourceType: "course",
+        readableId: course.readable_id,
+        platform: PlatformEnum.Mitxonline,
         label,
       })
     }

--- a/frontends/main/src/common/constants.ts
+++ b/frontends/main/src/common/constants.ts
@@ -1,6 +1,7 @@
 export const PostHogEvents = {
   SearchUpdate: "search_update",
   CallToActionClicked: "cta_clicked",
+  EnrollCtaClicked: "enroll_cta_clicked",
   CourseCardClicked: "course_card_clicked",
   AskTimClicked: "asktim_clicked",
   LearningResourceDrawerOpen: "lrd_open",


### PR DESCRIPTION
### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/11941
- To merge immediately after #3523 

### Description (What does it do?)
This changes the posthog event tracking on product pages:
- **BEFORE:** Single `cta_clicked` event with course-identifying data and label. (Brittle... charts break whenever we change label)
- **AFTER**: Enrollment-specific `enroll_cta_clicked` event with enrollment-specific data, e.g., `enrollment_mode`.

### How can this be tested?

**Prerequisites:** Personal posthog integrated with your local, plus MIT Learn and MITxOnline integrated with courses set up; at least a course with both free and paid enrollment modes. 

1. View a product page with both free and paid enrollment modes. if it has both audit and verified modes, you will see it has 2 enrollment buttons in the infobox, and a third in the header.
2. In infobox, click "Enroll". You should be redirected to MITxOnline.
    - Check posthog; you should see an event come through with relevant data and **it should correctly reflect enrollment_mode ("verified")**
    - NB: This can take a minute or two to finish ingestion in posthog, and you can continue with the other steps
3. Try the header button, too. It should match the primary-styled (filled red) infobox button, so verified if both verified and audit modes are available.
4. In infobox, click "Learn for Free", you should be redirected to Dashboard.
    - Check posthog; you should see an event come through with relevant data and **it should correctly reflect enrollment_mode ("audit")**
5. If you try other courses (e.g., free-only or paid-only) the `enrollment_mode` should come through correctly
