### PR TITLE
Serialize new-resource embedding fan-out

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -433,9 +433,10 @@ def embed_new_learning_resources(self):
                 )
             ]
         )
-    embed_tasks = celery.group(tasks)
-
-    return self.replace(embed_tasks)
+    # Dispatch chunks sequentially instead of materializing the whole lookback
+    # window as one group. This bounds broker queue depth and prevents KEDA from
+    # scaling the embeddings worker fleet for a short-lived fan-out burst.
+    return _replace_with_chain(self, tasks)
 
 
 @app.task(bind=True)

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -235,11 +235,26 @@ def test_embed_new_learning_resources(mocker, mocked_celery):
 
     with pytest.raises(mocked_celery.replace_exception_class):
         embed_new_learning_resources.delay()
-    list(mocked_celery.group.call_args[0][0])
 
     assert generate_embeddings_mock.si.call_count == 1
+    embedding_signature = generate_embeddings_mock.si.return_value
+    mocked_celery.chain.assert_called_once_with(embedding_signature)
+    mocked_celery.group.assert_not_called()
+    assert mocked_celery.replace.call_args[0][1] == mocked_celery.chain.return_value
     embedded_ids = generate_embeddings_mock.si.mock_calls[0].args[0]
     assert sorted(new_resource_ids) == sorted(embedded_ids)
+
+
+def test_embed_new_learning_resources_no_work(mocker, mocked_celery):
+    """embed_new_learning_resources should not dispatch an empty canvas"""
+    settings.QDRANT_EMBEDDINGS_TASK_LOOKBACK_WINDOW = 1
+    mocker.patch("vector_search.tasks.now_in_utc", return_value=now_in_utc())
+
+    assert embed_new_learning_resources.run() is None
+
+    mocked_celery.chain.assert_not_called()
+    mocked_celery.group.assert_not_called()
+    mocked_celery.replace.assert_not_called()
 
 
 def test_embed_new_content_files(mocker, mocked_celery):


### PR DESCRIPTION
### What are the relevant tickets?
Related: #3623 and #3639

### Description (What does it do?)
`embed_new_learning_resources` runs every 30 minutes and looks back across a wider window for newly created resources. It previously dispatched every Qdrant embedding chunk in that window as one `celery.group`, immediately materializing the entire fan-out on the shared Redis broker. That creates a short-lived queue-depth burst, prompts KEDA to scale the embeddings worker fleet aggressively, and adds avoidable broker CPU pressure.

This changes the task to use the existing `_replace_with_chain` helper, dispatching one embedding chunk at a time. The full-catalog and by-ID embedding entrypoints already use this pattern following #3484, where sequential chains were introduced specifically to prevent large embedding workloads from overwhelming Qdrant.

The no-work path now completes directly instead of replacing the task with an empty group.

This is independent of #3639: that PR bounds OpenSearch reindex chords while preserving parallel batches and aggregate results; embedding chunks do not require chord result aggregation, so the existing sequential-chain mechanism is simpler and avoids chord bookkeeping entirely.

### How can this be tested?
- Run `pytest vector_search/tasks_test.py` (44 passed locally).
- The updated test verifies the task creates a chain, does not create a group, and preserves the generated resource IDs.
- A new test verifies an empty lookback window does not dispatch an empty canvas.
- Pre-commit passes for both changed files.

For operational validation, observe the `embeddings` Celery queue during the next scheduled run: queue depth should no longer jump by the full number of lookback chunks at once, and KEDA should not scale the worker deployment solely for that fan-out burst.

### Additional Context
This deliberately trades parallelism for bounded pressure, matching the existing Qdrant protection strategy used by `start_embed_resources`, `embed_learning_resources_by_id`, and content-file embedding tasks.
