### PR TITLE
fix: block meta-externalads/1.1 crawler in robots.txt

### DIFF
--- a/frontends/main/src/app/robots.ts
+++ b/frontends/main/src/app/robots.ts
@@ -20,17 +20,27 @@ export default function robots(): MetadataRoute.Robots {
 
   if (shouldIndex) {
     return {
-      rules: {
-        userAgent: "*",
-        allow: "/",
-        disallow: [
-          "/dashboard/",
-          "/learningpaths/",
-          "/onboarding/",
-          "/cart/",
-          "/program_letter/",
-        ],
-      },
+      rules: [
+        {
+          userAgent: "*",
+          allow: "/",
+          disallow: [
+            "/dashboard/",
+            "/learningpaths/",
+            "/onboarding/",
+            "/cart/",
+            "/program_letter/",
+          ],
+        },
+        // Meta's ad-preview crawler, not a real visitor -- driving disproportionate
+        // load against expensive, uncached SSR routes. robots.txt is advisory only
+        // (a non-compliant crawler can ignore it), so if this doesn't reduce its
+        // request volume, blocking it at the gateway/WAF layer is the follow-up.
+        {
+          userAgent: "meta-externalads/1.1",
+          disallow: "/",
+        },
+      ],
       sitemap: `${BASE_URL}/sitemaps/sitemap-index.xml`,
     }
   } else {


### PR DESCRIPTION
## Summary

While investigating a production incident (the `mitlearn-app` backend webapp repeatedly pinned at its HPA replica ceiling, and cascading OOM issues in the nextjs frontend), we suspected bot traffic was contributing disproportionate load against expensive, uncached SSR routes. `meta-externalads/1.1` (Meta's ad-preview crawler) was flagged as a likely candidate.

## Change

Adds a `meta-externalads/1.1`-specific rule to `robots.ts` disallowing the entire site, alongside the existing catch-all `*` rule. Resulting `robots.txt`:

```
User-Agent: *
Allow: /
Disallow: /dashboard/
Disallow: /learningpaths/
Disallow: /onboarding/
Disallow: /cart/
Disallow: /program_letter/

User-Agent: meta-externalads/1.1
Disallow: /

Sitemap: https://learn.mit.edu/sitemaps/sitemap-index.xml
```

## Caveat

robots.txt is advisory only — a non-compliant crawler can ignore it. If this doesn't reduce request volume from this user agent, blocking it at the gateway/WAF layer would be the follow-up.

## Test plan

- [ ] Deploy and confirm `https://learn.mit.edu/robots.txt` reflects the new rule
- [ ] Monitor whether `meta-externalads` request volume drops in access logs
- [ ] If it doesn't, escalate to a gateway-level block

🤖 Generated with [Claude Code](https://claude.com/claude-code)