### PR TITLE
feat: Add "Send Test Email to Me" to the seat assignment confirmation modal

### DIFF
--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -6,6 +6,7 @@ import {
   B2bApiB2bManagerOrganizationsContractsCodesReassignUpdateRequest,
   B2bApiB2bManagerOrganizationsContractsCodesRemindCreateRequest,
   B2bApiB2bManagerOrganizationsContractsCodesRevokeDestroyRequest,
+  B2bApiB2bManagerOrganizationsContractsCodesSendTestEmailCreateRequest,
 } from "@mitodl/mitxonline-api-axios/v2"
 import {
   organizationQueries,
@@ -106,6 +107,14 @@ const useReassignCode = () => {
   })
 }
 
+/** Send a test enrollment code email (with placeholder values) to the given address. */
+const useSendTestEmail = () =>
+  useMutation({
+    mutationFn: (
+      opts: B2bApiB2bManagerOrganizationsContractsCodesSendTestEmailCreateRequest,
+    ) => b2bApi.b2bManagerOrganizationsContractsCodesSendTestEmailCreate(opts),
+  })
+
 export {
   organizationQueries,
   managerOrganizationQueries,
@@ -114,6 +123,7 @@ export {
   useReassignCode,
   useRemindCode,
   useRevokeCode,
+  useSendTestEmail,
 }
 export type {
   ManagerEnrollmentCode,

--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -107,7 +107,7 @@ const useReassignCode = () => {
   })
 }
 
