### PR TITLE
Single-source the app version from pyproject.toml

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -15,6 +15,8 @@ import datetime
 import logging
 import os
 import platform
+import tomllib
+from pathlib import Path
 from urllib.parse import urljoin
 
 import dj_database_url
@@ -35,7 +37,10 @@ from main.settings_course_etl import *  # noqa: F403
 from main.settings_pluggy import *  # noqa: F403
 from openapi.settings_spectacular import open_spectacular_settings
 
-VERSION = "0.73.4"
+# Single source of truth for the app version is pyproject.toml, bumped by the
+# Concourse release pipeline via bump-my-version.
+with (Path(__file__).resolve().parent.parent / "pyproject.toml").open("rb") as f:
+    VERSION = tomllib.load(f)["project"]["version"]
 
 log = logging.getLogger()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mit-learn"
-version = "0.70.10"
+version = "0.73.4"
 description = "Search index for use with other MIT applications."
 authors = [{ name = "MIT ODL" }]
 requires-python = ">=3.12,<3.13"
@@ -279,11 +279,6 @@ calver_format = "{YYYY}.{MM}.{DD}"
 
 [tool.bumpversion.parts.build]
 first_value = "1"
-
-[[tool.bumpversion.files]]
-filename = "main/settings.py"
-search = 'VERSION = "{current_version}"'
-replace = 'VERSION = "{new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"

--- a/uv.lock
+++ b/uv.lock
@@ -2546,7 +2546,7 @@ wheels = [
 
 [[package]]
 name = "mit-learn"
-version = "0.70.10"
+version = "0.73.4"
 source = { virtual = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A — fixes the `test_bump_my_version_format` failure currently breaking CI on every PR.

### Description (What does it do?)
`main/settings.py` (`VERSION = "0.73.4"`) and `pyproject.toml` (`version = "0.70.10"`) are out of sync on `main`, so `test_bump_my_version_format` fails on every PR. The mismatch was introduced when #3220 merged: it was written when the version was 0.70.10, while Doof releases kept bumping only `main/settings.py` up to 0.73.4.

Syncing the numbers alone would break again on the next Doof release, since Doof only writes `settings.py`. This PR removes the possibility of drift by making `pyproject.toml` the single source of truth:

- `main/settings.py` now reads `VERSION` from `pyproject.toml` at import (the file is present in all Docker image targets via `COPY . /src`)
- The `main/settings.py` entry is dropped from the `[tool.bumpversion]` file list — the Concourse pipeline only needs to bump `pyproject.toml` and `uv.lock`
- `pyproject.toml` and `uv.lock` are synced to the last released version, 0.73.4

`test_bump_my_version_format` is intentionally unchanged: it still loads `pyproject.toml` independently, so it now guards against anyone re-hardcoding a version in settings.

### How can this be tested?
- `docker compose run --rm web uv run pytest main/settings_test.py` — all 15 pass (previously `test_bump_my_version_format` failed)
- `uv lock --check` passes
- `python -c 'from django.conf import settings; print(settings.VERSION)'` in the web container prints `0.73.4`

### Additional Context
Two transitional caveats for the release-pipeline migration (ol-infrastructure#4506):

1. **If Doof releases mit-learn again**, its `VERSION = "..."` regex against `settings.py` will no longer match, so the version won't advance until the Concourse pipeline takes over. Drift (and red CI) can no longer happen, but Doof should be considered retired for this repo once this merges.
2. **The first calver version still needs planting.** The `[tool.bumpversion]` parse regex expects `YYYY.MM.DD.N` and matches neither 0.70.10 nor 0.73.4, so `bump-my-version bump` would fail on current values regardless of this PR. When the Concourse pipeline goes live, set the initial calver version in `pyproject.toml` (now a one-line change, since settings derives from it).