### PR TITLE
feat(b2b): org analytics dashboard for the manager surface

### DIFF
--- a/env/frontend.env
+++ b/env/frontend.env
@@ -29,6 +29,10 @@ NEXT_PUBLIC_LEARN_AI_CSRF_COOKIE_NAME=csrftoken
 NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=https://api.rc.learn.mit.edu/ai/http/recommendation_agent/
 NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=https://api.rc.learn.mit.edu/ai/http/syllabus_agent/
 
+# OL Analytics API (ol-analytics-api). Auth is cookie-based via APISIX — the
+# frontend attaches no token. Leave unset to disable the org analytics dashboard.
+NEXT_PUBLIC_ANALYTICS_API_BASE_URL=${ANALYTICS_API_BASE_URL}
+
 NEXT_PUBLIC_MITX_ONLINE_BASE_URL=${MITX_ONLINE_BASE_URL}
 NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL=http://mitxonline.odl.local:8065/
 NEXT_PUBLIC_VERSION="local-dev"

--- a/env/frontend.env
+++ b/env/frontend.env
@@ -30,7 +30,10 @@ NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=https://api.rc.learn.mit.edu/ai/htt
 NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=https://api.rc.learn.mit.edu/ai/http/syllabus_agent/
 
 # OL Analytics API (ol-analytics-api). Auth is cookie-based via APISIX — the
-# frontend attaches no token. Leave unset to disable the org analytics dashboard.
+# frontend attaches no token. Leave unset when there is no analytics API to talk
+# to: the org analytics dashboard then reports itself unavailable rather than
+# loading data. Access to the route itself is gated by the
+# b2b-analytics-dashboard PostHog flag, not by this variable.
 NEXT_PUBLIC_ANALYTICS_API_BASE_URL=${ANALYTICS_API_BASE_URL}
 
 NEXT_PUBLIC_MITX_ONLINE_BASE_URL=${MITX_ONLINE_BASE_URL}

--- a/env/frontend.local.example.env
+++ b/env/frontend.local.example.env
@@ -12,8 +12,11 @@ NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=""
 # NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
 # NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
 
-# ol-analytics-api integration: powers the B2B org analytics dashboard at
-# /dashboard/organization/<org>/analytics. Leave unset to keep the dashboard
-# hidden. Point at the APISIX route rather than the API directly — the API
-# expects the JWT that APISIX mints from the session cookie.
+# ol-analytics-api integration: supplies the data for the B2B org analytics
+# dashboard at /dashboard/organization/<org>/analytics. Whether that route is
+# reachable at all is controlled by the b2b-analytics-dashboard PostHog flag,
+# not by this variable: with the flag on and this unset the page still renders,
+# reporting "Analytics is not available in this environment".
+# Point at the APISIX route rather than the API directly — the API expects the
+# JWT that APISIX mints from the session cookie.
 # NEXT_PUBLIC_ANALYTICS_API_BASE_URL=http://open.odl.local:8065/analytics/

--- a/env/frontend.local.example.env
+++ b/env/frontend.local.example.env
@@ -11,3 +11,9 @@ NEXT_PUBLIC_STAY_UPDATED_HUBSPOT_FORM_ID=""
 # in the README. Requires learn-ai running locally.
 # NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT=http://open.odl.local:8065/ai/http/recommendation_agent/
 # NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT=http://open.odl.local:8065/ai/http/syllabus_agent/
+
+# ol-analytics-api integration: powers the B2B org analytics dashboard at
+# /dashboard/organization/<org>/analytics. Leave unset to keep the dashboard
+# hidden. Point at the APISIX route rather than the API directly — the API
+# expects the JWT that APISIX mints from the session cookie.
+# NEXT_PUBLIC_ANALYTICS_API_BASE_URL=http://open.odl.local:8065/analytics/

--- a/frontends/api/package.json
+++ b/frontends/api/package.json
@@ -16,7 +16,10 @@
     "./test-utils/mockAxios": "./src/test-utils/mockAxios.ts",
     "./test-utils": "./src/test-utils/index.ts",
     "./mitxonline-hooks/*": "./src/mitxonline/hooks/*/index.ts",
