### PR TITLE
Expire orphaned Celery event queues in Redis

### DIFF
--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -216,6 +216,11 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
 CELERY_TASK_TASK_TRACK_STARTED = True
 CELERY_TASK_SEND_SENT_EVENT = True
+# Expire orphaned per-consumer event queues so celeryev traffic does not
+# accumulate unbounded in Redis when an event consumer (Flower, `celery events`,
+# or a worker started with -E) disconnects without deregistering.
+CELERY_EVENT_QUEUE_EXPIRES = get_int("CELERY_EVENT_QUEUE_EXPIRES", 60)
+CELERY_EVENT_QUEUE_TTL = get_int("CELERY_EVENT_QUEUE_TTL", 5)
 CELERY_RATE_LIMIT = get_string("CELERY_DEFAULT_RATE_LIMIT", "600/m")
 CELERY_SEARCH_RATE_LIMIT = get_string("CELERY_SEARCH_RATE_LIMIT", CELERY_RATE_LIMIT)
 CELERY_VECTOR_SEARCH_RATE_LIMIT = get_string(

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -214,7 +214,6 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
-CELERY_TASK_TASK_TRACK_STARTED = True
 CELERY_TASK_SEND_SENT_EVENT = True
 # Expire orphaned per-consumer event queues so celeryev traffic does not
 # accumulate unbounded in Redis when an event consumer (Flower, `celery events`,


### PR DESCRIPTION
### What are the relevant tickets?

Partially addresses mitodl/hq#12442 (Parts 2 and 3)

### Description (What does it do?)

Follow-on to #3625 (which bounded `CELERY_RESULT_EXPIRES`). That PR handled the ~1.4M `celery-task-meta-*` result-key backlog; this handles the other half of the ~21 GB Redis-memory incident — the ~10k orphaned `celeryev.*` event queues that accumulate because dead event consumers never deregister and we never set expiry.

**Part 2 — expire orphaned event queues:**
- `CELERY_EVENT_QUEUE_EXPIRES=60` — drop a consumer's queue 60s after it disconnects.
- `CELERY_EVENT_QUEUE_TTL=5` — individual events expire after 5s.

**Part 3 — reduce event volume at the source:**

The audit asked whether anything consumes our Celery events before removing the event settings. It does: **Leek** (`celery-monitoring.odl.mit.edu`, CI/QA/Prod) subscribes to mit-learn's broker on the `celeryev` exchange, and the team uses it to watch queued/started/completed/failed tasks. So the event stream stays:
- `-E` / `worker_send_task_events` stays — it drives the `task-started`/`succeeded`/`failed` events (started/completed/failed views + failure tracebacks).
- `CELERY_TASK_SEND_SENT_EVENT` stays — it drives the producer-side `task-sent` event, the only signal behind Leek's **queued** view.

What was removed is `CELERY_TASK_TASK_TRACK_STARTED`. It is **not** an event setting: it writes an extra `STARTED` state into the Redis result backend for every task. Verified against Celery 5.6.2 source that this is independent of the `task-started` monitoring event (that event is gated by `-E` in `worker/request.py`, not by `track_started`), and verified nothing in the codebase reads the STARTED result state (no `AsyncResult`/`.state`/`.ready()` consumers in Python, tests, or frontend). Removing it trims result-backend churn with zero loss of Leek visibility.

### How can this be tested?

1. Event-queue expiry settings wired into the app:
   ```
   docker compose run --rm web python manage.py shell -c \
     "from main.celery import app; print(app.conf.event_queue_expires, app.conf.event_queue_ttl)"
   ```
   Expect `60 5`. Env override works: `CELERY_EVENT_QUEUE_EXPIRES=120 docker compose run …` → `120`.
2. `track_started` is off:
   ```
   docker compose run --rm web python manage.py shell -c \
     "from main.celery import app; print(app.conf.task_track_started)"
   ```
   Expect `False`.
3. Monitoring unaffected: with `-E` and `CELERY_TASK_SEND_SENT_EVENT` still on, Leek continues to show queued/started/completed/failed tasks.

### Additional Context

The one-time `celeryev.*` unlink and the consumer-churn investigation described in the issue remain manual ops steps, not part of this PR. `CELERY_RESULT_EXPIRES` was in an earlier draft of this branch but already landed on main via #3625, so it is not duplicated here — main's 1h default stands.
