### PR TITLE
Fix embedding summarizer task when overwrite=True

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -468,7 +468,7 @@ def embed_run_content_files(self, run_id):
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
 
-    return _replace_with_finalized_chain(self, content_file_ids, overwrite=False)
+    return _replace_with_finalized_chain(self, content_file_ids, overwrite=True)
 
 
 @app.task(bind=True)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -468,7 +468,7 @@ def embed_run_content_files(self, run_id):
         ContentFile.objects.filter(run__id=run_id).values_list("id", flat=True)
     )
 
-    return _replace_with_finalized_chain(self, content_file_ids, overwrite=True)
+    return _replace_with_finalized_chain(self, content_file_ids, overwrite=False)
 
 
 @app.task(bind=True)

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -616,6 +616,9 @@ def _content_file_stored_checksum_changed(serialized_document: dict) -> bool:
     if not point:
         return False
     stored_checksum = (point.payload or {}).get("checksum")
+    # Missing checksums should not force an expensive summary rewrite by themselves.
+    # should_generate_content_embeddings still treats them as changed so embeddings
+    # can repair older Qdrant points without overwriting existing summaries.
     return stored_checksum is not None and stored_checksum != serialized_document.get(
         "checksum"
     )

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -591,12 +591,9 @@ def should_generate_resource_embeddings(serialized_document):
     return True
 
 
-def should_generate_content_embeddings(
+def _retrieve_content_file_point(
     serialized_document: dict, point_id: str | None = None
-) -> bool:
-    """
-    Determine if we should generate embeddings for a content file
-    """
+):
     client = qdrant_client()
     if not point_id:
         # we just need metadata from the first chunk
@@ -610,10 +607,31 @@ def should_generate_content_embeddings(
         ids=[point_id],
     )
     if len(response) > 0:
-        qdrant_checksum = response[0].payload.get("checksum")
-        if qdrant_checksum == serialized_document["checksum"]:
-            return False
-    return True
+        return response[0]
+    return None
+
+
+def _content_file_stored_checksum_changed(serialized_document: dict) -> bool:
+    point = _retrieve_content_file_point(serialized_document)
+    if not point:
+        return False
+    stored_checksum = (point.payload or {}).get("checksum")
+    return stored_checksum is not None and stored_checksum != serialized_document.get(
+        "checksum"
+    )
+
+
+def should_generate_content_embeddings(
+    serialized_document: dict, point_id: str | None = None
+) -> bool:
+    """
+    Determine if we should generate embeddings for a content file
+    """
+    point = _retrieve_content_file_point(serialized_document, point_id=point_id)
+    if not point:
+        return True
+    qdrant_checksum = (point.payload or {}).get("checksum")
+    return qdrant_checksum != serialized_document["checksum"]
 
 
 def _embed_course_metadata_as_contentfile(serialized_resources):
@@ -849,7 +867,8 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
         serialized_resources = _iter_serialized_content_files(ids)
 
         # populated/modified by reference in process_batch
-        summary_content_ids = []
+        fill_summary_content_ids = []
+        changed_summary_content_ids = []
 
         # Batching parameters
         current_batch_docs = []
@@ -857,7 +876,7 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
 
         collection_name = CONTENT_FILES_COLLECTION_NAME
 
-        def process_batch(docs_batch, summaries_list):
+        def process_batch(docs_batch, fill_summaries_list, changed_summaries_list):
             """Process a batch of documents"""
             # Collect IDs for summarization
             contentfile_points = [
@@ -889,7 +908,10 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
                     .filter(run__id=resource.get("run_id"))
                     .exists()
                 ):
-                    summaries_list.append(resource["id"])
+                    if _content_file_stored_checksum_changed(resource):
+                        changed_summaries_list.append(resource["id"])
+                    else:
+                        fill_summaries_list.append(resource["id"])
 
             points_generator_iter = _generate_content_file_points(docs_batch)
             points_upload_batch = []
@@ -935,20 +957,32 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
             current_batch_size += len(doc.get("content", "") or "")
 
             if current_batch_size >= settings.QDRANT_BATCH_SIZE_BYTES:
-                process_batch(current_batch_docs, summary_content_ids)
+                process_batch(
+                    current_batch_docs,
+                    fill_summary_content_ids,
+                    changed_summary_content_ids,
+                )
                 current_batch_docs = []
                 current_batch_size = 0
                 gc.collect()
 
         # Process remaining
         if current_batch_docs:
-            process_batch(current_batch_docs, summary_content_ids)
+            process_batch(
+                current_batch_docs,
+                fill_summary_content_ids,
+                changed_summary_content_ids,
+            )
             current_batch_docs = []
             gc.collect()
 
