### PR TITLE
Fix embeddings healthcheck missing-summaries filter

### DIFF
--- a/vector_search/tasks.py
+++ b/vector_search/tasks.py
@@ -632,11 +632,21 @@ def embeddings_healthcheck():
 
 
 def _missing_summaries():
-    summarizer = ContentSummarizer()
-    return summarizer.get_unprocessed_content_file_ids(
+    resource_ids = list(
         LearningResource.objects.filter(require_summaries=True)
         .filter(Q(published=True) | Q(test_mode=True))
         .values_list("id", flat=True)
+    )
+    if not resource_ids:
+        # get_unprocessed_content_file_ids treats an empty learning_resource_ids
+        # list the same as None (no restriction), so short-circuit here instead
+        # of letting it scan every learning resource.
+        return []
+
+    summarizer = ContentSummarizer()
+    return summarizer.get_unprocessed_content_file_ids(
+        overwrite=False,
+        learning_resource_ids=resource_ids,
     )
 
 

--- a/vector_search/tasks_test.py
+++ b/vector_search/tasks_test.py
@@ -884,6 +884,96 @@ def test_embeddings_healthcheck_missing_summaries(mocker):
     )
 
 
+def test_embeddings_healthcheck_excludes_already_summarized(mocker):
+    """
+    embeddings_healthcheck should not count content files that already have
+    a summary as missing (regression test for passing overwrite=True
+    implicitly by mis-ordering get_unprocessed_content_file_ids arguments)
+    """
+    content_extension = [".srt"]
+    content_type = ["file"]
+    platform = LearningResourcePlatformFactory.create()
+    ContentSummarizerConfigurationFactory.create(
+        allowed_extensions=content_extension,
+        allowed_content_types=content_type,
+        is_active=True,
+        llm_model="test",
+        platform__code=platform.code,
+    )
+    resource = LearningResourceFactory.create(
+        published=True, require_summaries=True, platform=platform
+    )
+    resource.runs.all().delete()
+    learning_resource_run = LearningResourceRunFactory.create(
+        published=True,
+        learning_resource=resource,
+    )
+    learning_resource_run.learning_resource = resource
+    learning_resource_run.save()
+
+    ContentFileFactory.create(
+        published=True,
+        content="test",
+        file_extension=content_extension[0],
+        summary="already summarized",
+        flashcards=[{"question": "q", "answer": "a"}],
+        content_type=content_type[0],
+        run=learning_resource_run,
+    )
+    mocker.patch(
+        "vector_search.tasks.filter_existing_qdrant_points_by_ids",
+    )
+    mock_sentry = mocker.patch("vector_search.tasks.sentry_sdk.capture_message")
+
+    embeddings_healthcheck()
+    assert mock_sentry.call_count == 0
+
+
+def test_embeddings_healthcheck_summaries_scoped_to_require_summaries(mocker):
+    """
+    embeddings_healthcheck should only count missing summaries for learning
+    resources that require them, not every learning resource (regression
+    test for get_unprocessed_content_file_ids never receiving
+    learning_resource_ids)
+    """
+    content_extension = [".srt"]
+    content_type = ["file"]
+    platform = LearningResourcePlatformFactory.create()
+    ContentSummarizerConfigurationFactory.create(
+        allowed_extensions=content_extension,
+        allowed_content_types=content_type,
+        is_active=True,
+        llm_model="test",
+        platform__code=platform.code,
+    )
+    resource = LearningResourceFactory.create(
+        published=True, require_summaries=False, platform=platform
+    )
+    resource.runs.all().delete()
+    learning_resource_run = LearningResourceRunFactory.create(
+        published=True,
+        learning_resource=resource,
+    )
+    learning_resource_run.learning_resource = resource
+    learning_resource_run.save()
+
+    ContentFileFactory.create(
+        published=True,
+        content="test",
+        file_extension=content_extension[0],
+        summary="",
+        content_type=content_type[0],
+        run=learning_resource_run,
+    )
+    mocker.patch(
+        "vector_search.tasks.filter_existing_qdrant_points_by_ids",
+    )
+    mock_sentry = mocker.patch("vector_search.tasks.sentry_sdk.capture_message")
+
+    embeddings_healthcheck()
+    assert mock_sentry.call_count == 0
+
+
 def test_generate_embeddings_retries_on_deadline(mocker):
     """A deadline with retry budget left calls self.retry (jittered backoff)."""
     mocker.patch(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`_missing_summaries()` in `vector_search/tasks.py` calls `ContentSummarizer.get_unprocessed_content_file_ids(self, overwrite, learning_resource_ids=None, content_file_ids=None)`, but was passing a `LearningResource` queryset positionally:

```python
def _missing_summaries():
    summarizer = ContentSummarizer()
    return summarizer.get_unprocessed_content_file_ids(
        LearningResource.objects.filter(require_summaries=True)
        .filter(Q(published=True) | Q(test_mode=True))
        .values_list("id", flat=True)
    )
```

That queryset landed in the `overwrite` parameter instead of `learning_resource_ids`. Since a non-empty queryset is truthy, this silently set `overwrite=True`, which skips the "only unprocessed" filter (`Q(summary="") | Q(flashcards=[])`) inside `get_unprocessed_content_file_ids`. And because `learning_resource_ids` was never actually passed, the `require_summaries=True` scoping was lost entirely.

The net effect: the `embeddings_healthcheck` Sentry alert this feeds (`vector_search/tasks.py`) was counting **every** content file across **every** learning resource — including ones that already have summaries and ones from resources that don't even require summaries — as "missing," rather than just genuinely unprocessed content on resources that require summaries.

Fix: pass both arguments as keywords (`overwrite=False`, `learning_resource_ids=resource_ids`). Also added a short-circuit for the case where no learning resources currently require summaries — `get_unprocessed_content_file_ids` treats an empty `learning_resource_ids` list the same as `None` (no restriction) rather than "match nothing," so without the short-circuit that edge case would still fall through to scanning every resource.

This was flagged by Sentry's bug-prediction bot as a review comment on https://github.com/mitodl/mit-learn/pull/3683 — it's a pre-existing bug (introduced in commit `3ba27bdc4e`, 2025-11-07) unrelated to that PR's changes, so it's being fixed here separately.

### Screenshots (if appropriate):
N/A - no UI changes

### How can this be tested?
Added two regression tests to `vector_search/tasks_test.py`:
- `test_embeddings_healthcheck_excludes_already_summarized` — a content file that already has a summary and flashcards should not be counted as missing.
- `test_embeddings_healthcheck_summaries_scoped_to_require_summaries` — a content file belonging to a learning resource with `require_summaries=False` should not be counted as missing.

Both fail against the old code (the first because `overwrite` ends up truthy, the second because `learning_resource_ids` is never applied) and pass with the fix.

Ran the full `vector_search/tasks_test.py` suite: `docker compose run --rm web uv run pytest vector_search/tasks_test.py -q` — 45 passed, including the existing `test_embeddings_healthcheck_missing_summaries` test.

`ruff check --select F401,F821` and `ruff format --diff` are clean on both touched files.

### Additional Context
No behavior change outside of `_missing_summaries()` / the `embeddings_healthcheck` task — this only affects what gets reported to Sentry, not any content-processing task itself.