### PR TITLE
add a "tie breaker" if all enrollments have no certificate or grade

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
@@ -99,10 +99,13 @@ describe("HomeEnrollmentsDisplay", () => {
     const sharedCourseId = faker.number.int()
     // Both enrollments share the same course and have identical default variant
     // fields, so they should collapse to a single card.
+    // Run A is the more recent of the two so the dedup policy (recency,
+    // since neither has a certificate or grade) deterministically picks it.
     const enrollmentA = mitxonline.factories.enrollment.courseEnrollment({
       run: {
         title: "Same Course — Run A",
         course: { id: sharedCourseId },
+        start_date: "2024-01-01T00:00:00Z",
       },
       certificate: null,
       grades: [],
@@ -111,6 +114,7 @@ describe("HomeEnrollmentsDisplay", () => {
       run: {
         title: "Same Course — Run B",
         course: { id: sharedCourseId },
+        start_date: "2020-01-01T00:00:00Z",
       },
       certificate: null,
       grades: [],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/helpers.test.tsx
@@ -342,23 +342,23 @@ describe("helpers", () => {
       expect(result).toEqual(enrollmentHighGrade)
     })
 
-    test("returns first enrollment when both have certificates and same grade", () => {
+    test("returns the more recent enrollment when both have certificates and the same grade", () => {
       const run = factories.courses.courseRun({ id: 1 })
       const course = factories.courses.course({ courseruns: [run] })
 
       const enrollment1 = factories.enrollment.courseEnrollment({
-        run: { id: 1 },
+        run: { id: 1, start_date: "2020-01-01T00:00:00Z" },
         certificate: { uuid: "cert-1" },
         grades: [factories.enrollment.grade({ grade: 0.8 })],
       })
       const enrollment2 = factories.enrollment.courseEnrollment({
-        run: { id: 1 },
+        run: { id: 1, start_date: "2023-01-01T00:00:00Z" },
         certificate: { uuid: "cert-2" },
         grades: [factories.enrollment.grade({ grade: 0.8 })],
       })
 
       const result = selectBestEnrollment(course, [enrollment1, enrollment2])
-      expect(result).toEqual(enrollment1)
+      expect(result).toEqual(enrollment2)
     })
 
     test("handles multiple course runs", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardAdapters.test.ts
@@ -5,7 +5,7 @@ import {
   type LegacyDashboardCardAdapterOutput,
 } from "./dashboardAdapters"
 import {
-  pickDisplayedEnrollmentForLegacyDashboard,
+  selectBestEnrollment,
   type DashboardCourseEntry,
 } from "./dashboardViewModel"
 
@@ -82,10 +82,10 @@ describe("dashboardAdapters", () => {
       certificate: { uuid: "cert-3" },
     })
 
-    const displayedEnrollment = pickDisplayedEnrollmentForLegacyDashboard(
-      course,
-      [noCertificate, withCertificate],
-    )
+    const displayedEnrollment = selectBestEnrollment(course, [
+      noCertificate,
+      withCertificate,
+    ])
     const entry = makeEntry({
       course,
       enrollments: [noCertificate, withCertificate],
@@ -111,10 +111,10 @@ describe("dashboardAdapters", () => {
       grades: [factories.enrollment.grade({ grade: 0.95 })],
     })
 
-    const displayedEnrollment = pickDisplayedEnrollmentForLegacyDashboard(
-      course,
-      [lowGrade, highGrade],
-    )
+    const displayedEnrollment = selectBestEnrollment(course, [
+      lowGrade,
+      highGrade,
+    ])
     const entry = makeEntry({
       course,
       enrollments: [lowGrade, highGrade],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -28,16 +28,16 @@ import {
   groupProgramEnrollmentsByProgramId,
   isNonContractEnrollment,
   isProgramAsCourse,
-  pickDisplayedEnrollmentForLegacyDashboard,
   pickDisplayedHomeEnrollments,
   programHasContractRuns,
   resolveDisplayedRunAndEnrollment,
+  selectBestEnrollment,
   selectVariantRunForCourse,
   sortVariants,
 } from "./dashboardViewModel"
 
 describe("dashboardViewModel", () => {
-  describe("pickDisplayedEnrollmentForLegacyDashboard", () => {
+  describe("selectBestEnrollment", () => {
     test("returns null when there are no matching course enrollments", () => {
       const course = factories.courses.course({
         courseruns: [factories.courses.courseRun({ id: 1 })],
@@ -46,9 +46,7 @@ describe("dashboardViewModel", () => {
         factories.enrollment.courseEnrollment({ run: { id: 999 } }),
       ]
 
-      expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, enrollments),
-      ).toBeNull()
+      expect(selectBestEnrollment(course, enrollments)).toBeNull()
     })
 
     test("prefers enrollment with certificate over one without", () => {
@@ -64,10 +62,7 @@ describe("dashboardViewModel", () => {
       })
 
       expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [
-          noCertificate,
-          withCertificate,
-        ]),
+        selectBestEnrollment(course, [noCertificate, withCertificate]),
       ).toEqual(withCertificate)
     })
 
@@ -85,9 +80,66 @@ describe("dashboardViewModel", () => {
         grades: [factories.enrollment.grade({ grade: 0.9 })],
       })
 
+      expect(selectBestEnrollment(course, [lower, higher])).toEqual(higher)
+    })
+
+    test("prefers highest grade over recency, even when the higher grade is on the older run", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 101,
+        start_date: "2020-01-01T00:00:00Z",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 202,
+        start_date: "2024-01-01T00:00:00Z",
+      })
+      const course = factories.courses.course({
+        courseruns: [olderRun, newerRun],
+      })
+      const olderHigherGrade = factories.enrollment.courseEnrollment({
+        run: { id: olderRun.id, start_date: olderRun.start_date },
+        certificate: null,
+        grades: [factories.enrollment.grade({ grade: 0.95 })],
+      })
+      const newerLowerGrade = factories.enrollment.courseEnrollment({
+        run: { id: newerRun.id, start_date: newerRun.start_date },
+        certificate: null,
+        grades: [factories.enrollment.grade({ grade: 0.4 })],
+      })
+
       expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [lower, higher]),
-      ).toEqual(higher)
+        selectBestEnrollment(course, [olderHigherGrade, newerLowerGrade]),
+      ).toEqual(olderHigherGrade)
+    })
+
+    test("prefers the more recent run when certificates and grades are tied", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 101,
+        start_date: "2020-01-01T00:00:00Z",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 202,
+        start_date: "2024-01-01T00:00:00Z",
+      })
+      const course = factories.courses.course({
+        courseruns: [olderRun, newerRun],
+      })
+      const olderEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: olderRun.id, start_date: olderRun.start_date },
+        certificate: { uuid: "cert-1" },
+        grades: [factories.enrollment.grade({ grade: 0.8 })],
+      })
+      const newerEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: newerRun.id, start_date: newerRun.start_date },
+        certificate: { uuid: "cert-2" },
+        grades: [factories.enrollment.grade({ grade: 0.8 })],
+      })
+
+      expect(
+        selectBestEnrollment(course, [olderEnrollment, newerEnrollment]),
+      ).toEqual(newerEnrollment)
+      expect(
+        selectBestEnrollment(course, [newerEnrollment, olderEnrollment]),
+      ).toEqual(newerEnrollment)
     })
 
     test("keeps an older enrolled run when the course payload only lists the newer run", () => {
@@ -102,7 +154,6 @@ describe("dashboardViewModel", () => {
       const course = factories.courses.course({
         id: 77,
         courseruns: [newerRun],
-        next_run_id: newerRun.id,
       })
       const olderEnrollment = factories.enrollment.courseEnrollment({
         run: {
@@ -114,12 +165,12 @@ describe("dashboardViewModel", () => {
         grades: [],
       })
 
-      expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [olderEnrollment]),
-      ).toEqual(olderEnrollment)
+      expect(selectBestEnrollment(course, [olderEnrollment])).toEqual(
+        olderEnrollment,
+      )
     })
 
-    test("prefers the run matching next_run_id when certificate and grade are tied", () => {
+    test("when neither enrollment has a certificate or grade, prefers the most recent run that has already started", () => {
       const olderRun = factories.courses.courseRun({
         id: 101,
         start_date: "2020-01-01T00:00:00Z",
@@ -130,45 +181,6 @@ describe("dashboardViewModel", () => {
       })
       const course = factories.courses.course({
         courseruns: [olderRun, newerRun],
-        next_run_id: newerRun.id,
-      })
-      const olderEnrollment = factories.enrollment.courseEnrollment({
-        run: { id: olderRun.id },
-        certificate: null,
-        grades: [],
-      })
-      const newerEnrollment = factories.enrollment.courseEnrollment({
-        run: { id: newerRun.id },
-        certificate: null,
-        grades: [],
-      })
-
-      expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [
-          olderEnrollment,
-          newerEnrollment,
-        ]),
-      ).toEqual(newerEnrollment)
-      expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [
-          newerEnrollment,
-          olderEnrollment,
-        ]),
-      ).toEqual(newerEnrollment)
-    })
-
-    test("prefers the run with the later start_date when certificate, grade, and next_run_id don't distinguish", () => {
-      const olderRun = factories.courses.courseRun({
-        id: 101,
-        start_date: "2020-01-01T00:00:00Z",
-      })
-      const newerRun = factories.courses.courseRun({
-        id: 202,
-        start_date: "2024-01-01T00:00:00Z",
-      })
-      const course = factories.courses.course({
-        courseruns: [olderRun, newerRun],
-        next_run_id: null,
       })
       const olderEnrollment = factories.enrollment.courseEnrollment({
         run: { id: olderRun.id, start_date: olderRun.start_date },
@@ -182,17 +194,99 @@ describe("dashboardViewModel", () => {
       })
 
       expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [
-          olderEnrollment,
-          newerEnrollment,
-        ]),
+        selectBestEnrollment(course, [olderEnrollment, newerEnrollment]),
       ).toEqual(newerEnrollment)
       expect(
-        pickDisplayedEnrollmentForLegacyDashboard(course, [
-          newerEnrollment,
-          olderEnrollment,
-        ]),
+        selectBestEnrollment(course, [newerEnrollment, olderEnrollment]),
       ).toEqual(newerEnrollment)
+    })
+
+    test("when neither enrollment has a certificate or grade, does not pick an upcoming run over the current in-progress run", () => {
+      const daysFromNow = (days: number) =>
+        new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+      const pastRun = factories.courses.courseRun({
+        id: 101,
+        start_date: daysFromNow(-400),
+        end_date: daysFromNow(-300),
+      })
+      const currentRun = factories.courses.courseRun({
+        id: 202,
+        start_date: daysFromNow(-30),
+        end_date: daysFromNow(30),
+      })
+      const upcomingRun = factories.courses.courseRun({
+        id: 303,
+        start_date: daysFromNow(60),
+        end_date: daysFromNow(150),
+      })
+      const course = factories.courses.course({
+        courseruns: [pastRun, currentRun, upcomingRun],
+      })
+      const pastEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: pastRun.id,
+          start_date: pastRun.start_date,
+          end_date: pastRun.end_date,
+        },
+        certificate: null,
+        grades: [],
+      })
+      const currentEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: currentRun.id,
+          start_date: currentRun.start_date,
+          end_date: currentRun.end_date,
+        },
+        certificate: null,
+        grades: [],
+      })
+      const upcomingEnrollment = factories.enrollment.courseEnrollment({
+        run: {
+          id: upcomingRun.id,
+          start_date: upcomingRun.start_date,
+          end_date: upcomingRun.end_date,
+        },
+        certificate: null,
+        grades: [],
+      })
+
+      expect(
+        selectBestEnrollment(course, [
+          pastEnrollment,
+          currentEnrollment,
+          upcomingEnrollment,
+        ]),
+      ).toEqual(currentEnrollment)
+    })
+
+    test("when neither enrollment has a certificate or grade and every run is upcoming, prefers the soonest one", () => {
+      const daysFromNow = (days: number) =>
+        new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+      const soonerRun = factories.courses.courseRun({
+        id: 101,
+        start_date: daysFromNow(10),
+      })
+      const laterRun = factories.courses.courseRun({
+        id: 202,
+        start_date: daysFromNow(100),
+      })
+      const course = factories.courses.course({
+        courseruns: [soonerRun, laterRun],
+      })
+      const soonerEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: soonerRun.id, start_date: soonerRun.start_date },
+        certificate: null,
+        grades: [],
+      })
+      const laterEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: laterRun.id, start_date: laterRun.start_date },
+        certificate: null,
+        grades: [],
+      })
+
+      expect(
+        selectBestEnrollment(course, [laterEnrollment, soonerEnrollment]),
+      ).toEqual(soonerEnrollment)
     })
   })
 
