### PR TITLE
Slim learning resource API payloads and cache rendered JSON

### DIFF
--- a/frontends/api/src/generated/v0/api.ts
+++ b/frontends/api/src/generated/v0/api.ts
@@ -643,10 +643,10 @@ export interface ContentFile {
   content_feature_type: Array<string>
   /**
    *
-   * @type {ContentTypeEnum}
+   * @type {ContentFileContentTypeEnum}
    * @memberof ContentFile
    */
-  content_type?: ContentTypeEnum
+  content_type?: ContentFileContentTypeEnum
   /**
    *
    * @type {string}
@@ -764,6 +764,41 @@ export interface ContentFile {
 }
 
 /**
+ * * `page` - page * `file` - file * `video` - video * `pdf` - pdf
+ * @export
+ * @enum {string}
+ */
+
+export const ContentFileContentTypeEnumDescriptions = {
+  page: "page",
+  file: "file",
+  video: "video",
+  pdf: "pdf",
+} as const
+
+export const ContentFileContentTypeEnum = {
+  /**
+   * page
+   */
+  Page: "page",
+  /**
+   * file
+   */
+  File: "file",
+  /**
+   * video
+   */
+  Video: "video",
+  /**
+   * pdf
+   */
+  Pdf: "pdf",
+} as const
+
+export type ContentFileContentTypeEnum =
+  (typeof ContentFileContentTypeEnum)[keyof typeof ContentFileContentTypeEnum]
+
+/**
  * SearchResponseSerializer with OpenAPI annotations for Content Files search
  * @export
  * @interface ContentFileVectorSearchResponse
@@ -842,41 +877,6 @@ export interface ContentFileVectorSearchResponseMetadataAggregationsValueInner {
    */
   doc_count: number
 }
-/**
- * * `page` - page * `file` - file * `video` - video * `pdf` - pdf
- * @export
- * @enum {string}
- */
-
-export const ContentTypeEnumDescriptions = {
-  page: "page",
-  file: "file",
-  video: "video",
-  pdf: "pdf",
-} as const
-
-export const ContentTypeEnum = {
-  /**
-   * page
-   */
-  Page: "page",
-  /**
-   * file
-   */
-  File: "file",
-  /**
-   * video
-   */
-  Video: "video",
-  /**
-   * pdf
-   */
-  Pdf: "pdf",
-} as const
-
-export type ContentTypeEnum =
-  (typeof ContentTypeEnum)[keyof typeof ContentTypeEnum]
-
 /**
  *
  * @export
@@ -1773,10 +1773,10 @@ export interface DocumentResource {
   resource_type: DocumentResourceResourceTypeEnum
   /**
    *
-   * @type {Array<ContentFile>}
+   * @type {Array<NestedContentFile>}
    * @memberof DocumentResource
    */
-  content_files: Array<ContentFile> | null
+  content_files: Array<NestedContentFile> | null
   /**
    *
    * @type {string}
@@ -3236,6 +3236,212 @@ export interface LearningResourcesVectorSearchResponse {
    */
   metadata: ContentFileVectorSearchResponseMetadata
 }
+/**
+ * ContentFileSerializer without the large text fields (content, summary, flashcards), for nesting inside learning resource API responses. The search indexing path re-adds full content where needed.
+ * @export
+ * @interface NestedContentFile
+ */
+export interface NestedContentFile {
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  id: number
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  run_id?: number
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  direct_learning_resource_id?: number | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_title?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_slug?: string
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof NestedContentFile
+   */
+  departments: Array<LearningResourceDepartment>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  semester?: string
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  year?: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof NestedContentFile
+   */
+  topics: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  key?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  uid?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  title?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  description?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof NestedContentFile
+   */
+  require_summaries: boolean
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  url?: string | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof NestedContentFile
+   */
+  content_feature_type: Array<string>
+  /**
+   *
+   * @type {ContentFileContentTypeEnum}
+   * @memberof NestedContentFile
+   */
+  content_type?: ContentFileContentTypeEnum
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_title?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_author?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_language?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  checksum?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  image_src?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  resource_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  resource_readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  source_path?: string
+  /**
+   * Extract the course number(s) from the associated course
+   * @type {Array<string>}
+   * @memberof NestedContentFile
+   */
+  course_number: Array<string>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  file_type?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  file_extension?: string | null
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof NestedContentFile
+   */
+  offered_by: LearningResourceOfferor
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof NestedContentFile
+   */
+  platform: LearningResourcePlatform
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_readable_id?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  edx_module_id?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  youtube_id?: string | null
+}
+
 /**
  * Serializer for News FeedItem
  * @export
@@ -6451,10 +6657,10 @@ export interface VideoResource {
   playlists: Array<string>
   /**
    *
-   * @type {Array<ContentFile>}
+   * @type {Array<NestedContentFile>}
    * @memberof VideoResource
    */
-  content_files: Array<ContentFile> | null
+  content_files: Array<NestedContentFile> | null
   /**
    *
    * @type {string}

--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -1655,10 +1655,10 @@ export interface DocumentResource {
   resource_type: DocumentResourceResourceTypeEnum
   /**
    *
-   * @type {Array<ContentFile>}
+   * @type {Array<NestedContentFile>}
    * @memberof DocumentResource
    */
-  content_files: Array<ContentFile> | null
+  content_files: Array<NestedContentFile> | null
   /**
    *
    * @type {string}
@@ -5153,6 +5153,212 @@ export interface MicroUserListRelationship {
    */
   child: number
 }
