### PR TITLE
show all facets from url

### DIFF
--- a/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.test.tsx
@@ -12,7 +12,7 @@ import type {
   LearningResourcesSearchResponse,
   PaginatedLearningResourceOfferorDetailList,
 } from "api"
-import { ResourceTypeEnum } from "api"
+import { ResourceTypeEnum, LearningResourceRunLevelInnerCodeEnum } from "api"
 import invariant from "tiny-invariant"
 import { Permission } from "api/hooks/user"
 import {
@@ -160,7 +160,6 @@ describe("SearchPage", () => {
         "department",
         "free",
         "offered_by",
-        "professional",
         "resource_category",
         "resource_type",
         "resource_type_group",
@@ -171,6 +170,70 @@ describe("SearchPage", () => {
       )
     },
   )
+
+  test("Shows and aggregates facets that are in the URL but not shown by default", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            level: [{ key: "graduate", doc_count: 100 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    renderWithProviders(<SearchPage />, { url: "?level=graduate" })
+
+    await waitFor(() => {
+      expect(makeRequest.mock.calls.length > 0).toBe(true)
+    })
+    // "level" is not a default facet, but is requested as an aggregation
+    // because it is present in the URL.
+    const apiSearchParams = getLastApiSearchParams()
+    expect(apiSearchParams.getAll("aggregations")).toContain("level")
+
+    // ...and it renders as a facet after "Department" and before Admin Options.
+    const facetsContainer = screen.getByTestId("facets-container")
+    await within(facetsContainer).findByText("Level")
+    const facetTitles = within(facetsContainer)
+      .getAllByText(/Department|Level/)
+      .map((el) => el.textContent)
+    expect(facetTitles.indexOf("Level")).toBeGreaterThan(
+      facetTitles.indexOf("Department"),
+    )
+  })
+
+  test("Clear all removes an extra (non-default) facet from URL and sidebar", async () => {
+    setMockApiResponses({
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            level: [{ key: "graduate", doc_count: 100 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+    const { location } = renderWithProviders(<SearchPage />, {
+      url: "?level=graduate",
+    })
+
+    const facetsContainer = screen.getByTestId("facets-container")
+    // The extra facet renders because it is present in the URL.
+    await within(facetsContainer).findByText("Level")
+
+    const clearAll = await screen.findByRole("button", { name: /clear all/i })
+    await user.click(clearAll)
+
+    // Clearing all filters removes the extra facet from the URL...
+    expect(location.current.search).toBe("")
+    // ...and, since it is no longer in the URL, from the sidebar.
+    await waitFor(() => {
+      expect(within(facetsContainer).queryByText("Level")).toBeNull()
+    })
+  })
 
   test("Toggling facets", async () => {
     setMockApiResponses({
@@ -1194,6 +1257,75 @@ describe("UniversalAIBanner", () => {
         args.url.includes(urls.search.vectorResources()),
     ).length
     expect(finalVectorRequestCount).toBe(initialVectorRequestCount)
+  })
+
+  test("Vector Hybrid Search computes client-side counts for extra URL facets (e.g. level)", async () => {
+    const makeCourse = (
+      title: string,
+      levelCode: LearningResourceRunLevelInnerCodeEnum,
+    ) =>
+      factories.learningResources.resource({
+        title,
+        resource_type: ResourceTypeEnum.Course,
+        runs: [
+          factories.learningResources.run({
+            level: [{ code: levelCode, name: levelCode }],
+          }),
+        ],
+      })
+
+    const resources = [
+      makeCourse(
+        "Grad Course A",
+        LearningResourceRunLevelInnerCodeEnum.Graduate,
+      ),
+      makeCourse(
+        "Grad Course B",
+        LearningResourceRunLevelInnerCodeEnum.Graduate,
+      ),
+      makeCourse(
+        "Undergrad Course",
+        LearningResourceRunLevelInnerCodeEnum.Undergraduate,
+      ),
+    ]
+
+    setMockApiResponses({
+      search: {
+        count: 3,
+        metadata: {
+          aggregations: {
+            resource_type_group: [{ key: "course", doc_count: 3 }],
+          },
+          suggestions: [],
+        },
+        results: resources,
+      },
+    })
+    setMockResponse.get(urls.userMe.get(), {
+      is_learning_path_editor: true,
+      is_authenticated: true,
+    })
+
+    // "level" is an extra facet (present in the URL, not shown by default).
+    renderWithProviders(<SearchPage />, {
+      url: "?vector_search=true&q=test&level=graduate",
+    })
+
+    // Client-side filtering keeps only graduate-level results.
+    await screen.findByText("Grad Course A")
+    await screen.findByText("Grad Course B")
+    expect(screen.queryByText("Undergrad Course")).not.toBeInTheDocument()
+
+    // Client-side aggregation populates the Level facet with disjunctive counts
+    // derived from run levels. Before the fix these counts were empty because
+    // getResourceFacetValues had no "level" case, so the facet showed nothing.
+    const facetsContainer = screen.getByTestId("facets-container")
+    await within(facetsContainer).findByText("Level")
+    // graduate is the active filter; undergraduate is still counted (disjunctive).
+    await within(facetsContainer).findByRole("checkbox", { name: "Graduate 2" })
+    await within(facetsContainer).findByRole("checkbox", {
+      name: "Undergraduate 1",
+    })
   })
 
   test("clicking Learn More fires cta_clicked with label and readableId", async () => {

--- a/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
+++ b/frontends/main/src/app-pages/SearchPage/SearchPage.tsx
@@ -2,7 +2,10 @@
 import { keyBy } from "lodash"
 
 import React, { useCallback, useMemo, useEffect, useState } from "react"
-import type { FacetManifest } from "@mitodl/course-search-utils"
+import type {
+  FacetManifest,
+  UseResourceSearchParamsProps,
+} from "@mitodl/course-search-utils"
 import { useSearchParams } from "@mitodl/course-search-utils/next"
 import { useResourceSearchParams } from "@mitodl/course-search-utils"
 import SearchDisplay, {
@@ -14,7 +17,7 @@ import { styled, Container, theme, Typography } from "ol-components"
 import { Checkbox, VisuallyHidden } from "@mitodl/smoot-design"
 import { SearchField } from "@/page-components/SearchField/SearchField"
 import { useOfferorsList } from "api/hooks/learningResources"
-import { facetNames } from "./searchRequests"
+import { defaultFacetNames, getExtraFacetNames } from "./searchRequests"
 import getFacetManifest from "@/page-components/SearchDisplay/getFacetManifest"
 import dynamic from "next/dynamic"
 import { useUserMe } from "api/hooks/user"
@@ -74,22 +77,49 @@ const StyledSearchField = styled(SearchField)({
 
 const constantSearchParams = {}
 
-const useFacetManifest = (resourceTypeGroup: string | null) => {
+const useFacetManifest = (
+  resourceTypeGroup: string | null,
+  extraFacetNames: string[],
+) => {
   const offerorsQuery = useOfferorsList()
   const offerors = useMemo(() => {
     return keyBy(offerorsQuery.data?.results ?? [], (o) => o.code)
   }, [offerorsQuery.data?.results])
   const facetManifest = useMemo(
-    () => getFacetManifest(offerors, resourceTypeGroup),
-    [offerors, resourceTypeGroup],
+    () => getFacetManifest(offerors, resourceTypeGroup, extraFacetNames),
+    [offerors, resourceTypeGroup, extraFacetNames],
   )
   return facetManifest
 }
 
 const SearchPage: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
+  const extraFacetNames = useMemo(
+    () => getExtraFacetNames(searchParams, defaultFacetNames) ?? [],
+    [searchParams],
+  )
+  // Facets shown by default plus any additional facets present in the URL.
+  const augmentedFacetNames = useMemo(
+    () =>
+      [
+        ...(defaultFacetNames ?? []),
+        ...extraFacetNames,
+      ] as UseResourceSearchParamsProps["facets"],
+    [extraFacetNames],
+  )
+  // The professional toggle is not aggregated, but must be treated as a facet
+  // so "Clear all filters" resets it.
+  const searchParamFacets = useMemo(
+    () =>
+      [
+        ...(augmentedFacetNames ?? []),
+        "professional",
+      ] as UseResourceSearchParamsProps["facets"],
+    [augmentedFacetNames],
+  )
   const facetManifest = useFacetManifest(
     searchParams.get("resource_type_group"),
+    extraFacetNames,
   )
   const isVectorSearch = searchParams.get("vector_search") === "true"
   const [fetchTime, setFetchTime] = useState<number | null>(null)
@@ -157,7 +187,7 @@ const SearchPage: React.FC = () => {
   } = useResourceSearchParams({
     searchParams,
     setSearchParams,
-    facets: facetNames,
+    facets: searchParamFacets,
     onFacetsChange,
   })
 
@@ -217,7 +247,7 @@ const SearchPage: React.FC = () => {
           requestParams={params}
           setPage={setPage}
           facetManifest={facetManifest as FacetManifest}
-          facetNames={facetNames}
+          facetNames={augmentedFacetNames}
           constantSearchParams={constantSearchParams}
           hasFacets={hasFacets}
           setParamValue={setParamValue}
@@ -236,7 +266,7 @@ const SearchPage: React.FC = () => {
           requestParams={params}
           setPage={setPage}
           facetManifest={facetManifest as FacetManifest}
-          facetNames={facetNames}
+          facetNames={augmentedFacetNames}
           constantSearchParams={constantSearchParams}
           hasFacets={hasFacets}
           setParamValue={setParamValue}

--- a/frontends/main/src/app-pages/SearchPage/searchRequests.ts
+++ b/frontends/main/src/app-pages/SearchPage/searchRequests.ts
@@ -1,6 +1,11 @@
-import { UseResourceSearchParamsProps } from "@mitodl/course-search-utils"
+import {
+  BOOLEAN_FACET_NAMES,
+  type Facets,
+  type UseResourceSearchParamsProps,
+} from "@mitodl/course-search-utils"
+import { LearningResourcesSearchRetrieveAggregationsEnum } from "api"
 
-export const facetNames = [
+export const defaultFacetNames = [
   "resource_type",
   "certification_type",
   "delivery",
@@ -8,6 +13,29 @@ export const facetNames = [
   "topic",
   "offered_by",
   "free",
-  "professional",
   "resource_category",
 ] as UseResourceSearchParamsProps["facets"]
+
+const NON_FACET_PARAMS = new Set<string>([
+  ...BOOLEAN_FACET_NAMES,
+  "resource_type_group",
+])
+
+const ALL_FACETS = Object.values(
+  LearningResourcesSearchRetrieveAggregationsEnum,
+).filter((name) => !NON_FACET_PARAMS.has(name)) as (keyof Facets)[]
+
+export const getExtraFacetNames = (
+  searchParams: URLSearchParams,
+  baseFacetNames: UseResourceSearchParamsProps["facets"] = defaultFacetNames,
+): UseResourceSearchParamsProps["facets"] => {
+  const base = new Set<string>(baseFacetNames ?? [])
+  const valid = new Set<string>(ALL_FACETS)
+  const extra: string[] = []
+  for (const key of searchParams.keys()) {
+    if (valid.has(key) && !base.has(key) && !extra.includes(key)) {
+      extra.push(key)
+    }
+  }
+  return extra as UseResourceSearchParamsProps["facets"]
+}

--- a/frontends/main/src/app/(site)/search/page.tsx
+++ b/frontends/main/src/app/(site)/search/page.tsx
@@ -6,7 +6,10 @@ import {
 } from "api/hooks/learningResources"
 import { getMetadataAsync, safeGenerateMetadata } from "@/common/metadata"
 import SearchPage from "@/app-pages/SearchPage/SearchPage"
-import { facetNames } from "@/app-pages/SearchPage/searchRequests"
+import {
+  defaultFacetNames,
+  getExtraFacetNames,
+} from "@/app-pages/SearchPage/searchRequests"
 import getSearchParams from "@/page-components/SearchDisplay/getSearchParams"
 import validateRequestParams from "@/page-components/SearchDisplay/validateRequestParams"
 import type { ResourceSearchRequest } from "@/page-components/SearchDisplay/validateRequestParams"
@@ -27,11 +30,22 @@ const Page: React.FC<PageProps<"/search">> = async ({ searchParams }) => {
     page?: string
   }
 
+  const urlParams = new URLSearchParams(
+    Object.entries(search).flatMap(([key, value]) =>
+      Array.isArray(value)
+        ? value.map((v) => [key, v])
+        : [[key, String(value)]],
+    ),
+  )
+
   const params = getSearchParams({
     // @ts-expect-error -- this will error until mitodl/mit-learn-api-axios is updated
     requestParams: validateRequestParams(search),
     constantSearchParams: {},
-    facetNames,
+    facetNames: [
+      ...(defaultFacetNames ?? []),
+      ...(getExtraFacetNames(urlParams) ?? []),
+    ] as typeof defaultFacetNames,
     page: Number(search.page ?? 1),
   })
 

--- a/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/HybridSearchDisplay.tsx
@@ -76,6 +76,9 @@ const VECTOR_CLIENT_FILTER_FACETS = [
   "professional",
   "resource_category",
   "resource_type_group",
+  "level",
+  "platform",
+  "course_feature",
 ] as const
 
 type VectorClientFilterFacet = (typeof VECTOR_CLIENT_FILTER_FACETS)[number]
@@ -133,6 +136,21 @@ const getResourceFacetValues = (
       return normalizeParamValues(resource.offered_by?.code)
     case "topic":
       return normalizeParamValues(resource.topics?.map((t) => t.name))
+    case "platform":
+      return normalizeParamValues(
+        "platform" in resource ? resource.platform?.code : undefined,
+      )
+    case "level":
+      // Level is aggregated from run levels, matching the OpenSearch facet.
+      return normalizeParamValues(
+        "runs" in resource
+          ? resource.runs?.flatMap((run) => run.level.map((l) => l.code))
+          : [],
+      )
+    case "course_feature":
+      return normalizeParamValues(
+        "course_feature" in resource ? resource.course_feature : [],
+      )
     case "free":
     case "professional":
     case "resource_type":

--- a/frontends/main/src/page-components/SearchDisplay/getFacetManifest.ts
+++ b/frontends/main/src/page-components/SearchDisplay/getFacetManifest.ts
@@ -1,15 +1,50 @@
 import {
   getCertificationTypeName,
   getDepartmentName,
+  getLevelName,
 } from "@mitodl/course-search-utils"
 import type { LearningResourceOfferor } from "api"
 import { capitalize } from "ol-utilities"
 
 const LEARNING_MATERIAL = "learning_material"
 
+// Human-readable titles for facets that may be surfaced from the URL.
+const EXTRA_FACET_TITLES: Partial<Record<string, string>> = {
+  level: "Level",
+  platform: "Platform",
+  resource_type: "Resource Type",
+  course_feature: "Features",
+  content_feature_type: "Content Features",
+}
+
+// Label functions for facet values that need friendly names.
+const EXTRA_FACET_LABEL_FUNCTIONS: Partial<
+  Record<string, (key: string) => string>
+> = {
+  level: (key: string) => getLevelName(key) || key,
+  department: (key: string) => getDepartmentName(key) || key,
+  certification_type: (key: string) => getCertificationTypeName(key) || key,
+}
+
+const titleize = (name: string) =>
+  name
+    .split("_")
+    .map((word) => capitalize(word))
+    .join(" ")
+
+const buildExtraFacet = (name: string) => ({
+  name,
+  title: EXTRA_FACET_TITLES[name] ?? titleize(name),
+  type: "filterable",
+  expandedOnLoad: true,
+  preserveItems: true,
+  labelFunction: EXTRA_FACET_LABEL_FUNCTIONS[name] ?? null,
+})
+
 export const getFacetManifest = (
   offerors: Record<string, LearningResourceOfferor>,
   resourceTypeGroup: string | null,
+  extraFacetNames: string[] = [],
 ) => {
   const manifest = [
     {
@@ -78,6 +113,16 @@ export const getFacetManifest = (
   //Only display the resource_type facet if the resource_type_group is learning_material
   if (resourceTypeGroup !== LEARNING_MATERIAL) {
     manifest.splice(1, 1)
+  }
+
+  // Append any facets present in the URL that aren't shown by default. These
+  // render after "Department" (the last default facet) and before Admin Options.
+  const existingNames = new Set(manifest.map((facet) => facet.name))
+  for (const name of extraFacetNames) {
+    if (!existingNames.has(name)) {
+      manifest.push(buildExtraFacet(name) as (typeof manifest)[number])
+      existingNames.add(name)
+    }
   }
 
   return manifest


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/12383

### Description (What does it do?)
Any facet that is in the url should be shown on the sidebar

### Screenshots (if appropriate):
<img width="970" height="887" alt="Screenshot 2026-07-21 at 3 38 18 PM" src="https://github.com/user-attachments/assets/38c59509-653d-49c5-8377-949813e4efba" />

### How can this be tested?
Run `docker-compose run web ./manage.py
backpopulate_ocw_data --course-name 14-12-economic-applications-of-game-theory-fall-2025`


Got to http://open.odl.local:8062/search?level=undergraduate
you should see the level facet in the sidebar after "department"

click "clear all"

You should no longer see the level facet