### PR TITLE
Bound program marketing-page embedding input to avoid token overflow

### DIFF
--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -646,6 +646,14 @@ def test_marketing_page_for_program_appends_children(mocker, settings):
         relation_type="PROGRAM_COURSES",
         position=0,
     )
+    models.ContentFile.objects.create(
+        learning_resource=child_course,
+        file_type=MARKETING_PAGE_FILE_TYPE,
+        file_extension=".md",
+        key="mktg-child-course",
+        content="Child Course marketing copy",
+        published=True,
+    )
 
     html_content = "<html><body><h1>Test Program</h1><p>Program info</p></body></html>"
     mocker.patch(

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -748,19 +748,19 @@ def build_resource_summary_dict(resource):
 PROGRAM_CHILDREN_CONTENT_MAX_CHARS = 1_000_000
 
 
-def _reachable_course_ids(relationships, course_type):
-    """Course ids from a program's child relationships (direct + via child programs)."""
-    course_ids = set()
+def _course_ids_by_program(relationships, course_type):
+    """Map program id -> reachable published course ids (direct + via subprograms)."""
+    result = defaultdict(set)
     for rel in relationships:
         if rel.child.resource_type == course_type:
-            course_ids.add(rel.child_id)
+            result[rel.parent_id].add(rel.child_id)
         else:
-            course_ids.update(
+            result[rel.parent_id].update(
                 sub_rel.child_id
                 for sub_rel in getattr(rel.child, "program_children", [])
                 if sub_rel.child.resource_type == course_type
             )
-    return course_ids
+    return result
 
 
 def build_program_children_content(learning_resource):
@@ -815,17 +815,7 @@ def build_program_children_content_bulk(program_resources):
     )
 
     course_type = LearningResourceType.course.name
-    relationships_by_program = defaultdict(list)
-    for rel in relationships:
-        relationships_by_program[rel.parent_id].append(rel)
-
-    # Reachable published course ids per program (direct + via child programs)
-    course_ids_by_program = {
-        program.id: _reachable_course_ids(
-            relationships_by_program.get(program.id, []), course_type
-        )
-        for program in programs
-    }
+    course_ids_by_program = _course_ids_by_program(relationships, course_type)
     all_course_ids = set().union(*course_ids_by_program.values())
 
     # One marketing-page content file per course (published), fetched in bulk

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -27,6 +27,7 @@ from learning_resources.constants import (
     LearningResourceType,
     semester_mapping,
 )
+from learning_resources.etl.constants import MARKETING_PAGE_FILE_TYPE
 from learning_resources.hooks import get_plugin_manager
 from learning_resources.models import (
     ContentFile,
@@ -740,62 +741,26 @@ def build_resource_summary_dict(resource):
     }
 
 
-# Bound program marketing-page content so it stays a reasonable embedding input.
-# Without these, a large program's page balloons with every child summary (seen
-# at 23MB in prod) and overflows the embedding API's per-request token limit.
-PROGRAM_CHILD_MAX_SUMMARIES = 20
+# Bound the program marketing-page content assembled from child courses so it
+# stays a reasonable embedding input. A program page previously concatenated
+# every child-course content-file summary and ballooned to 23MB in prod,
+# overflowing the embedding API's per-request token limit.
 PROGRAM_CHILDREN_CONTENT_MAX_CHARS = 1_000_000
 
 
-def _build_entry(resource, summaries_by_resource):
-    """Build a resource entry dict for markdown rendering."""
-    entry = build_resource_summary_dict(resource)
-    entry["summaries"] = summaries_by_resource.get(resource.id, [])[
-        :PROGRAM_CHILD_MAX_SUMMARIES
-    ]
-    return entry
-
-
-def _build_entries_from_relationships(relationships, summaries_by_resource):
-    """Build entry dicts from prefetched relationships, including grandchildren."""
-    entries = []
+def _reachable_course_ids(relationships, course_type):
+    """Course ids from a program's child relationships (direct + via child programs)."""
+    course_ids = set()
     for rel in relationships:
-        entry = _build_entry(rel.child, summaries_by_resource)
-
-        if (
-            rel.child.resource_type == LearningResourceType.program.name
-            and rel.relation_type == LearningResourceRelationTypes.PROGRAM_PROGRAMS
-        ):
-            sub_entries = [
-                _build_entry(sub_rel.child, summaries_by_resource)
+        if rel.child.resource_type == course_type:
+            course_ids.add(rel.child_id)
+        else:
+            course_ids.update(
+                sub_rel.child_id
                 for sub_rel in getattr(rel.child, "program_children", [])
-            ]
-            if sub_entries:
-                entry["children"] = sub_entries
-
-        entries.append(entry)
-    return entries
-
-
-def _format_resource_entries(entries, heading_level=3):
-    """Recursively format resource entries as markdown sections."""
-    sections = []
-    for entry in entries:
-        prefix = "#" * heading_level
-        lines = [f"{prefix} {entry['title']}"]
-        if entry["description"]:
-            lines.append(entry["description"])
-        if entry["topics"]:
-            lines.append(f"Topics: {', '.join(entry['topics'])}")
-        if entry.get("summaries"):
-            lines.append("\n**Content summaries:**")
-            lines.extend(f"- {summary}" for summary in entry["summaries"])
-        sections.append("\n".join(lines))
-        if entry.get("children"):
-            sections.extend(
-                _format_resource_entries(entry["children"], heading_level + 1)
+                if sub_rel.child.resource_type == course_type
             )
-    return sections
+    return course_ids
 
 
 def build_program_children_content(learning_resource):
@@ -810,8 +775,9 @@ def build_program_children_content(learning_resource):
 def build_program_children_content_bulk(program_resources):
     """Build program children markdown for many program resources in bulk.
 
-    Returns a dict keyed by learning_resource id with markdown content.
-    Non-program resources are ignored.
+    For each program, concatenates the marketing-page content of its published
+    child courses, including courses reached through child programs. Returns a
+    dict keyed by learning_resource id. Non-program resources are ignored.
     """
     programs = [
         resource
@@ -834,64 +800,62 @@ def build_program_children_content_bulk(program_resources):
             relation_type__in=program_relation_types,
         )
         .filter(child_visibility)
-        .select_related("parent", "child")
+        .select_related("child")
         .prefetch_related(
-            "child__topics",
             Prefetch(
                 "child__children",
                 queryset=LearningResourceRelationship.objects.filter(
                     relation_type__in=program_relation_types,
                 )
                 .filter(child_visibility)
-                .select_related("child")
-                .prefetch_related("child__topics"),
+                .select_related("child"),
                 to_attr="program_children",
             ),
         )
     )
 
-    child_ids = [rel.child_id for rel in relationships]
-    grandchild_ids = [
-        gc.child_id
-        for rel in relationships
-        for gc in getattr(rel.child, "program_children", [])
-    ]
-    all_ids = set(child_ids + grandchild_ids) - set(program_ids)
-
-    summaries_by_resource = {}
-    if all_ids:
-        summary_qs = (
-            ContentFile.objects.filter(
-                run__learning_resource_id__in=all_ids,
-                published=True,
-                run__published=True,
-            )
-            .exclude(summary="")
-            # Stable ordering so the per-child summary cap keeps a deterministic
-            # subset instead of a DB-order-dependent one.
-            .order_by("run__learning_resource_id", "id")
-            .values_list("run__learning_resource_id", "summary")
-        )
-        for resource_id, summary in summary_qs:
-            summaries_by_resource.setdefault(resource_id, []).append(summary)
-
+    course_type = LearningResourceType.course.name
     relationships_by_program = defaultdict(list)
     for rel in relationships:
         relationships_by_program[rel.parent_id].append(rel)
 
+    # Reachable published course ids per program (direct + via child programs)
+    course_ids_by_program = {
+        program.id: _reachable_course_ids(
+            relationships_by_program.get(program.id, []), course_type
+        )
+        for program in programs
+    }
+    all_course_ids = set().union(*course_ids_by_program.values())
+
+    # One marketing-page content file per course (published), fetched in bulk
+    marketing_by_course = {}
+    if all_course_ids:
+        marketing_qs = (
+            ContentFile.objects.filter(
+                learning_resource_id__in=all_course_ids,
+                file_type=MARKETING_PAGE_FILE_TYPE,
+                published=True,
+            )
+            .exclude(content="")
+            .order_by("learning_resource_id", "id")
+            .values_list("learning_resource_id", "learning_resource__title", "content")
+        )
+        for lr_id, title, content in marketing_qs:
+            marketing_by_course.setdefault(lr_id, (title, content))
+
     content_by_program_id = {}
     for program in programs:
-        rels = relationships_by_program.get(program.id, [])
-        entries = _build_entries_from_relationships(rels, summaries_by_resource)
-
-        if not entries:
+        sections = []
+        for course_id in sorted(course_ids_by_program.get(program.id, set())):
+            page = marketing_by_course.get(course_id)
+            if page:
+                title, content = page
+                sections.append(f"### {title}\n\n{content}")
+        if not sections:
             content_by_program_id[program.id] = ""
             continue
-
-        sections = ["\n\n## Program Contents\n"]
-        sections.extend(_format_resource_entries(entries))
-        content_by_program_id[program.id] = "\n\n".join(sections)[
-            :PROGRAM_CHILDREN_CONTENT_MAX_CHARS
-        ]
+        body = "\n\n".join(["\n\n## Program Contents\n", *sections])
+        content_by_program_id[program.id] = body[:PROGRAM_CHILDREN_CONTENT_MAX_CHARS]
 
     return content_by_program_id

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -740,10 +740,19 @@ def build_resource_summary_dict(resource):
     }
 
 
