### PR TITLE
chore(deps): drop unused psycopg2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ dependencies = [
     "pluggy>=1.3.0,<2",
     "posthog>=5.0.0,<6",
     "psycopg>=3.2.4,<4",
-    "psycopg2>=2.9.6,<3",
     "pycountry>=24.6.1,<25",
     "pygithub>=2.0.0,<3",
     "pyparsing>=3.2.1,<4",

--- a/uv.lock
+++ b/uv.lock
@@ -1860,7 +1860,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon" },
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -2650,7 +2650,6 @@ dependencies = [
     { name = "pluggy" },
     { name = "posthog" },
     { name = "psycopg" },
-    { name = "psycopg2" },
     { name = "pyarrow" },
     { name = "pycountry" },
     { name = "pygithub" },
@@ -2792,7 +2791,6 @@ requires-dist = [
     { name = "pluggy", specifier = ">=1.3.0,<2" },
     { name = "posthog", specifier = ">=5.0.0,<6" },
     { name = "psycopg", specifier = ">=3.2.4,<4" },
-    { name = "psycopg2", specifier = ">=2.9.6,<3" },
     { name = "pyarrow", specifier = ">=24,<25" },
     { name = "pycountry", specifier = ">=24.6.1,<25" },
     { name = "pygithub", specifier = ">=2.0.0,<3" },
@@ -3804,15 +3802,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
-]
-
-[[package]]
-name = "psycopg2"
-version = "2.9.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/8d/9d12bc8677c24dad342ec777529bce705b3e785fa05d85122b5502b9ab55/psycopg2-2.9.11.tar.gz", hash = "sha256:964d31caf728e217c697ff77ea69c2ba0865fa41ec20bb00f0977e62fdcc52e3", size = 379598, upload-time = "2025-10-10T11:14:46.075Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/bf/635fbe5dd10ed200afbbfbe98f8602829252ca1cce81cc48fb25ed8dadc0/psycopg2-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:e03e4a6dbe87ff81540b434f2e5dc2bddad10296db5eea7bdc995bf5f4162938", size = 2713969, upload-time = "2025-10-10T11:10:15.946Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Removes the `psycopg2` dependency, which Django has not used since `psycopg` (v3) was added.

Why it's unused:

- Django's PostgreSQL backend imports `psycopg` first and only falls back to `psycopg2` on `ImportError` — [`django/db/backends/postgresql/base.py#L23-L29`](https://github.com/django/django/blob/4.2.30/django/db/backends/postgresql/base.py#L23-L29)
- psycopg 3 support landed in Django 4.2 ([release notes](https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support), [PostgreSQL notes](https://docs.djangoproject.com/en/4.2/ref/databases/#postgresql-notes)). We pin `Django==4.2.30` and `psycopg>=3.2.4,<4`, so the first import always wins.
- Confirmed against a running deployment: `django.db.connection.Database.__name__` is `psycopg`, version `3.3.3`.
- Nothing in the repo imports `psycopg2`, and no other package in `uv.lock` depends on it.
- Our OpenTelemetry instrumentation is already the v3 flavor (`opentelemetry-instrumentation-psycopg`, not `-psycopg2`).

Side benefit:

- `psycopg2` 2.9.11 publishes only a `win_amd64` wheel, so every Linux image build and every macOS dev environment was compiling it from sdist for nothing.
- Because that source build needs libpq's `pg_config`, `uv sync` previously failed outright on macOS hosts. It now succeeds.

### How can this be tested?

- CI is the real check: the pytest suite exercises the DB on nearly every test, so a green run means Django connected through psycopg 3 with `psycopg2` absent from the lockfile.
- Locally: `docker compose run --rm web uv run pytest -n logical`
- Confirm which driver is bound:
  ```
  docker compose run --rm web python manage.py shell \
    -c "from django.db import connection; print(connection.Database.__name__)"
  ```
  Expected output: `psycopg`

### Additional Context

- Five installed packages contain `import psycopg2` without declaring it as a dependency, so they don't appear as psycopg2 dependents in `uv.lock`. All are unreachable here:
  - `django` — the documented fallback above, skipped because psycopg 3 imports first
  - `sqlalchemy` — the `postgresql+psycopg2` dialect; no `create_engine` anywhere in the repo
  - `langchain_community` — Apache AGE graph and Yellowbrick vectorstore modules; we use Qdrant
  - `openid` — its SQL store backend, unused
  - `server_status` — see below
- `server_status` is the one worth flagging: [`get_pg_info()`](https://github.com/mitodl/django-server-status/blob/master/server_status/views.py) does a lazy `from psycopg2 import connect, OperationalError` with no `ImportError` guard. It is unreachable because `server_status.urls` is never included — the package appears nowhere but `INSTALLED_APPS` — and `/health/` (which both the liveness and readiness probes hit) is served by `django-health-check` via `main/urls_healthcheck.py`. Anyone who later wires up `server_status.urls` would need to revisit this.
