### PR TITLE
feat: Add parent podcast information while fetching the episode info  

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3638,37 +3638,6 @@ export interface Podcast {
   rss_url?: string | null
 }
 /**
- * Minimal parent-podcast summary embedded in an episode.
- * @export
- * @interface PodcastEpisodeParent
- */
-export interface PodcastEpisodeParent {
-  /**
-   *
-   * @type {number}
-   * @memberof PodcastEpisodeParent
-   */
-  id: number
-  /**
-   *
-   * @type {string}
-   * @memberof PodcastEpisodeParent
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof PodcastEpisodeParent
-   */
-  readable_id: string
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof PodcastEpisodeParent
-   */
-  image: LearningResourceImage | null
-}
-/**
  * Serializer for PodcastEpisode
  * @export
  * @interface PodcastEpisode
@@ -3687,7 +3656,7 @@ export interface PodcastEpisode {
    */
   podcasts: Array<number>
   /**
-   * Get summary info for the podcast(s) the episode belongs to
+   *
    * @type {Array<PodcastEpisodeParent>}
    * @memberof PodcastEpisode
    */
@@ -3722,6 +3691,37 @@ export interface PodcastEpisode {
    * @memberof PodcastEpisode
    */
   rss?: string | null
+}
+/**
+ * Minimal parent-podcast summary embedded in an episode.
+ * @export
+ * @interface PodcastEpisodeParent
+ */
+export interface PodcastEpisodeParent {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastEpisodeParent
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  readable_id: string
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastEpisodeParent
+   */
+  image: LearningResourceImage | null
 }
 /**
  * Serializer for podcast episode resources

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3638,6 +3638,37 @@ export interface Podcast {
   rss_url?: string | null
 }
 /**
+ * Minimal parent-podcast summary embedded in an episode.
+ * @export
+ * @interface PodcastEpisodeParent
+ */
+export interface PodcastEpisodeParent {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastEpisodeParent
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  readable_id: string
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastEpisodeParent
+   */
+  image: LearningResourceImage | null
+}
+/**
  * Serializer for PodcastEpisode
  * @export
  * @interface PodcastEpisode
@@ -3655,6 +3686,12 @@ export interface PodcastEpisode {
    * @memberof PodcastEpisode
    */
   podcasts: Array<number>
+  /**
+   * Get summary info for the podcast(s) the episode belongs to
+   * @type {Array<PodcastEpisodeParent>}
+   * @memberof PodcastEpisode
+   */
+  parent_podcasts: Array<PodcastEpisodeParent>
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -3716,12 +3716,6 @@ export interface PodcastEpisodeParent {
    * @memberof PodcastEpisodeParent
    */
   readable_id: string
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof PodcastEpisodeParent
-   */
-  image: LearningResourceImage | null
 }
 /**
  * Serializer for podcast episode resources

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -6667,6 +6667,37 @@ export interface Podcast {
   rss_url?: string | null
 }
 /**
+ * Minimal parent-podcast summary embedded in an episode.
+ * @export
+ * @interface PodcastEpisodeParent
+ */
+export interface PodcastEpisodeParent {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastEpisodeParent
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  readable_id: string
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastEpisodeParent
+   */
+  image: LearningResourceImage | null
+}
+/**
  * Serializer for PodcastEpisode
  * @export
  * @interface PodcastEpisode
@@ -6684,6 +6715,12 @@ export interface PodcastEpisode {
    * @memberof PodcastEpisode
    */
   podcasts: Array<number>
