### PR TITLE
Ensure remove_qdrant_records includes platform code when deleting points from qdrant  

### DIFF
--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -637,7 +637,10 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
         )
         serialized_document = serializer.render_document()
         checksum = checksum_for_content(str(serialized_document))
-        key = f"{doc['readable_id']}.course_metadata"
+        key = (
+            f"{(doc.get('platform') or {}).get('code', '')}."
+            "{doc['readable_id']}.course_metadata"
+        )
         serialized_document["checksum"] = checksum
         serialized_document["key"] = key
         document_point_id = vector_point_id(
@@ -647,6 +650,7 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
             serialized_document, document_point_id
         ):
             continue
+
         # remove existing course info docs
         remove_points_matching_params(
             {"key": key}, collection_name=CONTENT_FILES_COLLECTION_NAME
@@ -736,6 +740,7 @@ def _generate_content_file_points(serialized_content):
         remove_params = {
             "key": doc["key"],
             "resource_readable_id": doc["resource_readable_id"],
+            "platform": doc.get("platform"),
         }
         if doc.get("run_readable_id"):
             remove_params["run_readable_id"] = doc["run_readable_id"]

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1330,16 +1330,20 @@ def remove_qdrant_records(ids, resource_type):
     if resource_type != CONTENT_FILE_TYPE:
         serialized_documents = serialize_bulk_learning_resources(ids)
         collection_name = RESOURCES_COLLECTION_NAME
-        lookup_keys = ["readable_id"]
+        lookup_keys = ["readable_id", "platform"]
     else:
         serialized_documents = serialize_bulk_content_files(ids)
         collection_name = CONTENT_FILES_COLLECTION_NAME
-        lookup_keys = ["run_readable_id", "resource_readable_id", "key"]
+        lookup_keys = ["platform", "run_readable_id", "resource_readable_id", "key"]
     for doc in serialized_documents:
         params = {}
         for key in lookup_keys:
             if key in doc:
-                params[key] = doc[key]
+                value = doc[key]
+                if key == "platform" and isinstance(value, dict):
+                    value = value.get("code")
+                if value is not None:
+                    params[key] = value
         if params:
             remove_points_matching_params(params, collection_name=collection_name)
 

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -639,7 +639,7 @@ def _embed_course_metadata_as_contentfile(serialized_resources):
         checksum = checksum_for_content(str(serialized_document))
         key = (
             f"{(doc.get('platform') or {}).get('code', '')}."
-            "{doc['readable_id']}.course_metadata"
+            f"{doc['readable_id']}.course_metadata"
         )
         serialized_document["checksum"] = checksum
         serialized_document["key"] = key

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -740,7 +740,7 @@ def _generate_content_file_points(serialized_content):
         remove_params = {
             "key": doc["key"],
             "resource_readable_id": doc["resource_readable_id"],
-            "platform": (doc.get("platform") or {}).get("code", ""),
+            "platform": (doc.get("platform") or {}).get("code"),
         }
         if doc.get("run_readable_id"):
             remove_params["run_readable_id"] = doc["run_readable_id"]

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -740,7 +740,7 @@ def _generate_content_file_points(serialized_content):
         remove_params = {
             "key": doc["key"],
             "resource_readable_id": doc["resource_readable_id"],
-            "platform": doc.get("platform"),
+            "platform": (doc.get("platform") or {}).get("code", ""),
         }
         if doc.get("run_readable_id"):
             remove_params["run_readable_id"] = doc["run_readable_id"]

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -320,7 +320,9 @@ def test_remove_qdrant_records_filters_learning_resources_by_platform(
     """Learning resource deletes should not cross platform boundaries."""
     mocker.patch(
         "vector_search.utils.serialize_bulk_learning_resources",
-        return_value=[{"readable_id": "shared-readable-id", "platform": platform_value}],
+        return_value=[
+            {"readable_id": "shared-readable-id", "platform": platform_value}
+        ],
     )
     mock_remove_points_matching_params = mocker.patch(
         "vector_search.utils.remove_points_matching_params"
@@ -332,6 +334,7 @@ def test_remove_qdrant_records_filters_learning_resources_by_platform(
         expected_params,
         collection_name=RESOURCES_COLLECTION_NAME,
     )
+
 
 def test_remove_qdrant_records_filters_content_files_by_platform(mocker):
     """Content file deletes should include the platform in their identity filter."""

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -311,7 +311,7 @@ def test_filter_existing_qdrant_points(mocker):
     ("platform_value", "expected_params"),
     [
         ({"code": "ocw"}, {"readable_id": "shared-readable-id", "platform": "ocw"}),
-        (None, {"readable_id": "shared-readable-id", "platform__isnull": True}),
+        (None, {"readable_id": "shared-readable-id"}),
     ],
 )
 def test_remove_qdrant_records_filters_learning_resources_by_platform(

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -307,16 +307,20 @@ def test_filter_existing_qdrant_points(mocker):
     assert filtered_resources.count() == 7
 
 
-def test_remove_qdrant_records_filters_learning_resources_by_platform(mocker):
+@pytest.mark.parametrize(
+    ("platform_value", "expected_params"),
+    [
+        ({"code": "ocw"}, {"readable_id": "shared-readable-id", "platform": "ocw"}),
+        (None, {"readable_id": "shared-readable-id", "platform__isnull": True}),
+    ],
+)
+def test_remove_qdrant_records_filters_learning_resources_by_platform(
+    mocker, platform_value, expected_params
+):
     """Learning resource deletes should not cross platform boundaries."""
     mocker.patch(
         "vector_search.utils.serialize_bulk_learning_resources",
-        return_value=[
-            {
-                "readable_id": "shared-readable-id",
-                "platform": {"code": "ocw"},
-            }
-        ],
+        return_value=[{"readable_id": "shared-readable-id", "platform": platform_value}],
     )
     mock_remove_points_matching_params = mocker.patch(
         "vector_search.utils.remove_points_matching_params"
@@ -325,10 +329,9 @@ def test_remove_qdrant_records_filters_learning_resources_by_platform(mocker):
     remove_qdrant_records([1], COURSE_TYPE)
 
     mock_remove_points_matching_params.assert_called_once_with(
-        {"readable_id": "shared-readable-id", "platform": "ocw"},
+        expected_params,
         collection_name=RESOURCES_COLLECTION_NAME,
     )
-
 
 def test_remove_qdrant_records_filters_content_files_by_platform(mocker):
     """Content file deletes should include the platform in their identity filter."""

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -27,6 +27,7 @@ from learning_resources.models import LearningResource
 from learning_resources.serializers import LearningResourceMetadataDisplaySerializer
 from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
+    COURSE_TYPE,
 )
 from learning_resources_search.serializers import (
     serialize_bulk_content_files,
@@ -72,6 +73,7 @@ from vector_search.utils import (
     embed_topics,
     filter_existing_qdrant_points,
     qdrant_query_conditions,
+    remove_qdrant_records,
     should_generate_content_embeddings,
     should_generate_resource_embeddings,
     update_content_file_payload,
@@ -303,6 +305,59 @@ def test_filter_existing_qdrant_points(mocker):
         == 0
     )
     assert filtered_resources.count() == 7
+
+
+def test_remove_qdrant_records_filters_learning_resources_by_platform(mocker):
+    """Learning resource deletes should not cross platform boundaries."""
+    mocker.patch(
+        "vector_search.utils.serialize_bulk_learning_resources",
+        return_value=[
+            {
+                "readable_id": "shared-readable-id",
+                "platform": {"code": "ocw"},
+            }
+        ],
+    )
+    mock_remove_points_matching_params = mocker.patch(
+        "vector_search.utils.remove_points_matching_params"
+    )
+
+    remove_qdrant_records([1], COURSE_TYPE)
+
+    mock_remove_points_matching_params.assert_called_once_with(
+        {"readable_id": "shared-readable-id", "platform": "ocw"},
+        collection_name=RESOURCES_COLLECTION_NAME,
+    )
+
+
+def test_remove_qdrant_records_filters_content_files_by_platform(mocker):
+    """Content file deletes should include the platform in their identity filter."""
+    mocker.patch(
+        "vector_search.utils.serialize_bulk_content_files",
+        return_value=[
+            {
+                "platform": {"code": "mitxonline"},
+                "run_readable_id": "shared-run-id",
+                "resource_readable_id": "shared-readable-id",
+                "key": "documents/syllabus.pdf",
+            }
+        ],
+    )
+    mock_remove_points_matching_params = mocker.patch(
+        "vector_search.utils.remove_points_matching_params"
+    )
+
+    remove_qdrant_records([1], CONTENT_FILE_TYPE)
+
+    mock_remove_points_matching_params.assert_called_once_with(
+        {
+            "platform": "mitxonline",
+            "run_readable_id": "shared-run-id",
+            "resource_readable_id": "shared-readable-id",
+            "key": "documents/syllabus.pdf",
+        },
+        collection_name=CONTENT_FILES_COLLECTION_NAME,
+    )
 
 
 def test_force_create_qdrant_collections(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12225
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where the platform is not included as a filter when removing embeddings.

### How can this be tested?
1. checkout main
2. run the following in django shell which creates 2 courses that share the same readable id but have different platform codes:
```python
import time

from learning_resources.constants import PlatformType
from learning_resources.factories import (
    LearningResourceFactory,
    LearningResourcePlatformFactory,
)
from learning_resources_search.constants import COURSE_TYPE
from vector_search.constants import RESOURCES_COLLECTION_NAME
from vector_search.utils import (
    embed_learning_resources,
    qdrant_client,
    remove_qdrant_records,
    vector_point_id,
)

client = qdrant_client()
readable_id = "manual-shared-readable-id"

ocw = LearningResourcePlatformFactory(code=PlatformType.ocw.name)
mitx = LearningResourcePlatformFactory(code=PlatformType.mitxonline.name)

ocw_resource = LearningResourceFactory(
    readable_id=readable_id,
    platform=ocw,
    resource_type=COURSE_TYPE,
)
mitx_resource = LearningResourceFactory(
    readable_id=readable_id,
    platform=mitx,
    resource_type=COURSE_TYPE,
)

embed_learning_resources([ocw_resource.id, mitx_resource.id], COURSE_TYPE, overwrite=True)

ocw_point_id = vector_point_id(f"{ocw.code}.{readable_id}")
mitx_point_id = vector_point_id(f"{mitx.code}.{readable_id}")

print("Before delete:")
print(f"there are {len(client.retrieve(collection_name=RESOURCES_COLLECTION_NAME, ids=[ocw_point_id, mitx_point_id]))} records in qdrant for course:{readable_id}")
remove_qdrant_records([ocw_resource.id], COURSE_TYPE)
time.sleep(1)  
print("After delete:")
print(f"there are {len(client.retrieve(collection_name=RESOURCES_COLLECTION_NAME, ids=[ocw_point_id, mitx_point_id]))} records in qdrant for course:{readable_id}")
```
3. note that both records are removed from qdrant
4. checkout this branch and try the same. note that it correctly removes only one of the records.
