### PR TITLE
Pin chromium to 149.0.7827.196 to fix headless crash in current Debian build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       libcairo2-dev \
       poppler-utils \
       default-jre && \
-    echo "deb http://deb.debian.org/debian/ sid main" >> /etc/apt/sources.list && \
+    # chromium 150.0.7871.46 crashes on startup in headless mode (Debian bug
+    # #1141488), breaking all chromedriver sessions. Pin the last working
+    # build from snapshot.debian.org; unpin once a fixed version ships.
+    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260628T000000Z/ trixie-security main" >> /etc/apt/sources.list && \
     apt-get update -qqy && \
-    apt-get install -qqy --no-install-recommends chromium chromium-driver
+    apt-get install -qqy --no-install-recommends \
+      chromium=149.0.7827.196-1~deb13u1 \
+      chromium-common=149.0.7827.196-1~deb13u1 \
+      chromium-driver=149.0.7827.196-1~deb13u1
 
 FROM base AS deps
 


### PR DESCRIPTION
### What are the relevant tickets?

N/A — upstream regression: [Debian bug #1141488](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1141488)

### Description (What does it do?)

Pins `chromium`/`chromium-driver` in the Dockerfile to `149.0.7827.196-1~deb13u1`, installed from a frozen snapshot.debian.org archive, instead of installing whatever Debian **sid** has at image build time.

### How can this be tested?

Rebuild the image (`docker compose build --no-cache web`), then in a Django shell with `EMBEDDINGS_EXTERNAL_FETCH_USE_WEBDRIVER=True` (already set on RC; required locally or the task skips chromium entirely):

```python
from learning_resources.tasks import marketing_page_for_resources
from learning_resources.models import *

lr = LearningResource.objects.filter(published=True, resource_type="course", etl_source="mitxonline").first()
lr.url = lr.url.replace("http://open.odl.local:8062", "https://learn.mit.edu")
lr.save()
marketing_page_for_resources([lr.id])
```

It should complete and write a `marketing_page` ContentFile for the resource. On the old image it raises `SessionNotCreatedException: Chrome instance exited` immediately.

Verified locally against the rebuilt image (resource pointed at a real mitxonline marketing page, since local seed resources use fake `open.odl.local` URLs): task completed and produced a 7,002-char markdown ContentFile. Note the browser session outlives the task (`get_web_driver()` is `@cache`d), so a lingering chromium process afterward is expected.

### Additional Context

The pin should be dropped (or bumped) once Debian ships a fixed chromium — #1141488 already has a patch attached. Until then any rebuild without this pin produces images with non-functional scraping.
