### PR TITLE
Sort dateless runs without crashing embeddings

### DIFF
--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -704,16 +704,21 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
             and serialized_resource.get("availability") == Availability.anytime.name
         )
 
+    def _run_sort_key(self, run):
+        """Sort key for a run; dateless or unparseable runs sort last."""
+        start_date = run.get("start_date")
+        parsed = dateparser.parse(start_date) if start_date else None
+        if parsed is None:
+            return datetime.max.replace(tzinfo=UTC)
+        return (
+            parsed.replace(tzinfo=UTC)
+            if parsed.tzinfo is None
+            else parsed.astimezone(UTC)
+        )
+
     def runs_by_date(self, serialized_resource):
         """Get runs sorted by date"""
-        return sorted(
-            serialized_resource.get("runs", []),
-            key=lambda run: (
-                dateparser.parse(run["start_date"]).replace(tzinfo=UTC)
-                if run.get("start_date")
-                else datetime.max.replace(tzinfo=UTC)
-            ),
-        )
+        return sorted(serialized_resource.get("runs", []), key=self._run_sort_key)
 
     def dates_for_runs(self, serialized_resource):
         """Get a list of sorted and formatted run dates"""

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from datetime import UTC
+from datetime import UTC, datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -708,8 +708,10 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
         """Get runs sorted by date"""
         return sorted(
             serialized_resource.get("runs", []),
-            key=lambda run: dateparser.parse(
-                run["start_date"] if run.get("start_date", "") else ""
+            key=lambda run: (
+                dateparser.parse(run["start_date"]).replace(tzinfo=UTC)
+                if run.get("start_date")
+                else datetime.max.replace(tzinfo=UTC)
             ),
         )
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -704,17 +704,21 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
             and serialized_resource.get("availability") == Availability.anytime.name
         )
 
-    def _run_sort_key(self, run):
-        """Sort key for a run; dateless or unparseable runs sort last."""
+    def _parse_run_start(self, run):
+        """Parse a run's start_date as a UTC datetime, or None if unusable"""
         start_date = run.get("start_date")
         parsed = dateparser.parse(start_date) if start_date else None
         if parsed is None:
-            return datetime.max.replace(tzinfo=UTC)
+            return None
         return (
             parsed.replace(tzinfo=UTC)
             if parsed.tzinfo is None
             else parsed.astimezone(UTC)
         )
+
+    def _run_sort_key(self, run):
+        """Sort key for a run; dateless or unparseable runs sort last."""
+        return self._parse_run_start(run) or datetime.max.replace(tzinfo=UTC)
 
     def runs_by_date(self, serialized_resource):
         """Get runs sorted by date"""
@@ -738,6 +742,7 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
 
     def format_run_date(self, run, as_taught_in):
         """Format the run date based on available data"""
+        parsed_start = self._parse_run_start(run)
         if as_taught_in:
             run_semester = run.get("semester", "")
             if run_semester:
@@ -746,18 +751,10 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
                     return f"{run_semester} {run['year']}"
                 if run.get("start_date"):
                     return f"{run_semester} {run['start_date']}"
-            if run.get("start_date"):
-                return (
-                    dateparser.parse(run["start_date"])
-                    .replace(tzinfo=UTC)
-                    .strftime("%B, %Y")
-                )
-        if run.get("start_date"):
-            return (
-                dateparser.parse(run["start_date"])
-                .replace(tzinfo=UTC)
-                .strftime("%B %d, %Y")
-            )
+            if parsed_start:
+                return parsed_start.strftime("%B, %Y")
+        if parsed_start:
+            return parsed_start.strftime("%B %d, %Y")
         return None
 
     def should_show_format(self, serialized_resource):
@@ -1036,12 +1033,8 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
         if self.all_runs_are_identical(serialized_resource):
             return None
         for run in serialized_resource.get("runs", []):
-            start_date = run["start_date"]
-            formatted_date = (
-                dateparser.parse(start_date).replace(tzinfo=UTC).strftime("%B %d, %Y")
-                if start_date
-                else ""
-            )
+            parsed_start = self._parse_run_start(run)
+            formatted_date = parsed_start.strftime("%B %d, %Y") if parsed_start else ""
             location = run.get("location") or "Online"
             duration = run.get("duration")
             prices = run.get("prices", [])

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -1130,6 +1130,25 @@ def test_metadata_display_serializer_show_start_anytime():
     assert metadata_serializer.show_start_anytime(serialized_resource) is False
 
 
+def test_runs_by_date_handles_dateless_runs():
+    """
+    runs_by_date should not crash when 2+ runs have no start_date (issue #12295);
+    dateless runs sort last.
+    """
+    serialized_resource = {
+        "runs": [
+            {"id": 1, "start_date": None},
+            {"id": 2, "start_date": "2024-01-01T00:00:00Z"},
+            {"id": 3, "start_date": None},
+        ]
+    }
+    serializer = serializers.LearningResourceMetadataDisplaySerializer(
+        serialized_resource
+    )
+    ordered = serializer.runs_by_date(serialized_resource)
+    assert [run["id"] for run in ordered] == [2, 1, 3]
+
+
 def test_total_runs_with_dates(mocker):
     """
     Test total_runs_with_dates method

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -1132,21 +1132,23 @@ def test_metadata_display_serializer_show_start_anytime():
 
 def test_runs_by_date_handles_dateless_runs():
     """
