### PR TITLE
Delete micromasters resources and remove ETLSource constant

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -8740,13 +8740,12 @@ export const SortbyEnum = {
 export type SortbyEnum = (typeof SortbyEnum)[keyof typeof SortbyEnum]
 
 /**
- * * `micromasters` - micromasters * `mit_edx` - mit_edx * `mitpe` - mitpe * `mitxonline` - mitxonline * `oll` - oll * `ocw` - ocw * `podcast` - podcast * `mit_climate` - mit_climate * `see` - see * `xpro` - xpro * `youtube` - youtube * `canvas` - canvas * `ovs` - ovs
+ * * `mit_edx` - mit_edx * `mitpe` - mitpe * `mitxonline` - mitxonline * `oll` - oll * `ocw` - ocw * `podcast` - podcast * `mit_climate` - mit_climate * `see` - see * `xpro` - xpro * `youtube` - youtube * `canvas` - canvas * `ovs` - ovs
  * @export
  * @enum {string}
  */
 
 export const SourceEnumDescriptions = {
-  micromasters: "micromasters",
   mit_edx: "mit_edx",
   mitpe: "mitpe",
   mitxonline: "mitxonline",
@@ -8762,10 +8761,6 @@ export const SourceEnumDescriptions = {
 } as const
 
 export const SourceEnum = {
-  /**
-   * micromasters
-   */
-  Micromasters: "micromasters",
   /**
    * mit_edx
    */
@@ -33384,7 +33379,7 @@ export const WebhooksApiAxiosParamCreator = function (
   return {
     /**
      * Webhook handler for ContentFile updates
-     * @param {WebhooksContentFilesCreateSourceEnum} source * &#x60;micromasters&#x60; - micromasters * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
+     * @param {WebhooksContentFilesCreateSourceEnum} source * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
      * @param {ContentFileWebHookRequestRequest} ContentFileWebHookRequestRequest
      * @param {string} [content_path]
      * @param {string} [course_id]
@@ -33573,7 +33568,7 @@ export const WebhooksApiFp = function (configuration?: Configuration) {
   return {
     /**
      * Webhook handler for ContentFile updates
-     * @param {WebhooksContentFilesCreateSourceEnum} source * &#x60;micromasters&#x60; - micromasters * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
+     * @param {WebhooksContentFilesCreateSourceEnum} source * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
      * @param {ContentFileWebHookRequestRequest} ContentFileWebHookRequestRequest
      * @param {string} [content_path]
      * @param {string} [course_id]
@@ -33758,8 +33753,8 @@ export const WebhooksApiFactory = function (
  */
 export interface WebhooksApiWebhooksContentFilesCreateRequest {
   /**
-   * * &#x60;micromasters&#x60; - micromasters * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
-   * @type {'micromasters' | 'mit_edx' | 'mitpe' | 'mitxonline' | 'oll' | 'ocw' | 'podcast' | 'mit_climate' | 'see' | 'xpro' | 'youtube' | 'canvas' | 'ovs'}
+   * * &#x60;mit_edx&#x60; - mit_edx * &#x60;mitpe&#x60; - mitpe * &#x60;mitxonline&#x60; - mitxonline * &#x60;oll&#x60; - oll * &#x60;ocw&#x60; - ocw * &#x60;podcast&#x60; - podcast * &#x60;mit_climate&#x60; - mit_climate * &#x60;see&#x60; - see * &#x60;xpro&#x60; - xpro * &#x60;youtube&#x60; - youtube * &#x60;canvas&#x60; - canvas * &#x60;ovs&#x60; - ovs
+   * @type {'mit_edx' | 'mitpe' | 'mitxonline' | 'oll' | 'ocw' | 'podcast' | 'mit_climate' | 'see' | 'xpro' | 'youtube' | 'canvas' | 'ovs'}
    * @memberof WebhooksApiWebhooksContentFilesCreate
    */
   readonly source: WebhooksContentFilesCreateSourceEnum
@@ -33894,7 +33889,6 @@ export class WebhooksApi extends BaseAPI {
  * @export
  */
 export const WebhooksContentFilesCreateSourceEnum = {
-  Micromasters: "micromasters",
   MitEdx: "mit_edx",
   Mitpe: "mitpe",
   Mitxonline: "mitxonline",

--- a/learning_resources/etl/constants.py
+++ b/learning_resources/etl/constants.py
@@ -80,7 +80,6 @@ ProgramLoaderConfig = namedtuple(  # noqa: PYI024
 class ETLSource(ExtendedEnum):
     """Enum of ETL sources"""
 
-    micromasters = "micromasters"
     mit_edx = "mit_edx"
     mitpe = "mitpe"
     mitxonline = "mitxonline"

--- a/learning_resources/migrations/0052_learningresource_certification_type.py
+++ b/learning_resources/migrations/0052_learningresource_certification_type.py
@@ -3,7 +3,6 @@
 from django.db import migrations, models
 
 from learning_resources.constants import CertificationType
-from learning_resources.etl.constants import ETLSource
 
 
 def add_certification_type(apps, schema_editor):
@@ -12,10 +11,10 @@ def add_certification_type(apps, schema_editor):
         certification_type=CertificationType.professional.name
     )
     LearningResource.objects.filter(certification=True, professional=False).exclude(
-        etl_source=ETLSource.micromasters.name
+        etl_source="micromasters"
     ).update(certification_type=CertificationType.completion.name)
     LearningResource.objects.filter(
-        certification=True, etl_source=ETLSource.micromasters.name
+        certification=True, etl_source="micromasters"
     ).update(certification_type=CertificationType.micromasters.name)
 
 

--- a/learning_resources/migrations/0118_delete_micromasters_resources.py
+++ b/learning_resources/migrations/0118_delete_micromasters_resources.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def delete_micromasters_resources(apps, schema_editor):
+    """Delete all micromasters resources (already deindexed by 0117)"""
+    LearningResource = apps.get_model("learning_resources", "LearningResource")
+    LearningResource.objects.filter(etl_source="micromasters").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0117_unpublish_micromasters_resources"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_micromasters_resources, migrations.RunPython.noop),
+    ]

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -9872,7 +9872,6 @@ paths:
         name: source
         schema:
           enum:
-          - micromasters
           - mit_edx
           - mitpe
           - mitxonline
@@ -9888,7 +9887,6 @@ paths:
           type: string
           minLength: 1
         description: |-
-          * `micromasters` - micromasters
           * `mit_edx` - mit_edx
           * `mitpe` - mitpe
           * `mitxonline` - mitxonline
@@ -16368,7 +16366,6 @@ components:
       - Next start date ascending
     SourceEnum:
       enum:
-      - micromasters
       - mit_edx
       - mitpe
       - mitxonline
@@ -16383,7 +16380,6 @@ components:
       - ovs
       type: string
       description: |-
-        * `micromasters` - micromasters
         * `mit_edx` - mit_edx
         * `mitpe` - mitpe
         * `mitxonline` - mitxonline
@@ -16397,7 +16393,6 @@ components:
         * `canvas` - canvas
         * `ovs` - ovs
       x-enum-descriptions:
-      - micromasters
       - mit_edx
       - mitpe
       - mitxonline


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #3663

### Description (What does it do?)
Follow-up cleanup to #3663, which removed the micromasters ETL pipeline and unpublished/deindexed all remaining `etl_source=micromasters` resources from OpenSearch and Qdrant.

- Deletes all `LearningResource` rows with `etl_source="micromasters"` via a new data migration (`0118`). No deindexing is needed — the resources were already removed from OpenSearch/Qdrant by the `0117` migration in #3663; related runs, content files, and relationship rows are removed by FK cascades.
- Removes the now-unused `ETLSource.micromasters` constant.
- Updates migration `0052` to use the `"micromasters"` string literal instead of `ETLSource.micromasters.name`, so historical migrations no longer depend on the removed enum member.

### How can this be tested?
- `docker compose run --rm web python manage.py migrate learning_resources` — `0118` should apply cleanly and delete any remaining micromasters resources.
- `docker compose run --rm web python manage.py makemigrations --check --dry-run` — no model changes detected (`etl_source` is a plain CharField, so removing the enum member causes no schema drift).
- `LearningResource.objects.filter(etl_source="micromasters").count()` should be 0 after migrating.
