### PR TITLE
Don't send non-transactional emails when opted out

### DIFF
--- a/learning_resources_search/tasks.py
+++ b/learning_resources_search/tasks.py
@@ -1032,7 +1032,7 @@ def attempt_send_digest_email_batch(user_template_items):
                 shortform=True,
             )
             send_template_email(
-                [user.email],
+                user,
                 subject,
                 "email/subscribed_channel_digest.html",
                 context={
@@ -1042,4 +1042,5 @@ def attempt_send_digest_email_batch(user_template_items):
                     "resource_group": group,
                     "short_subject": short_subject,
                 },
+                is_transactional=False,
             )

--- a/profiles/management/commands/send_test_email.py
+++ b/profiles/management/commands/send_test_email.py
@@ -1,5 +1,7 @@
 """Management command for sending a test welcome or digest email to a user"""  # noqa: INP001
 
+import sys
+
 from django.contrib.auth import get_user_model
 from django.core.management import BaseCommand, CommandError
 from requests.models import PreparedRequest
@@ -89,6 +91,7 @@ class Command(BaseCommand):
                     f"User {user.id} has a blank email, send_welcome_email will skip it"
                 )
             )
+            sys.exit(1)
         send_welcome_email(user.id)
         self.stdout.write(f"Sent welcome email to {user}")
 

