### PR TITLE
Add one-click unsubscribe to emails

### DIFF
--- a/Dockerfile.watch
+++ b/Dockerfile.watch
@@ -21,6 +21,10 @@ RUN apt-get update && apt-get install -y \
     libatspi2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
+# Trusted certs (org PKI + local-dev mkcert root injected at deploy time).
+COPY --chmod=644 certs/ /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /src
 
 # Copy all package.json files to enable yarn install

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 from types import SimpleNamespace
 
 import pytest
+from django.core import mail
 
 from fixtures.aws import *  # noqa: F403
 from fixtures.common import *  # noqa: F403
@@ -22,6 +23,18 @@ def prevent_requests(mocker, request):
         autospec=True,
         side_effect=DoNotUseRequestException,
     )
+
+
+@pytest.fixture(autouse=True)
+def _use_locmem_notification_email_backend(settings):
+    settings.NOTIFICATION_EMAIL_BACKEND = (
+        "django.core.mail.backends.locmem.EmailBackend"
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_mail_outbox():
+    mail.outbox = []
 
 
 @pytest.fixture(autouse=True)

--- a/env/frontend.env
+++ b/env/frontend.env
@@ -1,4 +1,5 @@
 NODE_ENV=development
+NODE_USE_SYSTEM_CA=1
 PORT=8062
 
 # Environment variables with `NEXT_PUBLIC_` prefix are exposed to the client side

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -31,6 +31,7 @@
     "ol-test-utilities": "0.0.0"
   },
   "dependencies": {
+    "@mitodl/mit-learn-api-axios": "2026.7.22",
     "@mitodl/mitxonline-api-axios": "2026.7.7",
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.12.2",

--- a/frontends/api/src/clients.ts
+++ b/frontends/api/src/clients.ts
@@ -14,6 +14,7 @@ import {
   MediaApi,
   VideoPlaylistsApi,
   HubspotApi,
+  UnsubscribeApi,
 } from "./generated/v1/api"
 
 import {
@@ -106,6 +107,8 @@ const vectorLearningResourcesSearchApi = new VectorLearningResourcesSearchApi(
   axiosInstance,
 )
 
+const unsubscribeApi = new UnsubscribeApi(undefined, BASE_PATH, axiosInstance)
+
 export {
   learningResourcesApi,
   learningPathsApi,
@@ -130,4 +133,5 @@ export {
   learningResourcesSearchAdminParamsApi,
   videoPlaylistsApi,
   vectorLearningResourcesSearchApi,
+  unsubscribeApi,
 }

--- a/frontends/api/src/clients.ts
+++ b/frontends/api/src/clients.ts
@@ -14,8 +14,9 @@ import {
   MediaApi,
   VideoPlaylistsApi,
   HubspotApi,
-  UnsubscribeApi,
 } from "./generated/v1/api"
+
+import { UnsubscribeApi } from "@mitodl/mit-learn-api-axios/v1"
 
 import {
   ChannelsApi,

--- a/frontends/api/src/hooks/unsubscribe/index.ts
+++ b/frontends/api/src/hooks/unsubscribe/index.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query"
+import { unsubscribeApi } from "../../clients"
+
+const useUnsubscribe = () =>
+  useMutation({
+    mutationFn: (token: string) =>
+      unsubscribeApi.unsubscribeCreate({ token }).then((res) => res.data),
+  })
+
+export { useUnsubscribe }

--- a/frontends/api/src/test-utils/urls.ts
+++ b/frontends/api/src/test-utils/urls.ts
@@ -250,6 +250,10 @@ const profileMe = {
   patch: () => `${getApiBaseUrl()}/api/v0/profiles/me/`,
 }
 
+const unsubscribe = {
+  post: (token: string) => `${getApiBaseUrl()}/api/v1/unsubscribe/${token}/`,
+}
+
 const newsEvents = {
   list: (params?: NewsEventsApiNewsEventsListRequest) =>
     `${getApiBaseUrl()}/api/v0/news_events/${query(params)}`,
@@ -283,4 +287,5 @@ export {
   newsEvents,
   testimonials,
   adminSearchParams,
+  unsubscribe,
 }

--- a/frontends/main/src/app-pages/DashboardPage/SettingsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/SettingsContent.test.tsx
@@ -8,15 +8,20 @@ type SetupApisOptions = {
   isAuthenticated?: boolean
   isSubscribed?: boolean
   subscriptionRequest?: CheckSubscriptionRequest
+  emailOptin?: boolean | null
 }
 const setupApis = ({
   isAuthenticated = false,
   isSubscribed = false,
   subscriptionRequest = {},
+  emailOptin = null,
 }: SetupApisOptions = {}) => {
   setMockResponse.get(urls.userMe.get(), {
     is_authenticated: isAuthenticated,
   })
+
+  setMockResponse.get(urls.profileMe.get(), { email_optin: emailOptin })
+  setMockResponse.patch(urls.profileMe.patch(), {})
 
   const subscribeResponse = isSubscribed
     ? factories.percolateQueries.percolateQueryList({ count: 5 }).results
@@ -99,5 +104,49 @@ describe("SettingsPage", () => {
     renderWithProviders(<SettingsContent />)
     const unfollowButton = screen.queryByText("Unfollow All")
     expect(unfollowButton).not.toBeInTheDocument()
+  })
+})
+
+describe("SettingsPage email preferences", () => {
+  it("renders the email opt-in checkbox checked when email_optin is true", async () => {
+    setupApis({ isAuthenticated: true, emailOptin: true })
+    renderWithProviders(<SettingsContent />)
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /receive emails from mit learn/i,
+    })
+    expect(checkbox).toBeChecked()
+  })
+
+  it("renders the email opt-in checkbox checked when email_optin is null (default)", async () => {
+    setupApis({ isAuthenticated: true, emailOptin: null })
+    renderWithProviders(<SettingsContent />)
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /receive emails from mit learn/i,
+    })
+    expect(checkbox).toBeChecked()
+  })
+
+  it("renders the email opt-in checkbox unchecked when email_optin is false", async () => {
+    setupApis({ isAuthenticated: true, emailOptin: false })
+    renderWithProviders(<SettingsContent />)
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /receive emails from mit learn/i,
+    })
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it("PATCHes the profile when the email opt-in checkbox is toggled", async () => {
+    setupApis({ isAuthenticated: true, emailOptin: true })
+    renderWithProviders(<SettingsContent />)
+    const checkbox = await screen.findByRole("checkbox", {
+      name: /receive emails from mit learn/i,
+    })
+    await user.click(checkbox)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "patch",
+        url: urls.profileMe.patch(),
+      }),
+    )
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/SettingsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/SettingsContent.tsx
@@ -10,8 +10,9 @@ import {
   DialogActions,
   Skeleton,
 } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
+import { Button, Checkbox } from "@mitodl/smoot-design"
 import { useUserMe } from "api/hooks/user"
+import { useProfileMeMutation, useProfileMeQuery } from "api/hooks/profile"
 import {
   useSearchSubscriptionDelete,
   useSearchSubscriptionList,
@@ -174,6 +175,8 @@ const UnfollowDialog = NiceModal.create(
 
 const SettingsContent: React.FC = () => {
   const { data: user } = useUserMe()
+  const { data: profile } = useProfileMeQuery()
+  const { mutateAsync: updateProfile } = useProfileMeMutation()
 
   const subscriptionList = useSearchSubscriptionList({
     enabled: !!user?.is_authenticated,
@@ -186,6 +189,13 @@ const SettingsContent: React.FC = () => {
   return (
     <div id="user-settings">
       <TitleText component="h1">Settings</TitleText>
+      <SubtitleTitleText>Email Preferences</SubtitleTitleText>
+      <Checkbox
+        name="email_optin"
+        label="Receive emails from MIT Learn"
+        checked={profile?.email_optin ?? true}
+        onChange={(e) => updateProfile({ email_optin: e.target.checked })}
+      />
       <SettingsHeader>
         <SettingsHeaderLeft>
           <SubtitleTitleText>Following</SubtitleTitleText>

--- a/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.test.tsx
+++ b/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.test.tsx
@@ -1,0 +1,73 @@
+import React from "react"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { renderWithProviders } from "@/test-utils"
+import { setMockResponse, urls } from "api/test-utils"
+import { UnsubscribePage } from "./UnsubscribePage"
+
+describe("UnsubscribePage", () => {
+  it("shows the error message when no token is present", () => {
+    renderWithProviders(<UnsubscribePage />)
+    expect(
+      screen.getByText(
+        /unable to unsubscribe you with that link, login to unsubscribe manually/i,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("shows a confirmation prompt with a button when a token is present", () => {
+    renderWithProviders(<UnsubscribePage token="abc123" />)
+    expect(
+      screen.getByText(/are you sure you want to unsubscribe/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: /confirm unsubscribe/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("posts to the unsubscribe endpoint and shows success on confirm", async () => {
+    setMockResponse.post(urls.unsubscribe.post("abc123"), {})
+    renderWithProviders(<UnsubscribePage token="abc123" />)
+
+    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/you have successfully unsubscribed from mit learn/i),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("shows an error message if the unsubscribe request fails", async () => {
+    setMockResponse.post(
+      urls.unsubscribe.post("abc123"),
+      { error: "Invalid or expired token" },
+      { code: 400 },
+    )
+    renderWithProviders(<UnsubscribePage token="abc123" />)
+
+    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /unable to unsubscribe you with that link, login to unsubscribe manually/i,
+        ),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it("disables the button while the request is pending", async () => {
+    setMockResponse.post(urls.unsubscribe.post("abc123"), new Promise(() => {}))
+    renderWithProviders(<UnsubscribePage token="abc123" />)
+
+    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(button).toBeDisabled()
+    })
+  })
+})

--- a/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.test.tsx
+++ b/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.test.tsx
@@ -21,7 +21,7 @@ describe("UnsubscribePage", () => {
       screen.getByText(/are you sure you want to unsubscribe/i),
     ).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: /confirm unsubscribe/i }),
+      screen.getByRole("button", { name: /yes, unsubscribe me/i }),
     ).toBeInTheDocument()
   })
 
@@ -29,7 +29,7 @@ describe("UnsubscribePage", () => {
     setMockResponse.post(urls.unsubscribe.post("abc123"), {})
     renderWithProviders(<UnsubscribePage token="abc123" />)
 
-    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    const button = screen.getByRole("button", { name: /yes, unsubscribe me/i })
     await userEvent.click(button)
 
     await waitFor(() => {
@@ -47,7 +47,7 @@ describe("UnsubscribePage", () => {
     )
     renderWithProviders(<UnsubscribePage token="abc123" />)
 
-    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    const button = screen.getByRole("button", { name: /yes, unsubscribe me/i })
     await userEvent.click(button)
 
     await waitFor(() => {
@@ -63,7 +63,7 @@ describe("UnsubscribePage", () => {
     setMockResponse.post(urls.unsubscribe.post("abc123"), new Promise(() => {}))
     renderWithProviders(<UnsubscribePage token="abc123" />)
 
-    const button = screen.getByRole("button", { name: /confirm unsubscribe/i })
+    const button = screen.getByRole("button", { name: /yes, unsubscribe me/i })
     await userEvent.click(button)
 
     await waitFor(() => {

--- a/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.tsx
+++ b/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import React from "react"
+import { Container, Typography, styled } from "ol-components"
+import { Button, ButtonLoadingIcon } from "@mitodl/smoot-design"
+import { useUnsubscribe } from "api/hooks/unsubscribe"
+import { UnsubscribedPage } from "@/app-pages/UnsubscribedPage/UnsubscribedPage"
+
+const PageContainer = styled(Container)({
+  paddingTop: "40px",
+  paddingBottom: "80px",
+})
+
+type UnsubscribePageProps = {
+  token?: string
+}
+
+const UnsubscribePage: React.FC<UnsubscribePageProps> = ({ token }) => {
+  const unsubscribe = useUnsubscribe()
+
+  if (!token) {
+    return <UnsubscribedPage errorCode="invalid_token" />
+  }
+  if (unsubscribe.isSuccess) {
+    return <UnsubscribedPage />
+  }
+  if (unsubscribe.isError) {
+    return <UnsubscribedPage errorCode="invalid_token" />
+  }
+
+  return (
+    <PageContainer>
+      <Typography variant="h3" component="h1" gutterBottom>
+        Unsubscribe from MIT Learn emails?
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        Are you sure you want to unsubscribe from MIT Learn emails?
+      </Typography>
+      <Button
+        disabled={unsubscribe.isPending}
+        endIcon={unsubscribe.isPending ? <ButtonLoadingIcon /> : undefined}
+        onClick={() => unsubscribe.mutate(token)}
+      >
+        Confirm unsubscribe
+      </Button>
+    </PageContainer>
+  )
+}
+
+export { UnsubscribePage }

--- a/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.tsx
+++ b/frontends/main/src/app-pages/UnsubscribePage/UnsubscribePage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React from "react"
-import { Container, Typography, styled } from "ol-components"
+import { Card, Container, Typography, styled } from "ol-components"
 import { Button, ButtonLoadingIcon } from "@mitodl/smoot-design"
 import { useUnsubscribe } from "api/hooks/unsubscribe"
 import { UnsubscribedPage } from "@/app-pages/UnsubscribedPage/UnsubscribedPage"
@@ -9,6 +9,19 @@ import { UnsubscribedPage } from "@/app-pages/UnsubscribedPage/UnsubscribedPage"
 const PageContainer = styled(Container)({
   paddingTop: "40px",
   paddingBottom: "80px",
+})
+
+const CardStyled = styled(Card)({
+  maxWidth: "600px",
+  margin: "0 auto",
+})
+
+const CardBody = styled.div({
+  padding: "32px",
+})
+
+const BodyText = styled(Typography)({
+  padding: "24px 0",
 })
 
 type UnsubscribePageProps = {
@@ -30,19 +43,27 @@ const UnsubscribePage: React.FC<UnsubscribePageProps> = ({ token }) => {
 
   return (
     <PageContainer>
-      <Typography variant="h3" component="h1" gutterBottom>
-        Unsubscribe from MIT Learn emails?
-      </Typography>
-      <Typography variant="body1" gutterBottom>
-        Are you sure you want to unsubscribe from MIT Learn emails?
-      </Typography>
-      <Button
-        disabled={unsubscribe.isPending}
-        endIcon={unsubscribe.isPending ? <ButtonLoadingIcon /> : undefined}
-        onClick={() => unsubscribe.mutate(token)}
-      >
-        Confirm unsubscribe
-      </Button>
+      <CardStyled>
+        <Card.Content>
+          <CardBody>
+            <Typography variant="h3" component="h1">
+              Unsubscribe
+            </Typography>
+            <BodyText variant="body1">
+              Are you sure you want to unsubscribe from MIT Learn emails?
+            </BodyText>
+            <Button
+              disabled={unsubscribe.isPending}
+              endIcon={
+                unsubscribe.isPending ? <ButtonLoadingIcon /> : undefined
+              }
+              onClick={() => unsubscribe.mutate(token)}
+            >
+              Yes, unsubscribe me
+            </Button>
+          </CardBody>
+        </Card.Content>
+      </CardStyled>
     </PageContainer>
   )
 }

--- a/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.test.tsx
+++ b/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.test.tsx
@@ -1,0 +1,33 @@
+import React from "react"
+import { screen } from "@testing-library/react"
+import { renderWithProviders } from "@/test-utils"
+import { UnsubscribedPage } from "./UnsubscribedPage"
+import * as urls from "@/common/urls"
+
+describe("UnsubscribedPage", () => {
+  it("shows success message when no errorCode", () => {
+    renderWithProviders(<UnsubscribedPage />)
+    expect(
+      screen.getByText(/you have successfully unsubscribed from mit learn/i),
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  it("shows error message when errorCode is present", () => {
+    renderWithProviders(<UnsubscribedPage errorCode="invalid_token" />)
+    expect(
+      screen.getByText(
+        /unable to unsubscribe you with that link, login to unsubscribe manually/i,
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("shows a login link pointing to the settings page when errorCode is present", () => {
+    renderWithProviders(<UnsubscribedPage errorCode="invalid_token" />)
+    const link = screen.getByRole("link", { name: /log in/i })
+    expect(link).toBeInTheDocument()
+    expect(decodeURIComponent(link.getAttribute("href") ?? "")).toContain(
+      urls.SETTINGS,
+    )
+  })
+})

--- a/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.tsx
+++ b/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import React from "react"
+import { Container, Typography, styled } from "ol-components"
+import { ButtonLink } from "@mitodl/smoot-design"
+import * as urls from "@/common/urls"
+
+const PageContainer = styled(Container)({
+  paddingTop: "40px",
+  paddingBottom: "80px",
+})
+
+type UnsubscribedPageProps = {
+  errorCode?: string
+}
+
+const UnsubscribedPage: React.FC<UnsubscribedPageProps> = ({ errorCode }) => {
+  if (errorCode) {
+    const loginUrl = urls.auth({
+      next: { pathname: urls.SETTINGS, searchParams: null },
+    })
+    return (
+      <PageContainer>
+        <Typography variant="h3" component="h1" gutterBottom>
+          Unable to Unsubscribe
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          Unable to unsubscribe you with that link, login to unsubscribe
+          manually.
+        </Typography>
+        <ButtonLink href={loginUrl}>Log in</ButtonLink>
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <Typography variant="h3" component="h1" gutterBottom>
+        Unsubscribed
+      </Typography>
+      <Typography variant="body1">
+        You have successfully unsubscribed from MIT Learn.
+      </Typography>
+    </PageContainer>
+  )
+}
+
+export { UnsubscribedPage }

--- a/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.tsx
+++ b/frontends/main/src/app-pages/UnsubscribedPage/UnsubscribedPage.tsx
@@ -1,13 +1,26 @@
 "use client"
 
 import React from "react"
-import { Container, Typography, styled } from "ol-components"
+import { Card, Container, Typography, styled } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import * as urls from "@/common/urls"
 
 const PageContainer = styled(Container)({
   paddingTop: "40px",
   paddingBottom: "80px",
+})
+
+const CardStyled = styled(Card)({
+  maxWidth: "600px",
+  margin: "0 auto",
+})
+
+const CardBody = styled.div({
+  padding: "32px",
+})
+
+const BodyText = styled(Typography)({
+  padding: "24px 0",
 })
 
 type UnsubscribedPageProps = {
@@ -21,26 +34,38 @@ const UnsubscribedPage: React.FC<UnsubscribedPageProps> = ({ errorCode }) => {
     })
     return (
       <PageContainer>
-        <Typography variant="h3" component="h1" gutterBottom>
-          Unable to Unsubscribe
-        </Typography>
-        <Typography variant="body1" gutterBottom>
-          Unable to unsubscribe you with that link, login to unsubscribe
-          manually.
-        </Typography>
-        <ButtonLink href={loginUrl}>Log in</ButtonLink>
+        <CardStyled>
+          <Card.Content>
+            <CardBody>
+              <Typography variant="h3" component="h1">
+                Unable to Unsubscribe
+              </Typography>
+              <BodyText variant="body1">
+                Unable to unsubscribe you with that link, login to unsubscribe
+                manually.
+              </BodyText>
+              <ButtonLink href={loginUrl}>Log in</ButtonLink>
+            </CardBody>
+          </Card.Content>
+        </CardStyled>
       </PageContainer>
     )
   }
 
   return (
     <PageContainer>
-      <Typography variant="h3" component="h1" gutterBottom>
-        Unsubscribed
-      </Typography>
-      <Typography variant="body1">
-        You have successfully unsubscribed from MIT Learn.
-      </Typography>
+      <CardStyled>
+        <Card.Content>
+          <CardBody>
+            <Typography variant="h3" component="h1">
+              Unsubscribed
+            </Typography>
+            <BodyText variant="body1">
+              You have successfully unsubscribed from MIT Learn.
+            </BodyText>
+          </CardBody>
+        </Card.Content>
+      </CardStyled>
     </PageContainer>
   )
 }

--- a/frontends/main/src/app/(site)/unsubscribe/page.tsx
+++ b/frontends/main/src/app/(site)/unsubscribe/page.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { Metadata } from "next"
+import { UnsubscribePage } from "@/app-pages/UnsubscribePage/UnsubscribePage"
+import { standardizeMetadata } from "@/common/metadata"
+
+export const metadata: Metadata = standardizeMetadata({
+  title: "Unsubscribe",
+})
+
+const Page = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string }>
+}) => {
+  const { token } = await searchParams
+  return <UnsubscribePage token={token} />
+}
+
+export default Page

--- a/frontends/main/src/app/(site)/unsubscribed/page.tsx
+++ b/frontends/main/src/app/(site)/unsubscribed/page.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+import { Metadata } from "next"
+import { UnsubscribedPage } from "@/app-pages/UnsubscribedPage/UnsubscribedPage"
+import { standardizeMetadata } from "@/common/metadata"
+
+export const metadata: Metadata = standardizeMetadata({
+  title: "Unsubscribed",
+})
+
+const Page = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ error_code?: string }>
+}) => {
+  const { error_code: errorCode } = await searchParams // eslint-disable-line camelcase
+  return <UnsubscribedPage errorCode={errorCode} />
+}
+
+export default Page

--- a/main/templates/email/email_base.html
+++ b/main/templates/email/email_base.html
@@ -357,12 +357,12 @@
             >
               {% block footer %}
 
+              {% if unsubscribe_url %}
               If you don't want to receive these emails in the future, you can
-              <a
-                href="{{ APP_BASE_URL }}/dashboard/settings/"
-                style="text-decoration: underline"
+              <a href="{{ unsubscribe_url }}" style="text-decoration: underline"
                 >unsubscribe</a
               >. <br /><br />
+              {% endif %}
 
               {% endblock %}
               {% block footer-address %}

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -20,6 +20,7 @@ from django.template.loader import render_to_string
 from PIL import Image
 
 from main.utils import generate_filepath
+from users.utils import generate_unsubscribe_url
 
 log = logging.getLogger(__name__)
 
@@ -417,7 +418,8 @@ def send_template_email(user, subject, template, context, *, is_transactional: b
         template(str): Path to an html template
         context(dict): context vars used in rendering the template
         is_transactional(bool): If true the email bypasses the user's
-            email_optin setting and always sends.
+            email_optin setting and always sends, so no unsubscribe URL
+            is included. Otherwise an unsubscribe URL is included.
     """
     if not is_transactional and not user_has_email_optin(user):
         log.debug("Not sending email to user %s: opted out of email", user.id)
@@ -425,13 +427,29 @@ def send_template_email(user, subject, template, context, *, is_transactional: b
 
     if not context:
         context = {}
+    unsubscribe_url = None
+    if not is_transactional:
+        unsubscribe_url = generate_unsubscribe_url(user)
+        context["unsubscribe_url"] = unsubscribe_url
     context["APP_BASE_URL"] = settings.APP_BASE_URL
     context["ABSOLUTE_STATIC_URL"] = urljoin(settings.APP_BASE_URL, settings.STATIC_URL)
     html_content = render_to_string(template, context)
-    return send_email(user, subject, html_content, text_only=False)
+    return send_email(
+        user,
+        subject,
+        html_content,
+        text_only=False,
+        unsubscribe_url=unsubscribe_url,
+    )
 
 
-def send_email(user, subject, content, text_only):
+def send_email(
+    user,
+    subject,
+    content,
+    text_only,
+    unsubscribe_url: str | None = None,
+):
     """
     Send an email
     Args:
@@ -440,6 +458,7 @@ def send_email(user, subject, content, text_only):
         content(str): The html or plain text content of the email.
         text_only(bool): If True html from the 'content' arg
         will be stripped and sent as plain text
+        unsubscribe_url(str): URL to include in List-Unsubscribe headers
     """
 
     if text_only:
@@ -449,6 +468,10 @@ def send_email(user, subject, content, text_only):
         for link in soup.find_all("a"):
             link.replace_with(link.attrs["href"])
         text_content = soup.get_text().strip()
+    headers = {}
+    if unsubscribe_url:
+        headers["List-Unsubscribe"] = f"<{unsubscribe_url}>"
+        headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
     with mail.get_connection(settings.NOTIFICATION_EMAIL_BACKEND) as connection:
         msg = AnymailMessage(
             subject=subject,
@@ -456,6 +479,7 @@ def send_email(user, subject, content, text_only):
             to=[user.email],
             from_email=settings.MAILGUN_FROM_EMAIL,
             connection=connection,
+            headers=headers or None,
         )
         if not text_only:
             msg.attach_alternative(content, "text/html")

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -20,7 +20,7 @@ from django.template.loader import render_to_string
 from PIL import Image
 
 from main.utils import generate_filepath
-from users.utils import generate_unsubscribe_url
+from users.utils import generate_unsubscribe_frontend_url, generate_unsubscribe_url
 
 log = logging.getLogger(__name__)
 
@@ -430,7 +430,7 @@ def send_template_email(user, subject, template, context, *, is_transactional: b
     unsubscribe_url = None
     if not is_transactional:
         unsubscribe_url = generate_unsubscribe_url(user)
-        context["unsubscribe_url"] = unsubscribe_url
+        context["unsubscribe_url"] = generate_unsubscribe_frontend_url(user)
     context["APP_BASE_URL"] = settings.APP_BASE_URL
     context["ABSOLUTE_STATIC_URL"] = urljoin(settings.APP_BASE_URL, settings.STATIC_URL)
     html_content = render_to_string(template, context)

--- a/profiles/utils_test.py
+++ b/profiles/utils_test.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+from django.core import mail
 from PIL import Image
 
 from main.factories import UserFactory
@@ -22,6 +23,7 @@ from profiles.utils import (
     profile_image_upload_uri,
     profile_image_upload_uri_medium,
     profile_image_upload_uri_small,
+    send_email,
     send_template_email,
     update_full_name,
     user_has_email_optin,
@@ -259,9 +261,88 @@ def test_user_has_email_optin_no_profile():
     assert user_has_email_optin(user) is False
 
 
+# send_email tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_send_email_adds_list_unsubscribe_headers_when_url_provided():
+    """send_email adds List-Unsubscribe headers when unsubscribe_url is given."""
+    user = UserFactory.create()
+
+    send_email(
+        user,
+        "Test",
+        "<p>content</p>",
+        text_only=False,
+        unsubscribe_url="https://api.example.com/api/v1/users/unsubscribe/token/",
+    )
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].extra_headers == {
+        "List-Unsubscribe": "<https://api.example.com/api/v1/users/unsubscribe/token/>",
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+    }
+
+
+@pytest.mark.django_db
+def test_send_email_no_list_unsubscribe_headers_without_url():
+    """send_email does not set List-Unsubscribe headers when no URL is given."""
+    user = UserFactory.create()
+
+    send_email(user, "Test", "<p>content</p>", text_only=False)
+
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].extra_headers == {}
+
+
 # ---------------------------------------------------------------------------
 # send_template_email tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_send_template_email_transactional_no_unsubscribe_url(mocker):
+    """When is_transactional=True, no unsubscribe_url is passed."""
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create()
+
+    send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=True,
+    )
+
+    mock_send_email.assert_called_once()
+    call_kwargs = mock_send_email.call_args.kwargs
+    assert call_kwargs.get("unsubscribe_url") is None
+
+
+@pytest.mark.django_db
+def test_send_template_email_not_transactional_sets_unsubscribe_url(mocker, settings):
+    """When is_transactional=False, unsubscribe_url is set from the user."""
+    settings.MITOL_API_BASE_URL = "https://api.example.com"
+    mock_send_email = mocker.patch("profiles.utils.send_email")
+    user = UserFactory.create(profile__email_optin=True)
+
+    send_template_email(
+        user,
+        "Test",
+        "email/welcome_email.html",
+        context={"display_name": "Test"},
+        is_transactional=False,
+    )
+
+    mock_send_email.assert_called_once()
+    call_kwargs = mock_send_email.call_args.kwargs
+    assert call_kwargs["unsubscribe_url"]
+    # The UUID is embedded in the signed token but should not be a standalone path segment
+    from urllib.parse import urlparse
+
+    segments = urlparse(call_kwargs["unsubscribe_url"]).path.strip("/").split("/")
+    assert str(user.unsubscribe_uuid) not in segments
 
 
 @pytest.mark.django_db
@@ -301,8 +382,9 @@ def test_send_template_email_not_transactional_opted_out_skips(mocker):
 
 
 @pytest.mark.django_db
-def test_send_template_email_transactional_opted_out_still_sends(mocker):
+def test_send_template_email_transactional_opted_out_still_sends(mocker, settings):
     """Transactional emails bypass email_optin even when the user opted out."""
+    settings.MITOL_API_BASE_URL = "https://api.example.com"
     mock_send_email = mocker.patch("profiles.utils.send_email")
     user = UserFactory.create(profile__email_optin=False)
 

--- a/profiles/utils_test.py
+++ b/profiles/utils_test.py
@@ -324,25 +324,31 @@ def test_send_template_email_transactional_no_unsubscribe_url(mocker):
 def test_send_template_email_not_transactional_sets_unsubscribe_url(mocker, settings):
     """When is_transactional=False, unsubscribe_url is set from the user."""
     settings.MITOL_API_BASE_URL = "https://api.example.com"
+    settings.APP_BASE_URL = "https://learn.example.com"
     mock_send_email = mocker.patch("profiles.utils.send_email")
     user = UserFactory.create(profile__email_optin=True)
 
     send_template_email(
         user,
         "Test",
-        "email/welcome_email.html",
+        "email/email_base.html",
         context={"display_name": "Test"},
         is_transactional=False,
     )
 
     mock_send_email.assert_called_once()
+    # The List-Unsubscribe header URL is still API-rooted (RFC 8058 one-click)
     call_kwargs = mock_send_email.call_args.kwargs
     assert call_kwargs["unsubscribe_url"]
+    assert call_kwargs["unsubscribe_url"].startswith("https://api.example.com")
     # The UUID is embedded in the signed token but should not be a standalone path segment
-    from urllib.parse import urlparse
-
     segments = urlparse(call_kwargs["unsubscribe_url"]).path.strip("/").split("/")
     assert str(user.unsubscribe_uuid) not in segments
+
+    # The footer link rendered into the email body points at the frontend page
+    html_content = mock_send_email.call_args.args[2]
+    assert "https://learn.example.com/unsubscribe?" in html_content
+    assert "https://api.example.com" not in html_content
 
 
 @pytest.mark.django_db

--- a/users/api.py
+++ b/users/api.py
@@ -1,0 +1,36 @@
+"""Users API"""
+
+import logging
+
+from django.contrib.auth import get_user_model
+from django.db import transaction
+from keycloak.exceptions import KeycloakError
+
+from profiles.api import sync_email_optin_to_keycloak
+from users.utils import unsign_unsubscribe_token
+
+log = logging.getLogger(__name__)
+User = get_user_model()
+
+
+def unsubscribe(token) -> bool:
+    """Unsubscribe the user identified by token.
+
+    Returns True on success, False if token is invalid/expired/unknown.
+    """
+    uuid_str = unsign_unsubscribe_token(token)
+    if not uuid_str:
+        return False
+    user = User.objects.filter(unsubscribe_uuid=uuid_str).first()
+    if not user:
+        return False
+    profile = user.profile
+    try:
+        with transaction.atomic():
+            sync_email_optin_to_keycloak(user, email_optin=False)
+            profile.email_optin = False
+            profile.save(update_fields=["email_optin"])
+    except KeycloakError:
+        log.exception("Failed to sync email_optin to Keycloak for user %s", user.id)
+        return False
+    return True

--- a/users/api_test.py
+++ b/users/api_test.py
@@ -1,0 +1,71 @@
+"""Tests for users.api"""
+
+import uuid
+
+import pytest
+from keycloak.exceptions import KeycloakError
+
+from main.factories import UserFactory
+from users.api import unsubscribe
+from users.utils import _get_unsubscribe_signer
+
+
+def _make_token(uuid_str):
+    return _get_unsubscribe_signer().sign(uuid_str)
+
+
+@pytest.mark.django_db
+def test_unsubscribe_valid_token_returns_true(mocker):
+    """Valid token unsubscribes the user and returns True."""
+    sync_mock = mocker.patch("users.api.sync_email_optin_to_keycloak")
+    user = UserFactory.create()
+    user.profile.email_optin = True
+    user.profile.save()
+
+    token = _make_token(str(user.unsubscribe_uuid))
+
+    assert unsubscribe(token) is True
+    user.profile.refresh_from_db()
+    assert user.profile.email_optin is False
+    sync_mock.assert_called_once_with(user, email_optin=False)
+
+
+@pytest.mark.django_db
+def test_unsubscribe_keycloak_sync_failure_returns_false(mocker):
+    """A Keycloak sync failure returns False and does not update the profile."""
+    mocker.patch(
+        "users.api.sync_email_optin_to_keycloak",
+        side_effect=KeycloakError("boom"),
+    )
+    user = UserFactory.create()
+    user.profile.email_optin = True
+    user.profile.save()
+
+    token = _make_token(str(user.unsubscribe_uuid))
+
+    assert unsubscribe(token) is False
+    user.profile.refresh_from_db()
+    assert user.profile.email_optin is True
+
+
+@pytest.mark.django_db
+def test_unsubscribe_invalid_token_returns_false():
+    """Invalid token returns False."""
+    assert unsubscribe("totally-invalid") is False
+
+
+@pytest.mark.django_db
+def test_unsubscribe_unknown_uuid_returns_false():
+    """Valid signature but unknown UUID returns False."""
+    token = _make_token(str(uuid.uuid4()))
+    assert unsubscribe(token) is False
+
+
+@pytest.mark.django_db
+def test_unsubscribe_expired_token_returns_false(settings):
+    """Expired token returns False."""
+    settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS = 0
+    user = UserFactory.create()
+    token = _make_token(str(user.unsubscribe_uuid))
+
+    assert unsubscribe(token) is False

--- a/users/api_test.py
+++ b/users/api_test.py
@@ -62,10 +62,15 @@ def test_unsubscribe_unknown_uuid_returns_false():
 
 
 @pytest.mark.django_db
-def test_unsubscribe_expired_token_returns_false(settings):
-    """Expired token returns False."""
+def test_unsubscribe_old_token_still_succeeds(mocker, settings):
+    """A token does not expire, regardless of MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS."""
+    mocker.patch("users.api.sync_email_optin_to_keycloak")
     settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS = 0
     user = UserFactory.create()
+    user.profile.email_optin = True
+    user.profile.save()
     token = _make_token(str(user.unsubscribe_uuid))
 
-    assert unsubscribe(token) is False
+    assert unsubscribe(token) is True
+    user.profile.refresh_from_db()
+    assert user.profile.email_optin is False

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,5 +1,7 @@
 """Users utilities"""
 
+from urllib.parse import urlencode
+
 from django.conf import settings
 from django.core import signing
 from django.core.exceptions import ImproperlyConfigured
@@ -22,6 +24,14 @@ def generate_unsubscribe_url(user) -> str:
     token = _get_unsubscribe_signer().sign(uuid_str)
     path = reverse("users:v1:unsubscribe", kwargs={"token": token})
     return f"{settings.MITOL_API_BASE_URL}{path}"
+
+
+def generate_unsubscribe_frontend_url(user) -> str:
+    """Return the frontend unsubscribe URL, matching UnsubscribeView.get's redirect."""
+    uuid_str = str(user.get_or_generate_unsubscribe_uuid())
+    token = _get_unsubscribe_signer().sign(uuid_str)
+    params = urlencode({"token": token})
+    return f"{settings.APP_BASE_URL}/unsubscribe?{params}"
 
 
 def unsign_unsubscribe_token(token: str) -> str | None:

--- a/users/utils.py
+++ b/users/utils.py
@@ -35,10 +35,8 @@ def generate_unsubscribe_frontend_url(user) -> str:
 
 
 def unsign_unsubscribe_token(token: str) -> str | None:
-    """Unsign and return the UUID string, or None if invalid/expired."""
+    """Unsign and return the UUID string, or None if invalid."""
     try:
-        return _get_unsubscribe_signer().unsign(
-            token, max_age=settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS
-        )
+        return _get_unsubscribe_signer().unsign(token)
     except signing.BadSignature:
         return None

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -90,10 +90,10 @@ def test_unsign_unsubscribe_token_invalid():
 
 
 @pytest.mark.django_db
-def test_unsign_unsubscribe_token_expired(settings):
-    """unsign_unsubscribe_token returns None for an expired token."""
+def test_unsign_unsubscribe_token_does_not_expire(settings):
+    """unsign_unsubscribe_token ignores MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS."""
     settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS = 0
     user = UserFactory.create()
     uuid_str = str(user.unsubscribe_uuid)
     token = _get_unsubscribe_signer().sign(uuid_str)
-    assert unsign_unsubscribe_token(token) is None
+    assert unsign_unsubscribe_token(token) == uuid_str

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -5,6 +5,7 @@ import pytest
 from main.factories import UserFactory
 from users.utils import (
     _get_unsubscribe_signer,
+    generate_unsubscribe_frontend_url,
     generate_unsubscribe_url,
     unsign_unsubscribe_token,
 )
@@ -42,6 +43,29 @@ def test_generate_unsubscribe_url_token_can_recover_uuid(settings):
     url = generate_unsubscribe_url(user)
     # token is the last non-empty path segment
     token = url.rstrip("/").rsplit("/", 1)[-1]
+    recovered = unsign_unsubscribe_token(token)
+    assert recovered == str(user.unsubscribe_uuid)
+
+
+@pytest.mark.django_db
+def test_generate_unsubscribe_frontend_url_rooted_at_app_base(settings):
+    """generate_unsubscribe_frontend_url should use APP_BASE_URL as the base."""
+    settings.APP_BASE_URL = "https://learn.example.com"
+    user = UserFactory.create()
+    url = generate_unsubscribe_frontend_url(user)
+    assert url.startswith("https://learn.example.com/unsubscribe?")
+
+
+@pytest.mark.django_db
+def test_generate_unsubscribe_frontend_url_token_can_recover_uuid(settings):
+    """The token in the frontend URL should unsign to the original UUID."""
+    settings.APP_BASE_URL = "https://learn.example.com"
+    user = UserFactory.create()
+    url = generate_unsubscribe_frontend_url(user)
+    from urllib.parse import parse_qs, urlparse
+
+    query = parse_qs(urlparse(url).query)
+    token = query["token"][0]
     recovered = unsign_unsubscribe_token(token)
     assert recovered == str(user.unsubscribe_uuid)
 

--- a/users/views.py
+++ b/users/views.py
@@ -50,10 +50,8 @@ class UnsubscribeView(APIView):
 
     @extend_schema(exclude=True)
     def get(self, request, token):  # noqa: ARG002
-        if not self._unsubscribe(token):
-            params = urlencode({"error_code": "invalid_token"})
-            return redirect(f"{settings.APP_BASE_URL}/unsubscribed?{params}")
-        return redirect(f"{settings.APP_BASE_URL}/unsubscribed")
+        params = urlencode({"token": token})
+        return redirect(f"{settings.APP_BASE_URL}/unsubscribe?{params}")
 
     @extend_schema(
         summary="One-click unsubscribe (RFC 8058)",

--- a/users/views.py
+++ b/users/views.py
@@ -1,23 +1,15 @@
 """Users views"""
 
-import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
-from django.db import transaction
 from django.shortcuts import redirect
 from drf_spectacular.utils import OpenApiResponse, extend_schema
-from keycloak.exceptions import KeycloakError
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from profiles.api import sync_email_optin_to_keycloak
-from users.utils import unsign_unsubscribe_token
-
-log = logging.getLogger(__name__)
-User = get_user_model()
+from users.api import unsubscribe
 
 
 class UnsubscribeView(APIView):
@@ -25,28 +17,6 @@ class UnsubscribeView(APIView):
 
     permission_classes = []
     authentication_classes = []
-
-    def _unsubscribe(self, token) -> bool:
-        """Unsubscribe the user identified by token.
-
-        Returns True on success, False if token is invalid/expired/unknown.
-        """
-        uuid_str = unsign_unsubscribe_token(token)
-        if not uuid_str:
-            return False
-        user = User.objects.filter(unsubscribe_uuid=uuid_str).first()
-        if not user:
-            return False
-        profile = user.profile
-        try:
-            with transaction.atomic():
-                sync_email_optin_to_keycloak(user, email_optin=False)
-                profile.email_optin = False
-                profile.save(update_fields=["email_optin"])
-        except KeycloakError:
-            log.exception("Failed to sync email_optin to Keycloak for user %s", user.id)
-            return False
-        return True
 
     @extend_schema(exclude=True)
     def get(self, request, token):  # noqa: ARG002
@@ -71,7 +41,7 @@ class UnsubscribeView(APIView):
         },
     )
     def post(self, request, token):  # noqa: ARG002
-        if not self._unsubscribe(token):
+        if not unsubscribe(token):
             return Response(
                 {"error": "Invalid or expired token"},
                 status=status.HTTP_400_BAD_REQUEST,

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 
 import pytest
 from django.urls import reverse
-from keycloak.exceptions import KeycloakError
 
 from main.factories import UserFactory
 from users.utils import _get_unsubscribe_signer
@@ -27,7 +26,7 @@ def _unsubscribe_url(token):
 def test_unsubscribe_get_redirects_to_frontend_with_token(mocker, client, settings):
     """GET redirects to the frontend confirmation page with the token, without unsubscribing."""
     settings.APP_BASE_URL = "https://learn.example.com"
-    sync_mock = mocker.patch("users.views.sync_email_optin_to_keycloak")
+    unsubscribe_mock = mocker.patch("users.views.unsubscribe")
     user = UserFactory.create()
     user.profile.email_optin = True
     user.profile.save()
@@ -38,9 +37,7 @@ def test_unsubscribe_get_redirects_to_frontend_with_token(mocker, client, settin
     assert resp.status_code == 302
     params = urlencode({"token": token})
     assert resp["Location"] == f"https://learn.example.com/unsubscribe?{params}"
-    user.profile.refresh_from_db()
-    assert user.profile.email_optin is True
-    sync_mock.assert_not_called()
+    unsubscribe_mock.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -58,72 +55,30 @@ def test_unsubscribe_get_invalid_token_redirects_with_token_anyway(client, setti
 
 # ---------------------------------------------------------------------------
 # POST tests (RFC 8058 one-click — returns JSON)
+#
+# The view just delegates to users.api.unsubscribe(), so these tests mock
+# that function and assert the view's response handling. The unsubscribe
+# logic itself is tested in users/api_test.py.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_unsubscribe_post_valid_token_returns_200(mocker, client):
-    """Valid token returns 200 and sets email_optin=False."""
-    sync_mock = mocker.patch("users.views.sync_email_optin_to_keycloak")
-    user = UserFactory.create()
-    user.profile.email_optin = True
-    user.profile.save()
-
-    token = _make_token(str(user.unsubscribe_uuid))
+def test_unsubscribe_post_success_returns_200(mocker, client):
+    """When users.api.unsubscribe() succeeds, POST returns 200."""
+    mocker.patch("users.views.unsubscribe", return_value=True)
+    token = _make_token("some-uuid")
     resp = client.post(_unsubscribe_url(token))
 
     assert resp.status_code == 200
-    user.profile.refresh_from_db()
-    assert user.profile.email_optin is False
-    sync_mock.assert_called_once_with(user, email_optin=False)
+    assert resp.json() == {}
 
 
 @pytest.mark.django_db
-def test_unsubscribe_post_keycloak_sync_failure_returns_400(mocker, client):
-    """A Keycloak sync failure returns 400 and does not update the profile."""
-    mocker.patch(
-        "users.views.sync_email_optin_to_keycloak",
-        side_effect=KeycloakError("boom"),
-    )
-    user = UserFactory.create()
-    user.profile.email_optin = True
-    user.profile.save()
-
-    token = _make_token(str(user.unsubscribe_uuid))
+def test_unsubscribe_post_failure_returns_400(mocker, client):
+    """When users.api.unsubscribe() fails, POST returns 400."""
+    mocker.patch("users.views.unsubscribe", return_value=False)
+    token = _make_token("some-uuid")
     resp = client.post(_unsubscribe_url(token))
-
-    assert resp.status_code == 400
-    user.profile.refresh_from_db()
-    assert user.profile.email_optin is True
-
-
-@pytest.mark.django_db
-def test_unsubscribe_post_invalid_token_returns_400(client):
-    """Invalid token returns 400."""
-    resp = client.post(_unsubscribe_url("totally-invalid"))
 
     assert resp.status_code == 400
     assert resp.json() == {"error": "Invalid or expired token"}
-
-
-@pytest.mark.django_db
-def test_unsubscribe_post_unknown_uuid_returns_400(client):
-    """Valid signature but unknown UUID returns 400."""
-    import uuid
-
-    token = _make_token(str(uuid.uuid4()))
-    resp = client.post(_unsubscribe_url(token))
-
-    assert resp.status_code == 400
-
-
-@pytest.mark.django_db
-def test_unsubscribe_post_expired_token_returns_400(client, settings):
-    """Expired token returns 400."""
-    settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS = 0
-    user = UserFactory.create()
-    token = _make_token(str(user.unsubscribe_uuid))
-
-    resp = client.post(_unsubscribe_url(token))
-
-    assert resp.status_code == 400

--- a/users/views_test.py
+++ b/users/views_test.py
@@ -1,5 +1,7 @@
 """Tests for users.views"""
 
+from urllib.parse import urlencode
+
 import pytest
 from django.urls import reverse
 from keycloak.exceptions import KeycloakError
@@ -17,13 +19,13 @@ def _unsubscribe_url(token):
 
 
 # ---------------------------------------------------------------------------
-# GET tests (always redirect)
+# GET tests (never unsubscribes, just hands the token to the frontend)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_unsubscribe_get_valid_token_redirects_to_success(mocker, client, settings):
-    """Valid token redirects to /unsubscribed and sets email_optin=False."""
+def test_unsubscribe_get_redirects_to_frontend_with_token(mocker, client, settings):
+    """GET redirects to the frontend confirmation page with the token, without unsubscribing."""
     settings.APP_BASE_URL = "https://learn.example.com"
     sync_mock = mocker.patch("users.views.sync_email_optin_to_keycloak")
     user = UserFactory.create()
@@ -34,77 +36,23 @@ def test_unsubscribe_get_valid_token_redirects_to_success(mocker, client, settin
     resp = client.get(_unsubscribe_url(token))
 
     assert resp.status_code == 302
-    assert resp["Location"] == "https://learn.example.com/unsubscribed"
-    user.profile.refresh_from_db()
-    assert user.profile.email_optin is False
-    sync_mock.assert_called_once_with(user, email_optin=False)
-
-
-@pytest.mark.django_db
-def test_unsubscribe_get_keycloak_sync_failure_redirects_with_error(
-    mocker, client, settings
-):
-    """A Keycloak sync failure redirects with an error and does not update the profile."""
-    settings.APP_BASE_URL = "https://learn.example.com"
-    mocker.patch(
-        "users.views.sync_email_optin_to_keycloak",
-        side_effect=KeycloakError("boom"),
-    )
-    user = UserFactory.create()
-    user.profile.email_optin = True
-    user.profile.save()
-
-    token = _make_token(str(user.unsubscribe_uuid))
-    resp = client.get(_unsubscribe_url(token))
-
-    assert resp.status_code == 302
-    assert resp["Location"] == (
-        "https://learn.example.com/unsubscribed?error_code=invalid_token"
-    )
+    params = urlencode({"token": token})
+    assert resp["Location"] == f"https://learn.example.com/unsubscribe?{params}"
     user.profile.refresh_from_db()
     assert user.profile.email_optin is True
+    sync_mock.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_unsubscribe_get_invalid_token_redirects_with_error(client, settings):
-    """Invalid token redirects to /unsubscribed?error_code=invalid_token."""
+def test_unsubscribe_get_invalid_token_redirects_with_token_anyway(client, settings):
+    """GET redirects with the token even when it's invalid, since GET never validates it."""
     settings.APP_BASE_URL = "https://learn.example.com"
     resp = client.get(_unsubscribe_url("totally-invalid"))
 
     assert resp.status_code == 302
-    assert resp["Location"] == (
-        "https://learn.example.com/unsubscribed?error_code=invalid_token"
-    )
-
-
-@pytest.mark.django_db
-def test_unsubscribe_get_unknown_uuid_redirects_with_error(client, settings):
-    """Valid signature but unknown UUID redirects with error_code."""
-    settings.APP_BASE_URL = "https://learn.example.com"
-    import uuid
-
-    token = _make_token(str(uuid.uuid4()))
-    resp = client.get(_unsubscribe_url(token))
-
-    assert resp.status_code == 302
-    assert resp["Location"] == (
-        "https://learn.example.com/unsubscribed?error_code=invalid_token"
-    )
-
-
-@pytest.mark.django_db
-def test_unsubscribe_get_expired_token_redirects_with_error(client, settings):
-    """Expired token redirects with error_code."""
-    settings.APP_BASE_URL = "https://learn.example.com"
-    settings.MITOL_UNSUBSCRIBE_TOKEN_MAX_AGE_SECONDS = 0
-    user = UserFactory.create()
-    token = _make_token(str(user.unsubscribe_uuid))
-
-    resp = client.get(_unsubscribe_url(token))
-
-    assert resp.status_code == 302
-    assert resp["Location"] == (
-        "https://learn.example.com/unsubscribed?error_code=invalid_token"
+    assert (
+        resp["Location"]
+        == "https://learn.example.com/unsubscribe?token=totally-invalid"
     )
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3350,6 +3350,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mitodl/mit-learn-api-axios@npm:2026.7.22":
+  version: 2026.7.22
+  resolution: "@mitodl/mit-learn-api-axios@npm:2026.7.22"
+  dependencies:
+    "@types/node": "npm:^22.0.0"
+    axios: "npm:^1.6.5"
+  checksum: 10/99c0084be726316cfb5ee9ac288f77a84fd594dfd96800b5d99873335047a80bea0a95a9d687e8ab1c3589e8809de01c274262619b5807dd5df83f8f4e6dfc4b
+  languageName: node
+  linkType: hard
+
 "@mitodl/mit-learn-api-axios@npm:^2026.3.4":
   version: 2026.3.4
   resolution: "@mitodl/mit-learn-api-axios@npm:2026.3.4"
@@ -9092,6 +9102,7 @@ __metadata:
   resolution: "api@workspace:frontends/api"
   dependencies:
     "@faker-js/faker": "npm:^10.0.0"
+    "@mitodl/mit-learn-api-axios": "npm:2026.7.22"
     "@mitodl/mitxonline-api-axios": "npm:2026.7.7"
     "@tanstack/react-query": "npm:^5.66.0"
     "@testing-library/react": "npm:^16.3.0"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/8424

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds one-click unsubscribe. It manifests in 2 ways:
1. Some email clients, particularly Gmail will present and Unsubscribe button at the top of the email that allows the user to unsubscribe without leaving their mail client. This happens via an HTTP post by the client in the background.
2. If a GET is performed against this URL, we redirect to the frontend with a confirmation to prevent any link crawling done by email clients from accidentally triggering an unsubscribe.
3. There is also a traditional unsubscribe link in the email footer which navigates the user to the frontend confirmation page.

I've also added a checkbox on the settings page that allows the user to opt out of emails without having to modify their subscriptions so they can put a non-destructive pause on these (and this is how the contactless unsubscribe works).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- You can send yourself a test email with `./manage.py send_test_email digest --count 3 --email EMAIL`.
- If you perform a POST request to the unsubscribe API url in the `List-Unsubscribe` header in the email, that should toggle your email_optin value to False.
- It should have an unsubscribe link at the bottom, clicking it should send you to a page to confirm the unsubscribe, clicking the button should perform the POST and toggle the email_optin value to false as well.
- Running the command again should not send the email.
- You should also be able to toggle the field value in the frontend on the settings page.

### Screenshots

<img width="1732" height="978" alt="Screenshot 2026-07-22 at 13-00-06 Unsubscribe MIT Learn" src="https://github.com/user-attachments/assets/d3291d78-9650-4222-890a-5e6634543878" />
<img width="1738" height="1125" alt="Screenshot 2026-07-22 at 12-59-58 Unsubscribe MIT Learn" src="https://github.com/user-attachments/assets/90daf935-ac53-48c5-9de6-57f7aae889be" />


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>