+# Bound program marketing-page content so it stays a reasonable embedding input.
+# Without these, a large program's page balloons with every child summary (seen
+# at 23MB in prod) and overflows the embedding API's per-request token limit.
+PROGRAM_CHILD_MAX_SUMMARIES = 20
+PROGRAM_CHILDREN_CONTENT_MAX_CHARS = 1_000_000
+
+
 def _build_entry(resource, summaries_by_resource):
     """Build a resource entry dict for markdown rendering."""
     entry = build_resource_summary_dict(resource)
-    entry["summaries"] = summaries_by_resource.get(resource.id, [])
+    entry["summaries"] = summaries_by_resource.get(resource.id, [])[
+        :PROGRAM_CHILD_MAX_SUMMARIES
+    ]
     return entry
 
 
@@ -878,6 +887,8 @@ def build_program_children_content_bulk(program_resources):
 
         sections = ["\n\n## Program Contents\n"]
         sections.extend(_format_resource_entries(entries))
-        content_by_program_id[program.id] = "\n\n".join(sections)
+        content_by_program_id[program.id] = "\n\n".join(sections)[
+            :PROGRAM_CHILDREN_CONTENT_MAX_CHARS
+        ]
 
     return content_by_program_id

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -867,6 +867,9 @@ def build_program_children_content_bulk(program_resources):
                 run__published=True,
             )
             .exclude(summary="")
