### PR TITLE
fix: For garbled non-Latin characters in certificate PDFs

### DIFF
--- a/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
+++ b/frontends/main/src/app/(site)/certificate/[certificateType]/[uuid]/pdf/route.tsx
@@ -50,6 +50,65 @@ Font.register({
   src: "https://use.typekit.net/af/305037/00000000000000007735bb39/30/l?primer=7cdcb44be4a7db8877ffa5c0007b8dd865b3bbc383831fe2ea177f62257a9191&fvd=n7&v=3",
 })
 
+/* Fallback fonts for non-Latin characters (hq#12554, hq#12475).
+ * Neue Haas Grotesk is a Latin-only typeface, and @react-pdf/renderer performs
+ * no automatic system-font fallback the way a browser does. Without these,
+ * user-supplied text with glyphs outside Neue Haas Grotesk's set — CJK names
+ * (e.g. 志云 黄) and extended-Latin letters (e.g. Turkish Ğ) — renders garbled.
+ *
+ * Noto Sans (latin-ext) covers extended-Latin; Noto Sans SC / TC cover
+ * Simplified / Traditional Chinese. They are only ever *used* for characters
+ * the brand font can't render (react-pdf falls back per-character), so branded
+ * text stays in Neue Haas Grotesk. Served from a version-pinned CDN, matching
+ * the remote-font approach already used above for the brand font.
+ *
+ * Note: this only affects the PDF/print output — the live web page is unaffected
+ * (it uses its own font stack with the browser's built-in fallback).
+ */
+const FONTSOURCE_CDN = "https://cdn.jsdelivr.net/fontsource/fonts"
+Font.register({
+  family: "Noto Sans 400",
+  src: `${FONTSOURCE_CDN}/noto-sans@5.3.0/latin-ext-400-normal.ttf`,
+})
+Font.register({
+  family: "Noto Sans 700",
+  src: `${FONTSOURCE_CDN}/noto-sans@5.3.0/latin-ext-700-normal.ttf`,
+})
+Font.register({
+  family: "Noto Sans SC 400",
+  src: `${FONTSOURCE_CDN}/noto-sans-sc@5.3.0/chinese-simplified-400-normal.ttf`,
+})
+Font.register({
+  family: "Noto Sans SC 700",
+  src: `${FONTSOURCE_CDN}/noto-sans-sc@5.3.0/chinese-simplified-700-normal.ttf`,
+})
+Font.register({
+  family: "Noto Sans TC 400",
+  src: `${FONTSOURCE_CDN}/noto-sans-tc@5.3.0/chinese-traditional-400-normal.ttf`,
+})
+Font.register({
+  family: "Noto Sans TC 700",
+  src: `${FONTSOURCE_CDN}/noto-sans-tc@5.3.0/chinese-traditional-700-normal.ttf`,
+})
+
+/* Font-family stacks: brand font first, then fallbacks for glyphs it lacks.
+ * Use these instead of the bare "Neue Haas Grotesk Text NNN" strings so every
+ * text element gets per-character fallback. Only the 400 and 700 weights are
+ * used on the certificate.
+ */
+const FONT_STACK_400 = [
+  "Neue Haas Grotesk Text 400",
+  "Noto Sans 400",
+  "Noto Sans SC 400",
+  "Noto Sans TC 400",
+]
+const FONT_STACK_700 = [
+  "Neue Haas Grotesk Text 700",
+  "Noto Sans 700",
+  "Noto Sans SC 700",
+  "Noto Sans TC 700",
+]
+
 // Disables hyphenation on word wrap
 Font.registerHyphenationCallback((word) => [word])
 
