### PR TITLE
Scrape child courses before programs and fix missing child course sections

### DIFF
--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -748,8 +748,20 @@ def marketing_page_for_resources(resource_ids):
 
     for learning_resource in resources:
         marketing_page_url = learning_resource.url
-        scraper = scraper_for_site(marketing_page_url)
-        page_content = scraper.scrape()
+        try:
+            scraper = scraper_for_site(marketing_page_url)
+            page_content = scraper.scrape()
+        except Exception:
+            # Isolate per-resource failures so one bad page can't fail the whole
+            # chunk. When these tasks are chained (course group -> program group),
+            # a failed task poisons the chord header and the program group never
+            # runs, so keep this batch succeeding for pages that do scrape.
+            log.exception(
+                "Failed to scrape marketing page for resource %s (%s)",
+                learning_resource.id,
+                marketing_page_url,
+            )
+            continue
         if page_content:
             content_file, _ = ContentFile.objects.update_or_create(
                 learning_resource=learning_resource,

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -45,6 +45,7 @@ from learning_resources.utils import (
     build_program_children_content_bulk,
     html_to_markdown,
     load_course_blocklist,
+    programs_needing_children_heal,
     resource_unpublished_actions,
     resource_upserted_actions,
     strip_markdown_images,
@@ -670,31 +671,53 @@ def sync_canvas_courses(canvas_course_ids, overwrite):
 @app.task(bind=True)
 def scrape_marketing_pages(self):
     """
-    Scrape marketing pages (for programs and courses)
-    and store them as content files if they dont exist
+    Scrape marketing pages for programs and courses and store them as content
+    files. Child courses are scraped before their parent programs so a program's
+    children section is built from child marketing pages that already exist.
+    Programs whose stored page is missing its children section (and whose
+    children content is now available) are re-scraped to heal them.
     """
     log.info("Running scrape_marketing_pages task")
-    resource_ids = set(
+    resource_types = dict(
         LearningResource.objects.filter(
             published=True, resource_type__in=["course", "program"]
-        ).values_list("id", flat=True)
+        ).values_list("id", "resource_type")
     )
-
     existing_page_resource_ids = set(
-        ContentFile.objects.filter(file_type="marketing_page").values_list(
+        ContentFile.objects.filter(file_type=MARKETING_PAGE_FILE_TYPE).values_list(
             "learning_resource_id", flat=True
         )
     )
-    missing_pages = list(resource_ids.difference(existing_page_resource_ids))
 
-    tasks = [
+    missing_ids = set(resource_types) - existing_page_resource_ids
+    missing_course_ids = [rid for rid in missing_ids if resource_types[rid] == "course"]
+    program_ids_with_pages = {
+        rid
+        for rid in existing_page_resource_ids
+        if resource_types.get(rid) == "program"
+    }
+    program_ids = {rid for rid in missing_ids if resource_types[rid] == "program"}
+    program_ids |= programs_needing_children_heal(program_ids_with_pages)
+
+    course_tasks = [
         marketing_page_for_resources.si(ids)
-        for ids in chunks(
-            missing_pages,
-            chunk_size=settings.QDRANT_CHUNK_SIZE,
-        )
+        for ids in chunks(missing_course_ids, chunk_size=settings.QDRANT_CHUNK_SIZE)
     ]
-    scrape_tasks = celery.group(tasks)
+    program_tasks = [
+        marketing_page_for_resources.si(ids)
+        for ids in chunks(sorted(program_ids), chunk_size=settings.QDRANT_CHUNK_SIZE)
+    ]
+
+    if course_tasks and program_tasks:
+        scrape_tasks = celery.chain(
+            celery.group(course_tasks), celery.group(program_tasks)
+        )
+    elif course_tasks:
+        scrape_tasks = celery.group(course_tasks)
+    elif program_tasks:
+        scrape_tasks = celery.group(program_tasks)
+    else:
+        return None
     return self.replace(scrape_tasks)
 
 

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -690,7 +690,9 @@ def scrape_marketing_pages(self):
     )
 
     missing_ids = set(resource_types) - existing_page_resource_ids
-    missing_course_ids = [rid for rid in missing_ids if resource_types[rid] == "course"]
+    missing_course_ids = sorted(
+        rid for rid in missing_ids if resource_types[rid] == "course"
+    )
     program_ids_with_pages = {
         rid
         for rid in existing_page_resource_ids

--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -780,6 +780,89 @@ def test_scrape_marketing_pages(mocker, settings, mocked_celery):
     mock_group.assert_called_once()
 
 
+@pytest.mark.django_db
+def test_scrape_marketing_pages_orders_courses_before_programs(
+    mocker, settings, mocked_celery
+):
+    """Courses are scraped in a group that runs before the programs group."""
+    settings.QDRANT_CHUNK_SIZE = 10
+    course = models.LearningResource.objects.create(
+        title="Course",
+        url="https://example.com/course",
+        resource_type="course",
+        published=True,
+    )
+    program = models.LearningResource.objects.create(
+        title="Program",
+        url="https://example.com/program",
+        resource_type="program",
+        published=True,
+    )
+    si_mock = mocker.patch("learning_resources.tasks.marketing_page_for_resources.si")
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        scrape_marketing_pages.delay()
+
+    # A chain enforces ordering (not a single flat group).
+    assert mocked_celery.chain.called
+    # Course task built before program task; each in its own chunk here.
+    queued_ids = [call.args[0] for call in si_mock.call_args_list]
+    assert queued_ids[0] == [course.id]
+    assert [program.id] in queued_ids
+    assert queued_ids.index([course.id]) < queued_ids.index([program.id])
+
+
+@pytest.mark.django_db
+def test_scrape_marketing_pages_queues_healable_programs(
+    mocker, settings, mocked_celery
+):
+    """A program that already has a page but is missing its children section
+    (with a child course page available) is queued for re-scrape.
+    """
+    settings.QDRANT_CHUNK_SIZE = 10
+    course = models.LearningResource.objects.create(
+        title="Course",
+        url="https://example.com/course",
+        resource_type="course",
+        published=True,
+    )
+    ContentFile.objects.create(
+        learning_resource=course,
+        file_type=MARKETING_PAGE_FILE_TYPE,
+        file_extension=".md",
+        key=course.url,
+        content="Child copy.",
+        published=True,
+    )
+    program = models.LearningResource.objects.create(
+        title="Program",
+        url="https://example.com/program",
+        resource_type="program",
+        published=True,
+    )
+    models.LearningResourceRelationship.objects.create(
+        parent=program, child=course, relation_type="PROGRAM_COURSES"
+    )
+    # Program already has a page, but WITHOUT the children marker.
+    ContentFile.objects.create(
+        learning_resource=program,
+        file_type=MARKETING_PAGE_FILE_TYPE,
+        file_extension=".md",
+        key=program.url,
+        content="Program page, no children yet.",
+        published=True,
+    )
+    si_mock = mocker.patch("learning_resources.tasks.marketing_page_for_resources.si")
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        scrape_marketing_pages.delay()
+
+    queued_ids = [i for call in si_mock.call_args_list for i in call.args[0]]
+    # Program re-queued for healing; course already has a page so it is NOT queued.
+    assert program.id in queued_ids
+    assert course.id not in queued_ids
+
+
 @pytest.mark.parametrize("canvas_ids", [["1"], None])
 def test_sync_canvas_courses(settings, mocker, django_assert_num_queries, canvas_ids):
     """

--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -799,6 +799,9 @@ def test_scrape_marketing_pages_orders_courses_before_programs(
         published=True,
     )
     si_mock = mocker.patch("learning_resources.tasks.marketing_page_for_resources.si")
+    # Make each .si(...) call's return value identify which ids it was built
+    # from, so the args passed into celery.group(...) can be told apart.
+    si_mock.side_effect = lambda ids: ("si", tuple(ids))
 
     with pytest.raises(mocked_celery.replace_exception_class):
         scrape_marketing_pages.delay()
@@ -810,6 +813,18 @@ def test_scrape_marketing_pages_orders_courses_before_programs(
     assert queued_ids[0] == [course.id]
     assert [program.id] in queued_ids
     assert queued_ids.index([course.id]) < queued_ids.index([program.id])
+
+    # Pin the guarantee to what is actually fed into celery.chain via
+    # celery.group: Python evaluates chain's positional args left-to-right,
+    # so the first group(...) call must be the course tasks and the second
+    # must be the program tasks. This fails if the two arguments to
+    # celery.chain(celery.group(...), celery.group(...)) are ever swapped.
+    assert mocked_celery.group.call_count == 2
+    first_group_tasks, second_group_tasks = (
+        call.args[0] for call in mocked_celery.group.call_args_list
+    )
+    assert first_group_tasks == [("si", (course.id,))]
+    assert second_group_tasks == [("si", (program.id,))]
 
 
 @pytest.mark.django_db

--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -620,6 +620,55 @@ def test_marketing_page_for_resources_with_webdriver(mocker, settings):
 
 
 @pytest.mark.django_db
+def test_marketing_page_for_resources_isolates_scrape_failures(mocker):
+    """A single resource's scrape failure must not fail the whole chunk.
+
+    When course and program tasks are chained, a chunk that raises poisons the
+    chord header and the program group never runs, so per-resource failures are
+    logged and skipped rather than propagated.
+    """
+    bad_course = models.LearningResource.objects.create(
+        title="Bad Course",
+        url="https://example.com/bad-course",
+        resource_type="course",
+        published=True,
+    )
+    good_course = models.LearningResource.objects.create(
+        title="Good Course",
+        url="https://example.com/good-course",
+        resource_type="course",
+        published=True,
+    )
+
+    good_scraper = mocker.Mock()
+    good_scraper.scrape.return_value = "<html><body><p>ok</p></body></html>"
+
+    def fake_scraper_for_site(url):
+        if url == bad_course.url:
+            msg = "scraper boom"
+            raise RuntimeError(msg)
+        return good_scraper
+
+    mocker.patch(
+        "learning_resources.tasks.scraper_for_site",
+        side_effect=fake_scraper_for_site,
+    )
+    mocker.patch("learning_resources.tasks.html_to_markdown", return_value="ok")
+    mock_generate_embeddings = mocker.patch("vector_search.tasks.generate_embeddings")
+
+    # Must not raise despite the bad course failing
+    marketing_page_for_resources([bad_course.id, good_course.id])
+
+    assert not models.ContentFile.objects.filter(learning_resource=bad_course).exists()
+    good_cf = models.ContentFile.objects.get(
+        learning_resource=good_course, file_type=MARKETING_PAGE_FILE_TYPE
+    )
+    mock_generate_embeddings.delay.assert_called_once_with(
+        [good_cf.id], "content_file", overwrite=True
+    )
+
+
+@pytest.mark.django_db
 def test_marketing_page_for_program_appends_children(mocker, settings):
     """Test that marketing_page_for_resources appends program children content"""
 

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -747,6 +747,8 @@ def build_resource_summary_dict(resource):
 # overflowing the embedding API's per-request token limit.
 PROGRAM_CHILDREN_CONTENT_MAX_CHARS = 1_000_000
 
+PROGRAM_CHILDREN_CONTENT_MARKER = "## Program Contents"
+
 
 def _course_ids_by_program(relationships, course_type):
     """Map program id -> reachable published course ids (direct + via subprograms)."""
@@ -761,6 +763,82 @@ def _course_ids_by_program(relationships, course_type):
                 if sub_rel.child.resource_type == course_type
             )
     return result
+
+
+def reachable_published_course_ids(program_ids):
+    """Map program id -> set of reachable published child-course ids.
+
+    Includes courses reached directly and courses reached through child
+    programs. Read-only and id-level only (loads no content).
+    """
+    program_ids = list(program_ids)
+    if not program_ids:
+        return {}
+    program_relation_types = [
+        LearningResourceRelationTypes.PROGRAM_COURSES,
+        LearningResourceRelationTypes.PROGRAM_PROGRAMS,
+    ]
+    child_visibility = Q(child__published=True) | Q(child__test_mode=True)
+    relationships = list(
+        LearningResourceRelationship.objects.filter(
+            parent_id__in=program_ids,
+            relation_type__in=program_relation_types,
+        )
+        .filter(child_visibility)
+        .select_related("child")
+        .prefetch_related(
+            Prefetch(
+                "child__children",
+                queryset=LearningResourceRelationship.objects.filter(
+                    relation_type__in=program_relation_types,
+                )
+                .filter(child_visibility)
+                .select_related("child"),
+                to_attr="program_children",
+            ),
+        )
+    )
+    return _course_ids_by_program(relationships, LearningResourceType.course.name)
+
+
+def programs_needing_children_heal(program_ids):
+    """Return the subset of the given program ids whose marketing page lacks a
+    children section but whose children content is now available.
+
+    A program qualifies only when it has a reachable published child course with
+    a non-empty marketing page, which guarantees re-scraping will populate the
+    section and prevents childless programs from being re-scraped every run.
+    Read-only and id-level only.
+    """
+    program_ids = list(program_ids)
+    if not program_ids:
+        return set()
+    candidate_ids = set(
+        ContentFile.objects.filter(
+            learning_resource_id__in=program_ids,
+            file_type=MARKETING_PAGE_FILE_TYPE,
+        )
+        .exclude(content__contains=PROGRAM_CHILDREN_CONTENT_MARKER)
+        .values_list("learning_resource_id", flat=True)
+    )
+    if not candidate_ids:
+        return set()
+    reachable = reachable_published_course_ids(candidate_ids)
+    all_course_ids = set().union(*reachable.values())
+    course_ids_with_pages = set(
+        ContentFile.objects.filter(
+            learning_resource_id__in=all_course_ids,
+            file_type=MARKETING_PAGE_FILE_TYPE,
+            published=True,
+        )
+        .exclude(content="")
+        .values_list("learning_resource_id", flat=True)
+    )
+    return {
+        program_id
+        for program_id, course_ids in reachable.items()
+        if course_ids & course_ids_with_pages
+    }
 
 
 def build_program_children_content(learning_resource):
@@ -789,34 +867,7 @@ def build_program_children_content_bulk(program_resources):
         return {}
 
     program_ids = [program.id for program in programs]
-    program_relation_types = [
-        LearningResourceRelationTypes.PROGRAM_COURSES,
-        LearningResourceRelationTypes.PROGRAM_PROGRAMS,
-    ]
-
-    child_visibility = Q(child__published=True) | Q(child__test_mode=True)
-    relationships = list(
-        LearningResourceRelationship.objects.filter(
-            parent_id__in=program_ids,
-            relation_type__in=program_relation_types,
-        )
-        .filter(child_visibility)
-        .select_related("child")
-        .prefetch_related(
-            Prefetch(
-                "child__children",
-                queryset=LearningResourceRelationship.objects.filter(
-                    relation_type__in=program_relation_types,
-                )
-                .filter(child_visibility)
-                .select_related("child"),
-                to_attr="program_children",
-            ),
-        )
-    )
-
-    course_type = LearningResourceType.course.name
-    course_ids_by_program = _course_ids_by_program(relationships, course_type)
+    course_ids_by_program = reachable_published_course_ids(program_ids)
     all_course_ids = set().union(*course_ids_by_program.values())
 
     # One marketing-page content file per course (published), fetched in bulk
@@ -846,7 +897,7 @@ def build_program_children_content_bulk(program_resources):
         if not sections:
             content_by_program_id[program.id] = ""
             continue
-        body = "\n\n".join(["\n\n## Program Contents\n", *sections])
+        body = "\n\n".join([f"\n\n{PROGRAM_CHILDREN_CONTENT_MARKER}\n", *sections])
         content_by_program_id[program.id] = body[:PROGRAM_CHILDREN_CONTENT_MAX_CHARS]
 
     return content_by_program_id

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -766,7 +766,7 @@ def _course_ids_by_program(relationships, course_type):
 
 
 def reachable_published_course_ids(program_ids):
-    """Map program id -> set of reachable published child-course ids.
+    """Map program id -> set of reachable published (or test-mode) child-course ids.
 
     Includes courses reached directly and courses reached through child
     programs. Read-only and id-level only (loads no content).
@@ -805,10 +805,10 @@ def programs_needing_children_heal(program_ids):
     """Return the subset of the given program ids whose marketing page lacks a
     children section but whose children content is now available.
 
-    A program qualifies only when it has a reachable published child course with
-    a non-empty marketing page, which guarantees re-scraping will populate the
-    section and prevents childless programs from being re-scraped every run.
-    Read-only and id-level only.
+    A program qualifies only when it has a reachable published (or test-mode)
+    child course with a non-empty marketing page, which guarantees re-scraping
+    will populate the section and prevents childless programs from being
+    re-scraped every run. Read-only and id-level only.
     """
     program_ids = list(program_ids)
     if not program_ids:

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -1028,7 +1028,7 @@ def _add_program_marketing_page(program_lr, content):
 
     return ContentFile.objects.create(
         learning_resource=program_lr,
-        file_type="marketing_page",
+        file_type=MARKETING_PAGE_FILE_TYPE,
         file_extension=".md",
         key=f"mktg-{program_lr.id}",
         content=content,
@@ -1037,41 +1037,29 @@ def _add_program_marketing_page(program_lr, content):
 
 
 @pytest.mark.django_db
-def test_programs_needing_children_heal_selects_missing_marker():
-    """A program whose page lacks the marker but has an available child page
-    is selected for healing.
-    """
+@pytest.mark.parametrize(
+    ("child_has_page", "program_content", "expected_selected"),
+    [
+        # missing marker + an available child page → heal
+        (True, "Program page with no children yet.", True),
+        # no reachable child page → skip (termination guard)
+        (False, "Program page with no children yet.", False),
+        # marker already present → skip
+        (True, "Program page.\n\n## Program Contents\n\n### Child", False),
+    ],
+)
+def test_programs_needing_children_heal(
+    child_has_page, program_content, expected_selected
+):
+    """Heal a program only when its page lacks the marker AND a child page exists."""
     course_lr = CourseFactory.create().learning_resource
-    _add_course_marketing_page(course_lr, "Child marketing copy.")
+    if child_has_page:
+        _add_course_marketing_page(course_lr, "Child marketing copy.")
     program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-    _add_program_marketing_page(program_lr, "Program page with no children yet.")
+    _add_program_marketing_page(program_lr, program_content)
 
-    assert utils.programs_needing_children_heal([program_lr.id]) == {program_lr.id}
-
-
-@pytest.mark.django_db
-def test_programs_needing_children_heal_skips_when_no_child_page():
-    """A program with no reachable child course page is NOT selected
-    (termination guard).
-    """
-    course_lr = CourseFactory.create().learning_resource  # no marketing page
-    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-    _add_program_marketing_page(program_lr, "Program page with no children yet.")
-
-    assert utils.programs_needing_children_heal([program_lr.id]) == set()
-
-
-@pytest.mark.django_db
-def test_programs_needing_children_heal_skips_when_marker_present():
-    """A program whose page already contains the children marker is skipped."""
-    course_lr = CourseFactory.create().learning_resource
-    _add_course_marketing_page(course_lr, "Child marketing copy.")
-    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
-    _add_program_marketing_page(
-        program_lr, "Program page.\n\n## Program Contents\n\n### Child"
-    )
-
-    assert utils.programs_needing_children_heal([program_lr.id]) == set()
+    expected = {program_lr.id} if expected_selected else set()
+    assert utils.programs_needing_children_heal([program_lr.id]) == expected
 
 
 @pytest.mark.parametrize(

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -35,6 +35,7 @@ from learning_resources.models import (
     LearningResource,
     LearningResourceOfferor,
     LearningResourcePlatform,
+    LearningResourceRelationship,
     LearningResourceTopic,
     LearningResourceTopicMapping,
 )
@@ -992,6 +993,85 @@ def test_build_program_children_content_bulk_excludes_unpublished_marketing_page
     result = build_program_children_content_bulk([program_lr])
     assert "Visible marketing copy." in result[program_lr.id]
     assert "Hidden marketing copy." not in result[program_lr.id]
+
+
+@pytest.mark.django_db
+def test_reachable_published_course_ids_direct_and_subprogram():
+    """Maps a program to its direct courses and courses via child programs."""
+    direct_course = CourseFactory.create(
+        learning_resource__title="Direct"
+    ).learning_resource
+    grandchild_course = CourseFactory.create(
+        learning_resource__title="Grandchild"
+    ).learning_resource
+    child_program = ProgramFactory.create(
+        courses=[grandchild_course], learning_resource__title="Child Program"
+    ).learning_resource
+    program = ProgramFactory.create(courses=[direct_course]).learning_resource
+    LearningResourceRelationship.objects.create(
+        parent=program, child=child_program, relation_type="PROGRAM_PROGRAMS"
+    )
+
+    result = utils.reachable_published_course_ids([program.id])
+    assert result[program.id] == {direct_course.id, grandchild_course.id}
+
+
+@pytest.mark.django_db
+def test_reachable_published_course_ids_empty_input():
+    """Empty program id input maps to an empty result."""
+    assert utils.reachable_published_course_ids([]) == {}
+
+
+def _add_program_marketing_page(program_lr, content):
+    """Attach a published marketing-page content file to a program."""
+    from learning_resources.models import ContentFile
+
+    return ContentFile.objects.create(
+        learning_resource=program_lr,
+        file_type="marketing_page",
+        file_extension=".md",
+        key=f"mktg-{program_lr.id}",
+        content=content,
+        published=True,
+    )
+
+
+@pytest.mark.django_db
+def test_programs_needing_children_heal_selects_missing_marker():
+    """A program whose page lacks the marker but has an available child page
+    is selected for healing.
+    """
+    course_lr = CourseFactory.create().learning_resource
+    _add_course_marketing_page(course_lr, "Child marketing copy.")
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+    _add_program_marketing_page(program_lr, "Program page with no children yet.")
+
+    assert utils.programs_needing_children_heal([program_lr.id]) == {program_lr.id}
+
+
+@pytest.mark.django_db
+def test_programs_needing_children_heal_skips_when_no_child_page():
+    """A program with no reachable child course page is NOT selected
+    (termination guard).
+    """
+    course_lr = CourseFactory.create().learning_resource  # no marketing page
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+    _add_program_marketing_page(program_lr, "Program page with no children yet.")
+
+    assert utils.programs_needing_children_heal([program_lr.id]) == set()
+
+
+@pytest.mark.django_db
+def test_programs_needing_children_heal_skips_when_marker_present():
+    """A program whose page already contains the children marker is skipped."""
+    course_lr = CourseFactory.create().learning_resource
+    _add_course_marketing_page(course_lr, "Child marketing copy.")
+    program_lr = ProgramFactory.create(courses=[course_lr]).learning_resource
+    _add_program_marketing_page(
+        program_lr, "Program page.\n\n## Program Contents\n\n### Child"
+    )
+
+    assert utils.programs_needing_children_heal([program_lr.id]) == set()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
Fixes mitodl/hq#12217

### Description (What does it do?)
Two changes to `scrape_marketing_pages`, so a program's embedded "Program Contents" section is actually populated from its child courses:

- **Ordering:** child courses are now scraped before their parent programs via `chain(group(courses), group(programs))`, so by the time a program is scraped its child marketing pages already exist.
- **Healing:** programs whose stored marketing page is missing the `## Program Contents` marker (and whose child content is now available) are re-queued. Selection is id-only and self-terminating — once a program is healed the marker is present, so it's excluded on the next run.

The worker task `marketing_page_for_resources` is unchanged. New read-only helpers live in `learning_resources/utils.py`; the child-course reachability query is shared between the content builder and the heal selection.

### How can this be tested?
0. Rebase with the `mb/pin-chromium-headless-fix` branch to fix a debian/chromium bug
1. Find a program whose `marketing_page` `ContentFile` content does **not** contain `## Program Contents` (and that has at least one child course with a marketing page).  One I had locally was "Differential Calculus" `program-v1:MITxT+18.01x`
2. Update the url of that program and it's child resources:
  ```python
  from learning_resources.models import *
  lr = LearningResource.objects.get(readable_id="program-v1:MITxT+18.01x")
  
  print(lr.id)
  print(lr.resources.values_list("id", flat=True))
  
  for lr in LearningResource.objects.filter(id__in=[86,366,280]):
      lr.url = lr.url.replace("http://open.odl.local:8062", "https://learn.mit.edu")
      lr.save()
  ```    
2. Trigger `scrape_marketing_pages.delay()`:
   ```python
   from learning_resources.tasks import *
   scrape_marketing_pages.delay()
   ```
3. Confirm child courses scrape first, then the program's page gains a populated `## Program Contents` section and `generate_embeddings` is queued for it.
4. Run `scrape_marketing_pages` again — the now-healed program is **not** re-queued.

### Additional Context
First run after deploy re-queues every healable program at once (Selenium scrape + re-embed). Intended one-time burst, bounded by the worker `rate_limit` and `QDRANT_CHUNK_SIZE` — worth watching queue depth / embedding spend on that run.