### PR TITLE
fix: Remove course enrollment from cache on unenroll for instant UI update

### DIFF
--- a/frontends/api/src/mitxonline/hooks/enrollment/index.ts
+++ b/frontends/api/src/mitxonline/hooks/enrollment/index.ts
@@ -64,6 +64,12 @@ const useDestroyEnrollment = () => {
   return useMutation({
     mutationFn: (enrollmentId: number) =>
       courseRunEnrollmentsApi.enrollmentsDestroy({ id: enrollmentId }),
+    onSuccess: (_data, enrollmentId) => {
+      queryClient.setQueryData(
+        enrollmentQueries.courseRunEnrollmentsList().queryKey,
+        (data) => data?.filter((enrollment) => enrollment.id !== enrollmentId),
+      )
+    },
     onSettled: () => {
       queryClient.invalidateQueries({
         queryKey: enrollmentKeys.courseRunEnrollmentsList(),

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -200,9 +200,7 @@ describe("DashboardDialogs", () => {
     await user.click(confirmButton)
 
     // Card is gone even though the refetch is still pending.
-    await waitFor(() => {
-      expect(screen.queryByText(enrollment.run.title)).not.toBeInTheDocument()
-    })
+    await waitFor(() => expect(card).not.toBeInTheDocument())
     expect(screen.getAllByTestId("enrollment-card-desktop")).toHaveLength(
       enrollments.length - 1,
     )

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/DashboardDialogs.test.tsx
@@ -5,6 +5,7 @@ import {
   setMockResponse,
   setupLocationMock,
   user,
+  waitFor,
   within,
 } from "@/test-utils"
 import { HomeEnrollmentsDisplay } from "./HomeEnrollmentsDisplay"
@@ -154,6 +155,60 @@ describe("DashboardDialogs", () => {
         url: mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
       }),
     )
+  })
+
+  test("Unenrolling removes the card immediately, before the enrollments list refetches", async () => {
+    const { enrollments } = setupApis()
+    const enrollment = faker.helpers.arrayElement(enrollments)
+
+    setMockResponse.delete(
+      mitxonline.urls.enrollment.courseEnrollment(enrollment.id),
+      null,
+    )
+    renderWithProviders(<HomeEnrollmentsDisplay />)
+
+    await screen.findByRole("heading", { name: "My Learning" })
+
+    const cards = await screen.findAllByTestId("enrollment-card-desktop")
+    expect(cards.length).toBe(enrollments.length)
+
+    const card = cards.find(
+      (c) => !!within(c).queryByText(enrollment.run.title),
+    )
+    invariant(card)
+
+    // Hold the post-unenroll invalidation refetch open. If the card only
+    // disappears once the list refetches, this test fails — proving the card is
+    // removed by the mutation's immediate cache update, not by the refetch.
+    const refetch = Promise.withResolvers<typeof enrollments>()
+    setMockResponse.get(
+      mitxonline.urls.enrollment.enrollmentsListV3(),
+      refetch.promise,
+    )
+
+    const contextMenuButton = await within(card).findByLabelText("More options")
+    await user.click(contextMenuButton)
+
+    const unenrollButton = await screen.findByRole("menuitem", {
+      name: "Unenroll",
+    })
+    await user.click(unenrollButton)
+
+    const confirmButton = await screen.findByRole("button", {
+      name: "Unenroll",
+    })
+    await user.click(confirmButton)
+
+    // Card is gone even though the refetch is still pending.
+    await waitFor(() => {
+      expect(screen.queryByText(enrollment.run.title)).not.toBeInTheDocument()
+    })
+    expect(screen.getAllByTestId("enrollment-card-desktop")).toHaveLength(
+      enrollments.length - 1,
+    )
+
+    // Let the held refetch settle so nothing dangles after the test.
+    refetch.resolve(enrollments.filter((e) => e.id !== enrollment.id))
   })
 })
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
 Closes https://github.com/mitodl/hq/issues/10104 
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

Unenrolling from a course on the dashboard was slow to update, the card stuck around until the enrollments list refetched. Program unenroll already handled this by dropping the enrollment from the cache in `onSuccess`, so I did the same thing for courses.

`useDestroyEnrollment` now filters the deleted enrollment out of the `courseRunEnrollments` cache in `onSuccess`, same as `useDestroyProgramEnrollment`. The card disappears as soon as the DELETE comes back. Left the `onSettled` invalidate in place so the list still reconciles with the server afterward.

The enroll-button spinner from the original ticket already went in with #3626, and I didn't touch the program flow.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

BEFORE 

https://github.com/user-attachments/assets/bf117d45-a13c-4a65-835d-908385120927



AFTER

https://github.com/user-attachments/assets/9523a9a9-af85-46a4-9741-e260800cf961



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Log in as someone with an active course enrollment, go to My Learning.
2. On a course card, ⋯ → Unenroll → confirm.
3. Spinner runs until the DELETE finishes (same as before), then the card should drop right away instead of hanging around.
4. If the DELETE fails (throttle/offline), you should still get the error alert and the card should stay put.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

In the local k3d stack the course DELETE hangs ~6s on a dead `edx.odl.local` DNS lookup in mitxonline — separate fix in ol-infrastructure, nothing to do with this repo.

I added a hostAliases entry to the mitxonline-webapp pod spec in ol-infrastructure/local dev/apps/mitxonline/deployment.yaml, pinning the edX hostnames to the pod loopback: 

```
      hostAliases:
        - ip: "127.0.0.1"
          hostnames:
            - edx.odl.local
            - studio.edx.odl.local
```


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
