### PR TITLE
Migration to fix non-credit level for runs

### DIFF
--- a/data_fixtures/migrations/0025_replace_non_credit_level.py
+++ b/data_fixtures/migrations/0025_replace_non_credit_level.py
@@ -1,0 +1,34 @@
+# Generated manually
+"""Replace invalid non-credit level keys on learning resource runs."""
+
+from django.db import migrations
+
+OLD_LEVEL = "non-credit"
+NEW_LEVEL = "noncredit"
+
+
+def replace_non_credit_level(apps, schema_editor):
+    """Replace non-credit with noncredit in LearningResourceRun.level arrays."""
+    LearningResourceRun = apps.get_model("learning_resources", "LearningResourceRun")
+
+    matching_runs = LearningResourceRun.objects.filter(level__icontains=OLD_LEVEL)
+    for run in matching_runs.iterator():
+        updated_level = [
+            NEW_LEVEL if level.lower() == OLD_LEVEL else level for level in run.level
+        ]
+        if updated_level != run.level:
+            run.level = updated_level
+            run.save(update_fields=["level"])
+
+
+class Migration(migrations.Migration):
+    """Normalize non-credit learning resource run levels."""
+
+    dependencies = [
+        ("data_fixtures", "0024_add_ovs_platform_offeror"),
+        ("learning_resources", "0115_videoplaylist_parent_learning_resource"),
+    ]
+
+    operations = [
+        migrations.RunPython(replace_non_credit_level, migrations.RunPython.noop),
+    ]

--- a/data_fixtures/migrations/0025_replace_non_credit_level.py
+++ b/data_fixtures/migrations/0025_replace_non_credit_level.py
@@ -3,7 +3,7 @@
 
 from django.db import migrations
 
-OLD_LEVEL = "non-credit"
+OLD_LEVELS = ("Non-Credit", "non-credit")
 NEW_LEVEL = "noncredit"
 
 
@@ -11,11 +11,12 @@ def replace_non_credit_level(apps, schema_editor):
     """Replace non-credit with noncredit in LearningResourceRun.level arrays."""
     LearningResourceRun = apps.get_model("learning_resources", "LearningResourceRun")
 
-    matching_runs = LearningResourceRun.objects.filter(level__icontains=OLD_LEVEL)
+    matching_runs = LearningResourceRun.objects.filter(level__overlap=OLD_LEVELS)
     for run in matching_runs.iterator():
         updated_level = [
-            NEW_LEVEL if level.lower() == OLD_LEVEL else level for level in run.level
+            NEW_LEVEL if level in OLD_LEVELS else level for level in run.level
         ]
+
         if updated_level != run.level:
             run.level = updated_level
             run.save(update_fields=["level"])


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10841
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR adds a data migration to fix the state of a few runs on production that have the invalid level of "Non-Credit" (should be noncredit)


### How can this be tested?
1. grab some random runs and set their level to the invalid "Non-Credit":
```python
from learning_resources.models import *

lrs = LearningResourceRun.objects.all()[:20]

for lr in lrs:
	lr.level = ['Non-Credit']
	lr.save()
```
2. checkout this branch
3. run the data migration via ` RUN_DATA_MIGRATIONS=True python manage.py migrate data_fixtures`
4. gio back into shell and see that the count of items with the invalid level is 0:
```python
from learning_resources.models import *
LearningResourceRun.objects.filter(level__contains=['Non-Credit']).count()
```

### Additional Context
It seems like the same handful of runs have had this issue for some time now so it is likely just instances left in a bad state at some point.