### PR TITLE
desktop dashboard design updates

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -334,16 +334,14 @@ describe("ContractContent", () => {
     expect(completedCard).toBeDefined()
     expect(enrolledCard).toBeDefined()
 
-    // Check enrollment status indicators
-    const completedIndicator = within(completedCard!).getByTestId(
-      "enrollment-status",
-    )
-    const enrolledIndicator = within(enrolledCard!).getByTestId(
-      "enrollment-status",
-    )
+    // Check progress badges (the enrollment-status icon is reserved for
+    // compact program module rows; contract cards convey status via the
+    // ProgressBadge next to the card type label instead)
+    const completedBadge = within(completedCard!).getByTestId("progress-badge")
+    const enrolledBadge = within(enrolledCard!).getByTestId("progress-badge")
 
-    expect(completedIndicator).toHaveTextContent(/^Completed$/)
-    expect(enrolledIndicator).toHaveTextContent(/^Enrolled$/)
+    expect(completedBadge).toHaveTextContent(/^Completed$/)
+    expect(enrolledBadge).toHaveTextContent(/^In Progress$/)
   })
 
   test("Renders program collections", async () => {
@@ -1271,15 +1269,17 @@ describe("ContractContent", () => {
     ).findAllByTestId("enrollment-card-desktop")
 
     expect(cards.length).toBe(3)
-    // First card should show enrolled status
-    const cardStatus0 = within(cards[0]).getByTestId("enrollment-status")
+    // Progress badges (the enrollment-status icon is reserved for compact
+    // program module rows; contract cards convey status via the
+    // ProgressBadge next to the card type label instead)
+    const cardStatus0 = within(cards[0]).getByTestId("progress-badge")
     expect(cardStatus0).toHaveTextContent(/^Completed$/)
 
-    const cardStatus1 = within(cards[1]).getByTestId("enrollment-status")
-    expect(cardStatus1).toHaveTextContent(/^Enrolled$/)
+    const cardStatus1 = within(cards[1]).getByTestId("progress-badge")
+    expect(cardStatus1).toHaveTextContent(/^In Progress$/)
 
-    const cardStatus2 = within(cards[2]).getByTestId("enrollment-status")
-    expect(cardStatus2).toHaveTextContent(/^Not Enrolled$/)
+    const cardStatus2 = within(cards[2]).getByTestId("progress-badge")
+    expect(cardStatus2).toHaveTextContent(/^Not Started$/)
   })
 
   test("shows the not found screen if the organization is not found by orgSlug", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -64,18 +64,21 @@ const CardRoot = styled.div<{
 ])
 
 const CardTypeText = styled(Typography)(({ theme }) => ({
-  ...theme.typography.subtitle4,
+  ...theme.typography.body3,
   color: theme.custom.colors.silverGrayDark,
 }))
 
 const TitleHeading = styled.h3(({ theme }) => ({
   margin: 0,
+  ...theme.typography.subtitle2,
   [theme.breakpoints.down("md")]: {
     maxWidth: "calc(100% - 16px)",
   },
 }))
 
-const TitleLink = styled(Link)()
+const TitleLink = styled(Link)(({ theme }) => ({
+  ...theme.typography.subtitle2,
+}))
 
 const TitleText = styled.h3<{ clickable?: boolean }>(
   ({ theme, clickable }) => ({
@@ -89,41 +92,29 @@ const TitleText = styled.h3<{ clickable?: boolean }>(
   }),
 )
 
-const SubtitleLinkRoot = styled.div<{ layout?: "default" | "compact" }>(
-  ({ theme, layout = "default" }) => ({
-    display: "flex",
-    alignItems: "center",
-    gap: "8px",
-    flex: 1,
-    color:
-      layout === "compact"
-        ? theme.custom.colors.silverGrayDark
-        : theme.custom.colors.darkGray2,
-    ...theme.typography.subtitle3,
-  }),
-)
+const SubtitleLinkRoot = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  flex: 1,
+  color: theme.custom.colors.red,
+  ...theme.typography.body3,
+}))
 
