### PR TITLE
Route content-archive tasks to the edx_content queue

### DIFF
--- a/main/celery.py
+++ b/main/celery.py
@@ -37,4 +37,8 @@ app.conf.task_routes = {
     "learning_resources_search.tasks.deindex_run_content_files": {
         "queue": "edx_content"
     },
+    "learning_resources.tasks.import_content_files": {"queue": "edx_content"},
+    "learning_resources.tasks.ingest_edx_run_archive": {"queue": "edx_content"},
+    "learning_resources.tasks.ingest_canvas_course": {"queue": "edx_content"},
+    "learning_resources.tasks.sync_canvas_courses": {"queue": "edx_content"},
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A 

### Description (What does it do?)
`import_content_files`, `ingest_edx_run_archive`, `ingest_canvas_course`, and `sync_canvas_courses` were missing from `task_routes` in `main/celery.py`, so they ran on the `default` queue instead of the dedicated `edx_content` worker. During a `backpopulate_mitxonline_data` run, `import_content_files` tasks dispatched from `load_run` piled onto the default worker, OOM-killed it, and took the in-flight `get_mitxonline_data` ETL task down with it.

This adds the four missing entries so all four content-archive tasks route to `edx_content`, matching the existing routing for `get_content_tasks`, `get_content_files`, `import_all_*_files`, etc.


### How can this be tested?
1. `docker compose run --rm web python manage.py backpopulate_mitxonline_data`
2. Confirm the command completes and prints `Population of MITX Online data finished, took ... seconds` rather than hanging or being killed.
3. While it runs, tail worker logs (`docker compose logs -f celery` and the `edx_content`-routed worker) and confirm `import_content_files` tasks are received/processed on the `edx_content` worker, not the default one.
4. Repeat with `docker compose run --rm web python manage.py backpopulate_canvas_courses` to confirm `sync_canvas_courses` and the `ingest_canvas_course` tasks it dispatches also complete successfully and land on `edx_content`.

