### PR TITLE
one click upgrade for courses in verified program enrollments

### DIFF
--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/CoursewareCard.tsx
@@ -120,6 +120,7 @@ const CoursewareCard: React.FC<CoursewareCardProps> = (props) => {
         entry.enrollments,
         entry.displayedEnrollment,
       )}
+      ancestorContext={entry.ancestorContext}
       layout={layout}
       headingLevel={headingLevel}
       onUpgradeError={onUpgradeError}

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -621,6 +621,47 @@ describe.each([
     })
   })
 
+  test("Falls back to checkout when the verified program enrollment has no resolvable program identifier", async () => {
+    const assign = jest.mocked(window.location.assign)
+    setupUserApis()
+    const productId = faker.number.int()
+    const price = faker.commerce.price()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      b2b_contract_id: null,
+      certificate: null,
+      run: {
+        is_upgradable: true,
+        upgrade_deadline: faker.date.future().toISOString(),
+        upgrade_product_id: productId,
+        upgrade_product_price: price,
+        upgrade_product_is_active: true,
+      },
+    })
+    const clearUrl = mitxonline.urls.baskets.clear()
+    setMockResponse.delete(clearUrl, undefined)
+    const basketUrl = mitxonline.urls.baskets.createFromProduct(productId)
+    setMockResponse.post(basketUrl, { id: 1, items: [] })
+
+    renderWithProviders(
+      <EnrolledCourseCard
+        enrollment={enrollment}
+        ancestorContext={{ useVerifiedEnrollment: true }}
+      />,
+    )
+    const banner = within(getCard()).getByTestId("upgrade-root")
+    expect(banner).toHaveTextContent(`Upgrade for certificate - $${price}`)
+
+    await user.click(
+      within(getCard()).getByRole("link", { name: /Upgrade for certificate/ }),
+    )
+
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "post", url: basketUrl }),
+    )
+    expect(assign).toHaveBeenCalledWith(mitxonlineLegacyUrl("/cart/"))
+  })
+
   // ---------------------------------------------------------------------------
   // Upgraded (paid, certificate not yet earned) banner
   // ---------------------------------------------------------------------------

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -496,6 +496,132 @@ describe.each([
   })
 
   // ---------------------------------------------------------------------------
