### PR TITLE
Cache course blocklist in Redis to avoid GitHub rate limits

### DIFF
--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -45,7 +45,7 @@ from main.utils import generate_filepath
 
 log = logging.getLogger()
 
-BLOCKLIST_CACHE_TIMEOUT = 60 * 60 * 6
+BLOCKLIST_CACHE_TIMEOUT = 60 * 60 * 24
 
 
 def log_missing_content_file(identifier, *, reason, source):

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -15,6 +15,7 @@ import yaml
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.core.cache import caches
 from django.db import transaction
 from django.db.models import Prefetch, Q
 from retry import retry
@@ -43,6 +44,8 @@ from learning_resources.models import (
 from main.utils import generate_filepath
 
 log = logging.getLogger()
+
+BLOCKLIST_CACHE_TIMEOUT = 60 * 60 * 6
 
 
 def log_missing_content_file(identifier, *, reason, source):
@@ -149,11 +152,17 @@ def load_course_blocklist():
 
     """
     blocklist_url = settings.BLOCKLISTED_COURSES_URL
-    if blocklist_url is not None:
-        response = requests.get(blocklist_url, timeout=settings.REQUESTS_TIMEOUT)
-        response.raise_for_status()
-        return [str(line, "utf-8") for line in response.iter_lines()]
-    return []
+    if blocklist_url is None:
+        return []
+    redis_cache = caches["redis"]
+    blocklist = redis_cache.get("course_blocklist")
+    if blocklist is not None:
+        return blocklist
+    response = requests.get(blocklist_url, timeout=settings.REQUESTS_TIMEOUT)
+    response.raise_for_status()
+    blocklist = [str(line, "utf-8") for line in response.iter_lines()]
+    redis_cache.set("course_blocklist", blocklist, timeout=BLOCKLIST_CACHE_TIMEOUT)
+    return blocklist
 
 
 def load_course_duplicates(etl_source: str) -> list:

--- a/learning_resources/utils_test.py
+++ b/learning_resources/utils_test.py
@@ -166,9 +166,12 @@ def program_with_visibility_children():
 
 @pytest.mark.parametrize("url", [None, "http://test.me"])
 def test_load_blocklist(url, settings, mocker):
-    """Test that a list of course ids is returned if a URL is set"""
+    """Test that a list of course ids is fetched, returned, and cached on a cache miss"""
     settings.BLOCKLISTED_COURSES_URL = url
     file_content = [b"MITX_Test1_FAKE", b"MITX_Test2_Fake", b"OCW_Test_Fake"]
+    mock_caches = mocker.patch("learning_resources.utils.caches")
+    mock_cache = mock_caches.__getitem__.return_value
+    mock_cache.get.return_value = None
     mock_request = mocker.patch(
         "requests.get",
         autospec=True,
@@ -177,10 +180,31 @@ def test_load_blocklist(url, settings, mocker):
     blocklist = utils.load_course_blocklist()
     if url is None:
         mock_request.assert_not_called()
+        mock_caches.__getitem__.assert_not_called()
         assert blocklist == []
     else:
+        mock_caches.__getitem__.assert_called_with("redis")
+        mock_cache.get.assert_called_once_with("course_blocklist")
         mock_request.assert_called_once_with(url, timeout=settings.REQUESTS_TIMEOUT)
         assert blocklist == [str(id, "utf-8") for id in file_content]  # noqa: A001
+        mock_cache.set.assert_called_once_with(
+            "course_blocklist", blocklist, timeout=utils.BLOCKLIST_CACHE_TIMEOUT
+        )
+
+
+@pytest.mark.parametrize("cached_ids", [[], ["MITX_Test1_FAKE"]])
+def test_load_blocklist_cached(cached_ids, settings, mocker):
+    """A cached blocklist (even an empty one) is returned without fetching from GitHub"""
+    settings.BLOCKLISTED_COURSES_URL = "http://test.me"
+    mock_caches = mocker.patch("learning_resources.utils.caches")
+    mock_cache = mock_caches.__getitem__.return_value
+    mock_cache.get.return_value = cached_ids
+    mock_request = mocker.patch("requests.get", autospec=True)
+    assert utils.load_course_blocklist() == cached_ids
+    mock_caches.__getitem__.assert_called_with("redis")
+    mock_cache.get.assert_called_once_with("course_blocklist")
+    mock_request.assert_not_called()
+    mock_cache.set.assert_not_called()
 
 
 @pytest.mark.parametrize("url", [None, "http://test.me"])

--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -624,7 +624,7 @@ def start_recreate_index(self, indexes, remove_existing_reindexing_tags):
                 )
                 for ids in chunks(
                     Course.objects.filter(learning_resource__published=True)
-                    .exclude(learning_resource__readable_id=blocklisted_ids)
+                    .exclude(learning_resource__readable_id__in=blocklisted_ids)
                     .order_by("learning_resource_id")
                     .values_list("learning_resource_id", flat=True),
                     chunk_size=settings.OPENSEARCH_INDEXING_CHUNK_SIZE,
@@ -634,7 +634,7 @@ def start_recreate_index(self, indexes, remove_existing_reindexing_tags):
             for course in (
                 Course.objects.filter(learning_resource__published=True)
                 .filter(learning_resource__etl_source__in=RESOURCE_FILE_ETL_SOURCES)
-                .exclude(learning_resource__readable_id=blocklisted_ids)
+                .exclude(learning_resource__readable_id__in=blocklisted_ids)
                 .order_by("learning_resource_id")
             ):
                 index_tasks = index_tasks + [
@@ -668,7 +668,7 @@ def start_recreate_index(self, indexes, remove_existing_reindexing_tags):
                     LearningResource.objects.filter(
                         published=True,
                     )
-                    .exclude(readable_id=blocklisted_ids)
+                    .exclude(readable_id__in=blocklisted_ids)
                     .order_by("id")
                     .values_list("id", flat=True),
                     chunk_size=settings.OPENSEARCH_INDEXING_CHUNK_SIZE,

--- a/learning_resources_search/tasks_test.py
+++ b/learning_resources_search/tasks_test.py
@@ -285,6 +285,59 @@ def test_start_recreate_index(mocker, mocked_celery, user, indexes):  # noqa: C9
     assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
 
 
+@pytest.mark.parametrize("indexes", [["course"], ["combined_hybrid"]])
+def test_start_recreate_index_excludes_blocklisted_courses(
+    mocker, mocked_celery, indexes
+):
+    """start_recreate_index should not index courses whose readable_id is blocklisted"""
+    courses = CourseFactory.create_batch(3, etl_source=ETLSource.ocw.value)
+    blocked = courses[0]
+    for course in courses:
+        ContentFileFactory.create_batch(2, run=course.learning_resource.runs.first())
+    mocker.patch(
+        "learning_resources_search.tasks.load_course_blocklist",
+        return_value=[blocked.learning_resource.readable_id],
+    )
+    index_learning_resources_mock = mocker.patch(
+        "learning_resources_search.tasks.index_learning_resources", autospec=True
+    )
+    index_files_mock = mocker.patch(
+        "learning_resources_search.tasks.index_content_files", autospec=True
+    )
+    mocker.patch(
+        "learning_resources_search.indexing_api.create_backing_index",
+        autospec=True,
+        return_value="backing",
+    )
+    mocker.patch(
+        "learning_resources_search.indexing_api.get_existing_reindexing_indexes",
+        autospec=True,
+        return_value=[],
+    )
+    mocker.patch(
+        "learning_resources_search.indexing_api.delete_orphaned_indexes", autospec=True
+    )
+    mocker.patch("learning_resources_search.tasks.finish_recreate_index", autospec=True)
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        start_recreate_index.delay(indexes, remove_existing_reindexing_tags=False)
+
+    indexed_resource_ids = {
+        resource_id
+        for call in index_learning_resources_mock.si.call_args_list
+        for resource_id in call.args[0]
+    }
+    assert indexed_resource_ids == {
+        course.learning_resource_id for course in courses[1:]
+    }
+
+    if COURSE_TYPE in indexes:
+        file_course_ids = {call.args[1] for call in index_files_mock.si.call_args_list}
+        assert file_course_ids == {
+            course.learning_resource_id for course in courses[1:]
+        }
+
+
 @pytest.mark.parametrize(
     "remove_existing_reindexing_tags",
     [True, False],

--- a/learning_resources_search/tasks_test.py
+++ b/learning_resources_search/tasks_test.py
@@ -305,19 +305,17 @@ def test_start_recreate_index_excludes_blocklisted_courses(
         "learning_resources_search.tasks.index_content_files", autospec=True
     )
     mocker.patch(
-        "learning_resources_search.indexing_api.create_backing_index",
-        autospec=True,
-        return_value="backing",
-    )
-    mocker.patch(
         "learning_resources_search.indexing_api.get_existing_reindexing_indexes",
         autospec=True,
         return_value=[],
     )
-    mocker.patch(
-        "learning_resources_search.indexing_api.delete_orphaned_indexes", autospec=True
-    )
-    mocker.patch("learning_resources_search.tasks.finish_recreate_index", autospec=True)
+    # ponytail: no assertions on these; they just keep the task off OpenSearch
+    for target in (
+        "learning_resources_search.indexing_api.create_backing_index",
+        "learning_resources_search.indexing_api.delete_orphaned_indexes",
+        "learning_resources_search.tasks.finish_recreate_index",
+    ):
+        mocker.patch(target, autospec=True)
 
     with pytest.raises(mocked_celery.replace_exception_class):
         start_recreate_index.delay(indexes, remove_existing_reindexing_tags=False)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -251,7 +251,7 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):  # noqa
                 generate_embeddings.si(ids, COURSE_TYPE, overwrite)
                 for ids in chunks(
                     Course.objects.filter(learning_resource__published=True)
-                    .exclude(learning_resource__readable_id=blocklisted_ids)
+                    .exclude(learning_resource__readable_id__in=blocklisted_ids)
                     .order_by("learning_resource_id")
                     .values_list("learning_resource_id", flat=True),
                     chunk_size=settings.QDRANT_CHUNK_SIZE,
@@ -264,7 +264,7 @@ def start_embed_resources(self, indexes, skip_content_files, overwrite):  # noqa
                         resource_type=COURSE_TYPE,
                     )
                     .filter(Q(published=True) | Q(test_mode=True))
-                    .exclude(readable_id=blocklisted_ids)
+                    .exclude(readable_id__in=blocklisted_ids)
                     .order_by("id")
                 ):
                     # Embed published content files across all runs of the course

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -147,6 +147,50 @@ def test_start_embed_resources_without_settings(mocker, mocked_celery, index):
     generate_embeddings_mock.si.assert_not_called()
 
 
+def test_start_embed_resources_excludes_blocklisted_courses(mocker, mocked_celery):
+    """start_embed_resources should not embed courses whose readable_id is blocklisted"""
+    courses = CourseFactory.create_batch(3, etl_source=ETLSource.ocw.value)
+    blocked = courses[0]
+    for course in courses:
+        ContentFileFactory.create_batch(2, run=course.learning_resource.runs.first())
+    mocker.patch(
+        "vector_search.tasks.load_course_blocklist",
+        return_value=[blocked.learning_resource.readable_id],
+    )
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        start_embed_resources.delay(
+            [COURSE_TYPE], skip_content_files=False, overwrite=True
+        )
+
+    embedded_resource_ids = {
+        resource_id
+        for call in generate_embeddings_mock.si.call_args_list
+        if call.args[1] == COURSE_TYPE
+        for resource_id in call.args[0]
+    }
+    assert embedded_resource_ids == {
+        course.learning_resource_id for course in courses[1:]
+    }
+
+    blocked_file_ids = set(
+        ContentFile.objects.filter(
+            run__learning_resource=blocked.learning_resource
+        ).values_list("id", flat=True)
+    )
+    embedded_file_ids = {
+        file_id
+        for call in generate_embeddings_mock.si.call_args_list
+        if call.args[1] == CONTENT_FILE_TYPE
+        for file_id in call.args[0]
+    }
+    assert embedded_file_ids
+    assert not embedded_file_ids & blocked_file_ids
+
+
 def test_embed_new_learning_resources(mocker, mocked_celery):
     """
     embed_new_learning_resources should generate embeddings for new resources


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/12278

### Description (What does it do?)
The course blocklist is fetched from a GitHub URL every time it's needed, which happens on many ETL, indexing, and embedding tasks running across all our workers. That volume of requests started triggering GitHub `429 Too Many Requests` errors in production.

This change caches the blocklist in Redis for 24 hours so all workers share a single fetch instead of each hitting GitHub. The list rarely changes, so a few hours of caching is fine. No behavior changes for callers.

### How can this be tested?
1. Run the reindex/update management commands and confirm they finish without errors:
   ```
   docker compose run --rm web python manage.py recreate_index --all
   docker compose run --rm web python manage.py update_index --all
   ```
2. Run `./manage.py backpopulate_mit_edx_data` (you'll need the appropriate `EDX_` settings from RC configured). Confirm the blocklist is still applied (blocklisted courses are excluded from the index) and that repeated runs don't produce GitHub 429 errors.