-/** Send a test enrollment code email (with placeholder values) to the given address. */
+/** Send a test enrollment code to the given email address. */
 const useSendTestEmail = () =>
   useMutation({
     mutationFn: (

--- a/frontends/api/src/mitxonline/test-utils/urls.ts
+++ b/frontends/api/src/mitxonline/test-utils/urls.ts
@@ -128,6 +128,8 @@ const contracts = {
     code: string,
   ) =>
     `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/${code}/reassign/`,
+  managerContractSendTestEmail: (orgId: number, contractId: number) =>
+    `${getApiBaseUrl()}/api/v0/b2b/manager/organizations/${orgId}/contracts/${contractId}/codes/send_test_email/`,
 }
 
 const certificates = {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -1,5 +1,5 @@
 import React, { act } from "react"
-import { renderWithTheme, screen, user } from "@/test-utils"
+import { renderWithTheme, screen, user, waitFor } from "@/test-utils"
 import { AssignSeatsConfirmModal } from "./AssignSeatsConfirmModal"
 
 const baseProps = {
@@ -294,6 +294,160 @@ describe("AssignSeatsConfirmModal — over-capacity state (CSV only)", () => {
 
     expect(baseProps.onClose).toHaveBeenCalledTimes(1)
     expect(baseProps.onConfirm).not.toHaveBeenCalled()
+  })
+})
+
+describe("AssignSeatsConfirmModal — email preview (send test email)", () => {
+  const sendTestEmailProps = {
+    ...baseProps,
+    userEmail: "manager@test.com",
+    onSendTestEmail: jest.fn(),
+  }
+
+  beforeEach(() => jest.clearAllMocks())
+
+  test("does not show Email Preview section when onSendTestEmail is not provided", () => {
+    renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
+
+    expect(screen.queryByText("Email Preview")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /send test email to me/i }),
+    ).not.toBeInTheDocument()
+  })
+
+  test("shows Email Preview section with button when onSendTestEmail is provided", () => {
+    renderWithTheme(<AssignSeatsConfirmModal {...sendTestEmailProps} />)
+
+    expect(screen.getByText("Email Preview")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    ).toBeInTheDocument()
+  })
+
+  test("button is disabled when userEmail is not provided", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...baseProps}
+        onSendTestEmail={jest.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    ).toBeDisabled()
+  })
+
+  test("shows 'Sending…' while test email is being sent", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>()
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        onSendTestEmail={() => promise}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    )
+
+    expect(
+      screen.getByRole("button", { name: /sending…/i }),
+    ).toBeInTheDocument()
+
+    await act(async () => resolve())
+  })
+
+  test("shows success alert after test email is sent successfully", async () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        onSendTestEmail={jest.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    )
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /test email successfully sent to manager@test\.com/i,
+    )
+  })
+
+  test("shows error alert when test email fails", async () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        onSendTestEmail={jest.fn().mockRejectedValue(new Error("Network error"))}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    )
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /something went wrong sending the test email/i,
+    )
+  })
+
+  test("Email Preview section is not shown in review step", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        invalidEmails={["bad@"]}
+      />,
+    )
+
+    expect(screen.queryByText("Email Preview")).not.toBeInTheDocument()
+  })
+
+  test("Email Preview section is not shown in over-capacity state", () => {
+    renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        validCount={15}
+        availableSeats={10}
+      />,
+    )
+
+    expect(screen.queryByText("Email Preview")).not.toBeInTheDocument()
+  })
+
+  test("resets to idle state when modal is reopened", async () => {
+    const { rerender } = renderWithTheme(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        onSendTestEmail={jest.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    )
+    await screen.findByRole("alert")
+
+    // Close then reopen
+    rerender(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        open={false}
+        onSendTestEmail={jest.fn().mockResolvedValue(undefined)}
+      />,
+    )
+    rerender(
+      <AssignSeatsConfirmModal
+        {...sendTestEmailProps}
+        onSendTestEmail={jest.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole("button", { name: /send test email to me/i }),
+    ).not.toBeDisabled()
   })
 })
 

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -326,10 +326,7 @@ describe("AssignSeatsConfirmModal — email preview (send test email)", () => {
 
   test("button is disabled when userEmail is not provided", () => {
     renderWithTheme(
-      <AssignSeatsConfirmModal
-        {...baseProps}
-        onSendTestEmail={jest.fn()}
-      />,
+      <AssignSeatsConfirmModal {...baseProps} onSendTestEmail={jest.fn()} />,
     )
 
     expect(
@@ -378,7 +375,9 @@ describe("AssignSeatsConfirmModal — email preview (send test email)", () => {
     renderWithTheme(
       <AssignSeatsConfirmModal
         {...sendTestEmailProps}
-        onSendTestEmail={jest.fn().mockRejectedValue(new Error("Network error"))}
+        onSendTestEmail={jest
+          .fn()
+          .mockRejectedValue(new Error("Network error"))}
       />,
     )
 

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -378,7 +378,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       )
     } catch {
       setTestEmailStatus("error")
-      const msg = "Something went wrong sending the test email. Please try again."
+      const msg =
+        "Something went wrong sending the test email. Please try again."
       setTestEmailAnnouncement("")
       if (testEmailAnnouncementTimerRef.current)
         clearTimeout(testEmailAnnouncementTimerRef.current)
@@ -672,14 +673,12 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           <DescriptionText>
             You are about to send <strong>{validCount}</strong> invitation{" "}
             {pluralize("email", validCount)} from MIT Learn. Learners will
-            receive an email with secure link to claim their seat and access
-            the materials.
+            receive an email with secure link to claim their seat and access the
+            materials.
           </DescriptionText>
           {onSendTestEmail && (
             <EmailPreviewSection>
-              <EmailPreviewLabel component="p">
-                Email Preview
-              </EmailPreviewLabel>
+              <EmailPreviewLabel component="p">Email Preview</EmailPreviewLabel>
               <EmailPreviewRow>
                 <DescriptionText component="p">
                   This is the email learners will receive.

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -9,7 +9,7 @@ import {
   alpha,
   styled,
 } from "ol-components"
-import { Button, VisuallyHidden } from "@mitodl/smoot-design"
+import { Alert, Button, VisuallyHidden } from "@mitodl/smoot-design"
 import { pluralize } from "ol-utilities"
 import {
   RiAlertFill,
@@ -157,6 +157,26 @@ const StatLabel = styled(Typography)(({ theme }) => ({
   width: "100%",
 })) as typeof Typography
 
+const EmailPreviewLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.darkGray2,
+})) as typeof Typography
+
+// ─── Confirm-step email preview block ──────────────────────────────────────────
+
+const EmailPreviewSection = styled("div")({
+  display: "flex",
+  flexDirection: "column",
+  gap: "8px",
+})
+
+const EmailPreviewRow = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "16px",
+})
+
 // ─── Small helpers ────────────────────────────────────────────────────────────
 
 const SHOW_MORE_THRESHOLD = 3
@@ -214,6 +234,8 @@ const copyToClipboard = async (text: string): Promise<boolean> => {
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
+type TestEmailStatus = "idle" | "sending" | "success" | "error"
+
 type AssignSeatsConfirmModalProps = {
   open: boolean
   onClose: () => void
@@ -223,6 +245,13 @@ type AssignSeatsConfirmModalProps = {
   invalidEmails: string[]
   duplicateEmails: string[]
   skippedCount: number
+  /** Email of the logged-in user, shown in the test-email success message. */
+  userEmail?: string | null
+  /**
+   * When provided, renders the "Email Preview" section with a "Send Test Email
+   * to Me" button that calls this handler. Omit to hide the section entirely.
+   */
+  onSendTestEmail?: () => Promise<void>
 }
 
 type Step = "review" | "confirm"
@@ -236,6 +265,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   invalidEmails,
   duplicateEmails,
   skippedCount,
+  userEmail,
+  onSendTestEmail,
 }) => {
   const descriptionId = useId()
   const overCapacitySummaryId = `${descriptionId}-summary`
@@ -252,6 +283,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const [copiedDuplicate, setCopiedDuplicate] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
+  const [testEmailStatus, setTestEmailStatus] =
+    useState<TestEmailStatus>("idle")
   // Assertive live region text for step transitions. Using reset-then-set (100ms
   // delay) so NVDA picks up the content change cleanly after focus settles on the
   // new step's first focusable element inside the same persistent dialog.
@@ -268,6 +301,10 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   const sendErrorAnnouncementTimerRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
+  const testEmailAnnouncementTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const [testEmailAnnouncement, setTestEmailAnnouncement] = useState("")
 
   // Only reset step and copy state when the dialog transitions from closed to
   // open. Without prevOpenRef the effect would also fire when hasIssues or
@@ -283,6 +320,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       setSendError(null)
       setSendErrorAnnouncement("")
       setStepAnnouncement("")
+      setTestEmailStatus("idle")
+      setTestEmailAnnouncement("")
     }
   }, [open, hasIssues, overCapacity])
 
@@ -295,6 +334,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         clearTimeout(stepAnnouncementTimerRef.current)
       if (sendErrorAnnouncementTimerRef.current)
         clearTimeout(sendErrorAnnouncementTimerRef.current)
+      if (testEmailAnnouncementTimerRef.current)
+        clearTimeout(testEmailAnnouncementTimerRef.current)
     }
   }, [])
 
