### PR TITLE
Upgrade django-health-check from pinned git commit to PyPI 3.24.0

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -140,47 +140,9 @@ INSTALLED_APPS = (
     "ol_hubspot",
     "mitol.scim.apps.ScimApp",
     "health_check",
-    "health_check.cache",
-    "health_check.contrib.migrations",
-    "health_check.contrib.celery_ping",
-    "health_check.contrib.redis",
-    "health_check.contrib.db_heartbeat",
 )
 
 WEBHOOK_SECRET = get_string("WEBHOOK_SECRET", "please-change-this")
-
-HEALTH_CHECK = {
-    "SUBSETS": {
-        # The 'startup' subset includes checks that must pass before the application can
-        # start.
-        "startup": [
-            "MigrationsHealthCheck",  # Ensures database migrations are applied.
-            "CacheBackend",  # Verifies the cache backend is operational.
-            "RedisHealthCheck",  # Confirms Redis is reachable and functional.
-            "DatabaseHeartBeatCheck",  # Checks the database connection is alive.
-        ],
-        # The 'liveness' subset includes checks to determine if the application is
-        # running.
-        "liveness": ["DatabaseHeartBeatCheck"],  # Minimal check to ensure the app is
-        # alive.
-        # The 'readiness' subset includes checks to determine if the application is
-        # ready to serve requests.
-        "readiness": [
-            "CacheBackend",  # Ensures the cache is ready for use.
-            "RedisHealthCheck",  # Confirms Redis is ready for use.
-            "DatabaseHeartBeatCheck",  # Verifies the database is ready for queries.
-        ],
-        # The 'full' subset includes all available health checks for a comprehensive
-        # status report.
-        "full": [
-            "MigrationsHealthCheck",  # Ensures database migrations are applied.
-            "CacheBackend",  # Verifies the cache backend is operational.
-            "RedisHealthCheck",  # Confirms Redis is reachable and functional.
-            "DatabaseHeartBeatCheck",  # Checks the database connection is alive.
-            "CeleryPingHealthCheck",  # Verifies Celery workers are responsive.
-        ],
-    }
-}
 
 if not get_bool("RUN_DATA_MIGRATIONS", default=False):
     MIGRATION_MODULES = {"data_fixtures": None}

--- a/main/urls.py
+++ b/main/urls.py
@@ -17,7 +17,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from rest_framework.routers import DefaultRouter
 
