### PR TITLE
chore: Include sourcemaps for the nextjs server in our docker image

### DIFF
--- a/frontends/main/Dockerfile.web
+++ b/frontends/main/Dockerfile.web
@@ -9,39 +9,20 @@
 # runtime by Kubernetes and surfaced to the browser via PublicEnvScript.
 # Only GIT_REF is needed at build time (for generateBuildId in next.config.js).
 
-
-# Run:
-# docker run -p 8062:8062 -e PORT=8062 mit-learn-frontend:latest
-
-# Heroku build/push:
-#
-# heroku container:push web \
-#   --app mitopen-rc-nextjs \
-#   --recursive \
-#   --arg NEXT_PUBLIC_ORIGIN=https://next.rc.learn.mit.edu
-# NEXT_PUBLIC_MITOL_API_BASE_URL=https://api.rc.learn.mit.edu,\
-# NEXT_PUBLIC_SITE_NAME="MIT Learn",\
-# NEXT_PUBLIC_MITOL_SUPPORT_EMAIL=mitlearn-support@mit.edu,\
-# NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS=$MITOL_AXIOS_WITH_CREDENTIALS,\
-# NEXT_PUBLIC_CSRF_COOKIE_NAME=learn-rc-csrftoken,\
-# NEXT_PUBLIC_POSTHOG_API_HOST=$POSTHOG_API_HOST,\
-# NEXT_PUBLIC_POSTHOG_PROJECT_ID=$POSTHOG_PROJECT_ID,\
-# NEXT_PUBLIC_POSTHOG_API_KEY=$POSTHOG_API_KEY,\
-# NEXT_PUBLIC_POSTHOG_ENABLE_SESSION_RECORDING=$POSTHOG_ENABLE_SESSION_RECORDING,\
-# NEXT_PUBLIC_SENTRY_DSN=$SENTRY_DSN,\
-# NEXT_PUBLIC_SENTRY_ENV=$SENTRY_ENV,\
-# NEXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE=$SENTRY_PROFILES_SAMPLE_RATE,\
-# NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=$SENTRY_TRACES_SAMPLE_RATE,\
-# NEXT_PUBLIC_APPZI_URL=$APPZI_URL,\
-# NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=$LEARN_AI_RECOMMENDATION_ENDPOINT,\
-# NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=$LEARN_AI_SYLLABUS_ENDPOINT,\
-# NEXT_PUBLIC_VERSION=$VERSION \
-#   --context-path .
-
-# Heroku release:
-# heroku ps:scale frontend=1 --app mitopen-rc-nextjs
-# heroku container:release --app mitopen-rc-nextjs frontend
-
+# Then run with your local env vars, e.g.,
+# docker run --rm --name mln-test -p 8062:3000 \
+#     --add-host=api.open.odl.local:host-gateway \
+#     -e NEXT_PUBLIC_ORIGIN=http://open.odl.local:8062 \
+#     -e NEXT_PUBLIC_MITOL_API_BASE_URL=http://api.open.odl.local:8065 \
+#     -e NEXT_PUBLIC_SITE_NAME="MIT Learn" \
+#     -e NEXT_PUBLIC_MITOL_SUPPORT_EMAIL=mitlearn-support@mit.edu \
+#     -e NEXT_PUBLIC_CSRF_COOKIE_NAME=csrftoken-local-learn \
+#     -e NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL=http://mitxonline.odl.local:8065/ \
+#     -e NEXT_PUBLIC_MITX_ONLINE_BASE_URL=https://api.learn.mit.edu/mitxonline \
+#     -e NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME=csrf_mitxonline \
+#     -e NEXT_CACHE_S_MAXAGE_SECONDS=7200 \
+#     -e NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS=true \
+#     mit-learn-nextjs:test
 
 FROM node:24-alpine AS base
 

--- a/frontends/main/Dockerfile.web
+++ b/frontends/main/Dockerfile.web
@@ -95,6 +95,17 @@ WORKDIR /app
 # sharp (Next.js image optimisation) requires glibc-compatible libs on Alpine.
 RUN apk add --no-cache libc6-compat
 
+# Copy the server build output including its .map files. `output: "standalone"`
+# only ships NFT-traced runtime files, which excludes source maps, so the
+# standalone copy below alone can't symbolicate server-side (SSR/RSC/route
+# handler) errors in Sentry. Maps are inert at runtime; a decoupled Concourse
+# task reads them out of the image rootfs and uploads them to Sentry.
+#
+# Copied BEFORE standalone so the runtime-authoritative standalone files win any
+# path collision. The .js chunks are byte-identical between the two, and the
+# .map files have no standalone counterpart, so they survive regardless.
+COPY --from=build /app/frontends/main/.next/server ./frontends/main/.next/server
+
 # Copy the standalone server (includes a minimal node_modules)
 COPY --from=build /app/frontends/main/.next/standalone ./
 


### PR DESCRIPTION
### What are the relevant tickets?
- For https://github.com/mitodl/hq/issues/12330

