### PR TITLE
Defer AI library imports to reduce process startup cost

### DIFF
--- a/learning_resources/converters/opendataloader_llm_converter.py
+++ b/learning_resources/converters/opendataloader_llm_converter.py
@@ -33,6 +33,9 @@ from PIL import Image
 
 log = logging.getLogger(__name__)
 
+# drop unsupported model params
+litellm.drop_params = True
+
 # --- Configuration ---
 MIN_IMAGE_DIMENSION = 32
 MIN_IMAGE_RATIO = 12

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -46,9 +46,6 @@ from learning_resources.constants import (
     OfferedBy,
     RunStatus,
 )
-from learning_resources.converters.opendataloader_llm_converter import (
-    OpenDataLoaderLLMConverter,
-)
 from learning_resources.etl.constants import (
     RESOURCE_DELIVERY_MAPPING,
     TIME_INTERVAL_MAPPING,
@@ -1294,6 +1291,10 @@ def _pdf_to_markdown(pdf_path):
     """
     Convert a PDF file to markdown using an llm
     """
+    from learning_resources.converters.opendataloader_llm_converter import (
+        OpenDataLoaderLLMConverter,
+    )
+
     converter = OpenDataLoaderLLMConverter(pdf_path)
     return converter.convert_to_markdown()
 

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -13,7 +13,6 @@ from django.db import transaction
 from django.db.models import F, Max, Prefetch, Q
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from isodate import parse_duration
-from langchain_text_splitters import RecursiveJsonSplitter
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -1128,6 +1127,8 @@ class LearningResourceMetadataDisplaySerializer(serializers.Serializer):
 
     def render_chunks(self):
         """Convert resource info to markdown chunks"""
+        from langchain_text_splitters import RecursiveJsonSplitter
+
         rendered_doc = self.render_document()
         resource_type = self.instance.get("resource_type", "course")
         """

--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -15,7 +15,6 @@ from django.db.models import Q
 from django.utils import timezone
 
 from learning_resources.constants import LearningResourceType
-from learning_resources.content_summarizer import ContentSummarizer
 from learning_resources.etl import ovs, pipelines, youtube
 from learning_resources.etl.canvas import (
     sync_canvas_archive,
@@ -549,6 +548,8 @@ def summarize_content_files_task(
     Returns:
         - None
     """
+    from learning_resources.content_summarizer import ContentSummarizer
+
     summarizer = ContentSummarizer()
     return summarizer.summarize_content_files_by_ids(content_file_ids, overwrite)
 

--- a/learning_resources/tasks_test.py
+++ b/learning_resources/tasks_test.py
@@ -546,7 +546,7 @@ def test_summarize_unprocessed_content(
         "learning_resources.tasks.summarize_content_files_task", autospec=True
     )
     get_unprocessed_content_file_ids_mock = mocker.patch(
-        "learning_resources.tasks.ContentSummarizer.get_unprocessed_content_file_ids",
+        "learning_resources.content_summarizer.ContentSummarizer.get_unprocessed_content_file_ids",
         autospec=True,
         return_value=ids,
     )

--- a/learning_resources/utils.py
+++ b/learning_resources/utils.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 import html2text
 import rapidjson
 import requests
-import tiktoken
 import yaml
 from botocore.exceptions import ClientError
 from django.conf import settings
@@ -800,6 +799,8 @@ def truncate_to_tokens(text: str, max_tokens: int, model: str = "gpt-4o") -> str
     """
     Truncate text to a maximum number of tokens for a given model.
     """
+    import tiktoken
+
     encoding = tiktoken.encoding_for_model(model)
     tokens = encoding.encode(text)
     if len(tokens) <= max_tokens:

--- a/main/boot_imports_test.py
+++ b/main/boot_imports_test.py
@@ -1,0 +1,77 @@
+"""
+Regression test for the AI-library import deferral work: boots Django and
+serves one request in a fresh subprocess (so nothing is already cached in
+sys.modules from other tests) and asserts that the packages this PR moved
+out of the boot path haven't crept back in as a module-scope import.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+# Packages that should only ever load lazily, inside the function/task that
+# actually needs them -- never as a side effect of booting the app or
+# serving an unrelated request. See PR #3683 and its review discussion.
+OFFENDING_PACKAGES = [
+    "tiktoken",
+    "litellm",
+    "langchain_core",
+    "langchain_classic",
+    "langchain_text_splitters",
+    "opendataloader_pdf",
+    "cv2",
+    "pdf2image",
+]
+
+PROBE_SCRIPT = textwrap.dedent(
+    """
+    import json
+    import sys
+
+    import django
+
+    django.setup()
+
+    from django.test import Client
+
+    response = Client().get("/health/liveness/")
+    offenders = json.loads(__OFFENDERS_JSON__)
+
+    print(
+        json.dumps(
+            {
+                "status_code": response.status_code,
+                "loaded": sorted(m for m in offenders if m in sys.modules),
+            }
+        )
+    )
+    """
+).replace("__OFFENDERS_JSON__", repr(json.dumps(OFFENDING_PACKAGES)))
+
+
+def test_boot_and_liveness_request_do_not_import_ai_libraries(tmp_path):
+    """Booting Django and serving a request shouldn't import deferred AI libs"""
+    script_path = tmp_path / "boot_imports_probe.py"
+    script_path.write_text(PROBE_SCRIPT)
+
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(script_path)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "DJANGO_SETTINGS_MODULE": "main.settings",
+            "PYTHONPATH": str(Path.cwd()),
+        },
+        timeout=60,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout.strip().splitlines()[-1])
+
+    assert output["status_code"] == 200
+    assert output["loaded"] == []

