### PR TITLE
extra facets from the url for channel page

### DIFF
--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.test.tsx
@@ -332,6 +332,62 @@ describe("ChannelSearch", () => {
     },
   )
 
+  test("Shows and aggregates a facet that is in the URL but not shown by default", async () => {
+    const { channel } = setMockApiResponses({
+      channelPatch: { channel_type: ChannelTypeEnum.Unit },
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            level: [{ key: "graduate", doc_count: 100 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+
+    renderWithProviders(<ChannelPage />, {
+      url: `/c/${channel.channel_type}/${channel.name}/?level=graduate`,
+    })
+
+    await waitFor(() => {
+      expect(makeRequest.mock.calls.length > 0).toBe(true)
+    })
+
+    // "level" is not a default facet for this channel type, but it is requested
+    // as an aggregation because it is present in the URL.
+    const apiSearchParams = getLastApiSearchParams()
+    expect(apiSearchParams.getAll("aggregations")).toContain("level")
+
+    // ...and it renders as a facet.
+    const facetsContainer = screen.getByTestId("facets-container")
+    await within(facetsContainer).findByText("Level")
+  })
+
+  test("Does not duplicate a facet already shown by default as an extra URL facet", async () => {
+    const { channel } = setMockApiResponses({
+      channelPatch: { channel_type: ChannelTypeEnum.Unit },
+      search: {
+        count: 700,
+        metadata: {
+          aggregations: {
+            topic: [{ key: "physics", doc_count: 100 }],
+          },
+          suggestions: [],
+        },
+      },
+    })
+
+    // "topic" is a default facet for Unit channels and is also present in the
+    // URL; it must appear exactly once.
+    renderWithProviders(<ChannelPage />, {
+      url: `/c/${channel.channel_type}/${channel.name}/?topic=physics`,
+    })
+
+    const facetsContainer = await screen.findByTestId("facets-container")
+    expect(await within(facetsContainer).findAllByText("Topic")).toHaveLength(1)
+  })
+
   test("Submitting search text updates URL correctly", async () => {
     const resources = factories.learningResources.resources({
       count: 10,

--- a/frontends/main/src/app-pages/ChannelPage/ChannelSearch.tsx
+++ b/frontends/main/src/app-pages/ChannelPage/ChannelSearch.tsx
@@ -57,8 +57,20 @@ const ChannelSearch: React.FC<ChannelSearchProps> = ({
 
   const { facetNames, facetManifest } = useMemo(
     () =>
-      getFacets(channelType, offerors, constantSearchParams, resourceTypeGroup),
-    [offerors, channelType, constantSearchParams, resourceTypeGroup],
+      getFacets(
+        channelType,
+        offerors,
+        constantSearchParams,
+        resourceTypeGroup,
+        searchParams,
+      ),
+    [
+      offerors,
+      channelType,
+      constantSearchParams,
+      resourceTypeGroup,
+      searchParams,
+    ],
   )
 
   const setPage = useCallback(

--- a/frontends/main/src/app-pages/ChannelPage/searchRequests.ts
+++ b/frontends/main/src/app-pages/ChannelPage/searchRequests.ts
@@ -8,6 +8,7 @@ import type {
 import { LearningResourceOfferor } from "api"
 import { ChannelTypeEnum } from "api/v0"
 import { getFacetManifest } from "@/page-components/SearchDisplay/getFacetManifest"
+import { getExtraFacetNames } from "@/app-pages/SearchPage/searchRequests"
 
 export const getConstantSearchParams = (searchFilter?: string) => {
   const searchParams: Facets & BooleanFacets = {}
@@ -63,9 +64,16 @@ const getFacetManifestForChannelType = (
   offerors: Record<string, LearningResourceOfferor>,
   constantSearchParams: Facets,
   resourceTypeGroup: string | null,
+  extraFacetNames: string[] = [],
 ): FacetManifest => {
-  const facets = FACETS_BY_CHANNEL_TYPE[channelType] || []
-  return getFacetManifest(offerors, resourceTypeGroup)
+  // Facets shown by default for this channel type plus any additional facets
+  // present in the URL. Facets hard-coded by the channel config
+  // (constantSearchParams) are filtered out below.
+  const facets = [
+    ...(FACETS_BY_CHANNEL_TYPE[channelType] || []),
+    ...extraFacetNames,
+  ]
+  return getFacetManifest(offerors, resourceTypeGroup, extraFacetNames)
     .filter(
       (facetSetting) =>
         !Object.keys(constantSearchParams).includes(facetSetting.name) &&
@@ -81,12 +89,24 @@ export const getFacets = (
   offerors: Record<string, LearningResourceOfferor>,
   constantSearchParams: Facets,
   resourceTypeGroup: string | null,
+  searchParams?: URLSearchParams,
 ) => {
+  // Facets already surfaced by the channel type or pinned by the channel config
+  // should not be duplicated as extra facets from the URL.
+  const baseFacetNames = [
+    ...(FACETS_BY_CHANNEL_TYPE[channelType] || []),
+    ...Object.keys(constantSearchParams),
+  ] as UseResourceSearchParamsProps["facets"]
+  const extraFacetNames = searchParams
+    ? (getExtraFacetNames(searchParams, baseFacetNames) ?? [])
+    : []
+
   const facetManifest = getFacetManifestForChannelType(
     channelType,
     offerors,
     constantSearchParams,
     resourceTypeGroup,
+    extraFacetNames,
   )
 
   const facetNames = Array.from(

--- a/frontends/main/src/app/(site)/c/[channelType]/[name]/page.tsx
+++ b/frontends/main/src/app/(site)/c/[channelType]/[name]/page.tsx
@@ -91,11 +91,20 @@ const Page: React.FC<PageProps<"/c/[channelType]/[name]">> = async ({
 
   const constantSearchParams = getConstantSearchParams(channel.search_filter)
 
+  const urlParams = new URLSearchParams(
+    Object.entries(search).flatMap(([key, value]) =>
+      Array.isArray(value)
+        ? value.map((v) => [key, v])
+        : [[key, String(value)]],
+    ),
+  )
+
   const { facetNames } = getFacets(
     channelType,
     offerors as unknown as Record<string, LearningResourceOfferorDetail>,
     constantSearchParams,
     null,
+    urlParams,
   )
 
   const searchRequest = getSearchParams({


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/12383

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/3655 updates the main search to add extra facets if there is a filter in the url. This does the same for channel searches. Filter parameters that are part of the saved filter for the channel are ignored

### How can this be tested?
http://open.odl.local:8062/c/unit/ocw?level=undergraduate should show the level facet

http://open.odl.local:8062/c/unit/ocw?offered_by=ocw and http://open.odl.local:8062/c/unit/ocw?offered_by=mitxonline should look exactly like the normal ocw unit search