### PR TITLE
fix: Show error message when a podcast episode fails to play

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/AudioPlayer.styled.ts
+++ b/frontends/main/src/app-pages/PodcastPage/AudioPlayer.styled.ts
@@ -159,3 +159,37 @@ export const SpeedButton = styled.button(({ theme }) => ({
     color: theme.custom.colors.red,
   },
 }))
+
+/**
+ * Playback-failure message. Takes the progress row's grid area, replacing the
+ * seek slider — which has nothing to scrub — so the players report the failure
+ * without growing taller and pushing the fixed bar over the page content.
+ */
+export const PlaybackError = styled.div(({ theme }) => ({
+  gridArea: "progress",
+  display: "flex",
+  alignItems: "center",
+  gap: "8px",
+  minWidth: 0,
+  color: theme.custom.colors.red,
+  "& > svg": {
+    flexShrink: 0,
+    width: "20px",
+    height: "20px",
+  },
+}))
+
+export const PlaybackErrorText = styled(Typography)({
+  minWidth: 0,
+  // Bound the message at two lines: one fits the desktop bar, two fit the
+  // taller mobile layout, and neither can push the transport controls around.
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  overflow: "hidden",
+})
+
+export const RetryButton = styled(SpeedButton)(({ theme }) => ({
+  borderColor: theme.custom.colors.red,
+  color: theme.custom.colors.red,
+}))

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.test.tsx
@@ -308,6 +308,69 @@ describe("PodcastEmbedPlayer", () => {
     })
   })
 
