### PR TITLE
Sync pyproject.toml version with settings.py VERSION (0.73.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mit-learn"
-version = "0.70.10"
+version = "0.73.4"
 description = "Search index for use with other MIT applications."
 authors = [{ name = "MIT ODL" }]
 requires-python = ">=3.12,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -2546,7 +2546,7 @@ wheels = [
 
 [[package]]
 name = "mit-learn"
-version = "0.70.10"
+version = "0.73.4"
 source = { virtual = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`pyproject.toml`'s `[project].version` was reset to `0.70.10` in #3220 while `main/settings.py` `VERSION` is `0.73.4`. The `test_bump_my_version_format` test (also added in #3220) asserts the two are equal, so it fails on `main` and on every branch cut from it — the failure on unrelated PRs (e.g. #3600) is this, not flakiness. This bumps `pyproject.toml` to `0.73.4` to match.

**Heads up — this will re-break on the next release.** The release-script bot (Doof) only bumps `settings.py`, not `pyproject.toml`, so they'll desync again and this test will fail after the next release. The real fix is to wire the release process to keep both in sync (or run bump-my-version) as part of the release-resource migration; the equality assertion was effectively merged ahead of that. Raising in standup.

### How can this be tested?
CI passes.