-        if summary_content_ids:
+        if fill_summary_content_ids:
             ContentSummarizer().summarize_content_files_by_ids(
-                summary_content_ids, overwrite
+                fill_summary_content_ids, overwrite=False
+            )
+        if changed_summary_content_ids:
+            ContentSummarizer().summarize_content_files_by_ids(
+                changed_summary_content_ids, overwrite=True
             )
 
         points = None  # Handled inside the loop

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -908,7 +908,7 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
                     .filter(run__id=resource.get("run_id"))
                     .exists()
                 ):
-                    if _content_file_stored_checksum_changed(resource):
+                    if overwrite and _content_file_stored_checksum_changed(resource):
                         changed_summaries_list.append(resource["id"])
                     else:
                         fill_summaries_list.append(resource["id"])

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -827,6 +827,42 @@ def _iter_serialized_content_files(ids):
         yield from serialize_bulk_content_files(id_batch)
 
 
+def _summarize_content_files_for_embedding(
+    docs_batch, fill_summary_content_ids, changed_summary_content_ids
+):
+    if not fill_summary_content_ids and not changed_summary_content_ids:
+        return docs_batch
+
+    summarizer = ContentSummarizer()
+    if fill_summary_content_ids:
+        summarizer.summarize_content_files_by_ids(
+            fill_summary_content_ids, overwrite=False
+        )
+
+    failed_changed_ids = set()
+    if changed_summary_content_ids:
+        statuses = summarizer.summarize_content_files_by_ids(
+            changed_summary_content_ids, overwrite=True
+        )
+        failed_changed_ids = {
+            content_file_id
+            for content_file_id, status in zip(
+                changed_summary_content_ids, statuses or []
+            )
+            if "failed" in str(status).lower()
+        }
+
+    refreshed_docs = list(
+        _iter_serialized_content_files([doc["id"] for doc in docs_batch])
+    )
+    if failed_changed_ids:
+        # Keep the old Qdrant checksum so the next run retries summary generation.
+        refreshed_docs = [
+            doc for doc in refreshed_docs if doc["id"] not in failed_changed_ids
+        ]
+    return refreshed_docs
+
+
 def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C901
     """
     Embed learning resources
@@ -866,18 +902,17 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
     else:
         serialized_resources = _iter_serialized_content_files(ids)
 
-        # populated/modified by reference in process_batch
-        fill_summary_content_ids = []
-        changed_summary_content_ids = []
-
         # Batching parameters
         current_batch_docs = []
         current_batch_size = 0
 
         collection_name = CONTENT_FILES_COLLECTION_NAME
 
-        def process_batch(docs_batch, fill_summaries_list, changed_summaries_list):
+        def process_batch(docs_batch):
             """Process a batch of documents"""
+            fill_summary_content_ids = []
+            changed_summary_content_ids = []
+
             # Collect IDs for summarization
             contentfile_points = [
                 (
@@ -909,9 +944,15 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
                     .exists()
                 ):
                     if overwrite and _content_file_stored_checksum_changed(resource):
-                        changed_summaries_list.append(resource["id"])
+                        changed_summary_content_ids.append(resource["id"])
                     else:
-                        fill_summaries_list.append(resource["id"])
+                        fill_summary_content_ids.append(resource["id"])
+
+            docs_batch = _summarize_content_files_for_embedding(
+                docs_batch,
+                fill_summary_content_ids,
+                changed_summary_content_ids,
+            )
 
             points_generator_iter = _generate_content_file_points(docs_batch)
             points_upload_batch = []
@@ -957,33 +998,16 @@ def embed_learning_resources(ids, resource_type, overwrite):  # noqa: PLR0915, C
             current_batch_size += len(doc.get("content", "") or "")
 
             if current_batch_size >= settings.QDRANT_BATCH_SIZE_BYTES:
-                process_batch(
-                    current_batch_docs,
-                    fill_summary_content_ids,
-                    changed_summary_content_ids,
-                )
+                process_batch(current_batch_docs)
                 current_batch_docs = []
                 current_batch_size = 0
                 gc.collect()
 
         # Process remaining
         if current_batch_docs:
-            process_batch(
-                current_batch_docs,
-                fill_summary_content_ids,
-                changed_summary_content_ids,
-            )
+            process_batch(current_batch_docs)
             current_batch_docs = []
             gc.collect()
-
-        if fill_summary_content_ids:
-            ContentSummarizer().summarize_content_files_by_ids(
-                fill_summary_content_ids, overwrite=False
-            )
-        if changed_summary_content_ids:
-            ContentSummarizer().summarize_content_files_by_ids(
-                changed_summary_content_ids, overwrite=True
-            )
 
         points = None  # Handled inside the loop
     if points:

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1056,7 +1056,7 @@ def test_update_payload_no_points(mocker):
 @pytest.mark.django_db
 def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mocker):
     """