-    "./mitxonline-test-utils": "./src/mitxonline/test-utils/index.ts"
+    "./mitxonline-test-utils": "./src/mitxonline/test-utils/index.ts",
+    "./analytics-hooks/*": "./src/analytics/hooks/*/index.ts",
+    "./analytics-types": "./src/analytics/types.ts",
+    "./analytics-test-utils": "./src/analytics/test-utils/index.ts"
   },
   "peerDependencies": {
     "react": "^19.2.1"

--- a/frontends/api/src/analytics/axios.ts
+++ b/frontends/api/src/analytics/axios.ts
@@ -1,0 +1,14 @@
+import { createConfigurableAxios } from "../configurableAxios"
+
+/**
+ * Axios instance for the OL Analytics API (`ol-analytics-api`).
+ *
+ * Auth is entirely cookie-based: the analytics API sits behind APISIX, which
+ * resolves the session cookie into the JWT the API expects. The browser sends
+ * the cookie because of `withCredentials`, so nothing here attaches a token.
+ */
+export const analyticsAxiosClient = createConfigurableAxios(
+  "mit-learn.api.axios.analytics",
+)
+
+export default analyticsAxiosClient.instance

--- a/frontends/api/src/analytics/clients.ts
+++ b/frontends/api/src/analytics/clients.ts
@@ -1,0 +1,107 @@
+import type { AxiosResponse } from "axios"
+import axiosInstance from "./axios"
+import type {
+  AnalyticsPageParams,
+  ContentEngagementDepth,
+  ContractUtilization,
+  EnrollmentCompletionFunnel,
+  MonthlyEngagementTrend,
+  OrgAnalyticsResponse,
+  ProgramFunnel,
+} from "./types"
+
+/**
+ * The b2b_dashboard tenant is mounted at this path by `ol-analytics-api`'s
+ * root ASGI app (`main.py`'s tenant registry). The configured axios `baseURL`
+ * is the API host, so every path here is relative to it.
+ */
+const B2B_DASHBOARD_ROOT = "/api/v1/analytics"
+
+/**
+ * `organizationId` is the **Keycloak organization UUID** (`sso_organization_id`),
+ * not the org slug and not MITx Online's numeric org id. It is the only
+ * identifier that is stable across the JWT, MITx Online and StarRocks, so the
+ * analytics API keys every org endpoint on it — see mitodl/ol-analytics-api#13.
+ */
+const orgRoot = (organizationId: string) =>
+  `${B2B_DASHBOARD_ROOT}/organizations/${encodeURIComponent(organizationId)}`
+
+const getOrgResource = <RowT>(
+  organizationId: string,
+  resource: string,
+  page: AnalyticsPageParams | undefined,
+  signal: AbortSignal | undefined,
+): Promise<AxiosResponse<OrgAnalyticsResponse<RowT>>> =>
+  axiosInstance.get<OrgAnalyticsResponse<RowT>>(
+    `${orgRoot(organizationId)}/${resource}`,
+    { params: page, signal },
+  )
+
+/**
+ * One method per org-scoped endpoint of the analytics API's b2b_dashboard
+ * tenant. Thin by design — paging and the response envelope are the only
+ * shared concerns, and both live in `getOrgResource`.
+ */
+const analyticsOrganizationsApi = {
+  contractUtilization: (
+    organizationId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getOrgResource<ContractUtilization>(
+      organizationId,
+      "contract-utilization",
+      page,
+      signal,
+    ),
+
+  enrollmentFunnel: (
+    organizationId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getOrgResource<EnrollmentCompletionFunnel>(
+      organizationId,
+      "enrollment-funnel",
+      page,
+      signal,
+    ),
+
+  engagementTrend: (
+    organizationId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getOrgResource<MonthlyEngagementTrend>(
+      organizationId,
+      "engagement-trend",
+      page,
+      signal,
+    ),
+
+  programFunnel: (
+    organizationId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getOrgResource<ProgramFunnel>(
+      organizationId,
+      "program-funnel",
+      page,
+      signal,
+    ),
+
+  contentEngagement: (
+    organizationId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getOrgResource<ContentEngagementDepth>(
+      organizationId,
+      "content-engagement",
+      page,
+      signal,
+    ),
+}
+
+export { analyticsOrganizationsApi, B2B_DASHBOARD_ROOT }

--- a/frontends/api/src/analytics/hooks/organizations/index.ts
+++ b/frontends/api/src/analytics/hooks/organizations/index.ts
@@ -1,0 +1,14 @@
+export {
+  analyticsOrganizationQueries,
+  analyticsOrganizationKeys,
+} from "./queries"
+
+export type {
+  AnalyticsPageParams,
+  ContentEngagementDepth,
+  ContractUtilization,
+  EnrollmentCompletionFunnel,
+  MonthlyEngagementTrend,
+  OrgAnalyticsResponse,
+  ProgramFunnel,
+} from "../../types"

--- a/frontends/api/src/analytics/hooks/organizations/queries.test.ts
+++ b/frontends/api/src/analytics/hooks/organizations/queries.test.ts
@@ -1,0 +1,117 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
+import { setupReactQueryTest } from "../../../hooks/test-utils"
+import { setMockResponse, makeRequest } from "../../../test-utils"
+import { factories, urls } from "../../test-utils"
+import { analyticsOrganizationQueries } from "./queries"
+
+const ORG_UUID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+/**
+ * Each factory returns options for its own row type, so a `test.each` table of
+ * them is a union that `useQuery` cannot resolve to a single overload. The
+ * table only needs "does this options object request that URL", so erase the
+ * row type here rather than splitting the table into five near-identical tests.
+ */
+type AnyQueryOptions = UseQueryOptions<
+  unknown,
+  Error,
+  unknown,
+  readonly unknown[]
+>
+const erase = (options: unknown) => options as AnyQueryOptions
+
+describe("analyticsOrganizationQueries", () => {
+  test.each([
+    {
+      name: "contractUtilization",
+      query: () =>
+        erase(analyticsOrganizationQueries.contractUtilization(ORG_UUID)),
+      url: urls.organizations.contractUtilization(ORG_UUID),
+      response: factories.envelope([factories.contractUtilization()]),
+    },
+    {
+      name: "enrollmentFunnel",
+      query: () =>
+        erase(analyticsOrganizationQueries.enrollmentFunnel(ORG_UUID)),
+      url: urls.organizations.enrollmentFunnel(ORG_UUID),
+      response: factories.envelope([factories.enrollmentCompletionFunnel()]),
+    },
+    {
+      name: "engagementTrend",
+      query: () =>
+        erase(analyticsOrganizationQueries.engagementTrend(ORG_UUID)),
+      url: urls.organizations.engagementTrend(ORG_UUID),
+      response: factories.envelope([factories.monthlyEngagementTrend()]),
+    },
+    {
+      name: "programFunnel",
+      query: () => erase(analyticsOrganizationQueries.programFunnel(ORG_UUID)),
+      url: urls.organizations.programFunnel(ORG_UUID),
+      response: factories.envelope([factories.programFunnel()]),
+    },
+    {
+      name: "contentEngagement",
+      query: () =>
+        erase(analyticsOrganizationQueries.contentEngagement(ORG_UUID)),
+      url: urls.organizations.contentEngagement(ORG_UUID),
+      response: factories.envelope([factories.contentEngagementDepth()]),
+    },
+  ])("$name requests its endpoint and returns the envelope", async (spec) => {
+    setMockResponse.get(spec.url, spec.response)
+    const { wrapper } = setupReactQueryTest()
+
+    const { result } = renderHook(() => useQuery(spec.query()), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(spec.response)
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "get", url: spec.url }),
+    )
+  })
+
+  test("paging params reach the request and change the query key", async () => {
+    const page = { limit: 200, offset: 0 }
+    const url = urls.organizations.contractUtilization(ORG_UUID, page)
+    const response = factories.envelope([factories.contractUtilization()])
+    setMockResponse.get(url, response)
+    const { wrapper } = setupReactQueryTest()
+
+    const { result } = renderHook(
+      () =>
+        useQuery(
+          analyticsOrganizationQueries.contractUtilization(ORG_UUID, page),
+        ),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(makeRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ method: "get", url }),
+    )
+    expect(
+      analyticsOrganizationQueries.contractUtilization(ORG_UUID, page).queryKey,
+    ).not.toEqual(
+      analyticsOrganizationQueries.contractUtilization(ORG_UUID).queryKey,
+    )
+  })
+
+  test("query keys are namespaced per org so one org cannot read another's cache", () => {
+    const [namespace, resource, orgId] =
+      analyticsOrganizationQueries.contractUtilization(ORG_UUID).queryKey
+    expect([namespace, resource, orgId]).toEqual([
+      "analytics",
+      "organizations",
+      ORG_UUID,
+    ])
+    expect(
+      analyticsOrganizationQueries.contractUtilization("other").queryKey,
+    ).not.toEqual(
+      analyticsOrganizationQueries.contractUtilization(ORG_UUID).queryKey,
+    )
+  })
+
+  test("the org id is url-encoded rather than spliced into the path raw", () => {
+    expect(urls.organizations.contractUtilization("a/b")).toContain("a%2Fb")
+  })
+})

--- a/frontends/api/src/analytics/hooks/organizations/queries.ts
+++ b/frontends/api/src/analytics/hooks/organizations/queries.ts
@@ -1,0 +1,99 @@
+import { queryOptions } from "@tanstack/react-query"
+import { analyticsOrganizationsApi } from "../../clients"
+import type { AnalyticsPageParams } from "../../types"
+
+/**
+ * `orgId` in every key is the Keycloak organization UUID — see
+ * `analyticsOrganizationsApi`. Keys are namespaced under "analytics" so the
+ * whole dashboard can be invalidated without touching mitxonline or learn
+ * queries.
+ */
+const analyticsOrganizationKeys = {
+  root: ["analytics", "organizations"] as const,
+  organization: (orgId: string) =>
+    [...analyticsOrganizationKeys.root, orgId] as const,
+  resource: (orgId: string, resource: string, page?: AnalyticsPageParams) =>
+    [...analyticsOrganizationKeys.organization(orgId), resource, page] as const,
+}
+
+/**
+ * The materialized views behind these endpoints refresh on a schedule measured
+ * in hours, so refetching on every window focus only costs StarRocks queries
+ * without ever changing what the manager sees. Freshness is communicated by the
+ * `as_of` in each response instead.
+ */
+const ANALYTICS_STALE_TIME = 5 * 60 * 1000
+
+const analyticsOrganizationQueries = {
+  contractUtilization: (orgId: string, page?: AnalyticsPageParams) =>
+    queryOptions({
+      queryKey: analyticsOrganizationKeys.resource(
+        orgId,
+        "contract-utilization",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsOrganizationsApi
+          .contractUtilization(orgId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  enrollmentFunnel: (orgId: string, page?: AnalyticsPageParams) =>
+    queryOptions({
+      queryKey: analyticsOrganizationKeys.resource(
+        orgId,
+        "enrollment-funnel",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsOrganizationsApi
+          .enrollmentFunnel(orgId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  engagementTrend: (orgId: string, page?: AnalyticsPageParams) =>
+    queryOptions({
+      queryKey: analyticsOrganizationKeys.resource(
+        orgId,
+        "engagement-trend",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsOrganizationsApi
+          .engagementTrend(orgId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  programFunnel: (orgId: string, page?: AnalyticsPageParams) =>
+    queryOptions({
+      queryKey: analyticsOrganizationKeys.resource(
+        orgId,
+        "program-funnel",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsOrganizationsApi
+          .programFunnel(orgId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  contentEngagement: (orgId: string, page?: AnalyticsPageParams) =>
+    queryOptions({
+      queryKey: analyticsOrganizationKeys.resource(
+        orgId,
+        "content-engagement",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsOrganizationsApi
+          .contentEngagement(orgId, page, signal)
+          .then((res) => res.data),
+    }),
+}
+
+export { analyticsOrganizationQueries, analyticsOrganizationKeys }

--- a/frontends/api/src/analytics/test-utils/factories.ts
+++ b/frontends/api/src/analytics/test-utils/factories.ts
@@ -1,0 +1,130 @@
+import { faker } from "@faker-js/faker/locale/en"
+import type {
+  ContentEngagementDepth,
+  ContractUtilization,
+  EnrollmentCompletionFunnel,
+  MonthlyEngagementTrend,
+  OrgAnalyticsResponse,
+  ProgramFunnel,
+} from "../types"
+
+/**
+ * Factories for the analytics API's org-scoped responses.
+ *
+ * Every nullable count here defaults to a real number: suppression is the
+ * exception, so a test that cares about it opts in by passing `null` rather
+ * than every other test having to opt out.
+ */
+
+const organizationId = () => faker.string.uuid()
+
+const envelope = <RowT>(
+  data: RowT[],
+  overrides: Partial<OrgAnalyticsResponse<RowT>> = {},
+): OrgAnalyticsResponse<RowT> => ({
+  organization_id: organizationId(),
+  as_of: "2026-07-01T04:00:00Z",
+  data,
+  ...overrides,
+})
+
+const contractUtilization = (
+  overrides: Partial<ContractUtilization> = {},
+): ContractUtilization => ({
+  organization_key: faker.string.alphanumeric(6).toUpperCase(),
+  organization_name: faker.company.name(),
+  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  b2b_contract_name: `${faker.company.name()} Contract`,
+  b2b_contract_is_active: true,
+  b2b_contract_start_date: "2026-01-01",
+  b2b_contract_end_date: "2026-12-31",
+  seat_limit: 100,
+  b2b_contract_membership_type: "fixed",
+  seats_consumed: 62,
+  active_learners: 48,
+  learners_certified: 20,
+  seat_utilization_pct: 62,
+  completion_rate_pct: 32.3,
+  ...overrides,
+})
+
+const enrollmentCompletionFunnel = (
+  overrides: Partial<EnrollmentCompletionFunnel> = {},
+): EnrollmentCompletionFunnel => ({
+  organization_key: faker.string.alphanumeric(6).toUpperCase(),
+  organization_name: faker.company.name(),
+  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  b2b_contract_name: `${faker.company.name()} Contract`,
+  courserun_pk: faker.number.int({ min: 1, max: 10000 }),
+  courserun_readable_id: `course-v1:MITx+${faker.string.alphanumeric(5)}+2026`,
+  courserun_title: faker.commerce.productName(),
+  enrolled_learners: 40,
+  active_learners: 31,
+  passing_learners: 18,
+  certified_learners: 16,
+  active_rate_pct: 77.5,
+  completion_rate_pct: 40,
+  ...overrides,
+})
+
+const monthlyEngagementTrend = (
+  overrides: Partial<MonthlyEngagementTrend> = {},
+): MonthlyEngagementTrend => ({
+  organization_key: faker.string.alphanumeric(6).toUpperCase(),
+  organization_name: faker.company.name(),
+  activity_year_and_month: "2026-01",
+  monthly_active_learners: 30,
+  new_enrollments: 12,
+  certificates_earned: 5,
+  total_videos_watched: 900,
+  total_problems_attempted: 1200,
+  total_chatbot_interactions: 80,
+  ...overrides,
+})
+
+const programFunnel = (
+  overrides: Partial<ProgramFunnel> = {},
+): ProgramFunnel => ({
+  organization_key: faker.string.alphanumeric(6).toUpperCase(),
+  organization_name: faker.company.name(),
+  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  b2b_contract_name: `${faker.company.name()} Contract`,
+  program_pk: faker.number.int({ min: 1, max: 10000 }),
+  program_title: `${faker.commerce.department()} Program`,
+  total_courses: 6,
+  enrolled_in_contract_courses: 50,
+  enrolled_via_program: 30,
+  program_course_completers: 12,
+  ...overrides,
+})
+
+const contentEngagementDepth = (
+  overrides: Partial<ContentEngagementDepth> = {},
+): ContentEngagementDepth => ({
+  organization_key: faker.string.alphanumeric(6).toUpperCase(),
+  organization_name: faker.company.name(),
+  courserun_readable_id: `course-v1:MITx+${faker.string.alphanumeric(5)}+2026`,
+  courserun_title: faker.commerce.productName(),
+  total_enrolled_learners: 40,
+  engaged_learners: 28,
+  engagement_rate_pct: 70,
+  total_videos_watched: 800,
+  avg_videos_per_engaged_learner: 28.6,
+  total_problems_attempted: 1000,
+  avg_problems_per_engaged_learner: 35.7,
+  total_chatbot_interactions: 60,
+  chatbot_users: 14,
+  chatbot_adoption_pct: 35,
+  certificates_earned: 16,
+  ...overrides,
+})
+
+export {
+  contentEngagementDepth,
+  contractUtilization,
+  enrollmentCompletionFunnel,
+  envelope,
+  monthlyEngagementTrend,
+  organizationId,
+  programFunnel,
+}

--- a/frontends/api/src/analytics/test-utils/factories.ts
+++ b/frontends/api/src/analytics/test-utils/factories.ts
@@ -24,6 +24,9 @@ const envelope = <RowT>(
 ): OrgAnalyticsResponse<RowT> => ({
   organization_id: organizationId(),
   as_of: "2026-07-01T04:00:00Z",
+  // Defaults to a complete result set; a test exercising truncation passes a
+  // larger total explicitly.
+  total_count: data.length,
   data,
   ...overrides,
 })

--- a/frontends/api/src/analytics/test-utils/index.ts
+++ b/frontends/api/src/analytics/test-utils/index.ts
@@ -1,0 +1,2 @@
+export * as factories from "./factories"
+export * as urls from "./urls"

--- a/frontends/api/src/analytics/test-utils/urls.ts
+++ b/frontends/api/src/analytics/test-utils/urls.ts
@@ -1,0 +1,34 @@
+import { queryify } from "ol-test-utilities"
+import analyticsAxios from "../axios"
+import { B2B_DASHBOARD_ROOT } from "../clients"
+import type { AnalyticsPageParams } from "../types"
+
+// Absolute, and read back from the configured axios instance, so the shared
+// request mock can tell analytics requests apart from Learn and MITx ones by
+// origin — same reasoning as the mitxonline URL builders.
+const getApiBaseUrl = () => analyticsAxios.defaults.baseURL
+
+const orgResource = (
+  organizationId: string,
+  resource: string,
+  params?: AnalyticsPageParams,
+) =>
+  // queryify supplies its own leading "?" (and "" when there are no params).
+  `${getApiBaseUrl()}${B2B_DASHBOARD_ROOT}/organizations/${encodeURIComponent(
+    organizationId,
+  )}/${resource}${queryify(params)}`
+
+const organizations = {
+  contractUtilization: (organizationId: string, params?: AnalyticsPageParams) =>
+    orgResource(organizationId, "contract-utilization", params),
+  enrollmentFunnel: (organizationId: string, params?: AnalyticsPageParams) =>
+    orgResource(organizationId, "enrollment-funnel", params),
+  engagementTrend: (organizationId: string, params?: AnalyticsPageParams) =>
+    orgResource(organizationId, "engagement-trend", params),
+  programFunnel: (organizationId: string, params?: AnalyticsPageParams) =>
+    orgResource(organizationId, "program-funnel", params),
+  contentEngagement: (organizationId: string, params?: AnalyticsPageParams) =>
+    orgResource(organizationId, "content-engagement", params),
+}
+
+export { organizations }

--- a/frontends/api/src/analytics/types.ts
+++ b/frontends/api/src/analytics/types.ts
@@ -23,10 +23,16 @@
  * endpoint, so it is per-section rather than per-page: one lagging view cannot
  * make another section look fresher than it is. It is `null` until that view
  * has refreshed for the first time.
+ *
+ * `total_count` is how many rows the org has in that view across every page,
+ * already net of the anonymity floor. `data.length` alone cannot distinguish a
+ * complete result from one truncated at the page cap, so this is what lets the
+ * dashboard admit to showing a subset instead of quietly dropping the rest.
  */
 export type OrgAnalyticsResponse<RowT> = {
   organization_id: string
   as_of: string | null
+  total_count: number
   data: RowT[]
 }
 

--- a/frontends/api/src/analytics/types.ts
+++ b/frontends/api/src/analytics/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Response types for the B2B dashboard tenant of the OL Analytics API.
+ *
+ * These are hand-written rather than generated: `ol-analytics-api` does not
+ * publish a TypeScript client the way MITx Online does (`@mitodl/mitxonline-api-axios`).
+ * They mirror `tenants/b2b_dashboard/models.py` — which in turn mirrors the
+ * StarRocks materialized views owned by dbt in `ol-data-platform` — column for
+ * column. When a view gains a column, update the matching type here.
+ *
+ * # Why so many nullable numbers
+ *
+ * The API applies a k-anonymity floor: any distinct-learner count below the
+ * floor, and every rate/average derived from it, comes back `null`. A `null`
+ * therefore means "suppressed to protect learner privacy", NOT zero and NOT
+ * missing — render it as such (see `SuppressibleValue` in the dashboard) and
+ * never coerce it to 0 in a chart or an average.
+ */
+
+/**
+ * Envelope shared by every org-scoped endpoint.
+ *
+ * `as_of` is the last refresh time of the single materialized view backing this
+ * endpoint, so it is per-section rather than per-page: one lagging view cannot
+ * make another section look fresher than it is. It is `null` until that view
+ * has refreshed for the first time.
+ */
+export type OrgAnalyticsResponse<RowT> = {
+  organization_id: string
+  as_of: string | null
+  data: RowT[]
+}
+
+/** `mv_b2b_contract_utilization` — grain: org x contract. */
+export type ContractUtilization = {
+  organization_key: string
+  organization_name: string
+  contract_pk: number
+  b2b_contract_name: string
+  b2b_contract_is_active: boolean
+  b2b_contract_start_date: string | null
+  b2b_contract_end_date: string | null
+  seat_limit: number | null
+  b2b_contract_membership_type: string | null
+  seats_consumed: number
+  active_learners: number | null
+  learners_certified: number | null
+  seat_utilization_pct: number | null
+  completion_rate_pct: number | null
+}
+
+/** `mv_b2b_enrollment_completion_funnel` — grain: org x contract x course run. */
+export type EnrollmentCompletionFunnel = {
+  organization_key: string
+  organization_name: string
+  contract_pk: number
+  b2b_contract_name: string
+  courserun_pk: number
+  courserun_readable_id: string
+  courserun_title: string
+  enrolled_learners: number
+  active_learners: number | null
+  passing_learners: number | null
+  certified_learners: number | null
+  active_rate_pct: number | null
+  completion_rate_pct: number | null
+}
+
+/**
+ * `mv_b2b_monthly_engagement_trend` — grain: org x year_month.
+ *
+ * `activity_year_and_month` is a `YYYY-MM` string, not a date.
+ */
+export type MonthlyEngagementTrend = {
+  organization_key: string
+  organization_name: string
+  activity_year_and_month: string
+  monthly_active_learners: number
+  new_enrollments: number | null
+  certificates_earned: number | null
+  total_videos_watched: number
+  total_problems_attempted: number
+  total_chatbot_interactions: number
+}
+
+/** `mv_b2b_program_funnel` — grain: org x contract x program. */
+export type ProgramFunnel = {
+  organization_key: string
+  organization_name: string
+  contract_pk: number
+  b2b_contract_name: string
+  program_pk: number
+  program_title: string
+  total_courses: number
+  enrolled_in_contract_courses: number
+  enrolled_via_program: number | null
+  program_course_completers: number | null
+}
+
+/** `mv_b2b_content_engagement_depth` — grain: org x course run, all-time. */
+export type ContentEngagementDepth = {
+  organization_key: string
+  organization_name: string
+  courserun_readable_id: string
+  courserun_title: string
+  total_enrolled_learners: number
+  engaged_learners: number | null
+  engagement_rate_pct: number | null
+  total_videos_watched: number | null
+  avg_videos_per_engaged_learner: number | null
+  total_problems_attempted: number | null
+  avg_problems_per_engaged_learner: number | null
+  total_chatbot_interactions: number | null
+  chatbot_users: number | null
+  chatbot_adoption_pct: number | null
+  certificates_earned: number | null
+}
+
+/**
+ * LIMIT/OFFSET paging, shared by every multi-row endpoint. The API caps `limit`
+ * at its own `max_page_size` and rejects anything larger with a 422.
+ */
+export type AnalyticsPageParams = {
+  limit?: number
+  offset?: number
+}

--- a/frontends/api/src/runtime/index.ts
+++ b/frontends/api/src/runtime/index.ts
@@ -1,10 +1,19 @@
 import { learnAxiosClient } from "../axios"
 import { mitxAxiosClient } from "../mitxonline/axios"
+import { analyticsAxiosClient } from "../analytics/axios"
 import type { ConfigurableAxiosConfig } from "../configurableAxios"
 
 export type ApiClientsConfig = {
   learn: ConfigurableAxiosConfig
   mitxonline: ConfigurableAxiosConfig
+  /**
+   * The OL Analytics API. Optional: it is a newer service that is not deployed
+   * to every environment yet, so an environment that does not set
+   * `NEXT_PUBLIC_ANALYTICS_API_BASE_URL` still boots — only the analytics
+   * dashboard is unavailable there. Callers gate on `isAnalyticsConfigured()`
+   * rather than letting the unconfigured instance throw from its interceptor.
+   */
+  analytics?: ConfigurableAxiosConfig
 }
 
 const normalizeBaseUrl = (label: string, value: string) => {
@@ -33,6 +42,12 @@ const normalizeConfig = (config: ApiClientsConfig): ApiClientsConfig => ({
     ...config.mitxonline,
     baseUrl: normalizeBaseUrl("mitxonline", config.mitxonline.baseUrl),
   },
+  ...(config.analytics && {
+    analytics: {
+      ...config.analytics,
+      baseUrl: normalizeBaseUrl("analytics", config.analytics.baseUrl),
+    },
+  }),
 })
 
 export const configureApiClients = (config: ApiClientsConfig): void => {
@@ -48,12 +63,25 @@ export const configureApiClients = (config: ApiClientsConfig): void => {
 
   learnAxiosClient.applyConfig(normalized.learn)
   mitxAxiosClient.applyConfig(normalized.mitxonline)
+  if (normalized.analytics) {
+    analyticsAxiosClient.applyConfig(normalized.analytics)
+  }
 }
 
+/**
+ * Whether the always-required clients are configured. Deliberately excludes the
+ * analytics client so that an environment without an analytics API still
+ * reports "configured" and `bootstrapApiClients()` stays first-wins.
+ */
 export const isApiClientsConfigured = (): boolean =>
   learnAxiosClient.isConfigured() && mitxAxiosClient.isConfigured()
+
+/** Whether this environment has an analytics API to talk to. */
+export const isAnalyticsConfigured = (): boolean =>
+  analyticsAxiosClient.isConfigured()
 
 export const resetApiClientsForTests = () => {
   learnAxiosClient.resetForTests()
   mitxAxiosClient.resetForTests()
+  analyticsAxiosClient.resetForTests()
 }

--- a/frontends/api/src/test-utils/setupJest.ts
+++ b/frontends/api/src/test-utils/setupJest.ts
@@ -26,4 +26,9 @@ configureApiClients({
     csrfCookieName: "mitxcsrftoken",
     withCredentials: false,
   },
+  analytics: {
+    baseUrl: "http://api.test.learn.odl.local:8065/analytics",
+    csrfCookieName: "csrftoken",
+    withCredentials: false,
+  },
 })

--- a/frontends/jest-shared-setup.ts
+++ b/frontends/jest-shared-setup.ts
@@ -1,3 +1,4 @@
+import v8 from "node:v8"
 import { faker } from "@faker-js/faker/locale/en"
 import failOnConsole from "jest-fail-on-console"
 
@@ -23,6 +24,20 @@ setDefaultTimezone("UTC")
 // jsdom), so they live in main/src/test-utils/setupJest.tsx. The api workspace
 // configures its clients with hardcoded test URLs in its own setup, and leaf
 // packages (ol-*) don't read NEXT_PUBLIC_* at all.
+
+/**
+ * jsdom does not expose `structuredClone`, which real browsers and Node both
+ * have. `@mui/x-charts` calls it while building series state, so any test that
+ * renders a chart dies with a ReferenceError without this.
+ *
+ * Implemented with v8's serializer rather than a JSON round-trip so it behaves
+ * like the real thing for Dates, Maps and Sets instead of flattening them to
+ * strings and plain objects.
+ */
+if (typeof globalThis.structuredClone === "undefined") {
+  globalThis.structuredClone = <T>(value: T): T =>
+    v8.deserialize(v8.serialize(value as never)) as T
+}
 
 // Pulled from the docs - see https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
 

--- a/frontends/main/package.json
+++ b/frontends/main/package.json
@@ -23,6 +23,7 @@
     "@mui/base": "5.0.0-beta.70",
     "@mui/material": "^6.4.5",
     "@mui/material-nextjs": "^6.4.3",
+    "@mui/x-charts": "^8.29.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/resources": "^2.6.1",

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -12,6 +12,7 @@ import {
   alpha,
   Chip,
   Container,
+  Link,
   Pagination,
   SearchInput,
   Skeleton,
@@ -30,6 +31,18 @@ import {
 import { AssignSeatsSection } from "./AssignSeatsSection"
 import { RowActionMenu } from "./RowActionMenu"
 import {
+  EmptyTableMessage,
+  MobileLabel,
+  STUB,
+  TableCard,
+  TableCell,
+  TableFooter,
+  TableFootnote,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+} from "@/components/B2BTable/B2BTable"
+import {
   managerOrganizationQueries,
   type ManagerEnrollmentCode,
 } from "api/mitxonline-hooks/organizations"
@@ -38,6 +51,7 @@ import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
 import { FeatureFlags } from "@/common/feature_flags"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import { organizationAnalyticsView } from "@/common/urls"
 import { ErrorContent } from "../ErrorPage/ErrorPageTemplate"
 import graduateLogo from "@/public/images/dashboard/graduate.png"
 
@@ -93,6 +107,12 @@ const ContractSubtitle = styled(Typography)(({ theme }) => ({
   ...theme.typography.subtitle1,
   color: theme.custom.colors.silverGrayDark,
 })) as typeof Typography
+
+const AnalyticsLink = styled(Link)(({ theme }) => ({
+  ...theme.typography.body2,
+  display: "inline-block",
+  paddingTop: "4px",
+}))
 
 const StatsSide = styled.div(({ theme }) => ({
   display: "flex",
@@ -185,89 +205,6 @@ const ControlsLeft = styled.div(({ theme }) => ({
   },
 }))
 
-const TableCard = styled.div(({ theme }) => ({
-  backgroundColor: theme.custom.colors.white,
-  border: `1px solid ${theme.custom.colors.lightGray2}`,
-  borderRadius: "8px",
-  padding: "24px",
-  [theme.breakpoints.down("md")]: {
-    padding: "16px",
-  },
-}))
-
-const TableHeaderRow = styled.div(({ theme }) => ({
-  display: "flex",
-  gap: "16px",
-  alignItems: "center",
-  paddingBottom: "16px",
-  borderBottom: `1px solid ${theme.custom.colors.silverGrayDark}`,
-  [theme.breakpoints.down("md")]: {
-    display: "none",
-  },
-}))
-
-const TableHeaderCell = styled("div", {
-  shouldForwardProp: (prop) => prop !== "$flex",
-})<{ $flex: number }>(({ $flex, theme }) => ({
-  flex: $flex,
-  minWidth: 0,
-  ...theme.typography.subtitle2,
-  color: theme.custom.colors.black,
-}))
-
-const TableRow = styled.div(({ theme }) => ({
-  display: "flex",
-  gap: "16px",
-  alignItems: "center",
-  padding: "14px 0",
-  borderBottom: `1px solid ${theme.custom.colors.silverGrayLight}`,
-  "&:last-child": {
-    borderBottom: "none",
-  },
-  [theme.breakpoints.down("md")]: {
-    position: "relative",
-    flexWrap: "wrap",
-    gap: "6px 0",
-    padding: "16px 40px 16px 0",
-  },
-}))
-
-const MobileLabel = styled.span(({ theme }) => ({
-  display: "none",
-  [theme.breakpoints.down("md")]: {
-    display: "inline",
-    ...theme.typography.subtitle2,
-    color: theme.custom.colors.darkGray2,
-    minWidth: "120px",
-    flexShrink: 0,
-  },
-}))
-
-const TableCell = styled("div", {
-  shouldForwardProp: (prop) => prop !== "$flex" && prop !== "$primary",
-})<{ $flex: number; $primary?: boolean }>(({ $flex, $primary, theme }) => ({
-  flex: $flex,
-  minWidth: 0,
-  ...theme.typography.body2,
-  color: theme.custom.colors.black,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-  [theme.breakpoints.down("md")]: {
-    flex: "none",
-    width: "100%",
-    display: "flex",
-    alignItems: "center",
-    gap: "8px",
-    overflow: "visible",
-    whiteSpace: "normal",
-    ...($primary && {
-      ...theme.typography.subtitle2,
-      marginBottom: "4px",
-    }),
-  },
-}))
-
 const StatusBadge = styled(Chip, {
   shouldForwardProp: (prop) => prop !== "$status",
 })<{ $status: "assigned" | "redeemed" }>(({ $status, theme }) => ({
@@ -299,27 +236,6 @@ const ActionCell = styled.div(({ theme }) => ({
     right: 0,
   },
 }))
-
-const TableFooter = styled.div({
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  paddingTop: "16px",
-})
-
-const TableFootnote = styled(Typography)(({ theme }) => ({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
-})) as typeof Typography
-
-const EmptyTableMessage = styled(Typography)(({ theme }) => ({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
-  padding: "32px 0",
-  textAlign: "center",
-})) as typeof Typography
-
-const STUB = "—"
 
 type StatusFilter = "all" | "pending" | "redeemed"
 
@@ -365,6 +281,9 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
   contractSlug,
 }) => {
   const queryClient = useQueryClient()
+  const analyticsEnabled = useFeatureFlagEnabled(
+    FeatureFlags.B2BAnalyticsDashboard,
+  )
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all")
   const [searchQuery, setSearchQuery] = useState("")
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("")
@@ -633,6 +552,19 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                   </>
                 ) : null}
               </ContractSubtitle>
+              {/* Analytics is the reporting half of this dashboard and is
+                  org-scoped, so it lives at its own URL rather than under this
+                  contract. Behind its own flag: the analytics API is not
+                  deployed everywhere this page is. */}
+              {analyticsEnabled ? (
+                <AnalyticsLink
+                  color="red"
+                  size="small"
+                  href={organizationAnalyticsView(orgSlug)}
+                >
+                  View analytics
+                </AnalyticsLink>
+              ) : null}
             </div>
           </OrgDetailsContainer>
           <StatsSide>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ContractKpiCards.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ContractKpiCards.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import React from "react"
+import { Skeleton, styled, Typography } from "ol-components"
+import type { ContractUtilization } from "api/analytics-hooks/organizations"
+import {
+  formatCount,
+  formatDate,
+  formatPercent,
+  SuppressibleValue,
+} from "./format"
+
+/**
+ * Headline numbers from `mv_b2b_contract_utilization`.
+ *
+ * # Why one card group per contract rather than one org-wide row
+ *
+ * The view's grain is org x contract, and the three headline figures cannot be
+ * honestly rolled up across contracts here:
+ *
+ *  - `active_learners` counts *distinct* learners per contract, so summing it
+ *    double-counts anyone on two contracts.
+ *  - `seat_utilization_pct` and `completion_rate_pct` are rates; averaging
+ *    rates across contracts of different sizes is simply the wrong number, and
+ *    recomputing them from the raw counts is impossible whenever a count has
+ *    been suppressed.
+ *
+ * So each contract gets its own group. Most orgs have exactly one, in which
+ * case this reads as a single KPI row.
+ */
+
+const Root = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+})
+
+const ContractCard = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "24px",
+  [theme.breakpoints.down("md")]: {
+    padding: "16px",
+  },
+}))
+
+const ContractName = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  color: theme.custom.colors.darkGray2,
+})) as typeof Typography
+
+const ContractMeta = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const StatRow = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: "64px",
+  flexWrap: "wrap",
+  paddingTop: "20px",
+  [theme.breakpoints.down("md")]: {
+    gap: "24px",
+  },
+}))
+
+const StatBlock = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+})
+
+const StatValue = styled(Typography)(({ theme }) => ({
+  ...theme.typography.h3,
+  color: theme.custom.colors.darkGray2,
+  fontVariantNumeric: "tabular-nums",
+})) as typeof Typography
+
+const StatLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const StatSubLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const Stat: React.FC<{
+  label: string
+  subLabel?: string | null
+  value: number | null
+  format?: (value: number) => string
+}> = ({ label, subLabel, value, format }) => (
+  <StatBlock role="group" aria-label={label}>
+    <StatValue>
+      <SuppressibleValue value={value} format={format} />
+    </StatValue>
+    <StatLabel>{label}</StatLabel>
+    {subLabel ? <StatSubLabel>{subLabel}</StatSubLabel> : null}
+  </StatBlock>
+)
+
+const contractDates = (row: ContractUtilization): string | null => {
+  const start = formatDate(row.b2b_contract_start_date)
+  const end = formatDate(row.b2b_contract_end_date)
+  if (start && end) return `${start} – ${end}`
+  return start ?? end
+}
+
+const ContractKpiCards: React.FC<{
+  rows: ContractUtilization[] | undefined
+  isLoading: boolean
+}> = ({ rows, isLoading }) => {
+  if (isLoading) {
+    return (
+      <Root>
+        <ContractCard>
+          <Skeleton width="260px" height="24px" />
+          <StatRow>
+            {Array.from({ length: 3 }).map((_, index) => (
+              <StatBlock key={index}>
+                <Skeleton width="96px" height="40px" />
+                <Skeleton width="140px" height="20px" />
+              </StatBlock>
+            ))}
+          </StatRow>
+        </ContractCard>
+      </Root>
+    )
+  }
+
+  if (!rows?.length) {
+    return null
+  }
+
+  return (
+    <Root>
+      {rows.map((row) => {
+        const dates = contractDates(row)
+        const seatLimit = row.seat_limit
+        return (
+          <ContractCard key={row.contract_pk}>
+            <ContractName component="h3">{row.b2b_contract_name}</ContractName>
+            <ContractMeta>
+              {[
+                row.b2b_contract_is_active ? "Active" : "Inactive",
+                row.b2b_contract_membership_type,
+                dates,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </ContractMeta>
+            <StatRow>
+              <Stat
+                label="Seat utilization"
+                // seat_limit is null on uncapped contracts, where a utilization
+                // percentage has no denominator and the API returns null too.
+                subLabel={
+                  seatLimit
+                    ? `${formatCount(row.seats_consumed)} of ${formatCount(seatLimit)} seats`
+                    : `${formatCount(row.seats_consumed)} seats used · no cap`
+                }
+                value={row.seat_utilization_pct}
+                format={formatPercent}
+              />
+              <Stat
+                label="Active learners"
+                value={row.active_learners}
+                format={formatCount}
+              />
+              <Stat
+                label="Completion rate"
+                subLabel={
+                  row.learners_certified === null
+                    ? undefined
+                    : `${formatCount(row.learners_certified)} certified`
+                }
+                value={row.completion_rate_pct}
+                format={formatPercent}
+              />
+            </StatRow>
+          </ContractCard>
+        )
+      })}
+    </Root>
+  )
+}
+
+export default ContractKpiCards

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ContractKpiCards.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ContractKpiCards.tsx
@@ -9,6 +9,7 @@ import {
   formatPercent,
   SuppressibleValue,
 } from "./format"
+import SectionError from "./SectionError"
 
 /**
  * Headline numbers from `mv_b2b_contract_utilization`.
@@ -112,7 +113,18 @@ const contractDates = (row: ContractUtilization): string | null => {
 const ContractKpiCards: React.FC<{
   rows: ContractUtilization[] | undefined
   isLoading: boolean
-}> = ({ rows, isLoading }) => {
+  isError?: boolean
+}> = ({ rows, isLoading, isError }) => {
+  if (isError) {
+    return (
+      <Root>
+        <ContractCard>
+          <SectionError />
+        </ContractCard>
+      </Root>
+    )
+  }
+
   if (isLoading) {
     return (
       <Root>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
@@ -20,6 +20,7 @@ import {
   SUPPRESSED_EXPLANATION,
   SuppressibleValue,
 } from "./format"
+import SectionError from "./SectionError"
 
 /**
  * Per-course-run performance from `mv_b2b_enrollment_completion_funnel`.
@@ -59,7 +60,16 @@ const COLUMN_FLEX = {
 const CoursePerformanceTable: React.FC<{
   rows: EnrollmentCompletionFunnel[] | undefined
   isLoading: boolean
-}> = ({ rows, isLoading }) => {
+  isError?: boolean
+}> = ({ rows, isLoading, isError }) => {
+  if (isError) {
+    return (
+      <TableCard>
+        <SectionError />
+      </TableCard>
+    )
+  }
+
   if (isLoading) {
     return (
       <TableCard>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import React from "react"
+import { Skeleton, styled, Typography } from "ol-components"
+import type { EnrollmentCompletionFunnel } from "api/analytics-hooks/organizations"
+import {
+  EmptyTableMessage,
+  MobileLabel,
+  TableCard,
+  TableCell,
+  TableFooter,
+  TableFootnote,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+} from "@/components/B2BTable/B2BTable"
+import {
+  formatCount,
+  formatPercent,
+  SUPPRESSED_EXPLANATION,
+  SuppressibleValue,
+} from "./format"
+
+/**
+ * Per-course-run performance from `mv_b2b_enrollment_completion_funnel`.
+ *
+ * Uses the same table primitives as the contract admin page so the two B2B
+ * manager surfaces read as one product, including the below-`md` reflow where
+ * each row becomes a stack of label/value pairs.
+ */
+
+const CourseTitle = styled.span(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.darkGray2,
+  display: "block",
+}))
+
+const CourseId = styled.span(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+  display: "block",
+}))
+
+const ContractLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.darkGray2,
+  paddingTop: "8px",
+})) as typeof Typography
+
+const COLUMN_FLEX = {
+  course: 3,
+  enrolled: 1,
+  active: 1,
+  certified: 1,
+  activeRate: 1.2,
+  completionRate: 1.4,
+}
+
+const CoursePerformanceTable: React.FC<{
+  rows: EnrollmentCompletionFunnel[] | undefined
+  isLoading: boolean
+}> = ({ rows, isLoading }) => {
+  if (isLoading) {
+    return (
+      <TableCard>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton
+            key={index}
+            width="100%"
+            height="44px"
+            style={{ marginBottom: "8px" }}
+          />
+        ))}
+      </TableCard>
+    )
+  }
+
+  if (!rows?.length) {
+    return (
+      <TableCard>
+        <EmptyTableMessage>
+          No course enrollments recorded yet.
+        </EmptyTableMessage>
+      </TableCard>
+    )
+  }
+
+  // The view's grain includes the contract, so a course run appears once per
+  // contract it is offered under. Grouping by contract keeps those rows from
+  // reading as duplicates; the label is dropped when there is only one.
+  const contracts = new Map<number, EnrollmentCompletionFunnel[]>()
+  rows.forEach((row) => {
+    const existing = contracts.get(row.contract_pk)
+    if (existing) {
+      existing.push(row)
+    } else {
+      contracts.set(row.contract_pk, [row])
+    }
+  })
+  const showContractLabels = contracts.size > 1
+  const hasSuppressed = rows.some(
+    (row) =>
+      row.active_learners === null ||
+      row.certified_learners === null ||
+      row.passing_learners === null,
+  )
+
+  return (
+    <TableCard>
+      <div role="table" aria-label="Course performance">
+        <div role="rowgroup">
+          <TableHeaderRow role="row">
+            <TableHeaderCell role="columnheader" $flex={COLUMN_FLEX.course}>
+              Course
+            </TableHeaderCell>
+            <TableHeaderCell
+              role="columnheader"
+              $flex={COLUMN_FLEX.enrolled}
+              $numeric
+            >
+              Enrolled
+            </TableHeaderCell>
+            <TableHeaderCell
+              role="columnheader"
+              $flex={COLUMN_FLEX.active}
+              $numeric
+            >
+              Active
+            </TableHeaderCell>
+            <TableHeaderCell
+              role="columnheader"
+              $flex={COLUMN_FLEX.certified}
+              $numeric
+            >
+              Certified
+            </TableHeaderCell>
+            <TableHeaderCell
+              role="columnheader"
+              $flex={COLUMN_FLEX.activeRate}
+              $numeric
+            >
+              Active rate
+            </TableHeaderCell>
+            <TableHeaderCell
+              role="columnheader"
+              $flex={COLUMN_FLEX.completionRate}
+              $numeric
+            >
+              Completion rate
+            </TableHeaderCell>
+          </TableHeaderRow>
+        </div>
+        <div role="rowgroup">
+          {Array.from(contracts.values()).map((contractRows) => (
+            <React.Fragment key={contractRows[0].contract_pk}>
+              {showContractLabels ? (
+                <ContractLabel>
+                  {contractRows[0].b2b_contract_name}
+                </ContractLabel>
+              ) : null}
+              {contractRows.map((row) => (
+                <TableRow
+                  role="row"
+                  key={`${row.contract_pk}-${row.courserun_pk}`}
+                >
+                  <TableCell role="cell" $flex={COLUMN_FLEX.course} $primary>
+                    <span>
+                      <CourseTitle>{row.courserun_title}</CourseTitle>
+                      <CourseId>{row.courserun_readable_id}</CourseId>
+                    </span>
+                  </TableCell>
+                  <TableCell role="cell" $flex={COLUMN_FLEX.enrolled} $numeric>
+                    <MobileLabel>Enrolled</MobileLabel>
+                    {formatCount(row.enrolled_learners)}
+                  </TableCell>
+                  <TableCell role="cell" $flex={COLUMN_FLEX.active} $numeric>
+                    <MobileLabel>Active</MobileLabel>
+                    <SuppressibleValue value={row.active_learners} />
+                  </TableCell>
+                  <TableCell role="cell" $flex={COLUMN_FLEX.certified} $numeric>
+                    <MobileLabel>Certified</MobileLabel>
+                    <SuppressibleValue value={row.certified_learners} />
+                  </TableCell>
+                  <TableCell
+                    role="cell"
+                    $flex={COLUMN_FLEX.activeRate}
+                    $numeric
+                  >
+                    <MobileLabel>Active rate</MobileLabel>
+                    <SuppressibleValue
+                      value={row.active_rate_pct}
+                      format={formatPercent}
+                    />
+                  </TableCell>
+                  <TableCell
+                    role="cell"
+                    $flex={COLUMN_FLEX.completionRate}
+                    $numeric
+                  >
+                    <MobileLabel>Completion rate</MobileLabel>
+                    <SuppressibleValue
+                      value={row.completion_rate_pct}
+                      format={formatPercent}
+                    />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+      {hasSuppressed ? (
+        <TableFooter>
+          <TableFootnote>{SUPPRESSED_EXPLANATION}</TableFootnote>
+        </TableFooter>
+      ) : null}
+    </TableCard>
+  )
+}
+
+export default CoursePerformanceTable
+export { COLUMN_FLEX }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import React from "react"
+import { LineChart } from "@mui/x-charts/LineChart"
+import { Skeleton, styled, Typography } from "ol-components"
+import type { MonthlyEngagementTrend } from "api/analytics-hooks/organizations"
+import { CATEGORICAL, CHART_INK } from "./chartPalette"
+import { formatCount, formatYearMonth, formatYearMonthShort } from "./format"
+
+/**
+ * Monthly enrollment/engagement trend from `mv_b2b_monthly_engagement_trend`.
+ *
+ * # What is and isn't on this axis
+ *
+ * All three series are counts of *people*, so they share one linear axis. The
+ * view also carries `total_videos_watched`, `total_problems_attempted` and
+ * `total_chatbot_interactions` — those are counts of *events*, run three or
+ * four orders of magnitude larger, and putting them here would need a second
+ * y-scale. A dual-axis chart invites the reader to compare two things that were
+ * never on the same scale, so they are deliberately left out; they belong in a
+ * separate content-engagement panel.
+ *
+ * # Suppressed months
+ *
+ * `new_enrollments` and `certificates_earned` are nullable under the
+ * k-anonymity floor. They are passed through to the chart as `null`, which the
+ * line series renders as a genuine gap. Coercing them to 0 would draw a dip
+ * that did not happen.
+ */
+
+const ChartCard = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "24px 24px 8px",
+  [theme.breakpoints.down("md")]: {
+    padding: "16px 8px 8px",
+  },
+}))
+
+const EmptyMessage = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  padding: "32px 0",
+  textAlign: "center",
+})) as typeof Typography
+
+const CHART_HEIGHT = 320
+
+const SERIES = [
+  {
+    key: "monthly_active_learners",
+    label: "Active learners",
+    color: CATEGORICAL[0],
+  },
+  { key: "new_enrollments", label: "New enrollments", color: CATEGORICAL[1] },
+  {
+    key: "certificates_earned",
+    label: "Certificates earned",
+    color: CATEGORICAL[2],
+  },
+] as const
+
+const EngagementTrendChart: React.FC<{
+  rows: MonthlyEngagementTrend[] | undefined
+  isLoading: boolean
+}> = ({ rows, isLoading }) => {
+  if (isLoading) {
+    return (
+      <ChartCard>
+        <Skeleton variant="rectangular" width="100%" height={CHART_HEIGHT} />
+      </ChartCard>
+    )
+  }
+
+  if (!rows?.length) {
+    return (
+      <ChartCard>
+        <EmptyMessage>No monthly activity recorded yet.</EmptyMessage>
+      </ChartCard>
+    )
+  }
+
+  // The API orders by activity_year_and_month, but sorting here keeps the chart
+  // correct even if paging ever returns rows out of order.
+  const months = [...rows].sort((a, b) =>
+    a.activity_year_and_month.localeCompare(b.activity_year_and_month),
+  )
+  const labels = months.map((row) => row.activity_year_and_month)
+
+  return (
+    <ChartCard>
+      <LineChart
+        height={CHART_HEIGHT}
+        margin={{ left: 8, right: 8, top: 8, bottom: 0 }}
+        // Horizontal rules only: vertical ones would fight the marks for
+        // attention without helping anyone read a monthly value.
+        grid={{ horizontal: true }}
+        xAxis={[
+          {
+            scaleType: "point",
+            data: labels,
+            valueFormatter: (value: string, context) =>
+              // The tooltip has room for the year; a dense monthly axis does not.
+              context.location === "tick"
+                ? formatYearMonthShort(value)
+                : formatYearMonth(value),
+            tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+          },
+        ]}
+        yAxis={[
+          {
+            min: 0,
+            valueFormatter: (value: number) => formatCount(value),
+            tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+            width: 56,
+          },
+        ]}
+        series={SERIES.map((series) => ({
+          // `null` is meaningful here: a month suppressed by the anonymity
+          // floor, drawn as a gap rather than a zero.
+          data: months.map((row) => row[series.key] ?? null),
+          label: series.label,
+          color: series.color,
+          curve: "linear",
+          // A mark per month keeps single-point series visible and gives the
+          // hover layer something bigger than a 2px line to aim at.
+          showMark: true,
+          valueFormatter: (value: number | null) =>
+            value === null ? "Withheld (too few learners)" : formatCount(value),
+        }))}
+        sx={{
+          "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
+            stroke: CHART_INK.axis,
+          },
+          "& .MuiChartsGrid-line": { stroke: CHART_INK.grid },
+          "& .MuiLineElement-root": { strokeWidth: 2 },
+        }}
+      />
+    </ChartCard>
+  )
+}
+
+export default EngagementTrendChart

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { LineChart } from "@mui/x-charts/LineChart"
-import { Skeleton, styled } from "ol-components"
+import { Skeleton, styled, useTheme } from "ol-components"
 import type { MonthlyEngagementTrend } from "api/analytics-hooks/organizations"
 import {
   EmptyTableMessage,
@@ -14,7 +14,7 @@ import {
   TableHeaderRow,
   TableRow,
 } from "@/components/B2BTable/B2BTable"
-import { CATEGORICAL, CHART_INK } from "./chartPalette"
+import { CATEGORICAL, chartInk } from "./chartPalette"
 import {
   formatCount,
   formatYearMonth,
@@ -110,6 +110,9 @@ const EngagementTrendChart: React.FC<{
   isLoading: boolean
   isError?: boolean
 }> = ({ rows, isLoading, isError }) => {
+  // Above the early returns: hooks cannot be called conditionally.
+  const ink = chartInk(useTheme())
+
   if (isError) {
     return (
       <ChartCard>
@@ -161,14 +164,14 @@ const EngagementTrendChart: React.FC<{
               context.location === "tick"
                 ? formatYearMonthShort(value)
                 : formatYearMonth(value),
-            tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+            tickLabelStyle: { fill: ink.label, fontSize: 12 },
           },
         ]}
         yAxis={[
           {
             min: 0,
             valueFormatter: (value: number) => formatCount(value),
-            tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+            tickLabelStyle: { fill: ink.label, fontSize: 12 },
             width: 56,
           },
         ]}
@@ -187,9 +190,9 @@ const EngagementTrendChart: React.FC<{
         }))}
         sx={{
           "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
-            stroke: CHART_INK.axis,
+            stroke: ink.axis,
           },
-          "& .MuiChartsGrid-line": { stroke: CHART_INK.grid },
+          "& .MuiChartsGrid-line": { stroke: ink.grid },
           "& .MuiLineElement-root": { strokeWidth: 2 },
         }}
       />

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
@@ -2,10 +2,27 @@
 
 import React from "react"
 import { LineChart } from "@mui/x-charts/LineChart"
