### PR TITLE
Preserve run.checksum when unpublishing runs during ETL prune

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -602,7 +602,6 @@ def load_course(
                 | Q(learning_resource__test_mode=True)
             ).filter(published=True):
                 run.published = False
-                run.checksum = None
                 run.save()
                 resource_run_unpublished_actions(run)
 
@@ -744,7 +743,6 @@ def load_program(
                 | Q(learning_resource__test_mode=True)
             ).filter(published=True):
                 run.published = False
-                run.checksum = None
                 run.save()
 
         load_run_dependent_values(learning_resource)

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -699,8 +699,12 @@ def test_load_course_bad_platform(mocker):
     )
 
 
-def test_load_course_prune_clears_checksum_on_unpublished_runs():
-    """Runs pruned from course data should have checksum reset."""
+def test_load_course_prune_preserves_checksum_on_unpublished_runs():
+    """
+    Runs pruned from course data are unpublished but KEEP their checksum, so a
+    later re-ingest of the same (unchanged) archive is skipped by the archive
+    guard instead of needlessly re-ingesting and re-embedding.
+    """
     platform = LearningResourcePlatformFactory.create()
     course = CourseFactory.create(
         learning_resource__runs=[],
@@ -746,7 +750,8 @@ def test_load_course_prune_clears_checksum_on_unpublished_runs():
     assert retained_run.published is True
     assert retained_run.checksum == "retain_checksum"
     assert pruned_run.published is False
-    assert pruned_run.checksum is None
+    # checksum is preserved (not nulled) so an unchanged archive re-ingest is skipped
+    assert pruned_run.checksum == "pruned_checksum"
 
 
 @pytest.mark.parametrize("course_exists", [True, False])

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -754,6 +754,62 @@ def test_load_course_prune_preserves_checksum_on_unpublished_runs():
     assert pruned_run.checksum == "pruned_checksum"
 
 
+def test_load_program_prune_preserves_checksum_on_unpublished_runs():
+    """
+    Runs pruned from program data are unpublished but KEEP their checksum, mirroring
+    the course prune path, so a later re-ingest of the same (unchanged) archive is
+    skipped by the archive guard instead of needlessly re-ingesting.
+    """
+    platform = LearningResourcePlatformFactory.create()
+    program = ProgramFactory.create(courses=[], platform=platform.code)
+    learning_resource = program.learning_resource
+    learning_resource.runs.set([])
+
+    retained_run = LearningResourceRunFactory.create(
+        learning_resource=learning_resource,
+        published=True,
+        checksum="retain_checksum",
+    )
+    pruned_run = LearningResourceRunFactory.create(
+        learning_resource=learning_resource,
+        published=True,
+        checksum="pruned_checksum",
+    )
+
+    load_program(
+        {
+            "platform": platform.code,
+            "readable_id": learning_resource.readable_id,
+            "professional": False,
+            "title": learning_resource.title,
+            "url": learning_resource.url,
+            "image": {"url": learning_resource.image.url},
+            "published": True,
+            "availability": learning_resource.availability,
+            "runs": [
+                {
+                    "run_id": retained_run.run_id,
+                    "enrollment_start": retained_run.enrollment_start,
+                    "start_date": retained_run.start_date,
+                    "end_date": retained_run.end_date,
+                    "prices": [],
+                }
+            ],
+            "courses": [],
+        },
+        [],
+        [],
+    )
+
+    retained_run.refresh_from_db()
+    pruned_run.refresh_from_db()
+    assert retained_run.published is True
+    assert retained_run.checksum == "retain_checksum"
+    assert pruned_run.published is False
+    # checksum is preserved (not nulled) so an unchanged archive re-ingest is skipped
+    assert pruned_run.checksum == "pruned_checksum"
+
+
 @pytest.mark.parametrize("course_exists", [True, False])
 @pytest.mark.parametrize("course_id_is_duplicate", [True, False])
 @pytest.mark.parametrize("duplicate_course_exists", [True, False])


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#12452

### Description (What does it do?)

Nulling `run.checksum` on prune-unpublish defeats the archive-level checksum guard in `process_course_archive`: the next ingest of a byte-identical archive re-ingests and re-embeds **all** of the run's content files instead of being skipped. Production logs show ~800 runs re-ingesting identical archives nightly for exactly this reason — the single largest source of avoidable content-file embedding load on Celery, Redis, and Qdrant.

This PR removes the two `run.checksum = None` lines from the `load_course` and `load_program` prune-unpublish blocks. The run is still unpublished (`published = False`); it just keeps its checksum, so the guard skips a subsequent unchanged re-ingest and still re-ingests a genuinely changed archive (checksum differs).

### How can this be tested?

1. Unit: `docker compose run --rm web uv run pytest learning_resources/etl/loaders_test.py -k preserves_checksum -v` — covers both the course and program prune paths.
2. Shell (confirms the prune loop no longer nulls the checksum on a real run):
   ```python
   from learning_resources.models import LearningResourceRun
   from learning_resources.utils import resource_run_unpublished_actions
   r = LearningResourceRun.objects.exclude(checksum="").filter(published=True).first()
   before = r.checksum
   r.published = False
   r.save()
   resource_run_unpublished_actions(r)
   r.refresh_from_db()
   assert r.checksum == before, "checksum was nulled"
   ```
3. End-to-end (needs the ETL stack: `COURSE_ARCHIVE_BUCKET_NAME`, `tika`, `opensearch`, `qdrant`): ingest a source, then re-run the same ingest — the second pass logs `Checksums match … skipping load` for unchanged runs and dispatches no `embed_run_content_files`.

### Additional Context

Risk is minimal — the change only affects the prune-unpublish path; a genuinely changed archive still re-ingests because its checksum differs. First in a series of PRs reducing content-file embedding load (see mitodl/hq#12453, mitodl/hq#12454).
