### PR TITLE
fix hacksnack postinstall

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "TZ=UTC next start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "typegen": "NEXT_BUILD_CI=1 next typegen"
+    "typegen": "NEXT_BUILD_CI=1 next typegen",
+    "postinstall": "hacksnack-copy-assets"
   },
   "dependencies": {
     "@ebay/nice-modal-react": "^1.2.13",


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/11688


### Description (What does it do?)
The hacksnack library has a postinstall step that copies image assets and puzzle data into ./public/games/hacksnack so that they are available to the game. I accidentally deleted it from package.json while rebasing https://github.com/mitodl/mit-learn/pull/3489


### How can this be tested?
Go to http://open.odl.local:8062/games/hacksnack

The game  should load