### PR TITLE
test: pin course-run end dates so session options stay unambiguous

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/InfoBoxCourse.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/InfoBoxCourse.test.tsx
@@ -33,6 +33,37 @@ const makeRun = mitxFactories.courses.courseRun
 const makeMode = mitxFactories.courses.enrollmentMode
 const makeProduct = mitxFactories.courses.product
 
+const daysFromNow = (days: number) =>
+  new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+
+/**
+ * A run with both ends of its date range pinned.
+ *
+ * Pinning `end_date` is not decoration. The session options are labelled with
+ * the *whole* range ("Aug 28 - Sep 27, 2026"), and the tests below select an
+ * option by a regex built from one run's start date — so an unpinned
+ * `end_date`, which the factory fills with `faker.date.future()`, can land on
+ * the same calendar day as another run's start and make that regex match two
+ * options. That is exactly what happened in
+ * https://github.com/mitodl/mit-learn/actions/runs/30469814580: a run starting
+ * "Aug 28" drew the random end date "Sep 27", which collided with the "Sep 27"
+ * start of the run the test was trying to click.
+ *
+ * The offsets below are spaced so no two labelled dates can share a calendar
+ * day, which makes every option's accessible name unambiguous by construction
+ * rather than by luck.
+ */
+const makeDatedRun = (
+  startInDays: number,
+  endInDays: number,
+  overrides: Parameters<typeof makeRun>[0] = {},
+) =>
+  makeRun({
+    ...overrides,
+    start_date: daysFromNow(startInDays),
+    end_date: daysFromNow(endInDays),
+  })
+
 function setupAuth(enrollments: unknown[] = []) {
   setMockResponse.get(
     apiUrls.userMe.get(),
@@ -113,7 +144,7 @@ describe("InfoBoxCourse — session selector", () => {
 describe("InfoBoxCourse — run selection changes enroll area", () => {
   test("switching from a both run to a free-only run changes the cards", async () => {
     setupAuth()
-    const bothRun = makeRun({
+    const bothRun = makeDatedRun(30, 45, {
       is_enrollable: true,
       is_archived: false,
       is_upgradable: true,
@@ -122,15 +153,13 @@ describe("InfoBoxCourse — run selection changes enroll area", () => {
         makeMode({ requires_payment: true }),
       ],
       products: [makeProduct()],
-      start_date: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
     })
-    const freeOnlyRun = makeRun({
+    const freeOnlyRun = makeDatedRun(60, 75, {
       is_enrollable: true,
       is_archived: false,
       is_upgradable: false,
       enrollment_modes: [makeMode({ requires_payment: false })],
       products: [],
-      start_date: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString(),
     })
     const course = makeCourse({
       next_run_id: bothRun.id,
@@ -170,21 +199,19 @@ describe("InfoBoxCourse — run selection changes enroll area", () => {
 
 describe("InfoBoxCourse — session-switch round-trip (enrolled run)", () => {
   test("selecting an enrolled run collapses to Enrolled; switching back restores cards", async () => {
-    const runA = makeRun({
+    const runA = makeDatedRun(30, 45, {
       is_enrollable: true,
       is_archived: false,
       is_upgradable: false,
       enrollment_modes: [makeMode({ requires_payment: false })],
       products: [],
-      start_date: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
     })
-    const runB = makeRun({
+    const runB = makeDatedRun(60, 75, {
       is_enrollable: true,
       is_archived: false,
       is_upgradable: false,
       enrollment_modes: [makeMode({ requires_payment: false })],
       products: [],
-      start_date: new Date(Date.now() + 60 * 24 * 60 * 60 * 1000).toISOString(),
     })
     const course = makeCourse({
       next_run_id: runA.id,


### PR DESCRIPTION
### What are the relevant tickets?

N/A — found while investigating a red `javascript-tests` on https://github.com/mitodl/mit-learn/pull/3679, which this failure had nothing to do with.

### Description (What does it do?)

Fixes a random CI flake in `InfoBoxCourse.test.tsx`.

The session-switch tests select an option with a regex built from one run's start date:

```ts
const runBDateLabel = formatDate(runB.start_date!, "MMM D")
screen.getByRole("option", { name: new RegExp(runBDateLabel, "i") })
```

They pinned `start_date` but left `end_date` to the factory, which fills it with `faker.date.future()` — see [`courses.ts`](https://github.com/mitodl/mit-learn/blob/main/frontends/api/src/mitxonline/test-utils/factories/courses.ts#L111-L113):

```ts
start_date: faker.date.future().toISOString(),
end_date: faker.date.future().toISOString(),
```

Session options are labelled with the **whole range** ("Aug 28 - Sep 27, 2026"), so whenever one run's random `end_date` happened to land on another run's `start_date`, the regex matched two options and the suite failed:

```
TestingLibraryElementError: Found multiple elements with the role "option" and name `/Sep 27/i`
  <li aria-selected="false" ...>Sep 27 - Nov 3, 2026 (no certificate available)</li>
  <li aria-selected="true"  ...>Aug 28 - Sep 27, 2026 (no certificate available) — Enrolled</li>
```

That is precisely what happened in [this run](https://github.com/mitodl/mit-learn/actions/runs/30469814580): the run starting Aug 28 drew the end date Sep 27, colliding with the Sep 27 start of the run the test was trying to click. It is roughly a 1-in-365 draw per execution, so it surfaces at random on whichever PR happens to be unlucky — the PR it lands on is never the cause.

The fix pins both ends of both runs via a small `makeDatedRun(startInDays, endInDays, overrides)` helper, with offsets spaced (30/45 and 60/75 days out) so no two labelled dates can share a calendar day. Every option's accessible name is then unambiguous by construction rather than by luck.

Two call sites were vulnerable; both are fixed. `SessionSelect.test.tsx` uses the same query pattern but is already safe — it either pins both dates with literals or anchors the regex on `.*Enrolled`, which can only match the enrolled run.

### How can this be tested?

`yarn jest src/app-pages/ProductPages` from `frontends/main` — 30 suites / 360 tests pass.

Because the bug is probabilistic, I verified the mechanism directly rather than by re-running and hoping. A scratch test (not committed) rendered `SessionSelect` with two runs where the first **ends** on the day the second **starts**, and asserted the failure reproduces:

```ts
// REPRO — passes, i.e. the ambiguous query does throw
const a = makeRun({ start_date: days(30), end_date: days(60) })
const b = makeRun({ start_date: days(60), end_date: days(75) })
expect(() =>
  screen.getByRole("option", { name: new RegExp(formatDate(b.start_date!, "MMM D"), "i") }),
).toThrow(/Found multiple elements/)

// CONTROL — the spacing this PR uses keeps the same query unique
const a = makeRun({ start_date: days(30), end_date: days(45) })
```

Both passed, which confirms the diagnosis and that the chosen spacing is what removes it.

### Additional Context

I deliberately scoped this to the test rather than changing the shared `courseRun` factory. The factory draws `start_date` and `end_date` independently, so it can also produce runs that end before they start — arguably worth fixing, but it would change fixture data under 227 test suites, which is a much larger blast radius than this flake warrants. Happy to do that as a follow-up if the team wants it.