### PR TITLE
Bound Celery result retention to reduce mitlearn Redis memory pressure

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -20,9 +20,10 @@ USE_CELERY = True
 REDIS_URL = get_string("REDIS_URL", get_string("REDISCLOUD_URL", None))
 CELERY_BROKER_URL = get_string("CELERY_BROKER_URL", REDIS_URL)
 CELERY_RESULT_BACKEND = get_string("CELERY_RESULT_BACKEND", REDIS_URL)
-# Results share the broker Redis. Celery's 24h default lets reindex chord
-# fan-outs (thousands of subtask result keys) accumulate and saturate memory;
-# keep results only long enough for chord callbacks to consume them.
+# Celery's 24h default lets reindex chord fan-outs (thousands of subtask
+# result keys) accumulate; when the result backend is the broker/cache Redis
+# (the default here) that saturates memory. Keep results only long enough for
+# chord callbacks to consume them.
 CELERY_RESULT_EXPIRES = get_int("CELERY_RESULT_EXPIRES", 60 * 60)
 CELERY_BEAT_SCHEDULER = RedBeatScheduler
 redbeat_redis_url = CELERY_BROKER_URL

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -20,6 +20,10 @@ USE_CELERY = True
 REDIS_URL = get_string("REDIS_URL", get_string("REDISCLOUD_URL", None))
 CELERY_BROKER_URL = get_string("CELERY_BROKER_URL", REDIS_URL)
 CELERY_RESULT_BACKEND = get_string("CELERY_RESULT_BACKEND", REDIS_URL)
+# Results share the broker Redis. Celery's 24h default lets reindex chord
+# fan-outs (thousands of subtask result keys) accumulate and saturate memory;
+# keep results only long enough for chord callbacks to consume them.
+CELERY_RESULT_EXPIRES = get_int("CELERY_RESULT_EXPIRES", 60 * 60)
 CELERY_BEAT_SCHEDULER = RedBeatScheduler
 redbeat_redis_url = CELERY_BROKER_URL
 CELERY_TASK_ALWAYS_EAGER = get_bool("CELERY_TASK_ALWAYS_EAGER", False)  # noqa: FBT003

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -286,6 +286,25 @@ class TestSettings(TestCase):
                 in settings_vars["CELERY_BEAT_SCHEDULE"]
             )
 
+    def test_celery_result_expires_default(self):
+        """Celery result expiry defaults to 1 hour"""
+        with mock.patch.dict("os.environ", REQUIRED_SETTINGS, clear=True):
+            settings_vars = self.reload_settings(module="main.settings_celery")
+            assert settings_vars["CELERY_RESULT_EXPIRES"] == 60 * 60
+
+    def test_celery_result_expires_override(self):
+        """Celery result expiry is configurable via an env var"""
+        with mock.patch.dict(
+            "os.environ",
+            {
+                **REQUIRED_SETTINGS,
+                "CELERY_RESULT_EXPIRES": "120",
+            },
+            clear=True,
+        ):
+            settings_vars = self.reload_settings(module="main.settings_celery")
+            assert settings_vars["CELERY_RESULT_EXPIRES"] == 120
+
     def _assert_s3_storage_config(
         self,
         storages_dict,


### PR DESCRIPTION
### What are the relevant tickets?
Closes #3624
Related: #3622, #3623

### Description (What does it do?)
Adds `CELERY_RESULT_EXPIRES` (env-configurable, default 1 hour) so Celery task results are reclaimed shortly after they're consumed instead of lingering for Celery's 24h default.

`mitlearn-redis-production` is a single-shard Valkey instance shared by the Celery broker, the Celery result backend, RedBeat, and the Django `redis` response cache. A catalog reindex (`start_recreate_index` / `start_update_index`) fans out into one enormous chord; its result-collection lists and thousands of `celery-task-meta-*` result keys land on that shared instance. With no result expiry configured, those keys stayed resident for 24h, keeping the baseline high (~60%) and leaving little headroom — so the next spike tipped memory to 99.98% and paged on-call. On 2026-07-15, memory jumped from ~13.5 GB to 21.2 GB in one hour alongside a ~140x spike in Redis list commands (chord result collection).

Full root-cause analysis and CloudWatch data are in #3624. This change is the immediate, low-risk mitigation; it lowers the resident baseline and shrinks the post-reindex danger window from 24h to ~1h. It does not shrink the in-flight chord peak — that is tracked in #3622 (separate result backend) and #3623 (batched reindex).

### How can this be tested?
- Confirm the setting resolves: with `DJANGO_SETTINGS_MODULE=main.settings`, `django.conf.settings.CELERY_RESULT_EXPIRES` is `3600` by default and overridable via the `CELERY_RESULT_EXPIRES` env var.
- Confirm Celery honors it: `celery -A main inspect conf` (or `app.conf.result_expires`) reflects the value; new `celery-task-meta-*` keys in Redis carry a TTL of ~1h (`TTL` on a result key) rather than 24h.
- Regression: task results are still readable within the window; chord callbacks (e.g. `finish_recreate_index`) that consume group results complete normally.

### Additional Context
`finish_recreate_index` genuinely consumes its subtask results (`merge_strings(results)`), so results can't simply be ignored — expiry must stay comfortably longer than a reindex run. 1h is well beyond observed completion times while being far below the previous 24h. Adjust via the `CELERY_RESULT_EXPIRES` env var if a longer window is ever needed.