### PR TITLE
Tighten robots.txt to cut duplicate bot crawl

### DIFF
--- a/frontends/main/src/app/robots.test.ts
+++ b/frontends/main/src/app/robots.test.ts
@@ -1,0 +1,76 @@
+import robots from "./robots"
+
+describe("robots", () => {
+  const originalNoindex = process.env.MITOL_NOINDEX
+
+  afterEach(() => {
+    process.env.MITOL_NOINDEX = originalNoindex
+  })
+
+  it("disallows everything when MITOL_NOINDEX is not 'false'", () => {
+    process.env.MITOL_NOINDEX = "true"
+    expect(robots()).toEqual({
+      rules: { userAgent: "*", disallow: "/" },
+    })
+  })
+
+  it("emits the crawl rules when indexing is enabled", () => {
+    process.env.MITOL_NOINDEX = "false"
+    expect(robots()).toEqual({
+      rules: [
+        {
+          userAgent: "*",
+          // Canonical resource drawer URLs (the form the resources sitemap
+          // emits) and the bare search landing stay crawlable; these win
+          // over the disallows below by longest-match precedence.
+          allow: ["/search$", "/search?resource="],
+          disallow: [
+            "/search",
+            "/*?resource=",
+            "/*&resource=",
+            "/*?_rsc=",
+            "/*&_rsc=",
+            "/dashboard/",
+            "/learningpaths/",
+            "/onboarding/",
+            "/cart/",
+            "/program_letter/",
+            "/enrollmentcode/",
+            "/organization/",
+            "/website_content/drafts",
+          ],
+        },
+        {
+          userAgent: [
+            "facebookexternalhit",
+            "Twitterbot",
+            "Slackbot",
+            "LinkedInBot",
+            "Discordbot",
+            "WhatsApp",
+            "TelegramBot",
+          ],
+          allow: "/",
+        },
+        {
+          userAgent: [
+            "GPTBot",
+            "CCBot",
+            "meta-externalagent",
+            "Google-Extended",
+            "Applebot-Extended",
+            "Bytespider",
+            "ClaudeBot",
+            "Amazonbot",
+          ],
+          disallow: "/",
+        },
+        {
+          userAgent: "meta-externalads",
+          disallow: "/",
+        },
+      ],
+      sitemap: "http://test.learn.odl.local:8062/sitemaps/sitemap-index.xml",
+    })
+  })
+})