+  describe("playback errors", () => {
+    const simulateMediaError = (audio: HTMLAudioElement, code: number) => {
+      Object.defineProperty(audio, "error", {
+        value: { code },
+        configurable: true,
+      })
+      fireEvent.error(audio)
+    }
+
+    test("shows a message when the source is rejected (e.g. HTTP 451)", async () => {
+      const { audio } = renderPlayer()
+      simulateMediaError(audio, 4) // MEDIA_ERR_SRC_NOT_SUPPORTED
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /unavailable in your region/i,
+      )
+    })
+
+    test("replaces the seek slider with the message", async () => {
+      const { audio } = renderPlayer()
+      expect(screen.getByRole("slider", { name: /seek/i })).toBeInTheDocument()
+
+      simulateMediaError(audio, 2)
+
+      await screen.findByRole("alert")
+      expect(
+        screen.queryByRole("slider", { name: /seek/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("reports missing audio for an episode with no audio_url", () => {
+      const resource = makeEpisode({
+        podcast_episode: {
+          ...makeEpisode().podcast_episode!,
+          audio_url: null as unknown as string,
+          episode_link: null,
+        },
+      })
+      renderPlayer(resource)
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /audio isn't available for this episode/i,
+      )
+      expect(
+        screen.queryByRole("button", { name: /try again/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Try again reloads the source and clears the message", async () => {
+      const { audio } = renderPlayer()
+      simulateMediaError(audio, 2)
+      await screen.findByRole("alert")
+
+      jest.clearAllMocks()
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }))
+
+      expect(window.HTMLMediaElement.prototype.load).toHaveBeenCalled()
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      )
+    })
+  })
+
   describe("no close button", () => {
     test("does not render a close button", () => {
       renderPlayer()

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
@@ -2,6 +2,7 @@
 
 import React from "react"
 import { styled } from "ol-components"
+import { VisuallyHidden } from "@mitodl/smoot-design"
 import {
   RiPlayCircleLine,
   RiPauseCircleLine,
@@ -12,6 +13,7 @@ import {
 import type { LearningResource } from "api/v1"
 import { getEpisodeAudioUrl } from "./PodcastsListingPage/helpers"
 import { useAudioPlayer, formatClockTime } from "./useAudioPlayer"
+import { usePlaybackRecovery, RETRYING_STATUS } from "./usePlaybackRecovery"
 import {
   TrackInfo as TrackInfoBase,
   TrackTitle,
@@ -141,6 +143,15 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
     retry,
   } = useAudioPlayer(audioUrl)
 
+  const isPlayDisabled = isBuffering || isPlayPending || !hasAudioSource
+  const {
+    playButtonRef,
+    retryButtonRef,
+    onProgressFocus,
+    requestRetry,
+    isRetrying,
+  } = usePlaybackRecovery(error, retry, isPlayDisabled)
+
   const Wrapper = inline ? InlineWrapper : Shell
 
   return (
@@ -148,7 +159,19 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} {...audioProps} />
 
-      <PlayerCard style={inline ? { maxWidth: "100%" } : undefined}>
+      <PlayerCard
+        style={inline ? { maxWidth: "100%" } : undefined}
+        aria-busy={isRetrying}
+      >
+        {/*
+          Mounted unconditionally, with only its text changing: a live region
+          added to the DOM at the same moment as its content is unreliably
+          announced.
+        */}
+        <VisuallyHidden aria-live="polite" aria-atomic="true">
+          {isRetrying ? RETRYING_STATUS : ""}
+        </VisuallyHidden>
+
         {resource.image?.url ? (
           <CoverArt
             src={resource.image.url}
@@ -174,6 +197,7 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
           </IconButton>
 
           <PlayPauseButton
+            ref={playButtonRef}
             onClick={togglePlay}
             aria-label={
               !hasAudioSource
@@ -212,11 +236,13 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
             <RiErrorWarningLine aria-hidden />
             <PlaybackErrorText variant="body3">{error}</PlaybackErrorText>
             {hasAudioSource ? (
-              <RetryButton onClick={retry}>Try again</RetryButton>
+              <RetryButton ref={retryButtonRef} onClick={requestRetry}>
+                Try again
+              </RetryButton>
             ) : null}
           </PlaybackError>
         ) : (
-          <ProgressWrapper>
+          <ProgressWrapper onFocus={onProgressFocus}>
             <TimeLabel variant="body3">
               {formatClockTime(currentTime)}
             </TimeLabel>

--- a/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastEmbedPlayer.tsx
@@ -7,6 +7,7 @@ import {
   RiPauseCircleLine,
   RiReplay10Line,
   RiForward30Line,
+  RiErrorWarningLine,
 } from "@remixicon/react"
 import type { LearningResource } from "api/v1"
 import { getEpisodeAudioUrl } from "./PodcastsListingPage/helpers"
@@ -23,6 +24,9 @@ import {
   ProgressRange,
   TimeLabel,
   SpeedButton as SpeedButtonBase,
+  PlaybackError,
+  PlaybackErrorText,
+  RetryButton,
 } from "./AudioPlayer.styled"
 
 // ─── Styled components (card layout) ────────────────────────────────────────────
@@ -129,10 +133,12 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
     duration,
     percent,
     speed,
+    error,
     togglePlay,
     skip,
     cycleSpeed,
     seek,
+    retry,
   } = useAudioPlayer(audioUrl)
 
   const Wrapper = inline ? InlineWrapper : Shell
@@ -201,23 +207,35 @@ const PodcastEmbedPlayer: React.FC<PodcastEmbedPlayerProps> = ({
           </SpeedButton>
         </Controls>
 
-        <ProgressWrapper>
-          <TimeLabel variant="body3">{formatClockTime(currentTime)}</TimeLabel>
-          <ProgressRange
-            type="range"
-            min={0}
-            max={duration || 1}
-            value={currentTime}
-            step={1}
-            percent={percent}
-            trackHeight={8}
-            thumbSize={12}
-            aria-valuetext={formatClockTime(currentTime)}
-            aria-label="Seek"
-            onChange={(e) => seek(Number(e.target.value))}
-          />
-          <TimeLabel variant="body3">{formatClockTime(duration)}</TimeLabel>
-        </ProgressWrapper>
+        {error ? (
+          <PlaybackError role="alert">
+            <RiErrorWarningLine aria-hidden />
+            <PlaybackErrorText variant="body3">{error}</PlaybackErrorText>
+            {hasAudioSource ? (
+              <RetryButton onClick={retry}>Try again</RetryButton>
+            ) : null}
+          </PlaybackError>
+        ) : (
+          <ProgressWrapper>
+            <TimeLabel variant="body3">
+              {formatClockTime(currentTime)}
+            </TimeLabel>
+            <ProgressRange
+              type="range"
+              min={0}
+              max={duration || 1}
+              value={currentTime}
+              step={1}
+              percent={percent}
+              trackHeight={8}
+              thumbSize={12}
+              aria-valuetext={formatClockTime(currentTime)}
+              aria-label="Seek"
+              onChange={(e) => seek(Number(e.target.value))}
+            />
+            <TimeLabel variant="body3">{formatClockTime(duration)}</TimeLabel>
+          </ProgressWrapper>
+        )}
       </PlayerCard>
     </Wrapper>
   )

--- a/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.test.tsx
@@ -429,6 +429,126 @@ describe("PodcastPlayer", () => {
       expect(screen.queryByRole("alert")).not.toBeInTheDocument()
     })
 
+    describe("focus handoff", () => {
+      test("moves focus to Try again when the focused control is replaced", async () => {
+        const { audio, simulateCanPlay } = await renderPlayer()
+        await simulateCanPlay()
+
+        const slider = screen.getByRole("slider", { name: /seek/i })
+        slider.focus()
+        expect(slider).toHaveFocus()
+
+        simulateMediaError(audio, 4)
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /try again/i }),
+          ).toHaveFocus(),
+        )
+      })
+
+      test("returns focus to the play button after a successful retry", async () => {
+        const { audio, simulateCanPlay } = await renderPlayer()
+        simulateMediaError(audio, 2)
+
+        const retryButton = await screen.findByRole("button", {
+          name: /try again/i,
+        })
+        retryButton.focus()
+        fireEvent.click(retryButton)
+
+        // The reload leaves the play button disabled, so the handoff has to
+        // wait for it to become focusable again: first the buffering clears,
+        // then the play() promise settles.
+        simulateCanPlay()
+
+        await waitFor(() =>
+          expect(
+            screen.getByRole("button", { name: /^pause$/i }),
+          ).toHaveFocus(),
+        )
+      })
+
+      test("announces the retry while it is in flight", async () => {
+        const { audio, simulateCanPlay } = await renderPlayer()
+        simulateMediaError(audio, 2)
+
+        const retryButton = await screen.findByRole("button", {
+          name: /try again/i,
+        })
+        // The live region must already exist so the text change is announced.
+        const status = document.querySelector("[aria-live='polite']")
+        expect(status).toBeInTheDocument()
+        expect(status).toHaveTextContent("")
+
+        fireEvent.click(retryButton)
+
+        // The alert is gone and the button unmounted — this is the silent gap.
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+        expect(retryButton).not.toBeInTheDocument()
+        expect(status).toHaveTextContent(/retrying/i)
+        expect(document.querySelector("[aria-busy='true']")).toBeInTheDocument()
+
+        simulateCanPlay()
+
+        await waitFor(() => expect(status).toHaveTextContent(""))
+        expect(document.querySelector("[aria-busy='true']")).toBeNull()
+      })
+
+      test("stops announcing when the retry fails again", async () => {
+        const { audio } = await renderPlayer()
+        simulateMediaError(audio, 2)
+
+        fireEvent.click(
+          await screen.findByRole("button", { name: /try again/i }),
+        )
+        const status = document.querySelector("[aria-live='polite']")
+        expect(status).toHaveTextContent(/retrying/i)
+
+        // The reload fails too; the alert speaks for the outcome from here.
+        simulateMediaError(audio, 2)
+
+        await waitFor(() => expect(status).toHaveTextContent(""))
+        expect(await screen.findByRole("alert")).toBeInTheDocument()
+      })
+
+      test("says nothing when playback is healthy", async () => {
+        const { simulateCanPlay } = await renderPlayer()
+        await simulateCanPlay()
+
+        expect(
+          document.querySelector("[aria-live='polite']"),
+        ).toHaveTextContent("")
+        expect(document.querySelector("[aria-busy='true']")).toBeNull()
+      })
+
+      test("does not steal focus from elsewhere on the page", async () => {
+        const { audio, simulateCanPlay } = await renderPlayer()
+        await simulateCanPlay()
+
+        const closeButton = screen.getByRole("button", {
+          name: /close player/i,
+        })
+        closeButton.focus()
+
+        simulateMediaError(audio, 4)
+
+        await screen.findByRole("alert")
+        expect(closeButton).toHaveFocus()
+      })
+
+      test("leaves focus alone when the error arrives unattended", async () => {
+        const { audio } = await renderPlayer()
+        // Nothing in the player was focused — a mouse user scrolling the page.
+        expect(document.body).toHaveFocus()
+
+        simulateMediaError(audio, 4)
+
+        await screen.findByRole("alert")
+        expect(document.body).toHaveFocus()
+      })
+    })
+
     test("clears the message when the track changes", async () => {
       const { audio, rerender } = await renderPlayer()
       simulateMediaError(audio, 4)

--- a/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.test.tsx
@@ -303,6 +303,183 @@ describe("PodcastPlayer", () => {
     ).toBeDisabled()
   })
 
+  describe("playback errors", () => {
+    /**
+     * Fire an `error` event carrying a specific MediaError code, the way a
+     * browser does when the fetch or the decode fails.
+     */
+    const simulateMediaError = (audio: HTMLAudioElement, code: number) => {
+      Object.defineProperty(audio, "error", {
+        value: { code },
+        configurable: true,
+      })
+      fireEvent.error(audio)
+    }
+
+    /** Override `navigator.onLine`, which jsdom reports as `true` by default. */
+    const setOnLine = (value: boolean) => {
+      Object.defineProperty(window.navigator, "onLine", {
+        value,
+        configurable: true,
+      })
+    }
+
+    afterEach(() => setOnLine(true))
+
+    test("blames the connection, not the provider, when the device is offline", async () => {
+      const { audio } = await renderPlayer()
+      setOnLine(false)
+      // An offline request never reaches the network, so the browser reports
+      // the same code a geo-block does.
+      simulateMediaError(audio, 4) // MEDIA_ERR_SRC_NOT_SUPPORTED
+
+      const alert = await screen.findByRole("alert")
+      expect(alert).toHaveTextContent(/you appear to be offline/i)
+      expect(alert).not.toHaveTextContent(/region/i)
+    })
+
+    test("reports offline when play() rejects with no connection", async () => {
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("nope"), { name: "NotSupportedError" }),
+      )
+      setOnLine(false)
+
+      await renderPlayer()
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /you appear to be offline/i,
+      )
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockResolvedValue(
+        undefined,
+      )
+    })
+
+    test("shows a region-restriction message when the source is rejected (e.g. HTTP 451)", async () => {
+      const { audio } = await renderPlayer()
+      simulateMediaError(audio, 4) // MEDIA_ERR_SRC_NOT_SUPPORTED
+
+      const alert = await screen.findByRole("alert")
+      expect(alert).toHaveTextContent(/can't be played/i)
+      expect(alert).toHaveTextContent(/unavailable in your region/i)
+    })
+
+    test("shows a connection message on a network failure", async () => {
+      const { audio } = await renderPlayer()
+      simulateMediaError(audio, 2) // MEDIA_ERR_NETWORK
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /couldn't load this episode/i,
+      )
+    })
+
+    test("shows a damaged-file message when the audio cannot be decoded", async () => {
+      const { audio } = await renderPlayer()
+      simulateMediaError(audio, 3) // MEDIA_ERR_DECODE
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(/damaged/i)
+    })
+
+    test("ignores aborted loads, which are just track changes", async () => {
+      const { audio } = await renderPlayer()
+      simulateMediaError(audio, 1) // MEDIA_ERR_ABORTED
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    })
+
+    test("replaces the seek slider with the message", async () => {
+      const { audio } = await renderPlayer()
+      expect(screen.getByRole("slider", { name: /seek/i })).toBeInTheDocument()
+
+      simulateMediaError(audio, 4)
+
+      await screen.findByRole("alert")
+      expect(
+        screen.queryByRole("slider", { name: /seek/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("reports missing audio without waiting for a failed load", async () => {
+      await renderPlayer(
+        makeTrack({ audioUrl: "" }),
+        {},
+        { waitForAutoPlay: false },
+      )
+
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /audio isn't available for this episode/i,
+      )
+      // Nothing to re-fetch, so no retry is offered.
+      expect(
+        screen.queryByRole("button", { name: /try again/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    test("Try again reloads the source and plays", async () => {
+      const { audio } = await renderPlayer()
+      simulateMediaError(audio, 2)
+      await screen.findByRole("alert")
+
+      jest.clearAllMocks()
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }))
+
+      expect(window.HTMLMediaElement.prototype.load).toHaveBeenCalled()
+      await waitFor(() =>
+        expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled(),
+      )
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    })
+
+    test("clears the message when the track changes", async () => {
+      const { audio, rerender } = await renderPlayer()
+      simulateMediaError(audio, 4)
+      await screen.findByRole("alert")
+
+      rerender(
+        <ThemeProvider>
+          <PodcastPlayer
+            track={makeTrack({ audioUrl: "https://example.com/ep2.mp3" })}
+            onClose={jest.fn()}
+          />
+        </ThemeProvider>,
+      )
+
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument(),
+      )
+    })
+
+    test("stays silent when autoplay is blocked by browser policy", async () => {
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("blocked"), { name: "NotAllowedError" }),
+      )
+
+      await renderPlayer()
+
+      await waitFor(() =>
+        expect(window.HTMLMediaElement.prototype.play).toHaveBeenCalled(),
+      )
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockResolvedValue(
+        undefined,
+      )
+    })
+
+    test("reports a generic failure when play() rejects for another reason", async () => {
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockRejectedValue(
+        Object.assign(new Error("nope"), { name: "NotSupportedError" }),
+      )
+
+      await renderPlayer()
+
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        /something went wrong playing this episode/i,
+      )
+      ;(window.HTMLMediaElement.prototype.play as jest.Mock).mockResolvedValue(
+        undefined,
+      )
+    })
+  })
+
   test("prevents duplicate play calls during rapid clicks while play is pending", async () => {
     const { simulateCanPlay } = await renderPlayer()
     await simulateCanPlay()

--- a/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
@@ -8,6 +8,7 @@ import {
   RiReplay10Line,
   RiForward30Line,
   RiCloseLine,
+  RiErrorWarningLine,
 } from "@remixicon/react"
 import { useAudioPlayer, formatClockTime } from "./useAudioPlayer"
 import {
@@ -22,6 +23,9 @@ import {
   ProgressRange,
   TimeLabel,
   SpeedButton as SpeedButtonBase,
+  PlaybackError,
+  PlaybackErrorText,
+  RetryButton,
 } from "./AudioPlayer.styled"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -171,12 +175,14 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
       duration,
       percent,
       speed,
+      error,
       togglePlay,
       skip,
       cycleSpeed,
       seek,
       pause,
       resume,
+      retry,
     } = useAudioPlayer(track.audioUrl, { autoPlay: true, onPlayStateChange })
 
     useImperativeHandle(ref, () => ({ pause, resume }), [pause, resume])
@@ -247,27 +253,37 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
             </IconButton>
           </Controls>
 
-          <ProgressWrapper>
-            <TimeLabel variant="body3">
-              {formatClockTime(currentTime)}
-            </TimeLabel>
-            <ProgressRange
-              type="range"
-              min={0}
-              max={duration || 1}
-              value={currentTime}
-              step={1}
-              percent={percent}
-              aria-label="Seek"
-              onChange={(e) => seek(Number(e.target.value))}
-              onKeyDown={handleSeekKeyDown}
-            />
-            <TimeLabel variant="body3">{formatClockTime(duration)}</TimeLabel>
+          {error ? (
+            <PlaybackError role="alert">
+              <RiErrorWarningLine aria-hidden />
+              <PlaybackErrorText variant="body3">{error}</PlaybackErrorText>
+              {hasAudioSource ? (
+                <RetryButton onClick={retry}>Try again</RetryButton>
+              ) : null}
+            </PlaybackError>
+          ) : (
+            <ProgressWrapper>
+              <TimeLabel variant="body3">
+                {formatClockTime(currentTime)}
+              </TimeLabel>
+              <ProgressRange
+                type="range"
+                min={0}
+                max={duration || 1}
+                value={currentTime}
+                step={1}
+                percent={percent}
+                aria-label="Seek"
+                onChange={(e) => seek(Number(e.target.value))}
+                onKeyDown={handleSeekKeyDown}
+              />
+              <TimeLabel variant="body3">{formatClockTime(duration)}</TimeLabel>
 
-            <SpeedButton onClick={cycleSpeed} aria-label="Playback speed">
-              {speed}x
-            </SpeedButton>
-          </ProgressWrapper>
+              <SpeedButton onClick={cycleSpeed} aria-label="Playback speed">
+                {speed}x
+              </SpeedButton>
+            </ProgressWrapper>
+          )}
 
           {/* Close */}
           <CloseButton onClick={onClose} aria-label="Close player">

--- a/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastPlayer.tsx
@@ -2,6 +2,7 @@
 
 import React, { forwardRef, useImperativeHandle } from "react"
 import { styled } from "ol-components"
+import { VisuallyHidden } from "@mitodl/smoot-design"
 import {
   RiPlayCircleLine,
   RiPauseCircleLine,
@@ -11,6 +12,7 @@ import {
   RiErrorWarningLine,
 } from "@remixicon/react"
 import { useAudioPlayer, formatClockTime } from "./useAudioPlayer"
+import { usePlaybackRecovery, RETRYING_STATUS } from "./usePlaybackRecovery"
 import {
   TrackInfo as TrackInfoBase,
   TrackTitle as TrackTitleBase,
@@ -185,6 +187,15 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
       retry,
     } = useAudioPlayer(track.audioUrl, { autoPlay: true, onPlayStateChange })
 
+    const isPlayDisabled = isBuffering || isPlayPending || !hasAudioSource
+    const {
+      playButtonRef,
+      retryButtonRef,
+      onProgressFocus,
+      requestRetry,
+      isRetrying,
+    } = usePlaybackRecovery(error, retry, isPlayDisabled)
+
     useImperativeHandle(ref, () => ({ pause, resume }), [pause, resume])
 
     const handleSeekKeyDown = (
@@ -201,7 +212,16 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
         {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
         <audio ref={audioRef} {...audioProps} />
 
-        <PlayerShell>
+        <PlayerShell aria-busy={isRetrying}>
+          {/*
+            Mounted unconditionally, with only its text changing: a live region
+            added to the DOM at the same moment as its content is unreliably
+            announced.
+          */}
+          <VisuallyHidden aria-live="polite" aria-atomic="true">
+            {isRetrying ? RETRYING_STATUS : ""}
+          </VisuallyHidden>
+
           <TrackInfo>
             <PodcastName variant="body1" sx={{ color: "text.secondary" }}>
               {track.podcastName}
@@ -221,6 +241,7 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
             </IconButton>
 
             <PlayPauseButton
+              ref={playButtonRef}
               buttonSize={64}
               mobileButtonSize={56}
               onClick={togglePlay}
@@ -233,7 +254,7 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
                       ? "Pause"
                       : "Play"
               }
-              disabled={isBuffering || isPlayPending || !hasAudioSource}
+              disabled={isPlayDisabled}
             >
               {isBuffering || isPlayPending ? (
                 <PlayerLoader loading size={40} color="inherit" />
@@ -258,11 +279,13 @@ const PodcastPlayer = forwardRef<PodcastPlayerHandle, PodcastPlayerProps>(
               <RiErrorWarningLine aria-hidden />
               <PlaybackErrorText variant="body3">{error}</PlaybackErrorText>
               {hasAudioSource ? (
-                <RetryButton onClick={retry}>Try again</RetryButton>
+                <RetryButton ref={retryButtonRef} onClick={requestRetry}>
+                  Try again
+                </RetryButton>
               ) : null}
             </PlaybackError>
           ) : (
-            <ProgressWrapper>
+            <ProgressWrapper onFocus={onProgressFocus}>
               <TimeLabel variant="body3">
                 {formatClockTime(currentTime)}
               </TimeLabel>

--- a/frontends/main/src/app-pages/PodcastPage/useAudioPlayer.ts
+++ b/frontends/main/src/app-pages/PodcastPage/useAudioPlayer.ts
@@ -21,6 +21,76 @@ export const formatClockTime = (seconds: number): string => {
   return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`
 }
 
+/**
+ * User-facing messages for the ways playback can fail. Kept deliberately short:
+ * the fixed player bar renders them in place of the progress bar, where there
+ * is room for about two lines.
+ */
+export const PLAYBACK_ERROR_MESSAGES = {
+  /** The episode has no audio URL at all — nothing to fetch. */
+  noSource: "Audio isn't available for this episode.",
+  /** The device has no connection at all. */
+  offline: "You appear to be offline. Check your connection and try again.",
+  /** Transport failed part-way through (connection dropped, timeout). */
+  network:
+    "We couldn't load this episode. Check your connection and try again.",
+  /** The bytes arrived but aren't decodable audio. */
+  decode: "This episode's audio file is damaged and can't be played.",
+  /**
+   * The host refused or the response wasn't playable media. This is what a
+   * geo-block (HTTP 451), a 403/404, or a CORS rejection surfaces as, so the
+   * message names region restriction as the likely cause.
+   */
+  unavailable:
+    "This episode can't be played. It may be unavailable in your region.",
+  /** Playback failed for a reason the browser didn't classify. */
+  generic: "Something went wrong playing this episode.",
+} as const
+
+// MediaError codes. Spelled out as literals rather than read off the global
+// `MediaError` so this stays valid in environments that don't define it.
+const MEDIA_ERR_ABORTED = 1
+const MEDIA_ERR_NETWORK = 2
+const MEDIA_ERR_DECODE = 3
+const MEDIA_ERR_SRC_NOT_SUPPORTED = 4
+
+/**
+ * Whether the device has no connection. Only `false` from `navigator.onLine` is
+ * trustworthy — `true` means an interface is up, not that anything is
+ * reachable — which is exactly the direction we need.
+ */
+const isOffline = () =>
+  typeof navigator !== "undefined" && navigator.onLine === false
+
+/**
+ * Translate the `<audio>` element's error into a message, or `null` when the
+ * failure isn't worth surfacing. Aborts are ignored: they are what a track
+ * change or a fresh `load()` looks like, not a problem the user caused or can
+ * act on.
+ *
+ * Connectivity is checked before the error code. A request that never reaches
+ * the network is reported as `MEDIA_ERR_SRC_NOT_SUPPORTED` — the same code a
+ * geo-block produces — because the browser only knows it received nothing
+ * playable, not why. Blaming the provider when the device is plainly offline
+ * sends the user chasing the wrong problem.
+ */
+const messageForMediaError = (
+  mediaError: MediaError | null | undefined,
+): string | null => {
+  if (mediaError?.code === MEDIA_ERR_ABORTED) return null
+  if (isOffline()) return PLAYBACK_ERROR_MESSAGES.offline
+  switch (mediaError?.code) {
+    case MEDIA_ERR_NETWORK:
+      return PLAYBACK_ERROR_MESSAGES.network
+    case MEDIA_ERR_DECODE:
+      return PLAYBACK_ERROR_MESSAGES.decode
+    case MEDIA_ERR_SRC_NOT_SUPPORTED:
+      return PLAYBACK_ERROR_MESSAGES.unavailable
+    default:
+      return PLAYBACK_ERROR_MESSAGES.generic
+  }
+}
+
 type UseAudioPlayerOptions = {
   /** Start playing as soon as a track loads (the fixed player bar). */
   autoPlay?: boolean
@@ -49,6 +119,7 @@ export const useAudioPlayer = (
   const [duration, setDuration] = useState(0)
   const [speedIndex, setSpeedIndex] = useState(1) // default 1x
   const speedIndexRef = useRef(1)
+  const [loadError, setLoadError] = useState<string | null>(null)
 
   const startPlayback = useCallback(async () => {
     if (!hasAudioSource || isPlayPendingRef.current) return
@@ -66,9 +137,21 @@ export const useAudioPlayer = (
       if (playAttemptIdRef.current === attemptId) {
         setIsPlaying(true)
       }
-    } catch {
+    } catch (err) {
       if (playAttemptIdRef.current === attemptId) {
         setIsPlaying(false)
+        const name = (err as DOMException | undefined)?.name
+        // NotAllowedError is the browser's autoplay policy, not a fault: the
+        // user only needs to press play. AbortError means a newer load()
+        // superseded this attempt. Neither is worth a message.
+        if (name !== "NotAllowedError" && name !== "AbortError") {
+          // Keep any message the `error` event already produced — it names the
+          // specific cause, where this fallback can only guess.
+          const fallback = isOffline()
+            ? PLAYBACK_ERROR_MESSAGES.offline
+            : PLAYBACK_ERROR_MESSAGES.generic
+          setLoadError((current) => current ?? fallback)
+        }
       }
     } finally {
       if (playAttemptIdRef.current === attemptId) {
@@ -89,6 +172,9 @@ export const useAudioPlayer = (
     setDuration(0)
     setIsPlaying(false)
     setIsBuffering(autoPlay && hasAudioSource)
+    // A new track gets a clean slate: the previous track's failure says nothing
+    // about this one.
+    setLoadError(null)
 
     if (!hasAudioSource) return
 
@@ -115,17 +201,37 @@ export const useAudioPlayer = (
     void startPlayback()
   }, [startPlayback])
 
+  /**
+   * Re-fetch the current track and try again after a failure. A plain `play()`
+   * would not do: once the element has errored it stays in that state until the
+   * resource is reloaded.
+   */
+  const retry = useCallback(() => {
+    const audio = audioRef.current
+    if (!audio || !hasAudioSource) return
+    setLoadError(null)
+    setIsBuffering(true)
+    audio.load()
+    void startPlayback()
+  }, [hasAudioSource, startPlayback])
+
   const togglePlay = useCallback(() => {
     if (!hasAudioSource) return
     const audio = audioRef.current
     if (!audio) return
+    // After a failure the play button acts as a second retry affordance, so
+    // pressing it does the same reload the "Try again" button does.
+    if (loadError) {
+      retry()
+      return
+    }
     if (isPlaying) {
       audio.pause()
       setIsPlaying(false)
     } else {
       void startPlayback()
     }
-  }, [hasAudioSource, isPlaying, startPlayback])
+  }, [hasAudioSource, isPlaying, startPlayback, loadError, retry])
 
   const skip = useCallback(
     (seconds: number) => {
@@ -157,6 +263,11 @@ export const useAudioPlayer = (
 
   const percent = duration ? (currentTime / duration) * 100 : 0
 
+  // A missing URL is reported the same way a failed fetch is — from the
+  // listener's point of view the episode simply won't play — but it is derived
+  // rather than stored, since no load is ever attempted.
+  const error = hasAudioSource ? loadError : PLAYBACK_ERROR_MESSAGES.noSource
+
   /** Props to spread onto `<audio ref={audioRef} {...audioProps} />`. */
   const audioProps = {
     src: hasAudioSource ? audioUrl : undefined,
@@ -165,6 +276,8 @@ export const useAudioPlayer = (
     onError: () => {
       setIsBuffering(false)
       setIsPlaying(false)
+      const message = messageForMediaError(audioRef.current?.error)
+      if (message) setLoadError(message)
     },
     onTimeUpdate: () => setCurrentTime(audioRef.current?.currentTime ?? 0),
     onLoadedMetadata: () => setDuration(audioRef.current?.duration ?? 0),
@@ -182,11 +295,14 @@ export const useAudioPlayer = (
     duration,
     percent,
     speed: SPEED_OPTIONS[speedIndex],
+    /** A user-facing failure message, or `null` while playback is healthy. */
+    error,
     togglePlay,
     skip,
     cycleSpeed,
     seek,
     pause,
     resume,
+    retry,
   }
 }

--- a/frontends/main/src/app-pages/PodcastPage/usePlaybackRecovery.ts
+++ b/frontends/main/src/app-pages/PodcastPage/usePlaybackRecovery.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/** Announced while a retry is in flight. */
+export const RETRYING_STATUS = "Retrying…"
+
+/** Focus has been dropped to nowhere, rather than moved somewhere deliberate. */
+const focusWasDropped = () => {
+  if (typeof document === "undefined") return false
+  const active = document.activeElement
+  return active === null || active === document.body
+}
+
+/**
+ * Owns what happens around a playback retry, which is otherwise imperceptible
+ * without sight.
+ *
+ * **Focus.** The players swap the progress row for the error message and back.
+ * Either direction unmounts the control the user was on, sending focus to
+ * `<body>` — from there a keyboard user has to tab in from the top of the page,
+ * and a screen reader loses its place. Both handoffs are conditional on focus
+ * having *actually* been lost: if the user has since moved elsewhere, pulling
+ * focus back would be more disruptive than the problem being fixed.
+ *
+ * **Announcement.** Pressing "Try again" clears the error, so the alert
+ * disappears and the button unmounts while the reload is still in flight. That
+ * leaves a silent gap, which `isRetrying` fills via a polite live region. Only
+ * this gap is announced — the outcome already is: success moves focus to the
+ * play button, and failure re-renders the alert.
+ *
+ * @param error the current playback error, or `null` while healthy
+ * @param retry the audio hook's retry action, wrapped as `requestRetry`
+ * @param isPlayDisabled whether the play/pause button currently rejects focus
+ */
+export const usePlaybackRecovery = (
+  error: string | null,
+  retry: () => void,
+  isPlayDisabled: boolean,
+) => {
+  const playButtonRef = useRef<HTMLButtonElement>(null)
+  const retryButtonRef = useRef<HTMLButtonElement>(null)
+  // Was the user on one of the controls the error message replaces?
+  const hadProgressFocusRef = useRef(false)
+  // Did the user ask for this recovery, rather than it arriving on its own?
+  const retryPendingRef = useRef(false)
+  const [isRetrying, setIsRetrying] = useState(false)
+
+  /** Spread onto the progress row so we know when focus is inside it. */
+  const onProgressFocus = useCallback(() => {
+    hadProgressFocusRef.current = true
+  }, [])
+
+  /** Use in place of `retry` so focus and announcements follow the recovery. */
+  const requestRetry = useCallback(() => {
+    retryPendingRef.current = true
+    setIsRetrying(true)
+    retry()
+  }, [retry])
+
+  useEffect(() => {
+    if (error) {
+      // The progress controls just unmounted, or a retry failed and put the
+      // message back. Either way, offer the retry button as the landing spot.
+      const shouldLand =
+        (hadProgressFocusRef.current || retryPendingRef.current) &&
+        focusWasDropped()
+      hadProgressFocusRef.current = false
+      retryPendingRef.current = false
+      setIsRetrying(false)
+      if (shouldLand) retryButtonRef.current?.focus()
+      return
+    }
+
+    if (!retryPendingRef.current) return
+    // Recovery reloads the source, so the play button is briefly disabled and
+    // cannot take focus. Hold the handoff — and the "retrying" status — until
+    // the player is actually ready again.
+    if (isPlayDisabled) return
+    retryPendingRef.current = false
+    setIsRetrying(false)
+    if (focusWasDropped()) playButtonRef.current?.focus()
+  }, [error, isPlayDisabled])
+
+  return {
+    playButtonRef,
+    retryButtonRef,
+    onProgressFocus,
+    requestRetry,
+    isRetrying,
+  }
+}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12585

### Description (What does it do?)
As a podcast listener, I want to be told when an episode won't play, so I can understand what went wrong instead of staring at a player that silently does nothing.


### Screenshots (if appropriate):
<img width="1423" height="713" alt="Screenshot 2026-07-28 at 2 02 21 PM" src="https://github.com/user-attachments/assets/c19dd9ad-3448-4a1a-b6ba-8a6bb3ca83e1" />
<img width="2852" height="1384" alt="image" src="https://github.com/user-attachments/assets/f01e7eb9-cf91-4a25-a45c-b51ffb3b5465" />


### How can this be tested?
- First test cast, for testing you can connect your local with PROD because we have some instances on PROD which are restricted to some countries like Pakistan, India and China, for example, `/podcast/14337/podcast_episode/14347/intro-women-in-leadership-series`, in this case you would see the error message and 
- Another test case, you can also load the episode page and before playing the audio you can make your browser offline from network tab and then try to play the audio, in this case you would see the message that you are offline

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
