### PR TITLE
Fix topic page pagination

### DIFF
--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -485,12 +485,12 @@ class QdrantView(APIView):
         aggregation_keys = params.get("aggregations") or []
 
         count_result, aggregations = await asyncio.gather(
-            # exact=True: this count drives the paginated result total, so an
-            # approximate value would advertise pages that return no results.
+            # we do not set exact=True for the contentfiles collection
+            # due to the number (millions) of points
             client.count(
                 collection_name=search_collection,
                 count_filter=search_filter,
-                exact=True,
+                exact=search_collection == RESOURCES_COLLECTION_NAME,
             ),
             async_qdrant_aggregations(
                 aggregation_keys,

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -485,10 +485,12 @@ class QdrantView(APIView):
         aggregation_keys = params.get("aggregations") or []
 
         count_result, aggregations = await asyncio.gather(
+            # exact=True: this count drives the paginated result total, so an
+            # approximate value would advertise pages that return no results.
             client.count(
                 collection_name=search_collection,
                 count_filter=search_filter,
-                exact=False,
+                exact=True,
             ),
             async_qdrant_aggregations(
                 aggregation_keys,

--- a/vector_search/views.py
+++ b/vector_search/views.py
@@ -485,8 +485,14 @@ class QdrantView(APIView):
         aggregation_keys = params.get("aggregations") or []
 
         count_result, aggregations = await asyncio.gather(
-            # we do not set exact=True for the contentfiles collection
-            # due to the number (millions) of points
+            # This total drives pagination, and Qdrant's approximate count
+            # overestimates a filtered collection -- which advertises pages
+            # that return no results. Exact counting fixes that but scales with
+            # the number of matched points (measured at ~60ms per million), so
+            # we only set exact=True for the resources collection (~1 point per
+            # resource). We do not set it for the contentfiles collection due to
+            # the number (millions) of points; its totals stay approximate,
+            # which is invisible while nothing paginates them.
             client.count(
                 collection_name=search_collection,
                 count_filter=search_filter,

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -1214,3 +1214,22 @@ def test_content_file_vector_search_partial_invalid_ids_searches_survivors(
     id_conditions = [c for c in must if getattr(c, "key", None) == "edx_module_id"]
     assert len(id_conditions) == 1
     assert list(id_conditions[0].match.any) == [valid_id]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_vector_search_count_is_exact(client, mock_qdrant):
+    """The result total must be an exact count.
+
+    Qdrant's approximate count overestimates filtered collections, which made
+    the paginator advertise pages that returned no results.
+    """
+    client.get(
+        reverse("vector_search:v0:vector_learning_resources_search"),
+        data={
+            "topic": "Art, Design & Architecture",
+            "resource_type_group": "learning_material",
+        },
+    )
+
+    mock_qdrant.count.assert_awaited()
+    assert mock_qdrant.count.await_args.kwargs["exact"] is True

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -1223,13 +1223,15 @@ def test_vector_search_count_is_exact(client, mock_qdrant):
     Qdrant's approximate count overestimates filtered collections, which made
     the paginator advertise pages that returned no results.
     """
-    client.get(
+    response = client.get(
         reverse("vector_search:v0:vector_learning_resources_search"),
         data={
             "topic": "Art, Design & Architecture",
             "resource_type_group": "learning_material",
         },
     )
+
+    assert response.status_code == 200
 
     mock_qdrant.count.assert_awaited()
     assert mock_qdrant.count.await_args.kwargs["exact"] is True

--- a/vector_search/views_test.py
+++ b/vector_search/views_test.py
@@ -1235,3 +1235,24 @@ def test_vector_search_count_is_exact(client, mock_qdrant):
 
     mock_qdrant.count.assert_awaited()
     assert mock_qdrant.count.await_args.kwargs["exact"] is True
+
+
+@pytest.mark.django_db(transaction=True)
+def test_content_file_vector_search_count_is_approximate(
+    client, mock_qdrant, content_file_viewer
+):
+    """Content-file totals must stay approximate.
+
+    Exact counting scales with matched points, and this collection holds
+    millions of chunks, so an exact count here would cost most of a second.
+    Nothing paginates content files, so the imprecision is invisible.
+    """
+    response = client.get(
+        reverse("vector_search:v0:vector_content_files_search"),
+        data={"q": "test"},
+    )
+
+    assert response.status_code == 200
+
+    mock_qdrant.count.assert_awaited()
+    assert mock_qdrant.count.await_args.kwargs["exact"] is False


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12397
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where the topic pages show more pages than can be paginated to. This is due to the use of exact=False for the final count returned by the api which ends up showing more results than there actually are.


### How can this be tested?
1. checkout main - make sure you have embeddings locally
2. go to a top-level topic page such as http://open.odl.local:8062/c/topic/engineering -> click on the very last page of results and it should come up empty.
3. checkout this branch and attempt the same - it should never be empty and the page count should be accurate


### Extra notes
the `exact=True` on the counts is only set on the learning resources collection since it will cause performance issues on the contentfiles collection which has north of 12m points on production 
