### PR TITLE
fix: Centralize podcast duration/audio/parent logic through helpers, remove moment from pages and Consolidate duplicated podcast styled components

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastContainer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastContainer.tsx
@@ -2,7 +2,7 @@ import { Container, styled } from "ol-components"
 
 type PodcastContainerProps = {
   /** Max content width in px (default 1080). */
-  width?: number
+  contentWidth?: number
   /** Horizontal padding in px applied above the gutter breakpoint (default 0). */
   gutter?: number
   /** Breakpoint below which a 16px horizontal gutter is applied (default "md"). */
@@ -12,15 +12,15 @@ type PodcastContainerProps = {
 /**
  * Shared page container for all podcast pages. Width and gutters are set via
  * props so callers don't redefine `maxWidth`/padding with `!important` overrides.
- * (Named `width` rather than `maxWidth` to avoid colliding with MUI Container's
- * own `maxWidth` breakpoint prop.)
+ * (Named `contentWidth` rather than `maxWidth`/`width` to avoid colliding with
+ * MUI Container's `maxWidth` breakpoint prop and the CSS `width` property.)
  */
 const PodcastContainer = styled(Container, {
   shouldForwardProp: (prop) =>
-    !["width", "gutter", "gutterBreakpoint"].includes(prop as string),
+    !["contentWidth", "gutter", "gutterBreakpoint"].includes(prop as string),
 })<PodcastContainerProps>(
-  ({ theme, width = 1080, gutter = 0, gutterBreakpoint = "md" }) => ({
-    maxWidth: `${width}px !important`,
+  ({ theme, contentWidth = 1080, gutter = 0, gutterBreakpoint = "md" }) => ({
+    maxWidth: `${contentWidth}px !important`,
     padding: gutter ? `0 ${gutter}px !important` : "0 !important",
     [theme.breakpoints.down(gutterBreakpoint)]: {
       padding: "0 16px !important",

--- a/frontends/main/src/app-pages/PodcastPage/PodcastContainer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastContainer.tsx
@@ -1,14 +1,31 @@
 import { Container, styled } from "ol-components"
 
-const PodcastContainer = styled(Container)(({ theme }) => ({
-  maxWidth: "1080px !important",
-  padding: "0 !important",
-  [theme.breakpoints.down("md")]: {
-    padding: "0 16px !important",
-  },
-  [theme.breakpoints.down("sm")]: {
-    padding: "0 16px !important",
-  },
-}))
+type PodcastContainerProps = {
+  /** Max content width in px (default 1080). */
+  width?: number
+  /** Horizontal padding in px applied above the gutter breakpoint (default 0). */
+  gutter?: number
+  /** Breakpoint below which a 16px horizontal gutter is applied (default "md"). */
+  gutterBreakpoint?: "md" | "sm"
+}
+
+/**
+ * Shared page container for all podcast pages. Width and gutters are set via
+ * props so callers don't redefine `maxWidth`/padding with `!important` overrides.
+ * (Named `width` rather than `maxWidth` to avoid colliding with MUI Container's
+ * own `maxWidth` breakpoint prop.)
+ */
+const PodcastContainer = styled(Container, {
+  shouldForwardProp: (prop) =>
+    !["width", "gutter", "gutterBreakpoint"].includes(prop as string),
+})<PodcastContainerProps>(
+  ({ theme, width = 1080, gutter = 0, gutterBreakpoint = "md" }) => ({
+    maxWidth: `${width}px !important`,
+    padding: gutter ? `0 ${gutter}px !important` : "0 !important",
+    [theme.breakpoints.down(gutterBreakpoint)]: {
+      padding: "0 16px !important",
+    },
+  }),
+)
 
 export default PodcastContainer

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -13,13 +13,22 @@ import {
 } from "api/hooks/learningResources"
 import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource } from "api/v1"
-import moment from "moment"
 import { formatDate } from "ol-utilities"
 import { HOME, podcastEpisodePageView } from "@/common/urls"
 import PodcastContainer from "./PodcastContainer"
 import { usePodcastPlayer } from "./usePodcastPlayer"
-import { getEpisodeAudioUrl } from "./PodcastsListingPage/helpers"
+import {
+  getEpisodeAudioUrl,
+  getEpisodeDurationMinutes,
+} from "./PodcastsListingPage/helpers"
 import { EpisodeItem } from "./PodcastsListingPage/EpisodeItem"
+import { EPISODES_PAGE_SIZE } from "./PodcastsListingPage/constants"
+import {
+  PageSection,
+  BreadcrumbBar,
+  EpisodeList,
+  PlayButton,
+} from "./PodcastsListingPage/styled"
 
 const HeaderSection = styled.div(({ theme }) => ({
   borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
@@ -149,21 +158,11 @@ const EpisodesHeading = styled(Typography)(({ theme }) => ({
   },
 }))
 
-const EpisodeList = styled.div({
-  margin: 0,
-  padding: 0,
-  display: "grid",
-  gridTemplateColumns: "1fr",
-})
-
-const StyledButton = styled(Button)(({ theme }) => ({
+const StyledButton = styled(PlayButton)(({ theme }) => ({
   padding: "16px 20px",
   ...theme.typography.body1,
   fontWeight: theme.typography.fontWeightMedium,
   lineHeight: "16px",
-  [theme.breakpoints.down("sm")]: {
-    width: "100%",
-  },
 }))
 
 const StyledShowMoreContainer = styled("div")({
@@ -189,25 +188,11 @@ const StyledPauseIcon = styled(RiPauseFill)({
   height: "24px !important",
 })
 
-const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "18px 0 2px 0",
-  borderBottom: `1px solid ${theme.custom.colors.red}`,
-  [theme.breakpoints.down("sm")]: {
-    padding: "12px 0 0px 0",
-  },
-}))
-
-const PageSection = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.white,
-}))
-
 /* ── Page ── */
 
 type PodcastDetailPageProps = {
   podcastId: string
 }
-
-const EPISODES_PAGE_SIZE = 5
 
 export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
   podcastId,
@@ -264,10 +249,8 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
   const latestEpisode = episodes?.[0]
   const isLatestEpisodePlaying =
     !!latestEpisode && playingEpisode?.id === latestEpisode.id && isAudioPlaying
-  const latestEpisodeDuration = latestEpisode?.podcast_episode?.duration
-    ? Math.round(
-        moment.duration(latestEpisode.podcast_episode.duration).asMinutes(),
-      )
+  const latestEpisodeDuration = latestEpisode
+    ? getEpisodeDurationMinutes(latestEpisode)
     : null
   const latestEpisodeDate = latestEpisode?.last_modified
     ? formatDate(latestEpisode.last_modified, "MMM D")
@@ -277,7 +260,7 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
 
   return (
     <>
-      <PageSection>
+      <PageSection variant="white">
         <HeaderSection>
           <BreadcrumbBar>
             <PodcastContainer>

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
@@ -9,6 +9,7 @@ import {
   RiForward30Line,
 } from "@remixicon/react"
 import type { LearningResource } from "api/v1"
+import { getEpisodeAudioUrl } from "./PodcastsListingPage/helpers"
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -21,11 +22,6 @@ const formatTime = (seconds: number): string => {
   const mm = String(m).padStart(2, "0")
   const ss = String(s).padStart(2, "0")
   return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
-}
-
-function getAudioUrl(resource: LearningResource): string {
-  if (resource.resource_type !== "podcast_episode") return ""
-  return resource.podcast_episode?.audio_url ?? ""
 }
 
 // ─── Styled components ────────────────────────────────────────────────────────
@@ -227,8 +223,11 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
   resource,
   inline = false,
 }) => {
-  const audioUrl = getAudioUrl(resource)
-  const hasAudioSource = Boolean(audioUrl.trim())
+  // The embed player feeds this URL straight into an <audio> element, so it must
+  // be a direct media file — never the (possibly webpage) episode_link fallback.
+  const audioUrl =
+    getEpisodeAudioUrl(resource, { allowEpisodeLink: false }) ?? ""
+  const hasAudioSource = Boolean(audioUrl)
   const audioRef = useRef<HTMLAudioElement>(null)
   const isPlayPendingRef = useRef(false)
   const playAttemptIdRef = useRef(0)

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -1,15 +1,8 @@
 "use client"
 
 import React, { useRef } from "react"
-import {
-  Breadcrumbs,
-  Typography,
-  Container,
-  styled,
-  useMediaQuery,
-} from "ol-components"
+import { Breadcrumbs, Typography, styled, useMediaQuery } from "ol-components"
 import type { Theme } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
 import { RiPlayFill, RiPauseFill } from "@remixicon/react"
 import PodcastPlayer from "./PodcastPlayer"
 import type { PodcastPlayerHandle } from "./PodcastPlayer"
@@ -20,7 +13,6 @@ import {
 
 import { ResourceTypeEnum } from "api/v1"
 import type { PodcastEpisodeResource } from "api/v1"
-import moment from "moment"
 import { formatDate } from "ol-utilities"
 import { HOME, podcastPageView, podcastEpisodePageView } from "@/common/urls"
 import DOMPurify from "isomorphic-dompurify"
@@ -28,26 +20,24 @@ import { EpisodeItem } from "./PodcastsListingPage/EpisodeItem"
 import PodcastContainer from "./PodcastContainer"
 import Link from "next/link"
 import { usePodcastPlayer } from "./usePodcastPlayer"
-import { getEpisodeAudioUrl } from "./PodcastsListingPage/helpers"
+import {
+  getEpisodeAudioUrl,
+  getEpisodeDurationMinutes,
+  getEpisodeParentPodcast,
+} from "./PodcastsListingPage/helpers"
+import { EPISODES_PAGE_SIZE } from "./PodcastsListingPage/constants"
+import {
+  PageSection,
+  BreadcrumbBar,
+  EpisodeList,
+  PlayButton,
+} from "./PodcastsListingPage/styled"
 
 import PodcastShareButton from "./PodcastShareButton"
 import { env } from "@/env"
 
 const NEXT_PUBLIC_ORIGIN = env("NEXT_PUBLIC_ORIGIN")
 /* ── Layout ── */
-
-const EpisodeContainer = styled(Container)(({ theme }) => ({
-  maxWidth: "624px !important",
-  padding: "0 !important",
-  [theme.breakpoints.down("sm")]: {
-    padding: "0 16px !important",
-  },
-}))
-
-const PageSection = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.lightGray1,
-  minHeight: "100vh",
-}))
 
 const HeaderSection = styled("div", {
   shouldForwardProp: (prop) => prop !== "hasEpisodes",
@@ -141,25 +131,10 @@ const Description = styled(Typography)(({ theme }) => ({
   },
 }))
 
-const EpisodeList = styled.ul({
-  listStyle: "none",
-  margin: 0,
-  padding: 0,
-  display: "grid",
-  gridTemplateColumns: "1fr",
-})
 const StyledPodcastShareButton = styled(PodcastShareButton)({
   padding: "18px 12px",
   margin: "0 0 24px",
 })
-
-export const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "18px 0 2px 0",
-  borderBottom: `1px solid ${theme.custom.colors.red}`,
-  [theme.breakpoints.down("sm")]: {
-    padding: "12px 0 0 0",
-  },
-}))
 
 const ViewAllLink = styled.a(({ theme }) => ({
   color: theme.custom.colors.darkRed,
@@ -180,18 +155,16 @@ const ViewAllLink = styled.a(({ theme }) => ({
   },
 }))
 
-const StyledButton = styled(Button)(({ theme }) => ({
+const StyledButton = styled(PlayButton)(({ theme }) => ({
   marginBottom: "32px",
-  padding: "12px 24px 12px 20px",
   minWidth: "175px",
   ...theme.typography.body1,
   [theme.breakpoints.down("sm")]: {
-    width: "100%",
     marginBottom: "16px",
   },
 }))
 
-export const PodcastShareSection = styled("div")({
+const PodcastShareSection = styled("div")({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
@@ -223,20 +196,15 @@ export const PodcastEpisodeDetailPage: React.FC<
 
   const { data: episode } = useLearningResourcesDetail(Number(episodeId))
 
-  const podcastEpisode =
-    episode?.resource_type === ResourceTypeEnum.PodcastEpisode
-      ? episode.podcast_episode
-      : null
-
   // Parent podcast summary comes embedded in the episode response — prefer the
   // one matching the URL's podcastId, else fall back to the first parent.
-  const parentPodcast =
-    podcastEpisode?.parent_podcasts?.find((p) => p.id === Number(podcastId)) ??
-    podcastEpisode?.parent_podcasts?.[0]
+  const parentPodcast = episode
+    ? getEpisodeParentPodcast(episode, Number(podcastId))
+    : null
 
   const { data: episodesData } = useInfiniteLearningResourceItems(
     Number(podcastId),
-    { learning_resource_id: Number(podcastId), limit: 5 },
+    { learning_resource_id: Number(podcastId), limit: EPISODES_PAGE_SIZE },
     { enabled: !!podcastId },
   )
   const episodes =
@@ -249,9 +217,7 @@ export const PodcastEpisodeDetailPage: React.FC<
             r.id !== Number(episodeId),
         ),
     ) ?? []
-  const duration = podcastEpisode?.duration
-    ? Math.round(moment.duration(podcastEpisode.duration).asMinutes())
-    : null
+  const duration = episode ? getEpisodeDurationMinutes(episode) : null
 
   const date = episode?.last_modified
     ? formatDate(episode.last_modified, "MMM D, YYYY")
@@ -275,12 +241,12 @@ export const PodcastEpisodeDetailPage: React.FC<
 
   const sharePageUrl =
     episode && podcastId
-      ? `${NEXT_PUBLIC_ORIGIN}${podcastEpisodePageView(String(episode!.id), podcastId, episode?.title)}`
+      ? `${NEXT_PUBLIC_ORIGIN}${podcastEpisodePageView(String(episode.id), podcastId, episode.title)}`
       : ""
 
   return (
     <>
-      <PageSection>
+      <PageSection variant="gray">
         <BreadcrumbBar>
           <PodcastContainer>
             <Breadcrumbs
@@ -294,7 +260,7 @@ export const PodcastEpisodeDetailPage: React.FC<
           </PodcastContainer>
         </BreadcrumbBar>
         <HeaderSection hasEpisodes={episodes.length > 0}>
-          <EpisodeContainer>
+          <PodcastContainer width={624} gutterBreakpoint="sm">
             {parentPodcast?.title && (
               <EpisodeLabel href={podcastHref}>
                 {parentPodcast.title}
@@ -339,10 +305,10 @@ export const PodcastEpisodeDetailPage: React.FC<
                 }}
               />
             )}
-          </EpisodeContainer>
+          </PodcastContainer>
         </HeaderSection>
         {episodes && episodes.length > 0 && (
-          <EpisodeContainer>
+          <PodcastContainer width={624} gutterBreakpoint="sm">
             <MoreItemDescription>
               More from {parentPodcast?.title ?? "Podcast"}
             </MoreItemDescription>
@@ -375,7 +341,7 @@ export const PodcastEpisodeDetailPage: React.FC<
             {podcastId && (
               <ViewAllLink href={podcastHref}>View all episodes →</ViewAllLink>
             )}
-          </EpisodeContainer>
+          </PodcastContainer>
         )}
       </PageSection>
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEpisodeDetailPage.tsx
@@ -260,7 +260,7 @@ export const PodcastEpisodeDetailPage: React.FC<
           </PodcastContainer>
         </BreadcrumbBar>
         <HeaderSection hasEpisodes={episodes.length > 0}>
-          <PodcastContainer width={624} gutterBreakpoint="sm">
+          <PodcastContainer contentWidth={624} gutterBreakpoint="sm">
             {parentPodcast?.title && (
               <EpisodeLabel href={podcastHref}>
                 {parentPodcast.title}
@@ -308,7 +308,7 @@ export const PodcastEpisodeDetailPage: React.FC<
           </PodcastContainer>
         </HeaderSection>
         {episodes && episodes.length > 0 && (
-          <PodcastContainer width={624} gutterBreakpoint="sm">
+          <PodcastContainer contentWidth={624} gutterBreakpoint="sm">
             <MoreItemDescription>
               More from {parentPodcast?.title ?? "Podcast"}
             </MoreItemDescription>

--- a/frontends/main/src/app-pages/PodcastPage/PodcastShareButton.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastShareButton.tsx
@@ -34,7 +34,7 @@ const PodcastShareButton: React.FC<PodcastShareButtonProps> = ({
       <ShareDialog
         open={shareOpen}
         onClose={() => setShareOpen(false)}
-        resource={resource as PodcastEpisodeResource}
+        resource={resource}
         pageUrl={sharePageUrl}
         title={title ?? ""}
       />

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/LatestEpisodesSection.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/LatestEpisodesSection.tsx
@@ -3,15 +3,16 @@ import { Link, Skeleton, styled } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import type { LearningResource, PodcastEpisodeResource } from "api/v1"
 import { SEARCH_PODCAST_EPISODES, podcastEpisodePageView } from "@/common/urls"
-import { Section, SectionHeader, SectionTitle, SectionMessage } from "./styled"
+import {
+  Section,
+  SectionHeader,
+  SectionTitle,
+  SectionMessage,
+  EpisodeList,
+} from "./styled"
 import { EpisodeItem } from "./EpisodeItem"
 import { getEpisodeParentPodcastId } from "./helpers"
 import { EPISODES_PAGE_SIZE } from "./constants"
-
-const EpisodeList = styled.div({
-  display: "grid",
-  gridTemplateColumns: "1fr",
-})
 
 const EpisodeSkeletonRow = styled.div(({ theme }) => ({
   display: "flex",

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/NowPlayingSection.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/NowPlayingSection.tsx
@@ -1,11 +1,10 @@
 import React from "react"
 import { Typography, Skeleton, styled } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
 import { RiPlayFill, RiPauseFill } from "@remixicon/react"
 import DOMPurify from "isomorphic-dompurify"
 import { formatDate } from "ol-utilities"
 import type { LearningResource } from "api/v1"
-import { Section } from "./styled"
+import { Section, PlayButton } from "./styled"
 import { getEpisodeAudioUrl, getEpisodeDurationMinutes } from "./helpers"
 
 const NowPlayingHeader = styled.div({
@@ -131,9 +130,8 @@ const NowPlayingRight = styled.div(({ theme }) => ({
   },
 }))
 
-const PlayEpisodeButton = styled(Button)({
+const PlayEpisodeButton = styled(PlayButton)({
   width: "100%",
-  padding: "12px 24px 12px 20px",
   height: "48px",
 })
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastsListingPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastsListingPage.tsx
@@ -13,12 +13,7 @@ import PodcastContainer from "../PodcastContainer"
 import PodcastPlayer from "../PodcastPlayer"
 import type { PodcastPlayerHandle } from "../PodcastPlayer"
 import { usePodcastPlayer } from "../usePodcastPlayer"
-import {
-  PageSection,
-  BreadcrumbBar,
-  StyledPodcastContainer,
-  SectionDivider,
-} from "./styled"
+import { PageSection, BreadcrumbBar, SectionDivider } from "./styled"
 import HeroSection from "./HeroSection"
 import NowPlayingSection from "./NowPlayingSection"
 import LatestEpisodesSection from "./LatestEpisodesSection"
@@ -119,13 +114,13 @@ export const PodcastsListingPage: React.FC = () => {
     <>
       <PageSection>
         <BreadcrumbBar>
-          <StyledPodcastContainer>
+          <PodcastContainer width={1320} gutter={24} gutterBreakpoint="sm">
             <Breadcrumbs
               variant="light"
               ancestors={[{ href: HOME, label: "Home" }]}
               current="Podcasts"
             />
-          </StyledPodcastContainer>
+          </PodcastContainer>
         </BreadcrumbBar>
 
         <HeroSection

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastsListingPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastsListingPage.tsx
@@ -114,7 +114,11 @@ export const PodcastsListingPage: React.FC = () => {
     <>
       <PageSection>
         <BreadcrumbBar>
-          <PodcastContainer width={1320} gutter={24} gutterBreakpoint="sm">
+          <PodcastContainer
+            contentWidth={1320}
+            gutter={24}
+            gutterBreakpoint="sm"
+          >
             <Breadcrumbs
               variant="light"
               ancestors={[{ href: HOME, label: "Home" }]}

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/helpers.test.ts
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   formatApproxCount,
   getEpisodeAudioUrl,
   getEpisodeDurationMinutes,
+  getEpisodeParentPodcast,
   getEpisodeParentPodcastId,
   getEpisodeParentPodcastName,
 } from "./helpers"
@@ -70,6 +71,34 @@ describe("getEpisodeAudioUrl", () => {
       },
     }) as unknown as LearningResource
     expect(getEpisodeAudioUrl(episode)).toBeNull()
+  })
+
+  it("falls back to episode_link by default when audio_url is absent", () => {
+    const episode = factories.learningResources.podcastEpisode({
+      podcast_episode: {
+        id: 1,
+        podcasts: [1],
+        duration: "PT1M",
+        audio_url: null as unknown as string,
+        episode_link: "https://example.com/link",
+      },
+    }) as unknown as LearningResource
+    expect(getEpisodeAudioUrl(episode)).toBe("https://example.com/link")
+  })
+
+  it("does not fall back to episode_link when allowEpisodeLink is false", () => {
+    // The embed player feeds the URL straight into an <audio> element, so the
+    // (possibly non-media) episode_link must never be used.
+    const episode = factories.learningResources.podcastEpisode({
+      podcast_episode: {
+        id: 1,
+        podcasts: [1],
+        duration: "PT1M",
+        audio_url: null as unknown as string,
+        episode_link: "https://example.com/webpage",
+      },
+    }) as unknown as LearningResource
+    expect(getEpisodeAudioUrl(episode, { allowEpisodeLink: false })).toBeNull()
   })
 })
 
@@ -225,5 +254,41 @@ describe("getEpisodeParentPodcastName", () => {
         "Podcast A",
       )
     })
+  })
+})
+
+describe("getEpisodeParentPodcast", () => {
+  const multiParentEpisode = factories.learningResources.podcastEpisode({
+    podcast_episode: {
+      id: 1,
+      podcasts: [1, 2],
+      parent_podcasts: [
+        { id: 1, title: "Podcast A", readable_id: "podcast-a" },
+        { id: 2, title: "Podcast B", readable_id: "podcast-b" },
+      ],
+      duration: "PT1M",
+      audio_url: "https://example.com/audio.mp3",
+      episode_link: "https://example.com/link",
+    },
+  }) as unknown as LearningResource
+
+  it("returns null for non-episode resources", () => {
+    const course = factories.learningResources.resource({
+      resource_type: ResourceTypeEnum.Course,
+    })
+    expect(getEpisodeParentPodcast(course)).toBeNull()
+  })
+
+  it("returns the full parent object matching the given podcastId", () => {
+    expect(getEpisodeParentPodcast(multiParentEpisode, 2)).toEqual({
+      id: 2,
+      title: "Podcast B",
+      readable_id: "podcast-b",
+    })
+  })
+
+  it("falls back to the first parent when no id is given or none matches", () => {
+    expect(getEpisodeParentPodcast(multiParentEpisode)?.id).toBe(1)
+    expect(getEpisodeParentPodcast(multiParentEpisode, 999)?.id).toBe(1)
   })
 })

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/helpers.ts
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/helpers.ts
@@ -1,17 +1,28 @@
 import moment from "moment"
 import { ResourceTypeEnum } from "api/v1"
-import type { LearningResource } from "api/v1"
+import type { LearningResource, PodcastEpisodeParent } from "api/v1"
 
 export const formatApproxCount = (count: number): string =>
   count >= 100 ? `${Math.floor(count / 100) * 100}+` : String(count)
 
+/**
+ * The URL to play/link for an episode.
+ *
+ * Defaults to the direct `audio_url`, falling back to `episode_link`. Pass
+ * `{ allowEpisodeLink: false }` when the URL is fed straight into an `<audio>`
+ * element (e.g. the embed player), since `episode_link` may point at a webpage
+ * rather than a media file.
+ */
 export const getEpisodeAudioUrl = (
   episode: LearningResource,
+  { allowEpisodeLink = true }: { allowEpisodeLink?: boolean } = {},
 ): string | null => {
   if (episode.resource_type !== ResourceTypeEnum.PodcastEpisode) return null
-  const candidateUrl =
-    episode.podcast_episode?.audio_url ?? episode.podcast_episode?.episode_link
-  return candidateUrl?.trim() ? candidateUrl : null
+  const candidateUrl = allowEpisodeLink
+    ? (episode.podcast_episode?.audio_url ??
+      episode.podcast_episode?.episode_link)
+    : episode.podcast_episode?.audio_url
+  return candidateUrl?.trim() ? candidateUrl.trim() : null
 }
 
 export const getEpisodeDurationMinutes = (
@@ -30,27 +41,36 @@ export const getEpisodeParentPodcastId = (
 }
 
 /**
- * The canonical "podcast name" shown for an episode (e.g. in the audio player).
- *
- * Resolves to the parent podcast series' title from the episode's embedded
+ * The parent podcast series an episode belongs to, from its embedded
  * `parent_podcasts` summary — the single source of truth across all podcast
- * pages. This is distinct from `offered_by.name`, which is the organization or
- * department credited with producing the episode, not the show name.
+ * pages.
  *
  * When an episode belongs to multiple podcasts, pass `podcastId` (e.g. the one
- * in the current URL) to name that specific series; this mirrors how the
+ * in the current URL) to select that specific series; this mirrors how the
  * page header/breadcrumb resolve the parent, so both stay in agreement. Falls
  * back to the first parent when no id is given or none matches.
  */
-export const getEpisodeParentPodcastName = (
+export const getEpisodeParentPodcast = (
   episode: LearningResource,
   podcastId?: number | null,
-): string | null => {
+): PodcastEpisodeParent | null => {
   if (episode.resource_type !== ResourceTypeEnum.PodcastEpisode) return null
   const parents = episode.podcast_episode?.parent_podcasts
   const match =
     typeof podcastId === "number"
       ? parents?.find((parent) => parent.id === podcastId)
       : undefined
-  return (match ?? parents?.[0])?.title ?? null
+  return match ?? parents?.[0] ?? null
 }
+
+/**
+ * The canonical "podcast name" shown for an episode (e.g. in the audio player).
+ *
+ * Resolves to the parent podcast series' title (see {@link getEpisodeParentPodcast}).
+ * This is distinct from `offered_by.name`, which is the organization or
+ * department credited with producing the episode, not the show name.
+ */
+export const getEpisodeParentPodcastName = (
+  episode: LearningResource,
+  podcastId?: number | null,
+): string | null => getEpisodeParentPodcast(episode, podcastId)?.title ?? null

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/styled.ts
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/styled.ts
@@ -1,14 +1,33 @@
 import { Typography, styled } from "ol-components"
-import PodcastContainer from "../PodcastContainer"
+import { Button } from "@mitodl/smoot-design"
 
-/* ── Shared layout used across PodcastsListingPage sections ── */
+/* ── Shared layout used across all podcast pages ── */
 
-export const PageSection = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.white,
-  [theme.breakpoints.down("sm")]: {
-    backgroundColor: theme.custom.colors.lightGray1,
-  },
-}))
+/**
+ * Full-width page background. The `variant` controls the backdrop:
+ * - `responsive` (default): white on desktop, light gray on mobile (listing)
+ * - `white`: always white (podcast detail)
+ * - `gray`: light gray, full viewport height (episode detail)
+ */
+export const PageSection = styled("div", {
+  shouldForwardProp: (prop) => prop !== "variant",
+})<{ variant?: "responsive" | "white" | "gray" }>(
+  ({ theme, variant = "responsive" }) => ({
+    ...(variant === "responsive" && {
+      backgroundColor: theme.custom.colors.white,
+      [theme.breakpoints.down("sm")]: {
+        backgroundColor: theme.custom.colors.lightGray1,
+      },
+    }),
+    ...(variant === "white" && {
+      backgroundColor: theme.custom.colors.white,
+    }),
+    ...(variant === "gray" && {
+      backgroundColor: theme.custom.colors.lightGray1,
+      minHeight: "100vh",
+    }),
+  }),
+)
 
 export const BreadcrumbBar = styled.div(({ theme }) => ({
   padding: "18px 0 2px 0",
@@ -18,11 +37,20 @@ export const BreadcrumbBar = styled.div(({ theme }) => ({
   },
 }))
 
-export const StyledPodcastContainer = styled(PodcastContainer)(({ theme }) => ({
-  maxWidth: "1320px !important",
-  padding: "0px 24px !important",
+/** Single-column grid list used to render `EpisodeItem` rows. */
+export const EpisodeList = styled.div({
+  display: "grid",
+  gridTemplateColumns: "1fr",
+})
+
+/**
+ * Primary "play" button shared across podcast pages: standard padding and
+ * full-width on mobile. Pages extend it (`styled(PlayButton)(...)`) for tweaks.
+ */
+export const PlayButton = styled(Button)(({ theme }) => ({
+  padding: "12px 24px 12px 20px",
   [theme.breakpoints.down("sm")]: {
-    padding: "0px 16px !important",
+    width: "100%",
   },
 }))
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12356
https://github.com/mitodl/hq/issues/12357

### Description (What does it do?)
- As a developer, I want duration/audio/date/parent logic centralized, so behavior is consistent and pages don't reimplement helpers.
- As a developer, I want one definition per shared podcast style, so the layout stays consistent and edits happen once.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
As this PR is about refactoring the podcasts code so we need to make sure that the existing page like `/podcasts` and `http://open.odl.local:8062/podcast/128673/beyond-biology` and `http://open.odl.local:8062/podcast/128673/podcast_episode/137377/the-fundamentals-of-understanding-cancer-genetics-with` should be working fine 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