-    Test that summarize_content_files_by_ids is only called with contentfiles that have an existing summary
+    Test that embedding overwrites don't overwrite existing summaries.
     """
     mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
     mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
@@ -1066,12 +1066,18 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
     )
     mocker.patch("vector_search.utils.remove_qdrant_records")
 
+    learning_resource = LearningResourceFactory.create(
+        resource_type="video", create_video=False, create_runs=False
+    )
     # Create ContentFiles, some with summary, some without
     contentfiles_with_summary = ContentFileFactory.create_batch(
-        2, content="abc", summary="summary text"
+        2,
+        content="abc",
+        learning_resource=learning_resource,
+        summary="summary text",
     )
     contentfiles_without_summary = ContentFileFactory.create_batch(
-        3, content="def", summary=""
+        3, content="def", learning_resource=learning_resource, summary=""
     )
     all_contentfiles = contentfiles_with_summary + contentfiles_without_summary
 
@@ -1081,6 +1087,7 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
         d = {
             "id": cf.id,
             "resource_readable_id": getattr(cf, "resource_readable_id", "resid"),
+            "run_id": cf.id,
             "run_readable_id": getattr(cf, "run_readable_id", "runid"),
             "key": getattr(cf, "key", "key"),
             "summary": cf.summary,
@@ -1090,6 +1097,9 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
         serialized.append(d)
     mocker.patch(
         "vector_search.utils.serialize_bulk_content_files", return_value=serialized
+    )
+    mocker.patch(
+        "vector_search.utils._content_file_stored_checksum_changed", return_value=False
     )
 
     summarize_mock = mocker.patch(
@@ -1101,7 +1111,65 @@ def test_embed_learning_resources_summarizes_only_contentfiles_with_summary(mock
 
     # Only contentfiles with summary should be passed
     expected_ids = [cf.id for cf in contentfiles_with_summary]
-    summarize_mock.assert_called_once_with(expected_ids, True)  # noqa: FBT003
+    summarize_mock.assert_called_once_with(expected_ids, overwrite=False)
+
+
+@pytest.mark.django_db
+def test_embed_learning_resources_overwrites_summaries_for_changed_content(mocker):
+    """Embedding overwrites regenerate summaries only when content changed."""
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
+    mocker.patch("vector_search.utils.create_qdrant_collections")
+    mocker.patch("vector_search.utils.remove_qdrant_records")
+
+    learning_resource = LearningResourceFactory.create(
+        resource_type="video", create_video=False, create_runs=False
+    )
+    unchanged_content_file = ContentFileFactory.create(
+        content="unchanged content",
+        learning_resource=learning_resource,
+        summary="summary text",
+    )
+    changed_content_file = ContentFileFactory.create(
+        content="changed content",
+        learning_resource=learning_resource,
+        summary="old summary text",
+    )
+    all_contentfiles = [unchanged_content_file, changed_content_file]
+
+    serialized = [
+        {
+            "id": cf.id,
+            "resource_readable_id": "resid",
+            "run_id": cf.id,
+            "run_readable_id": "runid",
+            "key": cf.key,
+            "summary": cf.summary,
+            "content": cf.content,
+            "checksum": cf.checksum,
+        }
+        for cf in all_contentfiles
+    ]
+
+    mocker.patch(
+        "vector_search.utils.serialize_bulk_content_files", return_value=serialized
+    )
+    mocker.patch(
+        "vector_search.utils._content_file_stored_checksum_changed",
+        side_effect=lambda resource: resource["id"] == changed_content_file.id,
+    )
+
+    summarize_mock = mocker.patch(
+        "learning_resources.content_summarizer.ContentSummarizer.summarize_content_files_by_ids"
+    )
+    embed_learning_resources(
+        [cf.id for cf in all_contentfiles], "content_file", overwrite=True
+    )
+
+    assert summarize_mock.mock_calls == [
+        mocker.call([unchanged_content_file.id], overwrite=False),
+        mocker.call([changed_content_file.id], overwrite=True),
+    ]
 
 
 def test_vector_search_group_by(mocker, client, django_user_model):

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -1162,6 +1162,15 @@ def test_embed_learning_resources_overwrites_summaries_for_changed_content(mocke
     summarize_mock = mocker.patch(
         "learning_resources.content_summarizer.ContentSummarizer.summarize_content_files_by_ids"
     )
+
+    def summarize_before_upsert(content_file_ids, *, overwrite):
+        mock_qdrant.batch_update_points.assert_not_called()
+        return [
+            f"Summarization succeeded for CONTENT_FILE_ID: {content_file_id}"
+            for content_file_id in content_file_ids
+        ]
+
+    summarize_mock.side_effect = summarize_before_upsert
     embed_learning_resources(
         [cf.id for cf in all_contentfiles], "content_file", overwrite=True
     )
@@ -1170,6 +1179,52 @@ def test_embed_learning_resources_overwrites_summaries_for_changed_content(mocke
         mocker.call([unchanged_content_file.id], overwrite=False),
         mocker.call([changed_content_file.id], overwrite=True),
     ]
+
+
+@pytest.mark.django_db
+def test_embed_learning_resources_keeps_old_checksum_when_summary_fails(mocker):
+    """A failed changed-content summary should be retried on the next embedding run."""
+    mock_qdrant = mocker.patch("qdrant_client.QdrantClient")
+    mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
+    mocker.patch("vector_search.utils.create_qdrant_collections")
+
+    learning_resource = LearningResourceFactory.create(
+        resource_type="video", create_video=False, create_runs=False
+    )
+    content_file = ContentFileFactory.create(
+        content="changed content",
+        learning_resource=learning_resource,
+        summary="old summary text",
+    )
+    serialized = [
+        {
+            "id": content_file.id,
+            "resource_readable_id": "resid",
+            "run_id": content_file.id,
+            "run_readable_id": "runid",
+            "key": content_file.key,
+            "summary": content_file.summary,
+            "content": content_file.content,
+            "checksum": content_file.checksum,
+        }
+    ]
+    mocker.patch(
+        "vector_search.utils.serialize_bulk_content_files", return_value=serialized
+    )
+    mocker.patch(
+        "vector_search.utils._content_file_stored_checksum_changed", return_value=True
+    )
+    summarize_mock = mocker.patch(
+        "learning_resources.content_summarizer.ContentSummarizer.summarize_content_files_by_ids",
+        return_value=[
+            f"Summary generation failed for CONTENT_FILE_ID: {content_file.id}"
+        ],
+    )
+
+    embed_learning_resources([content_file.id], "content_file", overwrite=True)
+
+    summarize_mock.assert_called_once_with([content_file.id], overwrite=True)
+    mock_qdrant.batch_update_points.assert_not_called()
 
 
 def test_vector_search_group_by(mocker, client, django_user_model):

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -979,6 +979,45 @@ def test_should_generate_for_changed_content_file(mocker):
     assert result is True
 
 
+@pytest.mark.parametrize(
+    ("stored_payload", "expected"),
+    [
+        ({"checksum": "previous-checksum"}, True),
+        ({"checksum": "current-checksum"}, False),
+        ({}, False),
+        (None, False),
+    ],
+)
+def test_content_file_stored_checksum_changed(mocker, stored_payload, expected):
+    """Only an existing, different stored checksum counts as changed for summaries."""
+    serialized_document = {
+        "resource_readable_id": "resource-1",
+        "run_readable_id": "run-1",
+        "key": "transcript.txt",
+        "checksum": "current-checksum",
+    }
+    mock_qdrant = mocker.MagicMock()
+    if stored_payload is None:
+        mock_qdrant.retrieve.return_value = []
+    else:
+        mock_point = mocker.MagicMock()
+        mock_point.payload = stored_payload
+        mock_qdrant.retrieve.return_value = [mock_point]
+    mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
+
+    assert (
+        vs_utils._content_file_stored_checksum_changed(  # noqa: SLF001
+            serialized_document
+        )
+        is expected
+    )
+    mock_qdrant.retrieve.assert_called_once()
+    assert (
+        mock_qdrant.retrieve.call_args.kwargs["collection_name"]
+        == CONTENT_FILES_COLLECTION_NAME
+    )
+
+
 def test_should_not_generate_for_unchanged_content_file(mocker):
     """Should not generate embeddings when content file hasn't changed"""
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12244
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR ensures that we don't continuously regenerate summaries when running the mitxonline etls


### How can this be tested?
1. checkout main
2. go to django admin and configure a ContentSummarizerConfig object (use [prod as a reference](https://api.learn.mit.edu/admin/learning_resources/contentsummarizerconfiguration/1/change/) for mitxonline
3. find some contentfile ids for .srt files (that are also part of a course in a platform that summarizer config is set to - in this case mitxonline) and run the generate embeddings task with overwrite=True via:
```python
generate_embeddings.apply([[17964642, 17964479, 17964266, 17964348, 17964067, 17964323, 17964168,], 'content_file', True])
```
4. see in the output that the model configured for the summarizer is shown and that the contentfiles have summaries
5. re-run the exact same snippet and note that it keeps regenerating summaries
6. checkout this branch and repeat - note that summaries are only generated once