@@ -68,27 +127,27 @@ const colors = {
  */
 const typography = {
   h1: {
-    fontFamily: "Neue Haas Grotesk Text 700",
+    fontFamily: FONT_STACK_700,
     fontSize: pxToPt(52),
     lineHeight: pxToPt(60),
   },
   h2: {
-    fontFamily: "Neue Haas Grotesk Text 700",
+    fontFamily: FONT_STACK_700,
     fontSize: pxToPt(34),
     lineHeight: pxToPt(40),
   },
   h3: {
-    fontFamily: "Neue Haas Grotesk Text 700",
+    fontFamily: FONT_STACK_700,
     fontSize: pxToPt(28),
     lineHeight: pxToPt(2.4),
   },
   h4: {
-    fontFamily: "Neue Haas Grotesk Text 700",
+    fontFamily: FONT_STACK_700,
     fontSize: pxToPt(24),
     lineHeight: pxToPt(2),
   },
   body1: {
-    fontFamily: "Neue Haas Grotesk Text 400",
+    fontFamily: FONT_STACK_400,
     fontSize: pxToPt(16),
     lineHeight: pxToPt(2),
   },
@@ -171,7 +230,7 @@ const Badge = ({ programType }: { programType?: string | null }) => {
   const { fontSizePx, lineHeightPx, registeredMarkScale } =
     getCertificateBadgeTypography(programType)
   const badgeStyle = {
-    fontFamily: "Neue Haas Grotesk Text 700",
+    fontFamily: FONT_STACK_700,
     fontSize: pxToPt(fontSizePx),
     lineHeight: pxToPt(lineHeightPx),
   }
@@ -302,7 +361,7 @@ const CertificateDoc = ({
             border: `${pxToPt(4)} solid ${colors.silverGray}`,
             padding: pxToPt(24),
             backgroundColor: colors.white,
-            fontFamily: "Neue Haas Grotesk Text 400",
+            fontFamily: FONT_STACK_400,
           }}
         >
           <View
@@ -326,7 +385,7 @@ const CertificateDoc = ({
                 top: pxToPt(164),
                 left: pxToPt(46),
                 ...typography.h4,
-                fontFamily: "Neue Haas Grotesk Text 400",
+                fontFamily: FONT_STACK_400,
               }}
             >
               This is to certify that
@@ -351,7 +410,7 @@ const CertificateDoc = ({
                 color: colors.silverGrayDark,
                 ...typography.h4,
                 fontSize: pxToPt(20),
-                fontFamily: "Neue Haas Grotesk Text 400",
+                fontFamily: FONT_STACK_400,
               }}
             >
               has successfully completed all requirements of{" "}
@@ -362,7 +421,7 @@ const CertificateDoc = ({
                 top: pxToPt(396),
                 left: pxToPt(46),
                 ...typography.h2,
-                fontFamily: "Neue Haas Grotesk Text 700",
+                fontFamily: FONT_STACK_700,
                 color: colors.black,
                 width: pxToPt(1150),
               }}
@@ -377,7 +436,7 @@ const CertificateDoc = ({
                   left: pxToPt(46),
                   color: colors.silverGrayDark,
                   ...typography.h4,
-                  fontFamily: "Neue Haas Grotesk Text 400",
+                  fontFamily: FONT_STACK_400,
                 }}
               >
                 {moment(issueDate).format("MMM D, YYYY")}
@@ -391,7 +450,7 @@ const CertificateDoc = ({
                   left: pxToPt(46),
                   ...typography.h4,
                   color: colors.silverGrayDark,
-                  fontFamily: "Neue Haas Grotesk Text 400",
+                  fontFamily: FONT_STACK_400,
                 }}
               >
                 Awarded {ceus} Continuing Education Units (CEUs)


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
 Fixes  https://github.com/mitodl/hq/issues/12554  
 Fixes  https://github.com/mitodl/hq/issues/12475  
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
Learners with non-Latin characters in their name see garbled/blank text when they use the certificate **Print / download PDF** 

The certificate PDF route renders with `@react-pdf/renderer`, which embeds only the fonts we register — the Latin-only **Neue Haas Grotesk** brand font — and, unlike a browser, does **no automatic system-font fallback**. Any character outside that font's glyph set (all CJK, plus some extended-Latin letters) has no glyph to render, so it comes out garbled.

This is why the bug is **print-only**: the live certificate page is HTML, so the browser silently substitutes a system font for those characters. The PDF has nothing to fall back to.

- Register **Noto Sans** (latin-ext), **Noto Sans SC** (Simplified Chinese), and **Noto Sans TC** (Traditional Chinese) as fallback fonts in the certificate PDF route (400 + 700 weights, version-pinned CDN — same remote-font approach already used for the brand font).
- Add these to the `fontFamily` stack for every text element via two shared stacks (`FONT_STACK_400` `FONT_STACK_700`). `@react-pdf/renderer` resolves fonts **per-character**, so branded text stays in Neue Haas Grotesk and only the unsupported glyphs fall through to Noto.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

BEFORE 
<img width="1052" height="776" alt="Screenshot 2026-07-27 at 1 43 53 PM" src="https://github.com/user-attachments/assets/40a98b2e-0e41-4353-9385-a0c6251765ef" />


AFTER 
<img width="1060" height="782" alt="Screenshot 2026-07-27 at 1 39 02 PM" src="https://github.com/user-attachments/assets/53e07dad-2343-461c-a43f-ebd07b7892ae" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

1. Give a **local** user a non-Latin name. Easiest via Django admin on your local MITx Online (`.../admin/users/user/<id>/change/`) — set **Name** to  something like `志云 黄 / YAVUZHAN ÇAĞRI` and save.
2. Open that user's certificate PDF: .../certificate/<course|program>/<uuid>/pdf
  - Expected: the name renders as real glyphs (not boxes/garbage), matching the live HTML page (drop /pdf). Confirm Cmd+P / download looks the same.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

The PDF route fetches the Noto fonts (~2.5 MB CJK) from the CDN on the first render after a cold start, then caches in-process — same remote-dependency model as the existing brand font. 


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
