### PR TITLE
fix: Align B2B admin dashboard copy across seat assignment, confirm modal, and row actions

### DIFF
--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.test.tsx
@@ -16,11 +16,11 @@ const baseProps = {
 describe("AssignSeatsConfirmModal — confirm step (no issues)", () => {
   beforeEach(() => jest.clearAllMocks())
 
-  test("shows 'Ready to send invitations' title when there are no issues", () => {
+  test("shows 'Review and send invitations' title when there are no issues", () => {
     renderWithTheme(<AssignSeatsConfirmModal {...baseProps} />)
 
     expect(
-      screen.getByRole("heading", { name: /ready to send invitations/i }),
+      screen.getByRole("heading", { name: /review and send invitations/i }),
     ).toBeInTheDocument()
   })
 
@@ -202,10 +202,12 @@ describe("AssignSeatsConfirmModal — review step (has issues)", () => {
       <AssignSeatsConfirmModal {...baseProps} invalidEmails={["bad@"]} />,
     )
 
-    await user.click(screen.getByRole("button", { name: /review & confirm/i }))
+    await user.click(
+      screen.getByRole("button", { name: /continue to email preview/i }),
+    )
 
     expect(
-      screen.getByRole("heading", { name: /ready to send invitations/i }),
+      screen.getByRole("heading", { name: /review and send invitations/i }),
     ).toBeInTheDocument()
   })
 
@@ -309,7 +311,7 @@ describe("AssignSeatsConfirmModal — unlimited contract (availableSeats null)",
 
     // Confirm step still renders normally.
     expect(
-      screen.getByRole("heading", { name: /ready to send invitations/i }),
+      screen.getByRole("heading", { name: /review and send invitations/i }),
     ).toBeInTheDocument()
 
     // Stat value is a dash and the label / group name convey no seat limit.
@@ -342,7 +344,7 @@ describe("AssignSeatsConfirmModal — unlimited contract (availableSeats null)",
     )
 
     expect(
-      screen.getByRole("heading", { name: /ready to send invitations/i }),
+      screen.getByRole("heading", { name: /review and send invitations/i }),
     ).toBeInTheDocument()
     expect(
       screen.queryByRole("heading", { name: /not enough seats available/i }),

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -511,7 +511,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             : "",
           " Only valid, unique emails will be assigned.",
         ].join("")
-      : `You're about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
+      : `You're about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with a secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
 
   // For overCapacity we point aria-describedby at the visible paragraph so
   // role="alertdialog" reads it exactly once on open. We do NOT programmatically

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -681,8 +681,8 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           <DescriptionText>
             You're about to send <strong>{validCount}</strong> invitation{" "}
             {pluralize("email", validCount)} from MIT Learn. Learners will
-            receive an email with a secure link to claim their seat and access the
-            materials.
+            receive an email with a secure link to claim their seat and access
+            the materials.
           </DescriptionText>
           {onSendTestEmail && (
             <EmailPreviewSection>

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -681,7 +681,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
           <DescriptionText>
             You're about to send <strong>{validCount}</strong> invitation{" "}
             {pluralize("email", validCount)} from MIT Learn. Learners will
-            receive an email with secure link to claim their seat and access the
+            receive an email with a secure link to claim their seat and access the
             materials.
           </DescriptionText>
           {onSendTestEmail && (

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsConfirmModal.tsx
@@ -437,7 +437,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
   // to re-discover a new role="dialog" element.
   const handleReviewAndConfirm = () => {
     setStep("confirm")
-    const confirmText = `Ready to send invitations. You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with a secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
+    const confirmText = `Review and send invitations. You're about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with a secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
     setStepAnnouncement("")
     if (stepAnnouncementTimerRef.current)
       clearTimeout(stepAnnouncementTimerRef.current)
@@ -464,7 +464,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       {reviewTitle}
     </>
   ) : (
-    "Ready to send invitations"
+    "Review and send invitations"
   )
 
   const dialogActions = overCapacity ? (
@@ -479,7 +479,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
         Cancel
       </Button>
       <Button variant="primary" onClick={handleReviewAndConfirm}>
-        Review &amp; Confirm
+        Continue to Email Preview
       </Button>
     </DialogActions>
   ) : (
@@ -511,7 +511,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
             : "",
           " Only valid, unique emails will be assigned.",
         ].join("")
-      : `You are about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
+      : `You're about to send ${validCount} invitation ${pluralize("email", validCount)} from MIT Learn. Learners will receive an email with secure link to claim their seat and access the materials. ${seatsAfterSendingText} Emails will be sent immediately and cannot be recalled.`
 
   // For overCapacity we point aria-describedby at the visible paragraph so
   // role="alertdialog" reads it exactly once on open. We do NOT programmatically
@@ -679,7 +679,7 @@ const AssignSeatsConfirmModal: React.FC<AssignSeatsConfirmModalProps> = ({
       {!overCapacity && step === "confirm" && (
         <Stack gap="24px">
           <DescriptionText>
-            You are about to send <strong>{validCount}</strong> invitation{" "}
+            You're about to send <strong>{validCount}</strong> invitation{" "}
             {pluralize("email", validCount)} from MIT Learn. Learners will
             receive an email with secure link to claim their seat and access the
             materials.

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -320,7 +320,7 @@ describe("AssignSeatsSection", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: /ready to send invitations/i,
+        name: /review and send invitations/i,
       }),
     ).toBeInTheDocument()
   })
@@ -376,13 +376,13 @@ describe("AssignSeatsSection", () => {
     const textarea = screen.getByPlaceholderText(/enter employee emails/i)
     await user.type(textarea, "alice@example.com")
     await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-    await screen.findByRole("heading", { name: /ready to send invitations/i })
+    await screen.findByRole("heading", { name: /review and send invitations/i })
 
     await user.click(screen.getByRole("button", { name: /cancel/i }))
 
     await waitFor(() =>
       expect(
-        screen.queryByRole("heading", { name: /ready to send invitations/i }),
+        screen.queryByRole("heading", { name: /review and send invitations/i }),
       ).not.toBeInTheDocument(),
     )
   })
@@ -410,7 +410,7 @@ describe("AssignSeatsSection", () => {
 
     expect(
       await screen.findByRole("heading", {
-        name: /ready to send invitations/i,
+        name: /review and send invitations/i,
       }),
     ).toBeInTheDocument()
     expect(screen.getByPlaceholderText(/enter employee emails/i)).toHaveValue(
@@ -572,7 +572,7 @@ describe("AssignSeatsSection", () => {
       const textarea = screen.getByPlaceholderText(/enter employee emails/i)
       await user.type(textarea, "alice@example.com")
       await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-      await screen.findByRole("heading", { name: /ready to send invitations/i })
+      await screen.findByRole("heading", { name: /review and send invitations/i })
     }
 
     test("shows 'Send Test Email to Me' button in the confirm modal", async () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.test.tsx
@@ -572,7 +572,9 @@ describe("AssignSeatsSection", () => {
       const textarea = screen.getByPlaceholderText(/enter employee emails/i)
       await user.type(textarea, "alice@example.com")
       await user.click(screen.getByRole("button", { name: "Assign Seats" }))
-      await screen.findByRole("heading", { name: /review and send invitations/i })
+      await screen.findByRole("heading", {
+        name: /review and send invitations/i,
+      })
     }
 
     test("shows 'Send Test Email to Me' button in the confirm modal", async () => {

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -433,8 +433,8 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       <div>
         <SectionTitle component="h2">Assign Seats</SectionTitle>
         <MutedText>
-          Each learner will receive an invitation email from MIT Learn to
-          access their learning.
+          Each learner will receive an invitation email from MIT Learn to access
+          their learning.
         </MutedText>
       </div>
       {/* Always-mounted live region — debounced so screen readers aren't spammed on every keystroke */}

--- a/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/AssignSeatsSection.tsx
@@ -433,8 +433,8 @@ const AssignSeatsSection: React.FC<AssignSeatsSectionProps> = ({
       <div>
         <SectionTitle component="h2">Assign Seats</SectionTitle>
         <MutedText>
-          Each learner will receive an email with a link to claim their seat and
-          access the program.
+          Each learner will receive an invitation email from MIT Learn to
+          access their learning.
         </MutedText>
       </div>
       {/* Always-mounted live region — debounced so screen readers aren't spammed on every keystroke */}

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -157,7 +157,10 @@ describe("RowActionMenu", () => {
     })
 
     test("revokes on confirm and reports success", async () => {
-      const code = makeCode({ redemption_status: "assigned" })
+      const code = makeCode({
+        redemption_status: "assigned",
+        assigned_to: "learner@example.com",
+      })
       setMockResponse.delete(
         urls.contracts.managerContractCodeRevoke(
           ORG_ID,
@@ -173,7 +176,10 @@ describe("RowActionMenu", () => {
       await user.click(screen.getByRole("button", { name: "Release seat" }))
 
       await waitFor(() => {
-        expect(onResult).toHaveBeenCalledWith("Seat released.", "success")
+        expect(onResult).toHaveBeenCalledWith(
+          "Seat released for learner@example.com.",
+          "success",
+        )
       })
     })
   })
@@ -309,7 +315,7 @@ describe("RowActionMenu", () => {
       )
       expect(
         await screen.findByRole("menuitem", {
-          name: "Link copied to clipboard",
+          name: "Claim link copied.",
         }),
       ).toBeInTheDocument()
     })
@@ -334,10 +340,10 @@ describe("RowActionMenu", () => {
 
       expect(
         await screen.findByRole("menuitem", {
-          name: "Link copied to clipboard",
+          name: "Claim link copied.",
         }),
       ).toBeInTheDocument()
-      expect(liveRegion).toHaveTextContent("Link copied to clipboard")
+      expect(liveRegion).toHaveTextContent("Claim link copied.")
     })
 
     test("falls back to execCommand when clipboard API is unavailable", async () => {
@@ -367,7 +373,7 @@ describe("RowActionMenu", () => {
       expect(document.execCommand).toHaveBeenCalledWith("copy")
       expect(
         await screen.findByRole("menuitem", {
-          name: "Link copied to clipboard",
+          name: "Claim link copied.",
         }),
       ).toBeInTheDocument()
     })

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.test.tsx
@@ -44,7 +44,7 @@ describe("RowActionMenu", () => {
         screen.getByRole("menuitem", { name: "Change assigned email" }),
       ).toBeInTheDocument()
       expect(
-        screen.getByRole("menuitem", { name: "Resend claim email" }),
+        screen.getByRole("menuitem", { name: "Resend invitation" }),
       ).toBeInTheDocument()
       expect(
         screen.getByRole("menuitem", { name: "Copy claim link" }),
@@ -52,6 +52,22 @@ describe("RowActionMenu", () => {
       expect(
         screen.getByRole("menuitem", { name: "Release seat" }),
       ).toBeInTheDocument()
+    })
+
+    test("orders items with common actions first and the destructive action last", async () => {
+      const code = makeCode({ redemption_status: "assigned" })
+      renderMenu(code)
+
+      await user.click(screen.getByRole("button", { name: /more actions/i }))
+
+      expect(
+        screen.getAllByRole("menuitem").map((item) => item.textContent),
+      ).toEqual([
+        "Resend invitation",
+        "Copy claim link",
+        "Change assigned email",
+        "Release seat",
+      ])
     })
   })
 
@@ -75,7 +91,7 @@ describe("RowActionMenu", () => {
     })
   })
 
-  describe("Resend claim email", () => {
+  describe("Resend invitation", () => {
     test("calls the remind endpoint and reports success", async () => {
       const code = makeCode({
         redemption_status: "assigned",
@@ -93,7 +109,7 @@ describe("RowActionMenu", () => {
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
       await user.click(
-        screen.getByRole("menuitem", { name: "Resend claim email" }),
+        screen.getByRole("menuitem", { name: "Resend invitation" }),
       )
 
       await waitFor(() => {
@@ -110,7 +126,7 @@ describe("RowActionMenu", () => {
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
 
-      const item = screen.getByRole("menuitem", { name: "Resend claim email" })
+      const item = screen.getByRole("menuitem", { name: "Resend invitation" })
       expect(item).toHaveAttribute("aria-disabled", "true")
 
       await user.click(item)
@@ -132,7 +148,7 @@ describe("RowActionMenu", () => {
 
       await user.click(screen.getByRole("button", { name: /more actions/i }))
       await user.click(
-        screen.getByRole("menuitem", { name: "Resend claim email" }),
+        screen.getByRole("menuitem", { name: "Resend invitation" }),
       )
 
       await waitFor(() => {

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -137,7 +137,7 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult(`Seat released for ${assignedTo}.`, "success")
+      onResult(`Seat released for ${code.assigned_to?.trim() || "unassigned seat"}.`, "success")
     } catch (err) {
       const status = (err as AxiosError)?.response?.status
       onResult(

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -75,8 +75,8 @@ type RowActionMenuProps = {
 /**
  * Three-dot row action menu for the contract admin codes table.
  *
- * Pending (assigned) rows: Change assigned email, Resend claim email, Copy
- * claim link, Release seat.
+ * Pending (assigned) rows: Resend invitation, Copy claim link, Change
+ * assigned email, Release seat.
  *
  * Redeemed rows: button is disabled — no actions available.
  */
@@ -124,9 +124,9 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult(`Claim email resent to ${code.assigned_to}.`, "success")
+      onResult(`Invitation resent to ${code.assigned_to}.`, "success")
     } catch {
-      onResult("Could not resend the claim email. Please try again.", "error")
+      onResult("Could not resend the invitation. Please try again.", "error")
     }
   }
 
@@ -263,12 +263,12 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
       >
         {hasAssignedEmail ? (
           <ActionMenuItem onClick={handleResend}>
-            Resend claim email
+            Resend invitation
           </ActionMenuItem>
         ) : (
           <Tooltip title="No email is assigned to this seat yet." describeChild>
-            <ActionMenuItem disabled aria-label="Resend claim email">
-              Resend claim email
+            <ActionMenuItem disabled aria-label="Resend invitation">
+              Resend invitation
             </ActionMenuItem>
           </Tooltip>
         )}

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -137,7 +137,7 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult("Seat released.", "success")
+      onResult(`Seat released for ${assignedTo}.`, "success")
     } catch (err) {
       const status = (err as AxiosError)?.response?.status
       onResult(
@@ -240,7 +240,7 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
   return (
     <>
       <VisuallyHidden aria-live="polite">
-        {copied ? "Link copied to clipboard" : ""}
+        {copied ? "Claim link copied." : ""}
       </VisuallyHidden>
       <ActionButton
         id={`row-action-trigger-${code.id}`}
@@ -261,9 +261,6 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         onClose={handleClose}
         MenuListProps={{ "aria-labelledby": `row-action-trigger-${code.id}` }}
       >
-        <ActionMenuItem onClick={openReassign}>
-          Change assigned email
-        </ActionMenuItem>
         {hasAssignedEmail ? (
           <ActionMenuItem onClick={handleResend}>
             Resend claim email
@@ -276,12 +273,16 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
           </Tooltip>
         )}
         {copied ? (
-          <CopiedMenuItem disabled>Link copied to clipboard</CopiedMenuItem>
+          <CopiedMenuItem disabled>Claim link copied.</CopiedMenuItem>
         ) : (
           <ActionMenuItem onClick={handleCopyClaimLink}>
             Copy claim link
           </ActionMenuItem>
         )}
+        <Divider component="li" role="separator" />
+        <ActionMenuItem onClick={openReassign}>
+          Change assigned email
+        </ActionMenuItem>
         <Divider component="li" role="separator" />
         <DestructiveMenuItem onClick={openRevokeConfirm}>
           Release seat

--- a/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/RowActionMenu.tsx
@@ -137,7 +137,10 @@ const RowActionMenu: React.FC<RowActionMenuProps> = ({
         id: contractId,
         parent_lookup_organization: orgId,
       })
-      onResult(`Seat released for ${code.assigned_to?.trim() || "unassigned seat"}.`, "success")
+      onResult(
+        `Seat released for ${code.assigned_to?.trim() || "unassigned seat"}.`,
+        "success",
+      )
     } catch (err) {
       const status = (err as AxiosError)?.response?.status
       onResult(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Reframes the assign-seats confirm modal as a review flow, not a false confirmation: "Ready to send invitations" → "Review and send invitations", and the review-step button "Review & Confirm" → "Continue to Email Preview" (it only advances to the email preview, it doesn't send anything)
- Reorders the row action menu so the most common actions lead and the destructive one trails: Resend claim email → Copy claim link → Change assigned email → Release seat
- Shortens a few strings for consistency: the Assign Seats helper text drops "program" in favor of "learning" and moves "claim seat" language out of admin-facing copy, "Link copied to clipboard" → "Claim link copied.", and "You are about to send" → "You're about to send" to match the app's voice elsewhere
- No behavior changes — copy and menu-order only, aside from `RowActionMenu`'s release-seat success toast now including the learner's email ("Seat released for `<email>`." instead of just "Seat released.")



### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### Assign Seats helper text
| Before | After |
|---|---|
| <img width="1222" height="44" alt="before-1-assign-seats-helper" src="https://github.com/user-attachments/assets/a7cde4a1-3f10-4057-b9d2-7225f23237bc" /> | <img width="1222" height="44" alt="after-1-assign-seats-helper" src="https://github.com/user-attachments/assets/69adcf41-0881-4f74-b325-719831409c35" /> |

Drops "program" for "learning," and moves "claim seat" language out of admin-facing copy — reserved for the learner email now.

### Confirm step — title & body copy
| Before | After |
|---|---|
| <!-- before-2-confirm-step.png --> <img width="600" height="456" alt="before-2-confirm-step" src="https://github.com/user-attachments/assets/5a9927b3-4da3-42aa-b3fe-2028797884a9" /> | <!-- after-2-confirm-step.png --> <img width="600" height="456" alt="after-2-confirm-step" src="https://github.com/user-attachments/assets/932c47bd-fe7e-4cc4-a2c5-4167deb386b6" /> |

"Ready to send" implied a done deal; "Review and send" matches what the screen is — the last look before anything goes out.

### Review step — advance button
| Before | After |
|---|---|
| <!-- before-3-review-step.png --><img width="600" height="526" alt="before-3-review-step" src="https://github.com/user-attachments/assets/6813f851-3e1b-431c-95fb-0062419763cb" />| <!-- after-3-review-step.png --> <img width="600" height="526" alt="after-3-review-step" src="https://github.com/user-attachments/assets/c23ab1ec-567b-4629-b5be-268ee60810ba" /> |

The button doesn't finalize the send — it only advances to the email preview. The new label says exactly what happens next.

### Row action menu — item order
| Before | After |
|---|---|
| <!-- before-4-row-menu-order.png --><img width="160" height="161" alt="before-4-row-menu-order" src="https://github.com/user-attachments/assets/be59664d-904e-4aae-88d5-e9154fd8c14c" /> |<img width="160" height="178" alt="after-4-row-menu-order" src="https://github.com/user-attachments/assets/04a17476-3a53-4bb0-bd25-8318e361b0a7" /> |

Reordered so the most common actions lead and the destructive one trails.

### Copy-link confirmation
| Before | After |
|---|---|
| <!-- before-5-copy-link-confirmation.png --> <img width="160" height="161" alt="before-5-copy-link-confirmation" src="https://github.com/user-attachments/assets/88c2dc03-6247-4b23-a25f-10d07171e4b9" /> | <img width="170" height="181" alt="Screenshot 2026-07-16 at 2 38 57 PM" src="https://github.com/user-attachments/assets/65034510-fce8-48b7-99fb-5749841da651" /> |

Shorter, and matches the past-tense pattern used by the other action confirmations in this menu.

### Release-seat success message
| Before | After |
|---|---|
| <img width="1272" height="46" alt="before-6-release-seat-toast" src="https://github.com/user-attachments/assets/c9270402-02ad-434d-98c6-eb833a353db7" /> |<img width="1272" height="46" alt="after-6-release-seat-toast" src="https://github.com/user-attachments/assets/5c41cbf4-0fcd-46d6-b9c5-1b49c8e321b6" />| 




Names the seat that was released instead of a generic confirmation — useful once you've released more than one in a session and want to confirm which one.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- [ ] `yarn test frontends/main/src/app-pages/ContractAdminPage` — all AssignSeatsSection/AssignSeatsConfirmModal/RowActionMenu/ContractAdminPage tests pass
- [ ] In the browser: paste a mix of valid/invalid/duplicate emails into Assign Seats and confirm the review step button reads "Continue to Email Preview", and the following confirm step reads "Review and send invitations"
- [ ] Open the row action menu on a pending (assigned, unredeemed) code and confirm the item order is Resend claim email, Copy claim link, Change assigned email, Release seat
- [ ] Click "Copy claim link" and confirm the menu item flips to "Claim link copied."
- [ ] Release a seat and confirm the success message reads "Seat released for `<email>`."

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

Email wording listed [here](https://mit.enterprise.slack.com/docs/T04JRPJF6/F0BHLUCGK7D) was not updated @dsubak I'll leave the email changes to you.


@steven-hatch I couldn't find anything matching
"Email invitation has been successfully sent to <email>" so this change wasn't made
<img width="741" height="54" alt="Screenshot 2026-07-16 at 2 03 14 PM" src="https://github.com/user-attachments/assets/a398625c-7d93-433c-904d-8f0ab1b5571f" />







<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