-const SubtitleLink = styled(NextLink)<{ layout?: "default" | "compact" }>(
-  ({ theme, layout = "default" }) => ({
-    ...theme.typography.subtitle3,
-    color:
-      layout === "compact"
-        ? theme.custom.colors.silverGrayDark
-        : theme.custom.colors.mitRed,
-    display: "flex",
-    alignItems: "center",
-    gap: "4px",
-    ":hover": {
-      textDecoration: "underline",
-    },
-  }),
-)
+const SubtitleLink = styled(NextLink)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.red,
+  display: "flex",
+  alignItems: "center",
+  gap: "2px",
+  ":hover": {
+    textDecoration: "underline",
+  },
+}))
 
 const MenuButton = styled(ActionButton)<{
   status: EnrollmentStatus
 }>(({ theme, status }) => [
   {
-    marginLeft: "-8px",
     [theme.breakpoints.down("md")]: {
       position: "absolute",
       top: "0",
@@ -170,6 +161,14 @@ const Separator = styled.span(({ theme }) => ({
   backgroundColor: theme.custom.colors.silverGrayLight,
 }))
 
+const Ellipse = styled.span(({ theme }) => ({
+  display: "inline-block",
+  width: "4px",
+  height: "4px",
+  borderRadius: "50%",
+  backgroundColor: theme.custom.colors.silverGrayLight,
+}))
+
 const DateText = styled(Typography)(({ theme }) => ({
   ...theme.typography.subtitle3,
   color: theme.custom.colors.silverGrayDark,
@@ -190,7 +189,7 @@ const UpgradedBannerRoot = styled.div(({ theme }) => ({
   alignItems: "center",
   gap: "4px",
   color: theme.custom.colors.silverGrayDark,
-  ...theme.typography.subtitle3,
+  ...theme.typography.body3,
 }))
 
 const UpgradedBanner: React.FC<{ className?: string }> = ({ className }) => (
@@ -212,7 +211,7 @@ const DatePopoverContent = styled.div({
 
 const DatePopoverTrigger = styled("button")<{ $upcoming: boolean }>(
   ({ theme, $upcoming }) => ({
-    ...theme.typography.body2,
+    ...theme.typography.subtitle3,
     color: $upcoming
       ? theme.custom.colors.red
       : theme.custom.colors.silverGrayDark,
@@ -332,6 +331,7 @@ export {
   CoursewareButton,
   CoursewareButtonLink,
   Separator,
+  Ellipse,
   DateText,
   CourseDateText,
   CourseDateSummary,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -42,6 +42,8 @@ type CourseDisplayProps = {
   layout?: "default" | "compact"
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
   onUpgradeError?: (error: string) => void
+  /** Display "Module" instead of "Course" as the card type label. */
+  isModule?: boolean
 }
 
 /** A course row from a program/contract dashboard (full entry available). */
@@ -91,7 +93,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
     )
   }
 
-  const { layout, headingLevel, onUpgradeError } = props
+  const { layout, headingLevel, onUpgradeError, isModule } = props
 
   if (props.kind === "enrollment") {
     return (
@@ -101,6 +103,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
         layout={layout}
         headingLevel={headingLevel}
         onUpgradeError={onUpgradeError}
+        isModule={isModule}
         Component={Component}
         className={className}
       />
@@ -120,6 +123,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
       layout={layout}
       headingLevel={headingLevel}
       onUpgradeError={onUpgradeError}
+      isModule={isModule}
       Component={Component}
       className={className}
     />
@@ -131,6 +135,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
       ancestorContext={entry.ancestorContext}
       layout={layout}
       headingLevel={headingLevel}
+      isModule={isModule}
       Component={Component}
       className={className}
     />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -808,3 +808,42 @@ describe("EnrolledCourseCard — multiple enrollment runs", () => {
     expect(screen.getAllByText("Course runs (5)").length).toBeGreaterThan(0)
   })
 })
+
+describe("EnrolledCourseCard card type label", () => {
+  setupLocationMock()
+
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  test("shows 'Course' for a non-B2B enrollment", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      b2b_contract_id: null,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(within(getDesktopCard()).getByText("Course")).toBeInTheDocument()
+    expect(
+      within(getDesktopCard()).queryByText("Module"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("shows 'Module' for a B2B enrollment", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      b2b_contract_id: faker.number.int(),
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+    expect(
+      within(getDesktopCard()).queryByText("Course"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("shows 'Module' when isModule is set", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      b2b_contract_id: null,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} isModule />)
+    expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -245,77 +245,6 @@ describe.each([
   })
 
   // ---------------------------------------------------------------------------
-  // Enrollment status indicator
-  // ---------------------------------------------------------------------------
-
-  test.each([
-    {
-      enrollmentData: {
-        grades: [],
-        certificate: null,
-        b2b_contract_id: faker.number.int(), // B2B so showNotComplete=true
-      },
-      expectedLabel: "Enrolled",
-    },
-    {
-      enrollmentData: {
-        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
-        certificate: {
-          uuid: faker.string.uuid(),
-          link: faker.internet.url(),
-        },
-        b2b_contract_id: null,
-      },
-      expectedLabel: "Completed",
-    },
-    {
-      enrollmentData: {
-        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
-        certificate: null,
-        b2b_contract_id: faker.number.int(), // B2B so indicator is visible
-      },
-      expectedLabel: "Completed",
-    },
-  ])(
-    "Enrollment status indicator shows '$expectedLabel'",
-    ({ enrollmentData, expectedLabel }) => {
-      setupUserApis()
-      const enrollment =
-        mitxonline.factories.enrollment.courseEnrollment(enrollmentData)
-      renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
-      expect(
-        within(getCard()).getByTestId("enrollment-status"),
-      ).toHaveTextContent(expectedLabel)
-    },
-  )
-
-  test("showNotComplete: status indicator visible for enrolled (not completed) B2B enrollment", () => {
-    setupUserApis()
-    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
-      grades: [],
-      certificate: null,
-      b2b_contract_id: faker.number.int(),
-    })
-    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
-    expect(
-      within(getCard()).getByTestId("enrollment-status"),
-    ).toBeInTheDocument()
-  })
-
-  test("showNotComplete: status indicator hidden for enrolled (not completed) non-B2B enrollment", () => {
-    setupUserApis()
-    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
-      grades: [],
-      certificate: null,
-      b2b_contract_id: null,
-    })
-    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
-    expect(
-      within(getCard()).queryByTestId("enrollment-status"),
-    ).not.toBeInTheDocument()
-  })
-
-  // ---------------------------------------------------------------------------
   // Upgrade banner
   // ---------------------------------------------------------------------------
 
@@ -584,7 +513,7 @@ describe.each([
     )
   })
 
-  test("Does not show 'Certificate track' when verified enrollment has a certificate", () => {
+  test("Shows 'Certificate track' alongside 'View Certificate' when verified enrollment has a certificate", () => {
     setupUserApis()
     const certUuid = faker.string.uuid()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
@@ -593,9 +522,9 @@ describe.each([
       run: currentRunDates,
     })
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
-    expect(
-      within(getCard()).queryByTestId("upgraded-banner"),
-    ).not.toBeInTheDocument()
+    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
+      "Certificate track",
+    )
     expect(
       within(getCard()).getByRole("link", { name: /View Certificate/ }),
     ).toBeInTheDocument()
@@ -809,6 +738,78 @@ describe("EnrolledCourseCard — multiple enrollment runs", () => {
   })
 })
 
+// The enrollment status icon only renders for compact program module rows
+// (i.e. within ProgramAsCourseCard), and even then only for non-B2B
+// enrollments. Every other card conveys progress via the ProgressBadge shown
+// next to the card type label instead.
+describe("EnrolledCourseCard enrollment status icon (module rows)", () => {
+  setupLocationMock()
+
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  test.each([
+    {
+      enrollmentData: { grades: [], certificate: null },
+      expectedLabel: "Enrolled",
+    },
+    {
+      enrollmentData: {
+        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
+        certificate: {
+          uuid: faker.string.uuid(),
+          link: faker.internet.url(),
+        },
+      },
+      expectedLabel: "Completed",
+    },
+  ])(
+    "Module row shows '$expectedLabel' status icon",
+    ({ enrollmentData, expectedLabel }) => {
+      setupUserApis()
+      const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+        ...enrollmentData,
+        b2b_contract_id: null,
+      })
+      renderWithProviders(
+        <EnrolledCourseCard
+          enrollment={enrollment}
+          isModule
+          layout="compact"
+        />,
+      )
+      expect(
+        within(getDesktopCard()).getByTestId("enrollment-status"),
+      ).toHaveTextContent(expectedLabel)
+    },
+  )
+
+  test("hidden for B2B module rows", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      grades: [],
+      certificate: null,
+      b2b_contract_id: faker.number.int(),
+    })
+    renderWithProviders(
+      <EnrolledCourseCard enrollment={enrollment} isModule layout="compact" />,
+    )
+    expect(
+      within(getDesktopCard()).queryByTestId("enrollment-status"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("hidden for non-module cards", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      b2b_contract_id: null,
+    })
+    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+    expect(
+      within(getDesktopCard()).queryByTestId("enrollment-status"),
+    ).not.toBeInTheDocument()
+  })
+})
+
 describe("EnrolledCourseCard card type label", () => {
   setupLocationMock()
 
@@ -838,12 +839,70 @@ describe("EnrolledCourseCard card type label", () => {
     ).not.toBeInTheDocument()
   })
 
-  test("shows 'Module' when isModule is set", () => {
+  test("shows enrollment status indicator instead of 'Module' text when isModule is set (compact layout)", () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      b2b_contract_id: null,
+      grades: [],
+      certificate: null,
+    })
+    renderWithProviders(
+      <EnrolledCourseCard enrollment={enrollment} isModule layout="compact" />,
+    )
+    expect(
+      within(getDesktopCard()).getByTestId("enrollment-status"),
+    ).toBeInTheDocument()
+    expect(
+      within(getDesktopCard()).queryByText("Module"),
+    ).not.toBeInTheDocument()
+  })
+})
+
+describe("EnrolledCourseCard progress badge", () => {
+  setupLocationMock()
+
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  test.each([
+    {
+      enrollmentData: { grades: [], certificate: null },
+      expectedLabel: "In Progress",
+    },
+    {
+      enrollmentData: {
+        grades: [mitxonline.factories.enrollment.grade({ passed: true })],
+        certificate: {
+          uuid: faker.string.uuid(),
+          link: faker.internet.url(),
+        },
+      },
+      expectedLabel: "Completed",
+    },
+  ])(
+    "shows '$expectedLabel' next to the card type label",
+    ({ enrollmentData, expectedLabel }) => {
+      setupUserApis()
+      const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+        ...enrollmentData,
+        b2b_contract_id: null,
+      })
+      renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
+      expect(
+        within(getDesktopCard()).getByTestId("progress-badge"),
+      ).toHaveTextContent(expectedLabel)
+    },
+  )
+
+  test("hidden on compact module rows, where the status icon takes over", () => {
     setupUserApis()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
       b2b_contract_id: null,
     })
-    renderWithProviders(<EnrolledCourseCard enrollment={enrollment} isModule />)
-    expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+    renderWithProviders(
+      <EnrolledCourseCard enrollment={enrollment} isModule layout="compact" />,
+    )
+    expect(
+      within(getDesktopCard()).queryByTestId("progress-badge"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -8,6 +8,7 @@ import {
   CoursewareButtonLink,
   MenuButton,
   Separator,
+  Ellipse,
   SubtitleLink,
   SubtitleLinkRoot,
   TitleHeading,
@@ -42,12 +43,27 @@ const formatUpgradeTime = (daysFloat: number) => {
   if (daysFloat < 0) return ""
   const days = Math.floor(daysFloat)
   if (days > 1) {
-    return ` · ${days} days remaining`
+    return `${days} days remaining`
   } else if (days === 1) {
-    return ` · ${days} day remaining`
+    return `${days} day remaining`
   }
-  return " · Less than a day remaining"
+  return "Less than a day remaining"
 }
+
+const RedEllipse = styled(Ellipse)(({ theme }) => ({
+  marginLeft: "6px",
+  marginRight: "6px",
+  backgroundColor: theme.custom.colors.red,
+}))
+
+const EnrolledTitleLink = styled(TitleLink)<{
+  enrollmentstatus: EnrollmentStatus
+}>(({ enrollmentstatus, theme }) => ({
+  color:
+    enrollmentstatus === EnrollmentStatus.Completed
+      ? theme.custom.colors.silverGrayDark
+      : theme.custom.colors.black,
+}))
 
 const UpgradeBanner: React.FC<
   {
@@ -56,7 +72,6 @@ const UpgradeBanner: React.FC<
     certificateUpgradePrice?: string | null
     productId?: number | null
     onError?: (error: Error) => void
-    layout?: "default" | "compact"
   } & React.HTMLAttributes<HTMLDivElement>
 > = ({
   canUpgrade,
@@ -64,7 +79,6 @@ const UpgradeBanner: React.FC<
   certificateUpgradePrice,
   productId,
   onError,
-  layout = "default",
   ...others
 }) => {
   const replaceBasketItem = useReplaceBasketItem()
@@ -95,16 +109,19 @@ const UpgradeBanner: React.FC<
     : null
 
   return (
-    <SubtitleLinkRoot layout={layout} {...others}>
-      <SubtitleLink layout={layout} href="#" onClick={handleUpgradeClick}>
+    <SubtitleLinkRoot {...others}>
+      <SubtitleLink href="#" onClick={handleUpgradeClick}>
         <RiArrowUpCircleLine size="16px" />
         {`Upgrade for certificate - ${formattedPrice}`}
       </SubtitleLink>
       {calendarDays !== null && (
-        <NoSSR>
-          {/* This uses local time. */}
-          {formatUpgradeTime(calendarDays)}
-        </NoSSR>
+        <>
+          <RedEllipse />
+          <NoSSR>
+            {/* This uses local time. */}
+            {formatUpgradeTime(calendarDays)}
+          </NoSSR>
+        </>
       )}
     </SubtitleLinkRoot>
   )
@@ -169,11 +186,16 @@ export const EnrolledCourseCard = ({
 }: EnrolledCourseCardProps) => {
   const course = enrollment.run.course
   const run = enrollment.run
+  const isCompact = layout === "compact"
   const isContractPageResource = Boolean(enrollment.b2b_contract_id)
-  const cardTypeLabel = isModule || isContractPageResource ? "Module" : "Course"
+  const cardTypeLabelText =
+    isModule || isContractPageResource ? "Module" : "Course"
+  const cardTypeLabel =
+    !isModule && !isCompact ? (
+      <CardTypeText>{cardTypeLabelText}</CardTypeText>
+    ) : null
   const mitxOnlineUser = useQuery(mitxUserQueries.me())
   const isStaff = mitxOnlineUser.data?.is_staff
-  const isCompact = layout === "compact"
   const title = isCompact ? course.title : run?.title || course.title
   const coursewareUrl = run?.courseware_url
   const certificateLink = getCertificateLink(
@@ -207,19 +229,21 @@ export const EnrolledCourseCard = ({
   })
   const upgradedAndIncomplete =
     !isContractPageResource && isVerifiedEnrollmentMode(enrollmentMode)
-  const certStatus = certificateLink ? (
-    <SubtitleLink href={certificateLink} layout={layout}>
-      <RiAwardLine size="16px" />
-      {isCompact ? "Certificate" : "View Certificate"}
-    </SubtitleLink>
-  ) : showUpgradeBanner ? (
+  const certButton = certificateLink ? (
+    <>
+      <SubtitleLink href={certificateLink}>
+        <RiAwardLine size="16px" />
+        {isCompact ? "Certificate" : "View Certificate"}
+      </SubtitleLink>
+    </>
+  ) : null
+  const certStatus = showUpgradeBanner ? (
     <UpgradeBanner
       data-testid="upgrade-root"
       canUpgrade={showUpgradeBanner}
       certificateUpgradeDeadline={run?.upgrade_deadline}
       certificateUpgradePrice={run?.upgrade_product_price}
       productId={run?.upgrade_product_id}
-      layout={layout}
       onError={() => {
         onUpgradeError?.(
           "There was a problem adding the certificate to your cart.",
@@ -235,12 +259,12 @@ export const EnrolledCourseCard = ({
     certStatus,
   ].filter(Boolean)
 
-  const endDateAndCertSection =
+  const endDateAndUpgradeSection =
     metaSegments.length > 0 ? (
-      <Stack direction="row" alignItems="center">
+      <Stack direction="row" alignItems="center" gap="12px">
         {metaSegments.map((segment, i) => (
           <React.Fragment key={i}>
-            {i > 0 && <Separator />}
+            {i > 0 && <Ellipse />}
             {segment}
           </React.Fragment>
         ))}
@@ -250,14 +274,19 @@ export const EnrolledCourseCard = ({
     <Stack gap="6px">
       {coursewareUrl ? (
         <TitleHeading as={headingLevel}>
-          <TitleLink size="medium" color="black" href={coursewareUrl}>
+          <EnrolledTitleLink
+            size="medium"
+            color="black"
+            href={coursewareUrl}
+            enrollmentstatus={enrollmentStatus}
+          >
             {title}
-          </TitleLink>
+          </EnrolledTitleLink>
         </TitleHeading>
       ) : (
         <TitleText as={headingLevel}>{title}</TitleText>
       )}
-      {isCompact ? null : endDateAndCertSection}
+      {endDateAndUpgradeSection}
     </Stack>
   )
   // Determine if button should be disabled
@@ -315,19 +344,20 @@ export const EnrolledCourseCard = ({
     </ButtonLink>
   )
   const buttonSection = isCompact ? (
-    <Stack direction="row" alignItems="center">
-      {endDateAndCertSection}
-      {endDateAndCertSection && <Separator />}
+    <Stack direction="row" gap="8px" alignItems="center">
+      {certButton && (
+        <>
+          {certButton}
+          <Separator />
+        </>
+      )}
       <CoursewareActionColumn direction="row" justifyContent="center">
         {ctaButton}
       </CoursewareActionColumn>
     </Stack>
   ) : (
     <>
-      <EnrollmentStatusIndicator
-        status={enrollmentStatus}
-        showNotComplete={Boolean(isContractPageResource)}
-      />
+      {certButton}
       {ctaButton}
     </>
   )
@@ -401,8 +431,19 @@ export const EnrolledCourseCard = ({
           as={Component}
         >
           <CardHeaderContent>
-            <Stack justifyContent="start" alignItems="stretch" flex={1}>
-              <CardTypeText>{cardTypeLabel}</CardTypeText>
+            <Stack>
+              <EnrollmentStatusIndicator
+                status={enrollmentStatus}
+                showNotComplete={Boolean(isContractPageResource)}
+              />
+            </Stack>
+            <Stack
+              gap="4px"
+              justifyContent="start"
+              alignItems="stretch"
+              flex={1}
+            >
+              {cardTypeLabel}
               {titleSection}
             </Stack>
             <Stack direction="row" gap="8px" alignItems="center">
@@ -423,8 +464,16 @@ export const EnrolledCourseCard = ({
           className={className}
           layout={layout}
         >
-          <Stack justifyContent="start" alignItems="stretch" flex={1}>
-            <CardTypeText>{cardTypeLabel}</CardTypeText>
+          {isModule && isCompact && (
+            <Stack alignSelf="start">
+              <EnrollmentStatusIndicator
+                status={enrollmentStatus}
+                showNotComplete={true}
+              />
+            </Stack>
+          )}
+          <Stack gap="4px" justifyContent="start" alignItems="stretch" flex={1}>
+            {cardTypeLabel}
             {titleSection}
           </Stack>
           <Stack direction="row" gap="8px" alignItems="center">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -29,7 +29,7 @@ import { RiArrowUpCircleLine, RiAwardLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
 import { SiblingRunsAccordion } from "./SiblingRunsAccordion"
-import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
+import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
 import { Button, ButtonLink } from "@mitodl/smoot-design"
@@ -38,6 +38,7 @@ import NiceModal from "@ebay/nice-modal-react"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
 import { getReceiptMenuItem } from "./receiptMenuItem"
 import { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
+import { ProgressBadge } from "./ProgressBadge"
 
 const formatUpgradeTime = (daysFloat: number) => {
   if (daysFloat < 0) return ""
@@ -419,7 +420,18 @@ export const EnrolledCourseCard = ({
     />
   )
 
+  const progressBadgeSection =
+    isModule && isCompact ? null : (
+      <Stack direction="row" gap="4px" alignItems="center">
+        <ProgressBadge enrollmentStatus={enrollmentStatus} />
+        <Separator />
+        {cardTypeLabel}
+      </Stack>
+    )
+
   const hasMultipleRuns = (siblingEnrollments?.length ?? 0) > 0
+  const showEnrollmentStatusIcon =
+    !isContractPageResource && isModule && isCompact
 
   return (
     <>
@@ -431,19 +443,18 @@ export const EnrolledCourseCard = ({
           as={Component}
         >
           <CardHeaderContent>
-            <Stack>
-              <EnrollmentStatusIndicator
-                status={enrollmentStatus}
-                showNotComplete={Boolean(isContractPageResource)}
-              />
-            </Stack>
+            {showEnrollmentStatusIcon && (
+              <Stack>
+                <EnrollmentStatusIcon status={enrollmentStatus} />
+              </Stack>
+            )}
             <Stack
               gap="4px"
               justifyContent="start"
               alignItems="stretch"
               flex={1}
             >
-              {cardTypeLabel}
+              {progressBadgeSection}
               {titleSection}
             </Stack>
             <Stack direction="row" gap="8px" alignItems="center">
@@ -464,16 +475,13 @@ export const EnrolledCourseCard = ({
           className={className}
           layout={layout}
         >
-          {isModule && isCompact && (
+          {showEnrollmentStatusIcon && (
             <Stack alignSelf="start">
-              <EnrollmentStatusIndicator
-                status={enrollmentStatus}
-                showNotComplete={true}
-              />
+              <EnrollmentStatusIcon status={enrollmentStatus} />
             </Stack>
           )}
           <Stack gap="4px" justifyContent="start" alignItems="stretch" flex={1}>
-            {cardTypeLabel}
+            {progressBadgeSection}
             {titleSection}
           </Stack>
           <Stack direction="row" gap="8px" alignItems="center">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -152,6 +152,7 @@ type EnrolledCourseCardProps = {
   layout?: "default" | "compact"
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
   onUpgradeError?: (error: string) => void
+  isModule?: boolean
   Component?: React.ElementType
   className?: string
 }
@@ -162,12 +163,14 @@ export const EnrolledCourseCard = ({
   layout = "default",
   headingLevel,
   onUpgradeError,
+  isModule,
   Component,
   className,
 }: EnrolledCourseCardProps) => {
   const course = enrollment.run.course
   const run = enrollment.run
   const isContractPageResource = Boolean(enrollment.b2b_contract_id)
+  const cardTypeLabel = isModule || isContractPageResource ? "Module" : "Course"
   const mitxOnlineUser = useQuery(mitxUserQueries.me())
   const isStaff = mitxOnlineUser.data?.is_staff
   const isCompact = layout === "compact"
@@ -399,7 +402,7 @@ export const EnrolledCourseCard = ({
         >
           <CardHeaderContent>
             <Stack justifyContent="start" alignItems="stretch" flex={1}>
-              <CardTypeText>Course</CardTypeText>
+              <CardTypeText>{cardTypeLabel}</CardTypeText>
               {titleSection}
             </Stack>
             <Stack direction="row" gap="8px" alignItems="center">
@@ -421,7 +424,7 @@ export const EnrolledCourseCard = ({
           layout={layout}
         >
           <Stack justifyContent="start" alignItems="stretch" flex={1}>
-            <CardTypeText>Course</CardTypeText>
+            <CardTypeText>{cardTypeLabel}</CardTypeText>
             {titleSection}
           </Stack>
           <Stack direction="row" gap="8px" alignItems="center">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatus.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatus.tsx
@@ -34,13 +34,11 @@ const Ring = styled.div(({ theme }) => ({
   },
 }))
 
-type EnrollmentStatusIndicatorProps = {
+type EnrollmentStatusIconProps = {
   status: EnrollmentStatus
-  showNotComplete?: boolean
 }
-const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
+const EnrollmentStatusIcon: React.FC<EnrollmentStatusIconProps> = ({
   status,
-  showNotComplete,
 }) => {
   if (status === EnrollmentStatus.Completed) {
     return (
@@ -50,7 +48,6 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
       </span>
     )
   }
-  if (!showNotComplete) return
 
   if (status === EnrollmentStatus.Enrolled) {
     return (
@@ -68,5 +65,5 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
   )
 }
 
-export { EnrollmentStatusIndicator }
-export type { EnrollmentStatusIndicatorProps }
+export { EnrollmentStatusIcon }
+export type { EnrollmentStatusIconProps }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatusIndicator.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrollmentStatusIndicator.tsx
@@ -1,16 +1,24 @@
 import React from "react"
-import Image from "next/image"
 import { styled } from "ol-components"
 import { VisuallyHidden } from "@mitodl/smoot-design"
-import CourseComplete from "@/public/images/icons/course-complete.svg"
-import CourseInProgress from "@/public/images/icons/course-in-progress.svg"
-import CourseUnenrolled from "@/public/images/icons/course-unenrolled.svg"
 import { EnrollmentStatus } from "./helpers"
+import {
+  RiCheckboxBlankCircleFill,
+  RiCheckboxCircleFill,
+} from "@remixicon/react"
 
-const CompletedImage = styled(Image)({
+const CompleteIcon = styled(RiCheckboxCircleFill)(({ theme }) => ({
+  color: theme.custom.colors.red,
   width: "16px",
   height: "16px",
-})
+}))
+
+const InProgressIcon = styled(RiCheckboxBlankCircleFill)(({ theme }) => ({
+  color: theme.custom.colors.red,
+  width: "16px",
+  height: "16px",
+}))
+
 const Ring = styled.div(({ theme }) => ({
   width: "16px",
   height: "16px",
@@ -37,12 +45,7 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
   if (status === EnrollmentStatus.Completed) {
     return (
       <span data-testid="enrollment-status">
-        <CompletedImage
-          src={CourseComplete}
-          alt=""
-          // use VisuallyHidden text for consistency with the non-image case.
-          aria-hidden
-        />
+        <CompleteIcon aria-hidden />
         <VisuallyHidden>Completed</VisuallyHidden>
       </span>
     )
@@ -52,12 +55,7 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
   if (status === EnrollmentStatus.Enrolled) {
     return (
       <Ring data-testid="enrollment-status">
-        <Image
-          src={CourseInProgress}
-          alt=""
-          // use VisuallyHidden text for consistency with the non-image case.
-          aria-hidden
-        />
+        <InProgressIcon aria-hidden />
         <VisuallyHidden>Enrolled</VisuallyHidden>
       </Ring>
     )
@@ -65,12 +63,6 @@ const EnrollmentStatusIndicator: React.FC<EnrollmentStatusIndicatorProps> = ({
 
   return (
     <Ring data-testid="enrollment-status">
-      <Image
-        src={CourseUnenrolled}
-        alt=""
-        // use VisuallyHidden text for consistency with the non-image case.
-        aria-hidden
-      />
       <VisuallyHidden>Not Enrolled</VisuallyHidden>
     </Ring>
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -122,7 +122,7 @@ describe("ProgramAsCourseCard", () => {
     ).toBeGreaterThan(0)
   })
 
-  test("module rows show 'Module' as the card type label", async () => {
+  test("module rows show an enrollment status indicator instead of a 'Module' label", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
 
     renderWithProviders(
@@ -138,9 +138,86 @@ describe("ProgramAsCourseCard", () => {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    // One label per module row (desktop card only)
-    expect(screen.getAllByText("Module")).toHaveLength(2)
-    expect(screen.queryByText("Course")).not.toBeInTheDocument()
+    // One status indicator per module row (desktop card only), replacing the type label
+    expect(screen.getAllByTestId("enrollment-status")).toHaveLength(2)
+    expect(screen.queryByText("Module")).not.toBeInTheDocument()
+    // The outer program-as-course card still shows its own 'Course' type label
+    // next to a progress badge; only the per-module rows omit it.
+    expect(screen.getByText("Course")).toBeInTheDocument()
+  })
+
+  test("progress badge reflects program enrollment status ('In Progress')", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    const programEnrollmentWithoutCert = {
+      ...cardData.courseProgramEnrollment,
+      certificate: null,
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollmentWithoutCert}
+      />,
+    )
+
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
+    expect(screen.getByTestId("progress-badge")).toHaveTextContent(
+      "In Progress",
+    )
+  })
+
+  test("progress badge reflects program enrollment status ('Not Started')", async () => {
+    const cardData = setupCardData()
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={{}}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
+    expect(screen.getByTestId("progress-badge")).toHaveTextContent(
+      "Not Started",
+    )
+  })
+
+  test("progress badge reflects program enrollment status ('Completed')", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+    invariant(cardData.courseProgramEnrollment)
+    const programEnrollmentWithCert = {
+      ...cardData.courseProgramEnrollment,
+      certificate: {
+        uuid: "test-certificate-uuid-456",
+        link: "/certificate/test-certificate-uuid-456/",
+      },
+    }
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={programEnrollmentWithCert}
+      />,
+    )
+
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
+    expect(screen.getByTestId("progress-badge")).toHaveTextContent("Completed")
   })
 
   test("renders when user is not enrolled in the ProgramAsCourse", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -122,6 +122,27 @@ describe("ProgramAsCourseCard", () => {
     ).toBeGreaterThan(0)
   })
 
+  test("module rows show 'Module' as the card type label", async () => {
+    const cardData = setupCardData({ includeProgramEnrollment: true })
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
+    // One label per module row (desktop card only)
+    expect(screen.getAllByText("Module")).toHaveLength(2)
+    expect(screen.queryByText("Course")).not.toBeInTheDocument()
+  })
+
   test("renders when user is not enrolled in the ProgramAsCourse", async () => {
     const cardData = setupCardData()
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -1,5 +1,11 @@
 import React from "react"
-import { SimpleMenu, SimpleMenuItem, Typography, styled } from "ol-components"
+import {
+  SimpleMenu,
+  SimpleMenuItem,
+  Stack,
+  Typography,
+  styled,
+} from "ol-components"
 import {
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
@@ -345,7 +351,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
             {courseProgram?.title}
           </Typography>
         </ProgramCardHeaderInner>
-        <>
+        <Stack direction="row" gap="0">
           {programCertificateUrl ? (
             <ProgramCertificateButton
               variant="bordered"
@@ -359,7 +365,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
             <UpgradedBanner />
           ) : null}
           {contextMenu}
-        </>
+        </Stack>
       </ProgramCardHeaderOuter>
       <ProgramCardSubHeader>
         <ProgramCardSubHeaderText variant="subtitle3">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -22,7 +22,12 @@ import {
 } from "./helpers"
 import { ProgressBadge } from "./ProgressBadge"
 import { CoursewareCard } from "./CoursewareCard"
-import { CourseDateSummary, UpgradedBanner } from "./CardShared"
+import {
+  CardTypeText,
+  CourseDateSummary,
+  Separator,
+  UpgradedBanner,
+} from "./CardShared"
 import {
   getCertificateLink,
   buildCourseEntry,
@@ -332,6 +337,14 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     />
   )
 
+  const progressBadgeSection = (
+    <Stack direction="row" gap="4px" alignItems="center">
+      <ProgressBadge enrollmentStatus={programEnrollmentStatus} />
+      <Separator />
+      <CardTypeText>Course</CardTypeText>
+    </Stack>
+  )
+
   return (
     <ProgramCardRoot
       as={Component}
@@ -341,7 +354,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
       <ProgramCardHeaderOuter>
         <ProgramCardHeaderInner>
           <StatusContainer>
-            <ProgressBadge enrollmentStatus={programEnrollmentStatus} />
+            {progressBadgeSection}
             <CourseDateSummary
               startDate={courseProgram?.start_date}
               endDate={courseProgram?.end_date}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -391,6 +391,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
               entry={entry}
               layout="compact"
               headingLevel="h4"
+              isModule
               onUpgradeError={onUpgradeError}
             />
           )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
@@ -101,7 +101,7 @@ describe.each([
     )
   })
 
-  test("does not show 'Certificate track' when verified enrollment has a certificate", () => {
+  test("shows 'Certificate track' alongside 'View Certificate' when verified enrollment has a certificate", () => {
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
         enrollment_mode: "verified",
@@ -110,9 +110,12 @@ describe.each([
     renderWithProviders(
       <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
     )
+    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
+      "Certificate track",
+    )
     expect(
-      within(getCard()).queryByTestId("upgraded-banner"),
-    ).not.toBeInTheDocument()
+      within(getCard()).getByRole("link", { name: /View Certificate/ }),
+    ).toBeInTheDocument()
   })
 
   test("does not show 'Certificate track' for audit enrollment", () => {
@@ -274,5 +277,36 @@ describe.each([
       "noopener,noreferrer",
     )
     windowOpenSpy.mockRestore()
+  })
+})
+
+// The progress badge only renders on the desktop card.
+describe("ProgramEnrollmentCard progress badge", () => {
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  test("shows 'In Progress' next to the 'Program' type label when no certificate is present", () => {
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        certificate: null,
+      })
+    renderWithProviders(
+      <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
+    )
+    expect(
+      within(getDesktopCard()).getByTestId("progress-badge"),
+    ).toHaveTextContent("In Progress")
+  })
+
+  test("shows 'Completed' next to the 'Program' type label when a certificate is present", () => {
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        certificate: { uuid: "test-uuid", link: "/certificate/test-uuid/" },
+      })
+    renderWithProviders(
+      <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
+    )
+    expect(
+      within(getDesktopCard()).getByTestId("progress-badge"),
+    ).toHaveTextContent("Completed")
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -8,6 +8,7 @@ import {
   CardRoot,
   CardTypeText,
   MenuButton,
+  Separator,
   SubtitleLink,
   TitleHeading,
   TitleLink,
@@ -26,6 +27,7 @@ import { UnenrollProgramDialog } from "./DashboardDialogs"
 import { getReceiptMenuItem } from "./receiptMenuItem"
 import { SimpleMenu, Stack } from "ol-components"
 import { EnrollmentStatus } from "./helpers"
+import { ProgressBadge } from "./ProgressBadge"
 
 type ProgramEnrollmentCardProps = {
   programEnrollment: V3UserProgramEnrollment
@@ -65,25 +67,26 @@ export const ProgramEnrollmentCard = ({
       ) : (
         <TitleText>{title}</TitleText>
       )}
-      {certificateLink ? (
+      {upgradedAndIncomplete ? <UpgradedBanner /> : null}
+    </Stack>
+  )
+  const buttonSection = (
+    <>
+      {certificateLink && (
         <SubtitleLink href={certificateLink}>
           <RiAwardLine size="16px" />
           View Certificate
         </SubtitleLink>
-      ) : upgradedAndIncomplete ? (
-        <UpgradedBanner />
-      ) : null}
-    </Stack>
-  )
-  const buttonSection = (
-    <ButtonLink
-      size="small"
-      variant="primary"
-      href={programView(program.id)}
-      aria-label={`View program: ${title}`}
-    >
-      View
-    </ButtonLink>
+      )}
+      <ButtonLink
+        size="small"
+        variant="primary"
+        href={programView(program.id)}
+        aria-label={`View program: ${title}`}
+      >
+        View
+      </ButtonLink>
+    </>
   )
   const detailsUrl = programPageView({
     readable_id: readableId,
@@ -142,6 +145,14 @@ export const ProgramEnrollmentCard = ({
     />
   )
 
+  const progressBadgeSection = (
+    <Stack direction="row" gap="4px" alignItems="center">
+      <ProgressBadge enrollmentStatus={enrollmentStatus} />
+      <Separator />
+      <CardTypeText>Program</CardTypeText>
+    </Stack>
+  )
+
   return (
     <>
       <CardRoot
@@ -151,7 +162,7 @@ export const ProgramEnrollmentCard = ({
         className={className}
       >
         <Stack gap="4px" justifyContent="start" alignItems="stretch" flex={1}>
-          <CardTypeText>Program</CardTypeText>
+          {progressBadgeSection}
           {titleSection}
         </Stack>
         <Stack gap="8px">

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -150,7 +150,7 @@ export const ProgramEnrollmentCard = ({
         as={Component}
         className={className}
       >
-        <Stack justifyContent="start" alignItems="stretch" flex={1}>
+        <Stack gap="4px" justifyContent="start" alignItems="stretch" flex={1}>
           <CardTypeText>Program</CardTypeText>
           {titleSection}
         </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { styled, Typography } from "ol-components"
 import { EnrollmentStatus } from "./helpers"
+import { RiCheckLine } from "@remixicon/react"
 
 const BadgeContainer = styled("div")<{
   status: EnrollmentStatus
@@ -17,6 +18,7 @@ const BadgeContainer = styled("div")<{
 
   return {
     display: "flex",
+    width: "100px",
     padding: "4px 8px",
     borderRadius: "4px",
     justifyContent: "center",
@@ -40,8 +42,11 @@ const ProgressBadge: React.FC<ProgressBadgeProps> = ({ enrollmentStatus }) => {
         : "Not Started"
 
   return (
-    <BadgeContainer status={enrollmentStatus}>
+    <BadgeContainer status={enrollmentStatus} data-testid="progress-badge">
       <Typography variant="body3">{label}</Typography>
+      {enrollmentStatus === EnrollmentStatus.Completed && (
+        <RiCheckLine size="16px" aria-hidden="true" />
+      )}
     </BadgeContainer>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
@@ -19,7 +19,7 @@ import {
   RiTimeLine,
 } from "@remixicon/react"
 import { isInPast, formatDate } from "ol-utilities"
-import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
+import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import NextLink from "next/link"
 import { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
 
@@ -234,10 +234,7 @@ const SiblingRunsAccordion: React.FC<SiblingRunsAccordionProps> = ({
                     ) : isExpired ? (
                       <ExpiredRunIcon aria-hidden="true" />
                     ) : (
-                      <EnrollmentStatusIndicator
-                        status={runEnrollmentStatus}
-                        showNotComplete
-                      />
+                      <EnrollmentStatusIcon status={runEnrollmentStatus} />
                     )}
                     <Typography variant="subtitle3" color="darkGray2" noWrap>
                       {runLabel}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -37,7 +37,7 @@ const setupUserApis = (overrides?: Parameters<typeof mitxUser>[0]) => {
 describe.each([
   { display: "desktop", testId: "enrollment-card-desktop" },
   { display: "mobile", testId: "enrollment-card-mobile" },
-])("UnenrolledCourseCard $display", ({ testId }) => {
+])("UnenrolledCourseCard $display", ({ display, testId }) => {
   const getCard = () => screen.getByTestId(testId)
 
   setupLocationMock()
@@ -248,12 +248,9 @@ describe.each([
     ).not.toBeInTheDocument()
   })
 
-  test.each([
-    { layout: "compact" as const, testId: "courseware-button" },
-    { layout: "default" as const, testId: undefined },
-  ])(
+  test.each([{ layout: "compact" as const }, { layout: "default" as const }])(
     "End date shown in correct position for $layout layout",
-    ({ layout, testId }) => {
+    ({ layout }) => {
       setupUserApis()
       const run = mitxonline.factories.courses.courseRun({
         is_enrollable: true,
@@ -268,16 +265,18 @@ describe.each([
         <UnenrolledCourseCard course={course} layout={layout} />,
       )
       const card = getCard()
-      if (testId) {
-        // Compact: end date and button are both inside the compact-meta-row
-        const metaRow = within(card).getByTestId("compact-meta-row")
-        expect(metaRow).toHaveTextContent(/ends in 5 days/i)
-        expect(within(metaRow).getByTestId(testId)).toBeInTheDocument()
-      } else {
-        // Default layout has no compact-meta-row; end date appears below the title
+      // End date always appears below the title now; there's no separate meta row
+      expect(
+        within(card).queryByTestId("compact-meta-row"),
+      ).not.toBeInTheDocument()
+
+      const isMobileCompact = display === "mobile" && layout === "compact"
+      if (isMobileCompact) {
+        // Mobile compact rows omit the end date entirely to save space
         expect(
-          within(card).queryByTestId("compact-meta-row"),
+          within(card).queryByText(/ends in 5 days/i),
         ).not.toBeInTheDocument()
+      } else {
         expect(within(card).getByText(/ends in 5 days/i)).toBeInTheDocument()
       }
     },
@@ -867,5 +866,37 @@ describe("UnenrolledCourseCard card type label", () => {
       <UnenrolledCourseCard course={setupCourse()} isModule />,
     )
     expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+  })
+})
+
+describe("UnenrolledCourseCard progress badge", () => {
+  setupLocationMock()
+
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  test("shows 'Not Started' next to the card type label", () => {
+    setupUserApis()
+    const run = mitxonline.factories.courses.courseRun({
+      is_enrollable: true,
+    })
+    const course = mitxOnlineCourse({ courseruns: [run], next_run_id: run.id })
+    renderWithProviders(<UnenrolledCourseCard course={course} />)
+    expect(
+      within(getDesktopCard()).getByTestId("progress-badge"),
+    ).toHaveTextContent("Not Started")
+  })
+
+  test("hidden on compact module rows, where the status icon takes over", () => {
+    setupUserApis()
+    const run = mitxonline.factories.courses.courseRun({
+      is_enrollable: true,
+    })
+    const course = mitxOnlineCourse({ courseruns: [run], next_run_id: run.id })
+    renderWithProviders(
+      <UnenrolledCourseCard course={course} isModule layout="compact" />,
+    )
+    expect(
+      within(getDesktopCard()).queryByTestId("progress-badge"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -819,3 +819,53 @@ describe.each([
     })
   })
 })
+
+describe("UnenrolledCourseCard card type label", () => {
+  setupLocationMock()
+
+  const getDesktopCard = () => screen.getByTestId("enrollment-card-desktop")
+
+  const setupCourse = (b2bContractId: number | null = null) => {
+    const run = mitxonline.factories.courses.courseRun({
+      b2b_contract: b2bContractId,
+      is_enrollable: true,
+    })
+    return mitxOnlineCourse({
+      title: run.title,
+      courseruns: [run],
+      next_run_id: run.id,
+    })
+  }
+
+  test("shows 'Course' for a non-B2B card", () => {
+    setupUserApis()
+    renderWithProviders(<UnenrolledCourseCard course={setupCourse()} />)
+    expect(within(getDesktopCard()).getByText("Course")).toBeInTheDocument()
+    expect(
+      within(getDesktopCard()).queryByText("Module"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("shows 'Module' for a B2B card", () => {
+    setupUserApis()
+    const b2bContractId = faker.number.int()
+    renderWithProviders(
+      <UnenrolledCourseCard
+        course={setupCourse(b2bContractId)}
+        contractId={b2bContractId}
+      />,
+    )
+    expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+    expect(
+      within(getDesktopCard()).queryByText("Course"),
+    ).not.toBeInTheDocument()
+  })
+
+  test("shows 'Module' when isModule is set", () => {
+    setupUserApis()
+    renderWithProviders(
+      <UnenrolledCourseCard course={setupCourse()} isModule />,
+    )
+    expect(within(getDesktopCard()).getByText("Module")).toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -11,11 +11,13 @@ import {
   CoursewareButton,
   TitleText,
   CourseDateSummary,
+  Separator,
 } from "./CardShared"
 import { EnrollmentStatus, getBestRun } from "./helpers"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useEnrollmentHandler } from "./hooks/useEnrollmentHandler"
-import { EnrollmentStatusIndicator } from "./EnrollmentStatusIndicator"
+import { EnrollmentStatusIcon } from "./EnrollmentStatus"
+import { ProgressBadge } from "./ProgressBadge"
 import { Button } from "@mitodl/smoot-design"
 
 type UnenrolledCourseCardProps = {
@@ -156,6 +158,18 @@ export const UnenrolledCourseCard = ({
     </Stack>
   )
 
+  const progressBadgeSection =
+    isModule && isCompact ? null : (
+      <Stack direction="row" gap="4px" alignItems="center">
+        <ProgressBadge enrollmentStatus={EnrollmentStatus.NotEnrolled} />
+        <Separator />
+        {cardTypeLabel}
+      </Stack>
+    )
+
+  const showEnrollmentStatusIcon =
+    !isContractPageResource && isModule && isCompact
+
   return (
     <>
       <CardRoot
@@ -165,16 +179,13 @@ export const UnenrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        {isModule && isCompact && (
+        {showEnrollmentStatusIcon && (
           <Stack alignSelf="start">
-            <EnrollmentStatusIndicator
-              status={EnrollmentStatus.NotEnrolled}
-              showNotComplete={true}
-            />
+            <EnrollmentStatusIcon status={EnrollmentStatus.NotEnrolled} />
           </Stack>
         )}
         <Stack justifyContent="start" alignItems="stretch" gap="4px" flex={1}>
-          {cardTypeLabel}
+          {progressBadgeSection}
           <Stack gap="6px">
             {titleSection}
             {courseDateText}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -8,7 +8,6 @@ import { LoadingSpinner, Stack } from "ol-components"
 import {
   CardRoot,
   CardTypeText,
-  CoursewareActionColumn,
   CoursewareButton,
   TitleText,
   CourseDateSummary,
@@ -56,7 +55,12 @@ export const UnenrolledCourseCard = ({
   const title =
     layout === "compact" ? course.title : courseRun?.title || course.title
   const isContractPageResource = Boolean(contractId)
-  const cardTypeLabel = isModule || isContractPageResource ? "Module" : "Course"
+  const cardTypeLabelText =
+    isModule || isContractPageResource ? "Module" : "Course"
+  const cardTypeLabel =
+    isModule && layout === "compact" ? null : (
+      <CardTypeText>{cardTypeLabelText}</CardTypeText>
+    )
   const handleEnrollmentClick = React.useCallback(() => {
     const isVerifiedProgramEnrollment =
       Boolean(ancestorContext?.useVerifiedEnrollment) ||
@@ -141,26 +145,13 @@ export const UnenrolledCourseCard = ({
       Start
     </Button>
   )
-  const buttonSection = isCompact ? (
-    <Stack direction="column" gap="4px" alignItems="stretch">
-      <Stack
-        direction="row"
-        gap="8px"
-        alignItems="center"
-        data-testid="compact-meta-row"
-      >
-        {courseDateText}
-        <CoursewareActionColumn direction="row" justifyContent="end">
-          {startButton}
-        </CoursewareActionColumn>
-      </Stack>
-    </Stack>
-  ) : (
-    <Stack direction="row" gap="8px" alignItems="center" justifyContent="end">
-      <EnrollmentStatusIndicator
-        status={EnrollmentStatus.NotEnrolled}
-        showNotComplete={Boolean(isContractPageResource)}
-      />
+  const buttonSection = (
+    <Stack
+      direction="row"
+      marginRight="8px"
+      alignItems="center"
+      justifyContent="end"
+    >
       {startButton}
     </Stack>
   )
@@ -174,10 +165,20 @@ export const UnenrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        <Stack justifyContent="start" alignItems="stretch" gap="6px" flex={1}>
-          <CardTypeText>{cardTypeLabel}</CardTypeText>
-          {titleSection}
-          {!isCompact && courseDateText}
+        {isModule && isCompact && (
+          <Stack alignSelf="start">
+            <EnrollmentStatusIndicator
+              status={EnrollmentStatus.NotEnrolled}
+              showNotComplete={true}
+            />
+          </Stack>
+        )}
+        <Stack justifyContent="start" alignItems="stretch" gap="4px" flex={1}>
+          {cardTypeLabel}
+          <Stack gap="6px">
+            {titleSection}
+            {courseDateText}
+          </Stack>
         </Stack>
         <Stack
           direction="row"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -30,6 +30,7 @@ type UnenrolledCourseCardProps = {
   }
   layout?: "default" | "compact"
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
+  isModule?: boolean
   Component?: React.ElementType
   className?: string
 }
@@ -41,6 +42,7 @@ export const UnenrolledCourseCard = ({
   ancestorContext,
   layout = "default",
   headingLevel,
+  isModule,
   Component,
   className,
 }: UnenrolledCourseCardProps) => {
@@ -54,6 +56,7 @@ export const UnenrolledCourseCard = ({
   const title =
     layout === "compact" ? course.title : courseRun?.title || course.title
   const isContractPageResource = Boolean(contractId)
+  const cardTypeLabel = isModule || isContractPageResource ? "Module" : "Course"
   const handleEnrollmentClick = React.useCallback(() => {
     const isVerifiedProgramEnrollment =
       Boolean(ancestorContext?.useVerifiedEnrollment) ||
@@ -172,7 +175,7 @@ export const UnenrolledCourseCard = ({
         layout={layout}
       >
         <Stack justifyContent="start" alignItems="stretch" gap="6px" flex={1}>
-          <CardTypeText>Course</CardTypeText>
+          <CardTypeText>{cardTypeLabel}</CardTypeText>
           {titleSection}
           {!isCompact && courseDateText}
         </Stack>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12216

### Description (What does it do?)
This PR mainly addresses design updates to the dashboard cards in desktop view. As part of this, the "Module" card type indicator was restored on B2B contract pages as described in the above issue. However, a large amount of other design changes were implemented from Figma. There are no issues for these, but I will try and do by best to summarize:

#### Figma links
- https://www.figma.com/design/mSDdN8giMcncBwNgwcVJL9/UX-Wireframes?node-id=19084-489146&m=dev
- https://www.figma.com/design/mSDdN8giMcncBwNgwcVJL9/UX-Wireframes?node-id=19084-487069&m=dev

#### Design updates
##### Card type & progress indication
- Replaced the plain "Course"/"Module" text label with a ProgressBadge + Separator + type-label combo on every card (Enrolled, Unenrolled, Program-as-Course, Program Enrollment)
- ProgressBadge shows "Not Started" / "In Progress" / "Completed" (with a checkmark icon for Completed), color-coded by status
- Renamed EnrollmentStatusIndicator to EnrollmentStatus/EnrollmentStatusIcon; simplified it by dropping the showNotComplete prop and swapping custom image icons for Remix icon components
- The status icon is now scoped to only compact module rows inside ProgramAsCourseCard, and is hidden there for B2B contract enrollments; it no longer appears on default single-run cards or in the sibling-runs accordion header
- CoursewareCard, EnrolledCourseCard, and UnenrolledCourseCard gained an isModule prop to drive "Module" vs "Course" labeling; B2B contract enrollments are automatically labeled "Module"

##### Certificate & upgrade messaging
- "Certificate track" (UpgradedBanner) now shows for any non-B2B verified enrollment regardless of whether a certificate has already been issued, coexisting with the "View Certificate" link instead of disappearing once earned
- On ProgramEnrollmentCard, the certificate link moved out of the title section and into the button row next to "View", matching EnrolledCourseCard and UnenrolledCourseCard
- Fixed alignment of the "View Certificate" button on the program-as-course card

##### End date & date summary placement
- End date text now renders consistently below the title on desktop for both compact and default layouts, replacing the old "compact-meta-row" pattern that grouped the end date and CTA button together
- On mobile, compact-layout cards omit the end date entirely; default layout still shows it
- Popover trigger styling switched from body2 to subtitle3 typography

##### Multiple enrollment runs
- Added a sibling-runs accordion on EnrolledCourseCard desktop that appears when a course has more than one active enrollment, showing a per-run status icon (or upcoming/expired icon) and a "Course runs (N)" count

##### Typography & spacing
- CardTypeText, SubtitleLink/SubtitleLinkRoot, and UpgradedBannerRoot switched from subtitle3/subtitle4 to body3 typography
- TitleHeading and TitleLink now explicitly set subtitle2 typography
- SubtitleLink color changed from conditional red/gray by layout to a flat red, with a tighter icon gap
- Removed the negative left margin on the "More options" menu button
- Added a small Ellipse separator dot for stacked meta segments, alongside the existing Separator bar

##### Other
- Fixed a spacing/gap bug in the card type text on ProgramEnrollmentCard
- General visual cleanup pass on UnenrolledCourseCard styling


### Screenshots (if appropriate):
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/2a2d8c0a-141f-4f24-a5cb-3bd1a86591cb" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/fd1c8bd5-3b25-4f55-84de-863052fe0ede" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ecb00d62-1909-4ceb-95be-01b03463bded" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/1ac975bf-3aa0-454d-a398-d0047afc1d87" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ffebd255-17f5-4400-ad2b-4d792f36e5ea" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6293dd6a-3113-4d2e-99c3-075556d4b1c6" />

### How can this be tested?
- Make sure you have an instance of MITx Online started and connected to Learn as described in the readme
- Your test user should have at least one B2B contract assigned to them as well as a B2C enrollment for each type of content (Course, Program, "Program As Course") with different enrollments in different states (not started, started, completed) for each type
- View the B2B contract in the dashboard. Ensure that the design changes noted above and in the Figma look correct and that the card type indicator says "Module"
- View the B2C enrollments on your dashboard home page / program dashboard and ensure that the UI changes are consistent