### PR TITLE
Rate-limit content_feedback submissions per user

### DIFF
--- a/content_feedback/views.py
+++ b/content_feedback/views.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 
 from content_feedback.models import ContentFeedback
 from content_feedback.serializers import ContentFeedbackSerializer
+from main.throttles import RedisScopedRateThrottle
 
 
 @extend_schema(
@@ -13,6 +14,7 @@ from content_feedback.serializers import ContentFeedbackSerializer
     responses={
         201: ContentFeedbackSerializer,
         400: OpenApiResponse(description="Invalid feedback submission"),
+        429: OpenApiResponse(description="Rate limit exceeded"),
     },
 )
 class ContentFeedbackView(CreateAPIView):
@@ -21,6 +23,8 @@ class ContentFeedbackView(CreateAPIView):
     queryset = ContentFeedback.objects.all()
     serializer_class = ContentFeedbackSerializer
     permission_classes = (IsAuthenticated,)
+    throttle_classes = (RedisScopedRateThrottle,)
+    throttle_scope = "content_feedback"
 
     def perform_create(self, serializer):
         """Attribute the feedback to the authenticated user (server-side)."""

--- a/content_feedback/views_test.py
+++ b/content_feedback/views_test.py
@@ -114,3 +114,33 @@ def test_factory_builds_valid_record():
     feedback = ContentFeedbackFactory.create()
     assert feedback.pk is not None
     assert feedback.sentiment in ("positive", "negative", "idea")
+
+
+def test_submit_rate_limited(user_client, mocker):
+    """Exceeding the per-user rate returns 429; a different user is unaffected."""
+    from django.core.cache.backends.locmem import LocMemCache
+    from rest_framework.test import APIClient
+
+    from main.factories import UserFactory
+    from main.throttles import RedisScopedRateThrottle
+
+    mocker.patch.object(
+        RedisScopedRateThrottle, "cache", LocMemCache("throttle-test", {})
+    )
+    mocker.patch.object(
+        RedisScopedRateThrottle, "THROTTLE_RATES", {"content_feedback": "2/min"}
+    )
+
+    url = reverse("content_feedback:v0:content_feedback")
+    assert user_client.post(url, _payload()).status_code == 201
+    assert user_client.post(url, _payload()).status_code == 201
+    response = user_client.post(url, _payload())
+    assert response.status_code == 429
+    assert response.json()["error_type"] == "Throttled"
+
+    # The limit is keyed per authenticated user: a different user still gets
+    # through even after the first user is throttled. (The user_client fixture
+    # shares one APIClient, so build a distinct client for the second user.)
+    other_client = APIClient()
+    other_client.force_login(UserFactory.create())
+    assert other_client.post(url, _payload()).status_code == 201

--- a/main/settings.py
+++ b/main/settings.py
@@ -643,6 +643,12 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "ALLOWED_VERSIONS": ["v0", "v1"],
     "ORDERING_PARAM": "sortby",
+    "DEFAULT_THROTTLE_RATES": {
+        # Rate format is "<count>/<period>" (e.g. "10/min", "30/hour"); a blank
+        # env value -> "" or None -> None -> throttle is a no-op (kill switch).
+        "content_feedback": get_string("CONTENT_FEEDBACK_THROTTLE_RATE", "10/min")
+        or None,
+    },
 }
 
 USE_X_FORWARDED_PORT = get_bool("USE_X_FORWARDED_PORT", False)  # noqa: FBT003

--- a/main/throttles.py
+++ b/main/throttles.py
@@ -1,0 +1,20 @@
+"""Custom DRF throttles for mit-learn."""
+
+from django.core.cache import caches
+from rest_framework.throttling import ScopedRateThrottle
+
+
+class RedisScopedRateThrottle(ScopedRateThrottle):
+    """ScopedRateThrottle backed by the shared redis cache.
+
+    DRF's default binds to the process-local ``default`` cache, which would not
+    share counters across gunicorn workers. The cache is resolved lazily (per
+    request) via a property rather than captured at import, so tests that swap
+    the ``redis`` alias for a DummyCache (conftest ``_use_dummy_redis_cache_backend``)
+    take effect. DRF only reads ``self.cache``, so a read-only property is safe.
+    """
+
+    @property
+    def cache(self):
+        """Return the shared redis cache backend."""
+        return caches["redis"]

--- a/main/throttles_test.py
+++ b/main/throttles_test.py
@@ -1,0 +1,23 @@
+"""Tests for main.throttles."""
+
+from django.core.cache import caches
+from rest_framework.throttling import ScopedRateThrottle
+
+from main.throttles import RedisScopedRateThrottle
+
+
+def test_redis_scoped_throttle_is_scoped():
+    """It subclasses ScopedRateThrottle (per-scope, per-user keying)."""
+    assert issubclass(RedisScopedRateThrottle, ScopedRateThrottle)
+
+
+def test_redis_scoped_throttle_resolves_redis_alias_lazily():
+    """`cache` resolves to the current `redis` alias at access time.
+
+    Resolving lazily (not at import) is what lets the autouse
+    `_use_dummy_redis_cache_backend` fixture take effect in tests.
+    """
+    # `cache` is a property (resolved per access), not an attribute captured at
+    # import — that is precisely what lets the autouse dummy-redis fixture apply.
+    assert isinstance(RedisScopedRateThrottle.__dict__["cache"], property)
+    assert RedisScopedRateThrottle().cache is caches["redis"]

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -156,6 +156,8 @@ paths:
           description: ''
         '400':
           description: Invalid feedback submission
