### PR TITLE
Followup to #3646: skip contentless files in embed pre-pass, retry Qdrant blips, purge before embed

### DIFF
--- a/learning_resources_search/plugins.py
+++ b/learning_resources_search/plugins.py
@@ -284,12 +284,13 @@ class SearchIndexPlugin:
                 index_tasks.append(tasks.index_run_content_files.si(run.id))
 
             if django_settings.QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS:
-                index_tasks.append(vector_tasks.embed_run_content_files.si(run.id))
-                # Always purge unpublished files' points so a failed removal
-                # task self-heals on the next load.
+                # Purge before embedding so unpublished files' points are
+                # removed even if the embed task fails; the two tasks touch
+                # disjoint sets (published=False vs published=True files).
                 index_tasks.append(
                     vector_tasks.remove_unpublished_run_content_files.si(run.id)
                 )
+                index_tasks.append(vector_tasks.embed_run_content_files.si(run.id))
 
         if index_tasks:
             try_with_retry_as_task(chain(*index_tasks))

--- a/learning_resources_search/plugins_test.py
+++ b/learning_resources_search/plugins_test.py
@@ -572,10 +572,14 @@ def test_search_index_plugin_resource_upserted_generate_embeddings(
 
 @pytest.mark.django_db
 def test_content_files_loaded_always_purges_unpublished(
-    mock_search_index_helpers, settings
+    mocker, mock_search_index_helpers, settings
 ):
-    """The remove-unpublished task always runs so failed removals self-heal."""
+    """
+    The remove-unpublished task always runs, and ahead of the embed task in the
+    chain, so a failed embed can't strand unpublished files' points in Qdrant.
+    """
     settings.QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS = True
+    chain_mock = mocker.patch("learning_resources_search.plugins.chain")
     run = LearningResourceRunFactory.create(
         published=True, learning_resource__create_runs=False
     )
@@ -586,3 +590,7 @@ def test_content_files_loaded_always_purges_unpublished(
     mock_search_index_helpers.mock_remove_unpublished_run_contentfiles_immutable_signature.assert_called_once_with(
         run.id
     )
+    chained = list(chain_mock.call_args.args)
+    purge = mock_search_index_helpers.mock_remove_unpublished_run_contentfiles_immutable_signature.return_value
+    embed = mock_search_index_helpers.mock_embed_run_contentfiles_immutable_signature.return_value
+    assert chained.index(purge) < chained.index(embed)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -480,7 +480,8 @@ def embed_run_content_files(self, run_id):
     as missing/stale points, so they self-heal on the next load.
 
     Content-less files are excluded: they never produce Qdrant points, so they
-    would otherwise be re-flagged on every load. Transient Qdrant errors during
+    would otherwise be re-flagged on every load. Any point left over from when
+    such a file still had content is removed. Transient Qdrant errors during
     the pre-pass retry with backoff so a blip doesn't defer the run's embedding
     to the next load.
     """
@@ -509,17 +510,24 @@ def embed_run_content_files(self, run_id):
             )
         )
 
+    contentless = Q(content__isnull=True) | Q(content="")
     pid_rows = [
         (cf_id, chunk0_point_id(key), checksum, meta)
         for cf_id, key, checksum, *meta in ContentFile.objects.filter(
             run=run, published=True
         )
-        .exclude(Q(content__isnull=True) | Q(content=""))
+        .exclude(contentless)
         .values_list("id", "key", "checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS)
+    ]
+    contentless_rows = [
+        (cf_id, chunk0_point_id(key))
+        for cf_id, key in ContentFile.objects.filter(
+            contentless, run=run, published=True
+        ).values_list("id", "key")
     ]
     try:
         stored = _stored_content_payloads(
-            [pid for _, pid, _, _ in pid_rows],
+            [pid for _, pid, _, _ in pid_rows] + [pid for _, pid in contentless_rows],
             fields=("checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS),
         )
     except grpc.RpcError as err:
@@ -544,12 +552,20 @@ def embed_run_content_files(self, run_id):
         for cf_id, pid, checksum, meta in pid_rows
         if is_stale(pid, checksum, meta)
     ]
+    # A stored point for a now-contentless file is a leftover from when the
+    # file had content — remove it. Inline rather than a chained task: leftovers
+    # are rare and few, and a failed delete self-heals on the next load.
+    leftover_ids = [cf_id for cf_id, pid in contentless_rows if pid in stored]
     log.info(
-        "embed_run_content_files run %s: %d of %d files need embedding",
+        "embed_run_content_files run %s: %d of %d files need embedding, "
+        "%d leftover contentless points to remove",
         run_id,
         len(ids),
         len(pid_rows),
+        len(leftover_ids),
     )
+    if leftover_ids:
+        remove_qdrant_records(leftover_ids, CONTENT_FILE_TYPE)
     if not ids:
         return None
     return _replace_with_finalized_chain(self, ids, overwrite=True)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -465,7 +465,7 @@ def embed_new_content_files(self):
     )
 
 
-@app.task(bind=True)
+@app.task(bind=True, max_retries=3)
 def embed_run_content_files(self, run_id):
     """
     Embed the run's published content files whose Qdrant points are missing or
@@ -478,6 +478,11 @@ def embed_run_content_files(self, run_id):
     newly generated summary, ...) is dispatched but exits via the payload-only
     update path downstream — no re-embedding. Failed or purged embeds show up
     as missing/stale points, so they self-heal on the next load.
+
+    Content-less files are excluded: they never produce Qdrant points, so they
+    would otherwise be re-flagged on every load. Transient Qdrant errors during
+    the pre-pass retry with backoff so a blip doesn't defer the run's embedding
+    to the next load.
     """
     run = (
         LearningResourceRun.objects.select_related("learning_resource__platform")
@@ -508,12 +513,22 @@ def embed_run_content_files(self, run_id):
         (cf_id, chunk0_point_id(key), checksum, meta)
         for cf_id, key, checksum, *meta in ContentFile.objects.filter(
             run=run, published=True
-        ).values_list("id", "key", "checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS)
+        )
+        .exclude(Q(content__isnull=True) | Q(content=""))
+        .values_list("id", "key", "checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS)
     ]
-    stored = _stored_content_payloads(
-        [pid for _, pid, _, _ in pid_rows],
-        fields=("checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS),
-    )
+    try:
+        stored = _stored_content_payloads(
+            [pid for _, pid, _, _ in pid_rows],
+            fields=("checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS),
+        )
+    except grpc.RpcError as err:
+        if err.code() in (
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+            grpc.StatusCode.UNAVAILABLE,
+        ):
+            raise self.retry(exc=err, countdown=_retry_countdown(self.request.retries))  # noqa: B904
+        raise
 
     def is_stale(pid, checksum, meta):
         payload = stored.get(pid)

--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -495,8 +495,9 @@ def embed_run_content_files(self, run_id):
     resource = run.learning_resource
     platform_code = resource.platform.code if resource.platform else ""
 
-    def chunk0_point_id(key):
-        # Mirrors the doc fields ContentFileSerializer emits for run files
+    def first_chunk_point_id(key):
+        # Returns the qdrant point id for the first chunk of the contentfile,
+        # mirroring the doc fields ContentFileSerializer emits for run files
         return vector_point_id(
             vector_point_key(
                 {
@@ -512,7 +513,7 @@ def embed_run_content_files(self, run_id):
 
     contentless = Q(content__isnull=True) | Q(content="")
     pid_rows = [
-        (cf_id, chunk0_point_id(key), checksum, meta)
+        (cf_id, first_chunk_point_id(key), checksum, meta)
         for cf_id, key, checksum, *meta in ContentFile.objects.filter(
             run=run, published=True
         )
@@ -520,7 +521,7 @@ def embed_run_content_files(self, run_id):
         .values_list("id", "key", "checksum", *CONTENT_FILE_PREPASS_PAYLOAD_FIELDS)
     ]
     contentless_rows = [
-        (cf_id, chunk0_point_id(key))
+        (cf_id, first_chunk_point_id(key))
         for cf_id, key in ContentFile.objects.filter(
             contentless, run=run, published=True
         ).values_list("id", "key")

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -705,7 +705,8 @@ def test_embed_run_content_files(mocker, mocked_celery, settings):
     settings.QDRANT_CHUNK_SIZE = 2
     run = LearningResourceRunFactory.create()
     content_file_ids = [
-        content_file.id for content_file in ContentFileFactory.create_batch(3, run=run)
+        content_file.id
+        for content_file in ContentFileFactory.create_batch(3, run=run, content="text")
     ]
     ContentFileFactory.create()
     generate_embeddings_mock = mocker.patch(
@@ -773,8 +774,8 @@ def test_embed_run_content_files_skips_unpublished(mocker, mocked_celery, settin
     """Unpublished files are never embedded."""
     settings.QDRANT_CHUNK_SIZE = 50
     run = LearningResourceRunFactory.create()
-    published = ContentFileFactory.create(run=run, published=True)
-    ContentFileFactory.create(run=run, published=False)
+    published = ContentFileFactory.create(run=run, published=True, content="aaa")
+    ContentFileFactory.create(run=run, published=False, content="bbb")
     generate_embeddings_mock = mocker.patch(
         "vector_search.tasks.generate_embeddings", autospec=True
     )
@@ -783,6 +784,56 @@ def test_embed_run_content_files_skips_unpublished(mocker, mocked_celery, settin
         embed_run_content_files.delay(run.id)
 
     assert _embedded_content_file_ids(generate_embeddings_mock) == {published.id}
+
+
+def test_embed_run_content_files_skips_contentless(mocker, mocked_celery, settings):
+    """
+    Files without content never produce Qdrant points, so the pre-pass must not
+    flag them as stale (they would otherwise be re-dispatched on every load).
+    """
+    settings.QDRANT_CHUNK_SIZE = 50
+    run = LearningResourceRunFactory.create()
+    with_content = ContentFileFactory.create(run=run, published=True, content="aaa")
+    ContentFileFactory.create(run=run, published=True, content="")
+    ContentFileFactory.create(run=run, published=True, content=None)
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+
+    with pytest.raises(mocked_celery.replace_exception_class):
+        embed_run_content_files.delay(run.id)
+
+    assert _embedded_content_file_ids(generate_embeddings_mock) == {with_content.id}
+
+
+def test_embed_run_content_files_retries_transient_qdrant_errors(mocker):
+    """A transient Qdrant error in the pre-pass retries instead of failing the run."""
+    run = LearningResourceRunFactory.create()
+    ContentFileFactory.create(run=run, published=True, content="aaa")
+    mocker.patch(
+        "vector_search.tasks._stored_content_payloads",
+        side_effect=_rpc_error(grpc.StatusCode.UNAVAILABLE),
+    )
+    retry = mocker.patch.object(embed_run_content_files, "retry", side_effect=Retry())
+
+    with pytest.raises(Retry):
+        embed_run_content_files(run.id)
+
+    retry.assert_called_once()
+    assert retry.call_args.kwargs["countdown"] >= 0
+
+
+def test_embed_run_content_files_does_not_retry_terminal_errors(mocker):
+    """A non-transient Qdrant error in the pre-pass propagates without retry."""
+    run = LearningResourceRunFactory.create()
+    ContentFileFactory.create(run=run, published=True, content="aaa")
+    mocker.patch(
+        "vector_search.tasks._stored_content_payloads",
+        side_effect=_rpc_error(grpc.StatusCode.INVALID_ARGUMENT),
+    )
+
+    with pytest.raises(grpc.RpcError):
+        embed_run_content_files(run.id)
 
 
 def _serializer_chunk0_pids(content_files):

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -806,6 +806,33 @@ def test_embed_run_content_files_skips_contentless(mocker, mocked_celery, settin
     assert _embedded_content_file_ids(generate_embeddings_mock) == {with_content.id}
 
 
+def test_embed_run_content_files_removes_leftover_contentless_points(mocker):
+    """
+    A published file whose content became empty keeps the point embedded from
+    its old content; the pre-pass detects and removes it. Contentless files
+    with no stored point trigger no removal.
+    """
+    run = LearningResourceRunFactory.create()
+    emptied = ContentFileFactory.create(run=run, published=True, content="")
+    ContentFileFactory.create(run=run, published=True, content=None)
+    pids = _serializer_chunk0_pids([emptied])
+    mocker.patch(
+        "vector_search.tasks._stored_content_payloads",
+        return_value={pids[emptied.id]: {"checksum": "from-old-content"}},
+    )
+    generate_embeddings_mock = mocker.patch(
+        "vector_search.tasks.generate_embeddings", autospec=True
+    )
+    remove_mock = mocker.patch(
+        "vector_search.tasks.remove_qdrant_records", autospec=True
+    )
+
+    assert embed_run_content_files(run.id) is None
+
+    generate_embeddings_mock.si.assert_not_called()
+    remove_mock.assert_called_once_with([emptied.id], CONTENT_FILE_TYPE)
+
+
 def test_embed_run_content_files_retries_transient_qdrant_errors(mocker):
     """A transient Qdrant error in the pre-pass retries instead of failing the run."""
     run = LearningResourceRunFactory.create()


### PR DESCRIPTION
### What are the relevant tickets?

Followup to #3646 (mitodl/hq#12454). Three enhancements to the change-detection pre-pass.

### Description (What does it do?)

**1. Content-less files are excluded from the pre-pass.** A published `ContentFile`
with null/empty `content` never produces a Qdrant point, so the pre-pass counted it as
"missing" and re-flagged it on *every* load. Those files now never enter the candidate
list, so an unchanged run settles at a true `0 of N`.

**2. Transient Qdrant errors during the pre-pass retry instead of deferring the run.**
`embed_run_content_files` gets `max_retries=3`, and a `DEADLINE_EXCEEDED` / `UNAVAILABLE`
from the batched payload fetch retries with the existing `_retry_countdown` backoff.
Previously a single blip failed the task and pushed the whole run's embedding to the
next load.

**3. Purge runs before embed in the indexing chain.** `remove_unpublished_run_content_files`
is now queued ahead of `embed_run_content_files` in the `content_files_loaded` hook. The
two tasks touch disjoint sets (`published=False` vs `published=True`), so ordering is
free — but with purge first, unpublished files' points are removed even when the embed
step fails.

### How can this be tested?

Verified locally against OCW **15.S12 Blockchain and Money, Fall 2018**
(`15.S12+fall_2018`, run `eca120b8a78ad938e60920323e127f21`) — 58 published content
files, 3 of which are content-less. Get its run pk:

```python
from learning_resources.models import LearningResourceRun
run = LearningResourceRun.objects.get(run_id="eca120b8a78ad938e60920323e127f21")
print(run.id, run.content_files.filter(published=True).count())
```

If that run isn't in your DB, any run with a mix of content-bearing and content-less
published files works — find one with:

```python
from django.db.models import Q, Count
from learning_resources.models import ContentFile
ContentFile.objects.filter(published=True).values("run_id").annotate(
    empty=Count("id", filter=Q(content__isnull=True) | Q(content="")),
    total=Count("id"),
).filter(empty__gt=0, total__gt=5).order_by("total")[:5]
```

**Restart the celery worker first** — prefork workers don't reload changed code, so a
worker started before checkout will silently run the old task and log nothing:

```bash
docker compose restart celery
```

**Content-less files excluded (fix 1)**

```python
from vector_search.tasks import embed_run_content_files
embed_run_content_files.delay(RUN_PK)
```

```bash
docker compose logs celery --since 5m | grep 'need embedding'
```

Queue it a second time once the first pass settles. Expect `0 of 55` — i.e. `N` equals
published-with-content, not total published:

```
embed_run_content_files run 4232: 0 of 55 files need embedding
```

On `mb/embed-change-detection` the same run reports `3 of 58` on every single load,
forever. The three files genuinely have no Qdrant point, which you can confirm directly:

```python
from django.db.models import Q
from learning_resources.models import ContentFile, LearningResourceRun
from vector_search.tasks import _stored_content_payloads
from vector_search.utils import vector_point_id, vector_point_key

run = LearningResourceRun.objects.select_related("learning_resource__platform").get(id=RUN_PK)
res = run.learning_resource

def pid(key):
    return vector_point_id(vector_point_key(
        {"platform": {"code": res.platform.code}, "resource_readable_id": res.readable_id,
         "run_readable_id": run.run_id, "key": key},
        chunk_number=0, document_type="content_file"))

empty = ContentFile.objects.filter(run=run, published=True).filter(
    Q(content__isnull=True) | Q(content="")).values_list("id", "key")
stored = _stored_content_payloads([pid(k) for _, k in empty], fields=("checksum",))
for cid, k in empty:
    print(cid, k, stored.get(pid(k)))   # all None
```

**Qdrant blip retries (fix 2)**

```bash
docker compose stop qdrant
```

Queue the task and watch the log — it should retry rather than fail terminally:

```
embed_run_content_files[...] retry: Retry in 64s: <_InactiveRpcError ...
        status = StatusCode.UNAVAILABLE
```

Bring Qdrant back inside that backoff window and the retry completes the pre-pass:

```bash
docker compose start qdrant
```

```
embed_run_content_files run 4232: 0 of 55 files need embedding
Task vector_search.tasks.embed_run_content_files[...] succeeded in 18.2s
```

Before this change the `UNAVAILABLE` was terminal and the run's embedding waited for
the next load.

**Purge before embed (fix 3)**

Unpublish one already-embedded file and fire the hook:

```python
from learning_resources.models import ContentFile, LearningResourceRun
from learning_resources.utils import content_files_loaded_actions

run = LearningResourceRun.objects.get(id=RUN_PK)
cf = ContentFile.objects.filter(run=run, published=True).exclude(
    content="").exclude(content__isnull=True).first()
print(cf.id, cf.key)
ContentFile.objects.filter(id=cf.id).update(published=False)
content_files_loaded_actions(run)
```

```bash
docker compose logs celery --since 5m | grep -E 'remove_unpublished|remove_embeddings|embed_run_content_files|need embedding'
```

Expected order — the purge fully completes before embedding starts:

```
remove_unpublished_run_content_files[...] received
remove_embeddings[...] received
remove_embeddings[...] succeeded
embed_run_content_files[...] received
embed_run_content_files run 4232: 0 of 54 files need embedding
```

Then confirm the unpublished file's point is gone (re-use the `pid()` helper above —
`_stored_content_payloads([pid(cf.key)], fields=("checksum",))` returns `{}`). It should
be absent regardless of how the embed step ends.

Republish it and fire the hook again to restore local state; the pre-pass picks it back
up as missing, which also shows the self-heal path:

```
embed_run_content_files run 4232: 1 of 55 files need embedding
```
