### PR TITLE
chore: Remove temporary seat-cap gate on B2B Manage button

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.test.tsx
@@ -44,21 +44,6 @@ jest.mock("api/mitxonline-hooks/enrollment", () => ({
 const API_BASE_URL = process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL
 const managerOrganizationsUrl = `${API_BASE_URL}/api/v0/b2b/manager/organizations/`
 
-// ManagerContractDetail = ContractPage plus seat-count fields. total_codes
-// mirrors the contract's max_learners (null/0 means no seat cap).
-const makeContractDetail = (
-  contract: ReturnType<typeof factories.contracts.contract>,
-  overrides: { total_codes?: number | null } = {},
-) => ({
-  ...contract,
-  attachment_percentage: null,
-  total_enrollments: 0,
-  total_codes: overrides.total_codes ?? 10,
-  assigned_codes: 0,
-  unassigned_codes: 0,
-  redeemed_codes: 0,
-})
-
 const makeCourseEnrollment = factories.enrollment.courseEnrollment
 const makeGrade = factories.enrollment.grade
 
@@ -1488,11 +1473,6 @@ describe("ContractContent", () => {
       previous: null,
       results: [orgX],
     })
-    setMockResponse.get(
-      urls.contracts.managerContractDetail(orgX.id, orgX.contracts[0].id),
-      makeContractDetail(orgX.contracts[0], { total_codes: 10 }),
-    )
-
     renderWithProviders(
       <ContractContent
         orgSlug={orgX.slug}
@@ -1506,42 +1486,6 @@ describe("ContractContent", () => {
       contractAdminView(orgX.slug, orgX.contracts[0].slug),
     )
   })
-
-  // TEMPORARY: the Manage button is gated on the contract having a seat cap
-  // (max_learners / total_codes). Contracts with no cap (null/0) hide it until
-  // the seat-assignment admin page supports uncapped contracts.
-  test.each([{ totalCodes: null }, { totalCodes: 0 }])(
-    "does not render the Manage button when the contract has no seat cap (total_codes=$totalCodes)",
-    async ({ totalCodes }) => {
-      mockedUseFeatureFlagEnabled.mockImplementation(
-        (flag) => flag === FeatureFlags.B2BContractManagerDashboard,
-      )
-      const { orgX } = setupProgramsAndCourses()
-
-      setMockResponse.get(managerOrganizationsUrl, {
-        count: 1,
-        next: null,
-        previous: null,
-        results: [orgX],
-      })
-      setMockResponse.get(
-        urls.contracts.managerContractDetail(orgX.id, orgX.contracts[0].id),
-        makeContractDetail(orgX.contracts[0], { total_codes: totalCodes }),
-      )
-
-      renderWithProviders(
-        <ContractContent
-          orgSlug={orgX.slug}
-          contractSlug={orgX.contracts[0].slug}
-        />,
-      )
-
-      await screen.findByRole("heading", { name: orgX.name })
-      expect(
-        screen.queryByRole("link", { name: "Manage" }),
-      ).not.toBeInTheDocument()
-    },
-  )
 
   test("sanitizes HTML content in welcome_message_extra", async () => {
     const { orgX } = setupProgramsAndCourses()

--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -406,21 +406,6 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
     managerOrgs?.some(matchOrganizationBySlug(stripOrgPrefix(org.slug))) ??
     false
 
-  // TEMPORARY: hide the Manage button for contracts with no seat cap
-  // (max_learners null/0). The seat-assignment admin page doesn't yet support
-  // uncapped contracts, so we gate the entry point until it does.
-  // total_codes mirrors the contract's max_learners (null/0 means no seat cap).
-  const { data: managerContractDetail } = useQuery({
-    ...managerOrganizationQueries.managerContractDetail({
-      id: contract.id,
-      parent_lookup_organization: org.id,
-    }),
-    enabled: managerDashboardFlag === true && isManager,
-  })
-  const hasSeatCap =
-    typeof managerContractDetail?.total_codes === "number" &&
-    managerContractDetail.total_codes > 0
-
   const skeleton = (
     <Stack gap="16px">
       {Array.from({ length: 2 }).map((_, index) => (
@@ -460,7 +445,7 @@ const ContractContentInternal: React.FC<ContractContentInternalProps> = ({
       <Stack>
         <ContractHeaderSection>
           <ContractHeader org={org} contract={contract} />
-          {managerDashboardFlag && isManager && hasSeatCap && (
+          {managerDashboardFlag && isManager && (
             <ManageButtonWrapper>
               <ButtonLink
                 size="small"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

This PR relies on https://github.com/mitodl/mitxonline/pull/3734 being merged first.
- This removes the gate to hide "Manage" button on the B2B contract dashboard for contracts with no seat cap `max_learners`/`total_codes` null or 0

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

<img width="1355" height="762" alt="Screenshot 2026-07-08 at 10 20 27 AM" src="https://github.com/user-attachments/assets/a2286eb6-a52c-42ff-8b5e-31a047af1063" />

<img width="1344" height="744" alt="Screenshot 2026-07-08 at 10 20 54 AM" src="https://github.com/user-attachments/assets/73dd1aac-f316-43d5-9567-64a27b14bfbf" />

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
- [ ] As a B2B manager, open the dashboard for an org/contract with **no** seat cap max_learners === null and confirm the "Manage" button now renders.
- [ ] As a B2B manager, open the dashboard for an org/contract with **no** seat cap max_learners === 0 and confirm the "Manage" button now renders.
- [ ] Confirm it loads and shows "Unlimited seats" with Total Purchased/Unassigned stat blocks hidden.
- [ ] Assign a seat with the CSV upload or manual input and confirm an invite is successful 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