@@ -60,7 +60,7 @@ urlpatterns = (
         re_path(r"", include("webhooks.urls", namespace="webhooks")),
         re_path(r"", include(features_router.urls)),
         re_path(r"^app", RedirectView.as_view(url=settings.APP_BASE_URL)),
-        re_path(r"^health/", include("health_check.urls")),
+        path("", include("main.urls_healthcheck")),
     ]
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/main/urls_healthcheck.py
+++ b/main/urls_healthcheck.py
@@ -1,0 +1,45 @@
+"""Healthcheck urls"""
+
+from django.urls import include, path
+from health_check.views import HealthCheckView
+
+MIGRATIONS_CHECK = "health_check.contrib.migrations.backends.MigrationsHealthCheck"
+
+BASE_CHECKS = [
+    # "default" is in-memory and always available; "redis" is the real backing cache.
+    ("health_check.Cache", {"alias": "redis"}),
+    "health_check.Database",
+    "health_check.contrib.redis.Redis",
+]
+
+urlpatterns = [
+    path(
+        "health/",
+        include(
+            [
+                path(
+                    "startup/",
+                    HealthCheckView.as_view(checks=[*BASE_CHECKS, MIGRATIONS_CHECK]),
+                ),
+                path(
+                    "liveness/",
+                    HealthCheckView.as_view(checks=["health_check.Database"]),
+                ),
+                path(
+                    "readiness/",
+                    HealthCheckView.as_view(checks=[*BASE_CHECKS]),
+                ),
+                path(
+                    "full/",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                            MIGRATIONS_CHECK,
+                            "health_check.contrib.celery.Ping",
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+]

--- a/main/urls_healthcheck.py
+++ b/main/urls_healthcheck.py
@@ -18,6 +18,16 @@ urlpatterns = [
         include(
             [
                 path(
+                    "",
+                    HealthCheckView.as_view(
+                        checks=[
+                            *BASE_CHECKS,
+                            MIGRATIONS_CHECK,
+                            "health_check.contrib.celery.Ping",
+                        ]
+                    ),
+                ),
+                path(
                     "startup/",
                     HealthCheckView.as_view(checks=[*BASE_CHECKS, MIGRATIONS_CHECK]),
                 ),

--- a/main/urls_healthcheck_test.py
+++ b/main/urls_healthcheck_test.py
@@ -1,0 +1,23 @@
+"""Tests for the healthcheck urls"""
+
+import pytest
+from django.urls import get_resolver
+from health_check.views import HealthCheckView
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/health/",
+        "/health/startup/",
+        "/health/liveness/",
+        "/health/readiness/",
+        "/health/full/",
+    ],
+)
+def test_healthcheck_urls_resolve(path):
+    """All healthcheck endpoints should resolve to HealthCheckView"""
+    # Resolve directly against this urlconf module rather than django.urls.resolve()
+    # (which walks the full project urlconf) to avoid pulling in unrelated apps.
+    match = get_resolver("main.urls_healthcheck").resolve(path)
+    assert match.func.view_class is HealthCheckView

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "django-cors-headers>=4.0.0,<5",
     "django-filter>=2.4.0,<3",
     "django-guardian>=3.0.0,<4",
-    "django-health-check",
+    "django-health-check>=3.24.0,<4",
     "django-imagekit>=6.0.0,<7",
     "django-ipware>=7.0.0,<8",
     "django-json-widget>=2.0.0,<3",
@@ -153,9 +153,6 @@ dev = [
 package = false
 default-groups = "all"
 override-dependencies = ["setuptools<80"]
-
-[tool.uv.sources]
-django-health-check = { git = "https://github.com/revsys/django-health-check", rev = "53f9bdc3a7acc8a577319987fef0bd3040eef4b4" } # pragma: allowlist secret
 
 [tool.uv.build-backend]
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -833,10 +833,15 @@ wheels = [
 
 [[package]]
 name = "django-health-check"
-version = "3.20.1.dev10+g53f9bdc3a"
-source = { git = "https://github.com/revsys/django-health-check?rev=53f9bdc3a7acc8a577319987fef0bd3040eef4b4#53f9bdc3a7acc8a577319987fef0bd3040eef4b4" }
+version = "3.24.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
+    { name = "psutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/a6/f474f443b0a7f9e7e52a25a3773a31c5c061bdb28cf311b7801fc250db9b/django_health_check-3.24.0.tar.gz", hash = "sha256:b5e01d2013a254cc5a2c7b19c62f11ea6fd2624c87a9d990e11a1b3874df78b5", size = 20807, upload-time = "2026-02-12T10:02:18.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/17/51aabb4908e007accf3c596b92a62ed7e456c581a1e45f06e0f2219dc6c0/django_health_check-3.24.0-py3-none-any.whl", hash = "sha256:bd568d7d3813980668dfbe730214aef5da7c8da73bc2aa60ec2eeca8a3788da6", size = 37964, upload-time = "2026-02-12T10:02:17.08Z" },
 ]
 
 [[package]]
@@ -2705,7 +2710,7 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.0.0,<5" },
     { name = "django-filter", specifier = ">=2.4.0,<3" },
     { name = "django-guardian", specifier = ">=3.0.0,<4" },
-    { name = "django-health-check", git = "https://github.com/revsys/django-health-check?rev=53f9bdc3a7acc8a577319987fef0bd3040eef4b4" },
+    { name = "django-health-check", specifier = ">=3.24.0,<4" },
     { name = "django-imagekit", specifier = ">=6.0.0,<7" },
     { name = "django-ipware", specifier = ">=7.0.0,<8" },
     { name = "django-json-widget", specifier = ">=2.0.0,<3" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Replaces the git-pinned `django-health-check` dependency with a published PyPI release.

Before:
```
django-health-check = { git = "https://github.com/revsys/django-health-check", rev = "53f9bdc3a7acc8a577319987fef0bd3040eef4b4" }
```
(a dev build of `3.20.1`, 10 commits past the tag)

After:
```
"django-health-check>=3.24.0,<4"
```

`3.24.0` is the newest PyPI release compatible with this project's pinned `Django==4.2.30` — `django-health-check>=4.0.0` requires `Django>=5.2`, so it isn't available here until this repo's Django version is upgraded separately.

Reviewed the upstream diff between the pinned commit and the `3.24.0` tag (`health_check/backends.py`, `health_check/contrib/{celery_ping,redis,db_heartbeat,migrations}/backends.py`) against this repo's usage in `main/settings.py` / `main/urls.py`:
- The `INSTALLED_APPS` entries (`health_check`, `health_check.cache`, `health_check.contrib.migrations`, `health_check.contrib.celery_ping`, `health_check.contrib.redis`, `health_check.contrib.db_heartbeat`) and the `health_check.urls` include are all still present and functional in `3.24.0`.
- `HEALTH_CHECK["SUBSETS"]` references bare check class names (e.g. `"MigrationsHealthCheck"`, `"CacheBackend"`, `"RedisHealthCheck"`, `"DatabaseHeartBeatCheck"`) — confirmed these still resolve correctly, since the subset filter matches on `repr(plugin)`, which defaults to `self.__class__.__name__` and none of those class names changed.
- No custom health-check backend subclasses exist in this repo, so the internal `BaseHealthCheckBackend` → `HealthCheck` dataclass refactor in upstream has no effect here.
- Two non-blocking deprecation warnings now surface (both slated for removal in a future v4 migration, which isn't in scope while this repo is on Django 4.2): `health_check.urls` is deprecated in favor of view-based checks, and `MigrationsHealthCheck` itself is deprecated in favor of Django's own system check framework.
- Picked up a new mandatory transitive dependency, `psutil`, which upstream added as a hard (not optional-extra) dependency starting around this release line — resolved cleanly via `uv lock`.

### How can this be tested?
- `uv lock` resolves cleanly and `uv sync --frozen` installs without conflicts.
- `python manage.py check` passes.
- Manually imported `main.urls` and confirmed only the expected (non-fatal) `health_check.urls` deprecation warning surfaces — no import/attribute errors.
- Recommend reviewers additionally hit `/health/`, `/health/startup/`, `/health/liveness/`, `/health/readiness/` in a review app or via `docker compose run --rm web uv run pytest` / CI, since there's no existing local test coverage for this integration and a full Postgres/Redis/Celery smoke test wasn't run locally for this change.

### Additional Context
Filed a separate follow-up task to extract this integration (settings + URL wiring) into a shared `ol-django` plugin (`mitol-django-health-check`) so `mit-learn`, `learn-ai`, and `mitxonline` stop each re-deriving the same wiring independently — that's a larger design/scoping effort tracked outside this PR, not part of this change.