### PR TITLE
fix: News, Articles, Django admin pages don't load on production

### DIFF
--- a/website_content/admin.py
+++ b/website_content/admin.py
@@ -21,6 +21,9 @@ class WebsiteContentAdmin(admin.ModelAdmin):
     search_fields = ("title", "slug", "author_name")
     readonly_fields = ("slug", "cover_image", "created_on", "updated_on")
     list_select_related = ("user",)
+    # Avoid rendering every user in a <select> on the change form, which times
+    # out in production. Uses an AJAX search widget instead.
+    autocomplete_fields = ("user",)
     ordering = ("-created_on",)
 
 
@@ -30,4 +33,5 @@ class WebsiteContentImageUploadAdmin(admin.ModelAdmin):
 
     list_display = ("user", "created_at")
     list_select_related = ("user",)
+    autocomplete_fields = ("user",)
     ordering = ("-created_at",)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12491

### Description (What does it do?)
Django admin page for website_content (news / articles) on MIT Learn production won't load because of too many user records so fix is to use autocomplete_fields while loading the website content record

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
For testing you need to open the django admin and try to add new website content instance and see if everything looks good 

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
