### PR TITLE
add upgraded banner

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -5,7 +5,7 @@ import { EnrollmentStatus } from "./helpers"
 import { ActionButton, Button, ButtonLink } from "@mitodl/smoot-design"
 import { formatDate, getTimezone, isInPast } from "ol-utilities"
 import { getCourseDateText, getRelativeDateContent } from "./courseDateUtils"
-import { RiCheckLine } from "@remixicon/react"
+import { RiAwardLine } from "@remixicon/react"
 
 const CardRoot = styled.div<{
   screenSize: "desktop" | "mobile"
@@ -197,8 +197,8 @@ const UpgradedBannerRoot = styled.div(({ theme }) => ({
 
 const UpgradedBanner: React.FC<{ className?: string }> = ({ className }) => (
   <UpgradedBannerRoot data-testid="upgraded-banner" className={className}>
-    <RiCheckLine size="16px" />
-    Paid - Certificate Included
+    <RiAwardLine size="16px" />
+    Certificate track
   </UpgradedBannerRoot>
 )
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -3,7 +3,7 @@ import { Link, Popover, Stack, styled, Typography } from "ol-components"
 import NextLink from "next/link"
 import { EnrollmentStatus } from "./helpers"
 import { ActionButton, Button, ButtonLink } from "@mitodl/smoot-design"
-import { formatDate, getTimezone } from "ol-utilities"
+import { formatDate, getTimezone, isInPast } from "ol-utilities"
 import { getCourseDateText, getRelativeDateContent } from "./courseDateUtils"
 
 const CardRoot = styled.div<{
@@ -196,18 +196,22 @@ const DatePopoverContent = styled.div({
   alignSelf: "stretch",
 })
 
-const DatePopoverTrigger = styled("button")(({ theme }) => ({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
-  background: "none",
-  border: "none",
-  padding: 0,
-  cursor: "pointer",
-  "&:hover": {
-    color: theme.custom.colors.silverGrayDark,
-    textDecoration: "underline",
-  },
-}))
+const DatePopoverTrigger = styled("button")<{ $upcoming: boolean }>(
+  ({ theme, $upcoming }) => ({
+    ...theme.typography.body2,
+    color: $upcoming
+      ? theme.custom.colors.red
+      : theme.custom.colors.silverGrayDark,
+    background: "none",
+    border: "none",
+    padding: 0,
+    cursor: "pointer",
+    "&:hover": {
+      color: $upcoming ? theme.custom.colors.red : theme.custom.colors.black,
+      textDecoration: "underline",
+    },
+  }),
+)
 
 const DatePopoverHeading = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.black,
@@ -230,6 +234,7 @@ const CourseDateSummary: React.FC<{
     React.useState<HTMLButtonElement | null>(null)
 
   const triggerText = getCourseDateText(startDate, endDate)
+  const isUpcoming = startDate ? !isInPast(startDate) : false
   const startDateFormatted = startDate
     ? `${formatDate(startDate, "MMMM D, YYYY h:mm A")} ${getTimezone(startDate)}`
     : null
@@ -288,6 +293,7 @@ const CourseDateSummary: React.FC<{
         </DatePopoverContent>
       </Popover>
       <DatePopoverTrigger
+        $upcoming={isUpcoming}
         aria-expanded={!!popoverAnchorEl}
         aria-haspopup="dialog"
         aria-controls={popoverAnchorEl ? popoverId : undefined}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -139,12 +139,6 @@ const COURSEWARE_BUTTON_WIDTH = "88px"
 
 // Thin vertical divider shown between the certificate/upgrade links and the
 // courseware action button in the compact (module row) layout.
-const HorizontalSeparator = styled.div(({ theme }) => ({
-  width: "1px",
-  height: "12px",
-  backgroundColor: theme.custom.colors.lightGray2,
-}))
-
 // Fixed-width column that keeps the courseware button (and countdown) aligned
 // in the compact (module row) layout.
 const CoursewareActionColumn = styled(Stack)({
@@ -314,7 +308,6 @@ export {
   SubtitleLinkRoot,
   SubtitleLink,
   MenuButton,
-  HorizontalSeparator,
   CoursewareActionColumn,
   CoursewareButton,
   CoursewareButtonLink,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -138,8 +138,6 @@ const MenuButton = styled(ActionButton)<{
 
 const COURSEWARE_BUTTON_WIDTH = "88px"
 
-// Thin vertical divider shown between the certificate/upgrade links and the
-// courseware action button in the compact (module row) layout.
 // Fixed-width column that keeps the courseware button (and countdown) aligned
 // in the compact (module row) layout.
 const CoursewareActionColumn = styled(Stack)({

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -5,6 +5,7 @@ import { EnrollmentStatus } from "./helpers"
 import { ActionButton, Button, ButtonLink } from "@mitodl/smoot-design"
 import { formatDate, getTimezone, isInPast } from "ol-utilities"
 import { getCourseDateText, getRelativeDateContent } from "./courseDateUtils"
+import { RiCheckLine } from "@remixicon/react"
 
 const CardRoot = styled.div<{
   screenSize: "desktop" | "mobile"
@@ -186,6 +187,21 @@ const CourseDateText: React.FC<{
   return <DateText className={className}>{text}</DateText>
 }
 
+const UpgradedBannerRoot = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.subtitle3,
+}))
+
+const UpgradedBanner: React.FC<{ className?: string }> = ({ className }) => (
+  <UpgradedBannerRoot data-testid="upgraded-banner" className={className}>
+    <RiCheckLine size="16px" />
+    Paid - Certificate Included
+  </UpgradedBannerRoot>
+)
+
 const DatePopoverContent = styled.div({
   maxWidth: "240px",
   display: "flex",
@@ -321,4 +337,5 @@ export {
   DateText,
   CourseDateText,
   CourseDateSummary,
+  UpgradedBanner,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -250,7 +250,7 @@ const CourseDateSummary: React.FC<{
     React.useState<HTMLButtonElement | null>(null)
 
   const triggerText = getCourseDateText(startDate, endDate)
-  const isUpcoming = startDate ? !isInPast(startDate) : false
+  const isUpcoming = startDate ? isInPast(startDate) === false : false
   const startDateFormatted = startDate
     ? `${formatDate(startDate, "MMMM D, YYYY h:mm A")} ${getTimezone(startDate)}`
     : null

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -562,6 +562,70 @@ describe.each([
   })
 
   // ---------------------------------------------------------------------------
+  // Upgraded (paid, certificate not yet earned) banner
+  // ---------------------------------------------------------------------------
+
+  test("Shows 'Paid - Certificate Included' for verified enrollment without a certificate", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Verified,
+      certificate: null,
+      grades: [],
+      run: currentRunDates,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
+      "Paid - Certificate Included",
+    )
+  })
+
+  test("Does not show 'Paid - Certificate Included' when verified enrollment has a certificate", () => {
+    setupUserApis()
+    const certUuid = faker.string.uuid()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Verified,
+      certificate: { uuid: certUuid, link: faker.internet.url() },
+      run: currentRunDates,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(getCard()).getByRole("link", { name: /View Certificate/ }),
+    ).toBeInTheDocument()
+  })
+
+  test("Does not show 'Paid - Certificate Included' for audit enrollment", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      certificate: null,
+      grades: [],
+      run: currentRunDates,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("Does not show 'Paid - Certificate Included' for B2B verified enrollment", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Verified,
+      b2b_contract_id: faker.number.int(),
+      certificate: null,
+      grades: [],
+      run: currentRunDates,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
   // Context menu
   // ---------------------------------------------------------------------------
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -464,7 +464,7 @@ describe.each([
     })
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
     const banner = within(getCard()).getByTestId("upgrade-root")
-    expect(banner).toHaveTextContent(`Add a certificate for $${price}`)
+    expect(banner).toHaveTextContent(`Upgrade for certificate - $${price}`)
     expect(banner).toHaveTextContent(/5 days remaining/)
   })
 
@@ -484,7 +484,7 @@ describe.each([
     })
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
     const banner = within(getCard()).getByTestId("upgrade-root")
-    expect(banner).toHaveTextContent(`Add a certificate for $${price}`)
+    expect(banner).toHaveTextContent(`Upgrade for certificate - $${price}`)
     expect(banner).not.toHaveTextContent(/days? remaining/)
   })
 
@@ -511,7 +511,7 @@ describe.each([
 
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
     await user.click(
-      within(getCard()).getByRole("link", { name: /Add a certificate/ }),
+      within(getCard()).getByRole("link", { name: /Upgrade for certificate/ }),
     )
 
     expect(makeRequest).toHaveBeenCalledWith(
@@ -552,7 +552,7 @@ describe.each([
       />,
     )
     await user.click(
-      within(getCard()).getByRole("link", { name: /Add a certificate/ }),
+      within(getCard()).getByRole("link", { name: /Upgrade for certificate/ }),
     )
     await waitFor(() => {
       expect(onUpgradeError).toHaveBeenCalledWith(
@@ -565,7 +565,7 @@ describe.each([
   // Upgraded (paid, certificate not yet earned) banner
   // ---------------------------------------------------------------------------
 
-  test("Shows 'Paid - Certificate Included' for verified enrollment without a certificate", () => {
+  test("Shows 'Certificate track' for verified enrollment without a certificate", () => {
     setupUserApis()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       enrollment_mode: EnrollmentMode.Verified,
@@ -575,11 +575,11 @@ describe.each([
     })
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
     expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
-      "Paid - Certificate Included",
+      "Certificate track",
     )
   })
 
-  test("Does not show 'Paid - Certificate Included' when verified enrollment has a certificate", () => {
+  test("Does not show 'Certificate track' when verified enrollment has a certificate", () => {
     setupUserApis()
     const certUuid = faker.string.uuid()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
@@ -596,7 +596,7 @@ describe.each([
     ).toBeInTheDocument()
   })
 
-  test("Does not show 'Paid - Certificate Included' for audit enrollment", () => {
+  test("Does not show 'Certificate track' for audit enrollment", () => {
     setupUserApis()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       enrollment_mode: EnrollmentMode.Audit,
@@ -610,7 +610,7 @@ describe.each([
     ).not.toBeInTheDocument()
   })
 
-  test("Does not show 'Paid - Certificate Included' for B2B verified enrollment", () => {
+  test("Does not show 'Certificate track' for B2B verified enrollment", () => {
     setupUserApis()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       enrollment_mode: EnrollmentMode.Verified,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -14,6 +14,7 @@ import {
   TitleLink,
   TitleText,
   CourseDateSummary,
+  UpgradedBanner,
 } from "./CardShared"
 import {
   EnrollmentStatus,
@@ -23,13 +24,13 @@ import {
 } from "./model/dashboardViewModel"
 import { getCourseDateText } from "./courseDateUtils"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
-import { RiAwardLine, RiCheckLine, RiMore2Line } from "@remixicon/react"
+import { RiAwardLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
 import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
-import { Button, ButtonLink, styled } from "@mitodl/smoot-design"
+import { Button, ButtonLink } from "@mitodl/smoot-design"
 import { coursePageView } from "@/common/urls"
 import NiceModal from "@ebay/nice-modal-react"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
@@ -107,14 +108,6 @@ const UpgradeBanner: React.FC<
     </SubtitleLinkRoot>
   )
 }
-
-const UpgradedBanner = styled.div(({ theme }) => ({
-  display: "flex",
-  alignItems: "center",
-  gap: "4px",
-  color: theme.custom.colors.silverGrayDark,
-  ...theme.typography.subtitle3,
-}))
 
 type EnrolledCourseCardProps = {
   enrollment: CourseRunEnrollmentV3
@@ -195,10 +188,7 @@ export const EnrolledCourseCard = ({
           }}
         />
       ) : alreadyUpgraded && !certificateLink ? (
-        <UpgradedBanner data-testid="upgraded-banner">
-          <RiCheckLine size="16px" />
-          Paid - Certificate Included
-        </UpgradedBanner>
+        <UpgradedBanner />
       ) : null}
       {certificateLink ? (
         <SubtitleLink href={certificateLink} layout={layout}>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -279,7 +279,10 @@ export const EnrolledCourseCard = ({
   const buttonSection = isCompact ? (
     <Stack direction="row" alignItems="center">
       {endDateAndCertSection}
-      {daysUntilEnd !== null || showUpgradeBanner || !!certificateLink ? (
+      {daysUntilEnd !== null ||
+      showUpgradeBanner ||
+      alreadyUpgraded ||
+      !!certificateLink ? (
         <Separator />
       ) : null}
       <CoursewareActionColumn direction="row" justifyContent="center">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -164,13 +164,13 @@ export const EnrolledCourseCard = ({
     type: DashboardType.CourseRunEnrollment,
     data: enrollment,
   })
-  const alreadyUpgraded =
+  const upgradedAndIncomplete =
     !isContractPageResource && isVerifiedEnrollmentMode(enrollmentMode)
   const endDateAndCertSection = (
     <Stack direction="row" alignItems="center">
       {courseDateText}
       {hasCourseDateText &&
-      (showUpgradeBanner || alreadyUpgraded || !!certificateLink) ? (
+      (showUpgradeBanner || upgradedAndIncomplete || !!certificateLink) ? (
         <Separator />
       ) : null}
       {showUpgradeBanner ? (
@@ -187,7 +187,7 @@ export const EnrolledCourseCard = ({
             )
           }}
         />
-      ) : alreadyUpgraded && !certificateLink ? (
+      ) : upgradedAndIncomplete && !certificateLink ? (
         <UpgradedBanner />
       ) : null}
       {certificateLink ? (
@@ -271,7 +271,7 @@ export const EnrolledCourseCard = ({
       {endDateAndCertSection}
       {daysUntilEnd !== null ||
       showUpgradeBanner ||
-      alreadyUpgraded ||
+      upgradedAndIncomplete ||
       !!certificateLink ? (
         <Separator />
       ) : null}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -24,7 +24,7 @@ import {
 } from "./model/dashboardViewModel"
 import { getCourseDateText } from "./courseDateUtils"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
-import { RiAwardLine, RiMore2Line } from "@remixicon/react"
+import { RiArrowUpCircleLine, RiAwardLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
 import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
@@ -41,11 +41,11 @@ const formatUpgradeTime = (daysFloat: number) => {
   if (daysFloat < 0) return ""
   const days = Math.floor(daysFloat)
   if (days > 1) {
-    return `${days} days remaining`
+    return ` · ${days} days remaining`
   } else if (days === 1) {
-    return `${days} day remaining`
+    return ` · ${days} day remaining`
   }
-  return "Less than a day remaining"
+  return " · Less than a day remaining"
 }
 
 const UpgradeBanner: React.FC<
@@ -96,8 +96,8 @@ const UpgradeBanner: React.FC<
   return (
     <SubtitleLinkRoot layout={layout} {...others}>
       <SubtitleLink layout={layout} href="#" onClick={handleUpgradeClick}>
-        <RiAwardLine size="16px" />
-        {`Add a certificate for ${formattedPrice}`}
+        <RiArrowUpCircleLine size="16px" />
+        {`Upgrade for certificate - ${formattedPrice}`}
       </SubtitleLink>
       {calendarDays !== null && (
         <NoSSR>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -143,7 +143,6 @@ export const EnrolledCourseCard = ({
   const startDate = run?.start_date
   const hasStarted = startDate ? isInPast(startDate) : true
   const endDate = run?.end_date
-  const daysUntilEnd = endDate ? calendarDaysUntil(endDate) : null
   const hasEnded = endDate ? isInPast(endDate) : false
   const hasCourseDateText = getCourseDateText(startDate, endDate) !== null
   const courseDateText = (
@@ -166,38 +165,45 @@ export const EnrolledCourseCard = ({
   })
   const upgradedAndIncomplete =
     !isContractPageResource && isVerifiedEnrollmentMode(enrollmentMode)
-  const endDateAndCertSection = (
-    <Stack direction="row" alignItems="center">
-      {courseDateText}
-      {hasCourseDateText &&
-      (showUpgradeBanner || upgradedAndIncomplete || !!certificateLink) ? (
-        <Separator />
-      ) : null}
-      {showUpgradeBanner ? (
-        <UpgradeBanner
-          data-testid="upgrade-root"
-          canUpgrade={showUpgradeBanner}
-          certificateUpgradeDeadline={run?.upgrade_deadline}
-          certificateUpgradePrice={run?.upgrade_product_price}
-          productId={run?.upgrade_product_id}
-          layout={layout}
-          onError={() => {
-            onUpgradeError?.(
-              "There was a problem adding the certificate to your cart.",
-            )
-          }}
-        />
-      ) : upgradedAndIncomplete && !certificateLink ? (
-        <UpgradedBanner />
-      ) : null}
-      {certificateLink ? (
-        <SubtitleLink href={certificateLink} layout={layout}>
-          <RiAwardLine size="16px" />
-          {isCompact ? "Certificate" : "View Certificate"}
-        </SubtitleLink>
-      ) : null}
-    </Stack>
-  )
+  const certStatus = showUpgradeBanner ? (
+    <UpgradeBanner
+      data-testid="upgrade-root"
+      canUpgrade={showUpgradeBanner}
+      certificateUpgradeDeadline={run?.upgrade_deadline}
+      certificateUpgradePrice={run?.upgrade_product_price}
+      productId={run?.upgrade_product_id}
+      layout={layout}
+      onError={() => {
+        onUpgradeError?.(
+          "There was a problem adding the certificate to your cart.",
+        )
+      }}
+    />
+  ) : certificateLink ? (
+    <SubtitleLink href={certificateLink} layout={layout}>
+      <RiAwardLine size="16px" />
+      {isCompact ? "Certificate" : "View Certificate"}
+    </SubtitleLink>
+  ) : upgradedAndIncomplete ? (
+    <UpgradedBanner />
+  ) : null
+
+  const metaSegments = [
+    hasCourseDateText ? courseDateText : null,
+    certStatus,
+  ].filter(Boolean)
+
+  const endDateAndCertSection =
+    metaSegments.length > 0 ? (
+      <Stack direction="row" alignItems="center">
+        {metaSegments.map((segment, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <Separator />}
+            {segment}
+          </React.Fragment>
+        ))}
+      </Stack>
+    ) : null
   const titleSection = (
     <Stack gap="6px">
       {coursewareUrl ? (
@@ -269,12 +275,7 @@ export const EnrolledCourseCard = ({
   const buttonSection = isCompact ? (
     <Stack direction="row" alignItems="center">
       {endDateAndCertSection}
-      {daysUntilEnd !== null ||
-      showUpgradeBanner ||
-      upgradedAndIncomplete ||
-      !!certificateLink ? (
-        <Separator />
-      ) : null}
+      {endDateAndCertSection && <Separator />}
       <CoursewareActionColumn direction="row" justifyContent="center">
         {ctaButton}
       </CoursewareActionColumn>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -6,7 +6,6 @@ import {
   CoursewareActionColumn,
   CoursewareButton,
   CoursewareButtonLink,
-  HorizontalSeparator,
   MenuButton,
   Separator,
   SubtitleLink,
@@ -24,13 +23,13 @@ import {
 } from "./model/dashboardViewModel"
 import { getCourseDateText } from "./courseDateUtils"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
-import { RiAwardLine, RiMore2Line } from "@remixicon/react"
+import { RiAwardLine, RiCheckLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
 import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
-import { Button, ButtonLink } from "@mitodl/smoot-design"
+import { Button, ButtonLink, styled } from "@mitodl/smoot-design"
 import { coursePageView } from "@/common/urls"
 import NiceModal from "@ebay/nice-modal-react"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
@@ -109,6 +108,14 @@ const UpgradeBanner: React.FC<
   )
 }
 
+const UpgradedBanner = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.subtitle3,
+}))
+
 type EnrolledCourseCardProps = {
   enrollment: CourseRunEnrollmentV3
   layout?: "default" | "compact"
@@ -164,10 +171,13 @@ export const EnrolledCourseCard = ({
     type: DashboardType.CourseRunEnrollment,
     data: enrollment,
   })
+  const alreadyUpgraded =
+    !isContractPageResource && isVerifiedEnrollmentMode(enrollmentMode)
   const endDateAndCertSection = (
     <Stack direction="row" alignItems="center">
       {courseDateText}
-      {hasCourseDateText && (showUpgradeBanner || !!certificateLink) ? (
+      {hasCourseDateText &&
+      (showUpgradeBanner || alreadyUpgraded || !!certificateLink) ? (
         <Separator />
       ) : null}
       {showUpgradeBanner ? (
@@ -184,6 +194,11 @@ export const EnrolledCourseCard = ({
             )
           }}
         />
+      ) : alreadyUpgraded && !certificateLink ? (
+        <UpgradedBanner data-testid="upgraded-banner">
+          <RiCheckLine size="16px" />
+          Paid - Certificate Included
+        </UpgradedBanner>
       ) : null}
       {certificateLink ? (
         <SubtitleLink href={certificateLink} layout={layout}>
@@ -262,10 +277,10 @@ export const EnrolledCourseCard = ({
     </ButtonLink>
   )
   const buttonSection = isCompact ? (
-    <Stack direction="row" gap="8px" alignItems="center">
+    <Stack direction="row" alignItems="center">
       {endDateAndCertSection}
       {daysUntilEnd !== null || showUpgradeBanner || !!certificateLink ? (
-        <HorizontalSeparator />
+        <Separator />
       ) : null}
       <CoursewareActionColumn direction="row" justifyContent="center">
         {ctaButton}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -66,6 +66,7 @@ describe("ProgramAsCourseCard", () => {
         ...moduleOne.courseruns[0],
         course: moduleOne,
       },
+      enrollment_mode: "audit",
       certificate: null,
     })
 
@@ -425,6 +426,81 @@ describe("ProgramAsCourseCard", () => {
     await screen.findByText(cardData.courseProgram.title)
     const certButton = screen.queryByRole("link", { name: "Certificate" })
     expect(certButton).not.toBeInTheDocument()
+  })
+
+  test("shows 'Paid - Certificate Included' for verified program enrollment without a certificate", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    const programEnrollment = {
+      ...cardData.courseProgramEnrollment,
+      enrollment_mode: "verified",
+      certificate: null,
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    expect(screen.getByTestId("upgraded-banner")).toHaveTextContent(
+      "Paid - Certificate Included",
+    )
+    expect(
+      screen.queryByRole("link", { name: "Certificate" }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("does not show 'Paid - Certificate Included' when verified program enrollment has a certificate", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    const certUuid = "cert-uuid"
+    const programEnrollment = {
+      ...cardData.courseProgramEnrollment,
+      enrollment_mode: "verified",
+      certificate: { uuid: certUuid, link: `/certificate/${certUuid}/` },
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    expect(screen.queryByTestId("upgraded-banner")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Certificate" }),
+    ).toBeInTheDocument()
+  })
+
+  test("does not show 'Paid - Certificate Included' for audit program enrollment", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    const programEnrollment = {
+      ...cardData.courseProgramEnrollment,
+      enrollment_mode: "audit",
+      certificate: null,
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollment}
+      />,
+    )
+
+    await screen.findByText(cardData.courseProgram.title)
+    expect(screen.queryByTestId("upgraded-banner")).not.toBeInTheDocument()
   })
 
   test("shows product-page details link in context menu", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -428,7 +428,7 @@ describe("ProgramAsCourseCard", () => {
     expect(certButton).not.toBeInTheDocument()
   })
 
-  test("shows 'Paid - Certificate Included' for verified program enrollment without a certificate", async () => {
+  test("shows 'Certificate track' for verified program enrollment without a certificate", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)
     const programEnrollment = {
@@ -448,14 +448,14 @@ describe("ProgramAsCourseCard", () => {
 
     await screen.findByText(cardData.courseProgram.title)
     expect(screen.getByTestId("upgraded-banner")).toHaveTextContent(
-      "Paid - Certificate Included",
+      "Certificate track",
     )
     expect(
       screen.queryByRole("link", { name: "Certificate" }),
     ).not.toBeInTheDocument()
   })
 
-  test("does not show 'Paid - Certificate Included' when verified program enrollment has a certificate", async () => {
+  test("does not show 'Certificate track' when verified program enrollment has a certificate", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)
     const certUuid = "cert-uuid"
@@ -481,7 +481,7 @@ describe("ProgramAsCourseCard", () => {
     ).toBeInTheDocument()
   })
 
-  test("does not show 'Paid - Certificate Included' for audit program enrollment", async () => {
+  test("does not show 'Certificate track' for audit program enrollment", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)
     const programEnrollment = {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -16,7 +16,7 @@ import {
 } from "./helpers"
 import { ProgressBadge } from "./ProgressBadge"
 import { CoursewareCard } from "./CoursewareCard"
-import { CourseDateSummary } from "./CardShared"
+import { CourseDateSummary, UpgradedBanner } from "./CardShared"
 import {
   getCertificateLink,
   buildCourseEntry,
@@ -299,6 +299,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     courseProgramEnrollment?.certificate?.link,
     "program",
   )
+  const alreadyUpgraded = useVerifiedEnrollment && !programCertificateUrl
 
   // Build context menu
   const menuItems = getContextMenuItems(
@@ -345,7 +346,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
           </Typography>
         </ProgramCardHeaderInner>
         <>
-          {programCertificateUrl && (
+          {programCertificateUrl ? (
             <ProgramCertificateButton
               variant="bordered"
               size="small"
@@ -354,7 +355,9 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
             >
               Certificate
             </ProgramCertificateButton>
-          )}
+          ) : alreadyUpgraded ? (
+            <UpgradedBanner />
+          ) : null}
           {contextMenu}
         </>
       </ProgramCardHeaderOuter>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -299,7 +299,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     courseProgramEnrollment?.certificate?.link,
     "program",
   )
-  const alreadyUpgraded = useVerifiedEnrollment && !programCertificateUrl
+  const upgradedAndIncomplete = useVerifiedEnrollment && !programCertificateUrl
 
   // Build context menu
   const menuItems = getContextMenuItems(
@@ -355,7 +355,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
             >
               Certificate
             </ProgramCertificateButton>
-          ) : alreadyUpgraded ? (
+          ) : upgradedAndIncomplete ? (
             <UpgradedBanner />
           ) : null}
           {contextMenu}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
@@ -87,6 +87,48 @@ describe.each([
     ).not.toBeInTheDocument()
   })
 
+  test("shows 'Paid - Certificate Included' for verified enrollment without a certificate", () => {
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+        certificate: null,
+      })
+    renderWithProviders(
+      <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
+    )
+    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
+      "Paid - Certificate Included",
+    )
+  })
+
+  test("does not show 'Paid - Certificate Included' when verified enrollment has a certificate", () => {
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+        certificate: { uuid: "abc", link: "https://example.com/cert/" },
+      })
+    renderWithProviders(
+      <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
+    )
+    expect(
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("does not show 'Paid - Certificate Included' for audit enrollment", () => {
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "audit",
+        certificate: null,
+      })
+    renderWithProviders(
+      <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
+    )
+    expect(
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+  })
+
   test("context menu includes View Program Details with product page URL", async () => {
     const program = mitxonline.factories.programs.simpleProgram()
     const programEnrollment =

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
@@ -87,7 +87,7 @@ describe.each([
     ).not.toBeInTheDocument()
   })
 
-  test("shows 'Paid - Certificate Included' for verified enrollment without a certificate", () => {
+  test("shows 'Certificate track' for verified enrollment without a certificate", () => {
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
         enrollment_mode: "verified",
@@ -97,11 +97,11 @@ describe.each([
       <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
     )
     expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
-      "Paid - Certificate Included",
+      "Certificate track",
     )
   })
 
-  test("does not show 'Paid - Certificate Included' when verified enrollment has a certificate", () => {
+  test("does not show 'Certificate track' when verified enrollment has a certificate", () => {
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
         enrollment_mode: "verified",
@@ -115,7 +115,7 @@ describe.each([
     ).not.toBeInTheDocument()
   })
 
-  test("does not show 'Paid - Certificate Included' for audit enrollment", () => {
+  test("does not show 'Certificate track' for audit enrollment", () => {
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
         enrollment_mode: "audit",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -12,6 +12,7 @@ import {
   TitleHeading,
   TitleLink,
   TitleText,
+  UpgradedBanner,
 } from "./CardShared"
 import { RiAwardLine, RiMore2Line } from "@remixicon/react"
 import {
@@ -49,6 +50,9 @@ export const ProgramEnrollmentCard = ({
   const enrollmentStatus = programEnrollment.certificate?.uuid
     ? EnrollmentStatus.Completed
     : EnrollmentStatus.Enrolled
+  const alreadyUpgraded = isVerifiedEnrollmentMode(
+    programEnrollment.enrollment_mode,
+  )
   const displayMode = program.display_mode
   const titleSection = (
     <Stack gap="6px">
@@ -66,6 +70,8 @@ export const ProgramEnrollmentCard = ({
           <RiAwardLine size="16px" />
           View Certificate
         </SubtitleLink>
+      ) : alreadyUpgraded ? (
+        <UpgradedBanner />
       ) : null}
     </Stack>
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -50,7 +50,7 @@ export const ProgramEnrollmentCard = ({
   const enrollmentStatus = programEnrollment.certificate?.uuid
     ? EnrollmentStatus.Completed
     : EnrollmentStatus.Enrolled
-  const alreadyUpgraded = isVerifiedEnrollmentMode(
+  const upgradedAndIncomplete = isVerifiedEnrollmentMode(
     programEnrollment.enrollment_mode,
   )
   const displayMode = program.display_mode
@@ -70,7 +70,7 @@ export const ProgramEnrollmentCard = ({
           <RiAwardLine size="16px" />
           View Certificate
         </SubtitleLink>
-      ) : alreadyUpgraded ? (
+      ) : upgradedAndIncomplete ? (
         <UpgradedBanner />
       ) : null}
     </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -98,10 +98,12 @@ export const UnenrolledCourseCard = ({
     </TitleText>
   )
   const courseDateText = (
-    <CourseDateSummary
-      startDate={courseRun?.start_date}
-      endDate={courseRun?.end_date}
-    />
+    <Stack direction="row" gap="8px" alignItems="start">
+      <CourseDateSummary
+        startDate={courseRun?.start_date}
+        endDate={courseRun?.end_date}
+      />
+    </Stack>
   )
   const startButton = isCompact ? (
     <CoursewareButton


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12093

### Description (What does it do?)
This PR does some more design updates detailed in a doc (https://docs.google.com/document/d/1D1-iD69-qIku5HUV8168FzBv1jnvtSwtSMFSWacdBj4/edit?tab=t.0) linked in the above issue:

- If a user has paid for a verified enrollment in a course or a program but not yet completed the requirements to get their certificate, this is now displayed as indicated in the designs
- Adds colors from the design to the `CourseDateSummary` component (red for "Starts," grey / black on hover for "Ends" and "Ended")

### Screenshots (if appropriate):
<img width="2560" height="1440" alt="enrolled-course-compact" src="https://github.com/user-attachments/assets/eb417966-949c-48df-bb86-53eff9ae6e86" />
<img width="2560" height="1440" alt="enrolled-course-default" src="https://github.com/user-attachments/assets/68a2f708-5827-4abd-8be8-3e7ed81e5b30" />
<img width="2560" height="1440" alt="program-as-course" src="https://github.com/user-attachments/assets/7b47e373-3459-4031-a089-6dcc4151c7c7" />
<img width="2560" height="1440" alt="program-enrollment" src="https://github.com/user-attachments/assets/19e2e57e-4aa7-4f4f-b8e7-a7c0df042d11" />
<img width="768" height="1024" alt="enrolled-course-compact" src="https://github.com/user-attachments/assets/040f9938-a48c-42d3-a6cb-8c6ec079ada3" />
<img width="768" height="1024" alt="enrolled-course-default" src="https://github.com/user-attachments/assets/05811814-2202-4d39-9029-c7144ca042f8" />
<img width="768" height="1024" alt="program-as-course" src="https://github.com/user-attachments/assets/66920238-4fe7-4e68-9aea-30c9381c38c4" />
<img width="768" height="1024" alt="program-enrollment" src="https://github.com/user-attachments/assets/60887946-2a8f-419d-a022-2153ed7111e1" />
<img width="390" height="844" alt="enrolled-course-compact" src="https://github.com/user-attachments/assets/2098c27d-e679-4b30-b4d9-5b005f042ff6" />
<img width="390" height="844" alt="enrolled-course-default" src="https://github.com/user-attachments/assets/2c4edd4a-422e-4297-a47b-213774352c26" />
<img width="390" height="844" alt="program-as-course" src="https://github.com/user-attachments/assets/9963775c-559d-4a31-bbfb-307162d8065b" />
<img width="390" height="844" alt="program-enrollment" src="https://github.com/user-attachments/assets/868e1611-941d-49c4-b09a-af0d88c332a5" />


### How can this be tested?
- You need 3 enrollments that are verified but not completed:
  - A course
  - A program
  - A "program as course" aka a crogram
- View the learn dashboard on the user that has these enrollments and ensure that they display as expected.