+/**
+ * ContentFileSerializer without the large text fields (content, summary, flashcards), for nesting inside learning resource API responses. The search indexing path re-adds full content where needed.
+ * @export
+ * @interface NestedContentFile
+ */
+export interface NestedContentFile {
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  id: number
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  run_id?: number
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  direct_learning_resource_id?: number | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_title?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_slug?: string
+  /**
+   *
+   * @type {Array<LearningResourceDepartment>}
+   * @memberof NestedContentFile
+   */
+  departments: Array<LearningResourceDepartment>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  semester?: string
+  /**
+   *
+   * @type {number}
+   * @memberof NestedContentFile
+   */
+  year?: number
+  /**
+   *
+   * @type {Array<LearningResourceTopic>}
+   * @memberof NestedContentFile
+   */
+  topics: Array<LearningResourceTopic>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  key?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  uid?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  title?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  description?: string | null
+  /**
+   *
+   * @type {boolean}
+   * @memberof NestedContentFile
+   */
+  require_summaries: boolean
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  url?: string | null
+  /**
+   *
+   * @type {Array<string>}
+   * @memberof NestedContentFile
+   */
+  content_feature_type: Array<string>
+  /**
+   *
+   * @type {ContentFileContentTypeEnum}
+   * @memberof NestedContentFile
+   */
+  content_type?: ContentFileContentTypeEnum
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_title?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_author?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  content_language?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  checksum?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  image_src?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  resource_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  resource_readable_id: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  source_path?: string
+  /**
+   * Extract the course number(s) from the associated course
+   * @type {Array<string>}
+   * @memberof NestedContentFile
+   */
+  course_number: Array<string>
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  file_type?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  file_extension?: string | null
+  /**
+   *
+   * @type {LearningResourceOfferor}
+   * @memberof NestedContentFile
+   */
+  offered_by: LearningResourceOfferor
+  /**
+   *
+   * @type {LearningResourcePlatform}
+   * @memberof NestedContentFile
+   */
+  platform: LearningResourcePlatform
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  run_readable_id?: string
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  edx_module_id?: string | null
+  /**
+   *
+   * @type {string}
+   * @memberof NestedContentFile
+   */
+  youtube_id?: string | null
+}
+
 /**
  *
  * @export
@@ -9794,10 +10000,10 @@ export interface VideoResource {
   playlists: Array<string>
   /**
    *
-   * @type {Array<ContentFile>}
+   * @type {Array<NestedContentFile>}
    * @memberof VideoResource
    */
