### PR TITLE
bump smoot-design

### DIFF
--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -19,7 +19,7 @@
     "@mitodl/course-search-utils": "^3.5.2",
     "@mitodl/hacksnack": "^0.1.0",
     "@mitodl/mitxonline-api-axios": "2026.7.7",
-    "@mitodl/smoot-design": "^6.27.0",
+    "@mitodl/smoot-design": "^6.28.1",
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",

--- a/frontends/ol-components/package.json
+++ b/frontends/ol-components/package.json
@@ -67,7 +67,7 @@
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "@mitodl/smoot-design": "^6.27.0",
+    "@mitodl/smoot-design": "^6.28.1",
     "next": "^16.2.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,9 +3370,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/smoot-design@npm:^6.27.0":
-  version: 6.27.0
-  resolution: "@mitodl/smoot-design@npm:6.27.0"
+"@mitodl/smoot-design@npm:^6.28.1":
+  version: 6.28.1
+  resolution: "@mitodl/smoot-design@npm:6.28.1"
   dependencies:
     "@ai-sdk/react": "npm:1.2.12"
     "@emotion/cache": "npm:^11.14.0"
@@ -3397,7 +3397,7 @@ __metadata:
     "@remixicon/react": ^4.2.0
     react: ^18 || ^19
     react-dom: ^18 || ^19
-  checksum: 10/3db7c26bf2c412a0c13b712b2473315d8ae945bd0819e1a896e6d91a20745ae50431b55a88599b155d16083bb7d75fd048ef72fc64674145d20e0790c4613d74
+  checksum: 10/0b6c04bfb3453d1d4c0dc65bab6ac2269fc7d21138932175b37c872c0de3887705f049755402f82b3456880d6f98f32d6246d81968fc4ae84f1482b5572a3f80
   languageName: node
   linkType: hard
 
@@ -16321,7 +16321,7 @@ __metadata:
     "@mitodl/course-search-utils": "npm:^3.5.2"
     "@mitodl/hacksnack": "npm:^0.1.0"
     "@mitodl/mitxonline-api-axios": "npm:2026.7.7"
-    "@mitodl/smoot-design": "npm:^6.27.0"
+    "@mitodl/smoot-design": "npm:^6.28.1"
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"
@@ -17971,7 +17971,7 @@ __metadata:
     typescript: "npm:^5.5.4"
     wheel-indicator: "npm:^1.3.0"
   peerDependencies:
-    "@mitodl/smoot-design": ^6.27.0
+    "@mitodl/smoot-design": ^6.28.1
     next: ^16.2.7
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
### What are the relevant tickets?
Related to #3576 

### Description (What does it do?)
Bumps smoot-design; per https://github.com/mitodl/smoot-design/releases, the only change that's really relevant here is new color `lightGray0`.

### How can this be tested?
1. Look at the frontend. It should look same.

### Additional Context
Bumping for use in  #3576 