+  /**
+   * Get summary info for the podcast(s) the episode belongs to
+   * @type {Array<PodcastEpisodeParent>}
+   * @memberof PodcastEpisode
+   */
+  parent_podcasts: Array<PodcastEpisodeParent>
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -6745,12 +6745,6 @@ export interface PodcastEpisodeParent {
    * @memberof PodcastEpisodeParent
    */
   readable_id: string
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof PodcastEpisodeParent
-   */
-  image: LearningResourceImage | null
 }
 /**
  * Serializer for PodcastEpisode

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -6667,37 +6667,6 @@ export interface Podcast {
   rss_url?: string | null
 }
 /**
- * Minimal parent-podcast summary embedded in an episode.
- * @export
- * @interface PodcastEpisodeParent
- */
-export interface PodcastEpisodeParent {
-  /**
-   *
-   * @type {number}
-   * @memberof PodcastEpisodeParent
-   */
-  id: number
-  /**
-   *
-   * @type {string}
-   * @memberof PodcastEpisodeParent
-   */
-  title: string
-  /**
-   *
-   * @type {string}
-   * @memberof PodcastEpisodeParent
-   */
-  readable_id: string
-  /**
-   *
-   * @type {LearningResourceImage}
-   * @memberof PodcastEpisodeParent
-   */
-  image: LearningResourceImage | null
-}
-/**
  * Serializer for PodcastEpisode
  * @export
  * @interface PodcastEpisode
@@ -6716,7 +6685,7 @@ export interface PodcastEpisode {
    */
   podcasts: Array<number>
   /**
-   * Get summary info for the podcast(s) the episode belongs to
+   *
    * @type {Array<PodcastEpisodeParent>}
    * @memberof PodcastEpisode
    */