--- a/frontends/main/src/app/robots.test.ts
+++ b/frontends/main/src/app/robots.test.ts
@@ -39,7 +39,11 @@ describe("robots", () => {
   const originalNoindex = process.env.MITOL_NOINDEX
 
   afterEach(() => {
-    process.env.MITOL_NOINDEX = originalNoindex
+    if (originalNoindex === undefined) {
+      delete process.env.MITOL_NOINDEX
+    } else {
+      process.env.MITOL_NOINDEX = originalNoindex
+    }
   })
 
   it("disallows everything when MITOL_NOINDEX is not 'false'", () => {
@@ -56,11 +60,11 @@ describe("robots", () => {
         {
           userAgent: "*",
           // Canonical resource drawer URLs (the form the resources sitemap
-          // emits) and the bare search landing stay crawlable; these win
-          // over the disallows below by longest-match precedence.
-          allow: ["/search$", "/search?resource="],
+          // emits) stay crawlable; this wins over the disallows below by
+          // longest-match precedence.
+          allow: ["/search?resource="],
           disallow: [
-            "/search",
+            "/search?",
             "/*?resource=",
             "/*&resource=",
             "/*?_rsc=",

--- a/frontends/main/src/app/robots.test.ts
+++ b/frontends/main/src/app/robots.test.ts
@@ -1,4 +1,39 @@
 import robots from "./robots"
+import { resourceDrawerSearch } from "@/common/urls"
+
+/**
+ * Minimal RFC 9309 rule evaluator: `*` matches any chars, `$` anchors the
+ * end, the longest matching pattern wins, and ties go to Allow. Used to pin
+ * rule *interactions* (which rule wins for a URL), not just the rule list.
+ */
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+const patternMatches = (pattern: string, path: string): boolean => {
+  const anchored = pattern.endsWith("$")
+  const body = anchored ? pattern.slice(0, -1) : pattern
+  const source = `^${body.split("*").map(escapeRegExp).join(".*")}${anchored ? "$" : ""}`
+  return new RegExp(source).test(path)
+}
+const asArray = (value: string | string[] | undefined): string[] =>
+  value === undefined ? [] : Array.isArray(value) ? value : [value]
+const isAllowed = (
+  group: { allow?: string | string[]; disallow?: string | string[] },
+  path: string,
+): boolean => {
+  const matched = [
+    ...asArray(group.allow).map((p) => ({ p, allow: true })),
+    ...asArray(group.disallow).map((p) => ({ p, allow: false })),
+  ].filter(({ p }) => patternMatches(p, path))
+  matched.sort((a, b) => b.p.length - a.p.length || (a.allow ? -1 : 1))
+  return matched[0]?.allow ?? true
+}
+
+const getDefaultGroup = () => {
+  const rules = robots().rules
+  if (!Array.isArray(rules)) throw new Error("expected an array of rule groups")
+  const group = rules.find((r) => r.userAgent === "*")
+  if (!group) throw new Error("expected a default (*) rule group")
+  return group
+}
 
 describe("robots", () => {
   const originalNoindex = process.env.MITOL_NOINDEX
@@ -71,6 +106,42 @@ describe("robots", () => {
         },
       ],
       sitemap: "http://test.learn.odl.local:8062/sitemaps/sitemap-index.xml",
+    })
+  })
+
+  /**
+   * The Allow rule for drawer URLs is a literal prefix, so it only covers
+   * URLs exactly as resourceDrawerSearch emits them — the same builder the
+   * resources sitemap and canonical tags use. If the builder changes (path,
+   * param order), these fail rather than silently de-indexing every resource.
+   */
+  describe("canonical drawer URLs stay crawlable", () => {
+    beforeEach(() => {
+      process.env.MITOL_NOINDEX = "false"
+    })
+
+    it("allows the URL form the resources sitemap emits", () => {
+      const group = getDefaultGroup()
+      expect(
+        isAllowed(
+          group,
+          resourceDrawerSearch(123, "Introduction to Algorithms"),
+        ),
+      ).toBe(true)
+      expect(isAllowed(group, resourceDrawerSearch(123, undefined))).toBe(true)
+    })
+
+    it("allows the bare search landing page but not faceted search", () => {
+      const group = getDefaultGroup()
+      expect(isAllowed(group, "/search")).toBe(true)
+      expect(isAllowed(group, "/search?q=physics")).toBe(false)
+    })
+
+    it("disallows drawer overlays anywhere else", () => {
+      const group = getDefaultGroup()
+      expect(isAllowed(group, "/?resource=123")).toBe(false)
+      expect(isAllowed(group, "/c/topic/physics?resource=123")).toBe(false)
+      expect(isAllowed(group, "/search?q=physics&resource=123")).toBe(false)
     })
   })
 })

--- a/frontends/main/src/app/robots.ts
+++ b/frontends/main/src/app/robots.ts
@@ -28,18 +28,21 @@ export default function robots(): MetadataRoute.Robots {
            * /search?resource=<id>&resource_title=<slug>, and the resources
            * sitemap enumerates every resource at exactly that URL. Crawling
            * drawer overlays anywhere else (/c/, /news, /, faceted search) is
-           * pure duplicate load, so allow only the canonical form (and the
-           * bare /search landing page) and block resource-carrying URLs
-           * site-wide. The allow rules win by longest-match precedence
-           * (RFC 9309); they are listed first for naive first-match parsers.
+           * pure duplicate load, so allow only the canonical form and block
+           * resource-carrying URLs site-wide. The bare /search landing page
+           * matches no disallow and stays crawlable by default. The allow
+           * rule wins by longest-match precedence (RFC 9309); it is listed
+           * first for naive first-match parsers.
            *
            * NOTE: the allow rule is a literal prefix match, so it depends on
            * `resource` being the FIRST query param in canonical drawer URLs
            * (see resourceDrawerSearch in common/urls.ts).
            */
-          allow: ["/search$", "/search?resource="],
+          allow: ["/search?resource="],
           disallow: [
-            "/search",
+            // Faceted/keyword search results (any query string except the
+            // canonical drawer form above)
+            "/search?",
             "/*?resource=",
             "/*&resource=",
             // Next.js router-prefetch payloads — never part of rendered or

--- a/frontends/main/src/app/robots.ts
+++ b/frontends/main/src/app/robots.ts
@@ -23,21 +23,89 @@ export default function robots(): MetadataRoute.Robots {
       rules: [
         {
           userAgent: "*",
-          allow: "/",
+          /**
+           * Resource drawer: every ?resource= URL canonicalizes to
+           * /search?resource=<id>&resource_title=<slug>, and the resources
+           * sitemap enumerates every resource at exactly that URL. Crawling
+           * drawer overlays anywhere else (/c/, /news, /, faceted search) is
+           * pure duplicate load, so allow only the canonical form (and the
+           * bare /search landing page) and block resource-carrying URLs
+           * site-wide. The allow rules win by longest-match precedence
+           * (RFC 9309); they are listed first for naive first-match parsers.
+           *
+           * NOTE: the allow rule is a literal prefix match, so it depends on
+           * `resource` being the FIRST query param in canonical drawer URLs
+           * (see resourceDrawerSearch in common/urls.ts).
+           */
+          allow: ["/search$", "/search?resource="],
           disallow: [
+            "/search",
+            "/*?resource=",
+            "/*&resource=",
+            // Next.js router-prefetch payloads — never part of rendered or
+            // indexed content
+            "/*?_rsc=",
+            "/*&_rsc=",
+            // Account / app-only areas
             "/dashboard/",
             "/learningpaths/",
             "/onboarding/",
             "/cart/",
             "/program_letter/",
+            "/enrollmentcode/",
+            "/organization/",
+            "/website_content/drafts",
           ],
         },
-        // Meta's ad-preview crawler, not a real visitor -- driving disproportionate
-        // load against expensive, uncached SSR routes. robots.txt is advisory only
-        // (a non-compliant crawler can ignore it), so if this doesn't reduce its
-        // request volume, blocking it at the gateway/WAF layer is the follow-up.
         {
-          userAgent: "meta-externalads/1.1",
+          /**
+           * Link-preview fetchers: fetch exact shared URLs on demand (tiny
+           * volume) and must be able to see ?resource= URLs for og: cards.
+           * A named group opts them out of ALL default-group rules.
+           */
+          userAgent: [
+            "facebookexternalhit",
+            "Twitterbot",
+            "Slackbot",
+            "LinkedInBot",
+            "Discordbot",
+            "WhatsApp",
+            "TelegramBot",
+          ],
+          allow: "/",
+        },
+        {
+          /**
+           * AI-training crawlers — blocking costs no search visibility.
+           * (Google-Extended / Applebot-Extended are opt-out tokens
+           * controlling training use of Googlebot/Applebot crawl data, not
+           * separate crawlers.)
+           */
+          userAgent: [
+            "GPTBot",
+            "CCBot",
+            "meta-externalagent",
+            "Google-Extended",
+            "Applebot-Extended",
+            "Bytespider",
+            "ClaudeBot",
+            "Amazonbot",
+          ],
+          disallow: "/",
+        },
+        {
+          /**
+           * Meta's advertising/business crawler. Blocked 2026-07-21 (#3653)
+           * after it crawled ?resource=/_rsc= URL permutations at up to
+           * ~90k req/hr — the majority of all origin-reaching traffic during
+           * the incident. robots.txt is advisory only (this UA has never
+           * fetched /robots.txt here), so the gateway/WAF layer is the
+           * enforcement backstop if volume doesn't drop.
+           *
+           * NOTE: RFC 9309 user-agent tokens cannot contain "/" — matching
+           * requires the bare product token, not "meta-externalads/1.1".
+           */
+          userAgent: "meta-externalads",
           disallow: "/",
         },
       ],

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -155,6 +155,11 @@ export const absoluteUrl = (path: string): string =>
  *   /search?resource={id}[&resource_title={slug}]
  * `resource` is the authoritative id; `resource_title` is a cosmetic slug,
  * omitted when blank and ignored on lookup.
+ *
+ * `resource` MUST stay the first query param: robots.ts re-allows canonical
+ * drawer URLs via the literal prefix rule `Allow: /search?resource=`, so
+ * reordering the params would silently block them from crawlers (these are
+ * the URLs the resources sitemap emits).
  */
 export const resourceDrawerSearch = (
   resourceId: number,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Rewrites the robots.txt rules (`frontends/main/src/app/robots.ts`) to stop crawlers from fetching URL variants that duplicate content they can already reach through canonical URLs, and blocks AI-training crawlers.

Every `?resource=` drawer URL canonicalizes to `/search?resource=<id>&resource_title=<slug>`, and the resources sitemap enumerates every resource at exactly that URL — so crawler fetches of drawer overlays on `/c/`, `/news`, home, and faceted search are pure duplicate load. A 7-day Fastly log analysis found this crawl is the dominant source of origin-reaching traffic: bot resource-URL crawl is roughly half of all origin-reaching requests (Applebot alone fans out over ~2.5M `/c/` + `/news` drawer URLs/week), and because each per-resource URL is fetched about once, the CDN can't absorb it. These are full page renders, so this is most of our real origin compute.

The new rules: allow only the canonical drawer form (`/search?resource=`) and the bare `/search` landing page; disallow resource-carrying URLs site-wide, internal search result pages (`/search?q=`/facets, per Google's own guidance), and `_rsc` router-prefetch payloads (never part of rendered or indexed content); extend the app-only disallows (`/enrollmentcode/`, `/organization/`, `/website_content/drafts`); exempt link-preview fetchers (Facebook/Twitter/Slack/etc.) via their own group so og: cards keep working on shared drawer URLs; and block AI-training crawlers (GPTBot, CCBot, meta-externalagent, Bytespider, ClaudeBot, Amazonbot) plus the Google-Extended/Applebot-Extended training opt-out tokens, which cost no search visibility.

Resource indexing is preserved: search engines keep the sitemap-enumerated canonical drawer URLs, and the drawer variants they lose all declare canonicals pointing at the form that stays crawlable.

### How can this be tested?
Unit test pins both `MITOL_NOINDEX` branches and the exact rule groups: `yarn test frontends/main/src/app/robots.test.ts`.

For manual validation, run the app with `MITOL_NOINDEX=false`, fetch `/robots.txt`, and check sample URLs against the rules — `/search?resource=123` and `/search` allowed; `/search?q=python`, `/c/topic/physics/?resource=5`, and `/?resource=5` disallowed. Google Search Console's robots.txt tester (or any RFC 9309 checker) confirms the longest-match precedence: `Allow: /search?resource=` (17 chars) beats `Disallow: /*?resource=` (12) and `Disallow: /search` (7).

### Additional Context
The `Allow: /search?resource=` rule is a literal prefix match, so it depends on `resource` staying the first query param in canonical drawer URLs — documented on `resourceDrawerSearch` in `common/urls.ts`, whose output was already pinned by `urls.test.ts`. Rule order within the group is Allow-first as a courtesy to naive first-match parsers; compliant crawlers use longest-match, where order is irrelevant.

This only affects robots-compliant crawlers. The disguised scraper traffic we've seen (rotating fake-browser UAs from a Tencent-cloud netblock) never fetches robots.txt and needs a Fastly rate-limit/ASN block, tracked separately. `meta-externalads` intentionally stays under the default group: on our logs it only fetches the UAI+B2C pages we advertise on Meta, so it keeps access to everything except drawer-overlay and `_rsc` URLs.