### Description (What does it do?)
NextJS's normal build output includes `.next/server` sourcemaps, but the `standalone` build we use does not. This PR copies the `.next/server` output into the final docker image so they can be uploaded via https://github.com/mitodl/ol-infrastructure/pull/4993

### How can this be tested?
1. Build the docker image:
    ```sh
     docker build \
            -f frontends/main/Dockerfile.web \
            --build-arg GIT_REF=$(git rev-parse HEAD) \
            -t mitodl/mit-learn-frontend:latest .
    ```
2. Run `docker run --rm -it --entrypoint sh mitodl/mit-learn-frontend:latest` to shell into the container. Look for sourcemaps in `/app/frontends/main/.next/server`
3. If you want to double check that the sourcemaps really are correct, you can check that they have `debugIds` and that the client-side ones (in static dir) have `sourceMappingURL` values. Or use the script below as `./verify-sourcemaps.sh`

```
#!/usr/bin/env bash
#
# Verify that Sentry debug IDs are injected into the built frontend bundles and
# that the source maps carry the SAME debug IDs, inside the built Docker image.
# This is what lets the Concourse `sentry-cli sourcemaps upload` task symbolicate
# both browser and server-side (SSR/RSC/route handler) errors.
#
# Sentry pairs a minified file with its source map purely by the debug ID
# embedded in each -- NOT by filename or path. So the real test is: does every
# debug ID that appears in a JS chunk also appear in some source map? This
# script answers that by comparing the two sets of IDs (not by filename).
#
# A few JS chunks (webpack/turbopack runtime, vendor shims) legitimately carry a
# debug ID but have no map -- those frames simply stay minified in Sentry, which
# is fine since they aren't your source. So a small number of "uncovered" IDs is
# expected; a large number is not.
#
# Runs from OUTSIDE the container: it starts a throwaway container from the image
# and feeds the checks to its shell over stdin, so nothing is installed or copied
# in. Requires only Docker and the image to already be built.
#
# Usage:   ./verify-sourcemaps.sh [image]     (default: mitodl/mit-learn-frontend:latest)
#
set -euo pipefail

IMAGE="${1:-mitodl/mit-learn-frontend:latest}"
echo "Verifying source maps + debug IDs in image: $IMAGE"
echo

# Quoted heredoc (<<'EOF') => runs verbatim under the container's BusyBox `sh`.
docker run --rm -i --entrypoint sh "$IMAGE" <<'EOF'
set -u
cd /app/frontends/main || { echo "ERROR: build output not found"; exit 1; }

# Canonical UUID shape (BusyBox BRE intervals).
UUID='[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}'
TMP=/tmp/vsm; mkdir -p "$TMP"

# Sorted-unique debug IDs embedded in JS chunks / in source maps under dir $1.
# -exec ... {} + avoids SIGPIPE; -h/-o keep just the id text.
js_ids()  { find "$1" -name '*.js'  -exec grep -ho "debugId=$UUID" {} + 2>/dev/null | sed 's/^debugId=//' | sort -u; }
map_ids() { find "$1" -name '*.map' -exec grep -h  'debug'         {} + 2>/dev/null | grep -o "$UUID" | sort -u; }

report() {
  label="$1"; dir="$2"
  js_ids "$dir" > "$TMP/js"; map_ids "$dir" > "$TMP/map"
  njs=$(grep -c .  "$TMP/js"  || true)
  nmap=$(grep -c . "$TMP/map" || true)
  # JS debug IDs with NO matching map ID => those chunks can't be symbolicated.
  grep -Fxv -f "$TMP/map" "$TMP/js" > "$TMP/uncov" || true
  nuncov=$(grep -c . "$TMP/uncov" || true)

  echo "$label:"
  echo "  distinct debugIds in JS chunks:   $njs"
  echo "  distinct debugIds in source maps: $nmap"
  echo "  JS ids matched to a map:          $((njs - nuncov)) / $njs"
  if [ "$nuncov" -eq 0 ]; then
    echo "  -> PASS: every JS debugId has a source map with the same id"
  else
    echo "  -> $nuncov JS debugId(s) have no matching map (expected for a few runtime/shim chunks); first few:"
    sed -n '1,5p' "$TMP/uncov" | sed 's/^/       /'
  fi
  echo
  # Signal only a hard failure: no maps at all, or nothing matched.
  [ "$nmap" -gt 0 ] && [ "$((njs - nuncov))" -gt 0 ]
}

rc=0
report "server (SSR/RSC/route handlers)" .next/server/chunks || rc=1
report "client (browser)"                .next/static/chunks || rc=1

if [ "$rc" -eq 0 ]; then
  echo "RESULT: PASS - debug IDs injected and maps present for both server and client"
else
  echo "RESULT: FAIL - see above"
fi
exit "$rc"
EOF
```

### Additional Context
Goes with https://github.com/mitodl/ol-infrastructure/pull/4993