### PR TITLE
Add local-dev Docker targets and fix granian reload hang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,16 @@ EXPOSE 8061
 ENV PORT=8061
 CMD ["sh", "-c", "exec granian --interface asginl --reload --host 0.0.0.0 --port ${PORT:-8061} --workers ${GRANIAN_WORKERS:-3} --blocking-threads 1 main.asgi:application"]
 
-# ─── Development target ───────────────────────────────────────────────────────
+# ─── Development target (docker compose) ─────────────────────────────────────
 FROM final AS development
 
 RUN --mount=type=cache,target=/opt/uv-cache,uid=1000,gid=1000 \
     uv sync --frozen --no-install-project
+
+# ─── Local-dev target (ol-infrastructure local-dev k8s/Tilt stack) ───────────
+# Runtime user owns /src (live-synced source); dev deps come from `development`.
+FROM development AS local-dev
+
+USER root
+RUN chown -R mitodl:mitodl /src
+USER mitodl

--- a/frontends/main/Dockerfile.web
+++ b/frontends/main/Dockerfile.web
@@ -91,6 +91,13 @@ ENV NEXT_BUILD_CI=1
 
 RUN yarn build
 
+# STAGE: local-dev
+# Local-dev target (ol-infrastructure local-dev k8s/Tilt stack): runs `next dev`
+FROM base AS local-dev
+
+ENV NODE_ENV=development
+CMD ["yarn", "dev"]
+
 # STAGE: runner (default)
 # Copies only the standalone server, static assets, and public directory from
 # the build stage into a clean image. No workspace install is needed; the

--- a/scripts/run-django-dev.sh
+++ b/scripts/run-django-dev.sh
@@ -7,7 +7,8 @@ python3 manage.py collectstatic --noinput --clear
 # run initial django migrations
 python3 manage.py migrate --noinput
 
-granian --interface asginl --host 0.0.0.0 --port "${PORT:-8061}" --workers "${GRANIAN_WORKERS:-3}" --blocking-threads 1 --reload --reload-ignore-dirs frontends --reload-ignore-dirs staticfiles --reload-ignore-dirs .git main.asgi:application &
+# --workers-kill-timeout: workers sometimes hang during graceful stop, wedging --reload.
+granian --interface asginl --host 0.0.0.0 --port "${PORT:-8061}" --workers "${GRANIAN_WORKERS:-3}" --workers-kill-timeout "${GRANIAN_WORKERS_KILL_TIMEOUT:-1}" --blocking-threads 1 --reload --reload-ignore-dirs frontends --reload-ignore-dirs staticfiles --reload-ignore-dirs .git main.asgi:application &
 GRANIAN_PID=$!
 echo "Application started with PID $GRANIAN_PID"
 


### PR DESCRIPTION
### What are the relevant tickets?

- For https://github.com/mitodl/ol-infrastructure/pull/4909

### Description (What does it do?)

Companion to https://github.com/mitodl/ol-infrastructure/pull/4909 (hot reload in the local-dev Tilt stack):

- **`Dockerfile`:** adds a `local-dev` build target based on `development` (so dev tools — pytest, ipdb, etc. — are available) with a runtime-user-owned `/src` so Tilt can live-sync source into the container; production stages unchanged.
- **`frontends/main/Dockerfile.web`:** adds a `local-dev` build target that runs `next dev`; production `runner` stage unchanged.
- **`scripts/run-django-dev.sh`:** adds `--workers-kill-timeout` to granian so `--reload` can't hang indefinitely when workers fail to stop gracefully.

### How can this be tested?

1. If using learn docker-compose stack, rebuild. All should work.
    - NOTE: If you're on a mac and haven't rebuilt recently, it might be slower due to the ol-python-base image, unrelated to these changes in this PR. Mac arm64 target coming soon
2. If using local-dev stack in ol-infra, see https://github.com/mitodl/ol-infrastructure/pull/4909
