### PR TITLE
Identify posthog persons by keycloak global_id, not django pk

### DIFF
--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
@@ -1,8 +1,8 @@
 import React from "react"
 
-import { render, waitFor } from "@testing-library/react"
+import { waitFor } from "@testing-library/react"
 import { PosthogIdentifier } from "./ConfiguredPostHogProvider"
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
+import { renderWithProviders } from "@/test-utils"
 
 // mock stuff
 import { setMockResponse, urls, factories } from "api/test-utils"
@@ -27,15 +27,15 @@ const mockPosthog = jest.mocked(posthog)
 
 describe("PosthogIdentifier", () => {
   const setup = (user: Partial<User>) => {
-    const queryClient = new QueryClient()
     const userData = factories.user.user(user)
 
     setMockResponse.get(urls.userMe.get(), userData)
-    render(
-      <QueryClientProvider client={queryClient}>
-        <PosthogIdentifier />
-      </QueryClientProvider>,
-    )
+    /**
+     * No `user` option: we want the user to arrive via the mocked request, so
+     * that the effect runs on a pending-then-resolved query as it does in the
+     * app, rather than on a pre-seeded cache.
+     */
+    renderWithProviders(<PosthogIdentifier />)
     return userData
   }
   test.each([

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.test.tsx
@@ -5,9 +5,8 @@ import { PosthogIdentifier } from "./ConfiguredPostHogProvider"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
 
 // mock stuff
-import { setMockResponse, urls } from "api/test-utils"
+import { setMockResponse, urls, factories } from "api/test-utils"
 import type { User } from "api/hooks/user"
-import { makeUserSettings } from "@/test-utils/factories"
 import { usePostHog } from "posthog-js/react"
 import type { PostHog } from "posthog-js"
 
@@ -29,7 +28,7 @@ const mockPosthog = jest.mocked(posthog)
 describe("PosthogIdentifier", () => {
   const setup = (user: Partial<User>) => {
     const queryClient = new QueryClient()
-    const userData = makeUserSettings(user)
+    const userData = factories.user.user(user)
 
     setMockResponse.get(urls.userMe.get(), userData)
     render(
@@ -55,11 +54,24 @@ describe("PosthogIdentifier", () => {
     },
   )
 
-  test("If authenticated, calls `identify` with user id and username", async () => {
+  test("If authenticated, calls `identify` with the user's global id", async () => {
     const user = setup({ is_authenticated: true })
     await waitFor(() => {
-      expect(mockPosthog.identify).toHaveBeenCalledWith(String(user.id))
+      expect(mockPosthog.identify).toHaveBeenCalledExactlyOnceWith(
+        user.global_id,
+      )
     })
+    expect(mockPosthog.reset).not.toHaveBeenCalled()
+  })
+
+  test("If authenticated with no global id, neither identifies nor resets", async () => {
+    // Not "anonymous", so a fall-through to the reset branch would be visible.
+    mockPosthog.get_property.mockReturnValue("identified")
+    setup({ is_authenticated: true, global_id: null })
+    await waitFor(() => {
+      expect(mockPosthog.get_property).toHaveBeenCalledWith("$user_state")
+    })
+    expect(mockPosthog.identify).not.toHaveBeenCalled()
     expect(mockPosthog.reset).not.toHaveBeenCalled()
   })
 })

--- a/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
+++ b/frontends/main/src/page-components/ConfiguredPostHogProvider/ConfiguredPostHogProvider.tsx
@@ -47,8 +47,17 @@ const PosthogIdentifier = () => {
   useEffect(() => {
     if (!user) return
     const anonymous = posthog.get_property("$user_state") === "anonymous"
-    if (user.is_authenticated && user.id) {
-      posthog.identify(String(user.id))
+    if (user.is_authenticated) {
+      /**
+       * Identify by the Keycloak global id rather than our Django user id.
+       * This posthog project is shared with other MIT applications, and
+       * mitxpro identifies people by its own integer user ids, so integer ids
+       * collide across applications. Users with no global id are left
+       * unidentified rather than identified by a colliding id.
+       */
+      if (user.global_id) {
+        posthog.identify(user.global_id)
+      }
     } else if (!anonymous) {
       posthog.reset()
     }

--- a/main/features.py
+++ b/main/features.py
@@ -109,10 +109,11 @@ def is_enabled(
         default (bool): default value if not set in settings
         unique_id (str):
             person identifier passed back to posthog which is the display value for
-            person. I recommend this be user.id for logged-in users to allow for
-            more readable user flags as well as more clear troubleshooting. For
-            anonymous users, a persistent ID will help with troubleshooting and tracking
-            efforts.
+            person. For logged-in users this should be the Keycloak global id
+            (user.global_id): this posthog project is shared with other MIT
+            applications that use their own integer user ids, so a Django pk
+            would collide across applications. For anonymous users, a persistent
+            ID will help with troubleshooting and tracking efforts.
 
     Returns:
         bool: True if the feature flag is enabled

--- a/main/middleware/apisix_user.py
+++ b/main/middleware/apisix_user.py
@@ -173,8 +173,11 @@ def get_user_from_apisix_headers(  # noqa: C901
             posthog = Posthog(
                 settings.POSTHOG_PROJECT_API_KEY, host=settings.POSTHOG_API_HOST
             )
+            # Identify by global_id, not user.id: this posthog project is
+            # shared with other MIT applications that use their own integer
+            # user ids, so integer ids collide across applications.
             posthog.capture(
-                user.id,
+                global_id,
                 event=PostHogEvents.ACCOUNT_CREATED.value,
                 properties={
                     "$current_url": request.build_absolute_uri(),

--- a/main/middleware/apisix_user_test.py
+++ b/main/middleware/apisix_user_test.py
@@ -10,6 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.db import close_old_connections
 
+from main.constants import PostHogEvents
 from main.factories import UserFactory
 from main.middleware.apisix_user import ApisixUserMiddleware
 
@@ -74,7 +75,11 @@ def test_get_request(mocker, mock_login, settings):
     assert user.profile.email_optin == apisix_user_info["emailOptIn"]
     assert user.global_id == apisix_user_info["sub"]
     mock_posthog_cls.assert_called_once()
-    mock_posthog_cls.return_value.capture.assert_called_once()
+    mock_posthog_cls.return_value.capture.assert_called_once_with(
+        apisix_user_info["sub"],
+        event=PostHogEvents.ACCOUNT_CREATED.value,
+        properties=mocker.ANY,
+    )
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
### What are the relevant tickets?

- For https://github.com/mitodl/hq/issues/12601

### Description (What does it do?)

Identifies posthog persons by the Keycloak `global_id` instead of the Django user pk, in both places this app names a person: the frontend `posthog.identify()` call and the server-side `account_created` event.

Users with no `global_id` are left unidentified rather than falling back to the pk.

### How can this be tested?

**Prerequesite:** Set `NEXT_PUBLIC_POSTHOG_API_KEY` to your **personal** (not mitodl) posthog project

**Posthog Query:** Run the following SQL throughout. You can run it at `https://us.posthog.com/project/YOUR_PROJECT_I_HERE/sql`

```sql
SELECT distinct_id,
       person_id,
       count() AS events,
       countIf(event = '$identify') AS identifies,
       min(timestamp) AS first_seen,
       max(timestamp) AS last_seen
FROM events
WHERE timestamp > now() - INTERVAL 500 SECOND
GROUP BY distinct_id, person_id
ORDER BY last_seen DESC
```

1. **On `main`**, start as an anonymous user. 
2. If you want to see how the data evolves, run the SQL above.
    - you should see recent data with an anonymous, posthog-generated  uuid-valued-`distinct_id` 
3. Log in. Re-run SQL. 
    - You should see a row with a primary key ID, same `person_id` as the events from (2).
    - **The PK-valued distinct_id row should have nonzero `identifies` events.**
4. Switch to this branch
5. Log out. Navigate a bit if you want. Re-run SQL You should see new row(s). New anonymous uuid-valued-distinct_id
6. Log in as the same user from (2). Navigate a bit. Re-run SQL.
    - you should **see a new row with nonzero `identifies` events**
    - The new row should have a `distinct_id` **that is your user's `user.global_id`**

The final SQL query results should look something like this:

| branch | distinct_id                          | events | identifies | last_seen                   | person_id                            |
| - | ------------------------------------ | ------ | ---------- | --------------------------- | ------------------------------------ |
| pr_3693 | user_gui | 21     | 3          | present | person_uuid_2 |
| pr_3693 | anon_uuid_4 | 2 | 0          | past | person_uuid_2 |
| pr_3693 | anon_uuid_3 | 24     | 0          | far_past | person_uuid_2 |
| main | user_primary_key | 63     | 6          | further_past | person_uuid_1 |
| main | anon_uuid_2 | 9      | 0          | furthest_past | person_uuid_1 |

⚠️ **NOTE:** The same human user has two `person_uuid` values. One human user, two Posthog persons.

This has been deemed acceptable. If we want to fix it, we can run a backend `$merge_dangerously`. (Though it's a little tricky, since xpro has been identifying posthog users in the same project with its primary key).
