### PR TITLE
fix: remove DatabaseHeartBeatCheck from liveness probe

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -160,9 +160,11 @@ HEALTH_CHECK = {
             "DatabaseHeartBeatCheck",  # Checks the database connection is alive.
         ],
         # The 'liveness' subset includes checks to determine if the application is
-        # running.
-        "liveness": ["DatabaseHeartBeatCheck"],  # Minimal check to ensure the app is
-        # alive.
+        # running. Intentionally empty: liveness only verifies the process can respond
+        # (HTTP 200 = alive). A DB query here would cause Kubernetes to kill slow-but-
+        # healthy pods under load (e.g. SCIM storms), triggering unnecessary restarts.
+        # DB health belongs in readiness/startup only.
+        "liveness": [],
         # The 'readiness' subset includes checks to determine if the application is
         # ready to serve requests.
         "readiness": [

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -277,6 +277,22 @@ class TestSettings(TestCase):
                 in settings_vars["CELERY_BEAT_SCHEDULE"]
             )
 
+    def test_liveness_probe_has_no_db_check(self):
+        """Liveness must not query the database.
+
+        A DB check in the liveness probe causes Kubernetes to kill pods that are
+        merely slow under load (e.g. SCIM storms), producing avoidable restart
+        cascades. DB health is covered by readiness and startup probes.
+        """
+        with mock.patch.dict("os.environ", REQUIRED_SETTINGS, clear=True):
+            settings_vars = self.reload_settings()
+            liveness_checks = settings_vars["HEALTH_CHECK"]["SUBSETS"]["liveness"]
+            assert liveness_checks == [], (
+                "liveness probe must not contain any checks — "
+                "DB checks belong in readiness/startup only"
+            )
+            assert "DatabaseHeartBeatCheck" not in liveness_checks
+
     def _assert_s3_storage_config(
         self,
         storages_dict,


### PR DESCRIPTION
## What are the relevant tickets?

Resolves: incident alert storm 2026-06-30 — DB-querying liveness probe killed slow-but-alive pods under SCIM load, triggering pod restart cascades.

## Description

Under SCIM load (50–100 req/5 min), database connections become busy and the liveness probe's `DatabaseHeartBeatCheck` query can timeout. Kubernetes interprets the timeout as an unhealthy pod and kills it, even though the pod is alive and processing requests. This produced a restart cascade that amplified the original load.

**Root cause:** `HEALTH_CHECK["SUBSETS"]["liveness"]` in `main/settings.py` included `DatabaseHeartBeatCheck`, which issues a real DB query on every liveness check.

**Fix:** Set `liveness` to an empty list. An empty list means the liveness endpoint returns HTTP 200 as long as the Django/Granian process is alive — which is the correct semantics for a liveness probe. `DatabaseHeartBeatCheck` remains in `readiness` and `startup` where it belongs.

Changes:
- `main/settings.py`: `"liveness": []`
- `main/settings_test.py`: adds `test_liveness_probe_has_no_db_check` to guard against regressions

## How can this be tested?

- Run `pytest main/settings_test.py::TestSettings::test_liveness_probe_has_no_db_check` — should pass.
- Verify the `/health/liveness/` endpoint returns 200 with no DB queries (check Django debug toolbar or query logging) after deploy.
- Confirm `/health/readiness/` and `/health/startup/` still include `DatabaseHeartBeatCheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)