@@ -319,6 +360,33 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       () => setCopiedDuplicate(false),
       2000,
     )
+  }
+
+  const handleSendTestEmail = async () => {
+    if (!onSendTestEmail) return
+    setTestEmailStatus("sending")
+    try {
+      await onSendTestEmail()
+      setTestEmailStatus("success")
+      const msg = `Test email successfully sent to ${userEmail}.`
+      setTestEmailAnnouncement("")
+      if (testEmailAnnouncementTimerRef.current)
+        clearTimeout(testEmailAnnouncementTimerRef.current)
+      testEmailAnnouncementTimerRef.current = setTimeout(
+        () => setTestEmailAnnouncement(msg),
+        100,
+      )
+    } catch {
+      setTestEmailStatus("error")
+      const msg = "Something went wrong sending the test email. Please try again."
+      setTestEmailAnnouncement("")
+      if (testEmailAnnouncementTimerRef.current)
+        clearTimeout(testEmailAnnouncementTimerRef.current)
+      testEmailAnnouncementTimerRef.current = setTimeout(
+        () => setTestEmailAnnouncement(msg),
+        100,
+      )
+    }
   }
 
   const handleSend = async () => {
@@ -470,6 +538,10 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       <VisuallyHidden aria-live="assertive" aria-atomic="true">
         {sendErrorAnnouncement}
       </VisuallyHidden>
+      {/* Test email announcement — same reset-then-set pattern for NVDA */}
+      <VisuallyHidden aria-live="assertive" aria-atomic="true">
+        {testEmailAnnouncement}
+      </VisuallyHidden>
       {/* Copy-success announcement — polite so it doesn't interrupt ongoing speech */}
       <VisuallyHidden aria-live="polite" aria-atomic="true">
         {copiedInvalid
@@ -600,9 +672,40 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           <DescriptionText>
             You are about to send <strong>{validCount}</strong> invitation{" "}
             {pluralize("email", validCount)} from MIT Learn. Learners will
-            receive an email with secure link to claim their seat and access the
-            materials.
+            receive an email with secure link to claim their seat and access
+            the materials.
           </DescriptionText>
+          {onSendTestEmail && (
+            <EmailPreviewSection>
+              <EmailPreviewLabel component="p">
+                Email Preview
+              </EmailPreviewLabel>
+              <EmailPreviewRow>
+                <DescriptionText component="p">
+                  This is the email learners will receive.
+                </DescriptionText>
+                <Button
+                  variant="bordered"
+                  onClick={handleSendTestEmail}
+                  disabled={!userEmail || testEmailStatus === "sending"}
+                >
+                  {testEmailStatus === "sending"
+                    ? "Sending…"
+                    : "Send Test Email to Me"}
+                </Button>
+              </EmailPreviewRow>
+            </EmailPreviewSection>
+          )}
+          {onSendTestEmail && testEmailStatus === "success" && (
+            <Alert severity="success">
+              Test email successfully sent to {userEmail}.
+            </Alert>
+          )}
+          {onSendTestEmail && testEmailStatus === "error" && (
+            <Alert severity="error">
+              Something went wrong sending the test email. Please try again.
+            </Alert>
+          )}
           <StatsCard $variant="default">
             <StatColumn
               role="group"

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -4,6 +4,8 @@ import { setMockResponse } from "api/test-utils"
 import { factories, urls } from "api/mitxonline-test-utils"
 import { AssignSeatsSection } from "./AssignSeatsSection"
 
+const USER_EMAIL = "manager@test.com"
+
 // jsdom's File/Blob has no .text() or .arrayBuffer(), so FileReader.readAsText
 // always fires onerror. Tests set mockFileContent before each upload so the mock
 // can return the expected text.
@@ -11,6 +13,13 @@ let mockFileContent: string | null = null
 
 describe("AssignSeatsSection", () => {
   let originalFileReader: typeof FileReader
+
+  beforeEach(() => {
+    setMockResponse.get(
+      urls.userMe.get(),
+      factories.user.user({ email: USER_EMAIL }),
+    )
+  })
 
   beforeAll(() => {
     originalFileReader = window.FileReader
@@ -553,6 +562,96 @@ describe("AssignSeatsSection", () => {
 
     expect(screen.getByText("2 valid")).toBeInTheDocument()
     expect(screen.getByText("1 invalid")).toBeInTheDocument()
+  })
+
+  describe("send test email", () => {
+    const ORG_ID = 1
+    const CONTRACT_ID = 2
+
+    const openConfirmModal = async () => {
+      const textarea = screen.getByPlaceholderText(/enter employee emails/i)
+      await user.type(textarea, "alice@example.com")
+      await user.click(screen.getByRole("button", { name: "Assign Seats" }))
+      await screen.findByRole("heading", { name: /ready to send invitations/i })
+    }
+
+    test("shows 'Send Test Email to Me' button in the confirm modal", async () => {
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+          isLoadingSeats={false}
+        />,
+      )
+
+      await openConfirmModal()
+
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /send test email to me/i }),
+        ).not.toBeDisabled(),
+      )
+    })
+
+    test("sends test email to the user's address and shows success alert", async () => {
+      setMockResponse.post(
+        urls.contracts.managerContractSendTestEmail(ORG_ID, CONTRACT_ID),
+        null,
+      )
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+          isLoadingSeats={false}
+        />,
+      )
+
+      await openConfirmModal()
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /send test email to me/i }),
+        ).not.toBeDisabled(),
+      )
+      await user.click(
+        screen.getByRole("button", { name: /send test email to me/i }),
+      )
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        new RegExp(`test email successfully sent to ${USER_EMAIL}`, "i"),
+      )
+    })
+
+    test("shows error alert when test email request fails", async () => {
+      setMockResponse.post(
+        urls.contracts.managerContractSendTestEmail(ORG_ID, CONTRACT_ID),
+        { detail: "Internal server error" },
+        { code: 500 },
+      )
+      renderWithProviders(
+        <AssignSeatsSection
+          orgId={ORG_ID}
+          contractId={CONTRACT_ID}
+          availableSeats={50}
+          isLoadingSeats={false}
+        />,
+      )
+
+      await openConfirmModal()
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: /send test email to me/i }),
+        ).not.toBeDisabled(),
+      )
+      await user.click(
+        screen.getByRole("button", { name: /send test email to me/i }),
+      )
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /something went wrong sending the test email/i,
+      )
+    })
   })
 
   describe("submitting the assignment", () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -399,13 +399,15 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
 
   const handleModalClose = () => setModalData(null)
 
-  const handleSendTestEmail = async () => {
-    await sendTestEmail.mutateAsync({
-      id: contractId,
-      parent_lookup_organization: orgId,
-      SendTestEmailRequest: { email: user?.email ?? "" },
-    })
-  }
+const handleSendTestEmail = async () => {
+  const email = user?.email
+  if (!email) throw new Error("Logged-in user email is unavailable")
+  await sendTestEmail.mutateAsync({
+    id: contractId,
+    parent_lookup_organization: orgId,
+    SendTestEmailRequest: { email },
+  })
+}
 
   const handleModalConfirm = async () => {
     const emails = modalData?.validEmails ?? []

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -11,7 +11,12 @@ import {
 } from "ol-utilities"
 import Papa from "papaparse"
 import { AssignSeatsConfirmModal } from "./AssignSeatsConfirmModal"
-import { useBulkAssignSeats } from "api/mitxonline-hooks/organizations"
+import {
+  useBulkAssignSeats,
+  useSendTestEmail,
+} from "api/mitxonline-hooks/organizations"
+import { mitxUserQueries } from "api/mitxonline-hooks/user"
+import { useQuery } from "@tanstack/react-query"
 import type { BulkAssignError } from "@mitodl/mitxonline-api-axios/v2"
 
 // Shared metrics — must be identical between EmailHighlightLayer and EmailTextarea
@@ -227,6 +232,8 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const bulkAssign = useBulkAssignSeats()
+  const sendTestEmail = useSendTestEmail()
+  const { data: user } = useQuery(mitxUserQueries.me())
 
   const submitResult = useMemo(
     () => parseEmailsForSubmit(emailInput),
@@ -391,6 +398,14 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
   }
 
   const handleModalClose = () => setModalData(null)
+
+  const handleSendTestEmail = async () => {
+    await sendTestEmail.mutateAsync({
+      id: contractId,
+      parent_lookup_organization: orgId,
+      SendTestEmailRequest: { email: user?.email ?? "" },
+    })
+  }
 
   const handleModalConfirm = async () => {
     const emails = modalData?.validEmails ?? []
@@ -612,6 +627,8 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
           invalidEmails={modalData.invalidEmails}
           duplicateEmails={modalData.duplicateEmails}
           skippedCount={modalData.skippedCount}
+          userEmail={user?.email}
+          onSendTestEmail={handleSendTestEmail}
         />
       )}
     </SectionCard>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -399,15 +399,15 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
 
   const handleModalClose = () => setModalData(null)
 
-const handleSendTestEmail = async () => {
-  const email = user?.email
-  if (!email) throw new Error("Logged-in user email is unavailable")
-  await sendTestEmail.mutateAsync({
-    id: contractId,
-    parent_lookup_organization: orgId,
-    SendTestEmailRequest: { email },
-  })
-}
+  const handleSendTestEmail = async () => {
+    const email = user?.email
+    if (!email) throw new Error("Logged-in user email is unavailable")
+    await sendTestEmail.mutateAsync({
+      id: contractId,
+      parent_lookup_organization: orgId,
+      SendTestEmailRequest: { email },
+    })
+  }
 
   const handleModalConfirm = async () => {
     const emails = modalData?.validEmails ?? []

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -57,6 +57,10 @@ describe("ContractAdminPage", () => {
   beforeEach(() => {
     mockedUseFeatureFlagsLoaded.mockReturnValue(false)
     mockedUseFeatureFlagEnabled.mockReturnValue(undefined)
+    setMockResponse.get(
+      urls.userMe.get(),
+      factories.user.user({ email: "manager@test.com" }),
+    )
   })
 
   test("throws ForbiddenError when feature flag is disabled", () => {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/11077
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Adds a "Send Test Email to Me" action to the Assign Seats confirmation modal's confirm step, letting a contract admin preview the actual invitation email before sending it to learners.
- Wires up `useSendTestEmail` (new mutation hook against the `send_test_email` B2B endpoint) and passes the logged-in manager's email from `mitxUserQueries.me()` down to the modal.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

<img width="613" height="459" alt="Screenshot 2026-07-01 at 2 51 27 PM" src="https://github.com/user-attachments/assets/c34d56c1-f71e-4542-a4e1-a55ad2610a7b" />

<img width="609" height="538" alt="Screenshot 2026-07-01 at 2 51 34 PM" src="https://github.com/user-attachments/assets/149f59ef-c276-4b14-ae3e-5405e6ac4b23" />

<img width="602" height="539" alt="Screenshot 2026-07-01 at 3 10 14 PM" src="https://github.com/user-attachments/assets/ebeae126-dfe4-450f-8aeb-5d8a3812e200" />


https://github.com/user-attachments/assets/abf6b420-d76f-4e14-b7ee-f642823fd4b5



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Happy Path:
1. type valid email(s) into the input and click "Assign Seats" 
- [ ] Email Preview section renders/hides correctly
2. Click "Send Test Email to Me" 
- [ ] shows "Sending…" state, success/error alerts render

Simulating an error:
1. Open the confirm modal and open DevTools → Network tab
2. Click Send Test Email to Me once so the request appears in the list (.../codes/send_test_email/). It'll succeed — that's fine, this is just to capture the URL.
3. Right-click that request row → Block request URL (Chrome) — this blocks all future requests matching that URL for the session.
4. Reopen/reset the modal (close and reopen, or re-trigger the confirm step) and click Send Test Email to Me again. 
- [ ] shows "Something went wrong sending the test email. Please try again." alert.
5. Unblock the URL afterward (Network tab → the blocked-URLs list icon, or DevTools Settings → remove it) so it doesn't affect other testing.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
