### PR TITLE
Log missing contentfiles only for important block types

### DIFF
--- a/learning_resources/filters_test.py
+++ b/learning_resources/filters_test.py
@@ -629,11 +629,12 @@ def test_content_file_filter_logs_missing_edx_module_id(
 ):
     """Requesting an absent edx_module_id logs a missing-content-file error."""
     mock_log = mocker.patch("learning_resources.filters.log_missing_content_file")
+    absent_id = "block-v1:MITx+6.00x+2T2020+type@problem+block@does_not_exist"
 
-    client.get(f"{CONTENT_API_URL}?edx_module_id=block_does_not_exist")
+    client.get(CONTENT_API_URL, {"edx_module_id": absent_id})
 
     mock_log.assert_called_once_with(
-        "block_does_not_exist", reason="not_in_db", source="contentfiles_api"
+        absent_id, reason="not_in_db", source="contentfiles_api"
     )
 
 

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -45,14 +45,32 @@ from main.utils import generate_filepath
 log = logging.getLogger()
 
 
+LOGGED_MISSING_CONTENT_REGEX = re.compile(
+    r"\+type@(?:problem|video|html)\+block@"
+    r"|\+type@asset\+block@.+\.(?:srt|vtt)$",
+    re.IGNORECASE,
+)
+
+
+def is_loggable_missing_content_id(edx_module_id):
+    """Return whether this id's block type warrants a missing-contentfile log."""
+    return bool(LOGGED_MISSING_CONTENT_REGEX.search(edx_module_id or ""))
+
+
 def log_missing_content_file(identifier, *, reason, source):
     """
     Log that a request referenced an edx_module_id with no backing ContentFile.
+
+    Only important block types (problem, video, html, .srt/.vtt transcripts) are
+    logged; everything else (and malformed ids) is silently ignored to keep the
+    Sentry signal meaningful.
 
     reason: "not_in_db" (no ContentFile row) or "not_in_index" (row exists but
     not embedded in Qdrant). LoggingIntegration forwards the error to Sentry,
     which groups by the stable message template and applies its own rate limiting.
     """