+        '429':
+          description: Rate limit exceeded
   /api/v0/learning_resources_search_admin_params/:
     get:
       operationId: learning_resources_search_admin_params_retrieve


### PR DESCRIPTION
### What are the relevant tickets?

mitodl/hq#12355

### Description (What does it do?)

Rate-limits `POST /api/v0/content_feedback/` to **10 submissions/min per authenticated user**, returning HTTP 429 when exceeded. Adds a reusable `RedisScopedRateThrottle` (redis-backed DRF `ScopedRateThrottle`) and opts the view in via `throttle_scope`. The rate is env-configurable via `CONTENT_FEEDBACK_THROTTLE_RATE`.

### Screenshots (if appropriate):

N/A — backend only.

### How can this be tested?

**1. Automated:**

```
docker compose run --rm web uv run pytest main/throttles_test.py content_feedback/ -v
```

`test_submit_rate_limited` forces a low rate and asserts `201, 201, 429` for one user, while a different user still gets `201` (per-user keying).

**2. Live endpoint through APISIX (real auth path, default 10/min):**

Same approach as the base PR #3593 — log in, then run the snippet from the devtools console on the `open.odl.local:8065` origin. It submits **11 times in the same minute**: the first **10 return 201**, the **11th returns 429**.

1. `docker compose up -d`, then log in at `http://open.odl.local:8065/login` (complete Keycloak). Sessions lapse; if you see `NotAuthenticated`, log in again.
2. On the `open.odl.local:8065` origin, open the console and run:

```js
(async () => {
  const API = "http://open.odl.local:8065";
  const me = await fetch(`${API}/api/v0/users/me/`, { credentials: "include" });
  if (me.status !== 200) { console.warn("Not logged in (", me.status, ") → visit /login first"); return; }
  console.log("authed as:", (await me.json()).username);
  const csrf = document.cookie.match(/(?:^|; )csrftoken-local=([^;]+)/)?.[1];
  const body = JSON.stringify({
    course_id: "course-v1:MITx+6.00+2T2026",
    course_name: "Introduction to Computer Science",
    block_usage_key: "block-v1:MITx+6.00+2T2026+type@video+block@abc123",
    block_type: "video",
    block_display_name: "Lecture 3: Recursion",
    unit_title: "Recursion and Dictionaries",
    url: "https://apps.mitxonline.mit.edu/learn/course/x/y/abc123",
    sentiment: "idea",
    comment: "throttle test",
  });
  for (let i = 1; i <= 11; i++) {
    const res = await fetch(`${API}/api/v0/content_feedback/`, {
      method: "POST",
      credentials: "include",
      headers: { "Content-Type": "application/json", "X-CSRFToken": csrf },
      body,
    });
    console.log(`request ${i} →`, res.status, res.status === 429 ? await res.json() : "");
  }
})();
```

Requests **1–10 → 201**; request **11 → 429** with:

```json
{ "detail": "Request was throttled. Expected available in 60 seconds.", "error_type": "Throttled" }
```

The countdown reflects time left in the window (e.g. `Expected available in 44 seconds.` on a later retry) and clears after a minute.

<details>
<summary>No-login alternative (curl straight to the web container)</summary>

Bypasses APISIX/Keycloak by passing the base64 `X-Userinfo` header that `ApisixUserMiddleware` decodes into a logged-in user. Cookies are scoped to `open.odl.local`.

```bash
USER=$(printf '%s' '{"sub":"tester-1","email":"tester-1@example.com","preferred_username":"tester_1","given_name":"T","family_name":"One","name":"T One"}' | base64)
BODY='{"course_id":"course-v1:MITx+6.00+2T2026","course_name":"Intro","block_usage_key":"block-v1:MITx+type@video+block@abc123","block_type":"video","block_display_name":"Lecture 3","unit_title":"Recursion","url":"https://example.com/x","sentiment":"idea","comment":"throttle test"}'
R=(--resolve open.odl.local:8061:127.0.0.1)

curl -s "${R[@]}" -c jar.txt -o /dev/null -H "X-Userinfo: $USER" http://open.odl.local:8061/api/v0/users/me/
CSRF=$(awk '/csrftoken/{print $7}' jar.txt)

for i in $(seq 1 11); do
  curl -s "${R[@]}" -b jar.txt -c jar.txt \
    -H "X-Userinfo: $USER" -H "X-CSRFToken: $CSRF" -H "Content-Type: application/json" \
    -o /dev/null -w "request $i -> HTTP %{http_code}\n" \
    -X POST http://open.odl.local:8061/api/v0/content_feedback/ -d "$BODY"
done
# requests 1-10 -> 201, request 11 -> 429
```

To trip it in just 3 requests instead of 11, start the app with `-e CONTENT_FEEDBACK_THROTTLE_RATE=2/min`.

</details>

### Additional Context

- First throttle in mit-learn; it opts in per-view rather than setting a global `DEFAULT_THROTTLE_CLASSES`, so no other endpoint is affected.
- Kill switch: a blank `CONTENT_FEEDBACK_THROTTLE_RATE` resolves to `None`, which DRF treats as no limit — disables the throttle with no deploy.
- The 429 body carries `error_type: "Throttled"` via the existing exception handler.
- The feedback drawer's rate-limit-specific 429 message is a separate smoot-design fast-follow and does not gate this backend protection.