### PR TITLE
fix hidden cta on product pages when the window is too short

### DIFF
--- a/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
+++ b/frontends/main/src/app-pages/ProductPages/ProductPageTemplate.tsx
@@ -26,6 +26,7 @@ import { getStayUpdatedHubspotFormId } from "@/common/config"
 import { usePostHog } from "posthog-js/react"
 import { PostHogEvents } from "@/common/constants"
 import { PlatformEnum } from "api"
+import { useStickyRevealTop } from "./useStickyRevealTop"
 
 const LearningResourceDrawer = dynamic(
   () =>
@@ -306,6 +307,7 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
   resource,
 }) => {
   const posthog = usePostHog()
+  const summaryColRef = useStickyRevealTop(HEADER_HEIGHT + OFFSET_FROM_HEADER)
   const stayUpdatedFormId = getStayUpdatedHubspotFormId()
   const shouldShowStayUpdatedButton = Boolean(
     stayUpdatedFormId && showStayUpdated,
@@ -414,7 +416,7 @@ const ProductPageTemplate: React.FC<ProductPageTemplateProps> = ({
         </TopContainer>
       </GradientBanner>
       <BottomContainer>
-        <SummaryCol>{infoBox}</SummaryCol>
+        <SummaryCol ref={summaryColRef}>{infoBox}</SummaryCol>
         <MainCol>
           <SectionsWrapper>{children}</SectionsWrapper>
         </MainCol>

--- a/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.test.tsx
@@ -1,0 +1,121 @@
+import React from "react"
+import { render, screen, act } from "@testing-library/react"
+import { useStickyRevealTop } from "./useStickyRevealTop"
+
+const setInnerHeight = (height: number) => {
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+const setOffsetHeight = (el: HTMLElement, height: number) => {
+  Object.defineProperty(el, "offsetHeight", {
+    configurable: true,
+    value: height,
+  })
+}
+
+class FakeVisualViewport extends EventTarget {
+  height: number
+  constructor(height: number) {
+    super()
+    this.height = height
+  }
+}
+
+const TestComponent: React.FC<{ defaultOffset: number }> = ({
+  defaultOffset,
+}) => {
+  const ref = useStickyRevealTop(defaultOffset)
+  return <div ref={ref} data-testid="sticky-el" />
+}
+
+describe("useStickyRevealTop", () => {
+  afterEach(() => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: undefined,
+    })
+  })
+
+  it("uses defaultOffset when the element fits within the viewport", () => {
+    setInnerHeight(800)
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 300,
+    })
+    render(<TestComponent defaultOffset={100} />)
+    expect(screen.getByTestId("sticky-el").style.top).toBe("100px")
+  })
+
+  it("uses a negative offset when the element is taller than the viewport", () => {
+    setInnerHeight(400)
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 500,
+    })
+    render(<TestComponent defaultOffset={100} />)
+    // min(100, 400 - 500) = -100
+    expect(screen.getByTestId("sticky-el").style.top).toBe("-100px")
+  })
+
+  it("recomputes top on window resize", () => {
+    setInnerHeight(800)
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 300,
+    })
+    render(<TestComponent defaultOffset={100} />)
+    const el = screen.getByTestId("sticky-el")
+    expect(el.style.top).toBe("100px")
+
+    setInnerHeight(350)
+    setOffsetHeight(el, 500)
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+    // min(100, 350 - 500) = -150
+    expect(el.style.top).toBe("-150px")
+  })
+
+  it("uses visualViewport height, not window.innerHeight, when available", () => {
+    setInnerHeight(800)
+    const visualViewport = new FakeVisualViewport(300)
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    })
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 500,
+    })
+    render(<TestComponent defaultOffset={100} />)
+    // min(100, 300 - 500) = -200; if window.innerHeight (800) were used
+    // instead this would be 100.
+    expect(screen.getByTestId("sticky-el").style.top).toBe("-200px")
+  })
+
+  it("recomputes top when visualViewport fires resize (e.g. mobile URL bar show/hide)", () => {
+    setInnerHeight(800)
+    const visualViewport = new FakeVisualViewport(300)
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    })
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+      configurable: true,
+      value: 500,
+    })
+    render(<TestComponent defaultOffset={100} />)
+    expect(screen.getByTestId("sticky-el").style.top).toBe("-200px")
+
+    visualViewport.height = 450
+    act(() => {
+      visualViewport.dispatchEvent(new Event("resize"))
+    })
+    // min(100, 450 - 500) = -50
+    expect(screen.getByTestId("sticky-el").style.top).toBe("-50px")
+  })
+})

--- a/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
+++ b/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Positions a `position: sticky` element so that, when it's taller than the
+ * viewport, it scrolls up with the page until its bottom edge reaches the
+ * viewport bottom and then sticks there - keeping its lower content (e.g. a
+ * CTA) reachable without an internal scrollbar or a scroll listener.
+ *
+ * The browser's native sticky positioning does all the scroll-time work; this
+ * only sets the sticky `top` offset, recomputing on resize and when the
+ * element's own content changes size:
+ *
+ *   top = min(defaultOffset, viewportHeight - elementHeight)
+ *
+ * - Shorter than the viewport -> `defaultOffset` (unchanged from before).
+ * - Taller -> a negative offset that lands the element's bottom at the
+ *   viewport bottom once stuck.
+ */
+export const useStickyRevealTop = (defaultOffset: number) => {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const update = () => {
+      const top = Math.min(defaultOffset, window.innerHeight - el.offsetHeight)
+      el.style.top = `${top}px`
+    }
+
+    update()
+    const resizeObserver = new ResizeObserver(update)
+    resizeObserver.observe(el)
+    window.addEventListener("resize", update)
+
+    return () => {
+      resizeObserver.disconnect()
+      window.removeEventListener("resize", update)
+    }
+  }, [defaultOffset])
+
+  return ref
+}