+    if not is_loggable_missing_content_id(identifier):
+        return
     log.error(
         "Missing ContentFile (%s) for edx_module_id=%s [source=%s]",
         reason,

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -46,8 +46,8 @@ log = logging.getLogger()
 
 
 LOGGED_MISSING_CONTENT_REGEX = re.compile(
-    r"block-v1:.+\+type@(?:problem|video|html)\+block@.+"
-    r"|asset-v1:.+\+type@asset\+block@.+\.(?:srt|vtt)",
+    r"(?:block-v1:\S+\+type@(?:problem|video|html)\+block@\S+)"
+    r"|(?:asset-v1:\S+\+type@asset\+block@\S+\.(?:srt|vtt))",
     re.IGNORECASE,
 )
 

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -46,15 +46,15 @@ log = logging.getLogger()
 
 
 LOGGED_MISSING_CONTENT_REGEX = re.compile(
-    r"\+type@(?:problem|video|html)\+block@"
-    r"|\+type@asset\+block@.+\.(?:srt|vtt)$",
+    r"block-v1:.+\+type@(?:problem|video|html)\+block@.+"
+    r"|asset-v1:.+\+type@asset\+block@.+\.(?:srt|vtt)",
     re.IGNORECASE,
 )
 
 
 def is_loggable_missing_content_id(edx_module_id):
     """Return whether this id's block type warrants a missing-contentfile log."""
-    return bool(LOGGED_MISSING_CONTENT_REGEX.search(edx_module_id or ""))
+    return bool(LOGGED_MISSING_CONTENT_REGEX.fullmatch(edx_module_id or ""))
 
 
 def log_missing_content_file(identifier, *, reason, source):

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -1047,6 +1047,8 @@ def test_log_missing_content_file_logs_error(mocker):
         ("block-v1:MITx+6.00x+2T2020+type@discussion+block@abc", False),
         ("block-v1:MITx+6.00x+2T2020+type@folder+block@abc", False),
         ("does-not-exist", False),
+        ("junk+type@problem+block@abc", False),
+        ("prefix block-v1:MITx+6.00x+2T2020+type@video+block@abc", False),
         ("", False),
         (None, False),
     ],

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -42,6 +42,7 @@ from learning_resources.utils import (
     add_parent_topics_to_learning_resource,
     build_program_children_content,
     build_program_children_content_bulk,
+    is_loggable_missing_content_id,
     log_missing_content_file,
     strip_markdown_images,
     transfer_list_resources,
@@ -1021,12 +1022,48 @@ def test_strip_markdown_images(input_md, expected):
 def test_log_missing_content_file_logs_error(mocker):
     """Logs an error with the reason, identifier, and source."""
     mock_log = mocker.patch("learning_resources.utils.log")
+    identifier = "block-v1:MITx+6.00x+2T2020+type@problem+block@abc"
 
-    log_missing_content_file("block_x", reason="not_in_db", source="contentfiles_api")
+    log_missing_content_file(identifier, reason="not_in_db", source="contentfiles_api")
 
     mock_log.error.assert_called_once_with(
         "Missing ContentFile (%s) for edx_module_id=%s [source=%s]",
         "not_in_db",
-        "block_x",
+        identifier,
         "contentfiles_api",
     )
+
+
+@pytest.mark.parametrize(
+    ("edx_module_id", "loggable"),
+    [
+        ("block-v1:MITx+6.00x+2T2020+type@problem+block@abc", True),
+        ("block-v1:MITx+6.00x+2T2020+type@video+block@abc", True),
+        ("block-v1:MITx+6.00x+2T2020+type@html+block@abc", True),
+        ("asset-v1:MITx+6.00x+2T2020+type@asset+block@transcript.srt", True),
+        ("asset-v1:MITx+6.00x+2T2020+type@asset+block@transcript.vtt", True),
+        ("asset-v1:MITx+6.00x+2T2020+type@asset+block@TRANSCRIPT.SRT", True),
+        ("asset-v1:MITx+6.00x+2T2020+type@asset+block@image.png", False),
+        ("block-v1:MITx+6.00x+2T2020+type@discussion+block@abc", False),
+        ("block-v1:MITx+6.00x+2T2020+type@folder+block@abc", False),
+        ("does-not-exist", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_is_loggable_missing_content_id(edx_module_id, loggable):
+    """Only important block types (problem/video/html/.srt/.vtt) are loggable."""
+    assert is_loggable_missing_content_id(edx_module_id) is loggable
+
+
+def test_log_missing_content_file_skips_unimportant_block_type(mocker):
+    """An unimportant block type is not logged at all."""
+    mock_log = mocker.patch("learning_resources.utils.log")
+
+    log_missing_content_file(
+        "block-v1:MITx+6.00x+2T2020+type@discussion+block@abc",
+        reason="not_in_db",
+        source="contentfiles_api",
+    )
+
+    mock_log.error.assert_not_called()

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -1049,6 +1049,8 @@ def test_log_missing_content_file_logs_error(mocker):
         ("does-not-exist", False),
         ("junk+type@problem+block@abc", False),
         ("prefix block-v1:MITx+6.00x+2T2020+type@video+block@abc", False),
+        ("block-v1:MITx+6.00x+2T2020+type@problem+block@abc ", False),
+        ("block-v1:MITx+6.00x +2T2020+type@problem+block@abc", False),
         ("", False),
         (None, False),
     ],

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -27,6 +27,7 @@ from learning_resources.serializers import (
     LearningResourceSerializer,
 )
 from learning_resources.utils import (
+    is_loggable_missing_content_id,
     log_missing_content_file,
     present_edx_module_ids,
 )
@@ -1065,6 +1066,11 @@ async def check_missing_content_file_ids(edx_module_ids, collection_name):
     the DB but absent from the Qdrant index (not_in_index). Probes existence
     directly, independent of q/other request filters.
     """
+    edx_module_ids = [
+        eid for eid in edx_module_ids if is_loggable_missing_content_id(eid)
+    ]
+    if not edx_module_ids:
+        return
     present = await sync_to_async(present_edx_module_ids)(edx_module_ids)
     for missing in set(edx_module_ids) - present:
         log_missing_content_file(

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -2371,17 +2371,18 @@ def test_embed_learning_resources_uses_collection_guard(mocker):
 @pytest.mark.django_db
 def test_check_missing_content_file_ids_not_in_db(mocker):
     """An edx_module_id with no ContentFile row is logged not_in_db."""
+    absent_id = "block-v1:MITx+6.00x+2T2020+type@problem+block@absent"
     mock_log = mocker.patch("vector_search.utils.log_missing_content_file")
     mock_client = mocker.AsyncMock()
     mock_client.count = mocker.AsyncMock(return_value=CountResult(count=5))
     mocker.patch("vector_search.utils.async_qdrant_client", return_value=mock_client)
 
     async_to_sync(check_missing_content_file_ids)(
-        ["block_absent"], CONTENT_FILES_COLLECTION_NAME
+        [absent_id], CONTENT_FILES_COLLECTION_NAME
     )
 
     mock_log.assert_called_once_with(
-        "block_absent", reason="not_in_db", source="vector_content_files_search"
+        absent_id, reason="not_in_db", source="vector_content_files_search"
     )
     mock_client.count.assert_not_called()
 
@@ -2389,18 +2390,19 @@ def test_check_missing_content_file_ids_not_in_db(mocker):
 @pytest.mark.django_db
 def test_check_missing_content_file_ids_not_in_index(mocker):
     """An edx_module_id present in the DB but with zero Qdrant points -> not_in_index."""
-    ContentFileFactory.create(edx_module_id="block_present")
+    present_id = "block-v1:MITx+6.00x+2T2020+type@problem+block@present"
+    ContentFileFactory.create(edx_module_id=present_id)
     mock_log = mocker.patch("vector_search.utils.log_missing_content_file")
     mock_client = mocker.AsyncMock()
     mock_client.count = mocker.AsyncMock(return_value=CountResult(count=0))
     mocker.patch("vector_search.utils.async_qdrant_client", return_value=mock_client)
 
     async_to_sync(check_missing_content_file_ids)(
-        ["block_present"], CONTENT_FILES_COLLECTION_NAME
+        [present_id], CONTENT_FILES_COLLECTION_NAME
     )
 
     mock_log.assert_called_once_with(
-        "block_present", reason="not_in_index", source="vector_content_files_search"
+        present_id, reason="not_in_index", source="vector_content_files_search"
     )
     assert mock_client.count.call_args.kwargs["exact"] is True
 
@@ -2408,14 +2410,37 @@ def test_check_missing_content_file_ids_not_in_index(mocker):
 @pytest.mark.django_db
 def test_check_missing_content_file_ids_present_and_indexed_silent(mocker):
     """An id present in DB and present in Qdrant logs nothing."""
-    ContentFileFactory.create(edx_module_id="block_ok")
+    present_id = "block-v1:MITx+6.00x+2T2020+type@problem+block@ok"
+    ContentFileFactory.create(edx_module_id=present_id)
     mock_log = mocker.patch("vector_search.utils.log_missing_content_file")
     mock_client = mocker.AsyncMock()
     mock_client.count = mocker.AsyncMock(return_value=CountResult(count=3))
     mocker.patch("vector_search.utils.async_qdrant_client", return_value=mock_client)
 
     async_to_sync(check_missing_content_file_ids)(
-        ["block_ok"], CONTENT_FILES_COLLECTION_NAME
+        [present_id], CONTENT_FILES_COLLECTION_NAME
     )
 
+    mock_log.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_check_missing_content_file_ids_skips_unimportant_block_types(mocker):
+    """Unimportant block types are filtered out before any DB or Qdrant probe."""
+    mock_present = mocker.patch("vector_search.utils.present_edx_module_ids")
+    mock_log = mocker.patch("vector_search.utils.log_missing_content_file")
+    mock_client = mocker.AsyncMock()
+    mock_client.count = mocker.AsyncMock(return_value=CountResult(count=0))
+    mocker.patch("vector_search.utils.async_qdrant_client", return_value=mock_client)
+
+    async_to_sync(check_missing_content_file_ids)(
+        [
+            "block-v1:MITx+6.00x+2T2020+type@discussion+block@abc",
+            "does-not-exist",
+        ],
+        CONTENT_FILES_COLLECTION_NAME,
+    )
+
+    mock_present.assert_not_called()
+    mock_client.count.assert_not_called()
     mock_log.assert_not_called()

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -1085,14 +1085,15 @@ def test_content_file_vector_search_logs_missing_edx_module_id(
 ):
     """Vector search for an edx_module_id with no ContentFile logs not_in_db."""
     mock_log = mocker.patch("vector_search.utils.log_missing_content_file")
+    absent_id = "block-v1:MITx+6.00x+2T2020+type@problem+block@absent"
 
     client.get(
         reverse("vector_search:v0:vector_content_files_search"),
-        data={"q": "test", "edx_module_id": ["block_absent"]},
+        data={"q": "test", "edx_module_id": [absent_id]},
     )
 
     mock_log.assert_any_call(
-        "block_absent", reason="not_in_db", source="vector_content_files_search"
+        absent_id, reason="not_in_db", source="vector_content_files_search"
     )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12260

### Description (What does it do?)
`log_missing_content_file` (added in #3539) was logging a Sentry error for every requested `edx_module_id` with no backing content, regardless of block type — mostly noise (discussions, folders, images, etc). This gates the log behind a regex so only `problem`, `video`, `html`, and `.srt`/`.vtt` transcript assets produce an alert; everything else (including malformed ids) is silent. The vector-search probe also skips its DB/Qdrant lookups entirely for ids that could never be logged.

### How can this be tested?
If you haven't already done so, run `./manage.py backpopulate_mitxonline_data` with the relevant settings pointing to the mitxonline production API urls.

Then run `./manage.py backpopulate_mitxonline_files --resource-ids <id of course-v1:MITxT+2.25.1x>`

This resource (`course-v1:MITxT+2.25.1x`, "Advanced Fluid Mechanics 1: Fundamentals") has a mix of important and unimportant types locally, e.g.:

- **Important (should log when missing):**
  - `block-v1:MITxT+2.25.1x+2T2026+type@problem+block@f44351e18f3743f888f687ccc292acac`
  - `block-v1:MITxT+2.25.1x+2T2026+type@video+block@e46232bd459642e78fa6cb1b1709f038`
  - `block-v1:MITxT+2.25.1x+2T2026+type@html+block@00a75e1ce7ff4c8185db3da9192845bb`
  - `asset-v1:MITxT+2.25.1x+2T2026+type@asset+block@1701e24b-6848-4357-82f5-e58ea050bac0-en.srt`
- **Unimportant (should stay silent even when missing):**
  - `block-v1:MITxT+2.25.1x+2T2026+type@sequential+block@5d7317fc91974fa6b4e9b70ece8fee28`
  - `block-v1:MITxT+2.25.1x+2T2026+type@course+block@course`

Log in as an admin user and hit these (values need URL-encoding):

**REST endpoint** — real id is silent; take a real *important* id and mangle a character in the `block@` suffix to make it absent, or use `does-not-exist` (should now be silent):

```
http://open.odl.local:8065/api/v1/contentfiles/?edx_module_id=<REAL_PROBLEM_ID>          # silent (exists)
http://open.odl.local:8065/api/v1/contentfiles/?edx_module_id=<REAL_PROBLEM_ID>x         # logs (important type, absent)
http://open.odl.local:8065/api/v1/contentfiles/?edx_module_id=does-not-exist              # silent (unimportant/malformed id)
http://open.odl.local:8065/api/v1/contentfiles/?edx_module_id=block-v1:MITxT+2.25.1x+2T2026+type@sequential+block@doesnotexist   # silent (unimportant type)
```

**Vector endpoint** — only probes when there are no hits:

```
http://open.odl.local:8065/api/v0/vector_content_files_search/?edx_module_id=<REAL_PROBLEM_ID>x   # logs not_in_db
http://open.odl.local:8065/api/v0/vector_content_files_search/?edx_module_id=does-not-exist        # silent
```

Watch the web container logs for lines like:

```
Missing ContentFile (not_in_db) for edx_module_id=... [source=contentfiles_api]
```

It should only appear for the important-type requests above, never for `does-not-exist` or the `sequential`/`course` block types.