-import { Skeleton, styled, Typography } from "ol-components"
+import { Skeleton, styled } from "ol-components"
 import type { MonthlyEngagementTrend } from "api/analytics-hooks/organizations"
+import {
+  EmptyTableMessage,
+  MobileLabel,
+  TableCell,
+  TableFooter,
+  TableFootnote,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+} from "@/components/B2BTable/B2BTable"
 import { CATEGORICAL, CHART_INK } from "./chartPalette"
-import { formatCount, formatYearMonth, formatYearMonthShort } from "./format"
+import {
+  formatCount,
+  formatYearMonth,
+  formatYearMonthShort,
+  SUPPRESSED_EXPLANATION,
+  SuppressibleValue,
+} from "./format"
+import SectionError from "./SectionError"
 
 /**
  * Monthly enrollment/engagement trend from `mv_b2b_monthly_engagement_trend`.
@@ -26,45 +43,81 @@ import { formatCount, formatYearMonth, formatYearMonthShort } from "./format"
  * k-anonymity floor. They are passed through to the chart as `null`, which the
  * line series renders as a genuine gap. Coercing them to 0 would draw a dip
  * that did not happen.
+ *
+ * # Why the chart is paired with a table
+ *
+ * The `<LineChart>` is an SVG of plotted geometry: a screen reader gets nothing
+ * readable out of it, and a suppressed month is drawn as a gap that reads
+ * identically to "no data". The table below carries the same monthly numbers as
+ * text, where a suppressed value can say so in words. Same pairing, and same
+ * reasoning, as `ProgramFunnelChart`.
  */
 
 const ChartCard = styled.div(({ theme }) => ({
   backgroundColor: theme.custom.colors.white,
   border: `1px solid ${theme.custom.colors.lightGray2}`,
   borderRadius: "8px",
-  padding: "24px 24px 8px",
+  padding: "24px",
   [theme.breakpoints.down("md")]: {
-    padding: "16px 8px 8px",
+    padding: "16px",
   },
 }))
 
-const EmptyMessage = styled(Typography)(({ theme }) => ({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
-  padding: "32px 0",
-  textAlign: "center",
-})) as typeof Typography
+const TableWrapper = styled.div(({ theme }) => ({
+  paddingTop: "24px",
+  marginTop: "8px",
+  borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
+}))
 
 const CHART_HEIGHT = 320
 
