### PR TITLE
Strip trailing slash from channel_url to avoid 308 redirects

### DIFF
--- a/channels/models.py
+++ b/channels/models.py
@@ -40,7 +40,6 @@ class ChannelQuerySet(TimestampedModelQuerySet):
                         "channel_type",
                         models.Value("/"),
                         "name",
-                        models.Value("/"),
                     ),
                 ),
                 default=None,
@@ -163,7 +162,7 @@ class Channel(TimestampedModel):
     def channel_url(self) -> str | None:
         """Return the channel url"""
         if self.published:
-            return frontend_absolute_url(f"/c/{self.channel_type}/{self.name}/")
+            return frontend_absolute_url(f"/c/{self.channel_type}/{self.name}")
         return None
 
     @property

--- a/channels/models_test.py
+++ b/channels/models_test.py
@@ -37,7 +37,7 @@ def test_channel_url_for_departments(published, channel_type, detail_factory):
     if published:
         assert (
             urlparse(channel.channel_url).path
-            == f"/c/{channel_type.name}/{channel.name}/"
+            == f"/c/{channel_type.name}/{channel.name}"
         )
     else:
         assert channel.channel_url is None

--- a/channels/serializers_test.py
+++ b/channels/serializers_test.py
@@ -105,7 +105,7 @@ def test_serialize_channel(  # pylint: disable=too-many-arguments
         "created_on": mocker.ANY,
         "id": channel.id,
         "channel_url": frontend_absolute_url(
-            f"/c/{channel.channel_type}/{channel.name}/"
+            f"/c/{channel.channel_type}/{channel.name}"
         ),
         "lists": [
             LearningPathPreviewSerializer(channel_list.channel_list).data

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -395,7 +395,7 @@ def test_learning_resource_serializer(  # noqa: PLR0913
                 "department_id": dept.department_id,
                 "name": dept.name,
                 "channel_url": frontend_absolute_url(
-                    f"/c/department/{Channel.objects.get(department_detail__department=dept).name}/",
+                    f"/c/department/{Channel.objects.get(department_detail__department=dept).name}",
                 ),
                 "school": {
                     "id": dept.school.id,
@@ -705,7 +705,7 @@ def test_content_file_serializer(settings, expected_types, has_channels):
                 "code": content_file.run.learning_resource.offered_by.code,
                 "display_facet": True,
                 "channel_url": frontend_absolute_url(
-                    f"/c/unit/{Channel.objects.get(unit_detail__unit=content_file.run.learning_resource.offered_by).name}/"
+                    f"/c/unit/{Channel.objects.get(unit_detail__unit=content_file.run.learning_resource.offered_by).name}"
                 )
                 if has_channels
                 else None,
@@ -717,7 +717,7 @@ def test_content_file_serializer(settings, expected_types, has_channels):
                     "name": dept.name,
                     "department_id": dept.department_id,
                     "channel_url": frontend_absolute_url(
-                        f"/c/department/{Channel.objects.get(department_detail__department=dept).name}/"
+                        f"/c/department/{Channel.objects.get(department_detail__department=dept).name}"
                     )
                     if has_channels
                     else None,
@@ -740,7 +740,7 @@ def test_content_file_serializer(settings, expected_types, has_channels):
                     "icon": topic.icon,
                     "parent": topic.parent,
                     "channel_url": frontend_absolute_url(
-                        f"/c/topic/{Channel.objects.get(topic_detail__topic=topic).name}/"
+                        f"/c/topic/{Channel.objects.get(topic_detail__topic=topic).name}"
                         if has_channels
                         else None,
                     )


### PR DESCRIPTION
### What are the relevant tickets?
Closes #3688

### Description (What does it do?)
`Channel.channel_url` and `ChannelQuerySet.annotate_channel_url()` built the channel URL with a trailing slash (`/c/{channel_type}/{name}/`), but the Next.js frontend's canonical route for that page has no trailing slash (`CHANNEL_VIEW` in `frontends/main/src/common/urls.ts`) and Next.js defaults to `trailingSlash: false`. Every consumer that followed a `channel_url` from the sitemap or an API response (crawlers, cached links, RSC prefetches) hit a 308 redirect to the slash-less canonical path.

This was discovered while investigating the `traefik-gateway-controller` HPA being pegged at max replicas in production — Loki analysis of Traefik access logs for `next.learn.mit.edu` over a 1-hour window showed 142,857 / 806,252 requests (~17.6%) were 308s, heavily concentrated on `/c/topic/<name>/?_rsc=<hash>`.

This PR strips the trailing slash from both `channel_url` and `annotate_channel_url` in `channels/models.py`, matching the frontend's existing no-trailing-slash convention rather than changing `next.config.js`'s `trailingSlash` default (lower risk, since other URL builders already assume no trailing slash).

### Screenshots (if appropriate):
N/A — backend-only change, no UI impact.

### How can this be tested?
- `channels/models_test.py::test_channel_url_for_departments` asserts the channel URL path no longer has a trailing slash.
- `channels/serializers_test.py` and `learning_resources/serializers_test.py` assertions were updated to match the slash-less URL.
- Ran the full affected test suite: `docker compose run --rm web uv run pytest channels/ learning_resources/serializers_test.py -q` — all passing (103 tests across `channels/models_test.py`, `channels/serializers_test.py`, `learning_resources/serializers_test.py`).
- Manually verify: fetch a channel's `channel_url` from the API or sitemap and confirm requesting it directly returns 200 (no 308 redirect).

### Additional Context
N/A
