### PR TITLE
feat: expose keycloak global_id on the users/me serializer

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -4,6 +4,6 @@
   "channels/serializers.py:136:24:ORM002",
   "profiles/serializers.py:136:31:ORM002",
   "profiles/serializers.py:196:16:ORM002",
-  "profiles/serializers.py:418:15:ORM001",
-  "profiles/serializers.py:419:27:ORM001"
+  "profiles/serializers.py:419:15:ORM001",
+  "profiles/serializers.py:420:27:ORM001"
 ]

--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -5770,6 +5770,12 @@ export interface User {
   username: string
   /**
    *
+   * @type {string}
+   * @memberof User
+   */
+  global_id: string | null
+  /**
+   *
    * @type {Profile}
    * @memberof User
    */

--- a/frontends/api/src/test-utils/factories/user.ts
+++ b/frontends/api/src/test-utils/factories/user.ts
@@ -33,6 +33,7 @@ const user: PartialFactory<User> = (overrides = {}): User => {
       // @ts-expect-error API Response can include anonymous user
       id: null,
       username: "",
+      global_id: null,
     }
   }
 
@@ -44,6 +45,7 @@ const user: PartialFactory<User> = (overrides = {}): User => {
     is_learning_path_editor: false,
     username: faker.internet.username(),
     is_authenticated: true,
+    global_id: faker.string.uuid(),
     ...overrides,
     profile: profile(overrides?.profile ?? {}),
   }

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -5731,6 +5731,10 @@ components:
         username:
           type: string
           readOnly: true
+        global_id:
+          type: string
+          readOnly: true
+          nullable: true
         profile:
           $ref: '#/components/schemas/Profile'
         first_name:
@@ -5750,6 +5754,7 @@ components:
           readOnly: true
       required:
       - first_name
+      - global_id
       - id
       - is_article_editor
       - is_authenticated

--- a/profiles/serializers.py
+++ b/profiles/serializers.py
@@ -383,6 +383,7 @@ class UserSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "username",
+            "global_id",
             "profile",
             "email",
             "first_name",
@@ -391,7 +392,7 @@ class UserSerializer(serializers.ModelSerializer):
             "is_learning_path_editor",
             "is_authenticated",
         )
-        read_only_fields = ("id", "username", "is_authenticated")
+        read_only_fields = ("id", "username", "global_id", "is_authenticated")
 
 
 class ProgramCertificateSerializer(serializers.ModelSerializer):

--- a/profiles/serializers_test.py
+++ b/profiles/serializers_test.py
@@ -38,6 +38,7 @@ def test_serialize_user(user):
     assert UserSerializer(user).data == {
         "id": user.id,
         "username": user.username,
+        "global_id": user.global_id,
         "first_name": user.first_name,
         "last_name": user.last_name,
         "is_learning_path_editor": False,
@@ -90,6 +91,7 @@ def test_serialize_create_user(db, mocker):
     assert UserSerializer(instance=user).data == {
         "id": user.id,
         "username": user.username,
+        "global_id": user.global_id,
         "first_name": user.first_name,
         "last_name": user.last_name,
         "is_learning_path_editor": False,

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -98,6 +98,7 @@ def test_get_user(staff_client, user):
     assert resp.json() == {
         "id": user.id,
         "username": user.username,
+        "global_id": user.global_id,
         "first_name": user.first_name,
         "last_name": user.last_name,
         "is_article_editor": True,
@@ -390,6 +391,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
         assert resp.json() == {
             "id": None,
             "username": "",
+            "global_id": None,
             "is_learning_path_editor": False,
             "is_article_editor": False,
             "is_authenticated": False,
@@ -398,6 +400,7 @@ def test_get_user_by_me(mocker, client, user, is_anonymous):
         assert resp.json() == {
             "id": user.id,
             "username": user.username,
+            "global_id": user.global_id,
             "first_name": user.first_name,
             "last_name": user.last_name,
             "is_learning_path_editor": False,

--- a/profiles/views_test.py
+++ b/profiles/views_test.py
@@ -39,6 +39,7 @@ def test_list_users(staff_client, staff_user):
         {
             "id": staff_user.id,
             "username": staff_user.username,
+            "global_id": staff_user.global_id,
             "first_name": staff_user.first_name,
             "last_name": staff_user.last_name,
             "is_learning_path_editor": True,
@@ -189,6 +190,7 @@ def test_patch_user(staff_client, user, email, email_optin, toc_optin):
     assert resp.json() == {
         "id": user.id,
         "username": user.username,
+        "global_id": user.global_id,
         "first_name": user.first_name,
         "last_name": user.last_name,
         "is_learning_path_editor": True,


### PR DESCRIPTION
### What are the relevant tickets?

- For https://github.com/mitodl/hq/issues/12601


### Description (What does it do?)
Adds the Keycloak-supplied user UUID to the `UserSerializer` response used by `GET /api/v0/users/me/`, so the frontend can identify the authenticated user by their SSO id.

- Uses the field name **`global_id`** to match how mitxonline already exposes the same value (`users.User.global_id`, documented there as "the SSO ID for the user, usually the Keycloak ID"). Same field already exists on mit-learn's `User` model.
- Read-only and nullable: authenticated users get their `global_id`; anonymous users get `null` (a stable key rather than an omitted one).
- Regenerated the OpenAPI spec (`v0.yaml`) and the TypeScript client — `User` now has `global_id: string | null`.
- Updated the `user` test factory for the new required field.
- Bumped two line numbers in `drf_lint_baseline.json` (pre-existing ORM violations shifted down by the added serializer line — not new findings).

### How can this be tested?
1. While authenticated, `GET /api/v0/users/me/` should return a `global_id` matching the user's Keycloak id. Make the same request while logged out and confirm the response contains `"global_id": null`.
2. With MITxOnline and MIT Learn connected to same keycloak, MITxOnline's users/me api should return the same global_id.


### Additional Context
The `global_id` key is present as `null` for anonymous users, whereas the existing authed-only fields (`first_name`, `profile`, …) are omitted entirely. This falls out of DRF's handling of a nullable read-only field, and an always-present key is arguably friendlier for the frontend — flagging in case a reviewer prefers it omitted for anonymous.