+  // Upgrade banner — verified program enrollment (one-click, no checkout)
+  // ---------------------------------------------------------------------------
+
+  test("Shows 'Upgrade for certificate' without a price when the program enrollment is verified", () => {
+    setupUserApis()
+    const price = faker.commerce.price()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      b2b_contract_id: null,
+      certificate: null,
+      run: {
+        is_upgradable: true,
+        upgrade_deadline: faker.date.future().toISOString(),
+        upgrade_product_id: faker.number.int(),
+        upgrade_product_price: price,
+        upgrade_product_is_active: true,
+      },
+    })
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+      })
+
+    renderWithProviders(
+      <EnrolledCourseCard
+        enrollment={enrollment}
+        ancestorContext={{ programEnrollment }}
+      />,
+    )
+    const banner = within(getCard()).getByTestId("upgrade-root")
+    expect(banner).toHaveTextContent("Upgrade for certificate")
+    expect(banner).not.toHaveTextContent(`$${price}`)
+  })
+
+  test("Clicking upgrade link one-click enrolls in verified mode and redirects to courseware when program enrollment is verified", async () => {
+    setupUserApis()
+    const coursewareUrl = faker.internet.url()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      b2b_contract_id: null,
+      certificate: null,
+      run: {
+        is_upgradable: true,
+        upgrade_deadline: faker.date.future().toISOString(),
+        upgrade_product_id: faker.number.int(),
+        upgrade_product_price: faker.commerce.price(),
+        upgrade_product_is_active: true,
+        courseware_url: coursewareUrl,
+      },
+    })
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+      })
+    const programEnrollmentEndpoint =
+      mitxonline.urls.verifiedProgramEnrollments.create(
+        enrollment.run.courseware_id,
+      )
+    setMockResponse.post(programEnrollmentEndpoint, {})
+
+    renderWithProviders(
+      <EnrolledCourseCard
+        enrollment={enrollment}
+        ancestorContext={{ programEnrollment }}
+      />,
+    )
+    await user.click(
+      within(getCard()).getByRole("link", { name: "Upgrade for certificate" }),
+    )
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          url: programEnrollmentEndpoint,
+        }),
+      )
+    })
+    await waitFor(() => {
+      expect(window.location.href).toBe(coursewareUrl)
+    })
+  })
+
+  test("Calls onUpgradeError when verified program enrollment API fails", async () => {
+    setupUserApis()
+    const enrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: EnrollmentMode.Audit,
+      b2b_contract_id: null,
+      certificate: null,
+      run: {
+        is_upgradable: true,
+        upgrade_deadline: faker.date.future().toISOString(),
+        upgrade_product_id: faker.number.int(),
+        upgrade_product_price: faker.commerce.price(),
+        upgrade_product_is_active: true,
+      },
+    })
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+      })
+    setMockResponse.post(
+      mitxonline.urls.verifiedProgramEnrollments.create(
+        enrollment.run.courseware_id,
+      ),
+      { error: "Server error" },
+      { code: 500 },
+    )
+    const onUpgradeError = jest.fn()
+
+    renderWithProviders(
+      <EnrolledCourseCard
+        enrollment={enrollment}
+        ancestorContext={{ programEnrollment }}
+        onUpgradeError={onUpgradeError}
+      />,
+    )
+    await user.click(
+      within(getCard()).getByRole("link", { name: "Upgrade for certificate" }),
+    )
+    await waitFor(() => {
+      expect(onUpgradeError).toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Upgraded (paid, certificate not yet earned) banner
   // ---------------------------------------------------------------------------
 

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -98,20 +98,27 @@ const UpgradeBanner: React.FC<
   const replaceBasketItem = useReplaceBasketItem()
   const createVerifiedProgramEnrollment = useCreateVerifiedProgramEnrollment()
 
+  const programRequestBody = programReadableIds?.length
+    ? programReadableIds
+    : programCoursewareId
+      ? [programCoursewareId]
+      : []
+  // Mirrors useEnrollmentHandler's gating: without a program identifier the
+  // verified-program-enrollment endpoint can't resolve which program to
+  // credit the upgrade against, so fall back to checkout instead of calling
+  // it with an empty request_body.
+  const canOneClickUpgrade = Boolean(
+    isVerifiedProgramEnrollment && readableId && programRequestBody.length > 0,
+  )
+
   const handleUpgradeClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
 
-    if (isVerifiedProgramEnrollment) {
-      if (!readableId) return
-      const requestBody = programReadableIds?.length
-        ? programReadableIds
-        : programCoursewareId
-          ? [programCoursewareId]
-          : []
+    if (canOneClickUpgrade) {
       try {
         await createVerifiedProgramEnrollment.mutateAsync({
-          courserun_id: readableId,
-          request_body: requestBody,
+          courserun_id: readableId!,
+          request_body: programRequestBody,
         })
         if (coursewareUrl) {
           window.location.href = coursewareUrl
@@ -148,7 +155,7 @@ const UpgradeBanner: React.FC<
     <SubtitleLinkRoot {...others}>
       <SubtitleLink href="#" onClick={handleUpgradeClick}>
         <RiArrowUpCircleLine size="16px" />
-        {isVerifiedProgramEnrollment
+        {canOneClickUpgrade
           ? "Upgrade for certificate"
           : `Upgrade for certificate - $${certificateUpgradePrice}`}
       </SubtitleLink>

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -27,6 +27,7 @@ import { getCourseDateText } from "./courseDateUtils"
 import { isVerifiedEnrollmentMode } from "@/common/mitxonline"
 import { RiArrowUpCircleLine, RiAwardLine, RiMore2Line } from "@remixicon/react"
 import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
+import { useCreateVerifiedProgramEnrollment } from "api/mitxonline-hooks/enrollment"
 import { isInPast, calendarDaysUntil, NoSSR } from "ol-utilities"
 import { SiblingRunsPanel, SiblingRunsToggle } from "./SiblingRunsAccordion"
 import { EnrollmentStatusIcon } from "./EnrollmentStatus"
@@ -36,7 +37,10 @@ import { coursePageView } from "@/common/urls"
 import NiceModal from "@ebay/nice-modal-react"
 import { EmailSettingsDialog, UnenrollDialog } from "./DashboardDialogs"
 import { getReceiptMenuItem } from "./receiptMenuItem"
-import { CourseRunEnrollmentV3 } from "@mitodl/mitxonline-api-axios/v2"
+import {
+  CourseRunEnrollmentV3,
+  V3UserProgramEnrollment,
+} from "@mitodl/mitxonline-api-axios/v2"
 import { ProgressBadge } from "./ProgressBadge"
 
 const formatUpgradeTime = (daysFloat: number) => {
@@ -71,6 +75,11 @@ const UpgradeBanner: React.FC<
     certificateUpgradeDeadline?: string | null
     certificateUpgradePrice?: string | null
     productId?: number | null
+    isVerifiedProgramEnrollment?: boolean
+    readableId?: string
+    coursewareUrl?: string
+    programReadableIds?: string[]
+    programCoursewareId?: string
     onError?: (error: Error) => void
   } & React.HTMLAttributes<HTMLDivElement>
 > = ({
@@ -78,13 +87,41 @@ const UpgradeBanner: React.FC<
   certificateUpgradeDeadline,
   certificateUpgradePrice,
   productId,
+  isVerifiedProgramEnrollment,
+  readableId,
+  coursewareUrl,
+  programReadableIds,
+  programCoursewareId,
   onError,
   ...others
 }) => {
   const replaceBasketItem = useReplaceBasketItem()
+  const createVerifiedProgramEnrollment = useCreateVerifiedProgramEnrollment()
 
   const handleUpgradeClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()
+
+    if (isVerifiedProgramEnrollment) {
+      if (!readableId) return
+      const requestBody = programReadableIds?.length
+        ? programReadableIds
+        : programCoursewareId
+          ? [programCoursewareId]
+          : []
+      try {
+        await createVerifiedProgramEnrollment.mutateAsync({
+          courserun_id: readableId,
+          request_body: requestBody,
+        })
+        if (coursewareUrl) {
+          window.location.href = coursewareUrl
+        }
+      } catch (error) {
+        onError?.(error as Error)
+      }
+      return
+    }
+
     if (!productId) return
 
     try {
@@ -103,7 +140,6 @@ const UpgradeBanner: React.FC<
     return null
   }
 
-  const formattedPrice = `$${certificateUpgradePrice}`
   const calendarDays = certificateUpgradeDeadline
     ? calendarDaysUntil(certificateUpgradeDeadline)
     : null
@@ -112,7 +148,9 @@ const UpgradeBanner: React.FC<
     <SubtitleLinkRoot {...others}>
       <SubtitleLink href="#" onClick={handleUpgradeClick}>
         <RiArrowUpCircleLine size="16px" />
-        {`Upgrade for certificate - ${formattedPrice}`}
+        {isVerifiedProgramEnrollment
+          ? "Upgrade for certificate"
+          : `Upgrade for certificate - $${certificateUpgradePrice}`}
       </SubtitleLink>
       {calendarDays !== null && (
         <>
@@ -166,6 +204,11 @@ const MobileAccordionWrapper = styled.div({
 type EnrolledCourseCardProps = {
   enrollment: CourseRunEnrollmentV3
   siblingEnrollments?: CourseRunEnrollmentV3[]
+  ancestorContext?: {
+    programEnrollment?: V3UserProgramEnrollment
+    parentProgramReadableIds?: string[]
+    useVerifiedEnrollment?: boolean
+  }
   layout?: "default" | "compact"
   headingLevel?: "h2" | "h3" | "h4" | "h5" | "h6"
   onUpgradeError?: (error: string) => void
@@ -177,6 +220,7 @@ type EnrolledCourseCardProps = {
 export const EnrolledCourseCard = ({
   enrollment,
   siblingEnrollments,
+  ancestorContext,
   layout = "default",
   headingLevel,
   onUpgradeError,
@@ -223,6 +267,11 @@ export const EnrolledCourseCard = ({
     !!run?.upgrade_product_price &&
     !!run?.upgrade_product_id &&
     !(run?.upgrade_deadline && isInPast(run.upgrade_deadline))
+  const isVerifiedProgramEnrollment =
+    Boolean(ancestorContext?.useVerifiedEnrollment) ||
+    isVerifiedEnrollmentMode(
+      ancestorContext?.programEnrollment?.enrollment_mode,
+    )
   const enrollmentStatus = getDashboardEnrollmentStatus({
     type: DashboardType.CourseRunEnrollment,
     data: enrollment,
@@ -246,6 +295,13 @@ export const EnrolledCourseCard = ({
       certificateUpgradeDeadline={run?.upgrade_deadline}
       certificateUpgradePrice={run?.upgrade_product_price}
       productId={run?.upgrade_product_id}
+      isVerifiedProgramEnrollment={isVerifiedProgramEnrollment}
+      readableId={run?.courseware_id}
+      coursewareUrl={coursewareUrl ?? undefined}
+      programReadableIds={ancestorContext?.parentProgramReadableIds}
+      programCoursewareId={
+        ancestorContext?.programEnrollment?.program.readable_id
+      }
       onError={() => {
         onUpgradeError?.(
           "There was a problem adding the certificate to your cart.",

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.tsx
@@ -80,7 +80,7 @@ const UpgradeBanner: React.FC<
     coursewareUrl?: string
     programReadableIds?: string[]
     programCoursewareId?: string
-    onError?: (error: Error) => void
+    onUpgradeFailure?: (message: string) => void
   } & React.HTMLAttributes<HTMLDivElement>
 > = ({
   canUpgrade,
@@ -92,7 +92,7 @@ const UpgradeBanner: React.FC<
   coursewareUrl,
   programReadableIds,
   programCoursewareId,
-  onError,
+  onUpgradeFailure,
   ...others
 }) => {
   const replaceBasketItem = useReplaceBasketItem()
@@ -123,8 +123,10 @@ const UpgradeBanner: React.FC<
         if (coursewareUrl) {
           window.location.href = coursewareUrl
         }
-      } catch (error) {
-        onError?.(error as Error)
+      } catch {
+        onUpgradeFailure?.(
+          "There was a problem upgrading your enrollment. Please try again.",
+        )
       }
       return
     }
@@ -133,8 +135,10 @@ const UpgradeBanner: React.FC<
 
     try {
       await replaceBasketItem.mutateAsync(productId)
-    } catch (error) {
-      onError?.(error as Error)
+    } catch {
+      onUpgradeFailure?.(
+        "There was a problem adding the certificate to your cart.",
+      )
     }
   }
 
@@ -309,11 +313,7 @@ export const EnrolledCourseCard = ({
       programCoursewareId={
         ancestorContext?.programEnrollment?.program.readable_id
       }
-      onError={() => {
-        onUpgradeError?.(
-          "There was a problem adding the certificate to your cart.",
-        )
-      }}
+      onUpgradeFailure={onUpgradeError}
     />
   ) : upgradedAndIncomplete ? (
     <UpgradedBanner />

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.tsx
@@ -333,12 +333,36 @@ const ProgramAsCourseCard: React.FC<ProgramAsCourseCardProps> = ({
     completedCount,
   )
 
-  const parentProgramIds = [
-    courseProgram.readable_id,
+  // Ordered nearest-to-furthest (ancestor last). verified_program_enrollments
+  // grants the free upgrade based on whichever given program is structurally
+  // the ancestor, so an unverified ancestor is useless and gets trimmed
+  // below - but the nearer program's id must stay even when unverified,
+  // since the backend also uses it to identify which program owns the
+  // course. See "uses verified enrollment when ancestor has verified mode"
+  // in ProgramAsCourseCard.test.tsx.
+  const programChain = [
+    {
+      readableId: courseProgram.readable_id,
+      enrollmentMode: courseProgramEnrollment?.enrollment_mode,
+    },
     ...(ancestorProgramEnrollment
-      ? [ancestorProgramEnrollment.readable_id]
+      ? [
+          {
+            readableId: ancestorProgramEnrollment.readable_id,
+            enrollmentMode: ancestorProgramEnrollment.enrollment_mode,
+          },
+        ]
       : []),
   ]
+  // Trim an unverified ancestor off the end; never trim the front.
+  const trimmedProgramChain = [...programChain]
+  while (
+    trimmedProgramChain.length > 0 &&
+    !isVerifiedEnrollmentMode(trimmedProgramChain.at(-1)?.enrollmentMode)
+  ) {
+    trimmedProgramChain.pop()
+  }
+  const parentProgramIds = trimmedProgramChain.map((p) => p.readableId)
   const useVerifiedEnrollment = [
     courseProgramEnrollment?.enrollment_mode,
     ancestorProgramEnrollment?.enrollment_mode,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -1692,6 +1692,318 @@ describe("ProgramEnrollmentDisplay", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 
+  test("Upgrading a module course omits an unverified root program from the request body", async () => {
+    // Regression test for a nested-program (e.g. SDS-style track) scenario:
+    // the learner has a verified enrollment in the program-as-course track
+    // itself but only an audit enrollment in its parent program, and is
+    // already audit-enrolled in the module course. The verified enrollment
+    // for the track alone is sufficient to grant the free upgrade, so the
+    // unverified parent must not be sent - see ProgramAsCourseCard's
+    // `parentProgramIds` trimming.
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const moduleRunUpgradeDeadline = faker.date.future().toISOString()
+    const moduleRunUpgradeProductId = faker.number.int()
+    const moduleRunUpgradeProductPrice = faker.commerce.price()
+    const moduleRun = mitxonline.factories.courses.courseRun({
+      title: "Module Course",
+      b2b_contract: null,
+      is_enrollable: true,
+      is_upgradable: true,
+      upgrade_deadline: moduleRunUpgradeDeadline,
+      courseware_url: faker.internet.url(),
+    })
+    const moduleCourse = mitxonline.factories.courses.course({
+      title: "Module Course",
+      courseruns: [moduleRun],
+      next_run_id: moduleRun.id,
+    })
+
+    const programAsCourseReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const moduleSection = programAsCourseReqTree.addOperator({
+      operator: "all_of",
+      title: "Modules",
+    })
+    moduleSection.addCourse({ course: moduleCourse.id })
+
+    const programAsCourse = mitxonline.factories.programs.program({
+      display_mode: "course",
+      courses: [moduleCourse.id],
+      req_tree: programAsCourseReqTree.serialize(),
+    })
+
+    const parentReqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const parentRequirements = parentReqTree.addOperator({
+      operator: "all_of",
+      title: "Program Requirements",
+    })
+    parentRequirements.addProgram({ program: programAsCourse.id })
+
+    const parentProgram = mitxonline.factories.programs.program({
+      req_tree: parentReqTree.serialize(),
+    })
+
+    // Root/ancestor program enrollment is audit - not verified.
+    const parentProgramEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "audit",
+        program: {
+          id: parentProgram.id,
+          title: parentProgram.title,
+          live: parentProgram.live,
+          program_type: parentProgram.program_type,
+          readable_id: parentProgram.readable_id,
+        },
+      })
+    // The nested track itself is verified.
+    const programAsCourseEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+        program: {
+          id: programAsCourse.id,
+          title: programAsCourse.title,
+          live: programAsCourse.live,
+          program_type: programAsCourse.program_type,
+          readable_id: programAsCourse.readable_id,
+        },
+      })
+
+    // Learner already has an audit enrollment in the module course run.
+    const moduleCourseEnrollment =
+      mitxonline.factories.enrollment.courseEnrollment({
+        enrollment_mode: "audit",
+        certificate: null,
+        run: {
+          id: moduleRun.id,
+          course_id: moduleCourse.id,
+          courseware_id: moduleRun.courseware_id,
+          courseware_url: moduleRun.courseware_url,
+          is_upgradable: true,
+          upgrade_deadline: moduleRunUpgradeDeadline,
+          upgrade_product_id: moduleRunUpgradeProductId,
+          upgrade_product_price: moduleRunUpgradeProductPrice,
+          upgrade_product_is_active: true,
+          course: {
+            id: moduleCourse.id,
+            title: moduleCourse.title,
+            readable_id: moduleCourse.readable_id,
+          },
+        },
+      })
+
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [
+      moduleCourseEnrollment,
+    ])
+    setMockResponse.get(
+      mitxonline.urls.programEnrollments.enrollmentsListV3(),
+      [parentProgramEnrollment, programAsCourseEnrollment],
+    )
+    setMockResponse.get(
+      mitxonline.urls.programs.programDetail(parentProgram.id),
+      parentProgram,
+    )
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: parentProgram.courses,
+        page_size: parentProgram.courses.length || undefined,
+      }),
+      { count: 0, next: null, previous: null, results: [] },
+    )
+    setMockResponse.get(
+      mitxonline.urls.programs.programsList({
+        id: [programAsCourse.id],
+        page_size: 1,
+      }),
+      {
+        count: 1,
+        next: null,
+        previous: null,
+        results: [programAsCourse],
+      },
+    )
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: [moduleCourse.id],
+        page_size: 1,
+      }),
+      { count: 1, next: null, previous: null, results: [moduleCourse] },
+    )
+    const moduleCourseEnrollmentEndpoint =
+      mitxonline.urls.verifiedProgramEnrollments.create(moduleRun.courseware_id)
+    setMockResponse.post(moduleCourseEnrollmentEndpoint, {})
+
+    renderWithProviders(
+      <ProgramEnrollmentDisplay programId={parentProgram.id} />,
+    )
+
+    await screen.findByText("Program Requirements")
+    await waitFor(
+      () => {
+        const skeletons = screen.queryAllByTestId("skeleton")
+        expect(skeletons).toHaveLength(0)
+      },
+      { timeout: 3000 },
+    )
+
+    const cards = screen.getAllByTestId("enrollment-card-desktop")
+    const card = cards.find((c) => within(c).queryByText(moduleCourse.title))
+    invariant(
+      card,
+      `Expected to find a card containing "${moduleCourse.title}"`,
+    )
+
+    const upgradeLink = within(card).getByRole("link", {
+      name: "Upgrade for certificate",
+    })
+    await user.click(upgradeLink)
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          url: moduleCourseEnrollmentEndpoint,
+          body: [programAsCourse.readable_id],
+        }),
+      )
+    })
+  })
+
+  test("Shows an error banner when the one-click verified-program upgrade fails", async () => {
+    const mitxOnlineUser = mitxonline.factories.user.user()
+    setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)
+
+    const courseRunUpgradeDeadline = faker.date.future().toISOString()
+    const courseRunUpgradeProductId = faker.number.int()
+    const courseRunUpgradeProductPrice = faker.commerce.price()
+    const courseRun = mitxonline.factories.courses.courseRun({
+      title: "Verified Track Course",
+      b2b_contract: null,
+      is_enrollable: true,
+      is_upgradable: true,
+      upgrade_deadline: courseRunUpgradeDeadline,
+      courseware_url: faker.internet.url(),
+    })
+    const course = mitxonline.factories.courses.course({
+      title: "Verified Track Course",
+      courseruns: [courseRun],
+      next_run_id: courseRun.id,
+    })
+
+    const reqTree =
+      new mitxonline.factories.requirements.RequirementTreeBuilder()
+    const requirements = reqTree.addOperator({
+      operator: "all_of",
+      title: "Program Requirements",
+    })
+    requirements.addCourse({ course: course.id })
+
+    const program = mitxonline.factories.programs.program({
+      courses: [course.id],
+      req_tree: reqTree.serialize(),
+    })
+    const programEnrollment =
+      mitxonline.factories.enrollment.programEnrollmentV3({
+        enrollment_mode: "verified",
+        program: {
+          id: program.id,
+          title: program.title,
+          live: program.live,
+          program_type: program.program_type,
+          readable_id: program.readable_id,
+        },
+      })
+
+    // Learner already has an audit enrollment in the course run.
+    const courseEnrollment = mitxonline.factories.enrollment.courseEnrollment({
+      enrollment_mode: "audit",
+      certificate: null,
+      run: {
+        id: courseRun.id,
+        course_id: course.id,
+        courseware_id: courseRun.courseware_id,
+        courseware_url: courseRun.courseware_url,
+        is_upgradable: true,
+        upgrade_deadline: courseRunUpgradeDeadline,
+        upgrade_product_id: courseRunUpgradeProductId,
+        upgrade_product_price: courseRunUpgradeProductPrice,
+        upgrade_product_is_active: true,
+        course: {
+          id: course.id,
+          title: course.title,
+          readable_id: course.readable_id,
+        },
+      },
+    })
+
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    setMockResponse.get(mitxonline.urls.enrollment.enrollmentsListV3(), [
+      courseEnrollment,
+    ])
+    setMockResponse.get(
+      mitxonline.urls.programEnrollments.enrollmentsListV3(),
+      [programEnrollment],
+    )
+    setMockResponse.get(
+      mitxonline.urls.programs.programDetail(program.id),
+      program,
+    )
+    setMockResponse.get(
+      mitxonline.urls.courses.coursesList({
+        id: program.courses,
+        page_size: program.courses.length,
+      }),
+      { count: 1, next: null, previous: null, results: [course] },
+    )
+
+    const enrollmentEndpoint =
+      mitxonline.urls.verifiedProgramEnrollments.create(courseRun.courseware_id)
+    setMockResponse.post(
+      enrollmentEndpoint,
+      { error: "No verified enrollment in root program" },
+      { code: 400 },
+    )
+
+    renderWithProviders(<ProgramEnrollmentDisplay programId={program.id} />)
+
+    await screen.findByText("Program Requirements")
+    await waitFor(
+      () => {
+        const skeletons = screen.queryAllByTestId("skeleton")
+        expect(skeletons).toHaveLength(0)
+      },
+      { timeout: 3000 },
+    )
+
+    const cards = screen.getAllByTestId("enrollment-card-desktop")
+    const card = cards.find((c) => within(c).queryByText(course.title))
+    invariant(card, `Expected to find a card containing "${course.title}"`)
+
+    const upgradeLink = within(card).getByRole("link", {
+      name: "Upgrade for certificate",
+    })
+    await user.click(upgradeLink)
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "post",
+          url: enrollmentEndpoint,
+        }),
+      )
+    })
+
+    expect(
+      await screen.findByText(/problem upgrading your enrollment/i),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Contact Support" }),
+    ).toBeInTheDocument()
+  })
+
   test("Displays courses in the order defined by the requirement tree, not API order", async () => {
     const mitxOnlineUser = mitxonline.factories.user.user()
     setMockResponse.get(mitxonline.urls.userMe.get(), mitxOnlineUser)

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.tsx
@@ -1,6 +1,6 @@
 import React from "react"
-import { Skeleton, Stack, Typography, styled, theme } from "ol-components"
-import { ButtonLink } from "@mitodl/smoot-design"
+import { Link, Skeleton, Stack, Typography, styled, theme } from "ol-components"
+import { Alert, ButtonLink } from "@mitodl/smoot-design"
 import { DisplayModeEnum } from "@mitodl/mitxonline-api-axios/v2"
 import { ResourceType, getKey } from "./model/dashboardViewModel"
 import { CoursewareCard } from "./CoursewareCard"
@@ -8,11 +8,18 @@ import NotFoundPage from "@/app-pages/ErrorPage/NotFoundPage"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { RiAwardFill } from "@remixicon/react"
 import { useProgramDashboardData } from "./hooks/useProgramDashboardData"
+import { env } from "@/env"
 
 const CourseEntryCardStyled = styled(CoursewareCard)({
   borderRadius: "8px",
   boxShadow: "0px 1px 6px 0px rgba(3, 21, 45, 0.05)",
 })
+
+const AlertBanner = styled(Alert)({
+  marginBottom: "16px",
+})
+
+const SUPPORT_EMAIL = env("NEXT_PUBLIC_MITOL_SUPPORT_EMAIL") || ""
 
 export const ProgramCertificateButton = styled(ButtonLink)(({ theme }) => ({
   color: theme.custom.colors.red,
@@ -30,6 +37,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
   programId,
 }) => {
   const data = useProgramDashboardData(programId)
+  const [upgradeError, setUpgradeError] = React.useState<string | null>(null)
 
   if (data.isLoading) {
     return (
@@ -52,6 +60,19 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
   }
   return (
     <Stack direction="column">
+      {upgradeError && (
+        <AlertBanner
+          severity="error"
+          closable={true}
+          onClose={() => setUpgradeError(null)}
+        >
+          {upgradeError}{" "}
+          <Link color="red" href={`mailto:${SUPPORT_EMAIL}`}>
+            Contact Support
+          </Link>{" "}
+          for assistance.
+        </AlertBanner>
+      )}
       <Stack direction="column" marginBottom="24px">
         <Stack
           direction="row"
@@ -130,6 +151,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       })}
                       kind="course"
                       entry={item.entry}
+                      onUpgradeError={setUpgradeError}
                     />
                   )
                 }
@@ -146,6 +168,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                       moduleEnrollmentsByCourseId={data.enrollmentsByCourseId}
                       courseProgramEnrollment={item.courseProgramEnrollment}
                       ancestorProgramEnrollment={data.ancestorProgramEnrollment}
+                      onUpgradeError={setUpgradeError}
                     />
                   )
                 }
@@ -164,6 +187,7 @@ const ProgramEnrollmentDisplay: React.FC<ProgramEnrollmentDisplayProps> = ({
                     moduleEnrollmentsByCourseId={data.enrollmentsByCourseId}
                     courseProgramEnrollment={item.programEnrollment}
                     ancestorProgramEnrollment={data.ancestorProgramEnrollment}
+                    onUpgradeError={setUpgradeError}
                   />
                 )
               })}


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12269

### Description (What does it do?)
Learners who audit-enrolled in a course before purchasing a program that includes that course were being sent to checkout when they clicked "Upgrade for certificate" on the program dashboard — even though their program purchase already entitles them to a free verified upgrade for that course.

The mitxonline backend already supported a free, one-click upgrade path for this case (`add_verified_program_course_enrollment` / `useCreateVerifiedProgramEnrollment`, the same endpoint the "Start" button uses for unenrolled courses in a verified program). The gap was entirely on the frontend: `EnrolledCourseCard`'s upgrade link was hard-wired to `useReplaceBasketItem`, and the card never received the ancestor program-enrollment context that `UnenrolledCourseCard` already had access to.

This PR:
- Threads `entry.ancestorContext` (already computed by the program dashboard's `DashboardCourseEntry`) from `CoursewareCard` into `EnrolledCourseCard`, for the `"course"` kind's enrolled branch.
- In `EnrolledCourseCard`, when the enrollment is audit and the ancestor program enrollment is verified, the "Upgrade for certificate" link now calls `useCreateVerifiedProgramEnrollment` (one-click, free) instead of `useReplaceBasketItem` (checkout), and redirects to courseware on success — matching the "Start" button's behavior, per the issue's suggested fix.
- Drops the price suffix from the link label in this case ("Upgrade for certificate" instead of "Upgrade for certificate - $999"), since the upgrade is free.
- Leaves the existing checkout behavior unchanged for every other case (no program context, or an audit program enrollment).

No backend changes were required — `add_verified_program_course_enrollment` already upgrades a pre-existing audit course-run enrollment to verified via a zero-value order when the program enrollment is verified.

### How can this be tested?
1. In mitxonline, seed repro data (no factories, real model calls) with `localdev/seed_verified_program_upgrade_repro.py`:
   ```
   docker compose exec -e REPRO_USER_EMAIL=<your test user email> web python manage.py shell < localdev/seed_verified_program_upgrade_repro.py
   ```
   This creates a live course/run with an active $999 upgrade product, a program requiring that course with its own product, a **verified** `ProgramEnrollment`, and an **audit** `CourseRunEnrollment` in the run for the given user. Idempotent — safe to re-run. Here is the code for the one shot:
```python
"""
One-shot repro data for: audit course enrollment + verified program enrollment
shows a paid "Upgrade for certificate" link on the program dashboard.

Creates:
- A live course with one live, upgradable run (fake run tag, so enrollment
  API calls skip edX locally)
- An active $999 Product for the run (with a reversion Version, required
  by checkout)
- A live program requiring the course, plus a program Product (required by
  create_verified_program_discount)
- A VERIFIED ProgramEnrollment for the user
- An AUDIT CourseRunEnrollment for the user in the run

Run with:
    docker compose run --rm \
        -e REPRO_USER_EMAIL=admin@odl.local \
        web python manage.py shell < localdev/seed_verified_program_upgrade_repro.py

Idempotent: safe to run more than once.
"""

import os
from datetime import timedelta
from decimal import Decimal

import reversion
from django.contrib.auth import get_user_model
from django.contrib.contenttypes.models import ContentType
from reversion.models import Version

from courses.models import (
    Course,
    CourseRun,
    CourseRunEnrollment,
    EnrollmentMode,
    Program,
    ProgramEnrollment,
)
from ecommerce.models import Product
from mitol.common.utils.datetime import now_in_utc
from openedx.constants import (
    EDX_ENROLLMENT_AUDIT_MODE,
    EDX_ENROLLMENT_VERIFIED_MODE,
)

USER_EMAIL = os.environ.get("REPRO_USER_EMAIL", "admin@odl.local")

COURSE_READABLE_ID = "course-v1:MITxT+VPE.Repro"
RUN_TAG = "fake-R1"  # "fake" prefix -> is_fake_course_run, skips edX calls
PROGRAM_READABLE_ID = "program-v1:MITxT+VPE.Repro-Program"

User = get_user_model()

try:
    user = User.objects.get(email=USER_EMAIL)
except User.DoesNotExist:
    msg = (
        f"No user with email {USER_EMAIL!r}. Log into mitxonline locally as "
        "that user first (or set REPRO_USER_EMAIL)."
    )
    raise SystemExit(msg)  # noqa: B904

now = now_in_utc()

audit_mode, _ = EnrollmentMode.objects.get_or_create(
    mode_slug=EDX_ENROLLMENT_AUDIT_MODE,
    defaults={"mode_display_name": "Audit"},
)
verified_mode, _ = EnrollmentMode.objects.get_or_create(
    mode_slug=EDX_ENROLLMENT_VERIFIED_MODE,
    defaults={"mode_display_name": "Verified", "requires_payment": True},
)

course, course_created = Course.objects.get_or_create(
    readable_id=COURSE_READABLE_ID,
    defaults={"title": "VPE Repro: Audit-then-Program Course", "live": True},
)

run, run_created = CourseRun.objects.get_or_create(
    courseware_id=f"{COURSE_READABLE_ID}+{RUN_TAG}",
    defaults={
        "course": course,
        "title": course.title,
        "run_tag": RUN_TAG,
        "live": True,
        "start_date": now - timedelta(days=30),
        "end_date": now + timedelta(days=180),
        "enrollment_start": now - timedelta(days=30),
        "enrollment_end": now + timedelta(days=150),
        "upgrade_deadline": now + timedelta(days=60),
        "certificate_available_date": now + timedelta(days=181),
    },
)
run.enrollment_modes.add(audit_mode, verified_mode)


def ensure_product(purchasable, price, description):
    """Get or create an active Product with a reversion Version."""
    content_type = ContentType.objects.get_for_model(purchasable)
    product = Product.objects.filter(
        content_type=content_type, object_id=purchasable.id, is_active=True
    ).first()
    if product is None:
        with reversion.create_revision():
            product = Product.objects.create(
                content_type=content_type,
                object_id=purchasable.id,
                price=price,
                description=description,
                is_active=True,
            )
    elif not Version.objects.get_for_object(product).exists():
        # Checkout resolves prices from the product's Version, not the row.
        with reversion.create_revision():
            product.save()
    return product


run_product = ensure_product(run, Decimal("999.00"), f"Certificate: {run.title}")

program, program_created = Program.objects.get_or_create(
    readable_id=PROGRAM_READABLE_ID,
    defaults={"title": "VPE Repro Program", "live": True},
)
if course not in [*program.required_courses, *program.elective_courses]:
    program.add_requirement(course)

program_product = ensure_product(
    program, Decimal("1999.00"), f"Program: {program.title}"
)

program_enrollment, pe_created = ProgramEnrollment.all_objects.get_or_create(
    user=user,
    program=program,
    defaults={"enrollment_mode": EDX_ENROLLMENT_VERIFIED_MODE, "active": True},
)
if (
    program_enrollment.enrollment_mode != EDX_ENROLLMENT_VERIFIED_MODE
    or not program_enrollment.active
):
    program_enrollment.enrollment_mode = EDX_ENROLLMENT_VERIFIED_MODE
    program_enrollment.active = True
    program_enrollment.save()

run_enrollment, cre_created = CourseRunEnrollment.all_objects.get_or_create(
    user=user,
    run=run,
    defaults={
        "enrollment_mode": EDX_ENROLLMENT_AUDIT_MODE,
        "active": True,
        "edx_enrolled": False,
    },
)
if (
    run_enrollment.enrollment_mode != EDX_ENROLLMENT_AUDIT_MODE
    or not run_enrollment.active
):
    run_enrollment.enrollment_mode = EDX_ENROLLMENT_AUDIT_MODE
    run_enrollment.active = True
    run_enrollment.save()

print(  # noqa: T201
    f"""
Done.
  user:                 {user.email} (id={user.id})
  course:               {course.readable_id} ({"created" if course_created else "existing"})
  run:                  {run.courseware_id} ({"created" if run_created else "existing"}, upgradable={run.is_upgradable})
  run product:          #{run_product.id} ${run_product.price}
  program:              {program.readable_id} (id={program.id}, {"created" if program_created else "existing"})
  program product:      #{program_product.id} ${program_product.price}
  program enrollment:   {program_enrollment.enrollment_mode} ({"created" if pe_created else "existing"})
  course run enrollment: {run_enrollment.enrollment_mode} ({"created" if cre_created else "existing"})

Repro: open the program dashboard in mit-learn:
  /dashboard/program/{program.id}
The audit-enrolled course should show "Upgrade for certificate - $999.00",
which currently sends you to checkout despite the verified program enrollment.

Note: leave SYNC_ON_DASHBOARD_LOAD disabled locally, or the edX sync may
clobber the seeded enrollment.
"""
)

```
2. Log into mit-learn as that user and open the printed program dashboard URL (`/dashboard/program/<id>`).
3. Before this change: the seeded course card shows "Upgrade for certificate - $999.00" and clicking it sends you to `/cart/`.
4. After this change: the same card shows "Upgrade for certificate" (no price) and clicking it one-click-upgrades the enrollment to verified and redirects to the course's courseware URL, with no checkout step.
5. Confirm the enrollment actually flipped: `CourseRunEnrollment.enrollment_mode` for that run/user should now be `verified`.
6. Regression check: on a course card with no ancestor program context (e.g. home "My Learning"), or where the program enrollment is audit, the upgrade link should still behave exactly as before (checkout with price shown).

Automated coverage: `EnrolledCourseCard.test.tsx` adds 3 tests for the verified-program path (label omits price, click one-click-enrolls and redirects, error handling), alongside the existing checkout-path tests (unchanged). Full suite (97 tests), `typecheck`, and `lint` all pass.

### Additional Context
- Home "My Learning" cards don't carry program `ancestorContext`, so a course enrolled outside its program dashboard won't get this one-click behavior even if the learner has a verified enrollment in some other program containing that course. Per team discussion, this is expected to be rare in practice (course-run enrollments for courses in an actively-enrolled program are supposed to be hidden from My Learning), so it's out of scope here.
- Post-click behavior redirects to courseware (same as the "Start" button), rather than staying on the dashboard. Flagging in case design wants to revisit this during review.
- Possible duplicates called out in the original issue: mitodl/hq#10646, mitodl/hq#12262.