-  content_files: Array<ContentFile> | null
+  content_files: Array<NestedContentFile> | null
   /**
    *
    * @type {string}

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -230,6 +230,10 @@ VALID_COURSE_CONTENT_CHOICES = list(
     zip(VALID_COURSE_CONTENT_TYPES, VALID_COURSE_CONTENT_TYPES)
 )
 
+# Large text fields excluded from API responses (both nested serializers and
+# OpenSearch _source filtering) but retained in the search index for querying
+CONTENT_FILE_LARGE_FIELDS = ("content", "summary", "flashcards")
+
 TUTOR_PROBLEM_TYPE = "problem"
 TUTOR_SOLUTION_TYPE = "solution"
 VALID_TUTOR_PROBLEM_TYPES = [TUTOR_PROBLEM_TYPE, TUTOR_SOLUTION_TYPE]

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1512,7 +1512,7 @@ class NestedContentFileSerializer(ContentFileSerializer):
         fields = [
             field
             for field in ContentFileSerializer.Meta.fields
-            if field not in ("content", "summary", "flashcards")
+            if field not in constants.CONTENT_FILE_LARGE_FIELDS
         ]
 
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1501,6 +1501,21 @@ class ContentFileSerializer(serializers.ModelSerializer):
         ]
 
 
+class NestedContentFileSerializer(ContentFileSerializer):
+    """
+    ContentFileSerializer without the large text fields (content, summary,
+    flashcards), for nesting inside learning resource API responses.
+    The search indexing path re-adds full content where needed.
+    """
+
+    class Meta(ContentFileSerializer.Meta):
+        fields = [
+            field
+            for field in ContentFileSerializer.Meta.fields
+            if field not in ("content", "summary", "flashcards")
+        ]
+
+
 class VideoResourceSerializer(LearningResourceBaseSerializer):
     """Serializer for video resources"""
 
@@ -1515,11 +1530,11 @@ class VideoResourceSerializer(LearningResourceBaseSerializer):
     content_files = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
 
-    @extend_schema_field(ContentFileSerializer(many=True, allow_null=True))
+    @extend_schema_field(NestedContentFileSerializer(many=True, allow_null=True))
     def get_content_files(self, instance):
         """Serialize content files with prefetch."""
         content_files = instance.direct_content_files_for_serialization()
-        return ContentFileSerializer(
+        return NestedContentFileSerializer(
             content_files,
             many=True,
             read_only=True,
@@ -1547,11 +1562,11 @@ class DocumentResourceSerializer(LearningResourceBaseSerializer):
     content_files = serializers.SerializerMethodField()
     description = serializers.SerializerMethodField()
 
-    @extend_schema_field(ContentFileSerializer(many=True, allow_null=True))
+    @extend_schema_field(NestedContentFileSerializer(many=True, allow_null=True))
     def get_content_files(self, instance):
         """Serialize content files with prefetch."""
         content_files = instance.direct_content_files_for_serialization()
-        return ContentFileSerializer(
+        return NestedContentFileSerializer(
             content_files,
             many=True,
             read_only=True,

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -212,6 +212,9 @@ def test_serialize_video_resource_with_content_files():
     assert len(serializer.data["content_files"]) == 1
     assert serializer.data["content_files"][0]["id"] == content_file.id
     assert serializer.data["content_files"][0]["title"] == "Video Content File"
+    # Full text fields are excluded from nested API responses
+    for field in ("content", "summary", "flashcards"):
+        assert field not in serializer.data["content_files"][0]
     # Description should fall back to content file's description when resource has none
     assert serializer.data["description"] == "Content file description"
 

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -219,6 +219,28 @@ def test_serialize_video_resource_with_content_files():
     assert serializer.data["description"] == "Content file description"
 
 
+def test_serialize_document_resource_with_content_files():
+    """
+    Verify that DocumentResourceSerializer serializes content files without
+    the full text fields
+    """
+    document_resource = factories.LearningResourceFactory.create(
+        resource_type=LearningResourceType.document.name,
+    )
+    content_file = factories.ContentFileFactory.create(
+        run=None,
+        direct_learning_resource=document_resource,
+        title="Document Content File",
+    )
+    resource = LearningResource.objects.for_serialization().get(pk=document_resource.pk)
+    serializer = serializers.DocumentResourceSerializer(instance=resource)
+
+    assert len(serializer.data["content_files"]) == 1
+    assert serializer.data["content_files"][0]["id"] == content_file.id
+    for field in ("content", "summary", "flashcards"):
+        assert field not in serializer.data["content_files"][0]
+
+
 def test_serialize_podcast_episode_playlists_to_json():
     """
     Verify that a serialized podcast episode resource has the correct podcast data

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -2422,6 +2422,9 @@ def test_execute_learn_search_for_learning_resource_query(settings, opensearch):
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }
@@ -2521,6 +2524,9 @@ def test_execute_learn_search_for_learning_resource_query_filter_ocw_files(
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }
@@ -3068,6 +3074,9 @@ def test_execute_learn_search_with_script_score(
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }
@@ -3574,6 +3583,9 @@ def test_execute_learn_search_with_hybrid_search(mocker, settings, opensearch):
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }
@@ -4065,6 +4077,9 @@ def test_execute_learn_search_with_min_score(mocker, settings, opensearch):
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }
@@ -4243,6 +4258,9 @@ def test_execute_learn_search_for_content_file_query(opensearch):
                 "flashcards",
                 "vector_embedding",
                 "video.transcript",
+                "content_files.content",
+                "content_files.summary",
+                "content_files.flashcards",
             ]
         },
     }

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -6,7 +6,10 @@ from enum import Enum
 from opensearchpy.exceptions import ConnectionError as ESConnectionError
 from urllib3.exceptions import TimeoutError as UrlTimeoutError
 
-from learning_resources.constants import LEARNING_RESOURCE_SORTBY_OPTIONS
+from learning_resources.constants import (
+    CONTENT_FILE_LARGE_FIELDS,
+    LEARNING_RESOURCE_SORTBY_OPTIONS,
+)
 
 ALIAS_ALL_INDICES = "all"
 COURSE_TYPE = "course"
@@ -489,14 +492,10 @@ SOURCE_EXCLUDED_FIELDS = [
     "resource_age_date",
     "featured_rank",
     "is_incomplete_or_stale",
-    "content",
-    "summary",
-    "flashcards",
+    *CONTENT_FILE_LARGE_FIELDS,
     "vector_embedding",
     "video.transcript",
-    "content_files.content",
-    "content_files.summary",
-    "content_files.flashcards",
+    *[f"content_files.{field}" for field in CONTENT_FILE_LARGE_FIELDS],
 ]
 
 LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS = {

--- a/learning_resources_search/constants.py
+++ b/learning_resources_search/constants.py
@@ -494,6 +494,9 @@ SOURCE_EXCLUDED_FIELDS = [
     "flashcards",
     "vector_embedding",
     "video.transcript",
+    "content_files.content",
+    "content_files.summary",
+    "content_files.flashcards",
 ]
 
 LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS = {

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -141,7 +141,9 @@ def serialize_learning_resource_for_update(
         serialized_data["video"]["transcript"] = learning_resource_obj.video.transcript
 
     if serialized_data.get("content_files"):
-        # The API serializer omits full text; re-add it for nested search
+        # The API serializer omits full text; re-serialize with the full
+        # serializer for nested search. Serializes content_files twice, which
+        # is acceptable in this celery-only indexing path.
         serialized_data["content_files"] = [
             ContentFileSerializer(content_file).data
             for content_file in (

--- a/learning_resources_search/serializers.py
+++ b/learning_resources_search/serializers.py
@@ -140,6 +140,15 @@ def serialize_learning_resource_for_update(
     ):
         serialized_data["video"]["transcript"] = learning_resource_obj.video.transcript
 
+    if serialized_data.get("content_files"):
+        # The API serializer omits full text; re-add it for nested search
+        serialized_data["content_files"] = [
+            ContentFileSerializer(content_file).data
+            for content_file in (
+                learning_resource_obj.direct_content_files_for_serialization()
+            )
+        ]
+
     if learning_resource_obj.in_featured_lists > 0:
         featured_rank = (
             LearningResourceRelationship.objects.filter(

--- a/learning_resources_search/serializers_test.py
+++ b/learning_resources_search/serializers_test.py
@@ -871,6 +871,25 @@ def test_serialize_bulk_learning_resources_for_deletion():
 
 
 @pytest.mark.django_db
+def test_serialize_learning_resource_for_update_readds_content_file_text():
+    """
+    Indexed learning material docs should include full content file text even
+    though the API serializer omits it
+    """
+    resource = factories.LearningResourceFactory.create(
+        resource_type=LearningResourceType.video.name, runs=[]
+    )
+    factories.ContentFileFactory.create(
+        run=None,
+        direct_learning_resource=resource,
+        content="full text for nested search",
+    )
+    resource = LearningResource.objects.for_search_serialization().get(pk=resource.pk)
+    serialized = serializers.serialize_learning_resource_for_update(resource)
+    assert serialized["content_files"][0]["content"] == "full text for nested search"
+
+
+@pytest.mark.django_db
 def test_serialize_content_file_for_bulk():
     """
     Test that serialize_content_file_for_bulk yields correct data

--- a/main/utils.py
+++ b/main/utils.py
@@ -42,9 +42,11 @@ def _sorted_query_string(query_dict):
 
 def _wants_html(request) -> bool:
     """Whether the request wants the browsable API (HTML) rather than JSON."""
-    return "text/html" in request.headers.get("Accept", "") or bool(
-        request.GET.get("format")
-    )
+    renderer = getattr(request, "accepted_renderer", None)
+    if renderer is not None:
+        # DRF negotiated the renderer in initial(), before the decorated handler
+        return renderer.format == "html"
+    return "text/html" in request.headers.get("Accept", "")
 
 
 def _cached_response(request, cached_data):

--- a/main/utils.py
+++ b/main/utils.py
@@ -1,6 +1,7 @@
 """main utilities"""
 
 import datetime
+import json
 import logging
 import os
 from collections.abc import Callable
@@ -15,8 +16,10 @@ import requests
 from bs4 import BeautifulSoup
 from django.conf import settings
 from django.core.cache import caches
+from django.http import HttpResponse
 from django.views.decorators.cache import cache_page
 from nh3 import nh3
+from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from main.constants import ALLOWED_HTML_ATTRIBUTES, ALLOWED_HTML_TAGS
@@ -35,6 +38,28 @@ def _sorted_query_string(query_dict):
         # (topic=a&topic=b and topic=b&topic=a should match)
         items.extend(f"{key}={value}" for value in sorted(query_dict.getlist(key)))
     return "&".join(items)
+
+
+def _wants_html(request) -> bool:
+    """Whether the request wants the browsable API (HTML) rather than JSON."""
+    return "text/html" in request.headers.get("Accept", "") or bool(
+        request.GET.get("format")
+    )
+
+
+def _cached_response(request, cached_data):
+    """
+    Build a response from a cache entry (rendered JSON bytes or legacy dict).
+
+    JSON requests get the cached bytes as-is, skipping re-rendering. Requests
+    wanting another format (e.g. the browsable API) get a DRF Response so
+    content negotiation still applies.
+    """
+    if not isinstance(cached_data, bytes):
+        return Response(cached_data)
+    if _wants_html(request):
+        return Response(json.loads(cached_data))
+    return HttpResponse(cached_data, content_type="application/json")
 
 
 def _resolve_cache_timeout(timeout: int | None) -> int:
@@ -99,12 +124,18 @@ def _cache_page_ignoring_cookies(  # noqa: C901
 
                 cached_data = await cache_backend.aget(cache_key)
                 if cached_data is not None:
-                    return Response(cached_data)
+                    return _cached_response(request, cached_data)
 
                 response = await func(request, *args, **kwargs)
 
                 if response.status_code == 200:  # noqa: PLR2004
-                    await cache_backend.aset(cache_key, response.data, cache_timeout)
+                    # Cache rendered JSON bytes so cache hits skip
+                    # DRF serialization entirely
+                    await cache_backend.aset(
+                        cache_key,
+                        JSONRenderer().render(response.data),
+                        cache_timeout,
+                    )
 
                 return response
 
@@ -136,14 +167,19 @@ def _cache_page_ignoring_cookies(  # noqa: C901
             # Try to get from cache
             cached_data = cache_backend.get(cache_key)
             if cached_data is not None:
-                return Response(cached_data)
+                return _cached_response(request, cached_data)
 
             # Execute view
             response = func(request, *args, **kwargs)
 
-            # Only cache successful responses
+            # Only cache successful responses. Cache rendered JSON bytes so
+            # cache hits skip DRF serialization entirely
             if response.status_code == 200:  # noqa: PLR2004
-                cache_backend.set(cache_key, response.data, cache_timeout)
+                cache_backend.set(
+                    cache_key,
+                    JSONRenderer().render(response.data),
+                    cache_timeout,
+                )
 
             return response
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -40,12 +40,15 @@ def _sorted_query_string(query_dict):
     return "&".join(items)
 
 
-def _wants_html(request) -> bool:
-    """Whether the request wants the browsable API (HTML) rather than JSON."""
+def _needs_negotiated_response(request) -> bool:
+    """
+    Whether the request needs content-negotiated rendering (e.g. the
+    browsable API) rather than raw cached JSON bytes.
+    """
     renderer = getattr(request, "accepted_renderer", None)
     if renderer is not None:
-        # DRF negotiated the renderer in initial(), before the decorated handler
-        return renderer.format == "html"
+        # DRF negotiated the renderer in initial(); raw bytes only serve JSON
+        return renderer.format != "json"
     return "text/html" in request.headers.get("Accept", "")
 
 
@@ -59,7 +62,7 @@ def _cached_response(request, cached_data):
     """
     if not isinstance(cached_data, bytes):
         return Response(cached_data)
-    if _wants_html(request):
+    if _needs_negotiated_response(request):
         return Response(json.loads(cached_data))
     return HttpResponse(cached_data, content_type="application/json")
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -67,6 +67,31 @@ def _cached_response(request, cached_data):
     return HttpResponse(cached_data, content_type="application/json")
 
 
+def _cache_response_json(cache_backend, cache_key, cache_timeout, response):
+    """
+    Cache the response's rendered JSON bytes.
+
+    Piggybacks on the response's own render pass so a cache miss doesn't render
+    the payload twice. Only a non-JSON renderer (the browsable API) needs a
+    separate JSON render.
+    """
+
+    def store(rendered):
+        content = (
+            rendered.content
+            if rendered.accepted_renderer.format == "json"
+            else JSONRenderer().render(rendered.data)
+        )
+        cache_backend.set(cache_key, content, cache_timeout)
+
+    if hasattr(response, "add_post_render_callback"):
+        response.add_post_render_callback(store)
+    else:
+        cache_backend.set(
+            cache_key, JSONRenderer().render(response.data), cache_timeout
+        )
+
+
 def _resolve_cache_timeout(timeout: int | None) -> int:
     """Resolve a cache timeout, deferring to settings when no timeout is given."""
     if timeout is None:
@@ -136,10 +161,8 @@ def _cache_page_ignoring_cookies(  # noqa: C901
                 if response.status_code == 200:  # noqa: PLR2004
                     # Cache rendered JSON bytes so cache hits skip
                     # DRF serialization entirely
-                    await cache_backend.aset(
-                        cache_key,
-                        JSONRenderer().render(response.data),
-                        cache_timeout,
+                    _cache_response_json(
+                        cache_backend, cache_key, cache_timeout, response
                     )
 
                 return response
@@ -180,11 +203,7 @@ def _cache_page_ignoring_cookies(  # noqa: C901
             # Only cache successful responses. Cache rendered JSON bytes so
             # cache hits skip DRF serialization entirely
             if response.status_code == 200:  # noqa: PLR2004
-                cache_backend.set(
-                    cache_key,
-                    JSONRenderer().render(response.data),
-                    cache_timeout,
-                )
+                _cache_response_json(cache_backend, cache_key, cache_timeout, response)
 
             return response
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -1,6 +1,7 @@
 """Utils tests"""
 
 import datetime
+import json
 from math import ceil
 from tempfile import NamedTemporaryFile
 from unittest.mock import MagicMock, patch
@@ -274,12 +275,15 @@ def test_clean_data_preserves_allowed_links():
     assert "javascript:" not in result  # nh3 drops unsafe schemes
 
 
-def _create_mock_request(*, is_authenticated=False, path="/test/", query=""):
+def _create_mock_request(
+    *, is_authenticated=False, path="/test/", query="", accept="application/json"
+):
     """Create a mock request object for testing cache decorators."""
     request = MagicMock()
     request.user.is_authenticated = is_authenticated
     request.path = path
     request.GET = QueryDict(query)
+    request.headers = {"Accept": accept}
     return request
 
 
@@ -396,7 +400,7 @@ def test_cache_page_for_all_users_caches_authenticated(mock_caches):
 
 @patch("main.utils.caches")
 def test_cache_returns_cached_response(mock_caches):
-    """Subsequent requests return cached data."""
+    """Subsequent requests return cached data (legacy dict entries)."""
     mock_cache = MagicMock()
     cached_data = {"result": "cached", "call": 0}
     mock_cache.get.return_value = cached_data
@@ -410,6 +414,58 @@ def test_cache_returns_cached_response(mock_caches):
 
     assert view.call_count["count"] == 0
     assert response.data == cached_data
+
+
+@patch("main.utils.caches")
+def test_cache_stores_rendered_json_bytes(mock_caches):
+    """Responses are cached as rendered JSON bytes, not raw data."""
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = None
+    mock_caches.__getitem__.return_value = mock_cache
+
+    view = _create_view()
+    decorated = cache_page_for_all_users(300)(view)
+
+    decorated(_create_mock_request())
+
+    cached_value = mock_cache.set.call_args.args[1]
+    assert isinstance(cached_value, bytes)
+    assert json.loads(cached_value) == {"result": "fresh", "call": 1}
+
+
+@patch("main.utils.caches")
+def test_cache_hit_returns_bytes_without_rendering(mock_caches):
+    """Cached rendered bytes are returned directly as an HttpResponse."""
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = b'{"result": "cached"}'
+    mock_caches.__getitem__.return_value = mock_cache
+
+    view = _create_view()
+    decorated = cache_page_for_all_users(300)(view)
+
+    response = decorated(_create_mock_request())
+
+    assert view.call_count["count"] == 0
+    assert response.content == b'{"result": "cached"}'
+    assert response["Content-Type"] == "application/json"
+
+
+@patch("main.utils.caches")
+def test_cache_hit_html_request_gets_negotiable_response(mock_caches):
+    """Browsable API (HTML) requests get a DRF Response from cached bytes."""
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = b'{"result": "cached"}'
+    mock_caches.__getitem__.return_value = mock_cache
+
+    view = _create_view()
+    decorated = cache_page_for_all_users(300)(view)
+
+    request = _create_mock_request(accept="text/html,application/xhtml+xml")
+    response = decorated(request)
+
+    assert view.call_count["count"] == 0
+    assert isinstance(response, Response)
+    assert response.data == {"result": "cached"}
 
 
 @patch("main.utils.caches")

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.contrib.auth import get_user_model
 from django.http import QueryDict
+from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 
 from main.constants import (
@@ -284,7 +285,9 @@ def _create_mock_request(
     request.path = path
     request.GET = QueryDict(query)
     request.headers = {"Accept": accept}
-    request.accepted_renderer.format = "html" if "text/html" in accept else "json"
+    request.accepted_renderer = (
+        BrowsableAPIRenderer() if "text/html" in accept else JSONRenderer()
+    )
     return request
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -284,6 +284,7 @@ def _create_mock_request(
     request.path = path
     request.GET = QueryDict(query)
     request.headers = {"Accept": accept}
+    request.accepted_renderer.format = "html" if "text/html" in accept else "json"
     return request
 
 

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -1,16 +1,21 @@
 """Utils tests"""
 
+import asyncio
 import datetime
 import json
 from math import ceil
 from tempfile import NamedTemporaryFile
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.core.cache import caches
 from django.http import QueryDict
+from django.utils.decorators import method_decorator
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory, force_authenticate
+from rest_framework.views import APIView
 
 from main.constants import (
     ALLOWED_HTML_ATTRIBUTES_WITH_LINKS,
@@ -328,78 +333,169 @@ def test_sorted_query_string_multi_value():
     assert result == "a=first&topic=math&topic=science"
 
 
+@pytest.fixture
+def view_cache(settings):
+    """Enable view caching against a fresh locmem backend."""
+    settings.REDIS_VIEW_CACHE_DURATION = 60
+    settings.CACHES = {
+        **settings.CACHES,
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "view-cache-tests",
+        },
+    }
+    caches["default"].clear()
+    return caches["default"]
+
+
+def _decorated_api_view(decorator=None, status=200):
+    """Build a real DRF view with a cache decorator applied to its handler."""
+    calls = {"count": 0}
+
+    class CachedView(APIView):
+        authentication_classes = ()
+        permission_classes = ()
+        versioning_class = None
+
+        @method_decorator(decorator or cache_page_for_all_users())
+        def get(self, request):  # noqa: ARG002
+            calls["count"] += 1
+            return Response({"result": "fresh", "call": calls["count"]}, status=status)
+
+    view = CachedView.as_view()
+    view.calls = calls
+    return view
+
+
+def _get(view, path="/test/", user=None):
+    """Issue a GET through the full DRF request/render cycle."""
+    request = APIRequestFactory().get(path)
+    if user is not None:
+        force_authenticate(request, user=user)
+    response = view(request)
+    return response.render() if hasattr(response, "render") else response
+
+
+def test_view_cache_end_to_end(view_cache):
+    """The second request is served from cache with identical JSON."""
+    view = _decorated_api_view()
+
+    first = _get(view)
+    second = _get(view)
+
+    assert view.calls["count"] == 1
+    assert first.content == second.content
+    assert json.loads(second.content) == {"result": "fresh", "call": 1}
+    assert second["Content-Type"] == "application/json"
+
+
+def test_cache_miss_renders_once(view_cache):
+    """A miss caches the bytes from the response's own render pass."""
+    view = _decorated_api_view()
+
+    with patch("main.utils.JSONRenderer") as mock_renderer:
+        first = _get(view)
+
+    mock_renderer.assert_not_called()
+    assert _get(view).content == first.content
+    assert view.calls["count"] == 1
+
+
+def test_anonymous_users_decorator_caches_anonymous(view_cache):
+    """Anonymous requests are cached by cache_page_for_anonymous_users."""
+    view = _decorated_api_view(cache_page_for_anonymous_users())
+
+    _get(view)
+    _get(view)
+
+    assert view.calls["count"] == 1
+
+
+def test_anonymous_users_decorator_skips_authenticated(view_cache):
+    """Authenticated requests bypass cache_page_for_anonymous_users."""
+    view = _decorated_api_view(cache_page_for_anonymous_users())
+    user = UserFactory.build()
+
+    _get(view, user=user)
+    _get(view, user=user)
+
+    assert view.calls["count"] == 2
+
+
+def test_all_users_decorator_caches_authenticated(view_cache):
+    """Authenticated requests are cached by cache_page_for_all_users."""
+    view = _decorated_api_view()
+
+    _get(view, user=UserFactory.build())
+    _get(view, user=UserFactory.build())
+
+    assert view.calls["count"] == 1
+
+
+def test_cache_timeout_zero_skips_caching(view_cache):
+    """A timeout of 0 disables caching entirely."""
+    view = _decorated_api_view(cache_page_for_all_users(0))
+
+    _get(view)
+    _get(view)
+
+    assert view.calls["count"] == 2
+
+
+def test_cache_default_timeout_resolves_at_request_time(view_cache, settings):
+    """The default timeout is read from settings per request, not at decoration."""
+    settings.REDIS_VIEW_CACHE_DURATION = 0
+    view = _decorated_api_view()
+    settings.REDIS_VIEW_CACHE_DURATION = 60
+
+    _get(view)
+    _get(view)
+
+    assert view.calls["count"] == 1
+
+
+def test_cache_default_timeout_zero_skips_caching(view_cache, settings):
+    """A default timeout of 0 disables caching entirely."""
+    settings.REDIS_VIEW_CACHE_DURATION = 0
+    view = _decorated_api_view()
+
+    _get(view)
+    _get(view)
+
+    assert view.calls["count"] == 2
+
+
+def test_cache_only_caches_200_responses(view_cache):
+    """Non-200 responses are not cached."""
+    view = _decorated_api_view(status=404)
+
+    _get(view)
+    _get(view)
+
+    assert view.calls["count"] == 2
+
+
 @patch("main.utils.caches")
-def test_cache_page_for_anonymous_users_caches_anonymous(mock_caches):
-    """Anonymous user requests are cached."""
+def test_async_cache_stores_rendered_json_bytes(mock_caches):
+    """The async decorator caches the bytes from the response's render pass."""
     mock_cache = MagicMock()
-    mock_cache.get.return_value = None
+    mock_cache.aget = AsyncMock(return_value=None)
     mock_caches.__getitem__.return_value = mock_cache
 
-    view = _create_view()
-    decorated = cache_page_for_anonymous_users(300)(view)
+    async def view(request):
+        return Response({"result": "fresh"})
 
-    request = _create_mock_request(is_authenticated=False)
-    response1 = decorated(request)
-
-    assert view.call_count["count"] == 1
-    mock_cache.set.assert_called_once()
-    assert response1.data["result"] == "fresh"
-
-
-@patch("main.utils.caches")
-def test_cache_page_for_anonymous_users_skips_authenticated(mock_caches):
-    """Authenticated user requests bypass the cache."""
-    mock_cache = MagicMock()
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_anonymous_users(300)(view)
-
-    request = _create_mock_request(is_authenticated=True)
-    response1 = decorated(request)
-    response2 = decorated(request)
-
-    assert view.call_count["count"] == 2
-    mock_cache.get.assert_not_called()
-    mock_cache.set.assert_not_called()
-    assert response1.data["call"] == 1
-    assert response2.data["call"] == 2
-
-
-@patch("main.utils.caches")
-def test_cache_page_for_all_users_caches_anonymous(mock_caches):
-    """Anonymous user requests are cached with cache_page_for_all_users."""
-    mock_cache = MagicMock()
-    mock_cache.get.return_value = None
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
+    response = asyncio.run(decorated(_create_mock_request()))
 
-    request = _create_mock_request(is_authenticated=False)
-    response1 = decorated(request)
+    # complete the render pass DRF runs after the handler returns
+    response.accepted_renderer = JSONRenderer()
+    response.accepted_media_type = "application/json"
+    response.renderer_context = {}
+    response.render()
 
-    assert view.call_count["count"] == 1
-    mock_cache.set.assert_called_once()
-    assert response1.data["result"] == "fresh"
-
-
-@patch("main.utils.caches")
-def test_cache_page_for_all_users_caches_authenticated(mock_caches):
-    """Authenticated user requests are also cached with cache_page_for_all_users."""
-    mock_cache = MagicMock()
-    mock_cache.get.return_value = None
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_all_users(300)(view)
-
-    request = _create_mock_request(is_authenticated=True)
-    response1 = decorated(request)
-
-    assert view.call_count["count"] == 1
-    mock_cache.set.assert_called_once()
-    assert response1.data["result"] == "fresh"
+    assert mock_cache.set.call_args.args[1] == response.content
+    assert json.loads(response.content) == {"result": "fresh"}
 
 
 @patch("main.utils.caches")
@@ -413,28 +509,10 @@ def test_cache_returns_cached_response(mock_caches):
     view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
 
-    request = _create_mock_request()
-    response = decorated(request)
+    response = decorated(_create_mock_request())
 
     assert view.call_count["count"] == 0
     assert response.data == cached_data
-
-
-@patch("main.utils.caches")
-def test_cache_stores_rendered_json_bytes(mock_caches):
-    """Responses are cached as rendered JSON bytes, not raw data."""
-    mock_cache = MagicMock()
-    mock_cache.get.return_value = None
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_all_users(300)(view)
-
-    decorated(_create_mock_request())
-
-    cached_value = mock_cache.set.call_args.args[1]
-    assert isinstance(cached_value, bytes)
-    assert json.loads(cached_value) == {"result": "fresh", "call": 1}
 
 
 @patch("main.utils.caches")
@@ -464,8 +542,7 @@ def test_cache_hit_html_request_gets_negotiable_response(mock_caches):
     view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
 
-    request = _create_mock_request(accept="text/html,application/xhtml+xml")
-    response = decorated(request)
+    response = decorated(_create_mock_request(accept="text/html,application/xhtml+xml"))
 
     assert view.call_count["count"] == 0
     assert isinstance(response, Response)
@@ -482,13 +559,10 @@ def test_cache_key_consistent_for_same_url(mock_caches):
     view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
 
-    request1 = _create_mock_request(path="/api/test/", query="a=1&b=2")
-    request2 = _create_mock_request(path="/api/test/", query="a=1&b=2")
-
-    decorated(request1)
+    decorated(_create_mock_request(path="/api/test/", query="a=1&b=2"))
     key1 = mock_cache.get.call_args_list[0][0][0]
 
-    decorated(request2)
+    decorated(_create_mock_request(path="/api/test/", query="a=1&b=2"))
     key2 = mock_cache.get.call_args_list[1][0][0]
 
     assert key1 == key2
@@ -504,13 +578,10 @@ def test_cache_key_consistent_with_reordered_params(mock_caches):
     view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
 
-    request1 = _create_mock_request(path="/api/test/", query="b=2&a=1")
-    request2 = _create_mock_request(path="/api/test/", query="a=1&b=2")
-
-    decorated(request1)
+    decorated(_create_mock_request(path="/api/test/", query="b=2&a=1"))
     key1 = mock_cache.get.call_args_list[0][0][0]
 
-    decorated(request2)
+    decorated(_create_mock_request(path="/api/test/", query="a=1&b=2"))
     key2 = mock_cache.get.call_args_list[1][0][0]
 
     assert key1 == key2
@@ -526,96 +597,13 @@ def test_cache_key_different_for_different_paths(mock_caches):
     view = _create_view()
     decorated = cache_page_for_all_users(300)(view)
 
-    request1 = _create_mock_request(path="/api/test1/")
-    request2 = _create_mock_request(path="/api/test2/")
-
-    decorated(request1)
+    decorated(_create_mock_request(path="/api/test1/"))
     key1 = mock_cache.get.call_args_list[0][0][0]
 
-    decorated(request2)
+    decorated(_create_mock_request(path="/api/test2/"))
     key2 = mock_cache.get.call_args_list[1][0][0]
 
     assert key1 != key2
-
-
-@patch("main.utils.caches")
-def test_cache_timeout_zero_skips_caching(mock_caches):
-    """Timeout of 0 or negative skips caching entirely."""
-    mock_cache = MagicMock()
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_all_users(0)(view)
-
-    request = _create_mock_request()
-    response1 = decorated(request)
-    response2 = decorated(request)
-
-    assert view.call_count["count"] == 2
-    mock_cache.get.assert_not_called()
-    mock_cache.set.assert_not_called()
-    assert response1.data["call"] == 1
-    assert response2.data["call"] == 2
-
-
-@patch("main.utils.caches")
-def test_cache_default_timeout_resolves_at_request_time(mock_caches, settings):
-    """Default timeout is read from settings when the request is handled."""
-    settings.REDIS_VIEW_CACHE_DURATION = 0
-    mock_cache = MagicMock()
-    mock_cache.get.return_value = None
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_all_users()(view)
-    settings.REDIS_VIEW_CACHE_DURATION = 300
-
-    request = _create_mock_request()
-    decorated(request)
-
-    assert view.call_count["count"] == 1
-    mock_cache.set.assert_called_once()
-    assert mock_cache.set.call_args.args[2] == 300
-
-
-@patch("main.utils.caches")
-def test_cache_default_timeout_zero_skips_caching(mock_caches, settings):
-    """Default timeout of 0 skips caching when the request is handled."""
-    settings.REDIS_VIEW_CACHE_DURATION = 0
-    mock_cache = MagicMock()
-    mock_caches.__getitem__.return_value = mock_cache
-
-    view = _create_view()
-    decorated = cache_page_for_all_users()(view)
-
-    request = _create_mock_request()
-    response1 = decorated(request)
-    response2 = decorated(request)
-
-    assert view.call_count["count"] == 2
-    mock_cache.get.assert_not_called()
-    mock_cache.set.assert_not_called()
-    assert response1.data["call"] == 1
-    assert response2.data["call"] == 2
-
-
-@patch("main.utils.caches")
-def test_cache_only_caches_200_responses(mock_caches):
-    """Non-200 responses are not cached."""
-    mock_cache = MagicMock()
-    mock_cache.get.return_value = None
-    mock_caches.__getitem__.return_value = mock_cache
-
-    def error_view(request):
-        response = Response({"error": "not found"}, status=404)
-        response.status_code = 404
-        return response
-
-    decorated = cache_page_for_all_users(300)(error_view)
-    request = _create_mock_request()
-    decorated(request)
-
-    mock_cache.set.assert_not_called()
 
 
 @patch("main.utils.caches")

--- a/openapi/settings_spectacular.py
+++ b/openapi/settings_spectacular.py
@@ -14,6 +14,9 @@ open_spectacular_settings = {
         "ContentFeedbackSentimentEnum": (
             "content_feedback.constants.CONTENT_FEEDBACK_SENTIMENT_CHOICES"
         ),
+        "ContentFileContentTypeEnum": (
+            "learning_resources.constants.VALID_COURSE_CONTENT_CHOICES"
+        ),
     },
     "AUTHENTICATION_WHITELIST": [],
     "SCHEMA_PATH_PREFIX": "/api/v[0-9]",

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -1864,7 +1864,7 @@ components:
           items:
             type: string
         content_type:
-          $ref: '#/components/schemas/ContentTypeEnum'
+          $ref: '#/components/schemas/ContentFileContentTypeEnum'
         content:
           type: string
           nullable: true
@@ -1941,6 +1941,23 @@ components:
       - resource_id
       - resource_readable_id
       - topics
+    ContentFileContentTypeEnum:
+      enum:
+      - page
+      - file
+      - video
+      - pdf
+      type: string
+      description: |-
+        * `page` - page
+        * `file` - file
+        * `video` - video
+        * `pdf` - pdf
+      x-enum-descriptions:
+      - page
+      - file
+      - video
+      - pdf
     ContentFileVectorSearchResponse:
       type: object
       description: SearchResponseSerializer with OpenAPI annotations for Content Files
@@ -1993,23 +2010,6 @@ components:
       - next
       - previous
       - results
-    ContentTypeEnum:
-      enum:
-      - page
-      - file
-      - video
-      - pdf
-      type: string
-      description: |-
-        * `page` - page
-        * `file` - file
-        * `video` - video
-        * `pdf` - pdf
-      x-enum-descriptions:
-      - page
-      - file
-      - video
-      - pdf
     Counts:
       type: object
       properties:
@@ -2663,7 +2663,7 @@ components:
         content_files:
           type: array
           items:
-            $ref: '#/components/schemas/ContentFile'
+            $ref: '#/components/schemas/NestedContentFile'
           nullable: true
           readOnly: true
         description:
@@ -3821,6 +3821,136 @@ components:
       - next
       - previous
       - results
+    NestedContentFile:
+      type: object
+      description: |-
+        ContentFileSerializer without the large text fields (content, summary,
+        flashcards), for nesting inside learning resource API responses.
+        The search indexing path re-adds full content where needed.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        run_id:
+          type: integer
+        direct_learning_resource_id:
+          type: integer
+          nullable: true
+        run_title:
+          type: string
+        run_slug:
+          type: string
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+        semester:
+          type: string
+        year:
+          type: integer
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+          readOnly: true
+        key:
+          type: string
+          nullable: true
+          maxLength: 1024
+        uid:
+          type: string
+          nullable: true
+          maxLength: 36
+        title:
+          type: string
+          nullable: true
+          maxLength: 1024
+        description:
+          type: string
+          nullable: true
+        require_summaries:
+          type: boolean
+          readOnly: true
+        url:
+          type: string
+          nullable: true
+        content_feature_type:
+          type: array
+          items:
+            type: string
+        content_type:
+          $ref: '#/components/schemas/ContentFileContentTypeEnum'
+        content_title:
+          type: string
+          nullable: true
+          maxLength: 1024
+        content_author:
+          type: string
+          nullable: true
+          maxLength: 1024
+        content_language:
+          type: string
+          nullable: true
+          maxLength: 24
+        checksum:
+          type: string
+        image_src:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        resource_id:
+          type: string
+          readOnly: true
+        resource_readable_id:
+          type: string
+          readOnly: true
+        source_path:
+          type: string
+        course_number:
+          type: array
+          items:
+            type: string
+          description: Extract the course number(s) from the associated course
+          readOnly: true
+        file_type:
+          type: string
+          nullable: true
+          maxLength: 128
+        file_extension:
+          type: string
+          nullable: true
+          maxLength: 32
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+        run_readable_id:
+          type: string
+        edx_module_id:
+          type: string
+          nullable: true
+          maxLength: 1024
+        youtube_id:
+          type: string
+          nullable: true
+          maxLength: 32
+      required:
+      - content_feature_type
+      - course_number
+      - departments
+      - id
+      - offered_by
+      - platform
+      - require_summaries
+      - resource_id
+      - resource_readable_id
+      - topics
     NewsFeedItem:
       type: object
       description: Serializer for News FeedItem
@@ -6366,7 +6496,7 @@ components:
         content_files:
           type: array
           items:
-            $ref: '#/components/schemas/ContentFile'
+            $ref: '#/components/schemas/NestedContentFile'
           nullable: true
           readOnly: true
         description:

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -11206,7 +11206,7 @@ components:
         content_files:
           type: array
           items:
-            $ref: '#/components/schemas/ContentFile'
+            $ref: '#/components/schemas/NestedContentFile'
           nullable: true
           readOnly: true
         description:
@@ -13653,6 +13653,136 @@ components:
       - child
       - id
       - parent
+    NestedContentFile:
+      type: object
+      description: |-
+        ContentFileSerializer without the large text fields (content, summary,
+        flashcards), for nesting inside learning resource API responses.
+        The search indexing path re-adds full content where needed.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        run_id:
+          type: integer
+        direct_learning_resource_id:
+          type: integer
+          nullable: true
+        run_title:
+          type: string
+        run_slug:
+          type: string
+        departments:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceDepartment'
+          readOnly: true
+        semester:
+          type: string
+        year:
+          type: integer
+        topics:
+          type: array
+          items:
+            $ref: '#/components/schemas/LearningResourceTopic'
+          readOnly: true
+        key:
+          type: string
+          nullable: true
+          maxLength: 1024
+        uid:
+          type: string
+          nullable: true
+          maxLength: 36
+        title:
+          type: string
+          nullable: true
+          maxLength: 1024
+        description:
+          type: string
+          nullable: true
+        require_summaries:
+          type: boolean
+          readOnly: true
+        url:
+          type: string
+          nullable: true
+        content_feature_type:
+          type: array
+          items:
+            type: string
+        content_type:
+          $ref: '#/components/schemas/ContentFileContentTypeEnum'
+        content_title:
+          type: string
+          nullable: true
+          maxLength: 1024
+        content_author:
+          type: string
+          nullable: true
+          maxLength: 1024
+        content_language:
+          type: string
+          nullable: true
+          maxLength: 24
+        checksum:
+          type: string
+        image_src:
+          type: string
+          format: uri
+          nullable: true
+          maxLength: 200
+        resource_id:
+          type: string
+          readOnly: true
+        resource_readable_id:
+          type: string
+          readOnly: true
+        source_path:
+          type: string
+        course_number:
+          type: array
+          items:
+            type: string
+          description: Extract the course number(s) from the associated course
+          readOnly: true
+        file_type:
+          type: string
+          nullable: true
+          maxLength: 128
+        file_extension:
+          type: string
+          nullable: true
+          maxLength: 32
+        offered_by:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourceOfferor'
+          readOnly: true
+        platform:
+          allOf:
+          - $ref: '#/components/schemas/LearningResourcePlatform'
+          readOnly: true
+        run_readable_id:
+          type: string
+        edx_module_id:
+          type: string
+          nullable: true
+          maxLength: 1024
+        youtube_id:
+          type: string
+          nullable: true
+          maxLength: 32
+      required:
+      - content_feature_type
+      - course_number
+      - departments
+      - id
+      - offered_by
+      - platform
+      - require_summaries
+      - resource_id
+      - resource_readable_id
+      - topics
     NullEnum:
       enum:
       - null
@@ -17213,7 +17343,7 @@ components:
         content_files:
           type: array
           items:
-            $ref: '#/components/schemas/ContentFile'
+            $ref: '#/components/schemas/NestedContentFile'
           nullable: true
           readOnly: true
         description:


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12534

### Description (What does it do?)

1. **Stop returning content file text in API responses.** Search results, resource detail, and similar-resource responses no longer include `content`, `summary`, or `flashcards` inside nested `content_files`. The full text stays in the OpenSearch index, so searching within file content still works. Cuts the search payload roughly 20×.

2. **Cache rendered JSON instead of Python data.** The Redis view cache stored the un-rendered response data, so every cache hit still rebuilt the full JSON response. It now stores the rendered bytes and returns them directly for JSON requests. The browsable API still works (cache hits are re-rendered for it), and old cache entries are served correctly until they expire.
### How can this be tested?

**Setup** (same OCW sample data as #3018):
```
./manage.py backpopulate_ocw_data --course-name 15-s12-blockchain-and-money-fall-2018 --overwrite
./manage.py backpopulate_ocw_data --course-name 6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 --overwrite
./manage.py backpopulate_ocw_data --course-name res-6-011-the-art-of-insight-in-science-and-engineering-mastering-complexity-fall-2014 --overwrite
./manage.py recreate_index --all
```

1. **Slim search results:** open `http://localhost:8063/api/v1/learning_resources_search/?resource_type_group=learning_material&show_ocw_files=true`. You should see OCW learning materials (problem sets, exams, and "The Art of Insight in Science and Engineering" textbook). Each result's `content_files` entries should have metadata (`title`, `url`, `image_src`, etc.) but **no** `content`, `summary`, or `flashcards` keys.
2. **Searching file text still works:** search a phrase that only appears inside the textbook's text, not in any title or description: `http://localhost:8063/api/v1/learning_resources_search/?q=Merely+watching+workout+videos&show_ocw_files=true&min_score=0`. The Art of Insight textbook should come back — proving the full text is still indexed even though it's no longer in the response. (`min_score=0` is needed because the default relevance cutoff scores content-only matches below threshold on the small local dataset — pre-existing behavior, unrelated to this PR.)
3. **Detail and similar endpoints:** open `/api/v1/learning_resources/<id>/` for one of the materials from step 1 (the textbook is id 582 in my local db) — same slim `content_files` shape. If you have Qdrant embeddings locally, `/api/v1/learning_resources/<id>/vector_similar/` too.
4. **Frontend:** open `http://localhost:8062/search?resource_type_group=learning_material&show_ocw_files=true` — the Learning Materials tab should render the OCW materials normally. Then open `http://localhost:8062/search?resource_type_group=learning_material&show_ocw_files=true&resource=582` — the drawer should show the textbook with its description (which falls back to the content file's description) and a populated "Similar Learning Resources" carousel (fed by the slimmed `vector_similar` endpoint; needs local Qdrant embeddings). Video playback can't be checked with this dataset — the three OCW courses above ingest no video resources — so spot-check a video page on RC after deploy.
5. **Caching:** open a cached endpoint like `/api/v1/topics/` in a browser twice — the browsable API HTML should render both times (the second is a cache hit). Request it with `Accept: application/json` and confirm JSON comes back.
6. On RC, `curl -s '<search url>' | wc -c` — the default search page should be a few hundred KB, not several MB.

### Additional Context
After deploying (and before any rollback), run `main.utils.clear_views_cache()` in a web shell. After deploy it evicts cached responses that still contain the old multi-MB payloads; before a rollback it removes bytes-format entries the previous code can't read.

### Checklist:
- [ ] Run `clear_views_cache()` after deploy to RC/production



