### PR TITLE
Ignore POM micromasters programs

### DIFF
--- a/learning_resources/etl/micromasters.py
+++ b/learning_resources/etl/micromasters.py
@@ -21,7 +21,7 @@ from learning_resources.models import LearningResource, default_pace
 
 OFFERED_BY = {"code": OfferedBy.mitx.name}
 READABLE_ID_PREFIX = "micromasters-program-"
-IGNORE_URLS = re.compile(r"/(dedp|scm|fin)/")
+IGNORE_URLS = re.compile(r"/(dedp|scm|fin|pom)/")
 
 log = logging.getLogger(__name__)
 

--- a/learning_resources/etl/micromasters_test.py
+++ b/learning_resources/etl/micromasters_test.py
@@ -193,12 +193,14 @@ def test_micromasters_transform(mock_micromasters_data, missing_url):
         ("http://example.com/scm/program/1/url", True),
         ("http://example.com/fin/program/1/url", True),
         ("http://example.com/finis/program/1/url", False),
+        ("http://example.com/pom/program/1/url", True),
+        ("http://example.com/pomelo/program/1/url", False),
     ],
 )
 def test_micromasters_transform_ignores_urls(
     mock_micromasters_data, url, expected_excluded
 ):
-    """Programs whose URL contains /dedp/ or /scm/ should be excluded"""
+    """Programs whose URL contains /dedp/, /scm/, /fin/, or /pom/ should be excluded"""
     # Drop the second program so only the program under test is considered
     mock_micromasters_data = mock_micromasters_data[:1]
     mock_micromasters_data[0]["programpage_url"] = url


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #3411

### Description (What does it do?)
Adds `/pom/` to the micromasters ETL `IGNORE_URLS` pattern so Principles of Manufacturing programs are excluded, same as the existing `/dedp/`, `/scm/`, and `/fin/` exclusions. Updates the exclusion unit test with `/pom/` (excluded) and `/pomelo/` (boundary, not excluded) cases.

### How can this be tested?
- set `MICROMASTERS_CATALOG_API_URL=https://micromasters.mit.edu/api/v0/catalog/` in `backend.local.env`, run `./manage.py backpopulate_micromasters_data`, and confirm no POM program appears at http://open.odl.local:8065/admin/learning_resources/learningresource/?etl_source=micromasters&resource_type__exact=program
