### PR TITLE
Retry generate_embeddings on gRPC UNAVAILABLE with minutes-scale backoff

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -131,9 +131,12 @@ def _queue_program_content_file_embedding_tasks(index_tasks, program_ids, overwr
 
 
 def _retry_countdown(retries: int) -> int:
-    """Full-jitter exponential backoff (mirrors retry_backoff=True), capped at 10m."""
+    """
+    Full-jitter exponential backoff capped at 10m. Minutes-scale so retries land
+    after a qdrant CPU-throttle episode instead of hammering it while saturated.
+    """
     return get_exponential_backoff_interval(
-        factor=1, retries=retries, maximum=600, full_jitter=True
+        factor=120, retries=retries, maximum=600, full_jitter=True
     )
 
 
@@ -168,11 +171,11 @@ def generate_embeddings(
             raise self.retry(exc=err, countdown=_retry_countdown(self.request.retries))  # noqa: B904
         raise
     except Exception as err:
-        is_deadline = (
-            isinstance(err, grpc.RpcError)
-            and err.code() == grpc.StatusCode.DEADLINE_EXCEEDED
+        is_transient_grpc = isinstance(err, grpc.RpcError) and err.code() in (
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+            grpc.StatusCode.UNAVAILABLE,
         )
-        if (isinstance(err, RetryError) or is_deadline) and (
+        if (isinstance(err, RetryError) or is_transient_grpc) and (
             self.request.retries < self.max_retries
         ):
             raise self.retry(exc=err, countdown=_retry_countdown(self.request.retries))  # noqa: B904

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -31,6 +31,7 @@ from learning_resources_search.exceptions import RetryError
 from main.utils import now_in_utc
 from vector_search.tasks import (
     _record_embedding_failure,
+    _retry_countdown,
     embed_learning_resources_by_id,
     embed_new_content_files,
     embed_new_learning_resources,
@@ -850,6 +851,25 @@ def test_generate_embeddings_retries_on_deadline(mocker):
         generate_embeddings([1], CONTENT_FILE_TYPE, overwrite=True, failure_key="k")
     retry.assert_called_once()
     assert retry.call_args.kwargs["countdown"] >= 0
+
+
+def test_generate_embeddings_retries_on_unavailable(mocker):
+    """UNAVAILABLE (e.g. 502 from a throttled qdrant node) retries like a deadline."""
+    mocker.patch(
+        "vector_search.tasks.embed_learning_resources",
+        side_effect=_rpc_error(grpc.StatusCode.UNAVAILABLE),
+    )
+    retry = mocker.patch.object(generate_embeddings, "retry", side_effect=Retry())
+    with pytest.raises(Retry):
+        generate_embeddings([1], CONTENT_FILE_TYPE, overwrite=True, failure_key="k")
+    retry.assert_called_once()
+
+
+def test_retry_countdown_is_minutes_scale():
+    """Backoff is minutes-scale so retries land after a qdrant throttle episode."""
+    samples = [_retry_countdown(0) for _ in range(50)]
+    assert max(samples) > 60  # jittered up to 2 minutes, not seconds
+    assert max(samples) <= 120
 
 
 def test_generate_embeddings_records_on_exhaustion(mocker):

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -865,11 +865,15 @@ def test_generate_embeddings_retries_on_unavailable(mocker):
     retry.assert_called_once()
 
 
-def test_retry_countdown_is_minutes_scale():
-    """Backoff is minutes-scale so retries land after a qdrant throttle episode."""
-    samples = [_retry_countdown(0) for _ in range(50)]
-    assert max(samples) > 60  # jittered up to 2 minutes, not seconds
-    assert max(samples) <= 120
+def test_retry_countdown_is_minutes_scale(mocker):
+    """Backoff is jittered exponential at minutes scale, capped at 10m."""
+    backoff = mocker.patch(
+        "vector_search.tasks.get_exponential_backoff_interval", return_value=42
+    )
+    assert _retry_countdown(2) == 42
+    backoff.assert_called_once_with(
+        factor=120, retries=2, maximum=600, full_jitter=True
+    )
 
 
 def test_generate_embeddings_records_on_exhaustion(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
None directly. Tangentially related to earlier embedding-pipeline reliability work: [mitodl/hq#12115](https://github.com/mitodl/hq/issues/12115) (embeddings task OOM thrashing) and [mitodl/hq#12018](https://github.com/mitodl/hq/issues/12018) (skip waiting on Qdrant payload operations).

### Description (What does it do?)
Prompted by a burst of `generate_embeddings` failures in Sentry overnight July 8–9 (gRPC `UNAVAILABLE`: *"Received http2 header with status: 502"*).

Our nightly embedding runs periodically saturate the Qdrant Cloud cluster's CPU (2 vCPUs per node). During those short throttle episodes, Qdrant's edge proxy returns 502s, which reach the task as gRPC `UNAVAILABLE` errors. `generate_embeddings` currently treats `UNAVAILABLE` as fatal, so each affected chunk fails immediately and its resources stay unembedded until the next overwrite run.

Two changes, both confined to `generate_embeddings`:

- Treat `UNAVAILABLE` as transient and retryable, same as `DEADLINE_EXCEEDED`.
- Scale the retry backoff from seconds (max 1s/2s/4s) to jittered minutes (max 2m/4m/8m), so retries land after a throttle episode has (hopefully) passed instead of hitting the cluster while it's still saturated.

Retries re-enter the queue through the task's existing `200/m` rate limit, and the full jitter spreads them out. If Qdrant is still unavailable after all retries (~14 min worst case), the task fails terminally exactly as it does today.

### How can this be tested?
Stop the local Qdrant container (`docker compose stop qdrant`), trigger an embedding task, and watch the celery logs — the task should schedule a retry with a minutes-scale countdown instead of failing. Start Qdrant again and the retry succeeds.