+const COLUMN_FLEX = {
+  month: 1.4,
+  active: 1.4,
+  enrollments: 1.4,
+  certificates: 1.6,
+}
+
+/** Drives both the chart series and the columns of the table beside it. */
 const SERIES = [
   {
     key: "monthly_active_learners",
+    column: "active",
     label: "Active learners",
     color: CATEGORICAL[0],
   },
-  { key: "new_enrollments", label: "New enrollments", color: CATEGORICAL[1] },
+  {
+    key: "new_enrollments",
+    column: "enrollments",
+    label: "New enrollments",
+    color: CATEGORICAL[1],
+  },
   {
     key: "certificates_earned",
+    column: "certificates",
     label: "Certificates earned",
     color: CATEGORICAL[2],
   },
-] as const
+] as const satisfies ReadonlyArray<{
+  key: keyof MonthlyEngagementTrend
+  column: keyof typeof COLUMN_FLEX
+  label: string
+  color: string
+}>
 
 const EngagementTrendChart: React.FC<{
   rows: MonthlyEngagementTrend[] | undefined
   isLoading: boolean
-}> = ({ rows, isLoading }) => {
+  isError?: boolean
+}> = ({ rows, isLoading, isError }) => {
+  if (isError) {
+    return (
+      <ChartCard>
+        <SectionError />
+      </ChartCard>
+    )
+  }
+
   if (isLoading) {
     return (
       <ChartCard>
@@ -76,7 +129,7 @@ const EngagementTrendChart: React.FC<{
   if (!rows?.length) {
     return (
       <ChartCard>
-        <EmptyMessage>No monthly activity recorded yet.</EmptyMessage>
+        <EmptyTableMessage>No monthly activity recorded yet.</EmptyTableMessage>
       </ChartCard>
     )
   }
@@ -87,6 +140,9 @@ const EngagementTrendChart: React.FC<{
     a.activity_year_and_month.localeCompare(b.activity_year_and_month),
   )
   const labels = months.map((row) => row.activity_year_and_month)
+  const hasSuppressed = months.some(
+    (row) => row.new_enrollments === null || row.certificates_earned === null,
+  )
 
   return (
     <ChartCard>
@@ -137,6 +193,52 @@ const EngagementTrendChart: React.FC<{
           "& .MuiLineElement-root": { strokeWidth: 2 },
         }}
       />
+      <TableWrapper>
+        <div role="table" aria-label="Monthly engagement">
+          <div role="rowgroup">
+            <TableHeaderRow role="row">
+              <TableHeaderCell role="columnheader" $flex={COLUMN_FLEX.month}>
+                Month
+              </TableHeaderCell>
+              {SERIES.map((series) => (
+                <TableHeaderCell
+                  key={series.key}
+                  role="columnheader"
+                  $flex={COLUMN_FLEX[series.column]}
+                  $numeric
+                >
+                  {series.label}
+                </TableHeaderCell>
+              ))}
+            </TableHeaderRow>
+          </div>
+          <div role="rowgroup">
+            {months.map((row) => (
+              <TableRow role="row" key={row.activity_year_and_month}>
+                <TableCell role="cell" $flex={COLUMN_FLEX.month} $primary>
+                  {formatYearMonth(row.activity_year_and_month)}
+                </TableCell>
+                {SERIES.map((series) => (
+                  <TableCell
+                    key={series.key}
+                    role="cell"
+                    $flex={COLUMN_FLEX[series.column]}
+                    $numeric
+                  >
+                    <MobileLabel>{series.label}</MobileLabel>
+                    <SuppressibleValue value={row[series.key]} />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </div>
+        </div>
+        {hasSuppressed ? (
+          <TableFooter>
+            <TableFootnote>{SUPPRESSED_EXPLANATION}</TableFootnote>
+          </TableFooter>
+        ) : null}
+      </TableWrapper>
     </ChartCard>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/EngagementTrendChart.tsx
@@ -149,53 +149,63 @@ const EngagementTrendChart: React.FC<{
 
   return (
     <ChartCard>
-      <LineChart
-        height={CHART_HEIGHT}
-        margin={{ left: 8, right: 8, top: 8, bottom: 0 }}
-        // Horizontal rules only: vertical ones would fight the marks for
-        // attention without helping anyone read a monthly value.
-        grid={{ horizontal: true }}
-        xAxis={[
-          {
-            scaleType: "point",
-            data: labels,
-            valueFormatter: (value: string, context) =>
-              // The tooltip has room for the year; a dense monthly axis does not.
-              context.location === "tick"
-                ? formatYearMonthShort(value)
-                : formatYearMonth(value),
-            tickLabelStyle: { fill: ink.label, fontSize: 12 },
-          },
-        ]}
-        yAxis={[
-          {
-            min: 0,
-            valueFormatter: (value: number) => formatCount(value),
-            tickLabelStyle: { fill: ink.label, fontSize: 12 },
-            width: 56,
-          },
-        ]}
-        series={SERIES.map((series) => ({
-          // `null` is meaningful here: a month suppressed by the anonymity
-          // floor, drawn as a gap rather than a zero.
-          data: months.map((row) => row[series.key] ?? null),
-          label: series.label,
-          color: series.color,
-          curve: "linear",
-          // A mark per month keeps single-point series visible and gives the
-          // hover layer something bigger than a 2px line to aim at.
-          showMark: true,
-          valueFormatter: (value: number | null) =>
-            value === null ? "Withheld (too few learners)" : formatCount(value),
-        }))}
-        sx={{
-          "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
-            stroke: ink.axis,
-          },
-          "& .MuiChartsGrid-line": { stroke: ink.grid },
-          "& .MuiLineElement-root": { strokeWidth: 2 },
-        }}
-      />
+      {/* Hidden from assistive tech: the table below carries the same numbers
+          as text, so leaving the SVG exposed only makes a screen reader walk
+          hundreds of series and axis nodes to reach data it is about to be
+          given properly. Safe to hide because the chart renders nothing
+          focusable — asserted in the test, since burying a focusable node
+          inside aria-hidden would be its own violation. */}
+      <div aria-hidden>
+        <LineChart
+          height={CHART_HEIGHT}
+          margin={{ left: 8, right: 8, top: 8, bottom: 0 }}
+          // Horizontal rules only: vertical ones would fight the marks for
+          // attention without helping anyone read a monthly value.
+          grid={{ horizontal: true }}
+          xAxis={[
+            {
+              scaleType: "point",
+              data: labels,
+              valueFormatter: (value: string, context) =>
+                // The tooltip has room for the year; a dense monthly axis does not.
+                context.location === "tick"
+                  ? formatYearMonthShort(value)
+                  : formatYearMonth(value),
+              tickLabelStyle: { fill: ink.label, fontSize: 12 },
+            },
+          ]}
+          yAxis={[
+            {
+              min: 0,
+              valueFormatter: (value: number) => formatCount(value),
+              tickLabelStyle: { fill: ink.label, fontSize: 12 },
+              width: 56,
+            },
+          ]}
+          series={SERIES.map((series) => ({
+            // `null` is meaningful here: a month suppressed by the anonymity
+            // floor, drawn as a gap rather than a zero.
+            data: months.map((row) => row[series.key] ?? null),
+            label: series.label,
+            color: series.color,
+            curve: "linear",
+            // A mark per month keeps single-point series visible and gives the
+            // hover layer something bigger than a 2px line to aim at.
+            showMark: true,
+            valueFormatter: (value: number | null) =>
+              value === null
+                ? "Withheld (too few learners)"
+                : formatCount(value),
+          }))}
+          sx={{
+            "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
+              stroke: ink.axis,
+            },
+            "& .MuiChartsGrid-line": { stroke: ink.grid },
+            "& .MuiLineElement-root": { strokeWidth: 2 },
+          }}
+        />
+      </div>
       <TableWrapper>
         <div role="table" aria-label="Monthly engagement">
           <div role="rowgroup">

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
@@ -146,7 +146,11 @@ const ProgramFunnelChart: React.FC<{
 
   return (
     <Card>
-      <ChartWrapper>
+      {/* Hidden from assistive tech for the same reason as the trend chart:
+          the table below is the accessible copy of these numbers, so exposing
+          the SVG only adds a long walk through series and axis nodes. Nothing
+          inside is focusable, which the test asserts. */}
+      <ChartWrapper aria-hidden>
         <BarChart
           layout="horizontal"
           height={rowHeight(rows.length)}

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
@@ -20,6 +20,7 @@ import {
   SUPPRESSED_EXPLANATION,
   SuppressibleValue,
 } from "./format"
+import SectionError from "./SectionError"
 
 /**
  * Program funnel from `mv_b2b_program_funnel`.
@@ -98,7 +99,16 @@ const rowHeight = (programCount: number) =>
 const ProgramFunnelChart: React.FC<{
   rows: ProgramFunnel[] | undefined
   isLoading: boolean
-}> = ({ rows, isLoading }) => {
+  isError?: boolean
+}> = ({ rows, isLoading, isError }) => {
+  if (isError) {
+    return (
+      <Card>
+        <SectionError />
+      </Card>
+    )
+  }
+
   if (isLoading) {
     return (
       <Card>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import React from "react"
+import { BarChart } from "@mui/x-charts/BarChart"
+import { Skeleton, styled, Typography } from "ol-components"
+import type { ProgramFunnel } from "api/analytics-hooks/organizations"
+import {
+  EmptyTableMessage,
+  MobileLabel,
+  TableCell,
+  TableFooter,
+  TableFootnote,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+} from "@/components/B2BTable/B2BTable"
+import { CHART_INK, FUNNEL_STAGES } from "./chartPalette"
+import {
+  formatCount,
+  SUPPRESSED_EXPLANATION,
+  SuppressibleValue,
+} from "./format"
+
+/**
+ * Program funnel from `mv_b2b_program_funnel`.
+ *
+ * Stage order carries the meaning here — each stage is a subset of the one
+ * before it — so the bars take a single-hue light-to-dark ramp rather than
+ * three unrelated hues: the reader sees the progression in the color itself.
+ *
+ * The chart is paired with a table of the same numbers rather than treated as
+ * the whole story. That table is what makes the exact values available to
+ * screen readers, and it is where a value suppressed by the anonymity floor can
+ * say so — a bar chart can only omit the bar, which reads as zero.
+ */
+
+const Card = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "24px",
+  [theme.breakpoints.down("md")]: {
+    padding: "16px",
+  },
+}))
+
+const ChartWrapper = styled.div(({ theme }) => ({
+  // A long program title needs room; below md the chart scrolls sideways rather
+  // than squeezing the labels into unreadable truncation.
+  overflowX: "auto",
+  [theme.breakpoints.down("md")]: {
+    "> *": { minWidth: "560px" },
+  },
+}))
+
+const TableWrapper = styled.div(({ theme }) => ({
+  paddingTop: "24px",
+  marginTop: "8px",
+  borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
+}))
+
+const ContractLabel = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.darkGray2,
+  paddingTop: "8px",
+})) as typeof Typography
+
+const STAGES = [
+  {
+    key: "enrolled_in_contract_courses",
+    label: "Enrolled in contract courses",
+    color: FUNNEL_STAGES[0],
+  },
+  {
+    key: "enrolled_via_program",
+    label: "Enrolled via program",
+    color: FUNNEL_STAGES[1],
+  },
+  {
+    key: "program_course_completers",
+    label: "Completed program courses",
+    color: FUNNEL_STAGES[2],
+  },
+] as const
+
+const COLUMN_FLEX = {
+  program: 3,
+  courses: 1,
+  enrolled: 1.4,
+  viaProgram: 1.4,
+  completers: 1.6,
+}
+
+/** Bar thickness plus its gap, times three stages, plus room for the legend. */
+const rowHeight = (programCount: number) =>
+  Math.max(220, programCount * 104 + 72)
+
+const ProgramFunnelChart: React.FC<{
+  rows: ProgramFunnel[] | undefined
+  isLoading: boolean
+}> = ({ rows, isLoading }) => {
+  if (isLoading) {
+    return (
+      <Card>
+        <Skeleton variant="rectangular" width="100%" height={260} />
+      </Card>
+    )
+  }
+
+  if (!rows?.length) {
+    return (
+      <Card>
+        <EmptyTableMessage>
+          No program enrollments recorded yet.
+        </EmptyTableMessage>
+      </Card>
+    )
+  }
+
+  const showContract = new Set(rows.map((row) => row.contract_pk)).size > 1
+  // A program can appear under more than one contract, so the axis label has to
+  // disambiguate or two distinct rows collapse into one visual band.
+  const labels = rows.map((row) =>
+    showContract
+      ? `${row.program_title} (${row.b2b_contract_name})`
+      : row.program_title,
+  )
+  const hasSuppressed = rows.some(
+    (row) =>
+      row.enrolled_via_program === null ||
+      row.program_course_completers === null,
+  )
+
+  return (
+    <Card>
+      <ChartWrapper>
+        <BarChart
+          layout="horizontal"
+          height={rowHeight(rows.length)}
+          margin={{ left: 8, right: 16, top: 8, bottom: 8 }}
+          // Vertical rules only: on a horizontal bar chart they are the ones
+          // that let a reader compare bar lengths.
+          grid={{ vertical: true }}
+          // Rounds the data end of each bar while it stays anchored to the
+          // baseline.
+          borderRadius={4}
+          yAxis={[
+            {
+              scaleType: "band",
+              data: labels,
+              width: 220,
+              tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+              // A gap between category groups keeps adjacent programs from
+              // reading as one block of bars.
+              categoryGapRatio: 0.4,
+              barGapRatio: 0.1,
+            },
+          ]}
+          xAxis={[
+            {
+              min: 0,
+              valueFormatter: (value: number) => formatCount(value),
+              tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+            },
+          ]}
+          series={STAGES.map((stage) => ({
+            data: rows.map((row) => row[stage.key] ?? null),
+            label: stage.label,
+            color: stage.color,
+            valueFormatter: (value: number | null) =>
+              value === null
+                ? "Withheld (too few learners)"
+                : formatCount(value),
+          }))}
+          sx={{
+            "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
+              stroke: CHART_INK.axis,
+            },
+            "& .MuiChartsGrid-line": { stroke: CHART_INK.grid },
+          }}
+        />
+      </ChartWrapper>
+      <TableWrapper>
+        <div role="table" aria-label="Program funnel">
+          <div role="rowgroup">
+            <TableHeaderRow role="row">
+              <TableHeaderCell role="columnheader" $flex={COLUMN_FLEX.program}>
+                Program
+              </TableHeaderCell>
+              <TableHeaderCell
+                role="columnheader"
+                $flex={COLUMN_FLEX.courses}
+                $numeric
+              >
+                Courses
+              </TableHeaderCell>
+              <TableHeaderCell
+                role="columnheader"
+                $flex={COLUMN_FLEX.enrolled}
+                $numeric
+              >
+                Enrolled in contract courses
+              </TableHeaderCell>
+              <TableHeaderCell
+                role="columnheader"
+                $flex={COLUMN_FLEX.viaProgram}
+                $numeric
+              >
+                Enrolled via program
+              </TableHeaderCell>
+              <TableHeaderCell
+                role="columnheader"
+                $flex={COLUMN_FLEX.completers}
+                $numeric
+              >
+                Completed program courses
+              </TableHeaderCell>
+            </TableHeaderRow>
+          </div>
+          <div role="rowgroup">
+            {rows.map((row) => (
+              <TableRow role="row" key={`${row.contract_pk}-${row.program_pk}`}>
+                <TableCell role="cell" $flex={COLUMN_FLEX.program} $primary>
+                  {row.program_title}
+                  {showContract ? (
+                    <ContractLabel component="span">
+                      {" "}
+                      · {row.b2b_contract_name}
+                    </ContractLabel>
+                  ) : null}
+                </TableCell>
+                <TableCell role="cell" $flex={COLUMN_FLEX.courses} $numeric>
+                  <MobileLabel>Courses</MobileLabel>
+                  {formatCount(row.total_courses)}
+                </TableCell>
+                <TableCell role="cell" $flex={COLUMN_FLEX.enrolled} $numeric>
+                  <MobileLabel>Enrolled in contract courses</MobileLabel>
+                  {formatCount(row.enrolled_in_contract_courses)}
+                </TableCell>
+                <TableCell role="cell" $flex={COLUMN_FLEX.viaProgram} $numeric>
+                  <MobileLabel>Enrolled via program</MobileLabel>
+                  <SuppressibleValue value={row.enrolled_via_program} />
+                </TableCell>
+                <TableCell role="cell" $flex={COLUMN_FLEX.completers} $numeric>
+                  <MobileLabel>Completed program courses</MobileLabel>
+                  <SuppressibleValue value={row.program_course_completers} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </div>
+        </div>
+        {hasSuppressed ? (
+          <TableFooter>
+            <TableFootnote>{SUPPRESSED_EXPLANATION}</TableFootnote>
+          </TableFooter>
+        ) : null}
+      </TableWrapper>
+    </Card>
+  )
+}
+
+export default ProgramFunnelChart

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/ProgramFunnelChart.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { BarChart } from "@mui/x-charts/BarChart"
-import { Skeleton, styled, Typography } from "ol-components"
+import { Skeleton, styled, Typography, useTheme } from "ol-components"
 import type { ProgramFunnel } from "api/analytics-hooks/organizations"
 import {
   EmptyTableMessage,
@@ -14,7 +14,7 @@ import {
   TableHeaderRow,
   TableRow,
 } from "@/components/B2BTable/B2BTable"
-import { CHART_INK, FUNNEL_STAGES } from "./chartPalette"
+import { chartInk, FUNNEL_STAGES } from "./chartPalette"
 import {
   formatCount,
   SUPPRESSED_EXPLANATION,
@@ -101,6 +101,9 @@ const ProgramFunnelChart: React.FC<{
   isLoading: boolean
   isError?: boolean
 }> = ({ rows, isLoading, isError }) => {
+  // Above the early returns: hooks cannot be called conditionally.
+  const ink = chartInk(useTheme())
+
   if (isError) {
     return (
       <Card>
@@ -159,7 +162,7 @@ const ProgramFunnelChart: React.FC<{
               scaleType: "band",
               data: labels,
               width: 220,
-              tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+              tickLabelStyle: { fill: ink.label, fontSize: 12 },
               // A gap between category groups keeps adjacent programs from
               // reading as one block of bars.
               categoryGapRatio: 0.4,
@@ -170,7 +173,7 @@ const ProgramFunnelChart: React.FC<{
             {
               min: 0,
               valueFormatter: (value: number) => formatCount(value),
-              tickLabelStyle: { fill: CHART_INK.label, fontSize: 12 },
+              tickLabelStyle: { fill: ink.label, fontSize: 12 },
             },
           ]}
           series={STAGES.map((stage) => ({
@@ -184,9 +187,9 @@ const ProgramFunnelChart: React.FC<{
           }))}
           sx={{
             "& .MuiChartsAxis-line, & .MuiChartsAxis-tick": {
-              stroke: CHART_INK.axis,
+              stroke: ink.axis,
             },
-            "& .MuiChartsGrid-line": { stroke: CHART_INK.grid },
+            "& .MuiChartsGrid-line": { stroke: ink.grid },
           }}
         />
       </ChartWrapper>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionError.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionError.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import React from "react"
+import { EmptyTableMessage } from "@/components/B2BTable/B2BTable"
+
+/**
+ * What a section renders in place of its content when its own query failed.
+ *
+ * Kept distinct from the empty state on purpose. Each section receives only
+ * `rows`, which is `undefined` on both a successful empty response and a failed
+ * one, so without this a failed section would say "No … recorded yet" — a
+ * manager would read that as "my org has no activity" rather than "we could not
+ * reach the analytics API". Same reasoning as the suppression marker: never let
+ * an absence of data render as a factual zero.
+ */
+
+const SECTION_ERROR_MESSAGE =
+  "This data could not be loaded. Please try again later."
+
+const SectionError: React.FC = () => (
+  <EmptyTableMessage role="status">{SECTION_ERROR_MESSAGE}</EmptyTableMessage>
+)
+
+export default SectionError
+export { SECTION_ERROR_MESSAGE }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionHeader.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionHeader.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import React from "react"
+import { Skeleton, styled, Typography } from "ol-components"
+
+/**
+ * Each analytics section is backed by its own materialized view with its own
+ * refresh cycle, so freshness is a per-section fact, not a per-page one. The
+ * `as_of` therefore lives in the section header rather than once at the top —
+ * one lagging view must never be able to make another section look fresher
+ * than it is.
+ */
+
+const Root = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "baseline",
+  justifyContent: "space-between",
+  gap: "16px",
+  flexWrap: "wrap",
+  [theme.breakpoints.down("md")]: {
+    gap: "4px",
+  },
+}))
+
+const TitleGroup = styled.div({
+  display: "flex",
+  flexDirection: "column",
+  gap: "4px",
+})
+
+const Title = styled(Typography)(({ theme }) => ({
+  ...theme.typography.h5,
+  color: theme.custom.colors.black,
+})) as typeof Typography
+
+const Description = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const AsOf = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+  whiteSpace: "nowrap",
+})) as typeof Typography
+
+const formatAsOf = (iso: string): string | null => {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+type SectionHeaderProps = {
+  title: string
+  description?: string
+  /** ISO timestamp of the backing view's last refresh; `null` before its first. */
+  asOf?: string | null
+  isLoading?: boolean
+  /** Heading level, so section headings nest correctly under the page `h1`. */
+  component?: React.ElementType
+}
+
+const SectionHeader: React.FC<SectionHeaderProps> = ({
+  title,
+  description,
+  asOf,
+  isLoading,
+  component = "h2",
+}) => {
+  const formatted = asOf ? formatAsOf(asOf) : null
+  return (
+    <Root>
+      <TitleGroup>
+        <Title component={component}>{title}</Title>
+        {description ? <Description>{description}</Description> : null}
+      </TitleGroup>
+      {isLoading ? (
+        <Skeleton width="180px" height="18px" />
+      ) : formatted && asOf ? (
+        <AsOf>
+          Data as of <time dateTime={asOf}>{formatted}</time>
+        </AsOf>
+      ) : (
+        // Distinguish "the view has never refreshed" from "we are still
+        // loading" — a manager reading a zero needs to know which.
+        <AsOf>Data not yet refreshed</AsOf>
+      )}
+    </Root>
+  )
+}
+
+export default SectionHeader
+export { formatAsOf }
+export type { SectionHeaderProps }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionHeader.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionHeader.tsx
@@ -62,6 +62,8 @@ type SectionHeaderProps = {
   /** ISO timestamp of the backing view's last refresh; `null` before its first. */
   asOf?: string | null
   isLoading?: boolean
+  /** The section's query failed, so nothing is known about its freshness. */
+  isError?: boolean
   /** Heading level, so section headings nest correctly under the page `h1`. */
   component?: React.ElementType
 }
@@ -71,26 +73,36 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   description,
   asOf,
   isLoading,
+  isError,
   component = "h2",
 }) => {
   const formatted = asOf ? formatAsOf(asOf) : null
+
+  /**
+   * A failed request tells us nothing about when the view last refreshed, so
+   * this slot claims nothing at all — "Data not yet refreshed" would be a
+   * statement about the view that we are in no position to make. The section
+   * body says it could not load.
+   */
+  const freshness = isError ? null : isLoading ? (
+    <Skeleton width="180px" height="18px" />
+  ) : formatted && asOf ? (
+    <AsOf>
+      Data as of <time dateTime={asOf}>{formatted}</time>
+    </AsOf>
+  ) : (
+    // Distinguish "the view has never refreshed" from "we are still
+    // loading" — a manager reading a zero needs to know which.
+    <AsOf>Data not yet refreshed</AsOf>
+  )
+
   return (
     <Root>
       <TitleGroup>
         <Title component={component}>{title}</Title>
         {description ? <Description>{description}</Description> : null}
       </TitleGroup>
-      {isLoading ? (
-        <Skeleton width="180px" height="18px" />
-      ) : formatted && asOf ? (
-        <AsOf>
-          Data as of <time dateTime={asOf}>{formatted}</time>
-        </AsOf>
-      ) : (
-        // Distinguish "the view has never refreshed" from "we are still
-        // loading" — a manager reading a zero needs to know which.
-        <AsOf>Data not yet refreshed</AsOf>
-      )}
+      {freshness}
     </Root>
   )
 }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.test.tsx
@@ -1,0 +1,118 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ThemeProvider } from "ol-components"
+import SectionTruncation from "./SectionTruncation"
+
+/**
+ * Branch-level cover for the truncation footer. The page test covers the wiring
+ * (that the real query's placeholder state reaches this component); driving the
+ * props directly here is what makes the completion branch cheap to test — via
+ * the page it would mean rendering a full result set into jsdom.
+ */
+
+const renderTruncation = (
+  props: Partial<React.ComponentProps<typeof SectionTruncation>> = {},
+) =>
+  render(
+    <ThemeProvider>
+      <SectionTruncation
+        shown={2}
+        total={340}
+        canShowAll
+        isExpanding={false}
+        onShowAll={jest.fn()}
+        {...props}
+      />
+    </ThemeProvider>,
+  )
+
+test("says nothing at all when the section holds every row", () => {
+  renderTruncation({ shown: 340, total: 340 })
+
+  expect(screen.queryByText(/Showing/)).not.toBeInTheDocument()
+  expect(screen.queryByRole("button")).not.toBeInTheDocument()
+})
+
+test("marks the control busy while the expanded page is in flight", () => {
+  renderTruncation({ isExpanding: true })
+
+  const button = screen.getByRole("button", { name: "Loading…" })
+  expect(button).toHaveAttribute("aria-busy", "true")
+  // aria-disabled rather than disabled, so a keyboard user keeps focus.
+  expect(button).toHaveAttribute("aria-disabled", "true")
+  expect(button).not.toBeDisabled()
+})
+
+test("ignores a second click while already expanding", async () => {
+  const onShowAll = jest.fn()
+  renderTruncation({ isExpanding: true, onShowAll })
+
+  await userEvent
+    .setup()
+    .click(screen.getByRole("button", { name: "Loading…" }))
+
+  expect(onShowAll).not.toHaveBeenCalled()
+})
+
+test("announces nothing before the reader has asked for anything", () => {
+  renderTruncation()
+
+  expect(screen.getByRole("status")).toHaveTextContent("")
+})
+
+/**
+ * The completion case is the one that needs the live region to outlive the
+ * control: once every row is shown, the message and button both unmount, so a
+ * region rendered inside that branch would announce into a node that no longer
+ * exists.
+ */
+test("announces completion even though the control has gone", async () => {
+  const onShowAll = jest.fn()
+  const { rerender } = renderTruncation({ onShowAll })
+
+  await userEvent
+    .setup()
+    .click(screen.getByRole("button", { name: "Show all 340" }))
+  expect(onShowAll).toHaveBeenCalled()
+
+  rerender(
+    <ThemeProvider>
+      <SectionTruncation
+        shown={340}
+        total={340}
+        canShowAll={false}
+        isExpanding={false}
+        onShowAll={onShowAll}
+      />
+    </ThemeProvider>,
+  )
+
+  expect(screen.getByRole("status")).toHaveTextContent(
+    "Now showing all 340 rows.",
+  )
+  expect(screen.queryByRole("button")).not.toBeInTheDocument()
+})
+
+test("announces the new count when the section is still partial", async () => {
+  const onShowAll = jest.fn()
+  const { rerender } = renderTruncation({ onShowAll })
+
+  await userEvent
+    .setup()
+    .click(screen.getByRole("button", { name: "Show all 340" }))
+
+  rerender(
+    <ThemeProvider>
+      <SectionTruncation
+        shown={3}
+        total={340}
+        canShowAll={false}
+        isExpanding={false}
+        onShowAll={onShowAll}
+      />
+    </ThemeProvider>,
+  )
+
+  expect(screen.getByRole("status")).toHaveTextContent("Showing 3 of 340 rows.")
+})

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import { styled, Typography } from "ol-components"
-import { Button } from "@mitodl/smoot-design"
+import { Button, VisuallyHidden } from "@mitodl/smoot-design"
 import { formatCount } from "./format"
 
 /**
@@ -15,6 +15,15 @@ import { formatCount } from "./format"
  * primary-cohort gate to the count as to the rows), so it can be compared
  * against the rows on screen without ever implying there are hidden rows the
  * caller could reach by paging.
+ *
+ * # Why this owns an announcement
+ *
+ * Expanding a section keeps the old rows on screen while the larger page loads
+ * (`keepPreviousData`), which is deliberate — blanking a table back to a
+ * skeleton on an explicit user action is worse. But it means a click otherwise
+ * produces no perceivable change at all until the rows quietly grow. The button
+ * therefore reports its own in-flight state, and the result is announced once
+ * it lands, so the click is observable without watching row counts.
  */
 
 const Root = styled.div(({ theme }) => ({
@@ -46,6 +55,8 @@ type SectionTruncationProps = {
    * that cannot deliver the rest would be a lie.
    */
   canShowAll: boolean
+  /** The expanded page is in flight; the rows on screen are the previous ones. */
+  isExpanding: boolean
 }
 
 const SectionTruncation: React.FC<SectionTruncationProps> = ({
@@ -53,22 +64,58 @@ const SectionTruncation: React.FC<SectionTruncationProps> = ({
   total,
   onShowAll,
   canShowAll,
+  isExpanding,
 }) => {
-  if (shown >= total) {
-    return null
-  }
+  const [hasExpanded, setHasExpanded] = React.useState(false)
+
+  /**
+   * Derived from render state rather than detected as a rising/falling edge in
+   * an effect. An edge detector has to observe the in-flight render to arm
+   * itself, and React is free to batch a fast resolution into a single commit —
+   * so on a warm cache the announcement would silently never fire. This says
+   * "the user asked to expand, and we are no longer loading", which is true in
+   * either case.
+   */
+  const announcement =
+    !hasExpanded || isExpanding
+      ? ""
+      : shown >= total
+        ? `Now showing all ${formatCount(total)} rows.`
+        : `Showing ${formatCount(shown)} of ${formatCount(total)} rows.`
 
   return (
-    <Root>
-      <Message>
-        Showing {formatCount(shown)} of {formatCount(total)}.
-      </Message>
-      {canShowAll ? (
-        <Button variant="tertiary" size="small" onClick={onShowAll}>
-          Show all {formatCount(total)}
-        </Button>
+    <>
+      {/* Rendered even once the section is complete, so the announcement of
+          that completion has somewhere to land — a live region that unmounts
+          in the same commit as the change it describes announces nothing. */}
+      <VisuallyHidden role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </VisuallyHidden>
+      {shown < total ? (
+        <Root>
+          <Message>
+            Showing {formatCount(shown)} of {formatCount(total)}.
+          </Message>
+          {canShowAll ? (
+            <Button
+              variant="tertiary"
+              size="small"
+              // aria-disabled rather than disabled: a disabled button drops
+              // focus, which strands a keyboard user mid-action.
+              aria-disabled={isExpanding}
+              aria-busy={isExpanding}
+              onClick={() => {
+                if (isExpanding) return
+                setHasExpanded(true)
+                onShowAll()
+              }}
+            >
+              {isExpanding ? "Loading…" : `Show all ${formatCount(total)}`}
+            </Button>
+          ) : null}
+        </Root>
       ) : null}
-    </Root>
+    </>
   )
 }
 

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/SectionTruncation.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import React from "react"
+import { styled, Typography } from "ol-components"
+import { Button } from "@mitodl/smoot-design"
+import { formatCount } from "./format"
+
+/**
+ * Every analytics endpoint is paged, and a page cap is invisible in the rows
+ * themselves: 200 rows out of 340 look exactly like 340 out of 340. A manager
+ * reading a truncated table has no way to know they are missing courses unless
+ * the page says so — so it says so, and offers the rest.
+ *
+ * `total_count` is net of the anonymity floor (the API applies the same
+ * primary-cohort gate to the count as to the rows), so it can be compared
+ * against the rows on screen without ever implying there are hidden rows the
+ * caller could reach by paging.
+ */
+
+const Root = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  flexWrap: "wrap",
+  gap: "8px",
+  [theme.breakpoints.down("md")]: {
+    alignItems: "flex-start",
+    flexDirection: "column",
+  },
+}))
+
+const Message = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+type SectionTruncationProps = {
+  /** Rows currently rendered. */
+  shown: number
+  /** Rows this org has in the backing view, across every page. */
+  total: number
+  onShowAll: () => void
+  /**
+   * False once the section already holds as many rows as the API will return
+   * in one response — there is nothing further to ask for, so offering a button
+   * that cannot deliver the rest would be a lie.
+   */
+  canShowAll: boolean
+}
+
+const SectionTruncation: React.FC<SectionTruncationProps> = ({
+  shown,
+  total,
+  onShowAll,
+  canShowAll,
+}) => {
+  if (shown >= total) {
+    return null
+  }
+
+  return (
+    <Root>
+      <Message>
+        Showing {formatCount(shown)} of {formatCount(total)}.
+      </Message>
+      {canShowAll ? (
+        <Button variant="tertiary" size="small" onClick={onShowAll}>
+          Show all {formatCount(total)}
+        </Button>
+      ) : null}
+    </Root>
+  )
+}
+
+export default SectionTruncation
+export type { SectionTruncationProps }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/chartPalette.ts
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/chartPalette.ts
@@ -1,0 +1,61 @@
+/**
+ * Chart colors for the B2B analytics dashboard.
+ *
+ * These are not eyeballed. Every value below was checked with the data-viz
+ * validator against the *light* surface the dashboard renders on (the app has
+ * no dark theme), on the adjacent pairlist that applies to lines and bars:
+ * lightness band, chroma floor, CVD separation under simulated protanopia and
+ * deuteranopia, a normal-vision separation floor, and >= 3:1 contrast vs the
+ * surface. Changing a value means re-running that check, not swapping a hex.
+ *
+ * Hues come from the smoot-design token set (`theme.custom.colors`), so the
+ * charts stay recognisably MIT Learn. Two of them are stepped:
+ *
+ *  - AMBER is the `orange` token's hue (#FAB005), darkened to enter the
+ *    lightness band and clear 3:1 on white. The token itself is far too light
+ *    to carry a 2px line.
+ *  - The lightest funnel step is the `blue` token's hue lightened; the
+ *    `lightBlue` token is too pale to be distinguishable from the card.
+ *
+ * Green and red are deliberately absent: they are reserved for status, so that
+ * a red mark on this page always means "bad" and never "series 3".
+ */
+
+/**
+ * Categorical hues — series *identity*. Assigned in this fixed order and never
+ * cycled; the order is what makes the palette colorblind-safe, so a chart with
+ * three series takes slots 1-3 in sequence rather than picking favourites.
+ *
+ * The list stops at three because these are the three MIT Learn hues that clear
+ * the separation floor together. A fourth series is not a fourth color: fold it
+ * into "Other" or split the chart.
+ */
+const CATEGORICAL = [
+  "#1966FF", // blue token
+  "#B17F21", // orange token hue, stepped into the lightness band
+  "#FF14F0", // pink token
+] as const
+
+/**
+ * Ordinal ramp for funnel stages — one hue, light to dark, so the reader sees
+ * the progression in the color itself. Stage order is the meaning here, which
+ * is why this is a ramp and not three categorical hues.
+ */
+const FUNNEL_STAGES = [
+  "#7FA4EA", // lightest — widest stage
+  "#1966FF",
+  "#002896", // darkest — narrowest stage
+] as const
+
+/**
+ * Non-data ink. Grid and axis lines stay recessive so the marks carry the
+ * chart; labels wear text tokens rather than the series color.
+ */
+const CHART_INK = {
+  grid: "#DDE1E6", // lightGray2
+  axis: "#B8C2CC", // silverGrayLight
+  label: "#626A73", // silverGrayDark
+  surface: "#FFFFFF",
+} as const
+
+export { CATEGORICAL, CHART_INK, FUNNEL_STAGES }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/chartPalette.ts
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/chartPalette.ts
@@ -1,3 +1,5 @@
+import type { Theme } from "ol-components"
+
 /**
  * Chart colors for the B2B analytics dashboard.
  *
@@ -50,12 +52,20 @@ const FUNNEL_STAGES = [
 /**
  * Non-data ink. Grid and axis lines stay recessive so the marks carry the
  * chart; labels wear text tokens rather than the series color.
+ *
+ * Read from the theme rather than pinned as hexes, unlike the two palettes
+ * above. Nothing here is a validated data color — these are the same greys the
+ * rest of the dashboard's chrome already uses, so if smoot-design retunes a
+ * token the chart chrome has to move with it or the charts drift out of step
+ * with the tables beside them. The series colors are the opposite case: they
+ * are pinned precisely *because* they must not move without re-running the
+ * contrast and CVD checks.
  */
-const CHART_INK = {
-  grid: "#DDE1E6", // lightGray2
-  axis: "#B8C2CC", // silverGrayLight
-  label: "#626A73", // silverGrayDark
-  surface: "#FFFFFF",
-} as const
+const chartInk = (theme: Theme) => ({
+  grid: theme.custom.colors.lightGray2,
+  axis: theme.custom.colors.silverGrayLight,
+  label: theme.custom.colors.silverGrayDark,
+  surface: theme.custom.colors.white,
+})
 
-export { CATEGORICAL, CHART_INK, FUNNEL_STAGES }
+export { CATEGORICAL, chartInk, FUNNEL_STAGES }

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
@@ -1,0 +1,152 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { ThemeProvider } from "ol-components"
+import { factories } from "api/analytics-test-utils"
+import EngagementTrendChart from "./EngagementTrendChart"
+import ProgramFunnelChart from "./ProgramFunnelChart"
+import { CATEGORICAL, FUNNEL_STAGES } from "./chartPalette"
+
+/**
+ * Smoke coverage for the real charts (they are stubbed out in the page test).
+ * jsdom does no layout, so there is no point asserting on geometry; what these
+ * check is that the chart code runs, draws one mark per series, and paints
+ * those marks with the validated palette rather than the library's defaults.
+ */
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider>{ui}</ThemeProvider>)
+
+describe("EngagementTrendChart", () => {
+  const months = [
+    factories.monthlyEngagementTrend({ activity_year_and_month: "2026-01" }),
+    factories.monthlyEngagementTrend({ activity_year_and_month: "2026-02" }),
+  ]
+
+  test("renders a line per series in the categorical palette", () => {
+    const { container } = renderWithTheme(
+      <EngagementTrendChart rows={months} isLoading={false} />,
+    )
+
+    // Testing Library has no query for "which paint attribute did this SVG
+    // element get", which is exactly what this asserts, so the container query
+    // is the only way to check the palette actually reached the marks.
+    // eslint-disable-next-line testing-library/no-container
+    const lines = container.querySelectorAll(".MuiLineElement-root")
+    expect(lines).toHaveLength(CATEGORICAL.length)
+    const strokes = Array.from(lines).map((line) => line.getAttribute("stroke"))
+    expect(strokes).toEqual([...CATEGORICAL])
+  })
+
+  test("labels every series so identity is never carried by color alone", () => {
+    renderWithTheme(<EngagementTrendChart rows={months} isLoading={false} />)
+
+    expect(screen.getByText("Active learners")).toBeInTheDocument()
+    expect(screen.getByText("New enrollments")).toBeInTheDocument()
+    expect(screen.getByText("Certificates earned")).toBeInTheDocument()
+  })
+
+  test("shows an empty state rather than an empty chart", () => {
+    renderWithTheme(<EngagementTrendChart rows={[]} isLoading={false} />)
+    expect(
+      screen.getByText("No monthly activity recorded yet."),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * A month suppressed by the anonymity floor must be a gap in the line, not a
+   * dip to zero — so the null has to survive all the way into the series data.
+   */
+  test("renders a suppressed month without inventing a zero", () => {
+    const rows = [
+      factories.monthlyEngagementTrend({
+        activity_year_and_month: "2026-01",
+        new_enrollments: null,
+        certificates_earned: null,
+      }),
+      factories.monthlyEngagementTrend({ activity_year_and_month: "2026-02" }),
+    ]
+
+    expect(() =>
+      renderWithTheme(<EngagementTrendChart rows={rows} isLoading={false} />),
+    ).not.toThrow()
+  })
+})
+
+describe("ProgramFunnelChart", () => {
+  const programs = [
+    factories.programFunnel({
+      program_title: "Widget Engineering",
+      enrolled_in_contract_courses: 50,
+      enrolled_via_program: 30,
+      program_course_completers: 12,
+    }),
+  ]
+
+  /**
+   * Asserted via the legend swatches rather than the bars themselves: bar
+   * geometry is derived from measured width, and jsdom reports zero, so no
+   * `.MuiBarElement-root` is ever emitted here. The legend marks carry the same
+   * per-series color, which is what this is actually checking.
+   */
+  test("assigns the ordinal ramp to the funnel stages in order", () => {
+    const { container } = renderWithTheme(
+      <ProgramFunnelChart rows={programs} isLoading={false} />,
+    )
+
+    // See the note on the line-chart palette test: paint attributes are not
+    // reachable through a Testing Library query.
+    // eslint-disable-next-line testing-library/no-container
+    const swatches = container.querySelectorAll(".MuiChartsLabelMark-fill")
+    expect(swatches).toHaveLength(FUNNEL_STAGES.length)
+    expect(
+      Array.from(swatches).map((swatch) => swatch.getAttribute("fill")),
+    ).toEqual([...FUNNEL_STAGES])
+  })
+
+  test("labels every funnel stage so identity is never carried by color alone", () => {
+    renderWithTheme(<ProgramFunnelChart rows={programs} isLoading={false} />)
+
+    expect(
+      screen.getByText("Enrolled in contract courses", {
+        selector: ".MuiChartsLabel-root",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Enrolled via program", {
+        selector: ".MuiChartsLabel-root",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Completed program courses", {
+        selector: ".MuiChartsLabel-root",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  test("pairs the chart with a table of the same numbers", () => {
+    renderWithTheme(<ProgramFunnelChart rows={programs} isLoading={false} />)
+
+    const table = screen.getByRole("table", { name: "Program funnel" })
+    expect(table).toBeInTheDocument()
+    expect(screen.getByText("50")).toBeInTheDocument()
+    expect(screen.getByText("30")).toBeInTheDocument()
+    expect(screen.getByText("12")).toBeInTheDocument()
+  })
+
+  test("explains suppressed stages in the table instead of omitting them silently", () => {
+    renderWithTheme(
+      <ProgramFunnelChart
+        rows={[
+          factories.programFunnel({
+            program_course_completers: null,
+          }),
+        ]}
+        isLoading={false}
+      />,
+    )
+
+    expect(
+      screen.getAllByLabelText(/Withheld: too few learners/).length,
+    ).toBeGreaterThan(0)
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
@@ -1,10 +1,22 @@
 import React from "react"
 import { render, screen, within } from "@testing-library/react"
-import { ThemeProvider } from "ol-components"
+import { ThemeProvider, useTheme } from "ol-components"
+import type { Theme } from "ol-components"
 import { factories } from "api/analytics-test-utils"
 import EngagementTrendChart from "./EngagementTrendChart"
 import ProgramFunnelChart from "./ProgramFunnelChart"
-import { CATEGORICAL, FUNNEL_STAGES } from "./chartPalette"
+import { CATEGORICAL, chartInk, FUNNEL_STAGES } from "./chartPalette"
+
+/**
+ * Captures the live theme so the ink assertions below compare against the
+ * token, not a hex copied into this file — copying one here would reintroduce
+ * exactly the drift the theme lookup exists to prevent.
+ */
+let capturedTheme: Theme
+const ThemeProbe = () => {
+  capturedTheme = useTheme() as Theme
+  return null
+}
 
 /**
  * Smoke coverage for the real charts (they are stubbed out in the page test).
@@ -14,7 +26,35 @@ import { CATEGORICAL, FUNNEL_STAGES } from "./chartPalette"
  */
 
 const renderWithTheme = (ui: React.ReactElement) =>
-  render(<ThemeProvider>{ui}</ThemeProvider>)
+  render(
+    <ThemeProvider>
+      <ThemeProbe />
+      {ui}
+    </ThemeProvider>,
+  )
+
+/**
+ * The two palettes above stay pinned as hexes on purpose — they are validated
+ * data colors and must not move without re-running the contrast/CVD checks.
+ * The non-data ink is the opposite case: it is the same grey chrome the tables
+ * beside these charts use, so it reads from the theme and moves when a
+ * smoot-design token is retuned. Asserted against the live token rather than a
+ * literal, since a literal here would just relocate the duplication and would
+ * still pass if the module went back to hardcoding.
+ */
+describe("chartInk", () => {
+  test("resolves non-data ink from theme tokens, not pinned hexes", () => {
+    renderWithTheme(<div />)
+    const colors = capturedTheme.custom.colors
+
+    expect(chartInk(capturedTheme)).toEqual({
+      grid: colors.lightGray2,
+      axis: colors.silverGrayLight,
+      label: colors.silverGrayDark,
+      surface: colors.white,
+    })
+  })
+})
 
 describe("EngagementTrendChart", () => {
   const months = [

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
@@ -56,6 +56,66 @@ describe("chartInk", () => {
   })
 })
 
+/**
+ * Both charts are paired with a table carrying the same numbers, which makes
+ * the SVG redundant for a screen reader — and worse than redundant, since
+ * traversing hundreds of series and axis nodes to reach data that is about to
+ * be presented properly is pure noise. So the chart is hidden and the table is
+ * the accessible copy.
+ *
+ * The second assertion in each case is the one that keeps this honest:
+ * `aria-hidden` on a subtree containing focusable content is itself a
+ * violation, because keyboard focus can land somewhere screen readers have been
+ * told does not exist. Neither chart renders anything focusable today; this
+ * fails if a future library version starts to.
+ */
+describe.each([
+  [
+    "EngagementTrendChart",
+    () => (
+      <EngagementTrendChart
+        rows={[factories.monthlyEngagementTrend()]}
+        isLoading={false}
+      />
+    ),
+    "Monthly engagement",
+  ],
+  [
+    "ProgramFunnelChart",
+    () => (
+      <ProgramFunnelChart
+        rows={[factories.programFunnel()]}
+        isLoading={false}
+      />
+    ),
+    "Program funnel",
+  ],
+])("%s accessibility", (_name, renderChart, tableLabel) => {
+  test("hides the chart from assistive tech but keeps its table", () => {
+    const { container } = renderWithTheme(renderChart())
+
+    // eslint-disable-next-line testing-library/no-container
+    const svg = container.querySelector("svg")
+    expect(svg).toBeInTheDocument()
+    expect(svg?.closest("[aria-hidden='true']")).not.toBeNull()
+
+    // The table is the accessible equivalent, so it must stay exposed.
+    const table = screen.getByRole("table", { name: tableLabel })
+    expect(table.closest("[aria-hidden='true']")).toBeNull()
+  })
+
+  test("puts nothing focusable inside the hidden subtree", () => {
+    const { container } = renderWithTheme(renderChart())
+
+    // eslint-disable-next-line testing-library/no-container
+    const hidden = container.querySelector("[aria-hidden='true']")
+    const focusable = hidden?.querySelectorAll(
+      "a[href], button, input, select, textarea, [tabindex]",
+    )
+    expect(focusable).toHaveLength(0)
+  })
+})
+
 describe("EngagementTrendChart", () => {
   const months = [
     factories.monthlyEngagementTrend({ activity_year_and_month: "2026-01" }),

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/charts.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, within } from "@testing-library/react"
 import { ThemeProvider } from "ol-components"
 import { factories } from "api/analytics-test-utils"
 import EngagementTrendChart from "./EngagementTrendChart"
@@ -37,12 +37,22 @@ describe("EngagementTrendChart", () => {
     expect(strokes).toEqual([...CATEGORICAL])
   })
 
+  // Scoped to the legend: the paired table repeats every series name as a
+  // column header, which is the point of it, so an unscoped query matches twice.
   test("labels every series so identity is never carried by color alone", () => {
     renderWithTheme(<EngagementTrendChart rows={months} isLoading={false} />)
 
-    expect(screen.getByText("Active learners")).toBeInTheDocument()
-    expect(screen.getByText("New enrollments")).toBeInTheDocument()
-    expect(screen.getByText("Certificates earned")).toBeInTheDocument()
+    expect(
+      screen.getByText("Active learners", { selector: ".MuiChartsLabel-root" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("New enrollments", { selector: ".MuiChartsLabel-root" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Certificates earned", {
+        selector: ".MuiChartsLabel-root",
+      }),
+    ).toBeInTheDocument()
   })
 
   test("shows an empty state rather than an empty chart", () => {
@@ -69,6 +79,70 @@ describe("EngagementTrendChart", () => {
     expect(() =>
       renderWithTheme(<EngagementTrendChart rows={rows} isLoading={false} />),
     ).not.toThrow()
+  })
+
+  /**
+   * The SVG is unreadable to a screen reader, so the monthly numbers have to
+   * exist as text too — the same pairing `ProgramFunnelChart` uses.
+   */
+  test("pairs the chart with a table of the same numbers", () => {
+    renderWithTheme(
+      <EngagementTrendChart
+        rows={[
+          factories.monthlyEngagementTrend({
+            activity_year_and_month: "2026-01",
+            monthly_active_learners: 84,
+            new_enrollments: 21,
+            certificates_earned: 7,
+          }),
+        ]}
+        isLoading={false}
+      />,
+    )
+
+    const table = screen.getByRole("table", { name: "Monthly engagement" })
+    expect(within(table).getByText("Jan 2026")).toBeInTheDocument()
+    expect(within(table).getByText("84")).toBeInTheDocument()
+    expect(within(table).getByText("21")).toBeInTheDocument()
+    expect(within(table).getByText("7")).toBeInTheDocument()
+  })
+
+  /**
+   * A gap in a line reads as "no data" — only the table can say a month was
+   * withheld and why.
+   */
+  test("explains suppressed months in the table instead of leaving a bare gap", () => {
+    renderWithTheme(
+      <EngagementTrendChart
+        rows={[
+          factories.monthlyEngagementTrend({
+            activity_year_and_month: "2026-01",
+            certificates_earned: null,
+          }),
+        ]}
+        isLoading={false}
+      />,
+    )
+
+    expect(
+      screen.getAllByLabelText(/Withheld: too few learners/).length,
+    ).toBeGreaterThan(0)
+    expect(screen.getByText(/Withheld: too few learners/)).toBeInTheDocument()
+  })
+
+  test("says the data could not be loaded rather than showing an empty state", () => {
+    renderWithTheme(
+      <EngagementTrendChart rows={undefined} isLoading={false} isError />,
+    )
+
+    expect(
+      screen.getByText(
+        "This data could not be loaded. Please try again later.",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("No monthly activity recorded yet."),
+    ).not.toBeInTheDocument()
   })
 })
 

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/format.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/format.test.tsx
@@ -1,0 +1,86 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import { ThemeProvider } from "ol-components"
+import {
+  formatCount,
+  formatDate,
+  formatPercent,
+  formatYearMonth,
+  formatYearMonthShort,
+  SUPPRESSED_EXPLANATION,
+  SuppressibleValue,
+} from "./format"
+
+describe("formatYearMonth", () => {
+  test.each([
+    { input: "2026-01", long: "Jan 2026", short: "Jan" },
+    { input: "2026-12", long: "Dec 2026", short: "Dec" },
+  ])("formats $input as $long", ({ input, long, short }) => {
+    expect(formatYearMonth(input)).toBe(long)
+    expect(formatYearMonthShort(input)).toBe(short)
+  })
+
+  /**
+   * `new Date("2026-03")` is parsed as UTC midnight, which renders as February
+   * for anyone west of Greenwich. The formatter builds a local date instead;
+   * this is the regression guard for that.
+   */
+  test("does not shift the month across timezones", () => {
+    expect(formatYearMonth("2026-03")).toBe("Mar 2026")
+  })
+
+  test("passes an unparseable value through rather than rendering garbage", () => {
+    expect(formatYearMonth("not-a-month")).toBe("not-a-month")
+    expect(formatYearMonthShort("")).toBe("")
+  })
+})
+
+describe("number formatting", () => {
+  test("counts are thousands-separated", () => {
+    expect(formatCount(1234567)).toBe("1,234,567")
+  })
+
+  test("percentages keep at most one decimal", () => {
+    expect(formatPercent(62)).toBe("62%")
+    expect(formatPercent(32.35)).toBe("32.4%")
+  })
+
+  test("formatDate returns null for missing or invalid dates", () => {
+    expect(formatDate(null)).toBeNull()
+    expect(formatDate(undefined)).toBeNull()
+    expect(formatDate("nope")).toBeNull()
+    expect(formatDate("2026-01-15")).toBe("Jan 15, 2026")
+  })
+})
+
+describe("SuppressibleValue", () => {
+  const renderValue = (value: number | null) =>
+    render(
+      <ThemeProvider>
+        <SuppressibleValue value={value} />
+      </ThemeProvider>,
+    )
+
+  test("renders the formatted number when the API returned one", () => {
+    renderValue(42)
+    expect(screen.getByText("42")).toBeInTheDocument()
+  })
+
+  /**
+   * The whole point of the component: a suppressed value must never read as
+   * zero, and its reason must be available without hovering.
+   */
+  test("explains a suppressed value instead of showing zero", () => {
+    renderValue(null)
+    expect(screen.queryByText("0")).not.toBeInTheDocument()
+    expect(screen.getByLabelText(SUPPRESSED_EXPLANATION)).toBeInTheDocument()
+  })
+
+  test("zero is a real value and is rendered as such", () => {
+    renderValue(0)
+    expect(screen.getByText("0")).toBeInTheDocument()
+    expect(
+      screen.queryByLabelText(SUPPRESSED_EXPLANATION),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/format.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/format.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import React from "react"
+import { styled, Tooltip } from "ol-components"
+
+/**
+ * The analytics API nulls out any learner count below its k-anonymity floor,
+ * along with every rate and average derived from it. A `null` from these
+ * endpoints therefore means "withheld to protect learner privacy" — it is not
+ * zero, and it is not missing data.
+ *
+ * Everything in this module exists to keep that distinction visible: a
+ * suppressed value renders as a marked placeholder that says why, and no
+ * formatter silently turns `null` into `0`.
+ */
+
+/** Copy used by both the tooltip and the per-section footnote, so they agree. */
+const SUPPRESSED_EXPLANATION =
+  "Withheld: too few learners in this group to report without identifying them."
+
+/** Thousands-separated integer. */
+const formatCount = (value: number): string => value.toLocaleString("en-US")
+
+/** One decimal place, because the API's rates are already rounded percentages. */
+const formatPercent = (value: number): string =>
+  `${value.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  })}%`
+
+/** One decimal place, for per-learner averages. */
+const formatAverage = (value: number): string =>
+  value.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  })
+
+/**
+ * `activity_year_and_month` arrives as a `YYYY-MM` string. Parsed by hand
+ * rather than with `new Date("2026-03")` — that parses as UTC midnight and then
+ * renders as the *previous* month for anyone west of Greenwich.
+ */
+const parseYearMonth = (yearMonth: string): Date | null => {
+  const match = /^(\d{4})-(\d{2})$/.exec(yearMonth)
+  if (!match) return null
+  return new Date(Number(match[1]), Number(match[2]) - 1, 1)
+}
+
+/** Month and year, e.g. "Mar 2026". */
+const formatYearMonth = (yearMonth: string): string =>
+  parseYearMonth(yearMonth)?.toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  }) ?? yearMonth
+
+/** Short month for a dense axis, e.g. "Mar". */
+const formatYearMonthShort = (yearMonth: string): string =>
+  parseYearMonth(yearMonth)?.toLocaleDateString("en-US", { month: "short" }) ??
+  yearMonth
+
+/**
+ * Contract start/end dates, which arrive as date-only `YYYY-MM-DD` strings.
+ *
+ * Built as a local date for the same reason as `parseYearMonth`: `new
+ * Date("2026-01-15")` is parsed as UTC midnight, so `toLocaleDateString`
+ * renders it as the 14th for any reader west of Greenwich. A contract that
+ * starts on the 15th must not display as starting on the 14th.
+ */
+const formatDate = (iso: string | null | undefined): string | null => {
+  if (!iso) return null
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso)
+  const date = dateOnly
+    ? new Date(
+        Number(dateOnly[1]),
+        Number(dateOnly[2]) - 1,
+        Number(dateOnly[3]),
+      )
+    : new Date(iso)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+const SuppressedMark = styled.span(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+  // Dotted underline marks it as explained-on-hover rather than an em dash the
+  // reader is meant to interpret as "zero".
+  borderBottom: `1px dotted ${theme.custom.colors.silverGray}`,
+  cursor: "help",
+}))
+
+/**
+ * Placeholder for a value the API suppressed. Carries its explanation to
+ * pointer users via the tooltip and to assistive tech via the accessible label,
+ * so the meaning never depends on hover alone.
+ */
+const Suppressed: React.FC = () => (
+  <Tooltip title={SUPPRESSED_EXPLANATION}>
+    <SuppressedMark aria-label={SUPPRESSED_EXPLANATION} tabIndex={0}>
+      —
+    </SuppressedMark>
+  </Tooltip>
+)
+
+/**
+ * Render a possibly-suppressed value: the formatted number when present, the
+ * suppression marker when not.
+ */
+const SuppressibleValue: React.FC<{
+  value: number | null | undefined
+  format?: (value: number) => string
+}> = ({ value, format = formatCount }) =>
+  value === null || value === undefined ? <Suppressed /> : <>{format(value)}</>
+
+export {
+  formatAverage,
+  formatCount,
+  formatDate,
+  formatPercent,
+  formatYearMonth,
+  formatYearMonthShort,
+  Suppressed,
+  SUPPRESSED_EXPLANATION,
+  SuppressibleValue,
+}

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/orgUuid.ts
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/orgUuid.ts
@@ -1,0 +1,28 @@
+import type { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
+
+/**
+ * The Keycloak organization UUID, which is what the analytics API keys every
+ * org endpoint on — it is the only identifier stable across the JWT, MITx
+ * Online and StarRocks (see mitodl/ol-analytics-api#13).
+ *
+ * MITx Online exposes it on `OrganizationPageSerializer` as
+ * `sso_organization_id` (mitodl/mitxonline#3789). That change has not been cut
+ * into a release of `@mitodl/mitxonline-api-axios` yet, so the generated
+ * `OrganizationPage` type does not declare the field and we have to read it
+ * off the wire ourselves.
+ *
+ * Returning `null` when it is absent is the load-bearing part: it is exactly
+ * what happens when mit-learn is pointed at a MITx Online deploy that predates
+ * that PR, and it must surface as "analytics unavailable for this org" rather
+ * than as a request to the analytics API with `undefined` in the path.
+ *
+ * TODO: delete this and read `org.sso_organization_id` directly once the
+ * regenerated client is picked up in `frontends/api/package.json`.
+ */
+const getOrgUuid = (org: OrganizationPage | undefined): string | null => {
+  const value = (org as { sso_organization_id?: unknown } | undefined)
+    ?.sso_organization_id
+  return typeof value === "string" && value.length > 0 ? value : null
+}
+
+export { getOrgUuid }

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -494,6 +494,48 @@ describe("AnalyticsContent", () => {
     })
 
     /**
+     * The API applies its LIMIT in SQL and drops sub-floor rows afterwards, so
+     * a page of `total_count` rows can still come back short — permanently.
+     * Asking again would resend the same limit and change nothing, so the
+     * button has to go rather than sit there doing nothing.
+     */
+    test("stops offering more once a section has already asked for the total", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
+        analyticsFactories.envelope(courseRows(188), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+      // Asked for 340, got 328: the other 12 were dropped by the floor after
+      // the LIMIT had already been applied.
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 340 }),
+        analyticsFactories.envelope(courseRows(328), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await user.click(
+        await screen.findByRole("button", { name: "Show all 340" }),
+      )
+
+      await screen.findByText("Showing 328 of 340.")
+      expect(
+        screen.queryByRole("button", { name: /Show all/ }),
+      ).not.toBeInTheDocument()
+    })
+
+    /**
      * The API answers 422 above its max_page_size, so past that point there is
      * no request left to make — the message has to stand on its own rather than
      * offering a button that cannot deliver.

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -6,7 +6,7 @@ import {
   factories as analyticsFactories,
   urls as analyticsUrls,
 } from "api/analytics-test-utils"
-import { waitFor } from "@testing-library/react"
+import { waitFor, within } from "@testing-library/react"
 import type { AxiosError } from "axios"
 import type { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -330,12 +330,12 @@ describe("AnalyticsContent", () => {
       )
 
       await screen.findByText("Widget Engineering")
-      expect(
-        screen.getByRole("table", { name: "Program funnel" }),
-      ).toBeInTheDocument()
-      expect(screen.getByText("50")).toBeInTheDocument()
-      expect(screen.getByText("30")).toBeInTheDocument()
-      expect(screen.getByText("12")).toBeInTheDocument()
+      // Scoped to this table: the monthly engagement section renders its own
+      // table of counts, which can legitimately carry the same numbers.
+      const table = screen.getByRole("table", { name: "Program funnel" })
+      expect(within(table).getByText("50")).toBeInTheDocument()
+      expect(within(table).getByText("30")).toBeInTheDocument()
+      expect(within(table).getByText("12")).toBeInTheDocument()
     })
 
     test("says so when a view has never refreshed rather than implying freshness", async () => {
@@ -386,6 +386,45 @@ describe("AnalyticsContent", () => {
       await screen.findByText("No course enrollments recorded yet.")
       expect(
         screen.getByText("No program enrollments recorded yet."),
+      ).toBeInTheDocument()
+    })
+
+    /**
+     * A section whose query failed has no rows and no `as_of`, which is exactly
+     * what a successful-but-empty section looks like. It must not borrow that
+     * section's copy: "No course enrollments recorded yet" is a claim about the
+     * org, and "Data not yet refreshed" is a claim about the view, and neither
+     * is known to be true when the request never came back.
+     */
+    test("distinguishes a failed section from an empty one", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      allowConsoleErrors()
+      setAnalyticsResponses()
+      // Overrides the successful response registered just above.
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
+        "Internal Server Error",
+        { code: 500 },
+      )
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText(
+        "This data could not be loaded. Please try again later.",
+      )
+      expect(
+        screen.queryByText("No course enrollments recorded yet."),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Data not yet refreshed"),
+      ).not.toBeInTheDocument()
+      // The three sections that did load keep their own freshness stamp.
+      expect(screen.getAllByText(/Data as of/)).toHaveLength(3)
+      expect(
+        screen.getByText(/Some analytics could not be loaded/),
       ).toBeInTheDocument()
     })
   })

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -1,0 +1,392 @@
+import React from "react"
+import { renderWithProviders, screen, TestingErrorBoundary } from "@/test-utils"
+import { setMockResponse } from "api/test-utils"
+import { factories, urls } from "api/mitxonline-test-utils"
+import {
+  factories as analyticsFactories,
+  urls as analyticsUrls,
+} from "api/analytics-test-utils"
+import { waitFor } from "@testing-library/react"
+import type { AxiosError } from "axios"
+import type { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { allowConsoleErrors } from "ol-test-utilities"
+import { ForbiddenError } from "@/common/errors"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import AnalyticsContent from "./AnalyticsContent"
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />
+  },
+}))
+
+/**
+ * The charts are stubbed out. They render SVG whose geometry depends on
+ * measured layout, which jsdom does not do — exercising them here would assert
+ * on nothing useful. What this file covers is the page's own behaviour: access,
+ * availability, freshness and suppression. The numbers those charts draw are
+ * also rendered as text (KPI cards, the course table, the funnel's table view),
+ * so they are still asserted on below.
+ */
+jest.mock("@mui/x-charts/LineChart", () => ({
+  __esModule: true,
+  LineChart: () => <div data-testid="line-chart" />,
+}))
+jest.mock("@mui/x-charts/BarChart", () => ({
+  __esModule: true,
+  BarChart: () => <div data-testid="bar-chart" />,
+}))
+
+jest.mock("posthog-js/react", () => ({
+  ...jest.requireActual("posthog-js/react"),
+  useFeatureFlagEnabled: jest.fn(),
+}))
+jest.mock("@/common/useFeatureFlagsLoaded")
+const mockedUseFeatureFlagsLoaded = jest.mocked(useFeatureFlagsLoaded)
+const mockedUseFeatureFlagEnabled = jest.mocked(useFeatureFlagEnabled)
+
+const managerOrgsUrl = urls.organization.managerOrganizationsList()
+
+const ORG_UUID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+
+/**
+ * `sso_organization_id` is not on the generated `OrganizationPage` type yet
+ * (mitodl/mitxonline#3789 has not been released into the client), so it is
+ * spliced on here the same way it arrives on the wire.
+ */
+const orgWithUuid = (
+  overrides: Partial<OrganizationPage> = {},
+  ssoOrganizationId: string | null = ORG_UUID,
+) => {
+  const org = factories.organizations.organization({
+    contracts: [factories.contracts.contract()],
+    ...overrides,
+  })
+  return ssoOrganizationId
+    ? { ...org, sso_organization_id: ssoOrganizationId }
+    : org
+}
+
+const setManagerOrgs = (orgs: unknown[]) => {
+  setMockResponse.get(managerOrgsUrl, {
+    count: orgs.length,
+    next: null,
+    previous: null,
+    results: orgs,
+  })
+}
+
+const AS_OF = "2026-07-01T04:00:00Z"
+
+const setAnalyticsResponses = ({
+  utilization = [analyticsFactories.contractUtilization()],
+  trend = [analyticsFactories.monthlyEngagementTrend()],
+  courses = [analyticsFactories.enrollmentCompletionFunnel()],
+  programs = [analyticsFactories.programFunnel()],
+  page = { limit: 200 },
+}: {
+  utilization?: ReturnType<typeof analyticsFactories.contractUtilization>[]
+  trend?: ReturnType<typeof analyticsFactories.monthlyEngagementTrend>[]
+  courses?: ReturnType<typeof analyticsFactories.enrollmentCompletionFunnel>[]
+  programs?: ReturnType<typeof analyticsFactories.programFunnel>[]
+  page?: { limit: number }
+} = {}) => {
+  setMockResponse.get(
+    analyticsUrls.organizations.contractUtilization(ORG_UUID, page),
+    analyticsFactories.envelope(utilization, { as_of: AS_OF }),
+  )
+  setMockResponse.get(
+    analyticsUrls.organizations.engagementTrend(ORG_UUID, page),
+    analyticsFactories.envelope(trend, { as_of: AS_OF }),
+  )
+  setMockResponse.get(
+    analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, page),
+    analyticsFactories.envelope(courses, { as_of: AS_OF }),
+  )
+  setMockResponse.get(
+    analyticsUrls.organizations.programFunnel(ORG_UUID, page),
+    analyticsFactories.envelope(programs, { as_of: AS_OF }),
+  )
+}
+
+describe("AnalyticsContent", () => {
+  beforeEach(() => {
+    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    setMockResponse.get(
+      urls.userMe.get(),
+      factories.user.user({ email: "manager@test.com" }),
+    )
+  })
+
+  describe("access", () => {
+    test("throws ForbiddenError when the feature flag is off", () => {
+      mockedUseFeatureFlagEnabled.mockReturnValue(false)
+      allowConsoleErrors()
+
+      expect(() =>
+        renderWithProviders(<AnalyticsContent orgSlug="any-org" />),
+      ).toThrow(ForbiddenError)
+    })
+
+    test("waits for PostHog rather than 403-ing on a bootstrapped false", () => {
+      mockedUseFeatureFlagsLoaded.mockReturnValue(false)
+      mockedUseFeatureFlagEnabled.mockReturnValue(undefined)
+
+      expect(() =>
+        renderWithProviders(<AnalyticsContent orgSlug="any-org" />),
+      ).not.toThrow()
+    })
+
+    test("denies access when the caller does not manage the requested org", async () => {
+      setManagerOrgs([orgWithUuid()])
+
+      renderWithProviders(<AnalyticsContent orgSlug="not-my-org" />)
+
+      await screen.findByRole("heading", { name: "Access denied" })
+    })
+
+    /**
+     * A 403 from the analytics API is not handled inside the page: the browser
+     * query client throws on 401/403 so the route's error boundary handles it,
+     * the same as every other page. This asserts the error actually escapes
+     * rather than being swallowed into a half-rendered dashboard.
+     */
+    test("lets an analytics 403 reach the error boundary", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      allowConsoleErrors()
+      const page = { limit: 200 }
+      const forbidden = ["Forbidden", { code: 403 }] as const
+      setMockResponse.get(
+        analyticsUrls.organizations.contractUtilization(ORG_UUID, page),
+        ...forbidden,
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.engagementTrend(ORG_UUID, page),
+        ...forbidden,
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, page),
+        ...forbidden,
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.programFunnel(ORG_UUID, page),
+        ...forbidden,
+      )
+
+      const onError = jest.fn()
+      renderWithProviders(
+        <TestingErrorBoundary onError={onError}>
+          <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />
+        </TestingErrorBoundary>,
+      )
+
+      await waitFor(() => expect(onError).toHaveBeenCalled())
+      expect((onError.mock.calls[0][0] as AxiosError).response?.status).toBe(
+        403,
+      )
+    })
+
+    test("shows an error page when the manager org lookup fails", async () => {
+      allowConsoleErrors()
+      setMockResponse.get(managerOrgsUrl, "Internal Server Error", {
+        code: 500,
+      })
+
+      renderWithProviders(<AnalyticsContent orgSlug="any-org" />)
+
+      await screen.findByRole("heading", { name: "Something went wrong" })
+    })
+  })
+
+  describe("availability", () => {
+    /**
+     * An org whose MITx Online record predates the `sso_organization_id`
+     * field has no key the analytics API can be called with. That must read as
+     * "unavailable", never as a request with `undefined` in the path.
+     */
+    test("reports unavailable, and issues no request, when the org has no UUID", async () => {
+      const org = orgWithUuid({}, null)
+      setManagerOrgs([org])
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText(
+        /Analytics is not available for this organization/,
+      )
+      // No analytics response was ever registered; reaching the API would have
+      // failed the test via the mock adapter's console.error.
+      expect(
+        screen.queryByRole("heading", { name: "Contract utilization" }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  describe("content", () => {
+    test("renders every section with its own as-of date", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByRole("heading", { name: "Contract utilization" })
+      expect(
+        screen.getByRole("heading", { name: "Monthly engagement" }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("heading", { name: "Course performance" }),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("heading", { name: "Program funnel" }),
+      ).toBeInTheDocument()
+
+      // One "Data as of" per section — freshness is per materialized view.
+      const asOfLabels = await screen.findAllByText(/Data as of/)
+      expect(asOfLabels).toHaveLength(4)
+    })
+
+    test("renders the KPI figures from contract utilization", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses({
+        utilization: [
+          analyticsFactories.contractUtilization({
+            b2b_contract_name: "Acme Site License",
+            seats_consumed: 62,
+            seat_limit: 100,
+            active_learners: 48,
+            seat_utilization_pct: 62,
+            completion_rate_pct: 32.3,
+          }),
+        ],
+      })
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByRole("heading", { name: "Acme Site License" })
+      expect(screen.getByText("62%")).toBeInTheDocument()
+      expect(screen.getByText("48")).toBeInTheDocument()
+      expect(screen.getByText("32.3%")).toBeInTheDocument()
+      expect(screen.getByText("62 of 100 seats")).toBeInTheDocument()
+    })
+
+    test("renders course rows and marks suppressed values as withheld", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses({
+        courses: [
+          analyticsFactories.enrollmentCompletionFunnel({
+            courserun_title: "Intro to Widgets",
+            enrolled_learners: 40,
+            // Below the anonymity floor: must not render as 0.
+            certified_learners: null,
+            completion_rate_pct: null,
+          }),
+        ],
+      })
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText("Intro to Widgets")
+      expect(screen.getByText("40")).toBeInTheDocument()
+      expect(
+        screen.getAllByLabelText(/Withheld: too few learners/).length,
+      ).toBeGreaterThan(0)
+      expect(
+        screen.getAllByText(/Withheld: too few learners/).length,
+      ).toBeGreaterThan(0)
+    })
+
+    test("renders the program funnel's table view alongside the chart", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses({
+        programs: [
+          analyticsFactories.programFunnel({
+            program_title: "Widget Engineering",
+            total_courses: 6,
+            enrolled_in_contract_courses: 50,
+            enrolled_via_program: 30,
+            program_course_completers: 12,
+          }),
+        ],
+      })
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText("Widget Engineering")
+      expect(
+        screen.getByRole("table", { name: "Program funnel" }),
+      ).toBeInTheDocument()
+      expect(screen.getByText("50")).toBeInTheDocument()
+      expect(screen.getByText("30")).toBeInTheDocument()
+      expect(screen.getByText("12")).toBeInTheDocument()
+    })
+
+    test("says so when a view has never refreshed rather than implying freshness", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      const page = { limit: 200 }
+      setMockResponse.get(
+        analyticsUrls.organizations.contractUtilization(ORG_UUID, page),
+        analyticsFactories.envelope(
+          [analyticsFactories.contractUtilization()],
+          {
+            as_of: null,
+          },
+        ),
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.engagementTrend(ORG_UUID, page),
+        analyticsFactories.envelope([], { as_of: null }),
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, page),
+        analyticsFactories.envelope([], { as_of: null }),
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.programFunnel(ORG_UUID, page),
+        analyticsFactories.envelope([], { as_of: null }),
+      )
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      expect(
+        (await screen.findAllByText("Data not yet refreshed")).length,
+      ).toBe(4)
+      expect(screen.queryByText(/Data as of/)).not.toBeInTheDocument()
+    })
+
+    test("renders empty states rather than blank sections", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses({ courses: [], programs: [], trend: [] })
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText("No course enrollments recorded yet.")
+      expect(
+        screen.getByText("No program enrollments recorded yet."),
+      ).toBeInTheDocument()
+    })
+  })
+})

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -7,6 +7,7 @@ import {
   urls as analyticsUrls,
 } from "api/analytics-test-utils"
 import { waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { AxiosError } from "axios"
 import type { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 import { useFeatureFlagEnabled } from "posthog-js/react"
@@ -426,6 +427,109 @@ describe("AnalyticsContent", () => {
       expect(
         screen.getByText(/Some analytics could not be loaded/),
       ).toBeInTheDocument()
+    })
+  })
+
+  /**
+   * Every endpoint is paged, and a truncated page is invisible in the rows: 2
+   * of 340 looks exactly like 2 of 2. The envelope's `total_count` is the only
+   * thing that distinguishes them.
+   */
+  describe("truncation", () => {
+    const courseRows = (count: number) =>
+      Array.from({ length: count }, (_, index) =>
+        analyticsFactories.enrollmentCompletionFunnel({
+          courserun_pk: index + 1,
+          courserun_title: `Course ${index + 1}`,
+        }),
+      )
+
+    test("says nothing when a section holds every row", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByRole("heading", { name: "Course performance" })
+      expect(screen.queryByText(/Showing \d+ of/)).not.toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /Show all/ }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("admits to showing a subset, and loads the rest on request", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
+        analyticsFactories.envelope(courseRows(2), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+      // "Show all" asks for the whole result set in one page.
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 340 }),
+        analyticsFactories.envelope(courseRows(3), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      await screen.findByText("Showing 2 of 340.")
+      await user.click(screen.getByRole("button", { name: "Show all 340" }))
+
+      await screen.findByText("Course 3")
+      // Still short of the total, so the count updates rather than disappearing.
+      expect(screen.getByText("Showing 3 of 340.")).toBeInTheDocument()
+    })
+
+    /**
+     * The API answers 422 above its max_page_size, so past that point there is
+     * no request left to make — the message has to stand on its own rather than
+     * offering a button that cannot deliver.
+     */
+    test("drops the button once a section is already at the API's page cap", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
+        analyticsFactories.envelope(courseRows(2), {
+          as_of: AS_OF,
+          total_count: 5000,
+        }),
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 1000 }),
+        analyticsFactories.envelope(courseRows(4), {
+          as_of: AS_OF,
+          total_count: 5000,
+        }),
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      // Capped at max_page_size rather than asking for all 5000.
+      await screen.findByRole("button", { name: "Show all 5,000" })
+      await user.click(screen.getByRole("button", { name: "Show all 5,000" }))
+
+      await screen.findByText("Showing 4 of 5,000.")
+      expect(
+        screen.queryByRole("button", { name: /Show all/ }),
+      ).not.toBeInTheDocument()
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -494,6 +494,47 @@ describe("AnalyticsContent", () => {
     })
 
     /**
+     * The expanded page keeps the old rows on screen while it loads, so nothing
+     * visibly changes on click. Without the busy state and the live region a
+     * screen reader gets no feedback at all that the button did anything.
+     */
+    test("marks the button busy while expanding and announces the result", async () => {
+      const org = orgWithUuid()
+      setManagerOrgs([org])
+      setAnalyticsResponses()
+      // Row counts stay tiny deliberately: rendering hundreds of rows in jsdom
+      // is slow enough to make this flaky under parallel load, and the wiring
+      // under test doesn't depend on the magnitudes. `total_count` still has to
+      // exceed the page size, or there would be nothing to expand.
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
+        analyticsFactories.envelope(courseRows(2), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+      setMockResponse.get(
+        analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 340 }),
+        analyticsFactories.envelope(courseRows(3), {
+          as_of: AS_OF,
+          total_count: 340,
+        }),
+      )
+
+      const user = userEvent.setup()
+      renderWithProviders(
+        <AnalyticsContent orgSlug={org.slug.replace(/^org-/, "")} />,
+      )
+
+      const button = await screen.findByRole("button", { name: "Show all 340" })
+      expect(button).toHaveAttribute("aria-busy", "false")
+
+      await user.click(button)
+
+      await screen.findByText("Showing 3 of 340 rows.")
+    })
+
+    /**
      * The API applies its LIMIT in SQL and drops sub-floor rows afterwards, so
      * a page of `total_count` rows can still come back short — permanently.
      * Asking again would resend the same limit and change nothing, so the
@@ -505,16 +546,17 @@ describe("AnalyticsContent", () => {
       setAnalyticsResponses()
       setMockResponse.get(
         analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 200 }),
-        analyticsFactories.envelope(courseRows(188), {
+        analyticsFactories.envelope(courseRows(2), {
           as_of: AS_OF,
           total_count: 340,
         }),
       )
-      // Asked for 340, got 328: the other 12 were dropped by the floor after
-      // the LIMIT had already been applied.
+      // Asked for all 340 and got 3 back: the rest were dropped by the floor
+      // after the LIMIT had already been applied. (Tiny counts on purpose — see
+      // the note in the busy/announce test.)
       setMockResponse.get(
         analyticsUrls.organizations.enrollmentFunnel(ORG_UUID, { limit: 340 }),
-        analyticsFactories.envelope(courseRows(328), {
+        analyticsFactories.envelope(courseRows(3), {
           as_of: AS_OF,
           total_count: 340,
         }),
@@ -529,7 +571,7 @@ describe("AnalyticsContent", () => {
         await screen.findByRole("button", { name: "Show all 340" }),
       )
 
-      await screen.findByText("Showing 328 of 340.")
+      await screen.findByText("Showing 3 of 340.")
       expect(
         screen.queryByRole("button", { name: /Show all/ }),
       ).not.toBeInTheDocument()

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -220,16 +220,20 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
     if (!query.data) return null
     const { total_count: total } = query.data
     const shown = query.data.data.length
+    const nextLimit = Math.min(total, MAX_PAGE_SIZE)
     return (
       <SectionTruncation
         shown={shown}
         total={total}
-        canShowAll={limits[key] < MAX_PAGE_SIZE}
+        // Offer the button only when it would actually ask for more than we
+        // already did. Two ways it would not: the section is at the API's cap,
+        // or it already requested `total` rows and got back fewer because the
+        // API applies its LIMIT before the anonymity floor drops sub-floor rows
+        // — so a page of `total` can still come back short, permanently. Either
+        // way the message stands alone rather than offering a no-op click.
+        canShowAll={nextLimit > limits[key]}
         onShowAll={() =>
-          setLimits((current) => ({
-            ...current,
-            [key]: Math.min(total, MAX_PAGE_SIZE),
-          }))
+          setLimits((current) => ({ ...current, [key]: nextLimit }))
         }
       />
     )

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -1,0 +1,325 @@
+"use client"
+
+import React from "react"
+import Image from "next/image"
+import { useQueries, useQuery } from "@tanstack/react-query"
+import type { AxiosError } from "axios"
+import { useFeatureFlagEnabled } from "posthog-js/react"
+import { Skeleton, Stack, styled, Typography } from "ol-components"
+import { ButtonLink } from "@mitodl/smoot-design"
+import { managerOrganizationQueries } from "api/mitxonline-hooks/organizations"
+import { analyticsOrganizationQueries } from "api/analytics-hooks/organizations"
+import { isAnalyticsConfigured } from "api/runtime"
+import { matchOrganizationBySlug } from "@/common/utils"
+import { ForbiddenError } from "@/common/errors"
+import { FeatureFlags } from "@/common/feature_flags"
+import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
+import { contractAdminView } from "@/common/urls"
+import { ErrorContent } from "../ErrorPage/ErrorPageTemplate"
+import graduateLogo from "@/public/images/dashboard/graduate.png"
+import ContractKpiCards from "./Analytics/ContractKpiCards"
+import CoursePerformanceTable from "./Analytics/CoursePerformanceTable"
+import EngagementTrendChart from "./Analytics/EngagementTrendChart"
+import ProgramFunnelChart from "./Analytics/ProgramFunnelChart"
+import SectionHeader from "./Analytics/SectionHeader"
+import { getOrgUuid } from "./Analytics/orgUuid"
+
+/**
+ * Org-scoped B2B analytics, the reporting half of the org-manager dashboard
+ * whose other half is `ContractAdminPage` (seat administration). It reuses that
+ * page's layout, header and table primitives so the two read as one product.
+ *
+ * # Access
+ *
+ * Authorization is the analytics API's job, not this component's: it checks
+ * membership and org-manager status from the JWT that APISIX mints from the
+ * session cookie, and answers 403 otherwise. What this component does is
+ * resolve which org the caller means. It does so through MITx Online's
+ * *manager* org list — the same source `ContractAdminPage` uses — so a learner
+ * who is not a manager never gets as far as issuing an analytics request.
+ */
+
+/**
+ * No page container here: the `/dashboard` layout already renders children
+ * inside its own `Container` and sidebar grid column, so adding another would
+ * double the padding and fight the grid. `ContractContent` does the same.
+ */
+const HeaderSection = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "24px",
+  [theme.breakpoints.down("md")]: {
+    flexDirection: "column",
+    alignItems: "flex-start",
+  },
+}))
+
+const OrgDetailsContainer = styled.div({
+  display: "flex",
+  alignItems: "center",
+  gap: "24px",
+})
+
+const ImageContainer = styled.div(({ theme }) => ({
+  display: "flex",
+  width: "60px",
+  height: "60px",
+  padding: "8px",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+  borderRadius: "8px",
+  backgroundColor: theme.custom.colors.white,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  overflow: "hidden",
+  "> img": {
+    width: "100%",
+    height: "auto",
+  },
+}))
+
+const OrgName = styled(Typography)(({ theme }) => ({
+  ...theme.typography.h3,
+  color: theme.custom.colors.darkGray2,
+})) as typeof Typography
+
+const PageSubtitle = styled(Typography)(({ theme }) => ({
+  ...theme.typography.subtitle1,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const Section = styled.section({
+  display: "flex",
+  flexDirection: "column",
+  gap: "16px",
+})
+
+const Notice = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  backgroundColor: theme.custom.colors.lightGray1,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "24px",
+})) as typeof Typography
+
+/**
+ * These views are small per org (contracts, programs, a couple of years of
+ * months), but the API caps every list endpoint, so ask for a page big enough
+ * that no org is silently truncated at the default.
+ */
+const PAGE_SIZE = 200
+
+/**
+ * Note there is no 401/403 branch for the analytics queries themselves. The
+ * browser query client (`makeBrowserQueryClient`) sets `throwOnError` for 400,
+ * 401 and 403, so a caller the analytics API rejects never reaches an
+ * `isError` branch here at all — the error is thrown to the route's error
+ * boundary, which is where every other page's access denial is handled too.
+ * Only the remaining statuses (5xx, network) surface as `isError` below, and
+ * those mean "could not load", not "not allowed".
+ */
+const isForbidden = (error: unknown) => {
+  const status = (error as AxiosError | null)?.response?.status
+  return status === 401 || status === 403
+}
+
+type AnalyticsContentInternalProps = {
+  orgSlug: string
+}
+
+const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
+  orgSlug,
+}) => {
+  const {
+    data: managerOrgs,
+    isLoading: isLoadingOrgs,
+    isError: isOrgsError,
+    error: orgsError,
+  } = useQuery(managerOrganizationQueries.managerOrganizationsList())
+
+  const org = managerOrgs?.find(matchOrganizationBySlug(orgSlug))
+  const orgUuid = getOrgUuid(org)
+  const analyticsAvailable = isAnalyticsConfigured() && !!orgUuid
+
+  // One query per endpoint, each backed by its own materialized view with its
+  // own refresh time, so sections load and report freshness independently.
+  // Spelled out as a literal tuple rather than built with `.map` so useQueries
+  // keeps each entry's own result type instead of widening them to `unknown`.
+  const page = { limit: PAGE_SIZE }
+  const [utilization, trend, courses, programs] = useQueries({
+    queries: [
+      {
+        ...analyticsOrganizationQueries.contractUtilization(
+          orgUuid ?? "",
+          page,
+        ),
+        enabled: analyticsAvailable,
+      },
+      {
+        ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", page),
+        enabled: analyticsAvailable,
+      },
+      {
+        ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", page),
+        enabled: analyticsAvailable,
+      },
+      {
+        ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", page),
+        enabled: analyticsAvailable,
+      },
+    ],
+  })
+
+  if (isLoadingOrgs) {
+    return <Skeleton width="100%" height="128px" />
+  }
+
+  if (isOrgsError) {
+    return isForbidden(orgsError) ? (
+      <ErrorContent title="Access denied" timSays="403" />
+    ) : (
+      <ErrorContent title="Something went wrong" timSays="Oops!" />
+    )
+  }
+
+  // Not in the manager org list means not an org manager for this org — the
+  // same 403 the contract admin page gives, decided before any analytics call.
+  if (!org) {
+    return <ErrorContent title="Access denied" timSays="403" />
+  }
+
+  const firstContractSlug = org.contracts[0]?.slug
+
+  const header = (
+    <HeaderSection>
+      <OrgDetailsContainer>
+        <ImageContainer>
+          <Image width={60} height={60} src={org.logo ?? graduateLogo} alt="" />
+        </ImageContainer>
+        <div>
+          <OrgName component="h1">{org.name}</OrgName>
+          <PageSubtitle>Analytics</PageSubtitle>
+        </div>
+      </OrgDetailsContainer>
+      {firstContractSlug ? (
+        <ButtonLink
+          size="small"
+          variant="bordered"
+          href={contractAdminView(orgSlug, firstContractSlug)}
+        >
+          Manage seats
+        </ButtonLink>
+      ) : null}
+    </HeaderSection>
+  )
+
+  if (!analyticsAvailable) {
+    return (
+      <Stack gap="24px">
+        {header}
+        <Notice>
+          {isAnalyticsConfigured()
+            ? // The org record has no Keycloak organization UUID, which is
+              // what the analytics API keys on. Nothing the manager can fix.
+              "Analytics is not available for this organization yet. Please contact support if you expect to see data here."
+            : "Analytics is not available in this environment."}
+        </Notice>
+      </Stack>
+    )
+  }
+
+  const failed = [utilization, trend, courses, programs].some(
+    (query) => query.isError,
+  )
+
+  return (
+    <Stack gap="40px" width="100%">
+      {header}
+
+      {failed ? (
+        <Notice>
+          Some analytics could not be loaded. The figures below may be
+          incomplete.
+        </Notice>
+      ) : null}
+
+      <Section>
+        <SectionHeader
+          title="Contract utilization"
+          description="Seats consumed and learner outcomes for each contract."
+          asOf={utilization.data?.as_of}
+          isLoading={utilization.isPending}
+        />
+        <ContractKpiCards
+          rows={utilization.data?.data}
+          isLoading={utilization.isPending}
+        />
+      </Section>
+
+      <Section>
+        <SectionHeader
+          title="Monthly engagement"
+          description="Distinct learners active, newly enrolled, and certified each month."
+          asOf={trend.data?.as_of}
+          isLoading={trend.isPending}
+        />
+        <EngagementTrendChart
+          rows={trend.data?.data}
+          isLoading={trend.isPending}
+        />
+      </Section>
+
+      <Section>
+        <SectionHeader
+          title="Course performance"
+          description="Enrollment, activity and completion for each course run."
+          asOf={courses.data?.as_of}
+          isLoading={courses.isPending}
+        />
+        <CoursePerformanceTable
+          rows={courses.data?.data}
+          isLoading={courses.isPending}
+        />
+      </Section>
+
+      <Section>
+        <SectionHeader
+          title="Program funnel"
+          description="How far learners progress through each program."
+          asOf={programs.data?.as_of}
+          isLoading={programs.isPending}
+        />
+        <ProgramFunnelChart
+          rows={programs.data?.data}
+          isLoading={programs.isPending}
+        />
+      </Section>
+    </Stack>
+  )
+}
+
+type AnalyticsContentProps = {
+  orgSlug: string
+}
+
+const AnalyticsContent: React.FC<AnalyticsContentProps> = ({ orgSlug }) => {
+  const flagEnabled = useFeatureFlagEnabled(FeatureFlags.B2BAnalyticsDashboard)
+  const flagsLoaded = useFeatureFlagsLoaded()
+
+  // The whole page is behind the flag, so wait for the real value rather than
+  // 403-ing on a bootstrapped `false` — same reasoning as ContractAdminPage.
+  if (!flagsLoaded) {
+    return <Skeleton width="100%" height="128px" />
+  }
+
+  if (!flagEnabled) {
+    throw new ForbiddenError("Not enabled.")
+  }
+
+  return <AnalyticsContentInternal orgSlug={orgSlug} />
+}
+
+export default AnalyticsContent
+export type { AnalyticsContentProps }

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import Image from "next/image"
-import { keepPreviousData, useQueries, useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { Skeleton, Stack, styled, Typography } from "ol-components"
@@ -168,43 +168,41 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
 
   // One query per endpoint, each backed by its own materialized view with its
   // own refresh time, so sections load and report freshness independently.
-  // Spelled out as a literal tuple rather than built with `.map` so useQueries
-  // keeps each entry's own result type instead of widening them to `unknown`.
   //
-  // `keepPreviousData` matters on the "Show all" path: the limit is part of the
-  // query key, so without it the section a manager just asked to expand would
-  // blank back to its skeleton before returning with more rows.
-  const [utilization, trend, courses, programs] = useQueries({
-    queries: [
-      {
-        ...analyticsOrganizationQueries.contractUtilization(orgUuid ?? "", {
-          limit: limits.utilization,
-        }),
-        enabled: analyticsAvailable,
-        placeholderData: keepPreviousData,
-      },
-      {
-        ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", {
-          limit: limits.trend,
-        }),
-        enabled: analyticsAvailable,
-        placeholderData: keepPreviousData,
-      },
-      {
-        ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", {
-          limit: limits.courses,
-        }),
-        enabled: analyticsAvailable,
-        placeholderData: keepPreviousData,
-      },
-      {
-        ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", {
-          limit: limits.programs,
-        }),
-        enabled: analyticsAvailable,
-        placeholderData: keepPreviousData,
-      },
-    ],
+  // Four `useQuery` calls rather than one `useQueries`, which is what this was
+  // originally. `placeholderData: keepPreviousData` is silently inert under
+  // `useQueries` here — on a limit change the result went straight to
+  // `data: undefined`, so the section a manager had just asked to expand blanked
+  // back to its skeleton, which is exactly what the option was there to prevent.
+  // It behaves as documented on `useQuery` (as it does on ContractAdminPage).
+  // The count is fixed and the order never changes, so this is hook-safe.
+  const utilization = useQuery({
+    ...analyticsOrganizationQueries.contractUtilization(orgUuid ?? "", {
+      limit: limits.utilization,
+    }),
+    enabled: analyticsAvailable,
+    placeholderData: keepPreviousData,
+  })
+  const trend = useQuery({
+    ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", {
+      limit: limits.trend,
+    }),
+    enabled: analyticsAvailable,
+    placeholderData: keepPreviousData,
+  })
+  const courses = useQuery({
+    ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", {
+      limit: limits.courses,
+    }),
+    enabled: analyticsAvailable,
+    placeholderData: keepPreviousData,
+  })
+  const programs = useQuery({
+    ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", {
+      limit: limits.programs,
+    }),
+    enabled: analyticsAvailable,
+    placeholderData: keepPreviousData,
   })
 
   /**
@@ -214,7 +212,10 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
    * since a button that cannot deliver the rest would be worse than none.
    */
   const truncation = (
-    query: { data?: { total_count: number; data: unknown[] } },
+    query: {
+      data?: { total_count: number; data: unknown[] }
+      isPlaceholderData: boolean
+    },
     key: SectionKey,
   ) => {
     if (!query.data) return null
@@ -225,6 +226,10 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
       <SectionTruncation
         shown={shown}
         total={total}
+        // `isPlaceholderData` is precisely "a differently-keyed query is in
+        // flight and these rows are the previous ones" — which is the state a
+        // manager cannot otherwise perceive, since the table does not blank.
+        isExpanding={query.isPlaceholderData}
         // Offer the button only when it would actually ask for more than we
         // already did. Two ways it would not: the section is at the API's cap,
         // or it already requested `total` rows and got back fewer because the

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -251,10 +251,12 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           description="Seats consumed and learner outcomes for each contract."
           asOf={utilization.data?.as_of}
           isLoading={utilization.isPending}
+          isError={utilization.isError}
         />
         <ContractKpiCards
           rows={utilization.data?.data}
           isLoading={utilization.isPending}
+          isError={utilization.isError}
         />
       </Section>
 
@@ -264,10 +266,12 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           description="Distinct learners active, newly enrolled, and certified each month."
           asOf={trend.data?.as_of}
           isLoading={trend.isPending}
+          isError={trend.isError}
         />
         <EngagementTrendChart
           rows={trend.data?.data}
           isLoading={trend.isPending}
+          isError={trend.isError}
         />
       </Section>
 
@@ -277,10 +281,12 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           description="Enrollment, activity and completion for each course run."
           asOf={courses.data?.as_of}
           isLoading={courses.isPending}
+          isError={courses.isError}
         />
         <CoursePerformanceTable
           rows={courses.data?.data}
           isLoading={courses.isPending}
+          isError={courses.isError}
         />
       </Section>
 
@@ -290,10 +296,12 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           description="How far learners progress through each program."
           asOf={programs.data?.as_of}
           isLoading={programs.isPending}
+          isError={programs.isError}
         />
         <ProgramFunnelChart
           rows={programs.data?.data}
           isLoading={programs.isPending}
+          isError={programs.isError}
         />
       </Section>
     </Stack>

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -2,7 +2,7 @@
 
 import React from "react"
 import Image from "next/image"
-import { useQueries, useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQueries, useQuery } from "@tanstack/react-query"
 import type { AxiosError } from "axios"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { Skeleton, Stack, styled, Typography } from "ol-components"
@@ -22,6 +22,7 @@ import CoursePerformanceTable from "./Analytics/CoursePerformanceTable"
 import EngagementTrendChart from "./Analytics/EngagementTrendChart"
 import ProgramFunnelChart from "./Analytics/ProgramFunnelChart"
 import SectionHeader from "./Analytics/SectionHeader"
+import SectionTruncation from "./Analytics/SectionTruncation"
 import { getOrgUuid } from "./Analytics/orgUuid"
 
 /**
@@ -107,9 +108,22 @@ const Notice = styled(Typography)(({ theme }) => ({
 /**
  * These views are small per org (contracts, programs, a couple of years of
  * months), but the API caps every list endpoint, so ask for a page big enough
- * that no org is silently truncated at the default.
+ * that no org is truncated at the default.
+ *
+ * "Big enough" is not "always enough", though, which is why every section
+ * compares what it rendered against the envelope's `total_count` and says so
+ * when it is showing a subset — see `SectionTruncation`.
  */
 const PAGE_SIZE = 200
+
+/**
+ * The analytics API's own `max_page_size`; it answers 422 above this. Caps what
+ * "Show all" is allowed to ask for, so the button never issues a request the
+ * API will reject.
+ */
+const MAX_PAGE_SIZE = 1000
+
+type SectionKey = "utilization" | "trend" | "courses" | "programs"
 
 /**
  * Note there is no 401/403 branch for the analytics queries themselves. The
@@ -143,34 +157,83 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
   const orgUuid = getOrgUuid(org)
   const analyticsAvailable = isAnalyticsConfigured() && !!orgUuid
 
+  // Per-section page size. Raised only by that section's "Show all", so
+  // expanding a truncated course table never refetches the other three.
+  const [limits, setLimits] = React.useState<Record<SectionKey, number>>({
+    utilization: PAGE_SIZE,
+    trend: PAGE_SIZE,
+    courses: PAGE_SIZE,
+    programs: PAGE_SIZE,
+  })
+
   // One query per endpoint, each backed by its own materialized view with its
   // own refresh time, so sections load and report freshness independently.
   // Spelled out as a literal tuple rather than built with `.map` so useQueries
   // keeps each entry's own result type instead of widening them to `unknown`.
-  const page = { limit: PAGE_SIZE }
+  //
+  // `keepPreviousData` matters on the "Show all" path: the limit is part of the
+  // query key, so without it the section a manager just asked to expand would
+  // blank back to its skeleton before returning with more rows.
   const [utilization, trend, courses, programs] = useQueries({
     queries: [
       {
-        ...analyticsOrganizationQueries.contractUtilization(
-          orgUuid ?? "",
-          page,
-        ),
+        ...analyticsOrganizationQueries.contractUtilization(orgUuid ?? "", {
+          limit: limits.utilization,
+        }),
         enabled: analyticsAvailable,
+        placeholderData: keepPreviousData,
       },
       {
-        ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", page),
+        ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", {
+          limit: limits.trend,
+        }),
         enabled: analyticsAvailable,
+        placeholderData: keepPreviousData,
       },
       {
-        ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", page),
+        ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", {
+          limit: limits.courses,
+        }),
         enabled: analyticsAvailable,
+        placeholderData: keepPreviousData,
       },
       {
-        ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", page),
+        ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", {
+          limit: limits.programs,
+        }),
         enabled: analyticsAvailable,
+        placeholderData: keepPreviousData,
       },
     ],
   })
+
+  /**
+   * The truncation footer for one section, or null when it is showing
+   * everything. "Show all" asks for the whole result set in a single page,
+   * bounded by what the API will serve — beyond that the message stands alone,
+   * since a button that cannot deliver the rest would be worse than none.
+   */
+  const truncation = (
+    query: { data?: { total_count: number; data: unknown[] } },
+    key: SectionKey,
+  ) => {
+    if (!query.data) return null
+    const { total_count: total } = query.data
+    const shown = query.data.data.length
+    return (
+      <SectionTruncation
+        shown={shown}
+        total={total}
+        canShowAll={limits[key] < MAX_PAGE_SIZE}
+        onShowAll={() =>
+          setLimits((current) => ({
+            ...current,
+            [key]: Math.min(total, MAX_PAGE_SIZE),
+          }))
+        }
+      />
+    )
+  }
 
   if (isLoadingOrgs) {
     return <Skeleton width="100%" height="128px" />
@@ -258,6 +321,7 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           isLoading={utilization.isPending}
           isError={utilization.isError}
         />
+        {truncation(utilization, "utilization")}
       </Section>
 
       <Section>
@@ -273,6 +337,7 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           isLoading={trend.isPending}
           isError={trend.isError}
         />
+        {truncation(trend, "trend")}
       </Section>
 
       <Section>
@@ -288,6 +353,7 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           isLoading={courses.isPending}
           isError={courses.isError}
         />
+        {truncation(courses, "courses")}
       </Section>
 
       <Section>
@@ -303,6 +369,7 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           isLoading={programs.isPending}
           isError={programs.isError}
         />
+        {truncation(programs, "programs")}
       </Section>
     </Stack>
   )

--- a/frontends/main/src/app/(site)/dashboard/organization/[orgSlug]/analytics/page.tsx
+++ b/frontends/main/src/app/(site)/dashboard/organization/[orgSlug]/analytics/page.tsx
@@ -1,0 +1,11 @@
+import React from "react"
+import AnalyticsContent from "@/app-pages/DashboardPage/AnalyticsContent"
+
+const Page: React.FC<
+  PageProps<"/dashboard/organization/[orgSlug]/analytics">
+> = async ({ params }) => {
+  const resolved = await params
+  return <AnalyticsContent orgSlug={resolved.orgSlug} />
+}
+
+export default Page

--- a/frontends/main/src/bootstrap/api.ts
+++ b/frontends/main/src/bootstrap/api.ts
@@ -20,6 +20,12 @@ export const bootstrapApiClients = () => {
   const withCredentials =
     env("NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS") === "true"
 
+  // The analytics API is not deployed to every environment yet, so its base URL
+  // is optional: when it is absent we leave that client unconfigured and the
+  // org analytics dashboard reports itself unavailable, rather than failing
+  // startup for every environment that does not have the service.
+  const analyticsBaseUrl = env("NEXT_PUBLIC_ANALYTICS_API_BASE_URL")
+
   configureApiClients({
     learn: {
       baseUrl: learnBaseUrl,
@@ -31,5 +37,15 @@ export const bootstrapApiClients = () => {
       csrfCookieName: requiredEnv("NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME"),
       withCredentials,
     },
+    ...(analyticsBaseUrl && {
+      analytics: {
+        baseUrl: analyticsBaseUrl,
+        // The analytics API is read-only (GET only), so there is no CSRF
+        // exchange to take part in; it shares learn's cookie name so axios
+        // still sends the header if a mutating endpoint is ever added.
+        csrfCookieName: requiredEnv("NEXT_PUBLIC_CSRF_COOKIE_NAME"),
+        withCredentials,
+      },
+    }),
   })
 }

--- a/frontends/main/src/common/feature_flags.ts
+++ b/frontends/main/src/common/feature_flags.ts
@@ -13,6 +13,7 @@ export enum FeatureFlags {
   OcwProductPages = "ocw-product-pages",
   VideoPlaylistPage = "video-playlist-page",
   B2BContractManagerDashboard = "b2b-contract-manager-dashboard",
+  B2BAnalyticsDashboard = "b2b-analytics-dashboard",
   Arithmix = "arithmix",
   Hacksnack = "hacksnack",
 }

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -103,6 +103,14 @@ export const CONTRACT_ADMIN_VIEW =
   "/organization/[orgSlug]/contract/[contractSlug]/admin"
 export const contractAdminView = (orgSlug: string, contractSlug: string) =>
   generatePath(CONTRACT_ADMIN_VIEW, { orgSlug, contractSlug })
+/**
+ * B2B analytics is org-scoped, not contract-scoped: the underlying materialized
+ * views are keyed on the organization and break out contracts as rows.
+ */
+export const ORGANIZATION_ANALYTICS_VIEW =
+  "/dashboard/organization/[orgSlug]/analytics"
+export const organizationAnalyticsView = (orgSlug: string) =>
+  generatePath(ORGANIZATION_ANALYTICS_VIEW, { orgSlug })
 export const PROGRAM_VIEW = "/dashboard/program/[id]"
 export const programView = (id: number) =>
   generatePath(PROGRAM_VIEW, { id: String(id) })

--- a/frontends/main/src/components/B2BTable/B2BTable.tsx
+++ b/frontends/main/src/components/B2BTable/B2BTable.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { styled, Typography } from "ol-components"
+
+/**
+ * The table primitives of the B2B org-manager dashboard, shared by the contract
+ * admin page and the org analytics dashboard so the two read as one product.
+ *
+ * These are ARIA-role tables built from `div`s rather than `<table>`: below the
+ * `md` breakpoint the header row is hidden and each row reflows into a stack of
+ * label/value pairs (see `MobileLabel`), which a real `<table>` cannot do
+ * without losing its own semantics. Callers supply `role="table"`,
+ * `role="row"`, `role="columnheader"` and `role="cell"` — the roles are not
+ * baked in here because the same visual row is sometimes a header and
+ * sometimes not.
+ *
+ * `$flex` sets each column's share of the row on desktop; every cell in a
+ * column must be given the same value, so callers keep a `COLUMN_FLEX` map
+ * rather than repeating numbers.
+ */
+
+const TableCard = styled.div(({ theme }) => ({
+  backgroundColor: theme.custom.colors.white,
+  border: `1px solid ${theme.custom.colors.lightGray2}`,
+  borderRadius: "8px",
+  padding: "24px",
+  [theme.breakpoints.down("md")]: {
+    padding: "16px",
+  },
+}))
+
+const TableHeaderRow = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: "16px",
+  alignItems: "center",
+  paddingBottom: "16px",
+  borderBottom: `1px solid ${theme.custom.colors.silverGrayDark}`,
+  [theme.breakpoints.down("md")]: {
+    display: "none",
+  },
+}))
+
+const TableHeaderCell = styled("div", {
+  shouldForwardProp: (prop) => prop !== "$flex" && prop !== "$numeric",
+})<{ $flex: number; $numeric?: boolean }>(({ $flex, $numeric, theme }) => ({
+  flex: $flex,
+  minWidth: 0,
+  ...theme.typography.subtitle2,
+  color: theme.custom.colors.black,
+  ...($numeric && { textAlign: "right" }),
+}))
+
+const TableRow = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: "16px",
+  alignItems: "center",
+  padding: "14px 0",
+  borderBottom: `1px solid ${theme.custom.colors.silverGrayLight}`,
+  "&:last-child": {
+    borderBottom: "none",
+  },
+  [theme.breakpoints.down("md")]: {
+    position: "relative",
+    flexWrap: "wrap",
+    gap: "6px 0",
+    padding: "16px 40px 16px 0",
+  },
+}))
+
+const MobileLabel = styled.span(({ theme }) => ({
+  display: "none",
+  [theme.breakpoints.down("md")]: {
+    display: "inline",
+    ...theme.typography.subtitle2,
+    color: theme.custom.colors.darkGray2,
+    minWidth: "120px",
+    flexShrink: 0,
+  },
+}))
+
+const TableCell = styled("div", {
+  shouldForwardProp: (prop) =>
+    prop !== "$flex" && prop !== "$primary" && prop !== "$numeric",
+})<{ $flex: number; $primary?: boolean; $numeric?: boolean }>(
+  ({ $flex, $primary, $numeric, theme }) => ({
+    flex: $flex,
+    minWidth: 0,
+    ...theme.typography.body2,
+    color: theme.custom.colors.black,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    ...($numeric && {
+      textAlign: "right",
+      // Digits line up column-wise only if they share an advance width.
+      fontVariantNumeric: "tabular-nums",
+    }),
+    [theme.breakpoints.down("md")]: {
+      flex: "none",
+      width: "100%",
+      display: "flex",
+      alignItems: "center",
+      gap: "8px",
+      overflow: "visible",
+      whiteSpace: "normal",
+      // Stacked rows read as "label: value" pairs, so the desktop right-align
+      // would strand the value away from its label.
+      textAlign: "left",
+      ...($primary && {
+        ...theme.typography.subtitle2,
+        marginBottom: "4px",
+      }),
+    },
+  }),
+)
+
+const TableFooter = styled.div({
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  paddingTop: "16px",
+})
+
+const TableFootnote = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+})) as typeof Typography
+
+const EmptyTableMessage = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  padding: "32px 0",
+  textAlign: "center",
+})) as typeof Typography
+
+/** Placeholder for a value the API did not return. */
+const STUB = "—"
+
+export {
+  EmptyTableMessage,
+  MobileLabel,
+  STUB,
+  TableCard,
+  TableCell,
+  TableFooter,
+  TableFootnote,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRow,
+}

