### PR TITLE
Capitalize foreign language name clean

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/VariantPicker.test.tsx
@@ -65,7 +65,7 @@ describe("VariantPicker labels", () => {
       name: /Customized Universal AI/,
     })
     // the language/industry/length detail moves to the card subtext
-    expect(esRadio).toHaveAccessibleName(/español.*General.*Full/)
+    expect(esRadio).toHaveAccessibleName(/español.*General.*Full/i)
     // the default label does not leak onto the variant card
     expect(esRadio).not.toHaveAccessibleName(/Universal AI Program/)
   })
@@ -86,7 +86,7 @@ describe("VariantPicker Viewing indicator", () => {
     const indicator = screen.getByText("Viewing:").closest("div")!
     expect(
       within(indicator).getByText(
-        /Customized Universal AI \(español.*General.*Full\)/,
+        /Customized Universal AI \(español.*General.*Full\)/i,
       ),
     ).toBeInTheDocument()
   })
@@ -149,7 +149,7 @@ describe("VariantPicker certificate badge", () => {
     renderPicker({ selectedVariant: esVariant })
 
     const esRadio = screen.getByRole("radio", {
-      name: /español.*General.*Full/,
+      name: /español.*General.*Full/i,
     })
     expect(esRadio).not.toHaveAccessibleName(/Certificate Eligible/)
   })
