### PR TITLE
Readd dropped GTM calls

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.test.tsx
@@ -28,6 +28,8 @@ jest.mock("posthog-js/react", () => ({
 
 jest.mock("@/common/analytics/gtm", () => ({
   trackCourseEnrolled: jest.fn(),
+  trackStartEnrollment: jest.fn(),
+  trackBeginCheckout: jest.fn(),
 }))
 
 const makeCourse = mitxFactories.courses.course

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -45,6 +45,8 @@ jest.mock("next-nprogress-bar", () => ({
 
 jest.mock("@/common/analytics/gtm", () => ({
   trackCourseEnrolled: jest.fn(),
+  trackStartEnrollment: jest.fn(),
+  trackBeginCheckout: jest.fn(),
   trackViewCoursePage: jest.fn(),
   trackCourseProgramView: jest.fn(),
 }))

--- a/frontends/main/src/app-pages/ProductPages/InfoBoxCourse.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/InfoBoxCourse.test.tsx
@@ -26,6 +26,8 @@ jest.mock("posthog-js/react", () => ({
 
 jest.mock("@/common/analytics/gtm", () => ({
   trackCourseEnrolled: jest.fn(),
+  trackStartEnrollment: jest.fn(),
+  trackBeginCheckout: jest.fn(),
 }))
 
 const makeCourse = mitxFactories.courses.course

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
@@ -22,10 +22,16 @@ import type {
 } from "@mitodl/mitxonline-api-axios/v2"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
-import { trackCourseEnrolled } from "@/common/analytics/gtm"
+import {
+  trackCourseEnrolled,
+  trackStartEnrollment,
+  trackBeginCheckout,
+} from "@/common/analytics/gtm"
 
 jest.mock("@/common/analytics/gtm", () => ({
   trackCourseEnrolled: jest.fn(),
+  trackStartEnrollment: jest.fn(),
+  trackBeginCheckout: jest.fn(),
 }))
 
 jest.mock("posthog-js/react", () => ({
@@ -380,6 +386,9 @@ describe("useCourseEnrollment — actions", () => {
 
     paidOption!.onClick!(fakeEvent)
 
+    expect(trackStartEnrollment).toHaveBeenCalledWith(course.title)
+    expect(trackBeginCheckout).toHaveBeenCalledWith(course.title)
+
     await waitFor(() =>
       expect(makeRequest).toHaveBeenCalledWith(
         expect.objectContaining({ method: "delete", url: clearUrl }),
@@ -421,6 +430,8 @@ describe("useCourseEnrollment — actions", () => {
     } as React.MouseEvent<HTMLButtonElement>
 
     freeOption!.onClick!(fakeEvent)
+
+    expect(trackStartEnrollment).toHaveBeenCalledWith(course.title)
 
     await waitFor(() =>
       expect(makeRequest).toHaveBeenCalledWith(

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
@@ -9,7 +9,11 @@ import { useReplaceBasketItem } from "@/common/mitxonline/useReplaceBasketItem"
 import { enrollmentAlertSuccessUrl } from "@/common/mitxonline"
 import { useRouter } from "next-nprogress-bar"
 import { usePostHog } from "posthog-js/react"
-import { trackCourseEnrolled } from "@/common/analytics/gtm"
+import {
+  trackCourseEnrolled,
+  trackStartEnrollment,
+  trackBeginCheckout,
+} from "@/common/analytics/gtm"
 import { DASHBOARD_HOME } from "@/common/urls"
 import { getCourseScenario, type CourseScenario } from "./courseRun"
 import { useCourseEnrolledRunIds } from "./useCourseEnrolledRunIds"
@@ -90,9 +94,11 @@ export const useCourseEnrollment = (
         opts?.onRequireSignup?.(e.currentTarget)
         return
       }
+      trackStartEnrollment(course.title)
       if (kind === "paid") {
         const product = selectedRun?.products?.[0]
         if (product) {
+          trackBeginCheckout(course.title)
           replaceBasketItem.mutate(product.id)
         }
       } else if (kind === "free") {


### PR DESCRIPTION
### Description (What does it do?)
It looks like we lost a few calls for GTM event instrumentation in the [recent infobox redesign](https://github.com/mitodl/mit-learn/pull/3523/changes). This just adds a few I noticed had been dropped.

### How can this be tested?
- Using [google tag assistant](https://tagassistant.google.com/), visit a course page w/ a certificate track you can pay for
- Enroll in that course, starting a checkout
- Observe that a begin-checkout and start-enrollment event are fired.

<img width="920" height="482" alt="Screenshot 2026-07-29 at 2 35 02 PM" src="https://github.com/user-attachments/assets/7199c831-8f30-4879-9a4d-0f787a8330bb" />
