### PR TITLE
multiple enrollment display updates

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -70,14 +70,14 @@ const CardTypeText = styled(Typography)(({ theme }) => ({
 
 const TitleHeading = styled.h3(({ theme }) => ({
   margin: 0,
-  ...theme.typography.subtitle2,
+  ...theme.typography.subtitle1,
   [theme.breakpoints.down("sm")]: {
     maxWidth: "calc(100% - 16px)",
   },
 }))
 
 const TitleLink = styled(Link)(({ theme }) => ({
-  ...theme.typography.subtitle2,
+  ...theme.typography.subtitle1,
 }))
 
 const TitleText = styled.h3<{ clickable?: boolean }>(

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -129,7 +129,7 @@ const MenuButton = styled(ActionButton)<{
     },
 ])
 
-const COURSEWARE_BUTTON_WIDTH = "88px"
+const COURSEWARE_BUTTON_WIDTH = "80px"
 
 // Fixed-width column that keeps the courseware button (and countdown) aligned
 // in the compact (module row) layout.

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CardShared.tsx
@@ -83,7 +83,7 @@ const TitleLink = styled(Link)(({ theme }) => ({
 const TitleText = styled.h3<{ clickable?: boolean }>(
   ({ theme, clickable }) => ({
     margin: 0,
-    ...theme.typography.subtitle2,
+    ...theme.typography.subtitle1,
     color: theme.custom.colors.darkGray2,
     cursor: clickable ? "pointer" : "default",
     [theme.breakpoints.down("sm")]: {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -56,12 +56,6 @@ const RedEllipse = styled(Ellipse)(({ theme }) => ({
   backgroundColor: theme.custom.colors.red,
 }))
 
-const CountdownGroup = styled.span({
-  display: "inline-flex",
-  alignItems: "center",
-  whiteSpace: "nowrap",
-})
-
 const EnrolledTitleLink = styled(TitleLink)<{
   enrollmentstatus: EnrollmentStatus
 }>(({ enrollmentstatus, theme }) => ({
@@ -121,13 +115,13 @@ const UpgradeBanner: React.FC<
         {`Upgrade for certificate - ${formattedPrice}`}
       </SubtitleLink>
       {calendarDays !== null && (
-        <CountdownGroup>
+        <>
           <RedEllipse />
           <NoSSR>
             {/* This uses local time. */}
             {formatUpgradeTime(calendarDays)}
           </NoSSR>
-        </CountdownGroup>
+        </>
       )}
     </SubtitleLinkRoot>
   )
@@ -138,7 +132,7 @@ const EnrolledCardShell = styled.div(({ theme }) => ({
   borderRadius: "8px",
   overflow: "hidden",
   backgroundColor: theme.custom.colors.white,
-  [theme.breakpoints.down("sm")]: {
+  [theme.breakpoints.down("md")]: {
     display: "none",
   },
   '&[data-layout="compact"]': {
@@ -243,9 +237,7 @@ export const EnrolledCourseCard = ({
       </SubtitleLink>
     </>
   ) : null
-  const certStatus = certButton ? (
-    certButton
-  ) : showUpgradeBanner ? (
+  const certStatus = showUpgradeBanner ? (
     <UpgradeBanner
       data-testid="upgrade-root"
       canUpgrade={showUpgradeBanner}
@@ -269,7 +261,7 @@ export const EnrolledCourseCard = ({
 
   const endDateAndUpgradeSection =
     metaSegments.length > 0 ? (
-      <Stack direction="row" flexWrap="wrap" alignItems="center" gap="8px">
+      <Stack direction="row" alignItems="center" gap="12px">
         {metaSegments.map((segment, i) => (
           <React.Fragment key={i}>
             {i > 0 && <Ellipse />}
@@ -279,7 +271,7 @@ export const EnrolledCourseCard = ({
       </Stack>
     ) : null
   const titleSection = (
-    <Stack gap="12px" minWidth={0}>
+    <Stack gap="6px">
       {coursewareUrl ? (
         <TitleHeading as={headingLevel}>
           <EnrolledTitleLink
@@ -307,6 +299,7 @@ export const EnrolledCourseCard = ({
   const isCompleted =
     enrollmentStatus === EnrollmentStatus.Completed || courseHasEnded
   const buttonText = isCompleted ? "View" : "Continue"
+  const variant = isCompleted ? "secondary" : "primary"
   const compactVariant = isCompleted ? "text" : "primary"
   const ctaButton = isCompact ? (
     isDisabled ? (
@@ -333,7 +326,7 @@ export const EnrolledCourseCard = ({
   ) : isDisabled ? (
     <CoursewareButton
       size="small"
-      variant="primary"
+      variant={variant}
       disabled
       data-testid="courseware-button"
       aria-label={`${buttonText} course: ${title}`}
@@ -343,13 +336,31 @@ export const EnrolledCourseCard = ({
   ) : (
     <CoursewareButtonLink
       size="small"
-      variant="primary"
+      variant={variant}
       href={coursewareUrl ?? ""}
       data-testid="courseware-button"
       aria-label={`${buttonText} course: ${title}`}
     >
       {buttonText}
     </CoursewareButtonLink>
+  )
+  const buttonSection = isCompact ? (
+    <Stack direction="row" gap="8px" alignItems="center">
+      {certButton && (
+        <>
+          {certButton}
+          <Separator />
+        </>
+      )}
+      <CoursewareActionColumn direction="row" justifyContent="center">
+        {ctaButton}
+      </CoursewareActionColumn>
+    </Stack>
+  ) : (
+    <>
+      {certButton}
+      {ctaButton}
+    </>
   )
   const menuItems = []
   const readableId = run?.course.readable_id
@@ -363,6 +374,7 @@ export const EnrolledCourseCard = ({
       href: detailsUrl,
     })
   }
+
   menuItems.push(
     {
       className: "dashboard-card-menu-item",
@@ -384,11 +396,13 @@ export const EnrolledCourseCard = ({
       },
     },
   )
+
   const receiptMenuItem = getReceiptMenuItem(
     enrollment?.enrollment_mode,
     `/orders/receipt/by-run/${enrollment?.run.id}/`,
   )
   if (receiptMenuItem) menuItems.push(receiptMenuItem)
+
   const contextMenu = (
     <SimpleMenu
       items={menuItems}
@@ -405,23 +419,6 @@ export const EnrolledCourseCard = ({
       }
     />
   )
-  const buttonSection = isCompact ? (
-    <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
-      <CoursewareActionColumn
-        direction="row"
-        flexGrow={1}
-        justifyContent="center"
-      >
-        {ctaButton}
-        {contextMenu}
-      </CoursewareActionColumn>
-    </Stack>
-  ) : (
-    <Stack direction="row" flexGrow={1} gap="8px" alignItems="center">
-      {ctaButton}
-      {contextMenu}
-    </Stack>
-  )
 
   const progressBadgeSection =
     isModule && isCompact ? null : (
@@ -435,7 +432,6 @@ export const EnrolledCourseCard = ({
   const hasMultipleRuns = (siblingEnrollments?.length ?? 0) > 0
   const showEnrollmentStatusIcon =
     !isContractPageResource && isModule && isCompact
-  const statusIconAlignment = metaSegments.length > 0 ? "start" : "center"
 
   return (
     <>
@@ -463,6 +459,7 @@ export const EnrolledCourseCard = ({
             </Stack>
             <Stack direction="row" gap="8px" alignItems="center">
               {buttonSection}
+              {contextMenu}
             </Stack>
           </CardHeaderContent>
           <SiblingRunsAccordion
@@ -479,7 +476,7 @@ export const EnrolledCourseCard = ({
           layout={layout}
         >
           {showEnrollmentStatusIcon && (
-            <Stack alignSelf={statusIconAlignment}>
+            <Stack alignSelf="start">
               <EnrollmentStatusIcon status={enrollmentStatus} />
             </Stack>
           )}
@@ -489,6 +486,7 @@ export const EnrolledCourseCard = ({
           </Stack>
           <Stack direction="row" gap="8px" alignItems="center">
             {buttonSection}
+            {contextMenu}
           </Stack>
         </CardRoot>
       )}
@@ -499,43 +497,26 @@ export const EnrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        <Stack direction="row" gap="8px" alignItems="flex-start" width="100%">
-          {showEnrollmentStatusIcon && (
-            <Stack alignSelf={statusIconAlignment}>
-              <EnrollmentStatusIcon status={enrollmentStatus} />
-            </Stack>
-          )}
-          <Stack
-            direction="column"
-            gap="16px"
-            flex={1}
-            minWidth={0}
-            width="100%"
-          >
-            <Stack
-              direction="row"
-              justifyContent="space-between"
-              alignItems="stretch"
-              flex={1}
-              minWidth={0}
-              width="100%"
-            >
-              <Stack direction="column" gap="8px" flex={1} minWidth={0}>
-                {titleSection}
-              </Stack>
-            </Stack>
-            <Stack
-              direction="row"
-              flexGrow={1}
-              gap="8px"
-              alignItems="center"
-              justifyContent="flex-end"
-              minWidth={0}
-              width="100%"
-            >
-              {buttonSection}
-            </Stack>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="stretch"
+          flex={1}
+          width="100%"
+        >
+          <Stack direction="column" gap="8px" flex={1}>
+            {titleSection}
           </Stack>
+          {contextMenu}
+        </Stack>
+        <Stack
+          direction="row"
+          gap="8px"
+          alignItems="center"
+          justifyContent="flex-end"
+          width="100%"
+        >
+          {buttonSection}
         </Stack>
         {hasMultipleRuns && (
           <MobileAccordionWrapper>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -457,7 +457,7 @@ export const EnrolledCourseCard = ({
             </Stack>
             <Stack
               direction="column"
-              height="stretch"
+              alignSelf="stretch"
               gap="8px"
               alignItems="flex-end"
               justifyContent="space-between"

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -449,7 +449,7 @@ export const EnrolledCourseCard = ({
               </Stack>
             )}
             <Stack
-              gap="4px"
+              gap="8px"
               justifyContent="start"
               alignItems="stretch"
               flex={1}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -28,7 +28,7 @@ import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { RiArrowUpCircleLine, RiAwardLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
-import { SiblingRunsAccordion } from "./SiblingRunsAccordion"
+import { SiblingRunsPanel, SiblingRunsToggle } from "./SiblingRunsAccordion"
 import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import { mitxUserQueries } from "api/mitxonline-hooks/user"
 import { useQuery } from "@tanstack/react-query"
@@ -132,7 +132,7 @@ const EnrolledCardShell = styled.div(({ theme }) => ({
   borderRadius: "8px",
   overflow: "hidden",
   backgroundColor: theme.custom.colors.white,
-  [theme.breakpoints.down("md")]: {
+  [theme.breakpoints.down("sm")]: {
     display: "none",
   },
   '&[data-layout="compact"]': {
@@ -153,7 +153,7 @@ const EnrolledCardShell = styled.div(({ theme }) => ({
 }))
 
 const CardHeaderContent = styled.div({
-  padding: "16px 16px 0 16px",
+  padding: "16px",
   display: "flex",
   gap: "8px",
   alignItems: "center",
@@ -237,7 +237,9 @@ export const EnrolledCourseCard = ({
       </SubtitleLink>
     </>
   ) : null
-  const certStatus = showUpgradeBanner ? (
+  const certStatus = certButton ? (
+    certButton
+  ) : showUpgradeBanner ? (
     <UpgradeBanner
       data-testid="upgrade-root"
       canUpgrade={showUpgradeBanner}
@@ -346,21 +348,12 @@ export const EnrolledCourseCard = ({
   )
   const buttonSection = isCompact ? (
     <Stack direction="row" gap="8px" alignItems="center">
-      {certButton && (
-        <>
-          {certButton}
-          <Separator />
-        </>
-      )}
       <CoursewareActionColumn direction="row" justifyContent="center">
         {ctaButton}
       </CoursewareActionColumn>
     </Stack>
   ) : (
-    <>
-      {certButton}
-      {ctaButton}
-    </>
+    ctaButton
   )
   const menuItems = []
   const readableId = run?.course.readable_id
@@ -432,6 +425,11 @@ export const EnrolledCourseCard = ({
   const hasMultipleRuns = (siblingEnrollments?.length ?? 0) > 0
   const showEnrollmentStatusIcon =
     !isContractPageResource && isModule && isCompact
+  const runCount = (siblingEnrollments?.length ?? 0) + 1
+  const [runsExpanded, setRunsExpanded] = React.useState(false)
+  const toggleRunsExpanded = () => setRunsExpanded((v) => !v)
+  const desktopRunsPanelId = `sibling-runs-panel-desktop-${enrollment.id}`
+  const mobileRunsPanelId = `sibling-runs-panel-mobile-${enrollment.id}`
 
   return (
     <>
@@ -457,14 +455,30 @@ export const EnrolledCourseCard = ({
               {progressBadgeSection}
               {titleSection}
             </Stack>
-            <Stack direction="row" gap="8px" alignItems="center">
-              {buttonSection}
-              {contextMenu}
+            <Stack
+              direction="column"
+              height="stretch"
+              gap="8px"
+              alignItems="flex-end"
+              justifyContent="space-between"
+            >
+              <Stack direction="row" gap="8px" alignItems="center">
+                {buttonSection}
+                {contextMenu}
+              </Stack>
+              <SiblingRunsToggle
+                runCount={runCount}
+                expanded={runsExpanded}
+                onClick={toggleRunsExpanded}
+                controls={desktopRunsPanelId}
+              />
             </Stack>
           </CardHeaderContent>
-          <SiblingRunsAccordion
+          <SiblingRunsPanel
             enrollment={enrollment}
             siblingEnrollments={siblingEnrollments ?? []}
+            expanded={runsExpanded}
+            id={desktopRunsPanelId}
           />
         </EnrolledCardShell>
       ) : (
@@ -520,9 +534,19 @@ export const EnrolledCourseCard = ({
         </Stack>
         {hasMultipleRuns && (
           <MobileAccordionWrapper>
-            <SiblingRunsAccordion
+            <Stack direction="row" justifyContent="flex-end" width="100%">
+              <SiblingRunsToggle
+                runCount={runCount}
+                expanded={runsExpanded}
+                onClick={toggleRunsExpanded}
+                controls={mobileRunsPanelId}
+              />
+            </Stack>
+            <SiblingRunsPanel
               enrollment={enrollment}
               siblingEnrollments={siblingEnrollments ?? []}
+              expanded={runsExpanded}
+              id={mobileRunsPanelId}
             />
           </MobileAccordionWrapper>
         )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -430,6 +430,8 @@ export const EnrolledCourseCard = ({
   const toggleRunsExpanded = () => setRunsExpanded((v) => !v)
   const desktopRunsPanelId = `sibling-runs-panel-desktop-${enrollment.id}`
   const mobileRunsPanelId = `sibling-runs-panel-mobile-${enrollment.id}`
+  const desktopRunsToggleId = `sibling-runs-toggle-desktop-${enrollment.id}`
+  const mobileRunsToggleId = `sibling-runs-toggle-mobile-${enrollment.id}`
 
   return (
     <>
@@ -470,6 +472,7 @@ export const EnrolledCourseCard = ({
                 runCount={runCount}
                 expanded={runsExpanded}
                 onClick={toggleRunsExpanded}
+                id={desktopRunsToggleId}
                 controls={desktopRunsPanelId}
               />
             </Stack>
@@ -479,6 +482,7 @@ export const EnrolledCourseCard = ({
             siblingEnrollments={siblingEnrollments ?? []}
             expanded={runsExpanded}
             id={desktopRunsPanelId}
+            labelledBy={desktopRunsToggleId}
           />
         </EnrolledCardShell>
       ) : (
@@ -548,6 +552,7 @@ export const EnrolledCourseCard = ({
                 runCount={runCount}
                 expanded={runsExpanded}
                 onClick={toggleRunsExpanded}
+                id={mobileRunsToggleId}
                 controls={mobileRunsPanelId}
               />
             </Stack>
@@ -556,6 +561,7 @@ export const EnrolledCourseCard = ({
               siblingEnrollments={siblingEnrollments ?? []}
               expanded={runsExpanded}
               id={mobileRunsPanelId}
+              labelledBy={mobileRunsToggleId}
             />
           </MobileAccordionWrapper>
         )}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -511,26 +511,35 @@ export const EnrolledCourseCard = ({
         className={className}
         layout={layout}
       >
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="stretch"
-          flex={1}
-          width="100%"
-        >
-          <Stack direction="column" gap="8px" flex={1}>
-            {titleSection}
+        <Stack direction="row" gap="8px" alignItems="flex-start" width="100%">
+          {showEnrollmentStatusIcon && (
+            <Stack alignSelf="start">
+              <EnrollmentStatusIcon status={enrollmentStatus} />
+            </Stack>
+          )}
+          <Stack direction="column" gap="8px" flex={1} minWidth={0}>
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              alignItems="stretch"
+              flex={1}
+              width="100%"
+            >
+              <Stack direction="column" gap="8px" flex={1}>
+                {titleSection}
+              </Stack>
+              {contextMenu}
+            </Stack>
+            <Stack
+              direction="row"
+              gap="8px"
+              alignItems="center"
+              justifyContent="flex-end"
+              width="100%"
+            >
+              {buttonSection}
+            </Stack>
           </Stack>
-          {contextMenu}
-        </Stack>
-        <Stack
-          direction="row"
-          gap="8px"
-          alignItems="center"
-          justifyContent="flex-end"
-          width="100%"
-        >
-          {buttonSection}
         </Stack>
         {hasMultipleRuns && (
           <MobileAccordionWrapper>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -376,7 +376,7 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
   )
 
   const progressBadgeSection = (
-    <Stack direction="row" gap="4px" alignItems="center">
+    <Stack direction="row" gap="8px" alignItems="center">
       <ProgressBadge enrollmentStatus={programEnrollmentStatus} />
       <Separator />
       <CardTypeText>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentCard.tsx
@@ -148,7 +148,7 @@ export const ProgramEnrollmentCard = ({
   )
 
   const progressBadgeSection = (
-    <Stack direction="row" gap="4px" alignItems="center">
+    <Stack direction="row" gap="8px" alignItems="center">
       <ProgressBadge enrollmentStatus={enrollmentStatus} />
       <Separator />
       <CardTypeText>Program</CardTypeText>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
@@ -18,12 +18,13 @@ const BadgeContainer = styled("div")<{
 
   return {
     display: "flex",
-    width: "80px",
+    minWidth: "80px",
     padding: "4px 8px",
     borderRadius: "4px",
     justifyContent: "center",
     alignItems: "center",
     gap: "4px",
+    whiteSpace: "nowrap",
     backgroundColor,
     color,
   }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgressBadge.tsx
@@ -18,7 +18,7 @@ const BadgeContainer = styled("div")<{
 
   return {
     display: "flex",
-    width: "100px",
+    width: "80px",
     padding: "4px 8px",
     borderRadius: "4px",
     justifyContent: "center",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.test.tsx
@@ -3,23 +3,52 @@ import { renderWithProviders, screen, user } from "@/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 import moment from "moment"
-import { SiblingRunsAccordion } from "./SiblingRunsAccordion"
+import { SiblingRunsPanel, SiblingRunsToggle } from "./SiblingRunsAccordion"
 
 const makeEnrollment = (
   runOverrides: Record<string, unknown> = {},
 ): ReturnType<typeof mitxonline.factories.enrollment.courseEnrollment> =>
   mitxonline.factories.enrollment.courseEnrollment({ run: runOverrides })
 
+/**
+ * SiblingRunsToggle and SiblingRunsPanel are rendered in
+ * different parts of the card DOM (the toggle in the header, the panel
+ * below it) but share a single `expanded` state lifted to their parent.
+ * This harness reproduces that pairing for tests.
+ */
+const SiblingRunsAccordionHarness: React.FC<{
+  enrollment: ReturnType<typeof makeEnrollment>
+  siblingEnrollments: ReturnType<typeof makeEnrollment>[]
+}> = ({ enrollment, siblingEnrollments }) => {
+  const [expanded, setExpanded] = React.useState(false)
+  return (
+    <>
+      <SiblingRunsToggle
+        runCount={siblingEnrollments.length + 1}
+        expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        controls="panel"
+      />
+      <SiblingRunsPanel
+        enrollment={enrollment}
+        siblingEnrollments={siblingEnrollments}
+        expanded={expanded}
+        id="panel"
+      />
+    </>
+  )
+}
+
 const expandAccordion = async () => {
   await user.click(screen.getByRole("button", { name: /Course runs/ }))
 }
 
-describe("SiblingRunsAccordion", () => {
+describe("SiblingRunsToggle + SiblingRunsPanel", () => {
   test("shows 'Course runs (N)' where N is total runs including current", () => {
     const enrollment = makeEnrollment()
     const siblings = [makeEnrollment(), makeEnrollment()]
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={siblings}
       />,
@@ -32,7 +61,7 @@ describe("SiblingRunsAccordion", () => {
     const enrollment = makeEnrollment()
     const sibling = makeEnrollment()
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={[sibling]}
       />,
@@ -43,11 +72,11 @@ describe("SiblingRunsAccordion", () => {
     )
   })
 
-  test("clicking the summary expands the accordion", async () => {
+  test("clicking the toggle expands the panel", async () => {
     const enrollment = makeEnrollment()
     const sibling = makeEnrollment()
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={[sibling]}
       />,
@@ -59,6 +88,23 @@ describe("SiblingRunsAccordion", () => {
     )
   })
 
+  test("shows the current run above the sibling list once expanded", async () => {
+    const enrollment = makeEnrollment({
+      start_date: moment("2026-01-05").toISOString(),
+      end_date: moment("2026-08-20").toISOString(),
+    })
+    const sibling = makeEnrollment()
+    renderWithProviders(
+      <SiblingRunsAccordionHarness
+        enrollment={enrollment}
+        siblingEnrollments={[sibling]}
+      />,
+    )
+    await expandAccordion()
+    expect(await screen.findByText("Current run:")).toBeInTheDocument()
+    expect(screen.getByText(/Jan 5, 2026/)).toBeInTheDocument()
+  })
+
   test("each sibling with a courseware URL shows a 'View content' link after expanding", async () => {
     const urlA = faker.internet.url()
     const urlB = faker.internet.url()
@@ -66,9 +112,9 @@ describe("SiblingRunsAccordion", () => {
       makeEnrollment({ courseware_url: urlA }),
       makeEnrollment({ courseware_url: urlB }),
     ]
-    const enrollment = makeEnrollment()
+    const enrollment = makeEnrollment({ courseware_url: null })
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={siblings}
       />,
@@ -96,9 +142,9 @@ describe("SiblingRunsAccordion", () => {
         end_date: moment("2021-08-10").toISOString(),
       }),
     ]
-    const enrollment = makeEnrollment()
+    const enrollment = makeEnrollment({ courseware_url: null })
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={siblings}
       />,
@@ -122,9 +168,9 @@ describe("SiblingRunsAccordion", () => {
 
   test("siblings without a courseware URL do not get a 'View content' link", async () => {
     const sibling = makeEnrollment({ courseware_url: null })
-    const enrollment = makeEnrollment()
+    const enrollment = makeEnrollment({ courseware_url: null })
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={[sibling]}
       />,
@@ -143,7 +189,7 @@ describe("SiblingRunsAccordion", () => {
     })
     const enrollment = makeEnrollment()
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={[sibling]}
       />,
@@ -160,7 +206,7 @@ describe("SiblingRunsAccordion", () => {
     })
     const enrollment = makeEnrollment()
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={[sibling]}
       />,
@@ -177,9 +223,9 @@ describe("SiblingRunsAccordion", () => {
     const siblings = Array.from({ length: 4 }, () =>
       makeEnrollment({ courseware_url: faker.internet.url() }),
     )
-    const enrollment = makeEnrollment()
+    const enrollment = makeEnrollment({ courseware_url: null })
     renderWithProviders(
-      <SiblingRunsAccordion
+      <SiblingRunsAccordionHarness
         enrollment={enrollment}
         siblingEnrollments={siblings}
       />,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.test.tsx
@@ -27,6 +27,7 @@ const SiblingRunsAccordionHarness: React.FC<{
         runCount={siblingEnrollments.length + 1}
         expanded={expanded}
         onClick={() => setExpanded((v) => !v)}
+        id="toggle"
         controls="panel"
       />
       <SiblingRunsPanel
@@ -34,6 +35,7 @@ const SiblingRunsAccordionHarness: React.FC<{
         siblingEnrollments={siblingEnrollments}
         expanded={expanded}
         id="panel"
+        labelledBy="toggle"
       />
     </>
   )
@@ -70,6 +72,38 @@ describe("SiblingRunsToggle + SiblingRunsPanel", () => {
       "aria-expanded",
       "false",
     )
+  })
+
+  test("while collapsed, the panel's links are not present in the DOM", () => {
+    const enrollment = makeEnrollment()
+    const sibling = makeEnrollment({ courseware_url: faker.internet.url() })
+    renderWithProviders(
+      <SiblingRunsAccordionHarness
+        enrollment={enrollment}
+        siblingEnrollments={[sibling]}
+      />,
+    )
+    // Collapsed content must not be mounted at all (not just visually
+    // hidden), so keyboard/screen-reader users can't tab into a link that
+    // isn't visible.
+    expect(
+      screen.queryByRole("link", { name: /View content/ }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByRole("region")).not.toBeInTheDocument()
+  })
+
+  test("once expanded, the panel is exposed as a region labelled by the toggle", async () => {
+    const enrollment = makeEnrollment()
+    const sibling = makeEnrollment()
+    renderWithProviders(
+      <SiblingRunsAccordionHarness
+        enrollment={enrollment}
+        siblingEnrollments={[sibling]}
+      />,
+    )
+    await expandAccordion()
+    const region = await screen.findByRole("region")
+    expect(region).toHaveAttribute("aria-labelledby", "toggle")
   })
 
   test("clicking the toggle expands the panel", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
@@ -133,6 +133,8 @@ type SiblingRunsToggleProps = {
   runCount: number
   expanded: boolean
   onClick: () => void
+  /** id of this toggle button, referenced by the panel's aria-labelledby. */
+  id?: string
   /** id of the SiblingRunsPanel this toggle controls. */
   controls?: string
 }
@@ -141,10 +143,12 @@ const SiblingRunsToggle: React.FC<SiblingRunsToggleProps> = ({
   runCount,
   expanded,
   onClick,
+  id,
   controls,
 }) => (
   <ToggleButton
     type="button"
+    id={id}
     onClick={onClick}
     aria-expanded={expanded}
     aria-controls={controls}
@@ -220,6 +224,8 @@ type SiblingRunsPanelProps = {
   expanded: boolean
   /** id referenced by the SiblingRunsToggle controlling this panel. */
   id?: string
+  /** id of the SiblingRunsToggle that labels this panel. */
+  labelledBy?: string
 }
 
 const SiblingRunsPanel: React.FC<SiblingRunsPanelProps> = ({
@@ -227,6 +233,7 @@ const SiblingRunsPanel: React.FC<SiblingRunsPanelProps> = ({
   siblingEnrollments,
   expanded,
   id,
+  labelledBy,
 }) => {
   const currentRun = enrollment.run
   const currentStatus = getDashboardEnrollmentStatus({
@@ -243,7 +250,14 @@ const SiblingRunsPanel: React.FC<SiblingRunsPanelProps> = ({
     : currentDateRange
 
   return (
-    <Collapse in={expanded} id={id}>
+    <Collapse
+      in={expanded}
+      id={id}
+      mountOnEnter
+      unmountOnExit
+      role="region"
+      aria-labelledby={labelledBy}
+    >
       <RunsListWrapper>
         <RunsListBox>
           <RunListRow

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
@@ -108,7 +108,7 @@ const RunLabelValue = styled(Typography)({
 const RunsListWrapper = styled.div(({ theme }) => ({
   padding: "0 16px 16px",
   [theme.breakpoints.down("sm")]: {
-    padding: "0 0 8px",
+    padding: "8px 0",
   },
 }))
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.tsx
@@ -1,12 +1,5 @@
 import React from "react"
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Stack,
-  styled,
-  Typography,
-} from "ol-components"
+import { Collapse, Stack, styled, Typography } from "ol-components"
 import {
   DashboardType,
   EnrollmentStatus,
@@ -22,28 +15,6 @@ import { isInPast, formatDate } from "ol-utilities"
 import { EnrollmentStatusIcon } from "./EnrollmentStatus"
 import NextLink from "next/link"
 import { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
-
-const AdditionalRunsAccordion = styled(Accordion)(({ theme }) => ({
-  boxShadow: "none",
-  "&:before": { display: "none" },
-  backgroundColor: theme.custom.colors.white,
-  "& .MuiAccordionSummary-content": {
-    minWidth: 0,
-    overflow: "hidden",
-  },
-  "& .MuiAccordionSummary-root": {
-    [theme.breakpoints.down("sm")]: {
-      padding: 0,
-    },
-  },
-}))
-
-const CurrentRunIcon = styled.div(({ theme }) => ({
-  width: "8px",
-  height: "8px",
-  backgroundColor: theme.custom.colors.green,
-  flexShrink: 0,
-}))
 
 const UpcomingRunIcon = styled(RiTimeLine)(({ theme }) => ({
   width: "16px",
@@ -86,13 +57,6 @@ const ViewContentLink = styled(NextLink)(({ theme }) => ({
   "&:hover": { textDecoration: "underline" },
 }))
 
-const ExpandChevron = styled(RiArrowDownSLine)(({ theme }) => ({
-  width: "16px",
-  height: "16px",
-  color: theme.custom.colors.silverGrayDark,
-  flexShrink: 0,
-}))
-
 const ViewContentArrow = styled(RiArrowRightSLine)(({ theme }) => ({
   width: "16px",
   height: "16px",
@@ -107,33 +71,39 @@ const CourseRunsCountText = styled.span(({ theme }) => ({
   whiteSpace: "nowrap",
 }))
 
-const DateRangeStack = styled(Stack)({
-  flex: 1,
-  minWidth: 0,
-  overflow: "hidden",
-})
-
-const RunsAccordionSummary = styled(AccordionSummary)(({ theme }) => ({
-  "&:hover": {
-    ".course-runs-count-text": {
-      color: theme.custom.colors.mitRed,
-      textDecoration: "underline",
-    },
-  },
+const ExpandChevron = styled(RiArrowDownSLine, {
+  shouldForwardProp: (prop) => prop !== "expanded",
+})<{ expanded: boolean }>(({ theme, expanded }) => ({
+  width: "16px",
+  height: "16px",
+  color: theme.custom.colors.silverGrayDark,
+  flexShrink: 0,
+  transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+  transition: "transform 0.2s ease",
 }))
 
-const RunsAccordionDetails = styled(AccordionDetails)({
+const ToggleButton = styled.button(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "4px",
+  background: "none",
+  border: "none",
   padding: 0,
-})
-
-const SummaryRow = styled(Stack)(({ theme }) => ({
-  flex: 1,
-  minWidth: 0,
-  gap: "24px",
-  [theme.breakpoints.down("sm")]: {
-    gap: "8px",
+  cursor: "pointer",
+  "&:hover .course-runs-count-text": {
+    color: theme.custom.colors.mitRed,
+    textDecoration: "underline",
   },
 }))
+
+const RunLabelPrefix = styled(Typography)({
+  flexShrink: 0,
+})
+
+const RunLabelValue = styled(Typography)({
+  flex: 1,
+  minWidth: 0,
+})
 
 const RunsListWrapper = styled.div(({ theme }) => ({
   padding: "0 16px 16px",
@@ -158,112 +128,168 @@ const getRunStatusLabel = (status: EnrollmentStatus): string => {
   return ""
 }
 
-type SiblingRunsAccordionProps = {
-  /** The currently displayed enrollment (shown in the summary bar). */
+type SiblingRunsToggleProps = {
+  /** Total number of runs, including the currently displayed one. */
+  runCount: number
+  expanded: boolean
+  onClick: () => void
+  /** id of the SiblingRunsPanel this toggle controls. */
+  controls?: string
+}
+
+const SiblingRunsToggle: React.FC<SiblingRunsToggleProps> = ({
+  runCount,
+  expanded,
+  onClick,
+  controls,
+}) => (
+  <ToggleButton
+    type="button"
+    onClick={onClick}
+    aria-expanded={expanded}
+    aria-controls={controls}
+  >
+    <CourseRunsCountText className="course-runs-count-text">
+      Course runs ({runCount})
+    </CourseRunsCountText>
+    <ExpandChevron expanded={expanded} aria-hidden="true" />
+  </ToggleButton>
+)
+
+type RunListRowProps = {
+  icon: React.ReactNode
+  /** Bold lead-in, e.g. "Current run:" or "Upcoming:". Omitted for plain past runs. */
+  labelPrefix?: string
+  labelValue: string
+  coursewareUrl?: string | null
+  ariaLabel: string
+  isFirst: boolean
+}
+
+const RunListRow: React.FC<RunListRowProps> = ({
+  icon,
+  labelPrefix,
+  labelValue,
+  coursewareUrl,
+  ariaLabel,
+  isFirst,
+}) => (
+  <RunRow isFirst={isFirst}>
+    <Stack direction="row" gap="8px" alignItems="center" flex={1} minWidth={0}>
+      {icon}
+      <Stack
+        direction="row"
+        gap="4px"
+        alignItems="center"
+        flex={1}
+        minWidth={0}
+      >
+        {labelPrefix && (
+          <RunLabelPrefix variant="subtitle3" color="darkGray2" noWrap>
+            {labelPrefix}
+          </RunLabelPrefix>
+        )}
+        <RunLabelValue
+          variant={labelPrefix ? "body3" : "subtitle3"}
+          color={labelPrefix ? "silverGrayDark" : "darkGray2"}
+          noWrap
+        >
+          {labelValue}
+        </RunLabelValue>
+      </Stack>
+    </Stack>
+    {coursewareUrl && (
+      <Stack direction="row" gap="4px" alignItems="center" flexShrink={0}>
+        <ViewContentLink href={coursewareUrl} aria-label={ariaLabel}>
+          View content
+        </ViewContentLink>
+        <ViewContentArrow />
+      </Stack>
+    )}
+  </RunRow>
+)
+
+type SiblingRunsPanelProps = {
+  /** The currently displayed enrollment (shown above the sibling list). */
   enrollment: CourseRunEnrollmentV3
   /**
    * Other enrollments for the same course variant, pre-filtered to exclude
-   * the current enrollment. Each entry becomes a row in the expanded list.
+   * the current enrollment. Each entry becomes a row in the list.
    */
   siblingEnrollments: CourseRunEnrollmentV3[]
+  expanded: boolean
+  /** id referenced by the SiblingRunsToggle controlling this panel. */
+  id?: string
 }
 
-const SiblingRunsAccordion: React.FC<SiblingRunsAccordionProps> = ({
+const SiblingRunsPanel: React.FC<SiblingRunsPanelProps> = ({
   enrollment,
   siblingEnrollments,
+  expanded,
+  id,
 }) => {
-  const [expanded, setExpanded] = React.useState(false)
-  const run = enrollment.run
-  const enrollmentStatus = getDashboardEnrollmentStatus({
+  const currentRun = enrollment.run
+  const currentStatus = getDashboardEnrollmentStatus({
     type: DashboardType.CourseRunEnrollment,
     data: enrollment,
   })
+  const currentStatusLabel = getRunStatusLabel(currentStatus)
+  const currentDateRange = formatRunDateRange(
+    currentRun?.start_date,
+    currentRun?.end_date,
+  )
+  const currentLabelValue = currentStatusLabel
+    ? `${currentDateRange} (${currentStatusLabel})`
+    : currentDateRange
 
   return (
-    <AdditionalRunsAccordion
-      expanded={expanded}
-      disableGutters
-      onChange={(_e, isExpanded) => setExpanded(isExpanded)}
-    >
-      <RunsAccordionSummary expandIcon={<ExpandChevron />}>
-        <SummaryRow direction="row" alignItems="flex-end">
-          <DateRangeStack direction="row" alignItems="center" gap="4px">
-            <CurrentRunIcon aria-hidden="true" />
-            <Typography variant="body3" color="darkGray2" noWrap>
-              Current run:
-            </Typography>
-            <Typography variant="body3" color="silverGrayDark" noWrap>
-              {formatRunDateRange(run?.start_date, run?.end_date)}
-              {getRunStatusLabel(enrollmentStatus)
-                ? ` (${getRunStatusLabel(enrollmentStatus)})`
-                : ""}
-            </Typography>
-          </DateRangeStack>
-          <CourseRunsCountText className="course-runs-count-text">
-            Course runs ({siblingEnrollments.length + 1})
-          </CourseRunsCountText>
-        </SummaryRow>
-      </RunsAccordionSummary>
-      <RunsAccordionDetails>
-        <RunsListWrapper>
-          <RunsListBox>
-            {siblingEnrollments.map((e, i) => {
-              const startDate = e.run?.start_date
-              const endDate = e.run?.end_date
-              const isUpcoming = startDate && !isInPast(startDate)
-              const isExpired = endDate && isInPast(endDate)
-              const runLabel = isUpcoming
-                ? `Upcoming: ${formatRunDateRange(startDate, endDate)}`
-                : formatRunDateRange(startDate, endDate)
-              const runEnrollmentStatus = getDashboardEnrollmentStatus({
-                type: DashboardType.CourseRunEnrollment,
-                data: e,
-              })
-              const coursewareUrl = e.run?.courseware_url
-              return (
-                <RunRow key={e.id} isFirst={i === 0}>
-                  <Stack
-                    direction="row"
-                    gap="8px"
-                    alignItems="center"
-                    flex={1}
-                    minWidth={0}
-                  >
-                    {isUpcoming ? (
-                      <UpcomingRunIcon aria-hidden="true" />
-                    ) : isExpired ? (
-                      <ExpiredRunIcon aria-hidden="true" />
-                    ) : (
-                      <EnrollmentStatusIcon status={runEnrollmentStatus} />
-                    )}
-                    <Typography variant="subtitle3" color="darkGray2" noWrap>
-                      {runLabel}
-                    </Typography>
-                  </Stack>
-                  {coursewareUrl && (
-                    <Stack
-                      direction="row"
-                      gap="4px"
-                      alignItems="center"
-                      flexShrink={0}
-                    >
-                      <ViewContentLink
-                        href={coursewareUrl}
-                        aria-label={`View content for ${runLabel}`}
-                      >
-                        View content
-                      </ViewContentLink>
-                      <ViewContentArrow />
-                    </Stack>
-                  )}
-                </RunRow>
-              )
-            })}
-          </RunsListBox>
-        </RunsListWrapper>
-      </RunsAccordionDetails>
-    </AdditionalRunsAccordion>
+    <Collapse in={expanded} id={id}>
+      <RunsListWrapper>
+        <RunsListBox>
+          <RunListRow
+            isFirst
+            icon={<EnrollmentStatusIcon status={currentStatus} />}
+            labelPrefix="Current run:"
+            labelValue={currentLabelValue}
+            coursewareUrl={currentRun?.courseware_url}
+            ariaLabel={`View content for Current run: ${currentLabelValue}`}
+          />
+          {siblingEnrollments.map((e) => {
+            const startDate = e.run?.start_date
+            const endDate = e.run?.end_date
+            const isUpcoming = startDate && !isInPast(startDate)
+            const isExpired = endDate && isInPast(endDate)
+            const dateRange = formatRunDateRange(startDate, endDate)
+            const fullLabel = isUpcoming ? `Upcoming: ${dateRange}` : dateRange
+            const runEnrollmentStatus = getDashboardEnrollmentStatus({
+              type: DashboardType.CourseRunEnrollment,
+              data: e,
+            })
+            const coursewareUrl = e.run?.courseware_url
+            return (
+              <RunListRow
+                key={e.id}
+                isFirst={false}
+                icon={
+                  isUpcoming ? (
+                    <UpcomingRunIcon aria-hidden="true" />
+                  ) : isExpired ? (
+                    <ExpiredRunIcon aria-hidden="true" />
+                  ) : (
+                    <EnrollmentStatusIcon status={runEnrollmentStatus} />
+                  )
+                }
+                labelPrefix={isUpcoming ? "Upcoming:" : undefined}
+                labelValue={dateRange}
+                coursewareUrl={coursewareUrl}
+                ariaLabel={`View content for ${fullLabel}`}
+              />
+            )
+          })}
+        </RunsListBox>
+      </RunsListWrapper>
+    </Collapse>
   )
 }
 
-export { SiblingRunsAccordion }
+export { SiblingRunsToggle, SiblingRunsPanel }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.tsx
@@ -137,7 +137,7 @@ export const UnenrolledCourseCard = ({
 
   const progressBadgeSection =
     isModule && isCompact ? null : (
-      <Stack direction="row" gap="4px" alignItems="center">
+      <Stack direction="row" gap="8px" alignItems="center">
         <ProgressBadge enrollmentStatus={EnrollmentStatus.NotEnrolled} />
         <Separator />
         {cardTypeLabel}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12477

### Description (What does it do?)
Reworks the `SiblingRunsAccordion` on the dashboard's enrolled course card to match the updated Figma design:

- **Broke the "Course runs (n)" trigger out of the accordion header.** It now renders in the card header's right-hand column, under the CTA/overflow menu (desktop) or in its own row under the CTA (mobile), instead of inside the accordion summary. Split `SiblingRunsAccordion` into `SiblingRunsToggle` (the trigger) and `SiblingRunsPanel` (the collapsible run list), with the expand/collapse state lifted to `EnrolledCourseCard` and shared between the desktop and mobile layouts so the panel doesn't lose sync when the viewport crosses a breakpoint.
- **Merged the "Current run" indicator into the run list.** It's now the first row in the table, styled like the other rows (bold "Current run:" prefix, secondary-gray date range, in-progress ring/dot icon, "View content" link) instead of living in a separate summary line above the list.
- **Several other minor layout adjustments**

### Screenshots (if appropriate):
<img width="2560" height="1440" alt="collapsed" src="https://github.com/user-attachments/assets/f7072be1-793a-4996-b833-91f6764c4cf8" />
<img width="2560" height="1440" alt="expanded" src="https://github.com/user-attachments/assets/e8f58383-7596-45ad-a8dc-266e20dc6ed6" />
<img width="768" height="1024" alt="collapsed" src="https://github.com/user-attachments/assets/94ae1cc9-bd85-4327-a792-171f846aa568" />
<img width="768" height="1024" alt="expanded" src="https://github.com/user-attachments/assets/9b0fc76a-12f8-4579-998f-1709360de005" />
<img width="390" height="844" alt="collapsed" src="https://github.com/user-attachments/assets/7a5251b1-23f5-4e1f-a39a-4feb1146c771" />
<img width="390" height="844" alt="expanded" src="https://github.com/user-attachments/assets/7326731b-8214-41fa-aa70-013cbcdb7a08" />


### How can this be tested?
1. `docker compose up` (or `yarn watch` on host with `COMPOSE_PROFILES=backend`) and log in as a user with a course enrollment that has multiple runs.
2. On the dashboard, find a course card with more than one run (e.g. a program/course with sibling runs seeded via the QA factories).
3. Confirm the "Course runs (n)" toggle appears under the CTA/overflow menu, not inside the run list header.
4. Click it — confirm the run list expands with the current run as the first row (in-progress icon, "Current run:" prefix, date range, status, "View content" link), followed by upcoming/past sibling runs.
5. Resize the browser across desktop → tablet (~768px) → mobile (~390px) widths:
   - Confirm the card renders at every width (previously blank at tablet width).
   - Confirm the expand/collapse state stays in sync across the resize (previously mobile and desktop tracked separately).
   - Confirm there's no extra gap below the trigger on mobile when collapsed.
6. Find (or set up via factories) an enrollment that is both `upgradedAndIncomplete` (verified enrollment mode) and has a certificate link — confirm only one of "Certificate track" / "View Certificate" renders, not both.
7. Run the automated suite: `yarn test frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/SiblingRunsAccordion.test.tsx frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx`, plus `yarn workspace frontends run typecheck` and `lint-check`.