@@ -2114,6 +2208,51 @@ describe("filterVariantSiblings", () => {
       },
     })
     expect(filterVariantSiblings([current, otherCourse], current)).toEqual([])
+  })
+
+  test("orders siblings by start_date, most recent first, regardless of input order", () => {
+    const courseId = 7
+    const current = factories.enrollment.courseEnrollment({
+      run: {
+        course: { id: courseId },
+        language: "en",
+        variant_industry: undefined,
+        variant_length: undefined,
+      },
+    })
+    const oldest = factories.enrollment.courseEnrollment({
+      run: {
+        course: { id: courseId },
+        language: "en",
+        variant_industry: undefined,
+        variant_length: undefined,
+        start_date: "2019-01-01T00:00:00Z",
+      },
+    })
+    const middle = factories.enrollment.courseEnrollment({
+      run: {
+        course: { id: courseId },
+        language: "en",
+        variant_industry: undefined,
+        variant_length: undefined,
+        start_date: "2022-01-01T00:00:00Z",
+      },
+    })
+    const newest = factories.enrollment.courseEnrollment({
+      run: {
+        course: { id: courseId },
+        language: "en",
+        variant_industry: undefined,
+        variant_length: undefined,
+        start_date: "2024-01-01T00:00:00Z",
+      },
+    })
+
+    expect(filterVariantSiblings([oldest, newest, middle], current)).toEqual([
+      newest,
+      middle,
+      oldest,
+    ])
   })
 })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -118,6 +118,82 @@ describe("dashboardViewModel", () => {
         pickDisplayedEnrollmentForLegacyDashboard(course, [olderEnrollment]),
       ).toEqual(olderEnrollment)
     })
