### PR TITLE
fix: News pages should show publication date not creation date and hover state for featured podcasts

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 import { Typography, Skeleton, styled } from "ol-components"
 import type { TypographyProps } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
-import { RiArrowRightLine } from "@remixicon/react"
+import { RiArrowRightLine, RiArrowRightSLine } from "@remixicon/react"
 import { formatDate } from "ol-utilities"
 import type { LearningResource } from "api/v1"
 import { SEARCH_PODCASTS, podcastPageView } from "@/common/urls"
@@ -63,6 +63,10 @@ const FeaturedPodcastCard = styled(Link)(({ theme }) => ({
   "&:hover .podcast-card-title": {
     color: theme.custom.colors.red,
   },
+  "&:hover .podcast-card-arrow": {
+    opacity: 1,
+    color: theme.custom.colors.red,
+  },
   [theme.breakpoints.down("sm")]: {
     padding: "24px",
     // Cards stack vertically on mobile, so adjacent cards share a single
@@ -74,13 +78,29 @@ const FeaturedPodcastCard = styled(Link)(({ theme }) => ({
   },
 }))
 
+const FeaturedPodcastHeader = styled.div({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "16px",
+  marginBottom: "24px",
+})
+
 const FeaturedPodcastImage = styled.img({
   width: "72px",
   height: "72px",
   objectFit: "cover",
   borderRadius: "8px",
-  marginBottom: "24px",
 })
+
+const FeaturedPodcastArrow = styled(RiArrowRightSLine)(({ theme }) => ({
+  flexShrink: 0,
+  fontSize: "24px",
+  color: theme.custom.colors.red,
+  // Revealed on card hover via the parent's ".podcast-card-arrow" rule.
+  opacity: 0,
+  marginLeft: "auto",
+}))
 
 const FeaturedPodcastTitle = styled(Typography)<
   Pick<TypographyProps, "component">
@@ -284,12 +304,18 @@ const PodcastSection: React.FC<PodcastSectionProps> = ({
                       key={item.id}
                       href={podcastPageView(String(item.id), item.title)}
                     >
-                      {item.image?.url && (
-                        <FeaturedPodcastImage
-                          src={item.image.url}
-                          alt={item.image.alt ?? item.title}
+                      <FeaturedPodcastHeader>
+                        {item.image?.url && (
+                          <FeaturedPodcastImage
+                            src={item.image.url}
+                            alt={item.image.alt ?? item.title}
+                          />
+                        )}
+                        <FeaturedPodcastArrow
+                          className="podcast-card-arrow"
+                          aria-hidden="true"
                         />
-                      )}
+                      </FeaturedPodcastHeader>
                       <FeaturedPodcastTitle
                         className="podcast-card-title"
                         variant="h4"

--- a/frontends/main/src/page-components/TiptapEditor/contentTypes/news/NewsEditor.happydom.test.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/contentTypes/news/NewsEditor.happydom.test.tsx
@@ -9,6 +9,7 @@ import { screen, waitFor, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { setMockResponse, factories, urls, makeRequest } from "api/test-utils"
 import { NewsEditor } from "./NewsEditor"
+import type { WebsiteContent } from "api/v1"
 import type { JSONContent } from "@tiptap/react"
 import { renderWithProviders } from "@/test-utils"
 
@@ -1527,5 +1528,73 @@ describe("NewsEditor - Document Rendering", () => {
         consoleErrorSpy.mockImplementation(currentMock)
       }
     })
+  })
+})
+
+describe("NewsEditor - Byline publish date", () => {
+  // A minimal valid document (banner + byline + paragraph) so the byline node
+  // renders in the read-only viewer.
+  const bylineDoc: JSONContent = {
+    type: "doc",
+    content: [
+      {
+        type: "banner",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 1 },
+            content: [{ type: "text", text: "Byline Article" }],
+          },
+          { type: "paragraph", content: [] },
+        ],
+      },
+      { type: "byline" },
+      { type: "paragraph", content: [] },
+    ],
+  }
+
+  const renderReadOnly = async (overrides: Partial<WebsiteContent>) => {
+    const user = factories.user.user({
+      is_authenticated: true,
+      is_article_editor: true,
+    })
+    setMockResponse.get(urls.userMe.get(), user)
+
+    const newsItem = factories.websiteContent.websiteContent({
+      id: 300,
+      title: "Byline Article",
+      content: bylineDoc,
+      ...overrides,
+    })
+    setMockResponse.get(urls.websiteContent.details(newsItem.id), newsItem)
+
+    renderWithProviders(<NewsEditor newsItem={newsItem} readOnly />, { user })
+    await screen.findByTestId("editor")
+    return newsItem
+  }
+
+  // publish_date and created_on are deliberately different so we can prove the
+  // byline reads from publish_date and never falls back to created_on.
+  test.each([
+    {
+      description: "shows the formatted publish_date when published",
+      isPublished: true,
+      expected: "Mar 15, 2024",
+    },
+    {
+      description: "shows 'Draft' (never created_on) when unpublished",
+      isPublished: false,
+      expected: "Draft",
+    },
+  ])("$description", async ({ isPublished, expected }) => {
+    await renderReadOnly({
+      is_published: isPublished,
+      publish_date: "2024-03-15T12:00:00Z",
+      created_on: "2020-01-01T12:00:00Z",
+    })
+
+    await screen.findByText(expected)
+    // The byline must never surface the created_on date.
+    expect(screen.queryByText("Jan 1, 2020")).not.toBeInTheDocument()
   })
 })

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/ByLineInfoBar/ByLineInfoBar.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/ByLineInfoBar/ByLineInfoBar.tsx
@@ -180,7 +180,7 @@ const ByLineInfoBar = ({
 }: ReactNodeViewProps) => {
   const article = useWebsiteContent()
 
-  const publishedDate = article?.is_published ? article?.created_on : null
+  const publishedDate = article?.is_published ? article?.publish_date : null
 
   const content = editor?.isEditable ? editor?.getJSON() : article?.content
 

--- a/frontends/main/src/page-components/TiptapEditor/extensions/node/ByLineInfoBar/ByLineInfoBarViewer.tsx
+++ b/frontends/main/src/page-components/TiptapEditor/extensions/node/ByLineInfoBar/ByLineInfoBarViewer.tsx
@@ -5,7 +5,7 @@ import { ByLineInfoBarContent } from "./ByLineInfoBar"
 const ByLineInfoBarViewer = () => {
   const article = useWebsiteContent()
 
-  const publishedDate = article?.is_published ? article?.created_on : null
+  const publishedDate = article?.is_published ? article?.publish_date : null
   const content = article?.content
   const authorName = article?.author_name ?? null
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12458#top

### Description (What does it do?)
- Date byline on news / articles should show published date, not created on date
- Hover state for featured podcasts on podcast listing page

### Screenshots (if appropriate):

<img width="1395" height="730" alt="Screenshot 2026-07-21 at 5 51 41 PM" src="https://github.com/user-attachments/assets/7ecae114-4812-4704-84c4-61f69e8a520e" />


### How can this be tested?
- For publish date testing you need to create article using the following url `/website_content/news/new` and publish it, once it is published please check the publish date is visible on reader sider.
- For featured podcast hover state testing you need to visit the `/podcasts` and see the featured podcasts and their hover state

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