--- a/frontends/main/src/test-utils/setupJest.tsx
+++ b/frontends/main/src/test-utils/setupJest.tsx
@@ -23,6 +23,7 @@ const { configureApiClients } = jest.requireActual("api/runtime")
 // don't need them.
 const LEARN_BASE_URL = "http://api.test.learn.odl.local:8065"
 const MITX_ONLINE_BASE_URL = "http://api.test.learn.odl.local:8065/mitxonline"
+const ANALYTICS_BASE_URL = "http://api.test.learn.odl.local:8065/analytics"
 
 process.env.NEXT_PUBLIC_ORIGIN = "http://test.learn.odl.local:8062"
 process.env.NEXT_PUBLIC_VERSION = "test-version"
@@ -30,6 +31,7 @@ process.env.NEXT_PUBLIC_MITOL_API_BASE_URL = LEARN_BASE_URL
 process.env.NEXT_PUBLIC_MITX_ONLINE_BASE_URL = MITX_ONLINE_BASE_URL
 process.env.NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL =
   "http://mitxonline.odl.local:8065"
+process.env.NEXT_PUBLIC_ANALYTICS_API_BASE_URL = ANALYTICS_BASE_URL
 
 configureApiClients({
   learn: {
@@ -40,6 +42,11 @@ configureApiClients({
   mitxonline: {
     baseUrl: MITX_ONLINE_BASE_URL,
     csrfCookieName: "mitxcsrftoken",
+    withCredentials: false,
+  },
+  analytics: {
+    baseUrl: ANALYTICS_BASE_URL,
+    csrfCookieName: "csrftoken",
     withCredentials: false,
   },
 })

--- a/frontends/main/validateEnv.js
+++ b/frontends/main/validateEnv.js
@@ -60,6 +60,10 @@ const schema = yup.object().shape({
   NEXT_PUBLIC_SENTRY_ENV: yup.string(),
   NEXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE: yup.string(),
   NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: yup.string(),
+  // Base URL of the OL Analytics API (ol-analytics-api). Optional: environments
+  // without an analytics deployment simply do not surface the org analytics
+  // dashboard — see isAnalyticsConfigured() in api/runtime.
+  NEXT_PUBLIC_ANALYTICS_API_BASE_URL: yup.string(),
   NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT: yup.string(),
   NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT: yup.string(),
   NEXT_PUBLIC_LEARN_AI_CSRF_COOKIE_NAME: yup.string(),

--- a/frontends/ol-components/src/index.ts
+++ b/frontends/ol-components/src/index.ts
@@ -4,7 +4,7 @@
 
 export { default as styled } from "@emotion/styled"
 export { css, Global } from "@emotion/react"
-export { alpha } from "@mui/material/styles"
+export { alpha, useTheme } from "@mui/material/styles"
 
 /**
  * Re-exports from MUI.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,6 +1739,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.28.6":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10/9883b4951787779fd382b121f22f92966d85f19434841f65fb00b2dfec232107e139683f47c6f252891826ad8ee18317b46c3a0e4819116a9885f47b46d7126a
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.25.7, @babel/template@npm:^7.3.3":
   version: 7.25.7
   resolution: "@babel/template@npm:7.25.7"
@@ -3646,6 +3653,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mui/types@npm:^7.4.12":
+  version: 7.4.12
+  resolution: "@mui/types@npm:7.4.12"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/343de29414643f8cda26c473d2f1a2a8ca702bd41edbfc5db0cc31aed73ccbb74c5c1ab729c4cd1dac2c1ea481300b547ba37dabb86891d96fc5254bc9993a30
+  languageName: node
+  linkType: hard
+
 "@mui/types@npm:~7.2.24":
   version: 7.2.24
   resolution: "@mui/types@npm:7.2.24"
@@ -3695,6 +3716,110 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/8b4110df220c7a3f4feee4e88b870fef20ac22499d24d572597f78ea6b586e28b19aac7f7cd2ed0b500d1b0b54b3b8b57d8d63cfa4f5a5cbae1c4527fbd77cbe
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^7.3.5":
+  version: 7.3.11
+  resolution: "@mui/utils@npm:7.3.11"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.6"
+    "@mui/types": "npm:^7.4.12"
+    "@types/prop-types": "npm:^15.7.15"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    react-is: "npm:^19.2.3"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0 || ^19.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/d2a595f1767483434345b3f9f5ded22cf260b3ff9f32762c560d559b203218bf003b32065d5727dcc16c25b5dba171eac869b3d738e222dcd4979aa85e22b84b
+  languageName: node
+  linkType: hard
+
+"@mui/x-charts-vendor@npm:8.29.0":
+  version: 8.29.0
+  resolution: "@mui/x-charts-vendor@npm:8.29.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@types/d3-array": "npm:^3.2.2"
+    "@types/d3-color": "npm:^3.1.3"
+    "@types/d3-format": "npm:^3.0.4"
+    "@types/d3-interpolate": "npm:^3.0.4"
+    "@types/d3-path": "npm:^3.1.1"
+    "@types/d3-scale": "npm:^4.0.9"
+    "@types/d3-shape": "npm:^3.1.8"
+    "@types/d3-time": "npm:^3.0.4"
+    "@types/d3-time-format": "npm:^4.0.3"
+    "@types/d3-timer": "npm:^3.0.2"
+    d3-array: "npm:^3.2.4"
+    d3-color: "npm:^3.1.0"
+    d3-format: "npm:^3.1.2"
+    d3-interpolate: "npm:^3.0.1"
+    d3-path: "npm:^3.1.0"
+    d3-scale: "npm:^4.0.2"
+    d3-shape: "npm:^3.2.0"
+    d3-time: "npm:^3.1.0"
+    d3-time-format: "npm:^4.1.0"
+    d3-timer: "npm:^3.0.1"
+    flatqueue: "npm:^3.0.0"
+    internmap: "npm:^2.0.3"
+  checksum: 10/6ae80d66895f24f8c175a582f035bbe593fe665b8734581e7e419c3dd8ad409ab680f4b3f71fc3531c6f83ae948afb678c5ff6de45c73497411f7db122e07589
+  languageName: node
+  linkType: hard
+
+"@mui/x-charts@npm:^8.29.2":
+  version: 8.29.2
+  resolution: "@mui/x-charts@npm:8.29.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@mui/utils": "npm:^7.3.5"
+    "@mui/x-charts-vendor": "npm:8.29.0"
+    "@mui/x-internal-gestures": "npm:0.5.0"
+    "@mui/x-internals": "npm:8.29.2"
+    bezier-easing: "npm:^2.1.0"
+    clsx: "npm:^2.1.1"
+    prop-types: "npm:^15.8.1"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@emotion/react": ^11.9.0
+    "@emotion/styled": ^11.8.1
+    "@mui/material": ^5.15.14 || ^6.0.0 || ^7.0.0
+    "@mui/system": ^5.15.14 || ^6.0.0 || ^7.0.0
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@emotion/react":
+      optional: true
+    "@emotion/styled":
+      optional: true
+  checksum: 10/5258801191e8fe4c4963d59983662b21866e9945b049d9c9edede8c9b2906e685c2a92b915c623152d3dab9a7459d004cbc09be23d5fb5e29fc9b5b7475dbba0
+  languageName: node
+  linkType: hard
+
+"@mui/x-internal-gestures@npm:0.5.0":
+  version: 0.5.0
+  resolution: "@mui/x-internal-gestures@npm:0.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+  checksum: 10/f7b277a8058e7548eba14d97475f9e63a4d5eb08262f02db230062d1bdfc11a18b025385916adf7175d75f07c2f38ebb886795d69ab7279c55c3b84eaf8c2d93
+  languageName: node
+  linkType: hard
+
+"@mui/x-internals@npm:8.29.2":
+  version: 8.29.2
+  resolution: "@mui/x-internals@npm:8.29.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.28.4"
+    "@mui/utils": "npm:^7.3.5"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/6d09aca1e8788bb159277cef67ef999ad8641e8f464daad62f83c6eabe97378c3429d43a025b9e631fb5b0026e584f5c50ea05012256f16246b83e2d2ca0adad
   languageName: node
   linkType: hard
 
@@ -7300,6 +7425,82 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-array@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@types/d3-array@npm:3.2.2"
+  checksum: 10/1afebd05b688cafaaea295f765b409789f088b274b8a7ca40a4bc2b79760044a898e06a915f40bbc59cf39eabdd2b5d32e960b136fc025fd05c9a9d4435614c6
+  languageName: node
+  linkType: hard
+
+"@types/d3-color@npm:*, @types/d3-color@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 10/1cf0f512c09357b25d644ab01b54200be7c9b15c808333b0ccacf767fff36f17520b2fcde9dad45e1bd7ce84befad39b43da42b4fded57680fa2127006ca3ece
+  languageName: node
+  linkType: hard
+
+"@types/d3-format@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/d3-format@npm:3.0.4"
+  checksum: 10/b937ecd2712d4aa38d5b4f5daab9cc8a576383868be1809e046aec99eeb1f1798c139f2e862dc400a82494c763be46087d154891773417f8eb53c73762ba3eb8
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "npm:*"
+  checksum: 10/72a883afd52c91132598b02a8cdfced9e783c54ca7e4459f9e29d5f45d11fb33f2cabc844e42fd65ba6e28f2a931dcce1add8607d2f02ef6fb8ea5b83ae84127
+  languageName: node
+  linkType: hard
+
+"@types/d3-path@npm:*, @types/d3-path@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@types/d3-path@npm:3.1.1"
+  checksum: 10/0437994d45d852ecbe9c4484e5abe504cd48751796d23798b6d829503a15563fdd348d93ac44489ba9c656992d16157f695eb889d9ce1198963f8e1dbabb1266
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "@types/d3-scale@npm:4.0.9"
+  dependencies:
+    "@types/d3-time": "npm:*"
+  checksum: 10/2cae90a5e39252ae51388f3909ffb7009178582990462838a4edd53dd7e2e08121b38f0d2e1ac0e28e41167e88dea5b99e064ca139ba917b900a8020cf85362f
+  languageName: node
+  linkType: hard
+
+"@types/d3-shape@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "@types/d3-shape@npm:3.1.8"
+  dependencies:
+    "@types/d3-path": "npm:*"
+  checksum: 10/ebc161d49101d84409829fea516ba7ec71ad51a1e97438ca0fafc1c30b56b3feae802d220375323632723a338dda7237c652e831e0b53527a6222ab0d1bb7809
+  languageName: node
+  linkType: hard
+
+"@types/d3-time-format@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@types/d3-time-format@npm:4.0.3"
+  checksum: 10/9dfc1516502ac1c657d6024bdb88b6dc7e21dd7bff88f6187616cf9a0108250f63507a2004901ece4f97cc46602005a2ca2d05c6dbe53e8a0f6899bd60d4ff7a
+  languageName: node
+  linkType: hard
+
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/d3-time@npm:3.0.4"
+  checksum: 10/b1eb4255066da56023ad243fd4ae5a20462d73bd087a0297c7d49ece42b2304a4a04297568c604a38541019885b2bc35a9e0fd704fad218e9bc9c5f07dc685ce
+  languageName: node
+  linkType: hard
+
+"@types/d3-timer@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: 10/1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.12
   resolution: "@types/debug@npm:4.1.12"
@@ -9723,6 +9924,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bezier-easing@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "bezier-easing@npm:2.1.0"
+  checksum: 10/086dfd042ccf91c3a9de811b635381aa6580e9f83d1951ed4ce4d4007645d8f3cebd491cb6259719ce9320df213316b99dd8e39e78997944b1c252a1d4b424b5
+  languageName: node
+  linkType: hard
+
 "bidi-js@npm:^1.0.2, bidi-js@npm:^1.0.3":
   version: 1.0.3
   resolution: "bidi-js@npm:1.0.3"
@@ -10881,6 +11089,92 @@ __metadata:
   version: 5.1.0
   resolution: "currency-symbol-map@npm:5.1.0"
   checksum: 10/7f6a4c58af8dc0150568a32bc5baa5dd8481abe6ae28918c2d7ccd86e8bd7e9dfa08e3bdeeb256da5dffb9974a91c11ce430023bf47fd9a19ea6f126668a4a20
+  languageName: node
+  linkType: hard
+
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "d3-array@npm:3.2.4"
+  dependencies:
+    internmap: "npm:1 - 2"
+  checksum: 10/5800c467f89634776a5977f6dae3f4e127d91be80f1d07e3e6e35303f9de93e6636d014b234838eea620f7469688d191b3f41207a30040aab750a63c97ec1d7c
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3, d3-color@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 10/536ba05bfd9f4fcd6fa289b5974f5c846b21d186875684637e22bf6855e6aba93e24a2eb3712985c6af3f502fbbfa03708edb72f58142f626241a8a17258e545
+  languageName: node
+  linkType: hard
+
+"d3-format@npm:1 - 3, d3-format@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "d3-format@npm:3.1.2"
+  checksum: 10/811d913c2c7624cb0d2a8f0ccd7964c50945b3de3c7f7aa14c309fba7266a3ec53cbee8c05f6ad61b2b65b93e157c55a0e07db59bc3180c39dac52be8e841ab1
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: "npm:1 - 3"
+  checksum: 10/988d66497ef5c190cf64f8c80cd66e1e9a58c4d1f8932d776a8e3ae59330291795d5a342f5a97602782ccbef21a5df73bc7faf1f0dc46a5145ba6243a82a0f0e
+  languageName: node
+  linkType: hard
+
+"d3-path@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-path@npm:3.1.0"
+  checksum: 10/8e97a9ab4930a05b18adda64cf4929219bac913a5506cf8585631020253b39309549632a5cbeac778c0077994442ddaaee8316ee3f380e7baf7566321b84e76a
+  languageName: node
+  linkType: hard
+
+"d3-scale@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "d3-scale@npm:4.0.2"
+  dependencies:
+    d3-array: "npm:2.10.0 - 3"
+    d3-format: "npm:1 - 3"
+    d3-interpolate: "npm:1.2.0 - 3"
+    d3-time: "npm:2.1.1 - 3"
+    d3-time-format: "npm:2 - 4"
+  checksum: 10/e2dc4243586eae2a0fdf91de1df1a90d51dfacb295933f0ca7e9184c31203b01436bef69906ad40f1100173a5e6197ae753cb7b8a1a8fcfda43194ea9cad6493
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "d3-shape@npm:3.2.0"
+  dependencies:
+    d3-path: "npm:^3.1.0"
+  checksum: 10/2e861f4d4781ee8abd85d2b435f848d667479dcf01a4e0db3a06600a5bdeddedb240f88229ec7b3bf7fa300c2b3526faeaf7e75f9a24dbf4396d3cc5358ff39d
+  languageName: node
+  linkType: hard
+
+"d3-time-format@npm:2 - 4, d3-time-format@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "d3-time-format@npm:4.1.0"
+  dependencies:
+    d3-time: "npm:1 - 3"
+  checksum: 10/ffc0959258fbb90e3890bfb31b43b764f51502b575e87d0af2c85b85ac379120d246914d07fca9f533d1bcedc27b2841d308a00fd64848c3e2cad9eff5c9a0aa
+  languageName: node
+  linkType: hard
+
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-time@npm:3.1.0"
+  dependencies:
+    d3-array: "npm:2 - 3"
+  checksum: 10/c110bed295ce63e8180e45b82a9b0ba114d5f33ff315871878f209c1a6d821caa505739a2b07f38d1396637155b8e7372632dacc018e11fbe8ceef58f6af806d
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 10/004128602bb187948d72c7dc153f0f063f38ac7a584171de0b45e3a841ad2e17f1e40ad396a4af9cce5551b6ab4a838d5246d23492553843d9da4a4050a911e2
   languageName: node
   linkType: hard
 
@@ -13004,6 +13298,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flatqueue@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "flatqueue@npm:3.1.0"
+  checksum: 10/81604306afd52d35f34b89f50c84f3c6c44d1c4134007a83d665bb20b7a0c69e0fd0777f010b6fae8c87ba3bc394b9414980c25db6c497e5a8a3acae4b886b8d
+  languageName: node
+  linkType: hard
+
 "flatted@npm:^3.2.9, flatted@npm:^3.3.3":
   version: 3.3.3
   resolution: "flatted@npm:3.3.3"
@@ -14307,6 +14608,13 @@ __metadata:
     hasown: "npm:^2.0.2"
     side-channel: "npm:^1.1.0"
   checksum: 10/1d5219273a3dab61b165eddf358815eefc463207db33c20fcfca54717da02e3f492003757721f972fd0bf21e4b426cab389c5427b99ceea4b8b670dc88ee6d4a
+  languageName: node
+  linkType: hard
+
+"internmap@npm:1 - 2, internmap@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "internmap@npm:2.0.3"
+  checksum: 10/873e0e7fcfe32f999aa0997a0b648b1244508e56e3ea6b8259b5245b50b5eeb3853fba221f96692bd6d1def501da76c32d64a5cb22a0b26cdd9b445664f805e0
   languageName: node
   linkType: hard
 
@@ -16336,6 +16644,7 @@ __metadata:
     "@mui/base": "npm:5.0.0-beta.70"
     "@mui/material": "npm:^6.4.5"
     "@mui/material-nextjs": "npm:^6.4.3"
+    "@mui/x-charts": "npm:^8.29.2"
     "@opentelemetry/api": "npm:^1.9.1"
     "@opentelemetry/exporter-trace-otlp-http": "npm:^0.214.0"
     "@opentelemetry/resources": "npm:^2.6.1"
@@ -19892,6 +20201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reselect@npm:^5.1.1":
+  version: 5.2.0
+  resolution: "reselect@npm:5.2.0"
+  checksum: 10/e53d37a35f84132682b0a819d942ff7debea90fe126f4bb5eef0f21b1f48f45dec89d27990f2ef5865f5e05d64bb88fb41e4341eb276674aee6f1f7f7362c3e8
+  languageName: node
+  linkType: hard
+
 "resize-observer-polyfill@npm:^1.5.0":
   version: 1.5.1
   resolution: "resize-observer-polyfill@npm:1.5.1"
@@ -23065,7 +23381,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.5.0":
+"use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:


### PR DESCRIPTION
### What are the relevant tickets?

N/A — no GitHub issue. This is the frontend piece of the B2B self-serve analytics work.

**Related PRs, and the required deploy order:**

1. [mitodl/mitxonline#3789](https://github.com/mitodl/mitxonline/pull/3789) — exposes `sso_organization_id` on `OrganizationPageSerializer` and adds the `?sso_organization_id=` filter to the manager org endpoint. **Must deploy first.**
2. [mitodl/ol-analytics-api#13](https://github.com/mitodl/ol-analytics-api/pull/13) — keys the org endpoints on the Keycloak org UUID. Deploying this before #3789 fails open: an older manager endpoint ignores the unknown filter param and returns *all* of the caller's managed orgs.
3. This PR — safe to merge at any point; the dashboard is behind a feature flag and reports itself unavailable until the API exists.

Identifier analysis: [mitodl/hq#11845](https://github.com/mitodl/hq/issues/11845).

### Description (What does it do?)

Adds the **reporting** half of the B2B org-manager dashboard, alongside the seat-administration half that already exists in [`ContractAdminPage`](https://github.com/mitodl/mit-learn/blob/main/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx). Four sections at `/dashboard/organization/[orgSlug]/analytics`, each backed by one of `ol-analytics-api`'s org-scoped materialized views:

| Section | Endpoint | Backing view |
|---|---|---|
| Contract utilization (KPI cards) | `/contract-utilization` | `mv_b2b_contract_utilization` |
| Monthly engagement (line chart) | `/engagement-trend` | `mv_b2b_monthly_engagement_trend` |
| Course performance (table) | `/enrollment-funnel` | `mv_b2b_enrollment_completion_funnel` |
| Program funnel (bars + table) | `/program-funnel` | `mv_b2b_program_funnel` |

A query factory for the fifth endpoint (`/content-engagement`) is included; its panel is deliberately out of scope for this PR.

Reachable from a "View analytics" link added to the contract admin page header, behind the same flag.

#### Charting: `@mui/x-charts`, not `recharts`

The original scope called for `recharts`. After evaluating both against this codebase I went with `@mui/x-charts@^8`:

- **Theme integration.** The app is MUI v6 + emotion throughout, with design tokens in `theme.custom.colors` via `ol-components`. x-charts reads that theme directly, so axis, tooltip and legend styling comes from the same tokens as everything else. Recharts styles per-component through props, so every token would have to be threaded by hand.
- **Dependency weight.** Recharts 3 ships `@reduxjs/toolkit`, `react-redux`, `immer` and `es-toolkit` as *runtime* dependencies — a second state-management stack inside a chart library, in an app that uses TanStack Query. Roughly 18MB installed vs ~6.6MB for x-charts.
- **Compatibility.** `@mui/x-charts@8` peer-accepts `@mui/material ^6.0.0` (we're on 6.4.5) and React 19. The charts needed here (Line, Bar) are MIT/community; only the dedicated Funnel *widget* is Pro, and this uses ordinary bars.

Trade-off worth knowing: x-charts pulls `@mui/utils@^7` as a direct dependency alongside MUI v6, so that small utils package is duplicated in the tree.

#### Organizations are keyed on the Keycloak UUID, not the slug

Per ol-analytics-api#13, every org endpoint filters on `sso_organization_id` — the only identifier stable across the JWT, MITx Online and StarRocks. The route keeps `[orgSlug]` (human-facing, consistent with its sibling routes) and `AnalyticsContent` resolves slug → manager org → UUID.

Because mitxonline#3789 has not been cut into a release of `@mitodl/mitxonline-api-axios` (we're pinned to 2026.7.7), the generated `OrganizationPage` type does not declare the field yet. `Analytics/orgUuid.ts` reads it off the wire and returns `null` when absent — so pointed at an older MITx Online, the page shows "Analytics is not available for this organization yet" rather than issuing a request with `undefined` in the path. That shim is marked for deletion once the client is regenerated.

#### Suppressed values are never rendered as zero

The API nulls out any learner count below its k-anonymity floor, plus every rate and average derived from it. Those nulls are carried through as nulls:

- Table cells render a marked placeholder with the reason, exposed to assistive tech via `aria-label`, not hover alone.
- A suppressed month is a **gap** in the trend line, not a dip to zero.
- The program funnel is paired with a table of the same numbers — a bar chart can only omit a bar, which reads as zero.

#### Auth

Unchanged from the rest of the app: cookie-based, `withCredentials` + CSRF, no bearer token. The analytics API sits behind APISIX, which mints the JWT from the session cookie. Authorization is the API's job; this component only resolves *which* org is meant, via MITx Online's manager org list — the same source `ContractAdminPage` uses — so a non-manager never issues an analytics request.

#### Chart colors were validated, not chosen by eye

Hues come from the smoot-design token set, then checked against lightness band, chroma floor, CVD separation under simulated protanopia/deuteranopia, a normal-vision separation floor, and ≥3:1 contrast on the surface. Two slots are *stepped* versions of brand hues because the tokens themselves fall outside the readable band (`orange` `#FAB005` is far too light to carry a 2px line; `lightBlue` is too pale to distinguish from the card). Green and red are deliberately excluded from the series palette so they stay reserved for status. Rationale is documented in `Analytics/chartPalette.ts` — changing a value there means re-running the check, not swapping a hex.

Funnel stages take a single-hue light→dark ramp rather than three unrelated hues, because stage order carries meaning. The trend chart deliberately omits the view's `total_videos_watched` / `total_problems_attempted` / `total_chatbot_interactions` columns: those are counts of *events*, orders of magnitude above the learner counts, and putting them on the same plot would need a second y-axis.

#### Incidental changes

- **`components/B2BTable`** — the contract admin page's table primitives are extracted so both manager surfaces share them (including the sub-`md` reflow where rows become label/value stacks). `ContractAdminPage`'s 122 tests still pass unchanged.
- **`structuredClone` polyfill** in `frontends/jest-shared-setup.ts` — jsdom does not provide it and `@mui/x-charts` calls it, so without this *any* test rendering a chart dies with a `ReferenceError`. Implemented with the v8 serializer rather than a JSON round-trip so Dates/Maps/Sets survive.
- **`NEXT_PUBLIC_ANALYTICS_API_BASE_URL` is optional** in the yup schema. Environments without an analytics deployment still boot; `bootstrapApiClients()` simply skips configuring that client and the page reports itself unavailable. This avoids breaking startup for every environment that doesn't have the service yet.

### How can this be tested?

**Automated** — all green:

```
yarn workspace frontends run lint-check     # clean
yarn workspace api run global:typecheck     # clean
yarn workspace main run global:typecheck    # clean
cd frontends/main && NODE_ENV=test npx jest src/app-pages/DashboardPage src/app-pages/ContractAdminPage src/bootstrap
cd frontends/api  && NODE_ENV=test npx jest src/analytics
```

30 new tests covering: the five query factories (correct URL per endpoint, paging params, per-org key namespacing, org-id URL encoding); formatters; both charts rendering with the validated palette; and the page's access / availability / freshness / suppression behaviour.

Note on the full suite: `AssignSeatsSection`, `CoursePage`, `NewsEditor` and `SearchPage` fail intermittently under parallel load. All pass in isolation, and `AssignSeatsSection` and `NewsEditor` fail identically on an untouched `main` checkout — pre-existing flakes, not regressions from this branch.

**Manual**, once the dependencies are in place:

1. Deploy mitodl/mitxonline#3789, then mitodl/ol-analytics-api#13.
2. Add an APISIX route proxying to the analytics API with the JWT plugin (mirroring the existing `/ai/*` learn-ai route), and set `NEXT_PUBLIC_ANALYTICS_API_BASE_URL` to that route — **not** to the API directly; the API expects the JWT APISIX mints from the session cookie.
3. Create the `b2b-analytics-dashboard` PostHog flag and enable it for your user.
4. As an org manager, visit `/dashboard/organization/<org>/analytics`.

Worth exercising specifically:

- **Not a manager of that org** → "Access denied" (decided before any analytics request is issued).
- **An analytics 403** → propagates to the route error boundary. This is intentional and not handled in the component: [`makeBrowserQueryClient`](https://github.com/mitodl/mit-learn/blob/main/frontends/main/src/app/getQueryClient.ts) sets `throwOnError` for 400/401/403, so those never reach an `isError` branch. I wrote an in-component 403 branch first and removed it once a test proved it was unreachable.
- **Org without a Keycloak UUID** (or `NEXT_PUBLIC_ANALYTICS_API_BASE_URL` unset) → "not available" notice, and **no request is issued**.
- **An org whose data is below the anonymity floor** → placeholders reading "Withheld: too few learners…", never `0`.
- **A view that has never refreshed** (`as_of: null`) → "Data not yet refreshed" rather than an implied freshness.
- **Multiple contracts** → one KPI card group per contract (see below).

Locally without the API, set nothing and confirm the page renders the unavailable notice rather than erroring.

### Additional Context

**KPI cards are per-contract, not rolled up org-wide — deliberately.** `mv_b2b_contract_utilization`'s grain is org × contract, and none of the three headline figures can be honestly aggregated here: `active_learners` counts *distinct* learners per contract, so summing double-counts anyone on two contracts; and `seat_utilization_pct` / `completion_rate_pct` are rates, where averaging across contracts of different sizes is the wrong number and recomputing from raw counts is impossible whenever a count has been suppressed. Most orgs have one contract, so this reads as a single KPI row.

**A bug this caught:** `formatDate("2026-01-15")` was rendering as **Jan 14** — `new Date()` parses a date-only ISO string as UTC midnight, which `toLocaleDateString` then renders as the previous day for anyone west of Greenwich. A contract starting on the 15th must not display as starting on the 14th. Fixed for both contract dates and the `YYYY-MM` trend labels; regression tests cover both.

**Follow-up work already identified** (not in this PR):

- Add OpenAPI export + TypeScript client generation to `ol-analytics-api`, replacing the hand-written types in `frontends/api/src/analytics/types.ts`. Worth flagging for whoever picks it up: the b2b_dashboard tenant is a *mounted sub-app*, so it owns its own `/openapi.json` and the root schema does not include it; and its endpoints are registered in a loop with a runtime-parametrized generic, so the generated schema needs checking that each row model is named distinctly rather than collapsed into one `OrgAnalyticsResponse`.
- Remove the `sso_organization_id` shim once the regenerated mitxonline client lands.
- Build the content-engagement panel (factory and types are already here).
- Provision the APISIX route, the env var, and the PostHog flag.

**Screenshots** are omitted because no environment can render the dashboard until the analytics API is deployed. I'll attach desktop and mobile captures once it's up in CI/RC.