--- a/profiles/management/commands/send_test_email.py
+++ b/profiles/management/commands/send_test_email.py
@@ -1,0 +1,156 @@
+"""Management command for sending a test welcome or digest email to a user"""  # noqa: INP001
+
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand, CommandError
+from requests.models import PreparedRequest
+
+from learning_resources.constants import LearningResourceType
+from learning_resources.models import LearningResource
+from learning_resources_search.tasks import (
+    _generate_subscription_digest_subject,
+    attempt_send_digest_email_batch,
+)
+from main.utils import frontend_absolute_url
+from profiles.tasks import send_welcome_email
+
+User = get_user_model()
+
+
+def _add_user_arguments(parser):
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--user-id", type=int, help="the id of the user")
+    group.add_argument("--email", help="the email of the user")
+
+
+def _resolve_user(options):
+    if options["user_id"]:
+        return User.objects.get(id=options["user_id"])
+    return User.objects.get(email=options["email"])
+
+
+class Command(BaseCommand):
+    """Send a test welcome or digest email to a user"""
+
+    help = "Send a test welcome or digest email to a user"
+
+    def add_arguments(self, parser):
+        """Add the welcome and digest subcommands"""
+        subparsers = parser.add_subparsers(dest="email_type", required=True)
+
+        welcome_parser = subparsers.add_parser(
+            "welcome", help="Send a test welcome email"
+        )
+        _add_user_arguments(welcome_parser)
+
+        digest_parser = subparsers.add_parser("digest", help="Send a test digest email")
+        _add_user_arguments(digest_parser)
+        digest_parser.add_argument(
+            "--resource-id",
+            type=int,
+            action="append",
+            dest="resource_ids",
+            help="a learning resource id to include (may be repeated)",
+        )
+        digest_parser.add_argument(
+            "--count",
+            type=int,
+            default=3,
+            help="number of recent published resources to include if --resource-id "
+            "is not given",
+        )
+        digest_parser.add_argument(
+            "--group",
+            default="Test Digest",
+            help="subscription group/source label shown in the email",
+        )
+        digest_parser.add_argument(
+            "--source-channel-type",
+            default="saved_search",
+            help="controls subject line wording, e.g. saved_search or topic",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Send the requested test email"""
+        try:
+            user = _resolve_user(options)
+        except User.DoesNotExist as exc:
+            msg = "No matching user found"
+            raise CommandError(msg) from exc
+
+        if options["email_type"] == "welcome":
+            self._handle_welcome(user)
+        else:
+            self._handle_digest(user, options)
+
+    def _handle_welcome(self, user):
+        if not user.email:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"User {user.id} has a blank email, send_welcome_email will skip it"
+                )
+            )
+        send_welcome_email(user.id)
+        self.stdout.write(f"Sent welcome email to {user}")
+
+    def _handle_digest(self, user, options):
+        if options["resource_ids"]:
+            resources = list(
+                LearningResource.objects.filter(id__in=options["resource_ids"])
+            )
+            found_ids = {resource.id for resource in resources}
+            missing_ids = set(options["resource_ids"]) - found_ids
+            if missing_ids:
+                msg = f"No learning resources found for ids: {sorted(missing_ids)}"
+                raise CommandError(msg)
+        else:
+            resources = list(
+                LearningResource.objects.filter(published=True).order_by("-created_on")[
+                    : options["count"]
+                ]
+            )
+            if not resources:
+                msg = "No published learning resources found"
+                raise CommandError(msg)
+
+        if user.profile.email_optin is False:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"User {user.id} has opted out of email; the digest email is "
+                    "non-transactional and will be silently skipped"
+                )
+            )
+
+        group = options["group"]
+        source_channel_type = options["source_channel_type"]
+        rows = [
+            self._build_row(resource, user, group, source_channel_type)
+            for resource in resources
+        ]
+        template_data = {group: rows}
+
+        unique_resource_types = {row["resource_type"] for row in rows}
+        subject = _generate_subscription_digest_subject(
+            rows[0], group, list(unique_resource_types), len(rows), shortform=False
+        )
+
+        attempt_send_digest_email_batch([(user.id, template_data)])
+        self.stdout.write(f'Sent digest email to {user} with subject "{subject}"')
+
+    @staticmethod
+    def _build_row(resource, user, group, source_channel_type):
+        search_url = frontend_absolute_url("/search")
+        req = PreparedRequest()
+        req.prepare_url(search_url, {"resource": resource.id})
+        return {
+            "resource_url": req.url,
+            "resource_title": resource.title,
+            "resource_image_url": resource.image.url
+            if resource.image
+            else frontend_absolute_url("/images/default_resource.jpg"),
+            "resource_type": LearningResourceType[resource.resource_type].value,
+            "user_id": user.id,
+            "source_label": group,
+            "source_channel_type": source_channel_type,
+            "group": group,
+            "search_url": search_url,
+        }

--- a/profiles/tasks.py
+++ b/profiles/tasks.py
@@ -34,8 +34,9 @@ def send_welcome_email(user_id):
     ).strip()
     display_name = profile_name or full_name or user.username or "there"
     send_template_email(
-        [user.email],
+        user,
         "MIT Learn - Welcome to MIT Learn",
         "email/welcome_email.html",
         context={"display_name": display_name},
+        is_transactional=True,
     )

--- a/profiles/tasks_test.py
+++ b/profiles/tasks_test.py
@@ -17,10 +17,11 @@ def test_send_welcome_email_sends_template_email(mocker):
     send_welcome_email(user.id)
 
     mocked_send.assert_called_once_with(
-        ["new.user@example.com"],
+        user,
         "MIT Learn - Welcome to MIT Learn",
         "email/welcome_email.html",
         context={"display_name": "Full Name"},
+        is_transactional=True,
     )
 
 
@@ -60,10 +61,11 @@ def test_send_welcome_email_uses_full_name_when_profile_name_missing(mocker):
     send_welcome_email(user.id)
 
     mocked_send.assert_called_once_with(
-        ["full.name@example.com"],
+        user,
         "MIT Learn - Welcome to MIT Learn",
         "email/welcome_email.html",
         context={"display_name": "Full Name"},
+        is_transactional=True,
     )
 
 
@@ -83,10 +85,11 @@ def test_send_welcome_email_uses_username_when_names_missing(mocker):
     send_welcome_email(user.id)
 
     mocked_send.assert_called_once_with(
-        ["username.only@example.com"],
+        user,
         "MIT Learn - Welcome to MIT Learn",
         "email/welcome_email.html",
         context={"display_name": "username-only"},
+        is_transactional=True,
     )
 
 
@@ -105,8 +108,9 @@ def test_send_welcome_email_handles_missing_profile_relation(mocker):
     send_welcome_email(user.id)
 
     mocked_send.assert_called_once_with(
-        ["missing.profile@example.com"],
+        user,
         "MIT Learn - Welcome to MIT Learn",
         "email/welcome_email.html",
         context={"display_name": "profile-missing"},
+        is_transactional=True,
     )

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,6 +1,7 @@
 """Utils for profiles"""
 
 import hashlib
+import logging
 import re
 import uuid
 from contextlib import contextmanager
@@ -18,6 +19,8 @@ from django.template.loader import render_to_string
 from PIL import Image
 
 from main.utils import generate_filepath
+
+log = logging.getLogger(__name__)
 
 # Max dimension of either height or width for small and medium images
 IMAGE_SMALL_MAX_DIMENSION = 64
@@ -390,32 +393,38 @@ def fetch_program_letter_template_data(letter):
     return None
 
 
-def send_template_email(recipients, subject, template, context):
+def send_template_email(user, subject, template, context, *, is_transactional: bool):
     """
     Send an html email using a provided template
     Args:
-        recipients(str[]): Emails to send to
+        user: User instance to send to
         subject(str): Subject line
         template(str): Path to an html template
         context(dict): context vars used in rendering the template
+        is_transactional(bool): If true the email bypasses the user's
+            email_optin setting and always sends.
     """
+    if not is_transactional and user.profile.email_optin is False:
+        log.debug("Not sending email to user %s: opted out of email", user.id)
+        return None
+
     if not context:
         context = {}
     context["APP_BASE_URL"] = settings.APP_BASE_URL
     context["ABSOLUTE_STATIC_URL"] = urljoin(settings.APP_BASE_URL, settings.STATIC_URL)
     html_content = render_to_string(template, context)
-    return send_email(recipients, subject, html_content, text_only=False)
+    return send_email(user, subject, html_content, text_only=False)
 
 
-def send_email(recipients, subject, content, text_only):
+def send_email(user, subject, content, text_only):
     """
     Send an email
     Args:
-        recipients(str[]): Emails to send to
+        user: User instance to send to
         subject(str): Subject line
         content(str): The html or plain text content of the email.
         text_only(bool): If True html from the 'content' arg
-        will be stripped and sent as plaint text
+        will be stripped and sent as plain text
     """
 
     if text_only:
@@ -429,7 +438,7 @@ def send_email(recipients, subject, content, text_only):
         msg = AnymailMessage(
             subject=subject,
             body=text_content,
-            to=recipients,
+            to=[user.email],
             from_email=settings.MAILGUN_FROM_EMAIL,
             connection=connection,
         )

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -14,6 +14,7 @@ from anymail.message import AnymailMessage
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core import mail
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.temp import NamedTemporaryFile
 from django.template.loader import render_to_string
 from PIL import Image
@@ -393,6 +394,20 @@ def fetch_program_letter_template_data(letter):
     return None
 
 
+def user_has_email_optin(user) -> bool:
+    """
+    Determine whether a non-transactional email may be sent to a user.
+
+    Returns False if the user has explicitly opted out, or has no Profile
+    at all (e.g. a user provisioned without a profile being created).
+    """
+    try:
+        profile = user.profile
+    except ObjectDoesNotExist:
+        return False
+    return profile.email_optin is not False
+
+
 def send_template_email(user, subject, template, context, *, is_transactional: bool):
     """
     Send an html email using a provided template
@@ -404,7 +419,7 @@ def send_template_email(user, subject, template, context, *, is_transactional: b
         is_transactional(bool): If true the email bypasses the user's
             email_optin setting and always sends.
     """
-    if not is_transactional and user.profile.email_optin is False:
+    if not is_transactional and not user_has_email_optin(user):
         log.debug("Not sending email to user %s: opted out of email", user.id)
         return None
 

--- a/profiles/utils_test.py
+++ b/profiles/utils_test.py
@@ -24,6 +24,7 @@ from profiles.utils import (
     profile_image_upload_uri_small,
     send_template_email,
     update_full_name,
+    user_has_email_optin,
 )
 
 
@@ -232,6 +233,33 @@ def test_fetch_program_letter_template_data_has_results(mocker, user, settings):
 
 
 # ---------------------------------------------------------------------------
+# user_has_email_optin tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("email_optin", [True, None])
+def test_user_has_email_optin_true_or_none(email_optin):
+    """user_has_email_optin is True when email_optin is True or None."""
+    user = UserFactory.create(profile__email_optin=email_optin)
+    assert user_has_email_optin(user) is True
+
+
+@pytest.mark.django_db
+def test_user_has_email_optin_false():
+    """user_has_email_optin is False when the user opted out."""
+    user = UserFactory.create(profile__email_optin=False)
+    assert user_has_email_optin(user) is False
+
+
+@pytest.mark.django_db
+def test_user_has_email_optin_no_profile():
+    """user_has_email_optin is False when the user has no profile."""
+    user = UserFactory.create(no_profile=True)
+    assert user_has_email_optin(user) is False
+
+
+# ---------------------------------------------------------------------------
 # send_template_email tests
 # ---------------------------------------------------------------------------
 
@@ -277,6 +305,41 @@ def test_send_template_email_transactional_opted_out_still_sends(mocker):
     """Transactional emails bypass email_optin even when the user opted out."""
     mock_send_email = mocker.patch("profiles.utils.send_email")
     user = UserFactory.create(profile__email_optin=False)
+
+    send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=True,
+    )
+
+    mock_send_email.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_send_template_email_not_transactional_no_profile_skips(mocker):
+    """When is_transactional=False and the user has no profile, the email is not sent."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(no_profile=True)
+
+    result = send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=False,
+    )
+
+    assert result is None
+    mock_send_email.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_template_email_transactional_no_profile_still_sends(mocker):
+    """Transactional emails bypass the opt-in check even when there's no profile."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(no_profile=True)
 
     send_template_email(
         user,

--- a/profiles/utils_test.py
+++ b/profiles/utils_test.py
@@ -22,6 +22,7 @@ from profiles.utils import (
     profile_image_upload_uri,
     profile_image_upload_uri_medium,
     profile_image_upload_uri_small,
+    send_template_email,
     update_full_name,
 )
 
@@ -228,3 +229,61 @@ def test_fetch_program_letter_template_data_has_results(mocker, user, settings):
     cert = ProgramCertificateFactory(user_email=user.email, micromasters_program_id=1)
     program_letter = ProgramLetterFactory(user=user, certificate=cert)
     assert fetch_program_letter_template_data(program_letter) == expected_item
+
+
+# ---------------------------------------------------------------------------
+# send_template_email tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("email_optin", [True, None])
+def test_send_template_email_not_transactional_opted_in_sends(mocker, email_optin):
+    """When is_transactional=False and email_optin is True or None, the email sends."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(profile__email_optin=email_optin)
+
+    send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=False,
+    )
+
+    mock_send_email.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_send_template_email_not_transactional_opted_out_skips(mocker):
+    """When is_transactional=False and email_optin is False, the email is not sent."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(profile__email_optin=False)
+
+    result = send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=False,
+    )
+
+    assert result is None
+    mock_send_email.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_send_template_email_transactional_opted_out_still_sends(mocker):
+    """Transactional emails bypass email_optin even when the user opted out."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(profile__email_optin=False)
+
+    send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=True,
+    )
+
+    mock_send_email.assert_called_once()


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8424

### Description (What does it do?)
<!--- Describe your changes in detail -->
Send emails to a User instance rather than a raw recipient list, and add an is_transactional flag so non-transactional email (e.g. digests) can respect the user's email_optin preference while transactional email (e.g. welcome) still always sends.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can use the `send_test_email` command to help test emails. The welcome email should send for your user but not the digest one if you're opted out and both should send if you're opted in.