--- a/main/sentry.py
+++ b/main/sentry.py
@@ -4,8 +4,10 @@ import logging
 
 import sentry_sdk
 from celery.exceptions import WorkerLostError
+from sentry_sdk.integrations.boto3 import Boto3Integration
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 
@@ -74,17 +76,22 @@ def init_sentry(  # noqa: PLR0913
         before_send=before_send,
         traces_sample_rate=traces_sample_rate,
         profiles_sample_rate=profiles_sample_rate,
-        # Sentry's auto-enabling integrations (langchain, boto3, openai, etc.)
-        # import their target library at init time just to check whether it's
+        # Sentry's auto-enabling integrations (langchain, openai, etc.) import
+        # their target library at init time just to check whether it's
         # installed, regardless of whether it's ever used -- e.g. langchain is
         # installed as a litellm transitive dependency but never used directly,
         # and importing its Sentry integration alone pulls in the whole
         # langchain/tiktoken stack on every process. Opt in explicitly instead.
+        # Boto3/Redis/Httpx are included because boto3, redis, and httpx are
+        # already imported elsewhere at boot regardless of Sentry, so these
+        # add no import cost of their own.
         auto_enabling_integrations=False,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),
             LoggingIntegration(level=log_level),
             RedisIntegration(),
+            Boto3Integration(),
+            HttpxIntegration(),
         ],
     )

--- a/main/sentry.py
+++ b/main/sentry.py
@@ -7,6 +7,7 @@ from celery.exceptions import WorkerLostError
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.redis import RedisIntegration
 
 # these errors occur when a shutdown is happening (usually caused by a SIGTERM)
 SHUTDOWN_ERRORS = (WorkerLostError, SystemExit)
@@ -73,9 +74,17 @@ def init_sentry(  # noqa: PLR0913
         before_send=before_send,
         traces_sample_rate=traces_sample_rate,
         profiles_sample_rate=profiles_sample_rate,
+        # Sentry's auto-enabling integrations (langchain, boto3, openai, etc.)
+        # import their target library at init time just to check whether it's
+        # installed, regardless of whether it's ever used -- e.g. langchain is
+        # installed as a litellm transitive dependency but never used directly,
+        # and importing its Sentry integration alone pulls in the whole
+        # langchain/tiktoken stack on every process. Opt in explicitly instead.
+        auto_enabling_integrations=False,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),
             LoggingIntegration(level=log_level),
