### PR TITLE
fix: Flaky JS test: ProgramAsCoursePage 'Enroll CTA posts program enrollment' times out on Loading button

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -44,6 +44,15 @@ const makeProgramAsCourse: typeof factories.programs.program = (
   })
 const makePage = factories.pages.programPageItem
 
+// The enroll button renders with aria-label="Loading" (and no "Start Learning"
+// accessible name) until the enrollment-status query resolves. Under CI load
+// that query can take longer than Testing Library's default 1s waitFor, leaving
+// the button in its loading state when findAllByRole gives up — a timing flake,
+// not a regression. Give these queries extra headroom so they retry until the
+// button leaves its loading state. See ProgramHeaderEnrollButton /
+// useProgramEnrollment.
+const ENROLL_STATUS_TIMEOUT = 5000
+
 const setupApis = ({
   program,
   page,
@@ -164,9 +173,11 @@ describe("ProgramAsCoursePage", () => {
     renderWithProviders(
       <ProgramAsCoursePage readableId={program.readable_id} />,
     )
-    const buttons = await screen.findAllByRole("button", {
-      name: "Start Learning",
-    })
+    const buttons = await screen.findAllByRole(
+      "button",
+      { name: "Start Learning" },
+      { timeout: ENROLL_STATUS_TIMEOUT },
+    )
     expect(buttons.length).toBeGreaterThanOrEqual(1)
   })
 
@@ -420,9 +431,11 @@ describe("ProgramAsCoursePage", () => {
       <ProgramAsCoursePage readableId={program.readable_id} />,
     )
 
-    const [enrollButton] = await screen.findAllByRole("button", {
-      name: "Start Learning",
-    })
+    const [enrollButton] = await screen.findAllByRole(
+      "button",
+      { name: "Start Learning" },
+      { timeout: ENROLL_STATUS_TIMEOUT },
+    )
     await user.click(enrollButton)
 
     await waitFor(() => {
@@ -484,9 +497,11 @@ describe("ProgramAsCoursePage", () => {
     expect(
       screen.queryByText("Earn a verified certificate of completion"),
     ).not.toBeInTheDocument()
-    const enrollButtons = await screen.findAllByRole("button", {
-      name: "Start Learning",
-    })
+    const enrollButtons = await screen.findAllByRole(
+      "button",
+      { name: "Start Learning" },
+      { timeout: ENROLL_STATUS_TIMEOUT },
+    )
     expect(enrollButtons.length).toBeGreaterThanOrEqual(1)
   })
 

--- a/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProgramAsCoursePage.test.tsx
@@ -44,13 +44,8 @@ const makeProgramAsCourse: typeof factories.programs.program = (
   })
 const makePage = factories.pages.programPageItem
 
-// The enroll button renders with aria-label="Loading" (and no "Start Learning"
-// accessible name) until the enrollment-status query resolves. Under CI load
-// that query can take longer than Testing Library's default 1s waitFor, leaving
-// the button in its loading state when findAllByRole gives up — a timing flake,
-// not a regression. Give these queries extra headroom so they retry until the
-// button leaves its loading state. See ProgramHeaderEnrollButton /
-// useProgramEnrollment.
+// Enrollment status can be slow to resolve, so wait longer for the enroll
+// button to leave its loading state before asserting on it.
 const ENROLL_STATUS_TIMEOUT = 5000
 
 const setupApis = ({


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12456


### Problem
`Enroll CTA posts program enrollment` intermittently failed in CI with
`Unable to find role="button" and name "Start Learning"` — the button was still
in its loading state (`aria-label="Loading"`). Re-running passed: a timing flake.

### Root cause
The "Start Learning" button is gated by `isStatusLoading`, which stays `true`
until the program-enrollment status query (`GET /api/v3/program_enrollments/`)
resolves — until then the button has no "Start Learning" name. `findAllByRole`
only retries for Testing Library's default ~1s, so under CI load the query
sometimes hadn't resolved in time.

### Fix
Added a shared `ENROLL_STATUS_TIMEOUT` constant and passed it as the `waitFor`
timeout on the three `findAllByRole("Start Learning")` call sites, so they retry
until the button leaves its loading state. No overhead on the fast path.

Also pinned `show_stay_updated: true` in the "Shows Stay Updated button" test —
the factory now emits a random value, making that assertion ~50% flaky (matches
the `CoursePage`/`ProgramPage` updates).

### Testing
Reproduced the flake locally (delayed status query) and confirmed the fix;
all `ProgramAsCoursePage.test.tsx` tests pass.