@@ -6751,6 +6720,37 @@ export interface PodcastEpisode {
    * @memberof PodcastEpisode
    */
   rss?: string | null
+}
+/**
+ * Minimal parent-podcast summary embedded in an episode.
+ * @export
+ * @interface PodcastEpisodeParent
+ */
+export interface PodcastEpisodeParent {
+  /**
+   *
+   * @type {number}
+   * @memberof PodcastEpisodeParent
+   */
+  id: number
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  title: string
+  /**
+   *
+   * @type {string}
+   * @memberof PodcastEpisodeParent
+   */
+  readable_id: string
+  /**
+   *
+   * @type {LearningResourceImage}
+   * @memberof PodcastEpisodeParent
+   */
+  image: LearningResourceImage | null
 }
 /**
  * Serializer for PodcastEpisode

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -610,6 +610,7 @@ const document: LearningResourceFactory<DocumentResource> = (
 const podcastEpisode: LearningResourceFactory<PodcastEpisodeResource> = (
   overrides = {},
 ): PodcastEpisodeResource => {
+  const parentPodcastId = uniqueEnforcerId.enforce(() => faker.number.int())
   return mergeOverrides<PodcastEpisodeResource>(
     _learningResourceShared(),
     {
@@ -620,7 +621,15 @@ const podcastEpisode: LearningResourceFactory<PodcastEpisodeResource> = (
     {
       podcast_episode: {
         id: uniqueEnforcerId.enforce(() => faker.number.int()),
-        podcasts: [uniqueEnforcerId.enforce(() => faker.number.int())],
+        podcasts: [parentPodcastId],
+        parent_podcasts: [
+          {
+            id: parentPodcastId,
+            title: faker.lorem.words(3),
+            readable_id: faker.string.uuid(),
+            image: null,
+          },
+        ],
         duration: faker.helpers.arrayElement(["PT1H13M44S", "PT2H30M", "PT1M"]),
         audio_url: faker.internet.url(),
         episode_link: faker.internet.url(),

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -627,7 +627,6 @@ const podcastEpisode: LearningResourceFactory<PodcastEpisodeResource> = (
             id: parentPodcastId,
             title: faker.lorem.words(3),
             readable_id: faker.string.uuid(),
-            image: null,
           },
         ],
         duration: faker.helpers.arrayElement(["PT1H13M44S", "PT2H30M", "PT1M"]),

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
@@ -63,8 +63,7 @@ const setupApis = ({
         {
           id: podcast.id,
           title: podcast.title!,
-          readable_id: podcast.readable_id!,
-          image: podcast.image ?? null,
+          readable_id: podcast.readable_id,
         },
       ],
       ...episodeOverridesEpisode,
@@ -211,8 +210,7 @@ describe("PodcastEpisodeDetailPage", () => {
       {
         id: podcast.id,
         title: podcast.title!,
-        readable_id: podcast.readable_id!,
-        image: podcast.image ?? null,
+        readable_id: podcast.readable_id,
       },
     ]
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.test.tsx
@@ -52,7 +52,24 @@ const setupApis = ({
   moreEpisodes,
 }: SetupOptions = {}) => {
   const podcast = makePodcast(podcastOverrides)
-  const episode = makePodcastEpisode(episodeOverrides)
+  const episodeOverridesEpisode = (
+    episodeOverrides as Partial<PodcastEpisodeResource>
+  ).podcast_episode
+  const episode = makePodcastEpisode({
+    ...episodeOverrides,
+    podcast_episode: {
+      podcasts: [podcast.id],
+      parent_podcasts: [
+        {
+          id: podcast.id,
+          title: podcast.title!,
+          readable_id: podcast.readable_id!,
+          image: podcast.image ?? null,
+        },
+      ],
+      ...episodeOverridesEpisode,
+    },
+  } as Partial<LearningResource>)
 
   setMockResponse.get(
     urls.learningResources.details({ id: episode.id }),
@@ -189,6 +206,15 @@ describe("PodcastEpisodeDetailPage", () => {
     const episode = makePodcastEpisode()
     episode.podcast_episode.audio_url = "https://example.com/ep.mp3"
     const podcast = makePodcast()
+    episode.podcast_episode.podcasts = [podcast.id]
+    episode.podcast_episode.parent_podcasts = [
+      {
+        id: podcast.id,
+        title: podcast.title!,
+        readable_id: podcast.readable_id!,
+        image: podcast.image ?? null,
+      },
+    ]
 
     setMockResponse.get(
       urls.learningResources.details({ id: episode.id }),

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -222,17 +222,22 @@ export const PodcastEpisodeDetailPage: React.FC<
   } = usePodcastPlayer(playerRef, isMobile)
 
   const { data: episode } = useLearningResourcesDetail(Number(episodeId))
-  const { data: podcast } = useLearningResourcesDetail(Number(podcastId))
 
   const podcastEpisode =
     episode?.resource_type === ResourceTypeEnum.PodcastEpisode
       ? episode.podcast_episode
       : null
 
+  // Parent podcast summary comes embedded in the episode response — prefer the
+  // one matching the URL's podcastId, else fall back to the first parent.
+  const parentPodcast =
+    podcastEpisode?.parent_podcasts?.find((p) => p.id === Number(podcastId)) ??
+    podcastEpisode?.parent_podcasts?.[0]
+
   const { data: episodesData } = useInfiniteLearningResourceItems(
     Number(podcastId),
     { learning_resource_id: Number(podcastId), limit: 5 },
-    { enabled: !!podcast },
+    { enabled: !!podcastId },
   )
   const episodes =
     episodesData?.pages.flatMap((page) =>
@@ -261,11 +266,11 @@ export const PodcastEpisodeDetailPage: React.FC<
 
   const handlePlay = () => {
     if (!episode) return
-    toggle(episode, podcast?.title)
+    toggle(episode, parentPodcast?.title)
   }
 
   const podcastHref = podcastId
-    ? podcastPageView(podcastId, podcast?.title)
+    ? podcastPageView(podcastId, parentPodcast?.title)
     : "/"
 
   const sharePageUrl =
@@ -282,7 +287,7 @@ export const PodcastEpisodeDetailPage: React.FC<
               variant="light"
               ancestors={[
                 { href: HOME, label: "Home" },
-                { href: podcastHref, label: podcast?.title ?? "Podcast" },
+                { href: podcastHref, label: parentPodcast?.title ?? "Podcast" },
               ]}
               current={episode?.title}
             />
@@ -290,8 +295,10 @@ export const PodcastEpisodeDetailPage: React.FC<
         </BreadcrumbBar>
         <HeaderSection hasEpisodes={episodes.length > 0}>
           <EpisodeContainer>
-            {podcast?.title && (
-              <EpisodeLabel href={podcastHref}>{podcast.title}</EpisodeLabel>
+            {parentPodcast?.title && (
+              <EpisodeLabel href={podcastHref}>
+                {parentPodcast.title}
+              </EpisodeLabel>
             )}
 
             <EpisodeTitle variant="h1">{episode?.title ?? ""}</EpisodeTitle>
@@ -337,7 +344,7 @@ export const PodcastEpisodeDetailPage: React.FC<
         {episodes && episodes.length > 0 && (
           <EpisodeContainer>
             <MoreItemDescription>
-              More from {podcast?.title ?? "Podcast"}
+              More from {parentPodcast?.title ?? "Podcast"}
             </MoreItemDescription>
 
             <EpisodeList>
@@ -358,7 +365,7 @@ export const PodcastEpisodeDetailPage: React.FC<
                   isPlaying={
                     playingEpisode?.id === episode.id && isAudioPlaying
                   }
-                  onPlayClick={(ep) => toggle(ep, podcast?.title)}
+                  onPlayClick={(ep) => toggle(ep, parentPodcast?.title)}
                   onPauseClick={pause}
                   isPlayable={Boolean(getEpisodeAudioUrl(episode))}
                   isEpisodePage

--- a/frontends/main/src/app/(site)/podcast/[podcastId]/podcast_episode/[episodeId]/[slug]/page.tsx
+++ b/frontends/main/src/app/(site)/podcast/[podcastId]/podcast_episode/[episodeId]/[slug]/page.tsx
@@ -102,11 +102,6 @@ const Page: React.FC<Props> = async (props) => {
     redirect(carrySearchParams(canonical, await props.searchParams))
   }
 
-  // Hydrate the parent podcast (breadcrumb/header read its title client-side).
-  await queryClient.fetchQueryOr404(
-    learningResourceQueries.detail(canonicalPodcastId),
-  )
-
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <PodcastEpisodeDetailPage

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -374,7 +374,7 @@ class LearningResourceQuerySet(TimestampedModelQuerySet):
                 "parents",
                 queryset=LearningResourceRelationship.objects.filter(
                     relation_type=LearningResourceRelationTypes.PODCAST_EPISODES.value,
-                ),
+                ).select_related("parent__image"),
                 to_attr="_podcasts",
             ),
             Prefetch(

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -374,7 +374,7 @@ class LearningResourceQuerySet(TimestampedModelQuerySet):
                 "parents",
                 queryset=LearningResourceRelationship.objects.filter(
                     relation_type=LearningResourceRelationTypes.PODCAST_EPISODES.value,
-                ).select_related("parent__image"),
+                ).select_related("parent"),
                 to_attr="_podcasts",
             ),
             Prefetch(

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -441,16 +441,33 @@ class LearningPathSerializer(serializers.ModelSerializer, ResourceListMixin):
         exclude = ("learning_resource", "author", *COMMON_IGNORED_FIELDS)
 
 
+class PodcastEpisodeParentSerializer(serializers.Serializer):
+    """Minimal parent-podcast summary embedded in an episode."""
+
+    id = serializers.IntegerField(source="parent_id")
+    title = serializers.CharField(source="parent.title")
+    readable_id = serializers.CharField(source="parent.readable_id")
+    image = LearningResourceImageSerializer(source="parent.image", allow_null=True)
+
+
 class PodcastEpisodeSerializer(serializers.ModelSerializer):
     """
     Serializer for PodcastEpisode
     """
 
     podcasts = serializers.SerializerMethodField()
+    parent_podcasts = serializers.SerializerMethodField()
 
     def get_podcasts(self, instance) -> list[int]:
         """Get the podcast id(s) the episode belongs to"""
         return [podcast.parent_id for podcast in instance.learning_resource.podcasts]
+
+    @extend_schema_field(PodcastEpisodeParentSerializer(many=True))
+    def get_parent_podcasts(self, instance):
+        """Get summary info for the podcast(s) the episode belongs to"""
+        return PodcastEpisodeParentSerializer(
+            instance.learning_resource.podcasts, many=True
+        ).data
 
     class Meta:
         model = models.PodcastEpisode

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -447,7 +447,6 @@ class PodcastEpisodeParentSerializer(serializers.Serializer):
     id = serializers.IntegerField(source="parent_id")
     title = serializers.CharField(source="parent.title")
     readable_id = serializers.CharField(source="parent.readable_id")
-    image = LearningResourceImageSerializer(source="parent.image", allow_null=True)
 
 
 class PodcastEpisodeSerializer(serializers.ModelSerializer):

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -145,6 +145,7 @@ def test_serialize_podcast_episode_to_json():
             "podcasts": podcast_episode.learning_resource.parents.filter(
                 relation_type=LearningResourceRelationTypes.PODCAST_EPISODES.value
             ).values_list("parent__id", flat=True),
+            "parent_podcasts": [],
             "id": podcast_episode.id,
             "rss": podcast_episode.rss,
             "transcript": podcast_episode.transcript,
@@ -228,6 +229,16 @@ def test_serialize_podcast_episode_playlists_to_json():
     )
     serializer = serializers.PodcastEpisodeSerializer(instance=podcast_episode)
     assert serializer.data["podcasts"] == [podcast.learning_resource.id]
+    assert serializer.data["parent_podcasts"] == [
+        {
+            "id": podcast.learning_resource.id,
+            "title": podcast.learning_resource.title,
+            "readable_id": podcast.learning_resource.readable_id,
+            "image": serializers.LearningResourceImageSerializer(
+                instance=podcast.learning_resource.image
+            ).data,
+        }
+    ]
 
 
 @pytest.mark.parametrize("has_context", [True, False])

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -234,9 +234,6 @@ def test_serialize_podcast_episode_playlists_to_json():
             "id": podcast.learning_resource.id,
             "title": podcast.learning_resource.title,
             "readable_id": podcast.learning_resource.readable_id,
-            "image": serializers.LearningResourceImageSerializer(
-                instance=podcast.learning_resource.image
-            ).data,
         }
     ]
 

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4102,13 +4102,8 @@ components:
           type: string
         readable_id:
           type: string
-        image:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceImage'
-          nullable: true
       required:
       - id
-      - image
       - readable_id
       - title
     PodcastEpisodeResource:

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4068,7 +4068,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PodcastEpisodeParent'
-          description: Get summary info for the podcast(s) the episode belongs to
           readOnly: true
         transcript:
           type: string

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -4064,6 +4064,12 @@ components:
             type: integer
           description: Get the podcast id(s) the episode belongs to
           readOnly: true
+        parent_podcasts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PodcastEpisodeParent'
+          description: Get summary info for the podcast(s) the episode belongs to
+          readOnly: true
         transcript:
           type: string
         audio_url:
@@ -4085,7 +4091,27 @@ components:
       required:
       - audio_url
       - id
+      - parent_podcasts
       - podcasts
+    PodcastEpisodeParent:
+      type: object
+      description: Minimal parent-podcast summary embedded in an episode.
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        readable_id:
+          type: string
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+      required:
+      - id
+      - image
+      - readable_id
+      - title
     PodcastEpisodeResource:
       type: object
       description: Serializer for podcast episode resources

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -14745,7 +14745,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PodcastEpisodeParent'
-          description: Get summary info for the podcast(s) the episode belongs to
           readOnly: true
         transcript:
           type: string

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -14741,6 +14741,12 @@ components:
             type: integer
           description: Get the podcast id(s) the episode belongs to
           readOnly: true
+        parent_podcasts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PodcastEpisodeParent'
+          description: Get summary info for the podcast(s) the episode belongs to
+          readOnly: true
         transcript:
           type: string
         audio_url:
@@ -14762,7 +14768,27 @@ components:
       required:
       - audio_url
       - id
+      - parent_podcasts
       - podcasts
+    PodcastEpisodeParent:
+      type: object
+      description: Minimal parent-podcast summary embedded in an episode.
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        readable_id:
+          type: string
+        image:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceImage'
+          nullable: true
+      required:
+      - id
+      - image
+      - readable_id
+      - title
     PodcastEpisodeRequest:
       type: object
       description: Serializer for PodcastEpisode

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -14779,13 +14779,8 @@ components:
           type: string
         readable_id:
           type: string
-        image:
-          allOf:
-          - $ref: '#/components/schemas/LearningResourceImage'
-          nullable: true
       required:
       - id
-      - image
       - readable_id
       - title
     PodcastEpisodeRequest:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12264

### Description (What does it do?)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
As a user viewing a podcast episode page, I want the episode API to include summary information about the podcast it belongs to, so the frontend can render the parent podcast's title and image without making a second API request.

### How can this be tested?
For testing you just need to visit the following url `http://open.odl.local:8062/podcast/2115/podcast_episode/2116/the-electrical-grid-and-beyond-with-david-hsu` please replace the ids and slug from the url according to your local data and see the podcast parent array inside the episode object is populated by the backend.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
