### PR TITLE
dashboard card mobile design improvements

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/ContractContent.tsx
@@ -364,6 +364,9 @@ const ContractHeaderSection = styled.div(({ theme }) => ({
     alignItems: "flex-start",
     gap: "16px",
     padding: "16px 0 0 0",
+    backgroundColor: theme.custom.colors.lightGray1,
+    boxShadow: "none",
+    borderRadius: "0px",
   },
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -106,6 +106,7 @@ const SubtitleLink = styled(NextLink)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: "2px",
+  whiteSpace: "nowrap",
   ":hover": {
     textDecoration: "underline",
   },
@@ -172,12 +173,14 @@ const Ellipse = styled.span(({ theme }) => ({
   width: "4px",
   height: "4px",
   borderRadius: "50%",
+  flexShrink: 0,
   backgroundColor: theme.custom.colors.silverGrayLight,
 }))
 
 const DateText = styled(Typography)(({ theme }) => ({
   ...theme.typography.subtitle3,
   color: theme.custom.colors.silverGrayDark,
+  whiteSpace: "nowrap",
 }))
 
 const CourseDateText: React.FC<{
@@ -195,6 +198,7 @@ const UpgradedBannerRoot = styled.div(({ theme }) => ({
   alignItems: "center",
   gap: "4px",
   color: theme.custom.colors.silverGrayDark,
+  whiteSpace: "nowrap",
   ...theme.typography.body3,
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -25,8 +25,8 @@ const CardRoot = styled.div<{
     [theme.breakpoints.down("md")]: {
       border: "none",
       borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-      borderRadius: "0px",
-      boxShadow: "none",
+      borderRadius: "8px",
+      boxShadow: "0 4px 8px 0 rgba(19, 20, 21, 0.08)",
       flexDirection: "column",
       gap: "16px",
     },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -16,6 +16,8 @@ const CardRoot = styled.div<{
     border: `1px solid ${theme.custom.colors.lightGray2}`,
     backgroundColor: theme.custom.colors.white,
     padding: "16px",
+    borderRadius: "8px",
+    boxShadow: "0 4px 8px 0 rgba(19, 20, 21, 0.08)",
     display: "flex",
     gap: "8px",
     alignItems: "center",
@@ -24,9 +26,6 @@ const CardRoot = styled.div<{
   layout === "default" && {
     [theme.breakpoints.down("md")]: {
       border: "none",
-      borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-      borderRadius: "8px",
-      boxShadow: "0 4px 8px 0 rgba(19, 20, 21, 0.08)",
       flexDirection: "column",
       gap: "16px",
     },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -94,7 +94,9 @@ const TitleText = styled.h3<{ clickable?: boolean }>(
 
 const SubtitleLinkRoot = styled.div(({ theme }) => ({
   display: "flex",
+  flexWrap: "wrap",
   alignItems: "center",
+  rowGap: "2px",
   flex: 1,
   minWidth: 0,
   color: theme.custom.colors.red,
@@ -107,7 +109,6 @@ const SubtitleLink = styled(NextLink)(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: "2px",
-  whiteSpace: "nowrap",
   ":hover": {
     textDecoration: "underline",
   },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -24,7 +24,7 @@ const CardRoot = styled.div<{
   },
   // Mobile styles for default layout
   layout === "default" && {
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       border: "none",
       flexDirection: "column",
       gap: "16px",
@@ -45,18 +45,19 @@ const CardRoot = styled.div<{
       borderBottomRightRadius: "8px !important",
       borderBottom: "none",
     },
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       flexDirection: "column",
+      flexGrow: 1,
       gap: "16px",
     },
   },
   screenSize === "desktop" && {
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       display: "none",
     },
   },
   screenSize === "mobile" && {
-    [theme.breakpoints.up("md")]: {
+    [theme.breakpoints.up("sm")]: {
       display: "none",
     },
   },
@@ -70,7 +71,7 @@ const CardTypeText = styled(Typography)(({ theme }) => ({
 const TitleHeading = styled.h3(({ theme }) => ({
   margin: 0,
   ...theme.typography.subtitle2,
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     maxWidth: "calc(100% - 16px)",
   },
 }))
@@ -85,7 +86,7 @@ const TitleText = styled.h3<{ clickable?: boolean }>(
     ...theme.typography.subtitle2,
     color: theme.custom.colors.darkGray2,
     cursor: clickable ? "pointer" : "default",
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       maxWidth: "calc(100% - 16px)",
     },
   }),
@@ -114,10 +115,9 @@ const MenuButton = styled(ActionButton)<{
   status: EnrollmentStatus
 }>(({ theme, status }) => [
   {
-    [theme.breakpoints.down("md")]: {
-      position: "absolute",
-      top: "0",
-      right: "0",
+    [theme.breakpoints.down("sm")]: {
+      borderRadius: "4px",
+      border: `1px solid ${theme.custom.colors.lightGray2}`,
     },
   },
   status !== EnrollmentStatus.Completed &&
@@ -131,17 +131,21 @@ const COURSEWARE_BUTTON_WIDTH = "88px"
 // Fixed-width column that keeps the courseware button (and countdown) aligned
 // in the compact (module row) layout.
 const CoursewareActionColumn = styled(Stack)({
-  width: COURSEWARE_BUTTON_WIDTH,
+  minWidth: COURSEWARE_BUTTON_WIDTH,
+  gap: "8px",
   flexShrink: 0,
 })
 
 // Compact-layout courseware buttons are fixed width and use the text variant.
 const CoursewareButton = styled(Button)(({ theme, variant }) => ({
-  width: COURSEWARE_BUTTON_WIDTH,
   minWidth: COURSEWARE_BUTTON_WIDTH,
+  gap: "8px",
   ...(variant === "text" && {
     color: theme.custom.colors.silverGrayDark,
   }),
+  [theme.breakpoints.down("sm")]: {
+    flexGrow: 1,
+  },
 }))
 
 const CoursewareButtonLink = styled(ButtonLink)(({ theme, variant }) => ({
@@ -150,6 +154,9 @@ const CoursewareButtonLink = styled(ButtonLink)(({ theme, variant }) => ({
   ...(variant === "text" && {
     color: theme.custom.colors.silverGrayDark,
   }),
+  [theme.breakpoints.down("sm")]: {
+    flexGrow: 1,
+  },
 }))
 
 const Separator = styled.span(({ theme }) => ({

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -96,6 +96,7 @@ const SubtitleLinkRoot = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   flex: 1,
+  minWidth: 0,
   color: theme.custom.colors.red,
   ...theme.typography.body3,
 }))

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -513,7 +513,7 @@ describe.each([
     )
   })
 
-  test("Shows 'Certificate track' alongside 'View Certificate' when verified enrollment has a certificate", () => {
+  test("Shows 'View Certificate' in place of 'Certificate track' when verified enrollment has a certificate", () => {
     setupUserApis()
     const certUuid = faker.string.uuid()
     const enrollment = mitxonline.factories.enrollment.courseEnrollment({
@@ -522,12 +522,12 @@ describe.each([
       run: currentRunDates,
     })
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
-    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
-      "Certificate track",
-    )
     expect(
-      within(getCard()).getByRole("link", { name: /View Certificate/ }),
-    ).toBeInTheDocument()
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(getCard()).getAllByRole("link", { name: /View Certificate/ }),
+    ).toHaveLength(1)
   })
 
   test("Does not show 'Certificate track' for audit enrollment", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -250,6 +250,8 @@ export const EnrolledCourseCard = ({
         )
       }}
     />
+  ) : certButton ? (
+    certButton
   ) : upgradedAndIncomplete ? (
     <UpgradedBanner />
   ) : null
@@ -399,12 +401,6 @@ export const EnrolledCourseCard = ({
   )
   const buttonSection = isCompact ? (
     <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
-      {certButton && (
-        <>
-          {certButton}
-          <Separator />
-        </>
-      )}
       <CoursewareActionColumn
         direction="row"
         flexGrow={1}
@@ -415,12 +411,9 @@ export const EnrolledCourseCard = ({
       </CoursewareActionColumn>
     </Stack>
   ) : (
-    <Stack flexGrow={1} gap="8px">
-      {certButton}
-      <Stack direction="row" gap="8px" alignItems="center">
-        {ctaButton}
-        {contextMenu}
-      </Stack>
+    <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
+      {ctaButton}
+      {contextMenu}
     </Stack>
   )
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -56,7 +56,9 @@ const RedEllipse = styled(Ellipse)(({ theme }) => ({
   backgroundColor: theme.custom.colors.red,
 }))
 
-const NowrapText = styled.span({
+const CountdownGroup = styled.span({
+  display: "inline-flex",
+  alignItems: "center",
   whiteSpace: "nowrap",
 })
 
@@ -119,15 +121,13 @@ const UpgradeBanner: React.FC<
         {`Upgrade for certificate - ${formattedPrice}`}
       </SubtitleLink>
       {calendarDays !== null && (
-        <>
+        <CountdownGroup>
           <RedEllipse />
-          <NowrapText>
-            <NoSSR>
-              {/* This uses local time. */}
-              {formatUpgradeTime(calendarDays)}
-            </NoSSR>
-          </NowrapText>
-        </>
+          <NoSSR>
+            {/* This uses local time. */}
+            {formatUpgradeTime(calendarDays)}
+          </NoSSR>
+        </CountdownGroup>
       )}
     </SubtitleLinkRoot>
   )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -279,7 +279,7 @@ export const EnrolledCourseCard = ({
       </Stack>
     ) : null
   const titleSection = (
-    <Stack gap="12px">
+    <Stack gap="12px" minWidth={0}>
       {coursewareUrl ? (
         <TitleHeading as={headingLevel}>
           <EnrolledTitleLink
@@ -498,26 +498,43 @@ export const EnrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="stretch"
-          flex={1}
-          width="100%"
-        >
-          <Stack direction="column" gap="8px" flex={1}>
-            {titleSection}
+        <Stack direction="row" gap="8px" alignItems="flex-start" width="100%">
+          {showEnrollmentStatusIcon && (
+            <Stack alignSelf="flex-start">
+              <EnrollmentStatusIcon status={enrollmentStatus} />
+            </Stack>
+          )}
+          <Stack
+            direction="column"
+            gap="16px"
+            flex={1}
+            minWidth={0}
+            width="100%"
+          >
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="stretch"
+              flex={1}
+              minWidth={0}
+              width="100%"
+            >
+              <Stack direction="column" gap="8px" flex={1} minWidth={0}>
+                {titleSection}
+              </Stack>
+            </Stack>
+            <Stack
+              direction="row"
+              flexGrow={1}
+              gap="8px"
+              alignItems="center"
+              justifyContent="flex-end"
+              minWidth={0}
+              width="100%"
+            >
+              {buttonSection}
+            </Stack>
           </Stack>
-        </Stack>
-        <Stack
-          direction="row"
-          flexGrow={1}
-          gap="8px"
-          alignItems="center"
-          justifyContent="flex-end"
-          width="100%"
-        >
-          {buttonSection}
         </Stack>
         {hasMultipleRuns && (
           <MobileAccordionWrapper>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -435,6 +435,7 @@ export const EnrolledCourseCard = ({
   const hasMultipleRuns = (siblingEnrollments?.length ?? 0) > 0
   const showEnrollmentStatusIcon =
     !isContractPageResource && isModule && isCompact
+  const statusIconAlignment = metaSegments.length > 0 ? "start" : "center"
 
   return (
     <>
@@ -478,7 +479,7 @@ export const EnrolledCourseCard = ({
           layout={layout}
         >
           {showEnrollmentStatusIcon && (
-            <Stack alignSelf="start">
+            <Stack alignSelf={statusIconAlignment}>
               <EnrollmentStatusIcon status={enrollmentStatus} />
             </Stack>
           )}
@@ -500,7 +501,7 @@ export const EnrolledCourseCard = ({
       >
         <Stack direction="row" gap="8px" alignItems="flex-start" width="100%">
           {showEnrollmentStatusIcon && (
-            <Stack alignSelf="flex-start">
+            <Stack alignSelf={statusIconAlignment}>
               <EnrollmentStatusIcon status={enrollmentStatus} />
             </Stack>
           )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -243,7 +243,9 @@ export const EnrolledCourseCard = ({
       </SubtitleLink>
     </>
   ) : null
-  const certStatus = showUpgradeBanner ? (
+  const certStatus = certButton ? (
+    certButton
+  ) : showUpgradeBanner ? (
     <UpgradeBanner
       data-testid="upgrade-root"
       canUpgrade={showUpgradeBanner}
@@ -256,8 +258,6 @@ export const EnrolledCourseCard = ({
         )
       }}
     />
-  ) : certButton ? (
-    certButton
   ) : upgradedAndIncomplete ? (
     <UpgradedBanner />
   ) : null

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -56,6 +56,10 @@ const RedEllipse = styled(Ellipse)(({ theme }) => ({
   backgroundColor: theme.custom.colors.red,
 }))
 
+const NowrapText = styled.span({
+  whiteSpace: "nowrap",
+})
+
 const EnrolledTitleLink = styled(TitleLink)<{
   enrollmentstatus: EnrollmentStatus
 }>(({ enrollmentstatus, theme }) => ({
@@ -117,10 +121,12 @@ const UpgradeBanner: React.FC<
       {calendarDays !== null && (
         <>
           <RedEllipse />
-          <NoSSR>
-            {/* This uses local time. */}
-            {formatUpgradeTime(calendarDays)}
-          </NoSSR>
+          <NowrapText>
+            <NoSSR>
+              {/* This uses local time. */}
+              {formatUpgradeTime(calendarDays)}
+            </NoSSR>
+          </NowrapText>
         </>
       )}
     </SubtitleLinkRoot>
@@ -263,7 +269,7 @@ export const EnrolledCourseCard = ({
 
   const endDateAndUpgradeSection =
     metaSegments.length > 0 ? (
-      <Stack direction="row" alignItems="center" gap="12px">
+      <Stack direction="row" flexWrap="wrap" alignItems="center" gap="8px">
         {metaSegments.map((segment, i) => (
           <React.Fragment key={i}>
             {i > 0 && <Ellipse />}
@@ -273,7 +279,7 @@ export const EnrolledCourseCard = ({
       </Stack>
     ) : null
   const titleSection = (
-    <Stack gap="6px">
+    <Stack gap="12px">
       {coursewareUrl ? (
         <TitleHeading as={headingLevel}>
           <EnrolledTitleLink

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -32,7 +32,6 @@ import { SiblingRunsAccordion } from "./SiblingRunsAccordion"
 import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
-import { Button, ButtonLink } from "@mitodl/smoot-design"
 import { coursePageView } from "@/common/urls"
 import NiceModal from "@ebay/nice-modal-react"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
@@ -133,7 +132,7 @@ const EnrolledCardShell = styled.div(({ theme }) => ({
   borderRadius: "8px",
   overflow: "hidden",
   backgroundColor: theme.custom.colors.white,
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     display: "none",
   },
   '&[data-layout="compact"]': {
@@ -324,7 +323,7 @@ export const EnrolledCourseCard = ({
       </CoursewareButtonLink>
     )
   ) : isDisabled ? (
-    <Button
+    <CoursewareButton
       size="small"
       variant="primary"
       disabled
@@ -332,9 +331,9 @@ export const EnrolledCourseCard = ({
       aria-label={`${buttonText} course: ${title}`}
     >
       {buttonText}
-    </Button>
+    </CoursewareButton>
   ) : (
-    <ButtonLink
+    <CoursewareButtonLink
       size="small"
       variant="primary"
       href={coursewareUrl ?? ""}
@@ -342,25 +341,7 @@ export const EnrolledCourseCard = ({
       aria-label={`${buttonText} course: ${title}`}
     >
       {buttonText}
-    </ButtonLink>
-  )
-  const buttonSection = isCompact ? (
-    <Stack direction="row" gap="8px" alignItems="center">
-      {certButton && (
-        <>
-          {certButton}
-          <Separator />
-        </>
-      )}
-      <CoursewareActionColumn direction="row" justifyContent="center">
-        {ctaButton}
-      </CoursewareActionColumn>
-    </Stack>
-  ) : (
-    <>
-      {certButton}
-      {ctaButton}
-    </>
+    </CoursewareButtonLink>
   )
   const menuItems = []
   const readableId = run?.course.readable_id
@@ -374,7 +355,6 @@ export const EnrolledCourseCard = ({
       href: detailsUrl,
     })
   }
-
   menuItems.push(
     {
       className: "dashboard-card-menu-item",
@@ -396,13 +376,11 @@ export const EnrolledCourseCard = ({
       },
     },
   )
-
   const receiptMenuItem = getReceiptMenuItem(
     enrollment?.enrollment_mode,
     `/orders/receipt/by-run/${enrollment?.run.id}/`,
   )
   if (receiptMenuItem) menuItems.push(receiptMenuItem)
-
   const contextMenu = (
     <SimpleMenu
       items={menuItems}
@@ -418,6 +396,32 @@ export const EnrolledCourseCard = ({
         </MenuButton>
       }
     />
+  )
+  const buttonSection = isCompact ? (
+    <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
+      {certButton && (
+        <>
+          {certButton}
+          <Separator />
+        </>
+      )}
+      <CoursewareActionColumn
+        direction="row"
+        flexGrow={1}
+        justifyContent="center"
+      >
+        {ctaButton}
+        {contextMenu}
+      </CoursewareActionColumn>
+    </Stack>
+  ) : (
+    <Stack flexGrow={1} gap="8px">
+      {certButton}
+      <Stack direction="row" gap="8px" alignItems="center">
+        {ctaButton}
+        {contextMenu}
+      </Stack>
+    </Stack>
   )
 
   const progressBadgeSection =
@@ -459,7 +463,6 @@ export const EnrolledCourseCard = ({
             </Stack>
             <Stack direction="row" gap="8px" alignItems="center">
               {buttonSection}
-              {contextMenu}
             </Stack>
           </CardHeaderContent>
           <SiblingRunsAccordion
@@ -486,7 +489,6 @@ export const EnrolledCourseCard = ({
           </Stack>
           <Stack direction="row" gap="8px" alignItems="center">
             {buttonSection}
-            {contextMenu}
           </Stack>
         </CardRoot>
       )}
@@ -507,10 +509,10 @@ export const EnrolledCourseCard = ({
           <Stack direction="column" gap="8px" flex={1}>
             {titleSection}
           </Stack>
-          {contextMenu}
         </Stack>
         <Stack
           direction="row"
+          flexGrow={1}
           gap="8px"
           alignItems="center"
           justifyContent="flex-end"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
@@ -39,8 +39,7 @@ const Wrapper = styled.div(({ theme }) => ({
   boxShadow: "0px 4px 8px 0px rgba(19, 20, 21, 0.08)",
   borderRadius: "8px",
   [theme.breakpoints.down("md")]: {
-    border: `1px solid ${theme.custom.colors.lightGray2}`,
-    backgroundColor: "rgba(243, 244, 248, 0.60);", // TODO: use theme color
+    backgroundColor: theme.custom.colors.lightGray1,
     marginTop: "16px",
     padding: "0",
   },
@@ -59,10 +58,6 @@ const Title = styled(Typography)<Pick<TypographyProps, "component">>(
   ({ theme }) => ({
     ...theme.typography.h5,
     marginBottom: "16px",
-    [theme.breakpoints.down("md")]: {
-      padding: "16px",
-      marginBottom: "0",
-    },
   }),
 )
 
@@ -72,6 +67,9 @@ const EnrollmentsList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
       borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
       ">li+li": {
         marginTop: "0",
+      },
+      ">li+li:not(:last-of-type)": {
+        marginBottom: "16px",
       },
     },
   }),

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
@@ -49,11 +49,6 @@ const AlertBanner = styled(Alert)({
   marginBottom: "16px",
 })
 
-const CoursewareCardStyled = styled(CoursewareCard)({
-  borderRadius: "8px",
-  boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
-})
-
 const Title = styled(Typography)<Pick<TypographyProps, "component">>(
   ({ theme }) => ({
     ...theme.typography.h5,
@@ -176,7 +171,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
         }
       }
       return (
-        <CoursewareCardStyled
+        <CoursewareCard
           key={getResourceKey(resource)}
           Component="li"
           kind="program-enrollment"
@@ -188,7 +183,7 @@ const EnrollmentExpandCollapse: React.FC<EnrollmentExpandCollapseProps> = ({
       const allCourseEnrollments =
         enrollmentsByCourseId[enrollment.run.course.id] ?? []
       return (
-        <CoursewareCardStyled
+        <CoursewareCard
           key={getResourceKey(resource)}
           Component="li"
           kind="enrollment"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.tsx
@@ -35,10 +35,7 @@ const Wrapper = styled.div(({ theme }) => ({
   marginTop: "32px",
   padding: "24px 32px",
   backgroundColor: theme.custom.colors.white,
-  borderBottom: `1px solid ${theme.custom.colors.red}`,
-  boxShadow: "0px 4px 8px 0px rgba(19, 20, 21, 0.08)",
-  borderRadius: "8px",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     backgroundColor: theme.custom.colors.lightGray1,
     marginTop: "16px",
     padding: "0",
@@ -58,7 +55,7 @@ const Title = styled(Typography)<Pick<TypographyProps, "component">>(
 
 const EnrollmentsList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
   ({ theme }) => ({
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
       ">li+li": {
         marginTop: "0",
@@ -72,7 +69,7 @@ const EnrollmentsList = styled(PlainList)<Pick<PlainListProps, "itemSpacing">>(
 
 const HiddenEnrollmentsList = styled(EnrollmentsList)({
   marginTop: "16px",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     borderTop: "none",
     marginTop: "0",
   },
@@ -82,7 +79,7 @@ const ShowAllContainer = styled.div(({ theme }) => ({
   display: "flex",
   justifyContent: "center",
   marginTop: "24px",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     marginBottom: "24px",
   },
 }))

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -109,7 +109,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
@@ -134,16 +134,18 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    // One status indicator per module row (desktop card only), replacing the type label
-    expect(screen.getAllByTestId("enrollment-status")).toHaveLength(2)
+    // One status indicator per module row, rendered in both the desktop and
+    // mobile markup (one of the two is hidden via CSS per breakpoint), replacing the type label
+    expect(screen.getAllByTestId("enrollment-status")).toHaveLength(4)
     expect(screen.queryByText("Module")).not.toBeInTheDocument()
     // The outer program-as-course card still shows its own 'Course' type label
-    // next to a progress badge; only the per-module rows omit it.
-    expect(screen.getByText("Course")).toBeInTheDocument()
+    // next to a progress badge; only the per-module rows omit it. Rendered
+    // once per (desktop/mobile) header copy.
+    expect(screen.getAllByText("Course")).toHaveLength(2)
   })
 
   test("progress badge reflects program enrollment status ('In Progress')", async () => {
@@ -163,11 +165,11 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    expect(screen.getByTestId("progress-badge")).toHaveTextContent(
+    expect(screen.getAllByTestId("progress-badge")[0]).toHaveTextContent(
       "In Progress",
     )
   })
@@ -184,11 +186,11 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    expect(screen.getByTestId("progress-badge")).toHaveTextContent(
+    expect(screen.getAllByTestId("progress-badge")[0]).toHaveTextContent(
       "Not Started",
     )
   })
@@ -213,11 +215,13 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    expect(screen.getByTestId("progress-badge")).toHaveTextContent("Completed")
+    expect(screen.getAllByTestId("progress-badge")[0]).toHaveTextContent(
+      "Completed",
+    )
   })
 
   test("renders when user is not enrolled in the ProgramAsCourse", async () => {
@@ -232,11 +236,11 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
-    expect(screen.getByText("Not Started")).toBeInTheDocument()
+    expect(screen.getAllByText("Not Started").length).toBeGreaterThan(0)
   })
 
   test("shows date popover content when date summary is clicked", async () => {
@@ -255,7 +259,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    const dateSummary = await screen.findByText(/ends in \d+ days/i)
+    const [dateSummary] = await screen.findAllByText(/ends in \d+ days/i)
     await user.click(dateSummary)
 
     expect(await screen.findByText("Important Dates:")).toBeInTheDocument()
@@ -273,7 +277,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByRole("heading", {
+    await screen.findAllByRole("heading", {
       name: cardData.courseProgram.title,
       level: 3,
     })
@@ -496,12 +500,15 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
-    const certButton = screen.getByRole("link", { name: "Certificate" })
+    await screen.findAllByText(cardData.courseProgram.title)
+    // Rendered once in the desktop header, once in the mobile header.
+    const certButtons = screen.getAllByRole("link", { name: "Certificate" })
     const expectedCertHref = `/certificate/program/${certUuid}`
-    expect(certButton).toBeInTheDocument()
-    expect(certButton).toHaveAttribute("href", expectedCertHref)
-    expect(certButton).not.toHaveAttribute("target")
+    expect(certButtons).toHaveLength(2)
+    for (const certButton of certButtons) {
+      expect(certButton).toHaveAttribute("href", expectedCertHref)
+      expect(certButton).not.toHaveAttribute("target")
+    }
   })
 
   test("does not display certificate button when program enrollment has no certificate", async () => {
@@ -521,7 +528,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     const certButton = screen.queryByRole("link", { name: "Certificate" })
     expect(certButton).not.toBeInTheDocument()
   })
@@ -544,8 +551,10 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
-    expect(screen.getByTestId("upgraded-banner")).toHaveTextContent(
+    await screen.findAllByText(cardData.courseProgram.title)
+    // Rendered once in the desktop header, once in the mobile header.
+    expect(screen.getAllByTestId("upgraded-banner")).toHaveLength(2)
+    expect(screen.getAllByTestId("upgraded-banner")[0]).toHaveTextContent(
       "Certificate track",
     )
     expect(
@@ -572,11 +581,10 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     expect(screen.queryByTestId("upgraded-banner")).not.toBeInTheDocument()
-    expect(
-      screen.getByRole("link", { name: "Certificate" }),
-    ).toBeInTheDocument()
+    // Rendered once in the desktop header, once in the mobile header.
+    expect(screen.getAllByRole("link", { name: "Certificate" })).toHaveLength(2)
   })
 
   test("does not show 'Certificate track' for audit program enrollment", async () => {
@@ -597,7 +605,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     expect(screen.queryByTestId("upgraded-banner")).not.toBeInTheDocument()
   })
 
@@ -613,7 +621,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     const programCard = screen.getByTestId("program-as-course-card")
     await user.click(within(programCard).getAllByLabelText("More options")[0])
 
@@ -648,7 +656,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     const programCard = screen.getByTestId("program-as-course-card")
     await user.click(within(programCard).getAllByLabelText("More options")[0])
     await user.click(await screen.findByRole("menuitem", { name: "Unenroll" }))
@@ -674,7 +682,7 @@ describe("ProgramAsCourseCard", () => {
       />,
     )
 
-    await screen.findByText(cardData.courseProgram.title)
+    await screen.findAllByText(cardData.courseProgram.title)
     const programCard = screen.getByTestId("program-as-course-card")
     await user.click(within(programCard).getAllByLabelText("More options")[0])
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -113,6 +113,12 @@ const ProgramCardSubHeaderText = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
 }))
 
+const ProgramCardContent = styled.div(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: {
+    margin: "16px",
+  },
+}))
+
 const ProgramCardSubHeader = styled.div(({ theme }) => ({
   display: "flex",
   padding: "8px 16px",
@@ -122,12 +128,13 @@ const ProgramCardSubHeader = styled.div(({ theme }) => ({
   borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
   background: `${theme.custom.colors.lightGray1}`,
   [theme.breakpoints.down("sm")]: {
+    borderRadius: "4px 4px 0 0",
     borderLeft: `1px solid ${theme.custom.colors.lightGray2}`,
     borderRight: `1px solid ${theme.custom.colors.lightGray2}`,
   },
 }))
 
-const ProgramCardBody = styled.div({
+const ProgramCardBody = styled.div(({ theme }) => ({
   display: "flex",
   width: "100%",
   flexDirection: "column",
@@ -135,7 +142,13 @@ const ProgramCardBody = styled.div({
   alignSelf: "stretch",
   overflow: "hidden",
   borderRadius: "0 0 8px 8px",
-})
+  [theme.breakpoints.down("sm")]: {
+    borderRadius: "0 0 4px 4px",
+    borderLeft: `1px solid ${theme.custom.colors.lightGray2}`,
+    borderRight: `1px solid ${theme.custom.colors.lightGray2}`,
+    borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+  },
+}))
 
 const getContextMenuItems = (
   title: string,
@@ -419,42 +432,44 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
           </ProgramCardHeaderInner>
         </ProgramCardHeaderOuter>
       </ProgramHeaderMobile>
-      <ProgramCardSubHeader>
-        <ProgramCardSubHeaderText variant="subtitle3">
-          {totalCount} Modules ({completedCount} of {totalCount} complete)
-        </ProgramCardSubHeaderText>
-      </ProgramCardSubHeader>
-      <ProgramCardBody>
-        {displayedModuleCourses.map((course) => {
-          const entry = buildCourseEntry(
-            course,
-            moduleEnrollmentsByCourseId[course.id] || [],
-            {
-              ancestorContext: {
-                useVerifiedEnrollment,
-                parentProgramReadableIds: parentProgramIds,
+      <ProgramCardContent>
+        <ProgramCardSubHeader>
+          <ProgramCardSubHeaderText variant="subtitle3">
+            {totalCount} Modules ({completedCount} of {totalCount} complete)
+          </ProgramCardSubHeaderText>
+        </ProgramCardSubHeader>
+        <ProgramCardBody>
+          {displayedModuleCourses.map((course) => {
+            const entry = buildCourseEntry(
+              course,
+              moduleEnrollmentsByCourseId[course.id] || [],
+              {
+                ancestorContext: {
+                  useVerifiedEnrollment,
+                  parentProgramReadableIds: parentProgramIds,
+                },
               },
-            },
-          )
-          if (!entry) return null
+            )
+            if (!entry) return null
 
-          return (
-            <CoursewareCard
-              key={getKey({
-                resourceType: ResourceType.Course,
-                id: course.id,
-                runId: entry.displayedEnrollment?.run.id,
-              })}
-              kind="course"
-              entry={entry}
-              layout="compact"
-              headingLevel="h4"
-              isModule
-              onUpgradeError={onUpgradeError}
-            />
-          )
-        })}
-      </ProgramCardBody>
+            return (
+              <CoursewareCard
+                key={getKey({
+                  resourceType: ResourceType.Course,
+                  id: course.id,
+                  runId: entry.displayedEnrollment?.run.id,
+                })}
+                kind="course"
+                entry={entry}
+                layout="compact"
+                headingLevel="h4"
+                isModule
+                onUpgradeError={onUpgradeError}
+              />
+            )
+          })}
+        </ProgramCardBody>
+      </ProgramCardContent>
     </ProgramCardRoot>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -63,13 +63,32 @@ const ProgramCardRoot = styled.div(({ theme }) => ({
   },
 }))
 
-const ProgramCardHeaderOuter = styled.div({
+const ProgramHeaderDesktop = styled.div(({ theme }) => ({
+  [theme.breakpoints.down("sm")]: {
+    display: "none",
+  },
+}))
+
+const ProgramHeaderMobile = styled.div(({ theme }) => ({
+  [theme.breakpoints.up("sm")]: {
+    display: "none",
+  },
+}))
+
+const ProgramCardHeaderOuter = styled.div(({ theme }) => ({
   display: "flex",
+  position: "relative",
   padding: "16px 16px 16px 24px",
   alignItems: "center",
   alignSelf: "stretch",
   gap: "16px",
-})
+  [theme.breakpoints.down("sm")]: {
+    flexDirection: "column",
+    alignItems: "stretch",
+    gap: "8px",
+    padding: "16px",
+  },
+}))
 
 const ProgramCardHeaderInner = styled.div({
   display: "flex",
@@ -79,11 +98,16 @@ const ProgramCardHeaderInner = styled.div({
   flex: "1 0 0",
 })
 
-const StatusContainer = styled.div({
+const StatusContainer = styled.div(({ theme }) => ({
   display: "flex",
   alignItems: "center",
   gap: "16px",
-})
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+    justifyContent: "space-between",
+    gap: "8px",
+  },
+}))
 
 const ProgramCardSubHeaderText = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
@@ -333,35 +357,68 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
       className={className}
       data-testid="program-as-course-card"
     >
-      <ProgramCardHeaderOuter>
-        <ProgramCardHeaderInner>
-          <StatusContainer>
-            {progressBadgeSection}
-            <CourseDateSummary
-              startDate={courseProgram?.start_date}
-              endDate={courseProgram?.end_date}
-            />
-          </StatusContainer>
-          <Typography variant="subtitle2" component="h3">
-            {courseProgram?.title}
-          </Typography>
-        </ProgramCardHeaderInner>
-        <Stack direction="row" gap="8px">
-          {programCertificateUrl ? (
-            <ProgramCertificateButton
-              variant="bordered"
-              size="small"
-              startIcon={<RiAwardFill />}
-              href={programCertificateUrl}
-            >
-              Certificate
-            </ProgramCertificateButton>
-          ) : upgradedAndIncomplete ? (
-            <UpgradedBanner />
-          ) : null}
-          {contextMenu}
-        </Stack>
-      </ProgramCardHeaderOuter>
+      <ProgramHeaderDesktop data-testid="program-as-course-card-desktop-header">
+        <ProgramCardHeaderOuter>
+          <ProgramCardHeaderInner>
+            <StatusContainer>
+              {progressBadgeSection}
+              <CourseDateSummary
+                startDate={courseProgram?.start_date}
+                endDate={courseProgram?.end_date}
+              />
+            </StatusContainer>
+            <Typography variant="subtitle2" component="h3">
+              {courseProgram?.title}
+            </Typography>
+          </ProgramCardHeaderInner>
+          <Stack direction="row" gap="8px">
+            {programCertificateUrl ? (
+              <ProgramCertificateButton
+                variant="bordered"
+                size="small"
+                startIcon={<RiAwardFill />}
+                href={programCertificateUrl}
+              >
+                Certificate
+              </ProgramCertificateButton>
+            ) : upgradedAndIncomplete ? (
+              <UpgradedBanner />
+            ) : null}
+            {contextMenu}
+          </Stack>
+        </ProgramCardHeaderOuter>
+      </ProgramHeaderDesktop>
+      <ProgramHeaderMobile data-testid="program-as-course-card-mobile-header">
+        <ProgramCardHeaderOuter>
+          <ProgramCardHeaderInner>
+            <StatusContainer>
+              {progressBadgeSection}
+              <CourseDateSummary
+                startDate={courseProgram?.start_date}
+                endDate={courseProgram?.end_date}
+              />
+              <Stack direction="row" gap="8px">
+                {programCertificateUrl ? (
+                  <ProgramCertificateButton
+                    variant="bordered"
+                    size="small"
+                    startIcon={<RiAwardFill />}
+                    href={programCertificateUrl}
+                  >
+                    Certificate
+                  </ProgramCertificateButton>
+                ) : upgradedAndIncomplete ? (
+                  <UpgradedBanner />
+                ) : null}
+                {contextMenu}
+              </Stack>
+            </StatusContainer>
+            <Typography variant="subtitle2" component="h3">
+              {courseProgram?.title}
+            </Typography>
+          </ProgramCardHeaderInner>
+        </ProgramCardHeaderOuter>
+      </ProgramHeaderMobile>
       <ProgramCardSubHeader>
         <ProgramCardSubHeaderText variant="subtitle3">
           {totalCount} Modules ({completedCount} of {totalCount} complete)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -60,7 +60,6 @@ const ProgramCardRoot = styled.div(({ theme }) => ({
     borderRadius: "0px",
     boxShadow: "none",
     flexDirection: "column",
-    gap: "16px",
   },
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -56,8 +56,7 @@ const ProgramCardRoot = styled.div(({ theme }) => ({
   boxShadow: "0 1px 3px 0 rgba(120, 147, 172, 0.20)",
   [theme.breakpoints.down("sm")]: {
     border: "none",
-    borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-    borderRadius: "0px",
+    borderBottom: `1px solid ${theme.custom.colors.red}`,
     boxShadow: "none",
     flexDirection: "column",
   },

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -25,6 +25,7 @@ import { CoursewareCard } from "./CoursewareCard"
 import {
   CardTypeText,
   CourseDateSummary,
+  MenuButton,
   Separator,
   UpgradedBanner,
 } from "./CardShared"
@@ -37,7 +38,6 @@ import {
   isVerifiedEnrollmentMode,
   mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
-import { ActionButton } from "@mitodl/smoot-design"
 import { RiAwardFill, RiMore2Line } from "@remixicon/react"
 import NiceModal from "@ebay/nice-modal-react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
@@ -54,7 +54,7 @@ const ProgramCardRoot = styled.div(({ theme }) => ({
   borderBottom: "none",
   backgroundColor: theme.custom.colors.white,
   boxShadow: "0 1px 3px 0 rgba(120, 147, 172, 0.20)",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     border: "none",
     borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
     borderRadius: "0px",
@@ -66,7 +66,7 @@ const ProgramCardRoot = styled.div(({ theme }) => ({
 
 const ProgramCardHeaderOuter = styled.div({
   display: "flex",
-  padding: "16px 24px",
+  padding: "16px 16px 16px 24px",
   alignItems: "center",
   alignSelf: "stretch",
   gap: "16px",
@@ -98,7 +98,7 @@ const ProgramCardSubHeader = styled.div(({ theme }) => ({
   gap: "10px",
   borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
   background: `${theme.custom.colors.lightGray1}`,
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     borderLeft: `1px solid ${theme.custom.colors.lightGray2}`,
     borderRight: `1px solid ${theme.custom.colors.lightGray2}`,
   },
@@ -113,23 +113,6 @@ const ProgramCardBody = styled.div({
   overflow: "hidden",
   borderRadius: "0 0 8px 8px",
 })
-
-const MenuButton = styled(ActionButton)<{
-  status: EnrollmentStatus
-}>(({ theme, status }) => [
-  {
-    marginLeft: "-8px",
-    [theme.breakpoints.down("md")]: {
-      position: "absolute",
-      top: "0",
-      right: "0",
-    },
-  },
-  status !== EnrollmentStatus.Completed &&
-    status !== EnrollmentStatus.Enrolled && {
-      visibility: "hidden",
-    },
-])
 
 const getContextMenuItems = (
   title: string,
@@ -364,7 +347,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
             {courseProgram?.title}
           </Typography>
         </ProgramCardHeaderInner>
-        <Stack direction="row" gap="0">
+        <Stack direction="row" gap="8px">
           {programCertificateUrl ? (
             <ProgramCertificateButton
               variant="bordered"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.test.tsx
@@ -101,7 +101,7 @@ describe.each([
     )
   })
 
-  test("shows 'Certificate track' alongside 'View Certificate' when verified enrollment has a certificate", () => {
+  test("shows 'View Certificate' in place of 'Certificate track' when verified enrollment has a certificate", () => {
     const programEnrollment =
       mitxonline.factories.enrollment.programEnrollmentV3({
         enrollment_mode: "verified",
@@ -110,12 +110,12 @@ describe.each([
     renderWithProviders(
       <ProgramEnrollmentCard programEnrollment={programEnrollment} />,
     )
-    expect(within(getCard()).getByTestId("upgraded-banner")).toHaveTextContent(
-      "Certificate track",
-    )
     expect(
-      within(getCard()).getByRole("link", { name: /View Certificate/ }),
-    ).toBeInTheDocument()
+      within(getCard()).queryByTestId("upgraded-banner"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(getCard()).getAllByRole("link", { name: /View Certificate/ }),
+    ).toHaveLength(1)
   })
 
   test("does not show 'Certificate track' for audit enrollment", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -57,7 +57,7 @@ export const ProgramEnrollmentCard = ({
   )
   const displayMode = program.display_mode
   const titleSection = (
-    <Stack gap="6px">
+    <Stack gap="12px">
       {titleHref ? (
         <TitleHeading>
           <TitleLink size="medium" color="black" href={titleHref}>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -67,7 +67,14 @@ export const ProgramEnrollmentCard = ({
       ) : (
         <TitleText>{title}</TitleText>
       )}
-      {upgradedAndIncomplete ? <UpgradedBanner /> : null}
+      {certificateLink ? (
+        <SubtitleLink href={certificateLink}>
+          <RiAwardLine size="16px" />
+          View Certificate
+        </SubtitleLink>
+      ) : upgradedAndIncomplete ? (
+        <UpgradedBanner />
+      ) : null}
     </Stack>
   )
   const detailsUrl = programPageView({
@@ -127,24 +134,16 @@ export const ProgramEnrollmentCard = ({
     />
   )
   const buttonSection = (
-    <Stack flexGrow={1} gap="8px">
-      {certificateLink && (
-        <SubtitleLink href={certificateLink}>
-          <RiAwardLine size="16px" />
-          View Certificate
-        </SubtitleLink>
-      )}
-      <Stack direction="row" gap="8px" alignItems="center">
-        <CoursewareButtonLink
-          size="small"
-          variant="primary"
-          href={programView(program.id)}
-          aria-label={`View program: ${title}`}
-        >
-          View
-        </CoursewareButtonLink>
-        {contextMenu}
-      </Stack>
+    <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
+      <CoursewareButtonLink
+        size="small"
+        variant="primary"
+        href={programView(program.id)}
+        aria-label={`View program: ${title}`}
+      >
+        View
+      </CoursewareButtonLink>
+      {contextMenu}
     </Stack>
   )
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -7,6 +7,7 @@ import {
 import {
   CardRoot,
   CardTypeText,
+  CoursewareButtonLink,
   MenuButton,
   Separator,
   SubtitleLink,
@@ -21,7 +22,6 @@ import {
   mitxonlineLegacyUrl,
 } from "@/common/mitxonline"
 import { getCertificateLink } from "./model/dashboardViewModel"
-import { ButtonLink } from "@mitodl/smoot-design"
 import NiceModal from "@ebay/nice-modal-react"
 import { UnenrollProgramDialog } from "./DashboardDialogs"
 import { getReceiptMenuItem } from "./receiptMenuItem"
@@ -69,24 +69,6 @@ export const ProgramEnrollmentCard = ({
       )}
       {upgradedAndIncomplete ? <UpgradedBanner /> : null}
     </Stack>
-  )
-  const buttonSection = (
-    <>
-      {certificateLink && (
-        <SubtitleLink href={certificateLink}>
-          <RiAwardLine size="16px" />
-          View Certificate
-        </SubtitleLink>
-      )}
-      <ButtonLink
-        size="small"
-        variant="primary"
-        href={programView(program.id)}
-        aria-label={`View program: ${title}`}
-      >
-        View
-      </ButtonLink>
-    </>
   )
   const detailsUrl = programPageView({
     readable_id: readableId,
@@ -144,6 +126,27 @@ export const ProgramEnrollmentCard = ({
       }
     />
   )
+  const buttonSection = (
+    <Stack flexGrow={1} gap="8px">
+      {certificateLink && (
+        <SubtitleLink href={certificateLink}>
+          <RiAwardLine size="16px" />
+          View Certificate
+        </SubtitleLink>
+      )}
+      <Stack direction="row" gap="8px" alignItems="center">
+        <CoursewareButtonLink
+          size="small"
+          variant="primary"
+          href={programView(program.id)}
+          aria-label={`View program: ${title}`}
+        >
+          View
+        </CoursewareButtonLink>
+        {contextMenu}
+      </Stack>
+    </Stack>
+  )
 
   const progressBadgeSection = (
     <Stack direction="row" gap="4px" alignItems="center">
@@ -165,12 +168,7 @@ export const ProgramEnrollmentCard = ({
           {progressBadgeSection}
           {titleSection}
         </Stack>
-        <Stack gap="8px">
-          <Stack direction="row" gap="8px" alignItems="center">
-            {buttonSection}
-            {contextMenu}
-          </Stack>
-        </Stack>
+        <Stack gap="8px">{buttonSection}</Stack>
       </CardRoot>
 
       <CardRoot
@@ -189,7 +187,6 @@ export const ProgramEnrollmentCard = ({
           <Stack direction="column" gap="8px" flex={1}>
             {titleSection}
           </Stack>
-          {contextMenu}
         </Stack>
         <Stack
           direction="row"
@@ -197,9 +194,7 @@ export const ProgramEnrollmentCard = ({
           justifyContent="end"
           width="100%"
         >
-          <Stack direction="row" gap="8px" alignItems="center">
-            {buttonSection}
-          </Stack>
+          {buttonSection}
         </Stack>
       </CardRoot>
     </>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -283,7 +283,10 @@ describe("ProgramEnrollmentDisplay", () => {
     )
 
     await screen.findByText("Requirements")
-    expect(await screen.findByText("Program As Course")).toBeInTheDocument()
+    // Rendered once in the desktop header, once in the mobile header.
+    expect(
+      (await screen.findAllByText("Program As Course")).length,
+    ).toBeGreaterThan(0)
     expect((await screen.findAllByText("Module A")).length).toBeGreaterThan(0)
     expect((await screen.findAllByText("Module B")).length).toBeGreaterThan(0)
   })

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -21,6 +21,9 @@ const StyledCoursewareCard = styled(CoursewareCard)({
 export const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   color: theme.custom.colors.red,
   width: "120px",
+  [theme.breakpoints.down("sm")]: {
+    width: "80px",
+  },
 }))
 
 interface ProgramEnrollmentDisplayProps {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
@@ -32,7 +32,7 @@ const AdditionalRunsAccordion = styled(Accordion)(({ theme }) => ({
     overflow: "hidden",
   },
   "& .MuiAccordionSummary-root": {
-    [theme.breakpoints.down("md")]: {
+    [theme.breakpoints.down("sm")]: {
       padding: 0,
     },
   },
@@ -130,14 +130,14 @@ const SummaryRow = styled(Stack)(({ theme }) => ({
   flex: 1,
   minWidth: 0,
   gap: "24px",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     gap: "8px",
   },
 }))
 
 const RunsListWrapper = styled.div(({ theme }) => ({
   padding: "0 16px 16px",
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     padding: "0 0 8px",
   },
 }))

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -122,6 +122,7 @@ export const UnenrolledCourseCard = ({
       variant={isCompact ? "secondary" : "primary"}
       data-testid="courseware-button"
       aria-label={`Start course: ${title}`}
+      aria-busy={isPending}
       onClick={isDisabled ? undefined : enrollClick}
       disabled={isDisabled}
       endIcon={

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -185,26 +185,43 @@ export const UnenrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="stretch"
-          flex={1}
-          width="100%"
-        >
-          <Stack direction="column" gap="8px" flex={1}>
-            {titleSection}
-            {!isCompact && courseDateText}
+        <Stack direction="row" gap="8px" alignItems="flex-start" width="100%">
+          {showEnrollmentStatusIcon && (
+            <Stack alignSelf="flex-start">
+              <EnrollmentStatusIcon status={EnrollmentStatus.NotEnrolled} />
+            </Stack>
+          )}
+          <Stack
+            direction="column"
+            gap="16px"
+            flex={1}
+            minWidth={0}
+            width="100%"
+          >
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="stretch"
+              flex={1}
+              minWidth={0}
+              width="100%"
+            >
+              <Stack direction="column" gap="8px" flex={1} minWidth={0}>
+                {titleSection}
+                {!isCompact && courseDateText}
+              </Stack>
+            </Stack>
+            <Stack
+              direction="row"
+              width="100%"
+              gap="8px"
+              alignItems="center"
+              justifyContent="end"
+              minWidth={0}
+            >
+              {startButton}
+            </Stack>
           </Stack>
-        </Stack>
-        <Stack
-          direction="row"
-          width="100%"
-          gap="8px"
-          alignItems="center"
-          justifyContent="end"
-        >
-          {startButton}
         </Stack>
       </CardRoot>
     </>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -13,6 +13,7 @@ import {
   CourseDateSummary,
   Separator,
 } from "./CardShared"
+import { getCourseDateText } from "./courseDateUtils"
 import { EnrollmentStatus, getBestRun } from "./helpers"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useEnrollmentHandler } from "./hooks/useEnrollmentHandler"
@@ -105,14 +106,16 @@ export const UnenrolledCourseCard = ({
       {title}
     </TitleText>
   )
-  const courseDateText = (
+  const hasCourseDateText =
+    getCourseDateText(courseRun?.start_date, courseRun?.end_date) !== null
+  const courseDateText = hasCourseDateText ? (
     <Stack direction="row" gap="8px" alignItems="start">
       <CourseDateSummary
         startDate={courseRun?.start_date}
         endDate={courseRun?.end_date}
       />
     </Stack>
-  )
+  ) : null
   const startButton = (
     <CoursewareButton
       size="small"
@@ -159,7 +162,7 @@ export const UnenrolledCourseCard = ({
         )}
         <Stack justifyContent="start" alignItems="stretch" gap="4px" flex={1}>
           {progressBadgeSection}
-          <Stack gap="6px">
+          <Stack gap="12px">
             {titleSection}
             {courseDateText}
           </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -18,7 +18,6 @@ import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { useEnrollmentHandler } from "./hooks/useEnrollmentHandler"
 import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import { ProgressBadge } from "./ProgressBadge"
-import { Button } from "@mitodl/smoot-design"
 
 type UnenrolledCourseCardProps = {
   course: CourseWithCourseRunsSerializerV2
@@ -114,10 +113,10 @@ export const UnenrolledCourseCard = ({
       />
     </Stack>
   )
-  const startButton = isCompact ? (
+  const startButton = (
     <CoursewareButton
       size="small"
-      variant="secondary"
+      variant={isCompact ? "secondary" : "primary"}
       data-testid="courseware-button"
       aria-label={`Start course: ${title}`}
       onClick={isDisabled ? undefined : enrollClick}
@@ -130,32 +129,6 @@ export const UnenrolledCourseCard = ({
     >
       Start
     </CoursewareButton>
-  ) : (
-    <Button
-      size="small"
-      variant="primary"
-      data-testid="courseware-button"
-      aria-label={`Start course: ${title}`}
-      onClick={isDisabled ? undefined : enrollClick}
-      disabled={isDisabled}
-      endIcon={
-        isPending ? (
-          <LoadingSpinner color="inherit" loading={isPending} size={16} />
-        ) : null
-      }
-    >
-      Start
-    </Button>
-  )
-  const buttonSection = (
-    <Stack
-      direction="row"
-      marginRight="8px"
-      alignItems="center"
-      justifyContent="end"
-    >
-      {startButton}
-    </Stack>
   )
 
   const progressBadgeSection =
@@ -194,11 +167,11 @@ export const UnenrolledCourseCard = ({
         <Stack
           direction="row"
           gap="8px"
-          paddingRight="32px"
+          paddingRight="40px"
           alignItems="center"
           justifyContent="end"
         >
-          {buttonSection}
+          {startButton}
         </Stack>
       </CardRoot>
 
@@ -228,7 +201,7 @@ export const UnenrolledCourseCard = ({
           alignItems="center"
           justifyContent="end"
         >
-          {buttonSection}
+          {startButton}
         </Stack>
       </CardRoot>
     </>


### PR DESCRIPTION
   ### What are the relevant tickets?                                                                                                                                                                                                                   
   Closes https://github.com/mitodl/hq/issues/12305                                                                                                                                                                                                     
                                                                                                                                                                                                                                                        
   ### Description (What does it do?)                                                                                                                                                                                                                   
   Mobile-specific follow-up to the desktop dashboard card redesign, addressing design review feedback for course cards, program-as-course cards, program enrollment cards, and the B2B contract page header:                                           
                                                                                                                                                                                                                                                        
   - Fixed the date / "Certificate track" / upgrade-banner meta text so it wraps by whole segment rather than breaking mid-word or mid-number. Each segment (date, certificate track indicator, upgrade promo) stays intact; if a segment doesn't fit   
 next to the date, it wraps to its own line instead.                                                                                                                                                                                                    
   - Standardized the mobile/desktop breakpoint for dashboard cards to `sm` (600px) instead of `md` (900px), so tablet-width viewports use the desktop card layout (properly sized CTA buttons, inline metadata) instead of the stretched, stacked      
 mobile styling. True mobile layout now only applies below 600px.                                                                                                                                                                                       
   - Fixed the "Certificate track" indicator so earning a certificate replaces it in place with a "View Certificate" link, instead of showing both simultaneously.                                                                                      
   - Added the enrollment status (progress) indicator to the mobile module-row layout on program-as-course cards, matching the existing desktop behavior.                                                                                               
   - Fixed card/header content overflowing past the right edge of the viewport on mobile (a nested flexbox `min-width` issue introduced by the progress-indicator column).                                                                              
   - Adjusted spacing throughout: title-to-metadata gap, program card header/subheader gaps, module-row icon-to-content gap, and outer card border/shadow rendering on program-as-course cards.                                                         
   - Applied the same "flush to page background" mobile header treatment used for the My Learning section header to the B2B contract page header.                                                                                                       
   - Updated and added tests covering certificate/track-indicator behavior, enrollment status indicators, and the dual desktop/mobile render pattern.                                                                                                   
                                                                                                                                                                                                                                                        
   ### Screenshots (if appropriate):                                                                                                                                                                                                                    
<img width="768" height="1024" alt="image" src="https://github.com/user-attachments/assets/b7b7be00-1fba-4375-a62b-a19245a0e9be" />
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/27c06e77-df2e-4232-a563-6ee801b76bd6" />
                                                                                                                                                                                                                                                        
   ### How can this be tested?                                                                                                                                                                                                                          
   1. Visit `/dashboard` and check the "My Learning" section, a program-as-course card, and a B2B org/contract page (`/dashboard/organization/<org>/contract/<contract>`).                                                                              
   2. Resize the browser across desktop, tablet (~768px), and mobile (~390px) widths, confirming cards use the desktop layout until true mobile (<600px).                                                                                               
   3. Check course/program cards in each state:                                                                                                                                                                                                         
      - In-progress verified enrollment → shows "Certificate track".                                                                                                                                                                                    
      - Completed enrollment with a certificate → shows "View Certificate" in the same slot (not both).                                                                                                                                                 
      - Unverified, upgrade-eligible enrollment → shows the upgrade promo banner, wrapping cleanly at narrow widths without overflowing or breaking mid-word.                                                                                           
   4. On a program-as-course card, confirm each module row shows a progress icon on mobile, and confirm module rows aren't pushed off the right edge of the screen.                                                                                     
   5. Run `yarn test` and `yarn workspace frontends run typecheck` — all should pass. 