### PR TITLE
Fix: header stat counts not updating after bulk-assign or revoke on Contract Admin page

### DIFF
--- a/frontends/api/src/mitxonline/hooks/organizations/index.ts
+++ b/frontends/api/src/mitxonline/hooks/organizations/index.ts
@@ -45,6 +45,14 @@ const useBulkAssignSeats = () => {
           vars.parent_lookup_organization,
         ),
       })
+      // Assigning seats moves them from unassigned to assigned, which changes
+      // the header stat counts on the contract admin page.
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractDetail({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
+      })
     },
   })
 }
@@ -80,6 +88,14 @@ const useRevokeCode = () => {
           vars.id,
           vars.parent_lookup_organization,
         ),
+      })
+      // Revoking returns the seat to the unassigned pool, which changes the
+      // header stat counts on the contract admin page.
+      queryClient.invalidateQueries({
+        queryKey: managerOrganizationKeys.contractDetail({
+          id: vars.id,
+          parent_lookup_organization: vars.parent_lookup_organization,
+        }),
       })
     },
   })

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.test.tsx
@@ -480,6 +480,150 @@ describe("ContractAdminPage", () => {
     })
   })
 
+  describe("header stat counts refresh after mutations", () => {
+    test("bulk-assigning seats updates Unassigned and Pending claim counts", async () => {
+      mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+
+      const { org, contract } = makeOrgWithContract()
+      setMockResponse.get(managerOrgsUrl, {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [org],
+      })
+
+      let contractDetailCalls = 0
+      setMockResponse.get(managerContractDetailUrl(org.id, contract.id), () => {
+        contractDetailCalls += 1
+        return contractDetailCalls === 1
+          ? makeContractDetail(contract, {
+              total_codes: 10,
+              assigned_codes: 2,
+              unassigned_codes: 6,
+              redeemed_codes: 2,
+            })
+          : makeContractDetail(contract, {
+              total_codes: 10,
+              assigned_codes: 3,
+              unassigned_codes: 5,
+              redeemed_codes: 2,
+            })
+      })
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 25,
+        }),
+        factories.contracts.paginatedContractCodes([]),
+      )
+      setMockResponse.post(
+        urls.contracts.managerContractBulkAssign(org.id, contract.id),
+        factories.contracts.bulkAssignResult({
+          assigned: [factories.contracts.contractCode()],
+          errors: [],
+        }),
+      )
+
+      renderWithProviders(
+        <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+      )
+
+      expect(
+        await screen.findByRole("group", { name: "Unassigned" }),
+      ).toHaveTextContent("6")
+
+      const textarea = screen.getByPlaceholderText(/enter employee emails/i)
+      await user.click(textarea)
+      await user.paste("alice@example.com")
+      await user.click(screen.getByRole("button", { name: "Assign Seats" }))
+      await user.click(
+        screen.getByRole("button", { name: /send 1 invitation/i }),
+      )
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("group", { name: "Unassigned" }),
+        ).toHaveTextContent("5")
+      })
+      expect(
+        screen.getByRole("group", { name: "Pending claim" }),
+      ).toHaveTextContent("3")
+    })
+
+    test("releasing a seat updates Unassigned and Pending claim counts", async () => {
+      mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+      mockedUseFeatureFlagEnabled.mockReturnValue(true)
+
+      const { org, contract } = makeOrgWithContract()
+      setMockResponse.get(managerOrgsUrl, {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [org],
+      })
+
+      let contractDetailCalls = 0
+      setMockResponse.get(managerContractDetailUrl(org.id, contract.id), () => {
+        contractDetailCalls += 1
+        return contractDetailCalls === 1
+          ? makeContractDetail(contract, {
+              total_codes: 10,
+              assigned_codes: 2,
+              unassigned_codes: 6,
+              redeemed_codes: 2,
+            })
+          : makeContractDetail(contract, {
+              total_codes: 10,
+              assigned_codes: 1,
+              unassigned_codes: 7,
+              redeemed_codes: 2,
+            })
+      })
+
+      const assignedCode = factories.contracts.contractCode({
+        redemption_status: "assigned",
+        assigned_to: "pending@example.com",
+      })
+      setMockResponse.get(
+        urls.contracts.managerContractCodes(org.id, contract.id, {
+          page: 1,
+          page_size: 25,
+        }),
+        factories.contracts.paginatedContractCodes([assignedCode]),
+      )
+      setMockResponse.delete(
+        urls.contracts.managerContractCodeRevoke(
+          org.id,
+          contract.id,
+          assignedCode.code,
+        ),
+        assignedCode,
+      )
+
+      renderWithProviders(
+        <ContractAdminPage orgSlug={org.slug} contractSlug={contract.slug} />,
+      )
+
+      expect(
+        await screen.findByRole("group", { name: "Unassigned" }),
+      ).toHaveTextContent("6")
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+      await user.click(screen.getByRole("menuitem", { name: "Release seat" }))
+      await user.click(screen.getByRole("button", { name: "Release seat" }))
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("group", { name: "Unassigned" }),
+        ).toHaveTextContent("7")
+      })
+      expect(
+        screen.getByRole("group", { name: "Pending claim" }),
+      ).toHaveTextContent("1")
+    })
+  })
+
   test("Pending claim tab filters to assigned codes only", async () => {
     mockedUseFeatureFlagsLoaded.mockReturnValue(true)
     mockedUseFeatureFlagEnabled.mockReturnValue(true)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
The Contract Admin page header shows stat counts (Unassigned, Pending claim, etc.) derived from the contract detail query. Bulk-assigning seats or revoking a code mutates those counts server-side, but the `contractDetail` query wasn't being invalidated on mutation, so the header stayed stale until a full page refresh.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots


https://github.com/user-attachments/assets/23a10011-5497-4d91-9631-16eeae4af253



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Navigate to a Contract Admin page for an org with an active contract
2. Note the Unassigned and Pending claim counts in the header.
3. Bulk-assign one or more seats via email (paste an email, click Assign Seats, confirm the send)
4. Confirm the header's Unassigned count decreases and Pending claim increases immediately — no manual page refresh needed.
5. From the codes table, open More actions on an assigned-but-unredeemed code and click Release seat (revoke), then confirm.
6. Confirm the header's Unassigned count increases and Pending claim decreases immediately.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