+            RedisIntegration(),
         ],
     )

--- a/vector_search/encoders/litellm.py
+++ b/vector_search/encoders/litellm.py
@@ -13,6 +13,9 @@ from vector_search.encoders.base import BaseEncoder
 log = logging.getLogger()
 redis_url = urlparse(settings.CELERY_BROKER_URL)
 
+# drop unsupported model params
+litellm.drop_params = True
+
 # these must be set directly via environ (litellm limitation)
 os.environ["REDIS_SSL"] = str(redis_url.scheme.endswith("ss"))
 litellm.cache = Cache(

--- a/vector_search/encoders/utils.py
+++ b/vector_search/encoders/utils.py
@@ -1,10 +1,8 @@
 import logging
 from functools import cache
 
-import tiktoken
 from django.conf import settings
 from django.utils.module_loading import import_string
-from litellm import get_model_info
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +72,8 @@ def truncate_to_model_limit(
     Returns:
         Truncated text.
     """
+    from litellm import get_model_info
+
     max_input_tokens = None
 
     try:
@@ -84,6 +84,8 @@ def truncate_to_model_limit(
 
     if max_input_tokens and token_encoding_name:
         try:
+            import tiktoken
+
             encoding = tiktoken.get_encoding(token_encoding_name)
             tokens = encoding.encode(text)
 

--- a/vector_search/encoders/utils_test.py
+++ b/vector_search/encoders/utils_test.py
@@ -34,11 +34,11 @@ def warning_mock(mocker):
 def test_truncate_to_model_limit_truncates_long_text(mocker, warning_mock):
     """Text over the model's max input tokens is cut to that token limit"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={"max_input_tokens": 5},
     )
     mocker.patch(
-        "vector_search.encoders.utils.tiktoken.get_encoding",
+        "tiktoken.get_encoding",
         return_value=FakeEncoding(),
     )
 
@@ -55,11 +55,11 @@ def test_truncate_to_model_limit_truncates_long_text(mocker, warning_mock):
 def test_truncate_to_model_limit_leaves_short_text_unchanged(mocker, warning_mock):
     """Text within the model's max input tokens is returned as-is"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={"max_input_tokens": 5},
     )
     mocker.patch(
-        "vector_search.encoders.utils.tiktoken.get_encoding",
+        "tiktoken.get_encoding",
         return_value=FakeEncoding(),
     )
 
@@ -78,12 +78,10 @@ def test_truncate_to_model_limit_unknown_model_falls_back_to_chars(
 ):
     """Fall back to the character limit when model info can't be determined"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         side_effect=ValueError("unknown model"),
     )
-    get_encoding_mock = mocker.patch(
-        "vector_search.encoders.utils.tiktoken.get_encoding"
-    )
+    get_encoding_mock = mocker.patch("tiktoken.get_encoding")
     text = "x" * (DEFAULT_TRUNCATE_CHARS + 100)
 
     result = truncate_to_model_limit(
@@ -102,7 +100,7 @@ def test_truncate_to_model_limit_missing_max_tokens_falls_back_to_chars(
 ):
     """Fall back to the character limit when the model has no max_input_tokens"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={},
     )
     text = "x" * (DEFAULT_TRUNCATE_CHARS + 100)
@@ -122,7 +120,7 @@ def test_truncate_to_model_limit_no_token_encoding_falls_back_to_chars(
 ):
     """Fall back to the character limit when no token encoding name is given"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={"max_input_tokens": 5},
     )
     text = "x" * (DEFAULT_TRUNCATE_CHARS + 100)
