### PR TITLE
Add acks_late to ETL tasks killed by worker autoscaling scale-downs

### DIFF
--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -65,7 +65,7 @@ log = logging.getLogger(__name__)
 CLEANUP_RETRY_EXCEPTIONS = (*SEARCH_CONN_EXCEPTIONS, OperationalError)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def update_next_start_date_and_prices():
     """Update expired next start dates and prices"""
     resources = LearningResource.objects.filter(next_start_date__lt=timezone.now())
@@ -79,7 +79,7 @@ def update_next_start_date_and_prices():
     return len(resources)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 @cooldown_task(
     wait_time=3600,
     key_func=lambda *, api_course_datafile=None, api_program_datafile=None: (
@@ -108,7 +108,7 @@ def get_mit_edx_data(
     return len(courses) + len(programs)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 @cooldown_task(wait_time=900)
 def get_mitxonline_data() -> int | None:
     """Execute the MITX Online ETL pipeline"""
@@ -136,21 +136,21 @@ def get_oll_data(sheets_id=None) -> int | None:
     return len(courses)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_mitpe_data():
     """Execute the Professional Education ETL pipeline"""
     courses, programs = pipelines.mitpe_etl()
     return len(courses) + len(programs)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_sloan_data():
     """Execute the Sloan ETL pipelines"""
     courses = pipelines.sloan_courses_etl()
     return len(courses)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 @cooldown_task(wait_time=900)
 def get_xpro_data() -> int | None:
     """Execute the xPro ETL pipeline"""
@@ -160,7 +160,7 @@ def get_xpro_data() -> int | None:
     return len(courses) + len(programs)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_mit_climate_data():
     """Execute the MIT Climate ETL pipeline"""
     articles = pipelines.mit_climate_etl()
@@ -168,7 +168,7 @@ def get_mit_climate_data():
     return len(articles)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_content_files(
     ids: list[int],
     etl_source: str,
@@ -317,7 +317,7 @@ def import_content_files(
     )
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_podcast_data():
     """
     Execute the Podcast ETL pipeline
@@ -530,7 +530,7 @@ def get_ovs_transcripts(*, overwrite=False):
     clear_views_cache()
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_learning_resource_views():
     """Load learning resource views from the PostHog ETL."""
 

--- a/news_events/tasks.py
+++ b/news_events/tasks.py
@@ -5,14 +5,14 @@ from main.utils import clear_views_cache
 from news_events.etl import pipelines
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_medium_mit_news():
     """Run the Medium MIT News ETL pipeline"""
     pipelines.medium_mit_news_etl()
     clear_views_cache()
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_ol_events():
     """Run the Open Learning Events ETL pipeline"""
     pipelines.ol_events_etl()
@@ -33,21 +33,21 @@ def get_sloan_exec_webinars():
     clear_views_cache()
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_mitpe_news():
     """Run the MIT Professional Education news ETL pipeline"""
     pipelines.mitpe_news_etl()
     clear_views_cache()
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_mitpe_events():
     """Run the MIT Professional Education events ETL pipeline"""
     pipelines.mitpe_events_etl()
     clear_views_cache()
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def get_website_content_news():
     """Run the website content news ETL pipeline"""
 

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -648,7 +648,7 @@ def _sentry_healthcheck_log(healthcheck, alert_type, context, message):
         sentry_sdk.capture_message(message)
 
 
-@app.task
+@app.task(acks_late=True, reject_on_worker_lost=True)
 def sync_topics():
     """
     Sync topics to the Qdrant collection


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/mit-learn/issues/3677

### Description (What does it do?)
Adds `acks_late=True, reject_on_worker_lost=True` to the scheduled ETL tasks that production logs show are being lost when celery worker pods are terminated by autoscaling scale-downs mid-run (details and 7-day loss counts in the issue). With early acks (celery's default) the broker message is gone the moment the task starts, so a killed run vanishes and stays STARTED forever in the monitoring app. With late acks the broker redelivers the message after the visibility timeout (1 hour) and the run completes on a surviving worker.

This matches the pattern already used by `get_ocw_courses`, `get_youtube_data`, `summarize_content_files_task`, etc., which are killed just as often but demonstrably recover via redelivery.

Tasks changed (all idempotent):
- `learning_resources`: `get_mitxonline_data`, `get_mit_edx_data`, `get_xpro_data`, `get_content_files`, `get_podcast_data`, `get_learning_resource_views`, `get_mitpe_data`, `get_sloan_data`, `get_mit_climate_data`, `update_next_start_date_and_prices`
- `news_events`: `get_medium_mit_news`, `get_ol_events`, `get_mitpe_news`, `get_mitpe_events`, `get_website_content_news`
- `vector_search`: `sync_topics`

Interaction with `cooldown_task` (#3363): unchanged. The cooldown check runs on the worker at execution time regardless of ack mode, and `Reject(requeue=False)` is terminal, so re-triggers during a cooldown window are still dropped. Cooldown locks (900s) expire well before the 1-hour visibility timeout, so a redelivered recovery run is not blocked by its own cooldown. (`get_mit_edx_data`'s 3600s lock ≈ the visibility timeout, so its recovery run can race the lock — worst case it is rejected, which is exactly today's behavior.)

### How can this be tested?
Verified locally end to end (steps reproducible with `COMPOSE_PROFILES=backend`):

1. `docker compose up -d celery`, then enqueue a run and note the task id:
   ```
   docker compose run --rm web python manage.py shell -c "from learning_resources.tasks import get_mitxonline_data; print(get_mitxonline_data.delay(_cooldown_force=True).id)"
   ```
2. While it runs (~3 min), confirm the message is still unacknowledged — this is the behavior this PR adds; on `main` the count for this task is 0 because the message is acked at start:
   ```
   docker compose exec redis redis-cli -n 4 hlen unacked
   ```
3. Kill the worker mid-run, as an autoscaling scale-down does after the grace period: `docker kill -s KILL mit-learn-celery-1`. The message survives in `unacked`.
4. Restart the worker (`docker compose up -d celery`). Redelivery normally happens after the 1-hour visibility timeout; to avoid waiting, age the pending entries so the next restore cycle picks them up:
   ```
   docker compose exec redis redis-cli -n 4 eval "local tags = redis.call('ZRANGE','unacked_index',0,-1); for i,t in ipairs(tags) do redis.call('ZADD','unacked_index',0,t) end; return #tags" 0
   ```
5. Within ~a minute the worker logs show the **same task id** received again, and it completes:
   ```
   Task learning_resources.tasks.get_mitxonline_data[0c5b14a5-...] received      <- original, killed
   Task learning_resources.tasks.get_mitxonline_data[0c5b14a5-...] received      <- redelivered
   Task learning_resources.tasks.get_mitxonline_data[0c5b14a5-...] succeeded in 158.7s: 446
   ```

Also verify cooldown behavior is preserved: enqueue the same task twice within 900s — the second run logs `Skipping ...: cooldown active` and is rejected without executing.

Sanity check that the flags are active:
```
docker compose run --rm web python manage.py shell -c "from learning_resources.tasks import get_mitxonline_data as t; print(t.acks_late, t.reject_on_worker_lost)"
```

### Additional Context
After deploy, killed runs will show as redelivered-then-succeeded in https://celery-monitoring.odl.mit.edu instead of stuck STARTED. Stuck-STARTED entries from before the deploy won't self-heal; their next scheduled run covers them.