-    runs_by_date should not crash when 2+ runs have no start_date (issue #12295);
-    dateless runs sort last.
+    runs_by_date should not crash when runs have no usable start_date (issue #12295);
+    such runs sort last, whether the value is None, missing, empty, or unparseable.
     """
     serialized_resource = {
         "runs": [
             {"id": 1, "start_date": None},
             {"id": 2, "start_date": "2024-01-01T00:00:00Z"},
-            {"id": 3, "start_date": None},
+            {"id": 3},  # start_date key missing
+            {"id": 4, "start_date": ""},  # empty string
+            {"id": 5, "start_date": "not a date"},  # unparseable
         ]
     }
     serializer = serializers.LearningResourceMetadataDisplaySerializer(
         serialized_resource
     )
     ordered = serializer.runs_by_date(serialized_resource)
-    assert [run["id"] for run in ordered] == [2, 1, 3]
+    assert [run["id"] for run in ordered] == [2, 1, 3, 4, 5]
 
 
 def test_total_runs_with_dates(mocker):

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -1151,6 +1151,84 @@ def test_runs_by_date_handles_dateless_runs():
     assert [run["id"] for run in ordered] == [2, 1, 3, 4, 5]
 
 
+def _serialized_resource_with_bad_run_date(bad_start_date):
+    """Serialize a course with one valid run and one with a bad start_date"""
+    resource = LearningResourceFactory.create(
+        resource_type="course", availability=Availability.dated.name
+    )
+    serialized_resource = serializers.LearningResourceSerializer(resource).data
+    delivery = [
+        {
+            "code": LearningResourceDelivery.online.name,
+            "name": LearningResourceDelivery.online.value,
+        }
+    ]
+    serialized_resource["delivery"] = delivery
+    good_run = serialized_resource["runs"][0]
+    good_run.update(
+        {
+            "start_date": "2024-01-01T00:00:00Z",
+            "delivery": delivery,
+            "location": "",
+            "resource_prices": [],
+        }
+    )
+    bad_run = copy.deepcopy(good_run)
+    if bad_start_date == "missing":
+        bad_run.pop("start_date")
+    else:
+        bad_run["start_date"] = bad_start_date
+    serialized_resource["runs"] = [good_run, bad_run]
+    return serialized_resource, bad_run
+
+
+@pytest.mark.parametrize("bad_start_date", [None, "", "not a date", "missing"])
+def test_date_methods_handle_unusable_start_dates(bad_start_date):
+    """
+    dates_for_runs, total_runs_with_dates, get_starts, and render_document
+    should skip runs with unusable start_date values, not crash on them.
+    """
+    serialized_resource, _ = _serialized_resource_with_bad_run_date(bad_start_date)
+    serializer = serializers.LearningResourceMetadataDisplaySerializer(
+        serialized_resource
+    )
+    assert serializer.dates_for_runs(serialized_resource) == ["January 01, 2024"]
+    assert serializer.total_runs_with_dates(serialized_resource) == 1
+    assert serializer.get_starts(serialized_resource) == ["January 01, 2024"]
+    assert isinstance(serializer.render_document(), dict)
+
+
+@pytest.mark.parametrize("bad_start_date", [None, "", "not a date", "missing"])
+def test_date_methods_handle_all_runs_dateless(bad_start_date):
+    """Date methods should return empty values when no run has a usable date"""
+    serialized_resource, bad_run = _serialized_resource_with_bad_run_date(
+        bad_start_date
+    )
+    serialized_resource["runs"] = [bad_run]
+    serializer = serializers.LearningResourceMetadataDisplaySerializer(
+        serialized_resource
+    )
+    assert serializer.dates_for_runs(serialized_resource) == []
+    assert serializer.total_runs_with_dates(serialized_resource) == 0
+    assert serializer.get_starts(serialized_resource) is None
+    assert isinstance(serializer.render_document(), dict)
+
+
+@pytest.mark.parametrize("bad_start_date", [None, "", "not a date", "missing"])
+def test_get_runs_handles_unusable_start_dates(bad_start_date):
+    """get_runs should render an empty date for runs with unusable start_dates"""
+    serialized_resource, bad_run = _serialized_resource_with_bad_run_date(
+        bad_start_date
+    )
+    # differing location so all_runs_are_identical is False
+    bad_run["location"] = "Elsewhere"
+    serializer = serializers.LearningResourceMetadataDisplaySerializer(
+        serialized_resource
+    )
+    runs = serializer.get_runs(serialized_resource)
+    assert [run["start_date"] for run in runs] == ["January 01, 2024", ""]
+
+
 def test_total_runs_with_dates(mocker):
     """
     Test total_runs_with_dates method


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12295

### Description (What does it do?)
`runs_by_date` in the metadata display serializer sorted runs by `dateparser.parse("")`, which returns `None`, for any run without a `start_date`. Two or more dateless runs produced two `None` sort keys and raised `TypeError: '<' not supported between instances of ...`, crashing `generate_embeddings` so the resource was never embedded (e.g. Sloan Exec Ed `anytime` courses, `variant-test-2` on mitxonline).

A falsy `start_date` (missing key, `None`, or `""`) now sorts last via a `datetime.max` UTC sentinel, and parsed dates are normalized to UTC-aware (matching `format_run_date`) so a naive/aware mix can't crash the sort either.

### How can this be tested?
Following the issue's Steps to Reproduce:

1. Pick a course resource where 2+ runs have `start_date=None` (e.g. `a05U1000004jDLNIA2` — Sloan Exec Ed "Accelerating Innovation through Ecosystems Sprint" — or `variant-test-2` on mitxonline).
2. Run `generate_embeddings([<id>], "course", overwrite=False)`.
3. Before this change the task raised the `TypeError` in `runs_by_date`; it should now complete and embed the resource, with dateless runs ordered last.

New regression test:
```
docker compose run --rm web uv run pytest \
  learning_resources/serializers_test.py::test_runs_by_date_handles_dateless_runs
```