### PR TITLE
Pin asyncapi to a non-compromised version.

### DIFF
--- a/load_testing/package.json
+++ b/load_testing/package.json
@@ -8,5 +8,11 @@
   "devDependencies": {
     "@grafana/openapi-to-k6": "^0.4.1",
     "@types/k6": "^1.7.0"
+  },
+  "overrides": {
+    "@asyncapi/specs": "6.11.1"
+  },
+  "resolutions": {
+    "@asyncapi/specs": "6.11.1"
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/mit-learn/issues/3611

### Description (What does it do?)
<!--- Describe your changes in detail -->
Pins the upstream dependency to a non-compromised version. `@grafana/openapi-to-k6` already did this too but hasn't released yet.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
N/A