--- a/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
+++ b/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
@@ -7,10 +7,14 @@ import { useEffect, useRef } from "react"
  * CTA) reachable without an internal scrollbar or a scroll listener.
  *
  * The browser's native sticky positioning does all the scroll-time work; this
- * only sets the sticky `top` offset, recomputing on resize and when the
- * element's own content changes size:
+ * only sets the sticky `top` offset, recomputing on resize, on visualViewport
+ * resize (mobile URL bar show/hide), and when the element's own content
+ * changes size:
  *
  *   top = min(defaultOffset, viewportHeight - elementHeight)
+ *
+ * where viewportHeight is window.visualViewport's height when available,
+ * falling back to window.innerHeight.
  *
  * - Fits in viewport at `defaultOffset` -> `defaultOffset` (unchanged from before).
  * - Otherwise -> a (possibly negative) offset that lands the element's bottom at the
@@ -24,7 +28,10 @@ export const useStickyRevealTop = (defaultOffset: number) => {
     if (!el) return
 
     const update = () => {
-      const top = Math.min(defaultOffset, window.innerHeight - el.offsetHeight)
+      // The visual viewport shrinks/grows when a mobile browser's URL bar
+      // shows or hides, without necessarily firing a window "resize" event.
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight
+      const top = Math.min(defaultOffset, viewportHeight - el.offsetHeight)
       el.style.top = `${top}px`
     }
 
@@ -32,10 +39,12 @@ export const useStickyRevealTop = (defaultOffset: number) => {
     const resizeObserver = new ResizeObserver(update)
     resizeObserver.observe(el)
     window.addEventListener("resize", update)
+    window.visualViewport?.addEventListener("resize", update)
 
     return () => {
       resizeObserver.disconnect()
       window.removeEventListener("resize", update)
+      window.visualViewport?.removeEventListener("resize", update)
     }
   }, [defaultOffset])
 

--- a/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
+++ b/frontends/main/src/app-pages/ProductPages/useStickyRevealTop.ts
@@ -12,8 +12,8 @@ import { useEffect, useRef } from "react"
  *
  *   top = min(defaultOffset, viewportHeight - elementHeight)
  *
- * - Shorter than the viewport -> `defaultOffset` (unchanged from before).
- * - Taller -> a negative offset that lands the element's bottom at the
+ * - Fits in viewport at `defaultOffset` -> `defaultOffset` (unchanged from before).
+ * - Otherwise -> a (possibly negative) offset that lands the element's bottom at the
  *   viewport bottom once stuck.
  */
 export const useStickyRevealTop = (defaultOffset: number) => {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12613

### Description (What does it do?)
Fixes the sticky summary info box on course and program product pages so its call-to-action stays reachable when the box is taller than the viewport.

Previously the box pinned at a fixed offset below the header and stayed stuck there for the full length of the page, so the main content column scrolled first and the CTA at the bottom of the box only came into view once you had scrolled nearly to the end of the page.

Now the box uses `position: sticky` with a runtime-computed `top`:

`top = min(HEADER_HEIGHT + OFFSET_FROM_HEADER, viewportHeight − boxHeight)`

- **Shorter than the viewport:** the existing offset is used — behavior is unchanged.
- **Taller than the viewport:** a negative offset is used, so the box scrolls up with the page (revealing top → bottom) and locks once its bottom edge (the CTA) reaches the viewport bottom.

Because CSS can't read an element's own height into `top`, the offset is set by a small hook (`useStickyRevealTop`) that recomputes on resize and content-size change via `ResizeObserver`.

Changes:
- `ProductPageTemplate.tsx`: `SummaryCol` keeps a CSS `top` default for SSR/pre-hydration and the common case; a ref from the new hook overrides `top` at runtime.
- `useStickyRevealTop.ts` (new): resize-only hook that computes the sticky offset.

### Screenshots (if appropriate):
<img width="1126" height="541" alt="image" src="https://github.com/user-attachments/assets/a7c3243f-6758-475c-a8a2-baaa29c29142" />

### How can this be tested?
1. Open a course or program product page with a tall info box (e.g. a program with certificate + free tracks).
2. Make the browser window short enough that the info box is taller than the viewport.
3. Scroll down from the top: the info box should scroll up with the page and then stick with its CTA flush at the bottom of the viewport — reachable without scrolling to the end of the page.
4. Regression checks:
   - Short info box / tall window: box stays pinned under the header with the original offset, fully visible (no change).
   - Below the `md` breakpoint (mobile): full-width, non-sticky layout is unaffected.
   - Resize the window while stuck: the offset recomputes and the CTA stays anchored to the viewport bottom.

Verified locally across short/tall viewports and mobile width; `typecheck`, `lint-check`, and the ProductPages test suite all pass.