@@ -136,11 +134,11 @@ def test_truncate_to_model_limit_no_token_encoding_falls_back_to_chars(
 def test_truncate_to_model_limit_bad_encoding_falls_back_to_chars(mocker, warning_mock):
     """Fall back to the character limit when the tiktoken encoding fails"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={"max_input_tokens": 5},
     )
     mocker.patch(
-        "vector_search.encoders.utils.tiktoken.get_encoding",
+        "tiktoken.get_encoding",
         side_effect=ValueError("bad encoding"),
     )
     text = "x" * (DEFAULT_TRUNCATE_CHARS + 100)
@@ -158,7 +156,7 @@ def test_truncate_to_model_limit_bad_encoding_falls_back_to_chars(mocker, warnin
 def test_truncate_to_model_limit_fallback_warns_once_per_model(mocker, warning_mock):
     """The fallback warning is deduplicated per model/encoding combination"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         side_effect=ValueError("unknown model"),
     )
 
@@ -183,7 +181,7 @@ def test_truncate_to_model_limit_strict_raises_instead_of_falling_back(
 ):
     """In strict mode any fallback condition raises instead of truncating"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         **model_info_kwargs,
     )
     # no token_encoding_name, so even a known model can't use token truncation
@@ -195,11 +193,11 @@ def test_truncate_to_model_limit_strict_raises_instead_of_falling_back(
 def test_truncate_to_model_limit_strict_allows_token_truncation(mocker, warning_mock):
     """Strict mode doesn't interfere when token-based truncation works"""
     mocker.patch(
-        "vector_search.encoders.utils.get_model_info",
+        "litellm.get_model_info",
         return_value={"max_input_tokens": 5},
     )
     mocker.patch(
-        "vector_search.encoders.utils.tiktoken.get_encoding",
+        "tiktoken.get_encoding",
         return_value=FakeEncoding(),
     )
 

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.core.cache import caches
 from django.db.models import Q
 
