### PR TITLE
display programs without display_mode set on the program dashboard

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -186,6 +186,48 @@ describe("ProgramAsCourseCard", () => {
     )
   })
 
+  test.each([
+    { displayMode: "course" as const, label: "Module" },
+    { displayMode: null, label: "Course" },
+  ])(
+    "singularizes the sub-header label when there is exactly 1 $label",
+    async ({ displayMode, label }) => {
+      const moduleOne = mitxonline.factories.courses.course({
+        courseruns: [mitxonline.factories.courses.courseRun()],
+      })
+      const reqTree =
+        new mitxonline.factories.requirements.RequirementTreeBuilder()
+      const modules = reqTree.addOperator({
+        operator: "all_of",
+        title: "Modules",
+      })
+      modules.addCourse({ course: moduleOne.id })
+
+      const program = mitxonline.factories.programs.program({
+        courses: [moduleOne.id],
+        req_tree: reqTree.serialize(),
+        display_mode: displayMode,
+      })
+
+      setMockResponse.get(
+        mitxonline.urls.userMe.get(),
+        mitxonline.factories.user.user(),
+      )
+
+      renderWithProviders(
+        <ProgramAsCourseCard
+          courseProgram={program}
+          moduleCourses={[moduleOne]}
+          moduleEnrollmentsByCourseId={{}}
+        />,
+      )
+
+      expect(
+        await screen.findByText(`1 ${label} (0 of 1 complete)`),
+      ).toBeInTheDocument()
+    },
+  )
+
   test("progress badge reflects program enrollment status ('In Progress')", async () => {
     const cardData = setupCardData({ includeProgramEnrollment: true })
     invariant(cardData.courseProgramEnrollment)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -33,10 +33,14 @@ describe("ProgramAsCourseCard", () => {
     includeProgramEnrollment = false,
     startDate,
     endDate,
+    // Most tests here exercise the program-as-course presentation, which requires
+    // display_mode "course" — pinned because the card's labels read it.
+    displayMode = "course",
   }: {
     includeProgramEnrollment?: boolean
     startDate?: string | null
     endDate?: string | null
+    displayMode?: "course" | null
   } = {}) => {
     const moduleOne = mitxonline.factories.courses.course({
       courseruns: [mitxonline.factories.courses.courseRun()],
@@ -59,6 +63,7 @@ describe("ProgramAsCourseCard", () => {
       req_tree: reqTree.serialize(),
       start_date: startDate ?? null,
       end_date: endDate ?? null,
+      display_mode: displayMode,
     })
 
     const moduleEnrollment = mitxonline.factories.enrollment.courseEnrollment({
@@ -146,6 +151,39 @@ describe("ProgramAsCourseCard", () => {
     // next to a progress badge; only the per-module rows omit it. Rendered
     // once per (desktop/mobile) header copy.
     expect(screen.getAllByText("Course")).toHaveLength(2)
+  })
+
+  test("uses 'Program' labels and program details link when display_mode is not 'course'", async () => {
+    const cardData = setupCardData({ displayMode: null })
+
+    renderWithProviders(
+      <ProgramAsCourseCard
+        courseProgram={cardData.courseProgram}
+        moduleCourses={cardData.moduleCourses}
+        moduleEnrollmentsByCourseId={cardData.moduleEnrollmentsByCourseId}
+        courseProgramEnrollment={cardData.courseProgramEnrollment}
+      />,
+    )
+
+    await screen.findAllByRole("heading", {
+      name: cardData.courseProgram.title,
+      level: 3,
+    })
+    // Card type label, rendered once per (desktop/mobile) header copy.
+    expect(screen.getAllByText("Program")).toHaveLength(2)
+    expect(screen.queryByText("Course")).not.toBeInTheDocument()
+    // Children are described as courses, not modules.
+    expect(screen.getByText("2 Courses (0 of 2 complete)")).toBeInTheDocument()
+
+    const programCard = screen.getByTestId("program-as-course-card")
+    await user.click(within(programCard).getAllByLabelText("More options")[0])
+    const detailsLink = await screen.findByRole("menuitem", {
+      name: "View Program Details",
+    })
+    expect(detailsLink).toHaveAttribute(
+      "href",
+      `/programs/${cardData.courseProgram.readable_id}`,
+    )
   })
 
   test("progress badge reflects program enrollment status ('In Progress')", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -9,6 +9,8 @@ import {
 import {
   CourseRunEnrollmentV3,
   CourseWithCourseRunsSerializerV2,
+  DisplayModeEnum,
+  V2ProgramDisplayMode,
   V3UserProgramEnrollment,
   V2ProgramRequirement,
 } from "@mitodl/mitxonline-api-axios/v2"
@@ -158,7 +160,7 @@ const getContextMenuItems = (
   const menuItems = []
   const detailsUrl = programPageView({
     readable_id: resource.readable_id,
-    display_mode: "course",
+    display_mode: resource.display_mode,
   })
 
   const courseMenuItems = []
@@ -167,7 +169,7 @@ const getContextMenuItems = (
     courseMenuItems.push({
       className: "dashboard-card-menu-item",
       key: "view-course-details",
-      label: "View Course Details",
+      label: `View ${getProgramTypeLabel(resource.display_mode)} Details`,
       href: detailsUrl,
     })
   }
@@ -197,6 +199,19 @@ const getContextMenuItems = (
   return [...menuItems, ...additionalItems]
 }
 
+/**
+ * Learner-facing wording for a program on the dashboard, driven by its
+ * display_mode: programs with `display_mode: "course"` (program-as-course)
+ * speak "Course"/"Modules"; any other program speaks "Program"/"Courses".
+ */
+const getProgramTypeLabel = (
+  displayMode: V2ProgramDisplayMode | null | undefined,
+) => (displayMode === DisplayModeEnum.Course ? "Course" : "Program")
+
+const getProgramChildrenLabel = (
+  displayMode: V2ProgramDisplayMode | null | undefined,
+) => (displayMode === DisplayModeEnum.Course ? "Modules" : "Courses")
+
 interface ProgramAsCourse {
   id: number
   readable_id: string
@@ -205,6 +220,7 @@ interface ProgramAsCourse {
   end_date?: string | null
   courses?: number[]
   req_tree?: V2ProgramRequirement[]
+  display_mode?: V2ProgramDisplayMode | null
 }
 
 interface ProgramAsCourseCardProps {
@@ -248,14 +264,14 @@ interface ProgramAsCourseCardProps {
 }
 
 /**
- * Renders a v3 program in the dashboard's course presentation mode.
+ * Renders a v3 program as a dashboard card with its child-course rows.
  *
- * When a program enrollment is configured with `display_mode="course"`, the
- * dashboard treats the program as a learner-facing "course" even though the
- * backing data still comes from the v3 program / program enrollment models.
- * In that presentation, the courses from the program's first requirement
- * section are shown as the course's "modules". It will only ever display
- * actual child courses of the program, never nested child programs.
+ * Wording is driven by the program's `display_mode`: programs with
+ * `display_mode="course"` present as a learner-facing "course" whose child
+ * courses are "modules"; any other program presents as a "Program" whose
+ * children are "courses". Either way the children come from the program's
+ * first requirement section, and only actual child courses are ever
+ * displayed — never nested child programs.
  *
  * This component keeps the underlying program terminology in its data inputs,
  * but translates that data into the course-and-modules UI used on the
@@ -359,7 +375,9 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     <Stack direction="row" gap="4px" alignItems="center">
       <ProgressBadge enrollmentStatus={programEnrollmentStatus} />
       <Separator />
-      <CardTypeText>Course</CardTypeText>
+      <CardTypeText>
+        {getProgramTypeLabel(courseProgram.display_mode)}
+      </CardTypeText>
     </Stack>
   )
 
@@ -434,7 +452,8 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
       <ProgramCardContent>
         <ProgramCardSubHeader>
           <ProgramCardSubHeaderText variant="subtitle3">
-            {totalCount} Modules ({completedCount} of {totalCount} complete)
+            {totalCount} {getProgramChildrenLabel(courseProgram.display_mode)} (
+            {completedCount} of {totalCount} complete)
           </ProgramCardSubHeaderText>
         </ProgramCardSubHeader>
         <ProgramCardBody>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -210,7 +210,11 @@ const getProgramTypeLabel = (
 
 const getProgramChildrenLabel = (
   displayMode: V2ProgramDisplayMode | null | undefined,
-) => (displayMode === DisplayModeEnum.Course ? "Modules" : "Courses")
+  count: number,
+) => {
+  const label = displayMode === DisplayModeEnum.Course ? "Module" : "Course"
+  return count === 1 ? label : `${label}s`
+}
 
 interface ProgramAsCourse {
   id: number
@@ -452,7 +456,8 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
       <ProgramCardContent>
         <ProgramCardSubHeader>
           <ProgramCardSubHeaderText variant="subtitle3">
-            {totalCount} {getProgramChildrenLabel(courseProgram.display_mode)} (
+            {totalCount}{" "}
+            {getProgramChildrenLabel(courseProgram.display_mode, totalCount)} (
             {completedCount} of {totalCount} complete)
           </ProgramCardSubHeaderText>
         </ProgramCardSubHeader>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -147,7 +147,7 @@ describe("ProgramEnrollmentDisplay", () => {
     renderWithProviders(<ProgramEnrollmentDisplay programId={456} />)
 
     // Wait for program data to load
-    await screen.findByText(/for this program/)
+    await screen.findByText(/You have completed/)
 
     // Wait for requirement sections to appear
     await waitFor(
@@ -156,6 +156,133 @@ describe("ProgramEnrollmentDisplay", () => {
         expect(coreCourses).toBeInTheDocument()
       },
       { timeout: 2000 },
+    )
+  })
+
+  test("Completion summary omits 'courses for this program' when the program's display_mode is unset", async () => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const coreCourses = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    coreCourses.addCourse({ course: 1 })
+
+    const program = mitxonline.factories.programs.program({
+      id: 457,
+      display_mode: null,
+      courses: [1],
+      req_tree: reqTree.serialize(),
+    })
+    const courses = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        mitxonline.factories.courses.course({
+          id: 1,
+          courseruns: [mitxonline.factories.courses.courseRun()],
+        }),
+      ],
+    }
+
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
+    setMockResponse.get(
+      mitxonline.urls.programEnrollments.enrollmentsListV3(),
+      [
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program: {
+            id: program.id,
+            title: program.title,
+            live: program.live,
+            program_type: program.program_type,
+            readable_id: program.readable_id,
+          },
+        }),
+      ],
+    )
+    setMockResponse.get(mitxonline.urls.programs.programDetail(457), program)
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: program.courses,
+        page_size: program.courses.length,
+      }),
+      courses,
+    )
+
+    renderWithProviders(<ProgramEnrollmentDisplay programId={457} />)
+
+    const completionCount = await screen.findByTestId(
+      "program-completion-count",
+    )
+    expect(completionCount).toHaveTextContent("You have completed 0 of 1.")
+    expect(completionCount).not.toHaveTextContent("courses for this program")
+  })
+
+  test("Completion summary keeps 'courses for this program' when the program's display_mode is 'course'", async () => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const coreCourses = reqTree.addOperator({
+      operator: "all_of",
+      title: "Core Courses",
+    })
+    coreCourses.addCourse({ course: 1 })
+
+    const program = mitxonline.factories.programs.program({
+      id: 458,
+      display_mode: "course",
+      courses: [1],
+      req_tree: reqTree.serialize(),
+    })
+    const courses = {
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        mitxonline.factories.courses.course({
+          id: 1,
+          courseruns: [mitxonline.factories.courses.courseRun()],
+        }),
+      ],
+    }
+
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
+    setMockResponse.get(
+      mitxonline.urls.programEnrollments.enrollmentsListV3(),
+      [
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program: {
+            id: program.id,
+            title: program.title,
+            live: program.live,
+            program_type: program.program_type,
+            readable_id: program.readable_id,
+          },
+        }),
+      ],
+    )
+    setMockResponse.get(mitxonline.urls.programs.programDetail(458), program)
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: program.courses,
+        page_size: program.courses.length,
+      }),
+      courses,
+    )
+
+    renderWithProviders(<ProgramEnrollmentDisplay programId={458} />)
+
+    const completionCount = await screen.findByTestId(
+      "program-completion-count",
+    )
+    expect(completionCount).toHaveTextContent(
+      "You have completed 0 of 1 courses for this program.",
     )
   })
 
@@ -291,6 +418,120 @@ describe("ProgramEnrollmentDisplay", () => {
     expect((await screen.findAllByText("Module B")).length).toBeGreaterThan(0)
   })
 
+  test("Shows nested Program cards (display_mode unset) with course children even when user is not enrolled in that program", async () => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const parentReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const parentRequirements = parentReqTree.addOperator({
+      operator: "min_number_of",
+      operator_value: "1",
+      title: "Learning Paths",
+    })
+    parentRequirements.addProgram({ program: 910 })
+
+    const parentProgram = mitxonline.factories.programs.program({
+      id: 2345,
+      title: "Program of Programs",
+      courses: [],
+      req_tree: parentReqTree.serialize(),
+    })
+
+    const trackReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const trackRequirements = trackReqTree.addOperator({
+      operator: "all_of",
+      title: "Track Courses",
+    })
+    trackRequirements.addCourse({ course: 21 })
+    trackRequirements.addCourse({ course: 22 })
+
+    const trackProgram = mitxonline.factories.programs.program({
+      id: 910,
+      title: "General Track",
+      display_mode: null,
+      courses: [21, 22],
+      req_tree: trackReqTree.serialize(),
+    })
+
+    const trackCourses = {
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        mitxonline.factories.courses.course({
+          id: 21,
+          title: "Track Course A",
+          courseruns: [mitxonline.factories.courses.courseRun()],
+        }),
+        mitxonline.factories.courses.course({
+          id: 22,
+          title: "Track Course B",
+          courseruns: [mitxonline.factories.courses.courseRun()],
+        }),
+      ],
+    }
+
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [])
+    setMockResponse.get(
+      mitxonline.urls.programEnrollments.enrollmentsListV3(),
+      [
+        mitxonline.factories.enrollment.programEnrollmentV3({
+          program: {
+            id: parentProgram.id,
+            title: parentProgram.title,
+            live: parentProgram.live,
+            program_type: parentProgram.program_type,
+            readable_id: parentProgram.readable_id,
+          },
+        }),
+      ],
+    )
+    setMockResponse.get(
+      mitxonline.urls.programs.programDetail(parentProgram.id),
+      parentProgram,
+    )
+    setMockResponse.get(
+      mitxonline.urls.programs.programsList({
+        id: [910],
+        page_size: 1,
+      }),
+      {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [trackProgram],
+      },
+    )
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: [21, 22],
+        page_size: 2,
+      }),
+      trackCourses,
+    )
+
+    renderWithProviders(
+      <ProgramEnrollmentDisplay programId={parentProgram.id} />,
+    )
+
+    await screen.findByText("Learning Paths")
+    expect(
+      (await screen.findAllByText("General Track")).length,
+    ).toBeGreaterThan(0)
+    expect(
+      (await screen.findAllByText("Track Course A")).length,
+    ).toBeGreaterThan(0)
+    expect(
+      (await screen.findAllByText("Track Course B")).length,
+    ).toBeGreaterThan(0)
+    // "Program" wording, not the program-as-course's "Course"/"Modules" wording.
+    expect(screen.getAllByText("Program").length).toBeGreaterThan(0)
+    expect(screen.getByText("2 Courses (0 of 2 complete)")).toBeInTheDocument()
+  })
+
   test("Completion counts include program-as-course items in required totals", async () => {
     /**
      * A section contains 1 course + 1 program-as-course.
@@ -412,7 +653,9 @@ describe("ProgramEnrollmentDisplay", () => {
     // Section header includes both the course and program-as-course item
     await screen.findByText(/Completed 0 of 2/)
     // Overall summary uses the same counting behavior
-    await screen.findByText(/0 of 2 courses/)
+    expect(screen.getByTestId("program-completion-count")).toHaveTextContent(
+      "0 of 2",
+    )
   })
 
   test("Completed program-as-course items count toward completion total", async () => {
@@ -547,7 +790,9 @@ describe("ProgramEnrollmentDisplay", () => {
 
     // program-as-course has certificate → counts as completed
     await screen.findByText(/Completed 1 of 2/)
-    await screen.findByText(/1 of 2 courses/)
+    expect(screen.getByTestId("program-completion-count")).toHaveTextContent(
+      "1 of 2",
+    )
   })
 
   test("Shows enrollment status for program courses", async () => {
@@ -938,7 +1183,9 @@ describe("ProgramEnrollmentDisplay", () => {
       if (expectCompletionCount) {
         const completionCount = screen.getByTestId("section-completion-count")
         expect(completionCount).toHaveTextContent("Completed 0 of 1")
-        expect(screen.getByText(/0 of 1 courses/)).toBeInTheDocument()
+        expect(
+          screen.getByTestId("program-completion-count"),
+        ).toHaveTextContent("0 of 1")
       } else {
         expect(
           screen.queryByTestId("section-completion-count"),
@@ -1064,7 +1311,7 @@ describe("ProgramEnrollmentDisplay", () => {
 
     // 1 required completed + min(2 electives completed, 1 required) = 2 total completed
     // total = 2 required + 1 elective min = 3
-    await screen.findByText(/2 of 3 courses/)
+    await screen.findByText(/2 of 3/)
   })
 
   test("Section header caps displayed count at operator_value for min_number_of sections", async () => {
@@ -1171,7 +1418,9 @@ describe("ProgramEnrollmentDisplay", () => {
     const sectionCount = screen.getByTestId("section-completion-count")
     expect(sectionCount).toHaveTextContent("Completed 1 of 1")
     // Overall header should also show 1 of 1 (only electives section)
-    expect(screen.getByText(/1 of 1 courses/)).toBeInTheDocument()
+    expect(screen.getByTestId("program-completion-count")).toHaveTextContent(
+      "1 of 1",
+    )
   })
 
   test("Returns 404 page when user is not enrolled in the program", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -1311,7 +1311,9 @@ describe("ProgramEnrollmentDisplay", () => {
 
     // 1 required completed + min(2 electives completed, 1 required) = 2 total completed
     // total = 2 required + 1 elective min = 3
-    await screen.findByText(/2 of 3/)
+    expect(
+      await screen.findByTestId("program-completion-count"),
+    ).toHaveTextContent("2 of 3")
   })
 
   test("Section header caps displayed count at operator_value for min_number_of sections", async () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Skeleton, Stack, Typography, styled, theme } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
+import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { ResourceType, getKey } from "./model/dashboardViewModel"
 import { CoursewareCard } from "./CoursewareCard"
 import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
@@ -9,11 +10,6 @@ import { RiAwardFill } from "@remixicon/react"
 import { useProgramDashboardData } from "./hooks/useProgramDashboardData"
 
 const CourseEntryCardStyled = styled(CoursewareCard)({
-  borderRadius: "8px",
-  boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
-})
-
-const StyledCoursewareCard = styled(CoursewareCard)({
   borderRadius: "8px",
   boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
 })
@@ -71,12 +67,14 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
           {data.programTitle}
         </Typography>
         <Stack direction="row" justifyContent="space-between">
-          <Typography variant="body2">
+          <Typography variant="body2" data-testid="program-completion-count">
             You have completed
             <Typography component="span" variant="subtitle2">
-              {` ${data.completedCount} of ${data.totalCount} courses `}
+              {` ${data.completedCount} of ${data.totalCount}`}
             </Typography>
-            for this program.
+            {data.programDisplayMode === DisplayModeEnum.Course
+              ? " courses for this program."
+              : "."}
           </Typography>
           <Stack direction="column" alignItems="flex-end" gap="8px">
             {data.programCertificateUrl && (
@@ -152,14 +150,23 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                   )
                 }
 
+                // item.kind === "program" — rendered with the same card as
+                // program-as-course for now; the card derives its "Program"
+                // wording from display_mode. Only course children can be
+                // displayed until the card grows a nested-program renderer.
                 return (
-                  <StyledCoursewareCard
+                  <ProgramAsCourseCard
                     key={getKey({
                       resourceType: ResourceType.Program,
-                      id: item.enrollment.program.id,
+                      id: item.program.id,
                     })}
-                    kind="program-enrollment"
-                    programEnrollment={item.enrollment}
+                    courseProgram={item.program}
+                    moduleCourses={item.children.flatMap((child) =>
+                      child.kind === "course" ? [child.entry.course] : [],
+                    )}
+                    moduleEnrollmentsByCourseId={data.enrollmentsByCourseId}
+                    courseProgramEnrollment={item.programEnrollment}
+                    ancestorProgramEnrollment={data.ancestorProgramEnrollment}
                   />
                 )
               })}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -151,9 +151,8 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                 }
 
                 // item.kind === "program" — rendered with the same card as
-                // program-as-course for now; the card derives its "Program"
-                // wording from display_mode. Only course children can be
-                // displayed until the card grows a nested-program renderer.
+                // program-as-course; the card derives its "Program" wording
+                // from display_mode.
                 return (
                   <ProgramAsCourseCard
                     key={getKey({
@@ -161,9 +160,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       id: item.program.id,
                     })}
                     courseProgram={item.program}
-                    moduleCourses={item.children.flatMap((child) =>
-                      child.kind === "course" ? [child.entry.course] : [],
-                    )}
+                    moduleCourses={item.moduleCourses}
                     moduleEnrollmentsByCourseId={data.enrollmentsByCourseId}
                     courseProgramEnrollment={item.programEnrollment}
                     ancestorProgramEnrollment={data.ancestorProgramEnrollment}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
@@ -483,11 +483,8 @@ describe("useProgramDashboardData", () => {
     if (item.kind === "program") {
       expect(item.program.id).toBe(901)
       expect(item.programEnrollment).toBeUndefined()
-      expect(item.children).toHaveLength(1)
-      expect(item.children[0].kind).toBe("course")
-      if (item.children[0].kind === "course") {
-        expect(item.children[0].entry.course.id).toBe(childCourse.id)
-      }
+      expect(item.moduleCourses).toHaveLength(1)
+      expect(item.moduleCourses[0].id).toBe(childCourse.id)
     }
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.test.tsx
@@ -431,7 +431,7 @@ describe("useProgramDashboardData", () => {
     }
   })
 
-  test("program-enrollment arm is correctly identified in sections", async () => {
+  test("program arm is produced for nested programs even without an enrollment", async () => {
     const parentReqTree =
       new mitxonline.factories.requirements.RequirementTreeBuilder()
     const requirements = parentReqTree.addOperator({
@@ -440,11 +440,22 @@ describe("useProgramDashboardData", () => {
     })
     requirements.addProgram({ program: 901 })
 
-    // Not display_mode=course, with a user enrollment in it → program-enrollment
-    // arm. Only `id` is under test; this arm reads neither courses nor req_tree
-    // of a required program, so no other overrides.
+    const childCourse = mitxonline.factories.courses.course({ id: 31 })
+    const nestedReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const trackCourses = nestedReqTree.addOperator({
+      operator: "all_of",
+      title: "Track Courses",
+    })
+    trackCourses.addCourse({ course: childCourse.id })
+
+    // Not display_mode=course (factory default null) and NO user enrollment
+    // in it — the unenrolled-track bug case. Must still render, with its
+    // course children resolved from the required-program courses query.
     const requiredProgram = mitxonline.factories.programs.program({
       id: 901,
+      courses: [childCourse.id],
+      req_tree: nestedReqTree.serialize(),
     })
 
     const parentProgram = mitxonline.factories.programs.program({
@@ -453,13 +464,13 @@ describe("useProgramDashboardData", () => {
       req_tree: parentReqTree.serialize(),
     })
     const parentProgramEnrollment = makeProgramEnrollment(parentProgram)
-    const requiredProgramEnrollment = makeProgramEnrollment(requiredProgram)
 
     const { mockAll } = buildProgramScenario({
       programId: parentProgram.id,
       program: parentProgram,
-      programEnrollments: [parentProgramEnrollment, requiredProgramEnrollment],
+      programEnrollments: [parentProgramEnrollment],
       requiredPrograms: [requiredProgram],
+      requiredProgramCourses: [childCourse],
     })
     mockAll()
 
@@ -468,9 +479,15 @@ describe("useProgramDashboardData", () => {
 
     expect(result.current.sections).toHaveLength(1)
     const item = result.current.sections[0].items[0]
-    expect(item.kind).toBe("program-enrollment")
-    if (item.kind === "program-enrollment") {
-      expect(item.enrollment.program.id).toBe(901)
+    expect(item.kind).toBe("program")
+    if (item.kind === "program") {
+      expect(item.program.id).toBe(901)
+      expect(item.programEnrollment).toBeUndefined()
+      expect(item.children).toHaveLength(1)
+      expect(item.children[0].kind).toBe("course")
+      if (item.children[0].kind === "course") {
+        expect(item.children[0].entry.course.id).toBe(childCourse.id)
+      }
     }
   })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/hooks/useProgramDashboardData.ts
@@ -3,8 +3,10 @@ import { useQuery } from "@tanstack/react-query"
 import { enrollmentQueries } from "api/mitxonline-hooks/enrollment"
 import { coursesQueries } from "api/mitxonline-hooks/courses"
 import { programsQueries } from "api/mitxonline-hooks/programs"
-import type { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
-import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
+import type {
+  CourseRunEnrollmentV3,
+  V2ProgramDisplayMode,
+} from "@mitodl/mitxonline-api-axios/v2"
 import { getIdsFromReqTree } from "@/common/mitxonline"
 import {
   groupCourseRunEnrollmentsByCourseId,
@@ -19,6 +21,7 @@ export type ProgramDashboardData = {
   sections: RequirementSection[]
   programTitle: string | undefined
   programType: string | null | undefined
+  programDisplayMode: V2ProgramDisplayMode | null | undefined
   programCertificateUrl: string | null
   completedCount: number
   totalCount: number
@@ -100,16 +103,13 @@ const useProgramDashboardData = (programId: number): ProgramDashboardData => {
     [requiredPrograms?.results],
   )
 
-  const programAsCourseCourseIds = React.useMemo(() => {
+  // Every nested program (program-as-course or not) renders with its course children
+  // on the program dashboard, so gather course ids across all of them.
+  const requiredProgramCourseIds = React.useMemo(() => {
     const uniqueIds = new Set<number>()
-    requiredProgramList
-      .filter(
-        (requiredProgram) =>
-          requiredProgram.display_mode === DisplayModeEnum.Course,
-      )
-      .forEach((requiredProgram) => {
-        requiredProgram.courses?.forEach((courseId) => uniqueIds.add(courseId))
-      })
+    requiredProgramList.forEach((requiredProgram) => {
+      requiredProgram.courses?.forEach((courseId) => uniqueIds.add(courseId))
+    })
     return [...uniqueIds]
   }, [requiredProgramList])
 
@@ -118,10 +118,10 @@ const useProgramDashboardData = (programId: number): ProgramDashboardData => {
     isLoading: requiredProgramCoursesLoading,
   } = useQuery({
     ...coursesQueries.coursesList({
-      id: programAsCourseCourseIds,
-      page_size: programAsCourseCourseIds.length || undefined,
+      id: requiredProgramCourseIds,
+      page_size: requiredProgramCourseIds.length || undefined,
     }),
-    enabled: Boolean(enrolledInProgram && programAsCourseCourseIds.length > 0),
+    enabled: Boolean(enrolledInProgram && requiredProgramCourseIds.length > 0),
   })
 
   const isLoading =
@@ -178,6 +178,7 @@ const useProgramDashboardData = (programId: number): ProgramDashboardData => {
     sections,
     programTitle: program?.title,
     programType: program?.program_type,
+    programDisplayMode: program?.display_mode,
     programCertificateUrl,
     completedCount,
     totalCount,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1183,7 +1183,7 @@ describe("dashboardViewModel", () => {
       }
     })
 
-    test("produces a program-enrollment arm for regular programs that have an enrollment", () => {
+    test("produces a program arm for regular programs, carrying the enrollment when one exists", () => {
       const requiredProgram = factories.programs.program({
         id: 4001,
         display_mode: null,
@@ -1206,13 +1206,14 @@ describe("dashboardViewModel", () => {
       })
 
       expect(sections).toHaveLength(1)
-      expect(sections[0].items[0].kind).toBe("program-enrollment")
-      if (sections[0].items[0].kind === "program-enrollment") {
-        expect(sections[0].items[0].enrollment).toBe(programEnrollment)
+      expect(sections[0].items[0].kind).toBe("program")
+      if (sections[0].items[0].kind === "program") {
+        expect(sections[0].items[0].program).toBe(requiredProgram)
+        expect(sections[0].items[0].programEnrollment).toBe(programEnrollment)
       }
     })
 
-    test("drops a regular program item when there is no enrollment for it", () => {
+    test("produces a program arm even when there is no enrollment for it (unenrolled nested programs still render)", () => {
       const requiredProgram = factories.programs.program({
         id: 5001,
         display_mode: null,
@@ -1231,7 +1232,56 @@ describe("dashboardViewModel", () => {
         requiredProgramModuleCoursesByProgramId: {},
       })
 
-      expect(sections).toHaveLength(0)
+      expect(sections).toHaveLength(1)
+      expect(sections[0].items[0].kind).toBe("program")
+      if (sections[0].items[0].kind === "program") {
+        expect(sections[0].items[0].program).toBe(requiredProgram)
+        expect(sections[0].items[0].programEnrollment).toBeUndefined()
+      }
+    })
+
+    test("program arm children resolve course leaves from module courses; unfetched grandchild programs drop", () => {
+      const childCourse = factories.courses.course({ id: 5101 })
+      const nestedTree = new RequirementTreeBuilder()
+      const nestedOp = nestedTree.addOperator({
+        operator: "all_of",
+        title: "Track Courses",
+      })
+      nestedOp.addCourse({ course: childCourse.id })
+      // Grandchild program — depth-2 data is never fetched, so it must drop.
+      nestedOp.addProgram({ program: 9998 })
+
+      const requiredProgram = factories.programs.program({
+        id: 5201,
+        display_mode: null,
+        courses: [childCourse.id],
+        req_tree: nestedTree.serialize(),
+      })
+      const root = new RequirementTreeBuilder()
+      const op = root.addOperator({ operator: "all_of", title: "Tracks" })
+      op.addProgram({ program: requiredProgram.id })
+
+      const { sections } = buildRequirementSections({
+        reqTree: root.serialize(),
+        programCourses: [],
+        enrollmentsByCourseId: {},
+        programEnrollmentsById: {},
+        requiredPrograms: [requiredProgram],
+        requiredProgramModuleCoursesByProgramId: {
+          [requiredProgram.id]: [childCourse],
+        },
+      })
+
+      expect(sections).toHaveLength(1)
+      const item = sections[0].items[0]
+      expect(item.kind).toBe("program")
+      if (item.kind === "program") {
+        expect(item.children).toHaveLength(1)
+        expect(item.children[0].kind).toBe("course")
+        if (item.children[0].kind === "course") {
+          expect(item.children[0].entry.course).toBe(childCourse)
+        }
+      }
     })
 
     test("drops a program item when the program id is not in requiredPrograms", () => {

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.test.ts
@@ -1240,22 +1240,12 @@ describe("dashboardViewModel", () => {
       }
     })
 
-    test("program arm children resolve course leaves from module courses; unfetched grandchild programs drop", () => {
+    test("program arm's moduleCourses resolve from requiredProgramModuleCoursesByProgramId", () => {
       const childCourse = factories.courses.course({ id: 5101 })
-      const nestedTree = new RequirementTreeBuilder()
-      const nestedOp = nestedTree.addOperator({
-        operator: "all_of",
-        title: "Track Courses",
-      })
-      nestedOp.addCourse({ course: childCourse.id })
-      // Grandchild program — depth-2 data is never fetched, so it must drop.
-      nestedOp.addProgram({ program: 9998 })
-
       const requiredProgram = factories.programs.program({
         id: 5201,
         display_mode: null,
         courses: [childCourse.id],
-        req_tree: nestedTree.serialize(),
       })
       const root = new RequirementTreeBuilder()
       const op = root.addOperator({ operator: "all_of", title: "Tracks" })
@@ -1276,11 +1266,7 @@ describe("dashboardViewModel", () => {
       const item = sections[0].items[0]
       expect(item.kind).toBe("program")
       if (item.kind === "program") {
-        expect(item.children).toHaveLength(1)
-        expect(item.children[0].kind).toBe("course")
-        if (item.children[0].kind === "course") {
-          expect(item.children[0].entry.course).toBe(childCourse)
-        }
+        expect(item.moduleCourses).toEqual([childCourse])
       }
     })
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -682,15 +682,13 @@ const getRequirementSectionTitle = (node: V2ProgramRequirement): string => {
  * The other two arms are not `DashboardCourseEntry`-shaped and are intentionally
  * left as lighter structs.
  *
- * The two program arms split on the nested program's `display_mode`:
- * - `program-as-course` is the program-with-`display_mode:"course"` presentation
- *   and only ever has course children (`moduleCourses`).
- * - `program` is any other nested program. Its `children` are recursively
- *   typed because a real program's requirements may reference further
- *   programs; today only one level is resolved (see `resolveRequirementItem`)
- *   and rendering still flows through the course-as-program card, so
- *   `children` is the model-layer truth that becomes the render source when
- *   this arm gets its own card component.
+ * The two program arms split on the nested program's `display_mode` and are
+ * otherwise structurally identical (`moduleCourses` course children, optional
+ * enrollment): `program-as-course` is the program-with-`display_mode:"course"`
+ * presentation; `program` is any other nested program. Kept as separate arms
+ * (rather than merged) because their learner-facing wording and future render
+ * paths are expected to diverge — see the `getProgramTypeLabel`/
+ * `getProgramChildrenLabel` split in `ProgramAsCourseCard`.
  */
 type RequirementSectionItem =
   | { kind: "course"; entry: DashboardCourseEntry }
@@ -703,7 +701,7 @@ type RequirementSectionItem =
   | {
       kind: "program"
       program: V2ProgramDetail
-      children: RequirementSectionItem[]
+      moduleCourses: CourseWithCourseRunsSerializerV2[]
       programEnrollment?: V3UserProgramEnrollment
     }
 
@@ -797,13 +795,9 @@ type ResolveRequirementItemContext = {
  * `RequirementSectionItem`, or `null` when the referenced entity is not in
  * the context pools (callers drop nulls).
  *
- * Program leaves split on `display_mode`:
- * - `display_mode === "course"` → `program-as-course` presentation.
- * - anything else → `program`, whose `children` are resolved recursively from
- *   the nested program's own req_tree. The recursive call scopes
- *   `coursesById` to that program's module courses and empties `programsById`,
- *   so resolution is depth-1 by construction: grandchild program leaves drop
- *   via the normal not-found rule until deeper fetching exists.
+ * Program leaves split on `display_mode`: `display_mode === "course"` →
+ * `program-as-course`, anything else → `program`. Both arms resolve their
+ * course children the same way, from `moduleCoursesByProgramId`.
  */
 const resolveRequirementItem = (
   resource: { type: "course" | "program"; id: number },
@@ -838,27 +832,10 @@ const resolveRequirementItem = (
     }
   }
 
-  const childCoursesById = new Map(
-    (ctx.moduleCoursesByProgramId[program.id] ?? []).map((course) => [
-      course.id,
-      course,
-    ]),
-  )
-  const children = parseProgramRequirementSections(program.req_tree)
-    .flatMap((section) => section.items)
-    .map((child) =>
-      resolveRequirementItem(child, {
-        ...ctx,
-        coursesById: childCoursesById,
-        programsById: new Map(),
-      }),
-    )
-    .filter((item): item is RequirementSectionItem => item !== null)
-
   return {
     kind: "program",
     program,
-    children,
+    moduleCourses: ctx.moduleCoursesByProgramId[program.id] ?? [],
     programEnrollment: ctx.programEnrollmentsById[program.id],
   }
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/model/dashboardViewModel.ts
@@ -681,6 +681,16 @@ const getRequirementSectionTitle = (node: V2ProgramRequirement): string => {
  * `course` arm (the only arm with language / contract / enrollment complexity).
  * The other two arms are not `DashboardCourseEntry`-shaped and are intentionally
  * left as lighter structs.
+ *
+ * The two program arms split on the nested program's `display_mode`:
+ * - `program-as-course` is the program-with-`display_mode:"course"` presentation
+ *   and only ever has course children (`moduleCourses`).
+ * - `program` is any other nested program. Its `children` are recursively
+ *   typed because a real program's requirements may reference further
+ *   programs; today only one level is resolved (see `resolveRequirementItem`)
+ *   and rendering still flows through the course-as-program card, so
+ *   `children` is the model-layer truth that becomes the render source when
+ *   this arm gets its own card component.
  */
 type RequirementSectionItem =
   | { kind: "course"; entry: DashboardCourseEntry }
@@ -690,7 +700,12 @@ type RequirementSectionItem =
       moduleCourses: CourseWithCourseRunsSerializerV2[]
       courseProgramEnrollment?: V3UserProgramEnrollment
     }
-  | { kind: "program-enrollment"; enrollment: V3UserProgramEnrollment }
+  | {
+      kind: "program"
+      program: V2ProgramDetail
+      children: RequirementSectionItem[]
+      programEnrollment?: V3UserProgramEnrollment
+    }
 
 /**
  * A fully-resolved requirement section for the program dashboard.
@@ -766,6 +781,88 @@ const buildCourseEntry = (
   }
 }
 
+type ResolveRequirementItemContext = {
+  /** Course pool for resolving course leaves at this level. */
+  coursesById: Map<number, CourseWithCourseRunsSerializerV2>
+  enrollmentsByCourseId: Record<number, CourseRunEnrollmentV3[]>
+  /** Program pool for resolving program leaves at this level. */
+  programsById: Map<number, V2ProgramDetail>
+  programEnrollmentsById: Record<number, V3UserProgramEnrollment>
+  moduleCoursesByProgramId: Record<number, CourseWithCourseRunsSerializerV2[]>
+  ancestorProgramEnrollment?: V3UserProgramEnrollment
+}
+
+/**
+ * Resolve one req_tree leaf (`{ type: "course" | "program", id }`) into a
+ * `RequirementSectionItem`, or `null` when the referenced entity is not in
+ * the context pools (callers drop nulls).
+ *
+ * Program leaves split on `display_mode`:
+ * - `display_mode === "course"` → `program-as-course` presentation.
+ * - anything else → `program`, whose `children` are resolved recursively from
+ *   the nested program's own req_tree. The recursive call scopes
+ *   `coursesById` to that program's module courses and empties `programsById`,
+ *   so resolution is depth-1 by construction: grandchild program leaves drop
+ *   via the normal not-found rule until deeper fetching exists.
+ */
+const resolveRequirementItem = (
+  resource: { type: "course" | "program"; id: number },
+  ctx: ResolveRequirementItemContext,
+): RequirementSectionItem | null => {
+  if (resource.type === "course") {
+    const course = ctx.coursesById.get(resource.id)
+    if (!course) return null
+    const entry = buildCourseEntry(
+      course,
+      ctx.enrollmentsByCourseId[course.id] ?? [],
+      {
+        ancestorContext: ctx.ancestorProgramEnrollment
+          ? { programEnrollment: ctx.ancestorProgramEnrollment }
+          : undefined,
+      },
+    )
+    if (!entry) return null
+    return { kind: "course", entry }
+  }
+
+  // resource.type === "program"
+  const program = ctx.programsById.get(resource.id)
+  if (!program) return null
+
+  if (isProgramAsCourse(program)) {
+    return {
+      kind: "program-as-course",
+      courseProgram: program,
+      moduleCourses: ctx.moduleCoursesByProgramId[program.id] ?? [],
+      courseProgramEnrollment: ctx.programEnrollmentsById[program.id],
+    }
+  }
+
+  const childCoursesById = new Map(
+    (ctx.moduleCoursesByProgramId[program.id] ?? []).map((course) => [
+      course.id,
+      course,
+    ]),
+  )
+  const children = parseProgramRequirementSections(program.req_tree)
+    .flatMap((section) => section.items)
+    .map((child) =>
+      resolveRequirementItem(child, {
+        ...ctx,
+        coursesById: childCoursesById,
+        programsById: new Map(),
+      }),
+    )
+    .filter((item): item is RequirementSectionItem => item !== null)
+
+  return {
+    kind: "program",
+    program,
+    children,
+    programEnrollment: ctx.programEnrollmentsById[program.id],
+  }
+}
+
 type BuildRequirementSectionsArgs = {
   /**
    * The program's `req_tree`. Assumes a flat structure: operators are never
@@ -828,8 +925,14 @@ const buildRequirementSections = ({
   completedCount: number
   totalCount: number
 } => {
-  const coursesById = new Map(programCourses.map((c) => [c.id, c]))
-  const programsById = new Map(requiredPrograms.map((p) => [p.id, p]))
+  const resolveContext: ResolveRequirementItemContext = {
+    coursesById: new Map(programCourses.map((c) => [c.id, c])),
+    enrollmentsByCourseId,
+    programsById: new Map(requiredPrograms.map((p) => [p.id, p])),
+    programEnrollmentsById,
+    moduleCoursesByProgramId: requiredProgramModuleCoursesByProgramId,
+    ancestorProgramEnrollment,
+  }
 
   const parsedSections: ProgramRequirementSection[] =
     parseProgramRequirementSections(reqTree)
@@ -837,42 +940,7 @@ const buildRequirementSections = ({
   const sections: RequirementSection[] = parsedSections
     .map((section) => {
       const items: RequirementSectionItem[] = section.items
-        .map((resource): RequirementSectionItem | null => {
-          if (resource.type === "course") {
-            const course = coursesById.get(resource.id)
-            if (!course) return null
-            const entry = buildCourseEntry(
-              course,
-              enrollmentsByCourseId[course.id] ?? [],
-              {
-                ancestorContext: ancestorProgramEnrollment
-                  ? { programEnrollment: ancestorProgramEnrollment }
-                  : undefined,
-              },
-            )
-            if (!entry) return null
-            return { kind: "course", entry }
-          }
-
-          // resource.type === "program"
-          const program = programsById.get(resource.id)
-          if (!program) return null
-
-          if (isProgramAsCourse(program)) {
-            return {
-              kind: "program-as-course",
-              courseProgram: program,
-              moduleCourses:
-                requiredProgramModuleCoursesByProgramId[program.id] ?? [],
-              courseProgramEnrollment: programEnrollmentsById[program.id],
-            }
-          }
-
-          const enrollment = programEnrollmentsById[program.id]
-          if (!enrollment) return null
-
-          return { kind: "program-enrollment", enrollment }
-        })
+        .map((resource) => resolveRequirementItem(resource, resolveContext))
         .filter((item): item is RequirementSectionItem => item !== null)
 
       const { completed, total } = getRequirementsProgress(

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/test-utils.ts
@@ -14,7 +14,6 @@ import {
   V2Program,
   V2ProgramDetail,
   V3UserProgramEnrollment,
-  DisplayModeEnum,
   LanguageEnum,
 } from "@mitodl/mitxonline-api-axios/v2"
 import { getIdsFromReqTree } from "@/common/mitxonline"
@@ -533,22 +532,20 @@ const buildProgramScenario = (
       )
     }
 
-    // Query 6: required-program courses (program-as-course module courses)
-    // enabled: Boolean(enrolledInProgram && programAsCourseCourseIds.length > 0)
-    // Must mirror useProgramDashboardData.ts programAsCourseCourseIds useMemo exactly — same drift risk.
+    // Query 6: required-program courses (nested-program course children)
+    // enabled: Boolean(enrolledInProgram && requiredProgramCourseIds.length > 0)
+    // Must mirror useProgramDashboardData.ts requiredProgramCourseIds useMemo exactly — same drift risk.
     const uniqueIds = new Set<number>()
-    requiredPrograms
-      .filter((p) => p.display_mode === DisplayModeEnum.Course)
-      .forEach((p) => {
-        p.courses?.forEach((courseId) => uniqueIds.add(courseId))
-      })
-    const programAsCourseCourseIds = [...uniqueIds]
+    requiredPrograms.forEach((p) => {
+      p.courses?.forEach((courseId) => uniqueIds.add(courseId))
+    })
+    const requiredProgramCourseIds = [...uniqueIds]
 
-    if (programAsCourseCourseIds.length > 0) {
+    if (requiredProgramCourseIds.length > 0) {
       setMockResponse.get(
         urls.courses.coursesList({
-          id: programAsCourseCourseIds,
-          page_size: programAsCourseCourseIds.length || undefined,
+          id: requiredProgramCourseIds,
+          page_size: requiredProgramCourseIds.length || undefined,
         }),
         {
           count: requiredProgramCourses.length,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12480

### Description (What does it do?)

Programs nested inside a program (e.g. the SDS MicroMasters "program of programs," where learners choose 1 of 4 track programs) previously did not render on the program dashboard at all unless the user already had an enrollment in the nested program. This PR renders them using the program-as-course card layout, with wording driven by the nested program's `display_mode`.

**Model layer (`dashboardViewModel.ts`)**
- Adds a new `"program"` arm to `RequirementSectionItem` for nested programs without `display_mode: "course"`, replacing the old enrollment-gated `"program-enrollment"` arm (whose `return null` for unenrolled programs was the bug). Nested programs now always render, enrolled or not.
- The existing `"program-as-course"` arm (programs with `display_mode: "course"`) is unchanged.
- Requirement-item resolution is extracted into a recursive `resolveRequirementItem`. The `"program"` arm's `children` are typed recursively (`RequirementSectionItem[]`) since a program's requirements may reference further programs, but resolution is depth-1 by construction: the recursive call gets an empty program pool, so grandchild program leaves drop via the normal not-found rule until deeper fetching exists.

**Data layer (`useProgramDashboardData.ts`)**
- The required-program courses query now gathers course ids from **all** nested programs, not just those with `display_mode: "course"`, so track programs get their course lists too.
- Exposes `programDisplayMode` for the completion-summary wording below.

**Display (`ProgramAsCourseCard.tsx`, `ProgramEnrollmentDisplay.tsx`)**
- `ProgramAsCourseCard` derives its wording from the program's `display_mode`: `"course"` → "Course" type label, "N Modules (…)" sub-header, "View Course Details" menu item; unset → "Program", "N Courses (…)", "View Program Details".
- Fixes the details-link URL, previously hardcoded to the course route: it now routes by actual `display_mode` (`/programs/[readable_id]` for regular programs, `/courses/p/[readable_id]` for program-as-course).
- The program dashboard's overall completion summary reads "You have completed N of M." when the program's `display_mode` is unset (items may be programs, not just courses); programs with `display_mode: "course"` keep "…N of M courses for this program."
- The home dashboard ("My Learning") is untouched — top-level program enrollments still render the flat card with a "View" CTA linking to the program dashboard.

### Screenshots (if appropriate):
<img width="2560" height="1440" alt="program-dashboard" src="https://github.com/user-attachments/assets/dd0b5b7a-f704-4172-b3ca-51d9c0c10668" />
<img width="2560" height="1440" alt="program-dashboard-scrolled" src="https://github.com/user-attachments/assets/c56894b4-befa-4392-8e6e-069696c30758" />
<img width="768" height="1024" alt="program-dashboard" src="https://github.com/user-attachments/assets/0b09720f-3e04-4b09-bae2-d2e73613fe15" />
<img width="768" height="1024" alt="program-dashboard-scrolled" src="https://github.com/user-attachments/assets/d963abae-c581-411b-b4b6-3e79658f0d60" />
<img width="390" height="844" alt="program-dashboard" src="https://github.com/user-attachments/assets/c0a0395b-4bab-461e-820a-7065d424bb2a" />
<img width="390" height="844" alt="program-dashboard-scrolled" src="https://github.com/user-attachments/assets/cc823c5f-e2b5-4762-a78f-ff3e6b7abeb6" />

### How can this be tested?

- Ensure you have MITx Online running and configured to be used alongside Learn.
- Run this script in a Django shell to create a clone of the SDS program:
```python
import json                                                                                                            
from datetime import timedelta                                                                                         
                                                                                                                        
from django.contrib.contenttypes.models import ContentType                                                             
from django.core.exceptions import ObjectDoesNotExist                                                                  
from mitol.common.utils import now_in_utc                                                                              
                                                                                                                        
from cms.api import (                                                                                                  
    create_default_courseware_page,                                                                                    
    ensure_home_page_and_site,                                                                                         
    ensure_product_index,                                                                                              
    ensure_program_product_index,                                                                                      
)                                                                                                                      
from courses.models import (                                                                                           
    Course,                                                                                                            
    CourseRun,                                                                                                         
    Department,                                                                                                        
    EnrollmentMode,                                                                                                    
    Program,                                                                                                           
    ProgramRequirementNodeType,                                                                                        
)                                                                                                                      
from ecommerce.models import Product                                                                                   
from variants.models import SupportedVariant                                                                           
                                                                                                                        
INPUT_PATH = "/src/program_export.json"                                                                                
                                                                                                                        
with open(INPUT_PATH) as f:                                                                                            
    data = json.load(f)                                                                                                
                                                                                                                        
now = now_in_utc()                                                                                                     
course_ct = ContentType.objects.get(app_label="courses", model="course")                                               
run_ct = ContentType.objects.get(app_label="courses", model="courserun")                                               
program_ct = ContentType.objects.get(app_label="courses", model="program")                                             
                                                                                                                        
print("Step 0: CMS infrastructure")                                                                                    
ensure_home_page_and_site()                                                                                            
ensure_product_index()                                                                                                 
ensure_program_product_index()                                                                                         
                                                                                                                        
                                                                                                                        
def ensure_page(courseware):                                                                                           
    try:                                                                                                               
        page = courseware.page                                                                                         
    except ObjectDoesNotExist:                                                                                         
        page = None                                                                                                    
    if page is not None:                                                                                               
        changed = False                                                                                                
        if not page.live:                                                                                              
            page.live = True                                                                                           
            changed = True                                                                                             
        if not page.include_in_learn_catalog:                                                                          
            page.include_in_learn_catalog = True                                                                       
            changed = True                                                                                             
        if changed:                                                                                                    
            page.save_revision().publish()                                                                             
        return page                                                                                                    
    return create_default_courseware_page(                                                                             
        courseware, live=True, include_in_learn_catalog=True                                                           
    )                                                                                                                  
                                                                                                                        
                                                                                                                        
def import_products(content_type, object_id, products_data):                                                           
    created = 0                                                                                                        
    for pd in products_data:                                                                                           
        exists = Product.all_objects.filter(                                                                           
            content_type=content_type, object_id=object_id, is_active=pd["is_active"]                                  
        ).exists()                                                                                                     
        if not exists:                                                                                                 
            Product.objects.create(                                                                                    
                content_type=content_type,                                                                             
                object_id=object_id,                                                                                   
                price=pd["price"],                                                                                     
                description=pd["description"],                                                                         
                is_active=pd["is_active"],                                                                             
            )                                                                                                          
            created += 1                                                                                               
    return created                                                                                                     
                                                                                                                        
                                                                                                                        
print("\nStep 1: Courses")                                                                                             
courses_by_id = {}                                                                                                     
for course_data in data["courses"]:                                                                                    
    course, was_created = Course.objects.get_or_create(                                                                
        readable_id=course_data["readable_id"],                                                                        
        defaults={"title": course_data["title"], "live": course_data.get("live", True)},                               
    )                                                                                                                  
    courses_by_id[course.readable_id] = course                                                                         
    print(("  Created " if was_created else "  Exists  ") + course.readable_id)                                        
                                                                                                                        
    for dept_name in course_data.get("departments", []):                                                               
        dept, _ = Department.objects.get_or_create(name=dept_name)                                                     
        course.departments.add(dept)                                                                                   
                                                                                                                        
    ensure_page(course)                                                                                                
                                                                                                                        
    for vd in course_data.get("variant_options", []):                                                                  
        SupportedVariant.objects.get_or_create(                                                                        
            content_type=course_ct,                                                                                    
            object_id=course.id,                                                                                       
            language=vd["language"],                                                                                   
            variant_industry=vd["variant_industry"],                                                                   
            variant_length=vd["variant_length"],                                                                       
            defaults={                                                                                                 
                "b2b_only": vd["b2b_only"],                                                                            
                "default_variant": vd["default_variant"],                                                              
                "active": True,                                                                                        
            },                                                                                                         
        )                                                                                                              
                                                                                                                        
    runs_with_start = []                                                                                               
    for rd in course_data.get("runs", []):                                                                             
        run, _run_created = CourseRun.all_objects.get_or_create(                                                       
            courseware_id=rd["courseware_id"],                                                                         
            defaults={                                                                                                 
                "course": course,                                                                                      
                "title": rd["title"],                                                                                  
                "run_tag": rd["run_tag"],                                                                              
                "is_source_run": rd.get("is_source_run", False),                                                       
                "is_primary_language": rd.get("is_primary_language", False),                                           
                "language": rd.get("language", ""),                                                                    
                "variant_industry": rd.get("variant_industry", ""),                                                    
                "variant_length": rd.get("variant_length", ""),                                                        
                "start_date": rd.get("start_date"),                                                                    
                "end_date": rd.get("end_date"),                                                                        
                "certificate_available_date": rd.get("certificate_available_date"),                                    
                "enrollment_start": rd.get("enrollment_start"),                                                        
                "enrollment_end": rd.get("enrollment_end"),                                                            
                "expiration_date": rd.get("expiration_date"),                                                          
                "upgrade_deadline": rd.get("upgrade_deadline"),                                                        
                "live": rd.get("live", True),                                                                          
                "is_self_paced": rd.get("is_self_paced", True),                                                        
                "has_courseware_url": rd.get("has_courseware_url", False),                                             
            },                                                                                                         
        )                                                                                                              
        for mode_slug in rd.get("enrollment_modes", []):                                                               
            mode, _ = EnrollmentMode.objects.get_or_create(mode_slug=mode_slug)                                        
            run.enrollment_modes.add(mode)                                                                             
        import_products(run_ct, run.id, rd.get("products", []))                                                        
        if run.start_date:                                                                                             
            runs_with_start.append(run)                                                                                
                                                                                                                        
    if runs_with_start:                                                                                                
        current_run = max(runs_with_start, key=lambda r: r.start_date)                                                 
        current_run.enrollment_start = now - timedelta(days=1)                                                         
        current_run.enrollment_end = now + timedelta(days=180)                                                         
        current_run.live = True                                                                                        
        current_run.save(update_fields=["enrollment_start", "enrollment_end", "live"])                                 
        for mode_slug in ("audit", "verified"):                                                                        
            mode, _ = EnrollmentMode.objects.get_or_create(mode_slug=mode_slug)                                        
            current_run.enrollment_modes.add(mode)                                                                     
        if not Product.all_objects.filter(                                                                             
            content_type=run_ct, object_id=current_run.id, is_active=True                                              
        ).exists():                                                                                                    
            Product.objects.create(                                                                                    
                content_type=run_ct,                                                                                   
                object_id=current_run.id,                                                                              
                price="0.00",                                                                                          
                description=f"{course.title} - local test",                                                            
                is_active=True,                                                                                        
            )                                                                                                          
        print(                                                                                                         
            f"    Current run: {current_run.courseware_id} "                                                           
            f"is_enrollable={current_run.is_enrollable}"                                                               
        )                                                                                                              
                                                                                                                        
print("\nStep 2: Programs")                                                                                            
programs_by_id = {}                                                                                                    
for prog_data in data["programs"]:                                                                                     
    program, was_created = Program.objects.get_or_create(                                                              
        readable_id=prog_data["readable_id"],                                                                          
        defaults={"title": prog_data["title"], "live": prog_data.get("live", True)},                                   
    )                                                                                                                  
    programs_by_id[program.readable_id] = program                                                                      
    print(("  Created " if was_created else "  Exists  ") + program.readable_id)                                       
                                                                                                                        
    program.live = True                                                                                                
    program.program_type = prog_data.get("program_type") or program.program_type                                       
    program.availability = prog_data.get("availability") or program.availability                                       
    program.enrollment_start = prog_data.get("enrollment_start")                                                       
    program.enrollment_end = prog_data.get("enrollment_end")                                                           
    program.display_mode = prog_data.get("display_mode")                                                               
    program.start_date = prog_data.get("start_date")                                                                   
    program.end_date = prog_data.get("end_date")                                                                       
    program.b2b_only = prog_data.get("b2b_only", False)                                                                
    program.save()                                                                                                     
                                                                                                                        
    for dept_name in prog_data.get("departments", []):
        dept, _ = Department.objects.get_or_create(name=dept_name)
        program.departments.add(dept)

    ensure_page(program)
    import_products(program_ct, program.id, prog_data.get("products", []))

    # Program.enrollment_modes is a plain, manually-assigned M2M (courses/models.py) -
    # it isn't derived from child courses/runs/products, and production's export of it
    # is empty for these programs. MIT Learn's getProgramOffering needs it set directly
    # or it renders a disabled "none" enroll button regardless of course-level data.
    audit_mode, _ = EnrollmentMode.objects.get_or_create(mode_slug="audit")
    program.enrollment_modes.add(audit_mode)
    if Product.all_objects.filter(
        content_type=program_ct, object_id=program.id, is_active=True
    ).exists():
        verified_mode, _ = EnrollmentMode.objects.get_or_create(mode_slug="verified")
        program.enrollment_modes.add(verified_mode)
                                                                                                                        
print("\nStep 3: Requirement trees")                                                                                   
                                                                                                                        
                                                                                                                        
def build_requirements(parent, children_data):                                                                         
    for node_data in children_data:                                                                                    
        kwargs = {                                                                                                     
            "node_type": node_data["node_type"],                                                                       
            "operator": node_data.get("operator"),                                                                     
            "operator_value": node_data.get("operator_value"),                                                         
            "title": node_data.get("title"),                                                                           
            "elective_flag": node_data.get("elective_flag", False),                                                    
        }                                                                                                              
        if node_data["node_type"] == ProgramRequirementNodeType.COURSE:                                                
            kwargs["course"] = courses_by_id[node_data["course_readable_id"]]                                          
        if node_data["node_type"] == ProgramRequirementNodeType.PROGRAM:                                               
            kwargs["required_program"] = programs_by_id[                                                               
                node_data["required_program_readable_id"]                                                              
            ]                                                                                                          
        child = parent.add_child(**kwargs)                                                                             
        if node_data.get("children"):                                                                                  
            build_requirements(child, node_data["children"])                                                           
                                                                                                                        
                                                                                                                        
for prog_data in data["programs"]:                                                                                     
    program = programs_by_id[prog_data["readable_id"]]                                                                 
    root = program.requirements_root                                                                                   
    if root.get_children().exists():                                                                                   
        print(f"  {program.readable_id}: requirements already exist, skipping")                                        
        continue                                                                                                       
    build_requirements(root, prog_data.get("requirements", []))                                                        
    print(f"  {program.readable_id}: requirements built")                                                              
                                                                                                                        
root_program = programs_by_id[data["root_program_readable_id"]]                                                        
print(f"\nDone. Root program '{root_program.readable_id}' live={root_program.live}") 
```
- Visit the program in Learn at `/programs/program-v1:MITxT+SDS` and give yourself an audit enrollment
- View the program in the dashboard by scrolling down and finding its card and clicking the View button
- Ensure that the program dashboard functions as desired in the issue and described above

### Additional Context

- The `"program"` arm's `children` are model-layer truth but don't drive rendering yet — `ProgramAsCourseCard` re-derives its rows from `req_tree` + `moduleCourses` internally (same pre-existing pattern as the program-as-course arm). When this arm gets its own card component, `children` becomes the render source, and nested-program children can then be displayed.
- Behavior change to be aware of: a nested program the user is *already* enrolled in previously rendered as a flat program-enrollment row; it now renders as the expanded card with course rows, per the issue's chosen approach.
- Pre-existing quirk left as-is: the card's "Program Record" menu item shows even for unenrolled nested programs.
- `test-utils.ts`'s `buildProgramScenario` mirrors the hook's `requiredProgramCourseIds` memo and was updated in lockstep (documented drift risk).
