### PR TITLE
fix: raise SCAN COUNT in clear_views_cache to cut Redis scan time + clear cache less often during website_content requests

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -589,9 +589,8 @@ def clear_views_cache(key_prefix: str | None = None) -> int:
         # Redis with the Celery broker + result backend) needs ~keyspace/10
         # round-trips. Raising it ~100x cuts a multi-second scan to a fraction.
         return cache.delete_pattern(pattern, itersize=1000)
-    if hasattr(cache, "keys"):
-        return cache.delete_many(cache.keys(pattern)) or 0
-    # Backends without pattern/key enumeration (e.g. LocMemCache) can only flush.
+    # Backends without SCAN-based pattern deletion (DummyCache in tests,
+    # LocMemCache) can't clear selectively -- flush everything instead.
     cache.clear()
     return 0
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -584,7 +584,11 @@ def clear_views_cache(key_prefix: str | None = None) -> int:
     )
 
     if hasattr(cache, "delete_pattern"):
-        return cache.delete_pattern(pattern)
+        # itersize is the SCAN COUNT: django-redis defaults it to 10, so a
+        # delete_pattern over a large shared keyspace (this cache shares its
+        # Redis with the Celery broker + result backend) needs ~keyspace/10
+        # round-trips. Raising it ~100x cuts a multi-second scan to a fraction.
+        return cache.delete_pattern(pattern, itersize=1000)
     if hasattr(cache, "keys"):
         return cache.delete_many(cache.keys(pattern)) or 0
     # Backends without pattern/key enumeration (e.g. LocMemCache) can only flush.

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -17,6 +17,7 @@ from main.utils import (
     cache_page_for_anonymous_users,
     chunks,
     clean_data,
+    clear_views_cache,
     extract_values,
     filter_dict_keys,
     filter_dict_with_renamed_keys,
@@ -586,3 +587,22 @@ def test_cache_key_format(mock_caches):
     hash_part = cache_key.split(".")[-1]
     assert len(hash_part) == 32
     assert all(c in "0123456789abcdef" for c in hash_part)
+
+
+@patch("main.utils.caches")
+def test_clear_views_cache_uses_large_itersize(mock_caches):
+    """
+    delete_pattern must be called with a large itersize (SCAN COUNT).
+
+    The default of 10 means a full-keyspace scan needs ~keyspace/10 round-trips
+    against the Redis shared with the Celery broker; a 55s scan on prod. Pinning
+    itersize guards against a regression back to the slow default.
+    """
+    mock_cache = MagicMock()
+    mock_cache.delete_pattern.return_value = 3
+    mock_caches.__getitem__.return_value = mock_cache
+
+    result = clear_views_cache()
+
+    mock_cache.delete_pattern.assert_called_once_with("views.*", itersize=1000)
+    assert result == 3

--- a/website_content/views.py
+++ b/website_content/views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django_filters.rest_framework import DjangoFilterBackend
@@ -76,21 +77,25 @@ class WebsiteContentViewSet(viewsets.ModelViewSet):
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
+    # NOTE: clear the view cache on every mutation, published or not -- the
+    # staff listing view is cached and includes unpublished content, so a draft
+    # create/edit/delete can change a cached response too. Deferred to
+    # on_commit so it runs after the write is durable.
     def perform_create(self, serializer):
-        clear_views_cache()
         content = serializer.save(user=self.request.user)
+        transaction.on_commit(clear_views_cache)
         purge_content_on_save(content)
         content_published_actions(content=content)
 
     def perform_update(self, serializer):
-        clear_views_cache()
         content = serializer.save()
+        transaction.on_commit(clear_views_cache)
         purge_content_on_save(content)
         content_published_actions(content=content)
 
-    def destroy(self, request, *args, **kwargs):
-        clear_views_cache()
-        return super().destroy(request, *args, **kwargs)
+    def perform_destroy(self, instance):
+        super().perform_destroy(instance)
+        transaction.on_commit(clear_views_cache)
 
     @extend_schema(
         summary="Retrieve by ID or slug",

--- a/website_content/views_test.py
+++ b/website_content/views_test.py
@@ -117,6 +117,87 @@ def test_staff_can_access_unpublished_content(client):
     assert data["id"] == content.id
 
 
+@pytest.fixture
+def mock_clear_views_cache(mocker):
+    """Patch the cache-clear hook so tests can assert whether it fired."""
+    return mocker.patch("website_content.views.clear_views_cache")
+
+
+def _make_content(user, *, is_published):
+    return WebsiteContent.objects.create(
+        title="t",
+        content={},
+        is_published=is_published,
+        user=user,
+        content_type="news",
+    )
+
+
+# The staff listing view is cached and includes unpublished content, so every
+# mutation must clear the view cache -- including on drafts. The is_published
+# parametrization guards against reintroducing a published-only gate.
+@pytest.mark.parametrize("is_published", [True, False])
+def test_create_clears_views_cache(
+    staff_client,
+    mock_clear_views_cache,
+    django_capture_on_commit_callbacks,
+    is_published,
+):
+    """Create clears the view cache on commit, published or draft."""
+    url = reverse("website_content:v1:website_content-list")
+    data = {
+        "content": {},
+        "title": "Some title",
+        "content_type": "news",
+        "is_published": is_published,
+    }
+    with django_capture_on_commit_callbacks(execute=True):
+        resp = staff_client.post(url, data, format="json")
+
+    assert resp.status_code == 201
+    assert mock_clear_views_cache.called is True
+
+
+@pytest.mark.parametrize("now_published", [True, False])
+def test_update_clears_views_cache(
+    staff_client,
+    user,
+    mock_clear_views_cache,
+    django_capture_on_commit_callbacks,
+    now_published,
+):
+    """Update clears the view cache on commit, even a draft-to-draft edit."""
+    content = _make_content(user, is_published=False)
+    url = reverse(
+        "website_content:v1:website_content-detail", kwargs={"pk": content.id}
+    )
+    with django_capture_on_commit_callbacks(execute=True):
+        resp = staff_client.patch(url, {"is_published": now_published}, format="json")
+
+    assert resp.status_code == 200
+    assert mock_clear_views_cache.called is True
+
+
+@pytest.mark.parametrize("is_published", [True, False])
+def test_destroy_clears_views_cache(
+    staff_client,
+    user,
+    mock_clear_views_cache,
+    django_capture_on_commit_callbacks,
+    is_published,
+):
+    """Destroy clears the view cache on commit, published or draft."""
+    content = _make_content(user, is_published=is_published)
+    url = reverse(
+        "website_content:v1:website_content-detail", kwargs={"pk": content.id}
+    )
+    with django_capture_on_commit_callbacks(execute=True):
+        resp = staff_client.delete(url)
+
+    assert resp.status_code == 204
+    assert mock_clear_views_cache.called is True
+
+
 def test_content_type_filter(client, user):
     """content_type query param should filter results"""
     WebsiteContent.objects.create(


### PR DESCRIPTION

### What are the relevant tickets?
- Closes https://github.com/mitodl/hq/issues/12443

### Description (What does it do?)
This PR:
1. sets an itersize on `cache.delete_pattern` to increase its performance; with 300k keys, it took about 30 seconds with default size (10) and 0.45 seconds with size 1000.
2. Changes website_content views slightly:
    - only clear cache after database changes are committed

### How can this be tested?
1. View `/news` on the frontend ... This ensures something at least is in your views cache. (FeedSourceViewSet caches its listing)
2. In a django shell, `./manage.py shell` and `from main.utils import clear_views_cache`, `clear_views_cache()`. It should succeed. It should return a nonzero number—number of keys deleted—so you know it still works.
3. Try creating a new news page via https://learn.mit.dev/website_content/news/new ... save it. 
    - if you save it without publishing, it should NOT show up on `/news` frontend page
    - when you publish it , it SHOULD show up
    - if you change the article's title and publish it again, it should update on `/news` frontend listing page.