+            # Stable ordering so the per-child summary cap keeps a deterministic
+            # subset instead of a DB-order-dependent one.
+            .order_by("run__learning_resource_id", "id")
             .values_list("run__learning_resource_id", "summary")
         )
         for resource_id, summary in summary_qs:

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -776,8 +776,9 @@ def build_program_children_content_bulk(program_resources):
     """Build program children markdown for many program resources in bulk.
 
     For each program, concatenates the marketing-page content of its published
-    child courses, including courses reached through child programs. Returns a
-    dict keyed by learning_resource id. Non-program resources are ignored.
+    (or test-mode) child courses, including courses reached through child
+    programs. Returns a dict keyed by learning_resource id. Non-program
+    resources are ignored.
     """
     programs = [
         resource

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -768,6 +768,34 @@ def test_build_program_children_content_caps_summaries_per_child():
     assert included == 20
 
 
+def test_build_program_children_content_summary_cap_is_deterministic():
+    """The capped subset of summaries is stable (ordered), not DB-order dependent"""
+    from learning_resources.models import ContentFile, LearningResourceRun
+
+    course_lr = CourseFactory.create().learning_resource
+    run = LearningResourceRun.objects.create(
+        learning_resource=course_lr,
+        run_id="test-run",
+    )
+    content_files = [
+        ContentFile.objects.create(
+            run=run,
+            key=f"file-{i}.txt",
+            summary=f"summary-{i}-end",
+        )
+        for i in range(30)
+    ]
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+
+    result = build_program_children_content(program_lr)
+
+    by_id = sorted(content_files, key=lambda cf: cf.id)
+    for cf in by_id[:20]:
+        assert cf.summary in result
+    for cf in by_id[20:]:
+        assert cf.summary not in result
+
+
 def test_build_program_children_content_caps_total_length():
     """Program children content is hard-capped in total size"""
     from learning_resources.models import ContentFile, LearningResourceRun

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -19,6 +19,7 @@ from learning_resources.constants import (
     CONTENT_TYPE_VIDEO,
     LearningResourceRelationTypes,
 )
+from learning_resources.etl.constants import MARKETING_PAGE_FILE_TYPE
 from learning_resources.etl.utils import get_content_type
 from learning_resources.factories import (
     CourseFactory,
@@ -124,7 +125,7 @@ def _add_course_marketing_page(course_lr, content):
 
     return ContentFile.objects.create(
         learning_resource=course_lr,
-        file_type="marketing_page",
+        file_type=MARKETING_PAGE_FILE_TYPE,
         file_extension=".md",
         key=f"mktg-{course_lr.id}",
         content=content,
@@ -763,7 +764,7 @@ def test_build_program_children_content_excludes_unpublished_marketing_pages():
     ).learning_resource
     ContentFile.objects.create(
         learning_resource=course_lr,
-        file_type="marketing_page",
+        file_type=MARKETING_PAGE_FILE_TYPE,
         file_extension=".md",
         key=f"mktg-{course_lr.id}",
         content="Hidden marketing copy.",
@@ -977,7 +978,7 @@ def test_build_program_children_content_bulk_excludes_unpublished_marketing_page
     ).learning_resource
     ContentFile.objects.create(
         learning_resource=unpublished_course,
-        file_type="marketing_page",
+        file_type=MARKETING_PAGE_FILE_TYPE,
         file_extension=".md",
         key=f"mktg-{unpublished_course.id}",
         content="Hidden marketing copy.",

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -118,6 +118,20 @@ def fixture_test_instructors_data():
         return json.load(test_data)["instructors"]
 
 
+def _add_course_marketing_page(course_lr, content):
+    """Attach a published marketing-page content file to a course."""
+    from learning_resources.models import ContentFile
+
+    return ContentFile.objects.create(
+        learning_resource=course_lr,
+        file_type="marketing_page",
+        file_extension=".md",
+        key=f"mktg-{course_lr.id}",
+        content=content,
+        published=True,
+    )
+
+
 @pytest.fixture
 def program_with_visibility_children():
     """Program with published, unpublished, and test_mode child courses."""
@@ -135,6 +149,8 @@ def program_with_visibility_children():
         learning_resource__published=False,
         learning_resource__test_mode=True,
     ).learning_resource
+    for child in (published, unpublished, test_mode):
+        _add_course_marketing_page(child, f"Marketing copy for {child.title}.")
     program_lr = ProgramFactory.create(courses=[published]).learning_resource
     # Manually add unpublished/test_mode children since ProgramFactory
     # only creates PROGRAM_COURSES relationships for visible courses
@@ -687,27 +703,40 @@ def test_build_program_children_content_non_program():
     assert build_program_children_content(course_lr) == ""
 
 
-def test_build_program_children_content_direct_courses():
-    """Programs with direct course children should include them"""
+def test_build_program_children_content_includes_child_course_marketing_pages():
+    """A published child course's marketing-page content is included."""
     course_lr = CourseFactory.create(
         learning_resource__title="Test Course",
-        learning_resource__description="A test course",
     ).learning_resource
+    _add_course_marketing_page(course_lr, "Marketing copy for the test course.")
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
 
     result = build_program_children_content(program_lr)
     assert "## Program Contents" in result
-    assert "Test Course" in result
-    assert "A test course" in result
+    assert "### Test Course" in result
+    assert "Marketing copy for the test course." in result
 
 
-def test_build_program_children_content_child_programs_with_courses():
-    """Programs with child programs should recurse to find courses"""
+def test_build_program_children_content_omits_courses_without_marketing_page():
+    """Child courses lacking a marketing-page content file contribute nothing."""
+    course_lr = CourseFactory.create(
+        learning_resource__title="No Marketing Course",
+    ).learning_resource
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+
+    assert build_program_children_content(program_lr) == ""
+
+
+def test_build_program_children_content_recurses_child_program_courses():
+    """Courses reached through a child program are included; the child program
+    itself is not emitted as a heading.
+    """
     from learning_resources.models import LearningResourceRelationship
 
     grandchild_course_lr = CourseFactory.create(
         learning_resource__title="Grandchild Course"
     ).learning_resource
+    _add_course_marketing_page(grandchild_course_lr, "Grandchild marketing copy.")
     child_program_lr = ProgramFactory.create(
         courses=[grandchild_course_lr], learning_resource__title="Child Program"
     ).learning_resource
@@ -719,102 +748,58 @@ def test_build_program_children_content_child_programs_with_courses():
     )
 
     result = build_program_children_content(parent_lr)
-    assert "Child Program" in result
-    assert "Grandchild Course" in result
+    assert "### Grandchild Course" in result
+    assert "Grandchild marketing copy." in result
+    # Child programs are traversed only to reach courses, not emitted themselves.
+    assert "Child Program" not in result
 
 
-def test_build_program_children_content_with_summaries():
-    """Child course contentfile summaries should be included"""
-    from learning_resources.models import ContentFile, LearningResourceRun
+def test_build_program_children_content_excludes_unpublished_marketing_pages():
+    """Unpublished marketing-page content files are excluded."""
+    from learning_resources.models import ContentFile
 
     course_lr = CourseFactory.create(
-        learning_resource__title="Course With Summary"
+        learning_resource__title="Course With Unpublished Page"
     ).learning_resource
-    run = LearningResourceRun.objects.create(
-        learning_resource=course_lr,
-        run_id="test-run",
-    )
     ContentFile.objects.create(
-        run=run,
-        key="transcript.txt",
-        summary="This is a summary of the course content.",
-    )
-    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-
-    result = build_program_children_content(program_lr)
-    assert "This is a summary of the course content." in result
-    assert "Content summaries" in result
-
-
-def test_build_program_children_content_caps_summaries_per_child():
-    """Only a bounded number of summaries per child course are included"""
-    from learning_resources.models import ContentFile, LearningResourceRun
-
-    course_lr = CourseFactory.create().learning_resource
-    run = LearningResourceRun.objects.create(
         learning_resource=course_lr,
-        run_id="test-run",
+        file_type="marketing_page",
+        file_extension=".md",
+        key=f"mktg-{course_lr.id}",
+        content="Hidden marketing copy.",
+        published=False,
     )
-    for i in range(30):
-        ContentFile.objects.create(
-            run=run,
-            key=f"file-{i}.txt",
-            summary=f"distinct-summary-{i}-end",
-        )
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
 
     result = build_program_children_content(program_lr)
-    included = sum(1 for i in range(30) if f"distinct-summary-{i}-end" in result)
-    assert included == 20
-
-
-def test_build_program_children_content_summary_cap_is_deterministic():
-    """The capped subset of summaries is stable (ordered), not DB-order dependent"""
-    from learning_resources.models import ContentFile, LearningResourceRun
-
-    course_lr = CourseFactory.create().learning_resource
-    run = LearningResourceRun.objects.create(
-        learning_resource=course_lr,
-        run_id="test-run",
-    )
-    content_files = [
-        ContentFile.objects.create(
-            run=run,
-            key=f"file-{i}.txt",
-            summary=f"summary-{i}-end",
-        )
-        for i in range(30)
-    ]
-    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-
-    result = build_program_children_content(program_lr)
-
-    by_id = sorted(content_files, key=lambda cf: cf.id)
-    for cf in by_id[:20]:
-        assert cf.summary in result
-    for cf in by_id[20:]:
-        assert cf.summary not in result
+    assert "Hidden marketing copy." not in result
+    assert result == ""
 
 
 def test_build_program_children_content_caps_total_length():
     """Program children content is hard-capped in total size"""
-    from learning_resources.models import ContentFile, LearningResourceRun
-
     course_lr = CourseFactory.create().learning_resource
-    run = LearningResourceRun.objects.create(
-        learning_resource=course_lr,
-        run_id="test-run",
-    )
-    for i in range(5):
-        ContentFile.objects.create(
-            run=run,
-            key=f"file-{i}.txt",
-            summary=f"summary-{i}-" + "x" * 300_000,
-        )
+    _add_course_marketing_page(course_lr, "x" * 1_500_000)
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
 
     result = build_program_children_content(program_lr)
     assert len(result) <= 1_000_000
+
+
+def test_build_program_children_content_deterministic_order():
+    """Child course sections appear in a stable order."""
+    courses = [
+        CourseFactory.create(learning_resource__title=f"Course {i}").learning_resource
+        for i in range(3)
+    ]
+    for i, course in enumerate(courses):
+        _add_course_marketing_page(course, f"body {i}")
+    program_lr = ProgramFactory.create(courses=courses).learning_resource
+
+    result = build_program_children_content(program_lr)
+    ordered_by_id = sorted(courses, key=lambda c: c.id)
+    positions = [result.index(f"### {c.title}") for c in ordered_by_id]
+    assert positions == sorted(positions)
 
 
 def test_build_program_children_content_ignores_non_program_relations():
@@ -824,12 +809,14 @@ def test_build_program_children_content_ignores_non_program_relations():
     course_lr = CourseFactory.create(
         learning_resource__title="Real Course"
     ).learning_resource
+    _add_course_marketing_page(course_lr, "Real course copy.")
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
 
     # Add a non-program relation (e.g. LEARNING_PATH_ITEMS)
     unrelated_lr = CourseFactory.create(
         learning_resource__title="Unrelated Item"
     ).learning_resource
+    _add_course_marketing_page(unrelated_lr, "Unrelated copy.")
     LearningResourceRelationship.objects.create(
         parent=program_lr,
         child=unrelated_lr,
@@ -837,30 +824,8 @@ def test_build_program_children_content_ignores_non_program_relations():
     )
 
     result = build_program_children_content(program_lr)
-    assert "Real Course" in result
-    assert "Unrelated Item" not in result
-
-
-def test_build_program_children_content_two_levels():
-    """Program -> child program -> courses are all included (2 levels)"""
-    from learning_resources.models import LearningResourceRelationship
-
-    nested_course = CourseFactory.create(
-        learning_resource__title="Nested Course"
-    ).learning_resource
-    mid_lr = ProgramFactory.create(
-        courses=[nested_course], learning_resource__title="Mid Program"
-    ).learning_resource
-    top_lr = ProgramFactory.create(courses=[]).learning_resource
-    LearningResourceRelationship.objects.create(
-        parent=top_lr,
-        child=mid_lr,
-        relation_type="PROGRAM_PROGRAMS",
-    )
-
-    result = build_program_children_content(top_lr)
-    assert "Mid Program" in result
-    assert "Nested Course" in result
+    assert "Real course copy." in result
+    assert "Unrelated copy." not in result
 
 
 # --- build_program_children_content_bulk tests ---
@@ -889,8 +854,8 @@ def test_build_program_children_content_bulk_single_program():
     """Bulk function produces same output as single-resource version."""
     course_lr = CourseFactory.create(
         learning_resource__title="Bulk Test Course",
-        learning_resource__description="A description",
     ).learning_resource
+    _add_course_marketing_page(course_lr, "Bulk marketing copy.")
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
 
     single_result = build_program_children_content(program_lr)
@@ -906,6 +871,8 @@ def test_build_program_children_content_bulk_multiple_programs():
     course2 = CourseFactory.create(
         learning_resource__title="Course For Prog2"
     ).learning_resource
+    _add_course_marketing_page(course1, "Prog1 course copy.")
+    _add_course_marketing_page(course2, "Prog2 course copy.")
     prog1, prog2 = (
         ProgramFactory.create(courses=[course]).learning_resource
         for course in [course1, course2]
@@ -914,9 +881,9 @@ def test_build_program_children_content_bulk_multiple_programs():
     result = build_program_children_content_bulk([prog1, prog2])
     assert prog1.id in result
     assert prog2.id in result
-    assert "Course For Prog1" in result[prog1.id]
-    assert "Course For Prog2" in result[prog2.id]
-    assert "Course For Prog2" not in result[prog1.id]
+    assert "Prog1 course copy." in result[prog1.id]
+    assert "Prog2 course copy." in result[prog2.id]
+    assert "Prog2 course copy." not in result[prog1.id]
 
 
 def test_build_program_children_content_bulk_mixed_resources():
@@ -924,6 +891,7 @@ def test_build_program_children_content_bulk_mixed_resources():
     course_child = CourseFactory.create(
         learning_resource__title="Child Course"
     ).learning_resource
+    _add_course_marketing_page(course_child, "Child course copy.")
     program_lr = ProgramFactory.create(courses=[course_child]).learning_resource
     non_program = CourseFactory.create().learning_resource
 
@@ -939,6 +907,7 @@ def test_build_program_children_content_bulk_with_grandchildren():
     grandchild = CourseFactory.create(
         learning_resource__title="Grandchild Course"
     ).learning_resource
+    _add_course_marketing_page(grandchild, "Grandchild copy.")
     child_prog = ProgramFactory.create(
         courses=[grandchild], learning_resource__title="Sub Program"
     ).learning_resource
@@ -948,8 +917,8 @@ def test_build_program_children_content_bulk_with_grandchildren():
     )
 
     result = build_program_children_content_bulk([parent_lr])
-    assert "Sub Program" in result[parent_lr.id]
-    assert "Grandchild Course" in result[parent_lr.id]
+    assert "### Grandchild Course" in result[parent_lr.id]
+    assert "Grandchild copy." in result[parent_lr.id]
 
 
 def test_build_program_children_content_excludes_unpublished_children(
@@ -973,6 +942,8 @@ def test_build_program_children_content_excludes_unpublished_grandchildren():
         is_unpublished=True,
         learning_resource__title="Unpublished Grandchild",
     ).learning_resource
+    _add_course_marketing_page(published_grandchild, "Published grandchild copy.")
+    _add_course_marketing_page(unpublished_grandchild, "Unpublished grandchild copy.")
     child_prog = ProgramFactory.create(
         courses=[published_grandchild], learning_resource__title="Sub Program"
     ).learning_resource
@@ -992,53 +963,34 @@ def test_build_program_children_content_excludes_unpublished_grandchildren():
     assert "Unpublished Grandchild" not in result[parent_lr.id]
 
 
-def test_build_program_children_content_bulk_excludes_unpublished_contentfiles():
-    """Unpublished content files and files on unpublished runs are excluded."""
-    from learning_resources.models import ContentFile, LearningResourceRun
+def test_build_program_children_content_bulk_excludes_unpublished_marketing_pages():
+    """Only published marketing-page content files are included."""
+    from learning_resources.models import ContentFile
 
-    course_lr = CourseFactory.create(
-        learning_resource__title="Course With Mixed Content"
+    published_course = CourseFactory.create(
+        learning_resource__title="Published Marketing Course"
+    ).learning_resource
+    _add_course_marketing_page(published_course, "Visible marketing copy.")
+
+    unpublished_course = CourseFactory.create(
+        learning_resource__title="Unpublished Marketing Course"
+    ).learning_resource
+    ContentFile.objects.create(
+        learning_resource=unpublished_course,
+        file_type="marketing_page",
+        file_extension=".md",
+        key=f"mktg-{unpublished_course.id}",
+        content="Hidden marketing copy.",
+        published=False,
+    )
+
+    program_lr = ProgramFactory.create(
+        courses=[published_course, unpublished_course]
     ).learning_resource
 
-    published_run = LearningResourceRun.objects.create(
-        learning_resource=course_lr,
-        run_id="published-run",
-        published=True,
-    )
-    unpublished_run = LearningResourceRun.objects.create(
-        learning_resource=course_lr,
-        run_id="unpublished-run",
-        published=False,
-    )
-
-    # Published content file on published run — should be included
-    ContentFile.objects.create(
-        run=published_run,
-        key="visible.txt",
-        summary="Visible summary",
-        published=True,
-    )
-    # Unpublished content file on published run — should be excluded
-    ContentFile.objects.create(
-        run=published_run,
-        key="hidden.txt",
-        summary="Hidden unpublished summary",
-        published=False,
-    )
-    # Published content file on unpublished run — should be excluded
-    ContentFile.objects.create(
-        run=unpublished_run,
-        key="hidden-run.txt",
-        summary="Hidden run summary",
-        published=True,
-    )
-
-    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-
     result = build_program_children_content_bulk([program_lr])
-    assert "Visible summary" in result[program_lr.id]
-    assert "Hidden unpublished summary" not in result[program_lr.id]
-    assert "Hidden run summary" not in result[program_lr.id]
+    assert "Visible marketing copy." in result[program_lr.id]
+    assert "Hidden marketing copy." not in result[program_lr.id]
 
 
 @pytest.mark.parametrize(

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -746,6 +746,49 @@ def test_build_program_children_content_with_summaries():
     assert "Content summaries" in result
 
 
+def test_build_program_children_content_caps_summaries_per_child():
+    """Only a bounded number of summaries per child course are included"""
+    from learning_resources.models import ContentFile, LearningResourceRun
+
+    course_lr = CourseFactory.create().learning_resource
+    run = LearningResourceRun.objects.create(
+        learning_resource=course_lr,
+        run_id="test-run",
+    )
+    for i in range(30):
+        ContentFile.objects.create(
+            run=run,
+            key=f"file-{i}.txt",
+            summary=f"distinct-summary-{i}-end",
+        )
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+
+    result = build_program_children_content(program_lr)
+    included = sum(1 for i in range(30) if f"distinct-summary-{i}-end" in result)
+    assert included == 20
+
+
+def test_build_program_children_content_caps_total_length():
+    """Program children content is hard-capped in total size"""
+    from learning_resources.models import ContentFile, LearningResourceRun
+
+    course_lr = CourseFactory.create().learning_resource
+    run = LearningResourceRun.objects.create(
+        learning_resource=course_lr,
+        run_id="test-run",
+    )
+    for i in range(5):
+        ContentFile.objects.create(
+            run=run,
+            key=f"file-{i}.txt",
+            summary=f"summary-{i}-" + "x" * 300_000,
+        )
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+
+    result = build_program_children_content(program_lr)
+    assert len(result) <= 1_000_000
+
+
 def test_build_program_children_content_ignores_non_program_relations():
     """Only PROGRAM_COURSES and PROGRAM_PROGRAMS relations are included"""
     from learning_resources.models import LearningResourceRelationship

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -708,8 +708,8 @@ def _generate_content_file_points(serialized_content):
     The 0.9 factor leaves headroom: markdown header prefixes are prepended
     after the chunk-size split, so real chunks can exceed the nominal size.
     """
-    request_chunk_size = int(
-        300000 * 0.9 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE
+    request_chunk_size = max(
+        1, int(300000 * 0.9 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE)
     )
 
     for doc in serialized_content:

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -704,9 +704,12 @@ def _generate_content_file_points(serialized_content):
     300,000 tokens per request
     max array size: 2048
     see: https://platform.openai.com/docs/guides/rate-limits
+
+    The 0.9 factor leaves headroom: markdown header prefixes are prepended
+    after the chunk-size split, so real chunks can exceed the nominal size.
     """
     request_chunk_size = int(
-        300000 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE
+        300000 * 0.9 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE
     )
 
     for doc in serialized_content:

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -709,7 +709,11 @@ def _generate_content_file_points(serialized_content):
     after the chunk-size split, so real chunks can exceed the nominal size.
     """
     request_chunk_size = max(
-        1, int(300000 * 0.9 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE)
+        1,
+        min(
+            2048,
+            int(300000 * 0.9 / settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE),
+        ),
     )
 
     for doc in serialized_content:

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -807,6 +807,48 @@ def test_generate_content_points_leaves_headroom_under_token_limit(mocker):
     assert max(batch_sizes) * 500 <= 285000
 
 
+def test_generate_content_points_request_chunk_size_never_zero(mocker):
+    """
+    A misconfigured (huge) chunk-size override must not make request_chunk_size 0,
+    which would raise ValueError in the range() batching loop
+    """
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = 500000
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 50
+
+    mocker.patch(
+        "vector_search.utils._chunk_documents",
+        return_value=[
+            Document(page_content=f"chunk{i}", metadata={"key": "k1"}) for i in range(3)
+        ],
+    )
+    mocker.patch(
+        "vector_search.utils.should_generate_content_embeddings", return_value=True
+    )
+    mocker.patch("vector_search.utils.remove_points_matching_params")
+
+    mock_dense = mocker.MagicMock()
+    mock_dense.embed_documents.side_effect = lambda texts: [[0.1] for _ in texts]
+    mock_dense.model_short_name.return_value = "dense"
+    mock_sparse = mocker.MagicMock()
+    mock_sparse.embed_documents.side_effect = lambda texts: [[0.2] for _ in texts]
+    mock_sparse.model_short_name.return_value = "sparse"
+    mocker.patch("vector_search.utils.dense_encoder", return_value=mock_dense)
+    mocker.patch("vector_search.utils.sparse_encoder", return_value=mock_sparse)
+
+    doc = {
+        "content": "Some plain text content",
+        "file_type": "page",
+        "file_extension": ".html",
+        "platform": {"code": "x"},
+        "resource_readable_id": "r1",
+        "run_readable_id": "run1",
+        "key": "k1",
+    }
+
+    points = list(_generate_content_file_points([doc]))
+    assert len(points) == 3
+
+
 def test_course_metadata_indexed_with_learning_resources(mocker):
     # test the we embed a metadata document when embedding learning resources
     resources = LearningResourceFactory.create_batch(5)

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -754,6 +754,59 @@ def test_generate_content_points_uses_standard_chunking_for_non_markdown(mocker)
     mock_md_chunk.assert_not_called()
 
 
+def test_generate_content_points_leaves_headroom_under_token_limit(mocker):
+    """
+    Embedding request batches must leave headroom under OpenAI's 300k
+    tokens-per-request limit, since markdown header prefixes are prepended
+    after the chunk-size split and inflate chunks past the nominal size
+    """
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = 500
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 50
+
+    # 600 chunks * 500 tokens == exactly 300k if packed with no headroom
+    num_chunks = 600
+    mocker.patch(
+        "vector_search.utils._chunk_documents",
+        return_value=[
+            Document(page_content=f"chunk{i}", metadata={"key": "k1"})
+            for i in range(num_chunks)
+        ],
+    )
+    mocker.patch(
+        "vector_search.utils.should_generate_content_embeddings", return_value=True
+    )
+    mocker.patch("vector_search.utils.remove_points_matching_params")
+
+    mock_dense = mocker.MagicMock()
+    mock_dense.embed_documents.side_effect = lambda texts: [[0.1] for _ in texts]
+    mock_dense.model_short_name.return_value = "dense"
+    mock_sparse = mocker.MagicMock()
+    mock_sparse.embed_documents.side_effect = lambda texts: [[0.2] for _ in texts]
+    mock_sparse.model_short_name.return_value = "sparse"
+    mocker.patch("vector_search.utils.dense_encoder", return_value=mock_dense)
+    mocker.patch("vector_search.utils.sparse_encoder", return_value=mock_sparse)
+
+    doc = {
+        "content": "Some plain text content",
+        "file_type": "page",
+        "file_extension": ".html",
+        "platform": {"code": "x"},
+        "resource_readable_id": "r1",
+        "run_readable_id": "run1",
+        "key": "k1",
+    }
+
+    points = list(_generate_content_file_points([doc]))
+
+    batch_sizes = [
+        len(call.args[0]) for call in mock_dense.embed_documents.call_args_list
+    ]
+    assert sum(batch_sizes) == num_chunks
+    assert len(points) == num_chunks
+    # nominal tokens per request must stay at least ~5% under the 300k limit
+    assert max(batch_sizes) * 500 <= 285000
+
+
 def test_course_metadata_indexed_with_learning_resources(mocker):
     # test the we embed a metadata document when embedding learning resources
     resources = LearningResourceFactory.create_batch(5)


### PR DESCRIPTION
### What are the relevant tickets?

Refs mitodl/hq#12117

### Description (What does it do?)

Program marketing-page content files were ballooning to multi-MB (23MB for `UAI+B2C.1` in production) because they concatenated the LLM summaries of every content file in every child-course run. When embedded, a fully packed request overflowed OpenAI's 300k tokens/request limit (`max_tokens_per_request`), failing that chunk. The `generate_embeddings` chunk swallows the error, so it surfaced only as recurring `finalize_embeddings` `RuntimeError: 1 embedding chunk(s) failed` in leek.

Changes:

- **Headroom in the embedding request batch size** (`vector_search/utils.py`): request batches now target 90% of the 300k limit, since markdown header prefixes are prepended *after* the chunk-size split and inflate chunks past the nominal size. Guarded with `max(1, …)` so a misconfigured chunk-size override can't produce a zero-step batching loop.
- **Rework program children content** (`learning_resources/utils.py`): a program's children content is now assembled from the **marketing-page content files of its published child courses** (direct, and reached through child programs), each under a light `### {course title}` heading — instead of a capped subset of child-course run content-file summaries. Each course contributes only its single scraped marketing page, so the program page stays a sensible embedding input by construction. A 1M-char total cap remains as a backstop.

### How can this be tested?

1. Make sure you have  contentfiles for this program's courses:
   ```python
     from learning_resources.utils import build_program_children_content
     from learning_resources.models import *
     lr = LearningResource.objects.get(readable_id="program-v1:MITxT+18.01x")
     print(lr.id)
     print(lr.resources.values_list("id", flat=True))
   ```
   
   `./manage.py backpopulate_mitxonline_files --resource-ids <list of ids>`

2. **Children content is built from child-course marketing pages.**  In a shell, generate marketing pages for the programs and courses:
   ```python
   from learning_resources.tasks import marketing_page_for_resources
   from learning_resources.utils import build_program_children_content
   from learning_resources.models import LearningResource
   
   for lr in LearningResource.objects.filter(id__in=[program + course ids]):
       lr.url = lr.url.replace("http://open.odl.local:8062", "https://learn.mit.edu")
       lr.save()   
   
   marketing_page_for_resources([program + course ids])
   lr =  LearningResource.objects.get(readable_id="program-v1:MITxT+18.01x")
   content = build_program_children_content(lr)
   ```
   Confirm the output contains a `### {course title}` section per published child course carrying that course's marketing-page text, that courses without a marketing page are absent, and `len(content) <= 1_000_000`.


4. **Embedding of a previously-failing program page succeeds.** After the re-scrape, embed it:
   ```python
   from vector_search.tasks import *
   cf = ContentFile.objects.get(learning_resource=lr, file_type="marketing_page")
   generate_embeddings.delay([cf.id], "content_file", overwrite=True)
   ```
   Confirm the task succeeds

5. **No more finalize failures.** Trigger a finalized chain covering that file (`embed_run_content_files.delay(lr.best)_run.id)`, or wait for `embed_new_content_files`) and verify it completes successfully
