### PR TITLE
fix(search): pass pool_maxsize instead of connections_per_node to opensearch-py

### DIFF
--- a/learning_resources_search/connection.py
+++ b/learning_resources_search/connection.py
@@ -32,7 +32,7 @@ def configure_connections():
             "http_auth": http_auth,
             "use_ssl": use_ssl,
             "timeout": settings.OPENSEARCH_DEFAULT_TIMEOUT,
-            "connections_per_node": settings.OPENSEARCH_CONNECTIONS_PER_NODE,
+            "pool_maxsize": settings.OPENSEARCH_CONNECTIONS_PER_NODE,
             # make sure we verify SSL certificates (off by default)
             "verify_certs": use_ssl,
         }

--- a/learning_resources_search/connection_test.py
+++ b/learning_resources_search/connection_test.py
@@ -3,9 +3,32 @@ Tests for the indexing API
 """
 
 import pytest
+from django.conf import settings
 
-from learning_resources_search.connection import get_active_aliases
+from learning_resources_search.connection import (
+    configure_connections,
+    get_active_aliases,
+)
 from learning_resources_search.constants import COURSE_TYPE, IndexestoUpdate
+
+
+def test_configure_connections_uses_pool_maxsize(mocker):
+    """configure_connections must pass pool_maxsize, not connections_per_node.
+
+    opensearch-py's Transport only reads pool_maxsize; connections_per_node is
+    silently dropped, leaving urllib3 at its default maxsize of 1.
+    """
+    mock_configure = mocker.patch(
+        "learning_resources_search.connection.connections.configure"
+    )
+    configure_connections()
+    call_kwargs = mock_configure.call_args[1]["default"]
+    assert "pool_maxsize" in call_kwargs, (
+        "pool_maxsize must be passed to connections.configure; "
+        "connections_per_node is ignored by opensearch-py Transport"
+    )
+    assert call_kwargs["pool_maxsize"] == settings.OPENSEARCH_CONNECTIONS_PER_NODE
+    assert "connections_per_node" not in call_kwargs
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

`configure_connections()` in `learning_resources_search/connection.py` was passing `connections_per_node` to `opensearch_dsl.connections.configure()`. This is not a recognised parameter in opensearch-py's `Transport.__init__` — the Transport only reads `pool_maxsize`. The unknown kwarg falls through into `self.kwargs` and is eventually passed to `Urllib3HttpConnection`, which also ignores it (it only reads the named parameter `pool_maxsize`).

The result: `pool_maxsize` is never set, so urllib3's `HTTPConnectionPool` defaults to `maxsize=1`. With a pool of one connection per pod, any burst of concurrent OpenSearch operations (e.g. SCIM-triggered user indexing) immediately exhausts the pool, producing:

```
Connection pool is full, discarding connection:
  search-opensearch-mitlearn-producti-<hash>.us-east-1.es.amazonaws.com.
  Connection pool size: 1
```

This was observed continuously in production logs (30+ warnings per minute across pods) during a SCIM sync storm, stalling Django async executor threads long enough for liveness probes at `/health/liveness/` to time out and trigger pod restarts.

**Fix:** rename the key from `connections_per_node` to `pool_maxsize` in the dict passed to `connections.configure()`. The env var `OPENSEARCH_CONNECTIONS_PER_NODE` (default 10) is unchanged.

The mechanism is confirmed by reading `Transport.set_connections()` in opensearch-py 2.8.0:

```python
if self.pool_maxsize and isinstance(self.pool_maxsize, int):
    kwargs["pool_maxsize"] = self.pool_maxsize
return self.connection_class(metrics=self.metrics, **kwargs)
```

`self.pool_maxsize` was `None` because the only way to set it is via the `pool_maxsize` kwarg to `Transport.__init__`.

### How can this be tested?

The new unit test `test_configure_connections_uses_pool_maxsize` in `connection_test.py` verifies this directly by mocking `connections.configure` and asserting the `pool_maxsize` key is present (and `connections_per_node` absent) in the `default` connection config.

```bash
docker compose run --rm web uv run pytest learning_resources_search/connection_test.py::test_configure_connections_uses_pool_maxsize -v
```

To observe the fix in a running environment, watch for the absence of `Connection pool is full` warnings after deployment, particularly during periods of high SCIM activity.

### Additional Context

- opensearch-py version in use: 2.8.0 (confirmed via `uv.lock`)
- The bug has likely been present since `OPENSEARCH_CONNECTIONS_PER_NODE` was introduced — the setting was never actually taking effect
- The default value of 10 is reasonable; it can be tuned per-env via the `OPENSEARCH_CONNECTIONS_PER_NODE` env var without code changes