-from learning_resources.content_summarizer import ContentSummarizer
 from learning_resources.models import (
     ContentFile,
     Course,
@@ -708,6 +707,8 @@ def _missing_summaries():
         # list the same as None (no restriction), so short-circuit here instead
         # of letting it scan every learning resource.
         return []
+
+    from learning_resources.content_summarizer import ContentSummarizer
 
     summarizer = ContentSummarizer()
     return summarizer.get_unprocessed_content_file_ids(

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -8,16 +8,11 @@ from asgiref.sync import sync_to_async
 from django.conf import settings
 from django.db import close_old_connections
 from django.db.models import Prefetch, Q
-from langchain_text_splitters import (
-    MarkdownHeaderTextSplitter,
-    RecursiveCharacterTextSplitter,
-)
 from qdrant_client import AsyncQdrantClient, QdrantClient, models
 
 from learning_resources.constants import (
     PROGRAM_COURSE_CACHE_KEY_TEST_MODE,
 )
-from learning_resources.content_summarizer import ContentSummarizer
 from learning_resources.models import (
     ContentFile,
     LearningResource,
@@ -393,6 +388,8 @@ def embed_topics():
 
 @cache
 def _get_text_splitter(**kwargs):
+    from langchain_text_splitters import RecursiveCharacterTextSplitter
+
     if settings.LITELLM_TOKEN_ENCODING_NAME:
         kwargs["encoding_name"] = settings.LITELLM_TOKEN_ENCODING_NAME
         return RecursiveCharacterTextSplitter.from_tiktoken_encoder(**kwargs)
@@ -429,6 +426,8 @@ def _chunk_markdown_documents(text, metadata):
     metadata so every chunk's page_content is self-describing
     for embedding.
     """
+    from langchain_text_splitters import MarkdownHeaderTextSplitter
+
     header_splitter = MarkdownHeaderTextSplitter(
         headers_to_split_on=MARKDOWN_HEADERS_TO_SPLIT_ON,
         strip_headers=False,
@@ -892,6 +891,8 @@ def _summarize_content_files_for_embedding(
 ):
     if not fill_summary_content_ids and not changed_summary_content_ids:
         return docs_batch
+
+    from learning_resources.content_summarizer import ContentSummarizer
 
     summarizer = ContentSummarizer()
     if fill_summary_content_ids:

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -607,7 +607,7 @@ def test_document_chunker_tiktoken(mocker):
     encoder = dense_encoder()
     encoder.token_encoding_name = None
     mocked_splitter = mocker.patch(
-        "vector_search.utils.RecursiveCharacterTextSplitter.from_tiktoken_encoder"
+        "langchain_text_splitters.RecursiveCharacterTextSplitter.from_tiktoken_encoder"
     )
 
     _chunk_documents(["this is a test document"], [{}])
@@ -628,11 +628,15 @@ def test_text_splitter_chunk_size_override(mocker):
     settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = chunk_size
     settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = chunk_size / 10
     encoder = dense_encoder()
-    mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
+    mocked_splitter = mocker.patch(
+        "langchain_text_splitters.RecursiveCharacterTextSplitter"
+    )
     encoder.token_encoding_name = "cl100k_base"  # noqa: S105
     _chunk_documents(["this is a test document"], [{}])
     assert mocked_splitter.mock_calls[0].kwargs["chunk_size"] == 100
-    mocked_splitter = mocker.patch("vector_search.utils.RecursiveCharacterTextSplitter")
+    mocked_splitter = mocker.patch(
+        "langchain_text_splitters.RecursiveCharacterTextSplitter"
+    )
     settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = None
     _chunk_documents(["this is a test document"], [{}])
     assert "chunk_size" not in mocked_splitter.mock_calls[0].kwargs


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`litellm`, `langchain_litellm`, `tiktoken`, the `opendataloader_pdf`/`cv2` (OpenCV) stack, and `langchain_text_splitters` were being imported at module scope in `learning_resources/tasks.py`, `vector_search/tasks.py`, `learning_resources/etl/utils.py`, and `vector_search/utils.py`.

Those modules sit on the import chain for ordinary web request handling:

- `learning_resources/tasks.py` is imported by `learning_resources/views.py`
- `vector_search/utils.py` is imported by `learning_resources_search/api.py`, `learning_resources_search/indexing_api.py`, and `vector_search/views.py`
- `learning_resources/etl/utils.py` is imported by `learning_resources/tasks.py` (and every ETL pipeline module)

Because Python imports are eager, every Django process (web/ASGI workers, every Celery worker, every management command) paid the full memory and startup-time cost of loading these libraries at process boot — even though they're only actually used by a handful of specific Celery tasks (content summarization, PDF-to-markdown OCR conversion, embedding-time text chunking) that the majority of code-paths never touch.

This PR moves each of those imports from module scope down to the single call site that uses them, so the import only happens when the relevant task/function actually runs. Log capture for these libraries is unaffected — Python's root logger configuration applies regardless of when a module (and its logger) is created, so litellm/langchain output is still captured once that code path is active.

### Screenshots (if appropriate):
N/A - no UI changes

### How can this be tested?
- `ruff check --select F401,F821` passes on all touched files (no unused imports, no unresolved names introduced by the deferred imports).
- Ran the full affected test suite via `docker compose run --rm web uv run pytest learning_resources/tasks_test.py learning_resources/content_summarizer_test.py learning_resources/converters/opendataloader_llm_converter_test.py vector_search/tasks_test.py vector_search/utils_test.py learning_resources/etl/utils_test.py` — all 545 tests pass.
- Two tests in `vector_search/utils_test.py` that previously patched `vector_search.utils.RecursiveCharacterTextSplitter` (a module attribute that no longer exists once the import is lazy) were updated to patch `langchain_text_splitters.RecursiveCharacterTextSplitter` directly, and one test in `learning_resources/tasks_test.py` was updated to patch `learning_resources.content_summarizer.ContentSummarizer` (the defining module) instead of `learning_resources.tasks.ContentSummarizer`.
- A reviewer can confirm the startup-cost reduction by checking that `sys.modules` does not contain `litellm`/`cv2`/`opendataloader_pdf` immediately after `django.setup()`, prior to any request being served.

### Additional Context
No functional behavior changes — this is purely an import-timing change. The libraries still fully load and function normally the first time their owning task/function runs; they're just no longer paid for by every process that never touches them.