@@ -160,7 +160,7 @@ describe("VariantPicker selection", () => {
     renderPicker({ selectedVariant: esVariant })
 
     const esRadio = screen.getByRole("radio", {
-      name: /español.*General.*Full/,
+      name: /español.*General.*Full/i,
     })
     const enRadio = screen.getByRole("radio", { name: /Universal AI Program/ })
     expect(esRadio).toBeChecked()
@@ -172,7 +172,7 @@ describe("VariantPicker selection", () => {
     renderPicker({ selectedVariant: enDefault, setSelectedVariant })
 
     const esRadio = screen.getByRole("radio", {
-      name: /español.*General.*Full/,
+      name: /español.*General.*Full/i,
     })
     await user.click(esRadio)
     expect(setSelectedVariant).toHaveBeenCalledWith(esVariant)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1868,12 +1868,20 @@ describe("buildVariantLabel", () => {
   })
 
   test("capitalizes only the first word of a multi-word language name", () => {
-    const label = buildVariantLabel(
-      makeVariant({ language: "es-419" as never }),
-    )
-    // Second word ("latinoamericano" as of current CLDR data) is left
-    // lowercase — only the first word should be title-cased.
-    expect(label).toMatch(/^Español [a-záéíóúñ]+ • General • Full$/)
+    const originalDisplayNames = Intl.DisplayNames
+    try {
+      // Make the test independent of the host Node/ICU/CLDR data.
+      ;(Intl as any).DisplayNames = function () {
+        return { of: () => "español latinoamericano" }
+      } as any
+
+      const label = buildVariantLabel(
+        makeVariant({ language: "es-419" as never }),
+      )
+      expect(label).toBe("Español latinoamericano • General • Full")
+    } finally {
+      ;(Intl as any).DisplayNames = originalDisplayNames
+    }
   })
 
   test("includes the industry label when variant_industry is set", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1869,18 +1869,23 @@ describe("buildVariantLabel", () => {
 
   test("capitalizes only the first word of a multi-word language name", () => {
     const originalDisplayNames = Intl.DisplayNames
+    const intlWithDisplayNames = Intl as unknown as {
+      DisplayNames: typeof Intl.DisplayNames
+    }
     try {
       // Make the test independent of the host Node/ICU/CLDR data.
-      ;(Intl as any).DisplayNames = function () {
-        return { of: () => "español latinoamericano" }
-      } as any
+      intlWithDisplayNames.DisplayNames = class {
+        of() {
+          return "español latinoamericano"
+        }
+      } as unknown as typeof Intl.DisplayNames
 
       const label = buildVariantLabel(
         makeVariant({ language: "es-419" as never }),
       )
       expect(label).toBe("Español latinoamericano • General • Full")
     } finally {
-      ;(Intl as any).DisplayNames = originalDisplayNames
+      intlWithDisplayNames.DisplayNames = originalDisplayNames
     }
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1857,21 +1857,23 @@ describe("buildVariantLabel", () => {
   })
 
   test("uses the Spanish native name for es_ES, capitalized", () => {
-    expect(
-      buildVariantLabel(makeVariant({ language: LanguageEnum.EsEs })),
-    ).toBe("Español de España • General • Full")
+    const label = buildVariantLabel(
+      makeVariant({ language: LanguageEnum.EsEs }),
+    )
+    // Exact ICU/CLDR wording (e.g. whether it disambiguates with "de España")
+    // can vary across Node/ICU versions — only assert the part this test
+    // owns: the name is capitalized and the industry/length suffix is intact.
+    expect(label).toMatch(/^Español\b/)
+    expect(label.endsWith("• General • Full")).toBe(true)
   })
 
   test("capitalizes only the first word of a multi-word language name", () => {
     const label = buildVariantLabel(
-      makeVariant({
-        language: "es-419" as unknown as SupportedVariant["language"],
-      }),
+      makeVariant({ language: "es-419" as never }),
     )
-    const languageLabel = label.split(" • ")[0] ?? ""
-    expect(languageLabel).toMatch(/^Español\b/)
-    expect(languageLabel).toMatch(/\blatinoamericano\b/i)
-    expect(languageLabel).not.toMatch(/\bLatinoamericano\b/)
+    // Second word ("latinoamericano" as of current CLDR data) is left
+    // lowercase — only the first word should be title-cased.
+    expect(label).toMatch(/^Español [a-záéíóúñ]+ • General • Full$/)
   })
 
   test("includes the industry label when variant_industry is set", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1863,9 +1863,15 @@ describe("buildVariantLabel", () => {
   })
 
   test("capitalizes only the first word of a multi-word language name", () => {
-    expect(
-      buildVariantLabel(makeVariant({ language: "es-419" as never })),
-    ).toBe("Español latinoamericano • General • Full")
+    const label = buildVariantLabel(
+      makeVariant({
+        language: "es-419" as unknown as SupportedVariant["language"],
+      }),
+    )
+    const languageLabel = label.split(" • ")[0] ?? ""
+    expect(languageLabel).toMatch(/^Español\b/)
+    expect(languageLabel).toMatch(/\blatinoamericano\b/i)
+    expect(languageLabel).not.toMatch(/\bLatinoamericano\b/)
   })
 
   test("includes the industry label when variant_industry is set", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1856,10 +1856,16 @@ describe("buildVariantLabel", () => {
     )
   })
 
-  test("uses the Spanish native name for es_ES", () => {
+  test("uses the Spanish native name for es_ES, capitalized", () => {
     expect(
       buildVariantLabel(makeVariant({ language: LanguageEnum.EsEs })),
-    ).toMatch(/español/i)
+    ).toBe("Español de España • General • Full")
+  })
+
+  test("capitalizes only the first word of a multi-word language name", () => {
+    expect(
+      buildVariantLabel(makeVariant({ language: "es-419" as never })),
+    ).toBe("Español latinoamericano • General • Full")
   })
 
   test("includes the industry label when variant_industry is set", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -1110,8 +1110,8 @@ const buildVariantKey = (variant: SupportedVariant): string =>
  * `Intl.DisplayNames` has no option to request this directly, so it's
  * applied here.
  */
-const capitalizeFirstWord = (value: string): string =>
-  value ? value.charAt(0).toUpperCase() + value.slice(1) : value
+const capitalizeFirstWord = (value: string, locale?: string): string =>
+  value ? value.charAt(0).toLocaleUpperCase(locale) + value.slice(1) : value
 
 // Per-dimension display labels. These are the single source of truth shared by
 // both buildVariantLabel (what the picker renders) and sortVariants (the order

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -1031,7 +1031,16 @@ const FALLBACK_NATIVE_LANGUAGE_NAMES: Record<string, string> = {
   "zh-tw": "繁體中文",
 }
 
-const nativeLanguageNameCache = new Map<string, string>()
+/**
+ * `resolved: false` marks a raw, untranslated locale code that fell through
+ * every lookup (unknown to both `Intl.DisplayNames` and the static fallback
+ * table) — as opposed to a genuine human-readable name. Callers should not
+ * apply display-name casing rules (e.g. title-casing the first word) to an
+ * unresolved code, since it isn't a name at all.
+ */
+type NativeLanguageNameResult = { label: string; resolved: boolean }
+
+const nativeLanguageNameCache = new Map<string, NativeLanguageNameResult>()
 let cachedDisplayNamesRef: typeof Intl.DisplayNames | undefined =
   Intl.DisplayNames
 
@@ -1042,30 +1051,35 @@ const ensureNativeLanguageNameCacheIsFresh = (): void => {
   }
 }
 
-const getFallbackNativeLanguageName = (languageCode: string): string | null => {
+const getFallbackNativeLanguageName = (
+  languageCode: string,
+): NativeLanguageNameResult | null => {
   const exactMatch = FALLBACK_NATIVE_LANGUAGE_NAMES[languageCode]
   if (exactMatch) {
-    return exactMatch
+    return { label: exactMatch, resolved: true }
   }
   const baseLanguageSubtag = languageCode.split("-")[0]
   if (!baseLanguageSubtag) {
     return null
   }
-  return (
-    FALLBACK_NATIVE_LANGUAGE_NAMES[baseLanguageSubtag] ?? baseLanguageSubtag
-  )
+  const baseMatch = FALLBACK_NATIVE_LANGUAGE_NAMES[baseLanguageSubtag]
+  return baseMatch
+    ? { label: baseMatch, resolved: true }
+    : { label: baseLanguageSubtag, resolved: false }
 }
 
-const getNativeLanguageName = (languageCode: string): string => {
+const getNativeLanguageName = (
+  languageCode: string,
+): NativeLanguageNameResult => {
   ensureNativeLanguageNameCacheIsFresh()
   const normalizedLanguageCode = languageCode
     .trim()
     .toLowerCase()
     .replace("_", "-")
   const baseLanguageSubtag = normalizedLanguageCode.split("-")[0]
-  const cachedLabel = nativeLanguageNameCache.get(normalizedLanguageCode)
-  if (cachedLabel) {
-    return cachedLabel
+  const cachedResult = nativeLanguageNameCache.get(normalizedLanguageCode)
+  if (cachedResult) {
+    return cachedResult
   }
   let resolvedLabel: string | null = null
   try {
@@ -1091,12 +1105,14 @@ const getNativeLanguageName = (languageCode: string): string => {
   } catch {
     // Fall through to static fallback labels.
   }
-  const finalLabel =
-    resolvedLabel ??
-    getFallbackNativeLanguageName(normalizedLanguageCode) ??
-    normalizedLanguageCode
-  nativeLanguageNameCache.set(normalizedLanguageCode, finalLabel)
-  return finalLabel
+  const result: NativeLanguageNameResult = resolvedLabel
+    ? { label: resolvedLabel, resolved: true }
+    : (getFallbackNativeLanguageName(normalizedLanguageCode) ?? {
+        label: normalizedLanguageCode,
+        resolved: false,
+      })
+  nativeLanguageNameCache.set(normalizedLanguageCode, result)
+  return result
 }
 
 const buildVariantKey = (variant: SupportedVariant): string =>
@@ -1110,16 +1126,17 @@ const buildVariantKey = (variant: SupportedVariant): string =>
  * `Intl.DisplayNames` has no option to request this directly, so it's
  * applied here.
  */
-const capitalizeFirstWord = (value: string, locale?: string): string =>
-  value ? value.charAt(0).toLocaleUpperCase(locale) + value.slice(1) : value
+const capitalizeFirstWord = (value: string): string =>
+  value ? value.charAt(0).toUpperCase() + value.slice(1) : value
 
 // Per-dimension display labels. These are the single source of truth shared by
 // both buildVariantLabel (what the picker renders) and sortVariants (the order
 // it renders in) so the sort always matches the visible text.
-const getVariantLanguageLabel = (variant: SupportedVariant): string =>
-  variant.language
-    ? capitalizeFirstWord(getNativeLanguageName(variant.language))
-    : ""
+const getVariantLanguageLabel = (variant: SupportedVariant): string => {
+  if (!variant.language) return ""
+  const { label, resolved } = getNativeLanguageName(variant.language)
+  return resolved ? capitalizeFirstWord(label) : label
+}
 
 const getVariantIndustryLabel = (variant: SupportedVariant): string =>
   variant.variant_industry

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -1102,11 +1102,24 @@ const getNativeLanguageName = (languageCode: string): string => {
 const buildVariantKey = (variant: SupportedVariant): string =>
   `language:${variant.language ?? ""}|industry:${variant.variant_industry ?? ""}|length:${variant.variant_length ?? ""}`
 
+/**
+ * `Intl.DisplayNames` returns language names in mid-sentence (dictionary)
+ * case, e.g. "español latinoamericano". Per CLDR's `contextTransforms` for
+ * the "languages" category (`titlecase-firstword`), UI list/menu and
+ * standalone contexts capitalize only the first word, not every word.
+ * `Intl.DisplayNames` has no option to request this directly, so it's
+ * applied here.
+ */
+const capitalizeFirstWord = (value: string): string =>
+  value ? value.charAt(0).toUpperCase() + value.slice(1) : value
+
 // Per-dimension display labels. These are the single source of truth shared by
 // both buildVariantLabel (what the picker renders) and sortVariants (the order
 // it renders in) so the sort always matches the visible text.
 const getVariantLanguageLabel = (variant: SupportedVariant): string =>
-  variant.language ? getNativeLanguageName(variant.language) : ""
+  variant.language
+    ? capitalizeFirstWord(getNativeLanguageName(variant.language))
+    : ""
 
 const getVariantIndustryLabel = (variant: SupportedVariant): string =>
   variant.variant_industry


### PR DESCRIPTION
### What are the relevant tickets?
Fixes, closes https://github.com/mitodl/hq/issues/11648

### Description (What does it do?)
Ensuring that first word for languages is capitalized, as per CTDL standards (see ticket).

### How can this be tested?
- Run new test added to `dashboardViewModel.test.ts‎`