### PR TITLE
Set Posthog Cookie on site domain, not mit.edu

### DIFF
--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -68,6 +68,9 @@ const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
       posthog.init(POSTHOG_API_KEY, {
         api_host: POSTHOG_API_HOST,
         ui_host: POSTHOG_UI_HOST,
+        // Scope the posthog cookie to this site's exact domain. Posthog
+        // defaults this to true, which sets the cookie on the root domain
+        // (e.g. mit.edu), sharing it with every other site there.
         cross_subdomain_cookie: false,
         bootstrap: {
           featureFlags: featureFlags

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -68,6 +68,7 @@ const ConfiguredPostHogProvider: React.FC<{ children: React.ReactNode }> = ({
       posthog.init(POSTHOG_API_KEY, {
         api_host: POSTHOG_API_HOST,
         ui_host: POSTHOG_UI_HOST,
+        cross_subdomain_cookie: false,
         bootstrap: {
           featureFlags: featureFlags
             ? {


### PR DESCRIPTION
### What are the relevant tickets?
For 
- https://github.com/mitodl/hq/issues/11158

### Description (What does it do?)
Set the posthog cookie on site domain (`open.odl.local`, or `learn.mit.edu`, or `rc.learn.mit.edu`) not MIT domain.


### How can this be tested?
1. With Posthog integrated locally, you should see a `ph_PROJECT_TOKEN_posthog` cookie set on your site domain exactly:
    - if site domain is `open.odl.local`, it should be set there, not on `odl.local`
    - if site domain is `learn.mit.dev`, it should be set there, not on `mit.dev`

### Additional Context
Setting the cookie on the site domain loses our ability to track **anonymous** (unauthenticated) users across sites within the same project, unless we do special setup like pass distinct_ids via query params in URLs, but that is deemed acceptable.

Companion PR, same change for the Keycloak login pages: https://github.com/mitodl/ol-keycloakify/pull/176

mitxonline already does this — it has passed `cross_subdomain_cookie: false` since 2023: https://github.com/mitodl/mitxonline/blob/80c2a512f1e3d2a93c06bb4270ba87976cf369ef/frontend/public/src/lib/util.js#L44