+
+    test("prefers the run matching next_run_id when certificate and grade are tied", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 101,
+        start_date: "2020-01-01T00:00:00Z",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 202,
+        start_date: "2024-01-01T00:00:00Z",
+      })
+      const course = factories.courses.course({
+        courseruns: [olderRun, newerRun],
+        next_run_id: newerRun.id,
+      })
+      const olderEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: olderRun.id },
+        certificate: null,
+        grades: [],
+      })
+      const newerEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: newerRun.id },
+        certificate: null,
+        grades: [],
+      })
+
+      expect(
+        pickDisplayedEnrollmentForLegacyDashboard(course, [
+          olderEnrollment,
+          newerEnrollment,
+        ]),
+      ).toEqual(newerEnrollment)
+      expect(
+        pickDisplayedEnrollmentForLegacyDashboard(course, [
+          newerEnrollment,
+          olderEnrollment,
+        ]),
+      ).toEqual(newerEnrollment)
+    })
+
+    test("prefers the run with the later start_date when certificate, grade, and next_run_id don't distinguish", () => {
+      const olderRun = factories.courses.courseRun({
+        id: 101,
+        start_date: "2020-01-01T00:00:00Z",
+      })
+      const newerRun = factories.courses.courseRun({
+        id: 202,
+        start_date: "2024-01-01T00:00:00Z",
+      })
+      const course = factories.courses.course({
+        courseruns: [olderRun, newerRun],
+        next_run_id: null,
+      })
+      const olderEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: olderRun.id, start_date: olderRun.start_date },
+        certificate: null,
+        grades: [],
+      })
+      const newerEnrollment = factories.enrollment.courseEnrollment({
+        run: { id: newerRun.id, start_date: newerRun.start_date },
+        certificate: null,
+        grades: [],
+      })
+
+      expect(
+        pickDisplayedEnrollmentForLegacyDashboard(course, [
+          olderEnrollment,
+          newerEnrollment,
+        ]),
+      ).toEqual(newerEnrollment)
+      expect(
+        pickDisplayedEnrollmentForLegacyDashboard(course, [
+          newerEnrollment,
+          olderEnrollment,
+        ]),
+      ).toEqual(newerEnrollment)
+    })
   })
 
   describe("groupCourseRunEnrollmentsByCourseId", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -20,6 +20,7 @@ import type {
   V3UserProgramEnrollment,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
+import { isInPast } from "ol-utilities"
 import {
   getBestRun,
   getIdsFromReqTree,
@@ -145,18 +146,20 @@ export const filterEnrollmentsByOrganization = (
 
 /**
  * Selects the best enrollment from multiple enrollments for the same course.
- * Priority:
- * 1. Prefer enrollment with a certificate
- * 2. If tied, prefer highest grade
- * 3. Otherwise take first match
- *
- * Delegates to `pickDisplayedEnrollmentForLegacyDashboard`.
+ * See `pickBestEnrollmentFromGroup` for the selection policy.
  */
 export const selectBestEnrollment = (
   course: CourseWithCourseRunsSerializerV2,
   enrollments: CourseRunEnrollmentV3[],
 ): CourseRunEnrollmentV3 | null => {
-  return pickDisplayedEnrollmentForLegacyDashboard(course, enrollments)
+  const courseEnrollments = enrollments.filter((enrollment) =>
+    enrollmentBelongsToCourse(course, enrollment),
+  )
+  if (courseEnrollments.length === 0) {
+    return null
+  }
+
+  return pickBestEnrollmentFromGroup(courseEnrollments)
 }
 
 export const getEnrollmentStatus = (
@@ -283,32 +286,63 @@ const enrollmentBelongsToCourse = (
 }
 
 /**
- * Legacy display policy used by dashboard cards.
+ * Sorts enrollments by their run's `start_date`, most recent first. Runs
+ * without a valid `start_date` sort last. Shared by `selectBestEnrollment`
+ * (as its recency tiebreak) and `filterVariantSiblings` (so the "other
+ * runs" list a card renders is in a stable, meaningful order rather than
+ * arbitrary database order).
+ */
+const sortEnrollmentsByStartDateDesc = (
+  enrollments: CourseRunEnrollmentV3[],
+): CourseRunEnrollmentV3[] => {
+  return [...enrollments].sort((a, b) => {
+    const aMs = a.run.start_date ? new Date(a.run.start_date).getTime() : NaN
+    const bMs = b.run.start_date ? new Date(b.run.start_date).getTime() : NaN
+    if (isNaN(aMs) && isNaN(bMs)) return 0
+    if (isNaN(aMs)) return 1
+    if (isNaN(bMs)) return -1
+    return bMs - aMs
+  })
+}
+
+/**
+ * Picks the single best enrollment from a group of enrollments that all
+ * represent the same underlying course (e.g. multiple runs a learner has
+ * enrolled in). Used by `selectBestEnrollment` (single course) and
+ * `pickDisplayedHomeEnrollments` (one group per course+variant).
  *
  * Priority:
  * 1. Prefer enrollment with a certificate
  * 2. If tied, prefer highest grade
- * 3. If tied and the enrollments are for different runs, prefer the run
- *    matching `course.next_run_id`, then the run with the later
- *    `start_date` (runs without a valid `start_date` sort last). Mirrors
- *    `getBestRun`'s recency policy so the fallback here is never an
- *    arbitrary (e.g. database-order) run.
+ * 3. If still tied (including "neither has a certificate or grade"),
+ *    prefer the more recent run — see `sortEnrollmentsByStartDateDesc`.
+ *    When NEITHER candidate has a certificate or grade at all, "more
+ *    recent" specifically means the most recent run that isn't upcoming
+ *    (i.e. the current/in-progress or most recently completed run, never
+ *    an unstarted future run); if every run is upcoming, the soonest one
+ *    is used.
  */
-const pickDisplayedEnrollmentForLegacyDashboard = (
-  course: CourseWithCourseRunsSerializerV2,
+const pickBestEnrollmentFromGroup = (
   enrollments: CourseRunEnrollmentV3[],
-): CourseRunEnrollmentV3 | null => {
-  const courseEnrollments = enrollments.filter((enrollment) =>
-    enrollmentBelongsToCourse(course, enrollment),
+): CourseRunEnrollmentV3 => {
+  const sorted = sortEnrollmentsByStartDateDesc(enrollments)
+  const hasAnyAchievement = sorted.some(
+    (e) => !!e.certificate?.uuid || getMaxEnrollmentGrade(e) > 0,
   )
-  if (courseEnrollments.length === 0) {
-    return null
+
+  if (!hasAnyAchievement) {
+    const withStartDate = sorted.filter((e) => e.run.start_date)
+    const started = withStartDate.filter(
+      (e) => e.run.start_date && isInPast(e.run.start_date),
+    )
+    // `withStartDate`/`sorted` are ordered most-recent-first, so the last
+    // entry is the earliest (soonest upcoming) when nothing has started yet.
+    return started[0] ?? withStartDate[withStartDate.length - 1] ?? sorted[0]
   }
 
-  return courseEnrollments.reduce((best, current) => {
+  return sorted.reduce((best, current) => {
     const bestHasCert = !!best.certificate?.uuid
     const currentHasCert = !!current.certificate?.uuid
-
     if (currentHasCert && !bestHasCert) return current
     if (bestHasCert && !currentHasCert) return best
 
@@ -318,23 +352,10 @@ const pickDisplayedEnrollmentForLegacyDashboard = (
       return currentGrade > bestGrade ? current : best
     }
 
-    if (best.run.id === current.run.id) return best
-
-    if (course.next_run_id !== null && course.next_run_id !== undefined) {
-      if (current.run.id === course.next_run_id) return current
-      if (best.run.id === course.next_run_id) return best
-    }
-
-    const bestMs = best.run.start_date
-      ? new Date(best.run.start_date).getTime()
-      : NaN
-    const currentMs = current.run.start_date
-      ? new Date(current.run.start_date).getTime()
-      : NaN
-    if (isNaN(bestMs) && !isNaN(currentMs)) return current
-    if (!isNaN(bestMs) && isNaN(currentMs)) return best
-    return currentMs > bestMs ? current : best
-  }, courseEnrollments[0])
+    // Cert state and grade are tied; `sorted` is ordered most-recent-first,
+    // so `best` (encountered first) is already the more recent candidate.
+    return best
+  })
 }
 
 const groupCourseRunEnrollmentsByCourseId = (
@@ -1249,8 +1270,8 @@ const getCollectionFirstCoursesInDisplayOrder = (
  *
  * Groups by (courseId × language × variant_industry × variant_length) — the
  * same key used by filterVariantSiblings — then picks the single best
- * enrollment per group (certificate first, then highest grade). Siblings are
- * NOT returned here; callers retrieve them at render time via
+ * enrollment per group via `pickBestEnrollmentFromGroup`. Siblings are NOT
+ * returned here; callers retrieve them at render time via
  * filterVariantSiblings + enrollmentsByCourseId so the full sibling list is
  * always fresh.
  */
@@ -1273,30 +1294,22 @@ const pickDisplayedHomeEnrollments = (
       groups.set(key, [enrollment])
     }
   }
-  return [...groups.values()].map((group) =>
-    group.reduce((best, current) => {
-      const bestHasCert = !!best.certificate?.uuid
-      const currentHasCert = !!current.certificate?.uuid
-      if (currentHasCert && !bestHasCert) return current
-      if (bestHasCert && !currentHasCert) return best
-      return getMaxEnrollmentGrade(current) > getMaxEnrollmentGrade(best)
-        ? current
-        : best
-    }),
-  )
+  return [...groups.values()].map(pickBestEnrollmentFromGroup)
 }
 
 /**
  * Returns all enrollments in `enrollments` that share the same variant
  * (language × variant_industry × variant_length) as `currentEnrollment`,
- * excluding `currentEnrollment` itself.
+ * excluding `currentEnrollment` itself. Ordered most-recent-first (see
+ * `sortEnrollmentsByStartDateDesc`) so cards render the "other runs" list
+ * in a stable, meaningful order rather than arbitrary database order.
  */
 const filterVariantSiblings = (
   enrollments: CourseRunEnrollmentV3[],
   currentEnrollment: CourseRunEnrollmentV3,
 ): CourseRunEnrollmentV3[] => {
   const run = currentEnrollment.run
-  return enrollments.filter(
+  const siblings = enrollments.filter(
     (e) =>
       e.id !== currentEnrollment.id &&
       e.run.course.id === run.course.id &&
@@ -1304,10 +1317,10 @@ const filterVariantSiblings = (
       (e.run.variant_industry ?? "") === (run.variant_industry ?? "") &&
       (e.run.variant_length ?? "") === (run.variant_length ?? ""),
   )
+  return sortEnrollmentsByStartDateDesc(siblings)
 }
 
 export {
-  pickDisplayedEnrollmentForLegacyDashboard,
   groupCourseRunEnrollmentsByCourseId,
   groupProgramEnrollmentsByProgramId,
   resolveDisplayedRunAndEnrollment,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -288,7 +288,10 @@ const enrollmentBelongsToCourse = (
  * Priority:
  * 1. Prefer enrollment with a certificate
  * 2. If tied, prefer highest grade
- * 3. Otherwise take first match
+ * 3. If tied, prefer the run matching `course.next_run_id`, then the run
+ *    with the later `start_date` (runs without a valid `start_date` sort
+ *    last). Mirrors `getBestRun`'s recency policy so the fallback here is
+ *    never an arbitrary (e.g. database-order) run.
  */
 const pickDisplayedEnrollmentForLegacyDashboard = (
   course: CourseWithCourseRunsSerializerV2,
@@ -310,7 +313,24 @@ const pickDisplayedEnrollmentForLegacyDashboard = (
 
     const bestGrade = getMaxEnrollmentGrade(best)
     const currentGrade = getMaxEnrollmentGrade(current)
-    return currentGrade > bestGrade ? current : best
+    if (currentGrade !== bestGrade) {
+      return currentGrade > bestGrade ? current : best
+    }
+
+    if (course.next_run_id !== null && course.next_run_id !== undefined) {
+      if (current.run.id === course.next_run_id) return current
+      if (best.run.id === course.next_run_id) return best
+    }
+
+    const bestMs = best.run.start_date
+      ? new Date(best.run.start_date).getTime()
+      : NaN
+    const currentMs = current.run.start_date
+      ? new Date(current.run.start_date).getTime()
+      : NaN
+    if (isNaN(bestMs) && !isNaN(currentMs)) return current
+    if (!isNaN(bestMs) && isNaN(currentMs)) return best
+    return currentMs > bestMs ? current : best
   }, courseEnrollments[0])
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -288,10 +288,11 @@ const enrollmentBelongsToCourse = (
  * Priority:
  * 1. Prefer enrollment with a certificate
  * 2. If tied, prefer highest grade
- * 3. If tied, prefer the run matching `course.next_run_id`, then the run
- *    with the later `start_date` (runs without a valid `start_date` sort
- *    last). Mirrors `getBestRun`'s recency policy so the fallback here is
- *    never an arbitrary (e.g. database-order) run.
+ * 3. If tied and the enrollments are for different runs, prefer the run
+ *    matching `course.next_run_id`, then the run with the later
+ *    `start_date` (runs without a valid `start_date` sort last). Mirrors
+ *    `getBestRun`'s recency policy so the fallback here is never an
+ *    arbitrary (e.g. database-order) run.
  */
 const pickDisplayedEnrollmentForLegacyDashboard = (
   course: CourseWithCourseRunsSerializerV2,
@@ -316,6 +317,8 @@ const pickDisplayedEnrollmentForLegacyDashboard = (
     if (currentGrade !== bestGrade) {
       return currentGrade > bestGrade ? current : best
     }
+
+    if (best.run.id === current.run.id) return best
 
     if (course.next_run_id !== null && course.next_run_id !== undefined) {
       if (current.run.id === course.next_run_id) return current


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12243

### Description (What does it do?)
This PR fixes the above bug by adding another phase of tie breaking to `pickDisplayedEnrollmentForLegacyDashboard`. If all enrollments have no grades or certificates, previously the first enrollment in database order would be selected. Instead of database order, we now try the following:

- Any enrollment who's run matches `next_run_id` of the course
- The latest enrollment by `start_date`

### Screenshots (if appropriate):
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/0653c8cb-f593-4da0-ae8d-6c57e7757831" />
<img width="768" height="1024" alt="image" src="https://github.com/user-attachments/assets/2b566c96-ff92-4484-a755-108dfac794b6" />
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/e542c2f9-55f3-4d7e-9003-92ed3b1e1331" />

### How can this be tested?
- Ensure you have an instance of MITx Online up and running and connected to Learn as described in the readme
- Run this script in a Django shell to create the appropriate test data on the admin@odl.local test user:
   ```python                                                                                                                                                                                                                                                            
   from django.contrib.auth import get_user_model                                                                                                                                                                                                                       
   from django.core.management import call_command                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                        
   from courses.api import create_program_enrollments, create_run_enrollments                                                                                                                                                                                           
   from courses.models import Course, CourseRun, Program                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                        
   User = get_user_model()                                                                                                                                                                                                                                              
   user = User.objects.get(email="admin@odl.local")  # swap for your test user                                                                                                                                                                                          
                                                                                                                                                                                                                                                                        
   COURSE_ID = "course-v1:QADEMO+MULTIRUN"                                                                                                                                                                                                                              
   PROGRAM_ID = "program-v1:QADEMO+MULTIRUNPROG"                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                        
   # --- Course with a past run ---                                                                                                                                                                                                                                     
   call_command(                                                                                                                                                                                                                                                        
       "create_courseware", "course", COURSE_ID, "QA Demo - Multi-Run Enrollment Course",                                                                                                                                                                               
       live=True, create_run="R1_OLD",                                                                                                                                                                                                                                  
       start="2025-04-01", end="2025-07-01",                                                                                                                                                                                                                            
       enrollment_start="2025-03-15", enrollment_end="2025-06-15",                                                                                                                                                                                                      
       depts=["QA Demo"], create_depts=True,                                                                                                                                                                                                                            
       create_page=True, create_certificate_page=True, create_signatory=True,                                                                                                                                                                                           
       mode_audit=True, mode_verified=True, primary_lang=True,                                                                                                                                                                                                          
   )                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                        
   # --- Add a currently in-progress run ---                                                                                                                                                                                                                            
   call_command(                                                                                                                                                                                                                                                        
       "create_courseware", "courserun", COURSE_ID, "QA Demo - Multi-Run Enrollment Course",                                                                                                                                                                            
       live=True, create_run="R2_CURRENT",                                                                                                                                                                                                                              
       start="2026-06-01", end="2026-09-01",                                                                                                                                                                                                                            
       enrollment_start="2026-05-15", enrollment_end="2026-08-15",                                                                                                                                                                                                      
       mode_audit=True, mode_verified=True,                                                                                                                                                                                                                             
   )                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                        
   # --- Add an upcoming run ---                                                                                                                                                                                                                                        
   call_command(                                                                                                                                                                                                                                                        
       "create_courseware", "courserun", COURSE_ID, "QA Demo - Multi-Run Enrollment Course",                                                                                                                                                                            
       live=True, create_run="R3_FUTURE",                                                                                                                                                                                                                               
       start="2026-09-15", end="2026-12-15",                                                                                                                                                                                                                            
       enrollment_start="2026-08-01", enrollment_end="2026-09-10",                                                                                                                                                                                                      
       mode_audit=True, mode_verified=True,                                                                                                                                                                                                                             
   )                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                        
   # --- Enroll the user in all 3 runs, oldest first (no grades/certificates) ---                                                                                                                                                                                       
   course = Course.objects.get(readable_id=COURSE_ID)                                                                                                                                                                                                                   
   runs = list(CourseRun.objects.filter(course=course).order_by("id"))                                                                                                                                                                                                  
   create_run_enrollments(user, runs, mode="audit", keep_failed_enrollments=True)                                                                                                                                                                                       
                                                                                                                                                                                                                                                                        
   # --- Wrap the course in its own program so it renders on a program dashboard ---                                                                                                                                                                                    
   call_command(                                                                                                                                                                                                                                                        
       "create_courseware", "program", PROGRAM_ID, "QA Demo - Multi-Run Bug Repro Program",                                                                                                                                                                             
       live=True, depts=["QA Demo"], create_depts=True,                                                                                                                                                                                                                 
       create_page=True, create_certificate_page=True, create_signatory=True,                                                                                                                                                                                           
   )                                                                                                                                                                                                                                                                    
   program = Program.objects.get(readable_id=PROGRAM_ID)                                                                                                                                                                                                                
   program.add_requirement(course)                                                                                                                                                                                                                                      
   create_program_enrollments(user, [program], enrollment_mode="verified")                                                                                                                                                                                              
                                                                                                                                                                                                                                                                        
   print("Program:", program.pk, program.readable_id)                                                                                                                                                                                                                   
   ```
 - Browse to the program it created and view the course card, expanding the course runs accordion
 - Verify that the "current run" is the actual current run