### PR TITLE
Only re-embed a run's content files when it is actually republished

### DIFF
--- a/learning_resources/etl/loaders.py
+++ b/learning_resources/etl/loaders.py
@@ -395,10 +395,12 @@ def load_run(
                     )
 
                 transaction.on_commit(enqueue_content_tasks)
-            elif previously_published is False:
+            elif previously_published is False and learning_resource_run.published:
                 # Run was republished. Its content files are still present and
                 # published (retained sources keep them in Qdrant), just absent
                 # from OpenSearch. Re-index them without a full re-ingest.
+                # Runs that remain unpublished must not trip this on every
+                # sync — it re-embeds their files with overwrite=True.
                 content_files_loaded_actions(learning_resource_run)
     return learning_resource_run
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -1346,18 +1346,9 @@ def test_load_run_content_files_loaded_actions_only_on_republish(mocker, new_pub
         published=True,
     )
     run = LearningResourceRunFactory.create(learning_resource=course, published=False)
-    ContentFileFactory.create_batch(2, run=run)
+    ContentFileFactory.create(run=run)
 
-    run_props = model_to_dict(run)
-    run_props["published"] = new_published
-    run_props["prices"] = []
-    run_props["instructors"] = []
-    run_props["image"] = None
-    del run_props["id"]
-    del run_props["learning_resource"]
-    del run_props["resource_prices"]
-
-    load_run(course, run_props)
+    load_run(course, {"run_id": run.run_id, "published": new_published})
 
     assert mock_loaded_actions.call_count == (1 if new_published else 0)
 

--- a/learning_resources/etl/loaders_test.py
+++ b/learning_resources/etl/loaders_test.py
@@ -1328,6 +1328,40 @@ def test_load_run_skips_import_content_files_when_content_files_exist(
     mock_import_task.delay.assert_not_called()
 
 
+@pytest.mark.parametrize("new_published", [True, False])
+def test_load_run_content_files_loaded_actions_only_on_republish(mocker, new_published):
+    """
+    content_files_loaded_actions should fire only when a previously unpublished
+    run becomes published, not on every sync of a run that stays unpublished
+    (which would re-embed its content files each time).
+    """
+    mock_loaded_actions = mocker.patch(
+        "learning_resources.etl.loaders.content_files_loaded_actions",
+        autospec=True,
+    )
+    course = LearningResourceFactory.create(
+        is_course=True,
+        create_runs=False,
+        etl_source=ETLSource.mitxonline.value,
+        published=True,
+    )
+    run = LearningResourceRunFactory.create(learning_resource=course, published=False)
+    ContentFileFactory.create_batch(2, run=run)
+
+    run_props = model_to_dict(run)
+    run_props["published"] = new_published
+    run_props["prices"] = []
+    run_props["instructors"] = []
+    run_props["image"] = None
+    del run_props["id"]
+    del run_props["learning_resource"]
+    del run_props["resource_prices"]
+
+    load_run(course, run_props)
+
+    assert mock_loaded_actions.call_count == (1 if new_published else 0)
+
+
 @pytest.mark.parametrize("parent_factory", [CourseFactory, ProgramFactory])
 @pytest.mark.parametrize("topics_exist", [True, False])
 def test_load_topics(mocker, parent_factory, topics_exist):


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-learn/issues/3661

### Description (What does it do?)
Fixes a bug in `load_run` where the "run was republished" branch checked only the run's *previous* published state, not its new one. A run that stays unpublished (but has retained content files) tripped the branch on every ETL sync, queueing `embed_run_content_files` with `overwrite=True` and fully re-embedding unchanged content files several times a day.

The branch now also requires the run to currently be published, so the re-index/re-embed actions only fire on a real unpublished → published transition.

### How can this be tested?
1. Set `QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS=True` in `env/backend.local.env` and start the stack (`docker compose up`).
2. In a second terminal, watch the celery logs for the embed task:
   `docker compose logs -f celery | grep embed_run_content_files`
3. Open a Django shell (`docker compose run --rm web python manage.py shell`) and set up an unpublished run that has content files on a published course:
   ```python
   from learning_resources.etl.loaders import load_run
   from learning_resources.models import LearningResource

   resource = LearningResource.objects.filter(
       published=True, etl_source="mitxonline",
       runs__published=False, runs__content_files__isnull=False,
   ).first()
   run = resource.runs.filter(published=False, content_files__isnull=False).first()
   # (if none exist, pick any run with content files and set run.published=False; run.save())
   ```
4. Simulate an ETL sync of the still-unpublished run:
   ```python
   load_run(resource, {"run_id": run.run_id, "published": False})
   ```
   **On `main`:** an `embed_run_content_files` task appears in the celery logs even though nothing changed. **On this branch:** no task is queued.
5. Now simulate the run actually being republished:
   ```python
   load_run(resource, {"run_id": run.run_id, "published": True})
   ```
   `embed_run_content_files` is queued once — same behavior as before the fix.

Automated coverage: `test_load_run_content_files_loaded_actions_only_on_republish` in `learning_resources/etl/loaders_test.py` covers both cases.
