### PR TITLE
Clean up and de-duplicate the VideoPlaylistCollectionPage folder

### DIFF
--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/FeaturedVideo.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/FeaturedVideo.tsx
@@ -7,6 +7,7 @@ import VideoContainer from "./VideoContainer"
 import { RiPlayFill } from "@remixicon/react"
 import { formatDurationClockTime } from "ol-utilities"
 import type { VideoResource } from "api/v1"
+import { DurationBadge } from "./shared.styled"
 
 const PLACEHOLDER_IMG = "/images/mit-open-learning-logo.svg"
 
@@ -56,6 +57,8 @@ const ImageWrapper = styled(Link, {
   }),
 }))
 
+// Distinct from the shared `PlayOverlay`: this one is always visible and scales
+// on hover (see ImageWrapper above) rather than fading a scrim in.
 const PlayOverlay = styled.div({
   position: "absolute",
   inset: 0,
@@ -75,18 +78,6 @@ const PlayCircle = styled.div({
   alignItems: "center",
   justifyContent: "center",
 })
-
-const DurationBadge = styled.span(({ theme }) => ({
-  ...theme.typography.body3,
-  position: "absolute",
-  bottom: 0,
-  right: 0,
-  backgroundColor: theme.custom.colors.darkGray2,
-  color: "#fff",
-  fontWeight: theme.typography.fontWeightMedium,
-  padding: "8px",
-  zIndex: 1,
-}))
 
 const TextSide = styled.div(({ theme }) => ({
   [theme.breakpoints.down("sm")]: {

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/MoreFromPlaylist.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/MoreFromPlaylist.tsx
@@ -1,0 +1,134 @@
+import React from "react"
+import Image from "next/image"
+import { Skeleton } from "ol-components"
+import { formatDurationClockTime } from "ol-utilities"
+import type { VideoResource } from "api/v1"
+import { videoDetailPageView, videoPlaylistPageView } from "@/common/urls"
+import * as Styled from "./VideoDetailPage.styled"
+
+type MoreFromPlaylistProps = {
+  playlistId: number
+  /** Display name of the playlist, used in headings and labels. */
+  playlistLabel: string
+  playlistTitle?: string
+  /** Sibling videos to list, already filtered and capped by the caller. */
+  videos: VideoResource[]
+  /** Total videos in the playlist, used to decide whether to link to the rest. */
+  totalVideos: number
+  isLoading: boolean
+}
+
+/** One row: thumbnail with duration badge and hover overlay, plus title/description. */
+const MoreFromPlaylistItem: React.FC<{
+  video: VideoResource
+  playlistId: number
+}> = ({ video, playlistId }) => {
+  const duration = video.video?.duration
+    ? formatDurationClockTime(video.video.duration)
+    : null
+  const imageUrl = video.image?.url ?? null
+  const topicNames = (video.topics ?? [])
+    .map((topic) => topic.name)
+    .filter(Boolean)
+    .join(" · ")
+
+  return (
+    <Styled.MoreFromItem
+      href={videoDetailPageView(video.id, playlistId, video.title)}
+      aria-label={`Open video ${video.title}`}
+    >
+      <Styled.ThumbnailWrapper>
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt={`Video thumbnail for ${video.title}. Duration: ${duration || "Unknown duration"}. Topics: ${topicNames || "No topics listed"}`}
+            fill
+            sizes="160px"
+            style={{ objectFit: "cover" }}
+          />
+        )}
+        {duration && (
+          <Styled.DurationBadge $dense>{duration}</Styled.DurationBadge>
+        )}
+        <Styled.PlayOverlay className="play-overlay">
+          <Styled.PlayIcon />
+        </Styled.PlayOverlay>
+      </Styled.ThumbnailWrapper>
+      <Styled.MoreFromTextSide>
+        <Styled.MoreFromItemTitle className="mf-title">
+          {video.title}
+        </Styled.MoreFromItemTitle>
+        {video.description && (
+          <Styled.MoreFromItemMeta
+            dangerouslySetInnerHTML={{ __html: video.description }}
+          />
+        )}
+      </Styled.MoreFromTextSide>
+    </Styled.MoreFromItem>
+  )
+}
+
+/**
+ * "More from <playlist>" — the sibling-video list at the foot of the video detail
+ * page. Renders nothing once loaded if the playlist has no other videos.
+ */
+const MoreFromPlaylist: React.FC<MoreFromPlaylistProps> = ({
+  playlistId,
+  playlistLabel,
+  playlistTitle,
+  videos,
+  totalVideos,
+  isLoading,
+}) => {
+  if (isLoading) {
+    return (
+      <>
+        <Skeleton
+          variant="text"
+          width={220}
+          height={24}
+          style={{ marginBottom: 8 }}
+        />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Styled.MoreFromSkeletonRow key={i}>
+            <Skeleton variant="rectangular" width={160} height={90} />
+            <div style={{ flex: 1 }}>
+              <Skeleton variant="text" width="70%" height={20} />
+              <Skeleton variant="text" width="50%" height={16} />
+            </div>
+          </Styled.MoreFromSkeletonRow>
+        ))}
+      </>
+    )
+  }
+
+  if (videos.length === 0) return null
+
+  // +1 accounts for the video currently being watched, which is excluded from
+  // `videos` — without it a fully-listed playlist would still offer "View all".
+  const hasMore = totalVideos > videos.length + 1
+
+  return (
+    <>
+      <Styled.MoreFromTitle>More from {playlistLabel}</Styled.MoreFromTitle>
+      <Styled.MoreFromList>
+        {videos.map((video) => (
+          <React.Fragment key={video.id}>
+            <MoreFromPlaylistItem video={video} playlistId={playlistId} />
+            <Styled.SpacerBlock className="spacer-block" />
+          </React.Fragment>
+        ))}
+      </Styled.MoreFromList>
+      {hasMore && (
+        <Styled.SeeAllLink
+          href={videoPlaylistPageView(String(playlistId), playlistTitle)}
+          aria-label={`View all videos in ${playlistLabel}`}
+        >
+          View all in {playlistLabel} →
+        </Styled.SeeAllLink>
+      )}
+    </>
+  )
+}
+
+export default MoreFromPlaylist

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/ShareDialog.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/ShareDialog.tsx
@@ -1,2 +1,0 @@
-export { default } from "@/components/ShareDialog/ShareDialog"
-export type { ShareDialogProps } from "@/components/ShareDialog/ShareDialog"

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoCard.tsx
@@ -3,8 +3,13 @@ import Image from "next/image"
 import Link from "next/link"
 import { Typography, styled, theme, Skeleton } from "ol-components"
 import { formatDurationClockTime } from "ol-utilities"
-import { RiPlayCircleFill } from "@remixicon/react"
 import type { VideoResource } from "api/v1"
+import {
+  DurationBadge,
+  PlayOverlay,
+  PlayIcon,
+  ThumbnailWrapper,
+} from "./shared.styled"
 
 const PLACEHOLDER_IMG = "/images/mit-open-learning-logo.svg"
 
@@ -35,19 +40,6 @@ const VideoCardItem = styled(Link)({
   },
 })
 
-const ThumbnailWrapper = styled.div({
-  position: "relative",
-  flexShrink: 0,
-  width: 160,
-  aspectRatio: "16/9",
-  overflow: "hidden",
-  backgroundColor: theme.custom.colors.black,
-
-  [theme.breakpoints.down("sm")]: {
-    width: "100%",
-  },
-})
-
 const ThumbnailImage = styled(Image)(({ theme }) => ({
   objectFit: "cover",
   width: "160px",
@@ -56,30 +48,6 @@ const ThumbnailImage = styled(Image)(({ theme }) => ({
     height: "201.375px",
   },
 }))
-
-const DurationBadge = styled.span(({ theme }) => ({
-  ...theme.typography.body3,
-  position: "absolute",
-  bottom: 0,
-  right: 0,
-  backgroundColor: theme.custom.colors.darkGray2,
-  color: "#fff",
-  fontWeight: theme.typography.fontWeightMedium,
-  padding: "8px",
-  zIndex: 1,
-}))
-
-const PlayOverlay = styled.div({
-  position: "absolute",
-  inset: 0,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  color: "#fff",
-  opacity: 0,
-  transition: "opacity 0.2s",
-  backgroundColor: "rgba(0, 0, 0, 0.18)",
-})
 
 const CardContent = styled.div({
   flex: 1,
@@ -106,11 +74,6 @@ const CardTitle = styled(Typography)(({ theme }) => ({
     marginTop: 0,
   },
 }))
-
-const PlayIcon = styled(RiPlayCircleFill)({
-  width: 36,
-  height: 36,
-})
 
 const CardMetaRow = styled.div({
   display: "flex",

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.styled.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.styled.ts
@@ -1,0 +1,234 @@
+import Link from "next/link"
+import { Typography, styled, theme } from "ol-components"
+import VideoResourcePlayer from "./VideoResourcePlayer"
+
+// Primitives shared with the other video pages, re-exported so consumers of this
+// module have a single import for the page's styles.
+export {
+  SkipLinksNav,
+  StyledBreadcrumbs,
+  ScreenReaderOnly,
+  DurationBadge,
+  PlayOverlay,
+  PlayIcon,
+  ThumbnailWrapper,
+  VideoTitle,
+} from "./shared.styled"
+
+// ── Page shell ──
+
+export const PageWrapper = styled.div({
+  backgroundColor: "#fff",
+  minHeight: "100vh",
+})
+
+export const BreadcrumbBar = styled.div(({ theme }) => ({
+  padding: "18px 0 2px 0",
+  borderBottom: `1px solid ${theme.custom.colors.red}`,
+  [theme.breakpoints.down("sm")]: {
+    padding: "12px 0 0 0",
+  },
+}))
+
+export const ContentArea = styled.div(({ theme }) => ({
+  padding: "56px 0 80px",
+  [theme.breakpoints.down("sm")]: {
+    padding: "32px 0 80px",
+  },
+}))
+
+export const CategoryLabel = styled(Link)(({ theme }) => ({
+  display: "block",
+  ...theme.typography.body3,
+  fontWeight: theme.typography.fontWeightBold,
+  color: theme.custom.colors.red,
+  textTransform: "uppercase",
+  letterSpacing: "1.92px",
+  marginBottom: "8px",
+  fontSize: "12px",
+  fontStyle: "normal",
+  lineHeight: "150%" /* 18px */,
+  "&:hover": {
+    textDecoration: "underline",
+  },
+}))
+
+// ── Title / meta row ──
+
+export const VideoShareSection = styled("div")({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  flexWrap: "wrap",
+  gap: "8px",
+  marginBottom: "24px",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "16px",
+  },
+})
+
+export const MetaRow = styled.div({
+  ...theme.typography.body2,
+  color: theme.custom.colors.darkGray1,
+})
+
+export const TopicText = styled.span(({ theme }) => ({
+  color: theme.custom.colors.silverGrayDark,
+  ...theme.typography.body2,
+  lineHeight: "22px",
+  paddingLeft: "8px",
+}))
+
+export const DurationText = styled.span(({ theme }) => ({
+  color: theme.custom.colors.black,
+  ...theme.typography.body2,
+  lineHeight: "22px",
+  fontWeight: theme.typography.fontWeightBold,
+}))
+
+// ── Player / description ──
+
+export const StyledVideoResourcePlayer = styled(VideoResourcePlayer)(
+  ({ theme }) => ({
+    [theme.breakpoints.down("sm")]: {
+      marginTop: "0",
+    },
+  }),
+)
+
+export const BorderLine = styled.div(({ theme }) => ({
+  borderBottom: `4px solid ${theme.custom.colors.darkGray2}`,
+  marginBottom: "40px",
+  [theme.breakpoints.down("sm")]: {
+    marginBottom: "24px",
+  },
+}))
+
+export const DescriptionText = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body1,
+  color: theme.custom.colors.darkGray2,
+  marginBottom: "22px",
+  fontSize: "18px",
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: "30px",
+  [theme.breakpoints.down("sm")]: {
+    fontSize: "16px",
+    lineHeight: "28px",
+    marginBottom: "24px",
+  },
+}))
+
+// ── "More from playlist" list ──
+
+export const MoreFromTitle = styled(Typography)(({ theme }) => ({
+  ...theme.typography.body3,
+  fontWeight: theme.typography.fontWeightBold,
+  textTransform: "uppercase",
+  color: theme.custom.colors.black,
+  padding: "32px 0",
+  lineHeight: "150%",
+  letterSpacing: "1.92px",
+  [theme.breakpoints.down("sm")]: {
+    padding: "24px 0",
+  },
+}))
+
+export const MoreFromList = styled.div({
+  display: "flex",
+  flexDirection: "column",
+})
+
+export const MoreFromItem = styled(Link)({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "24px",
+  padding: "24px 0",
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+  textDecoration: "none",
+  "&:hover .mf-title": { color: theme.custom.colors.red },
+
+  "&:hover .video-card-title, &:focus-visible .video-card-title": {
+    color: theme.custom.colors.red,
+  },
+
+  "&:hover .play-overlay": {
+    opacity: 0.5,
+  },
+
+  "&:focus-visible .play-overlay": {
+    opacity: 0.5,
+  },
+
+  "&:first-child": {
+    padding: "0 0 24px 0",
+  },
+
+  [theme.breakpoints.down("sm")]: {
+    flexDirection: "column",
+  },
+})
+
+export const MoreFromTextSide = styled.div(({ theme }) => ({
+  flex: 1,
+  minWidth: 0,
+  paddingTop: "17px",
+  [theme.breakpoints.down("sm")]: {
+    paddingTop: 0,
+  },
+}))
+
+export const MoreFromItemTitle = styled(Typography)({
+  ...theme.typography.subtitle2,
+  fontWeight: theme.typography.fontWeightBold,
+  color: theme.custom.colors.black,
+  transition: "color 0.15s",
+  marginBottom: "4px",
+  fontSize: "20px",
+  lineHeight: "26px" /* 130% */,
+})
+
+export const MoreFromItemMeta = styled(Typography)({
+  ...theme.typography.body2,
+  color: theme.custom.colors.silverGrayDark,
+  overflow: "hidden",
+  display: "-webkit-box",
+  WebkitLineClamp: 2,
+  WebkitBoxOrient: "vertical",
+  lineHeight: "22px",
+})
+
+export const SeeAllLink = styled(Link)(({ theme }) => ({
+  display: "inline-flex",
+  alignItems: "center",
+  marginTop: "40px",
+  ...theme.typography.body1,
+  color: theme.custom.colors.red,
+  fontWeight: theme.typography.fontWeightMedium,
+  lineHeight: "150%",
+  textDecoration: "none",
+  "&:hover": { textDecoration: "underline" },
+  [theme.breakpoints.down("sm")]: {
+    marginTop: "28px",
+  },
+}))
+
+/** Mobile-only gap between "More from" rows; collapses to nothing on desktop. */
+export const SpacerBlock = styled.div(({ theme }) => ({
+  "& .spacer-block": {
+    display: "none",
+  },
+  [theme.breakpoints.down("sm")]: {
+    height: "8px",
+    "& .spacer-block": {
+      display: "block",
+    },
+  },
+}))
+
+/** Row placeholder matching a "More from" item while the playlist loads. */
+export const MoreFromSkeletonRow = styled.div(({ theme }) => ({
+  display: "flex",
+  gap: 16,
+  padding: "16px 0",
+  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
+}))

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoDetailPage.tsx
@@ -2,13 +2,10 @@
 
 import { env } from "@/env"
 import React, { useEffect, useRef } from "react"
-import Link from "next/link"
-import Image from "next/image"
-import { Typography, styled, theme, Skeleton, SkipLink } from "ol-components"
+import { Skeleton, SkipLink } from "ol-components"
 import VideoContainer from "./VideoContainer"
-import { RiPlayCircleFill } from "@remixicon/react"
-import { SkipLinksNav, StyledBreadcrumbs } from "./shared.styled"
 import VideoShareButton from "./VideoShareButton"
+import MoreFromPlaylist from "./MoreFromPlaylist"
 import { useQuery } from "@tanstack/react-query"
 import {
   useLearningResourcesDetail,
@@ -19,284 +16,13 @@ import { VideoResourceResourceTypeEnum } from "api/v1"
 import { formatDurationClockTime } from "ol-utilities"
 import { videoDetailPageView, videoPlaylistPageView } from "@/common/urls"
 import { buildVideoStructuredData } from "./videoStructuredData"
-import VideoResourcePlayer from "./VideoResourcePlayer"
 import type { VideoPlayerHandle } from "./VideoResourcePlayer"
+import * as Styled from "./VideoDetailPage.styled"
 
 const NEXT_PUBLIC_ORIGIN = env("NEXT_PUBLIC_ORIGIN")
 
-const PageWrapper = styled.div({
-  backgroundColor: "#fff",
-  minHeight: "100vh",
-})
-
-const BreadcrumbBar = styled.div(({ theme }) => ({
-  padding: "18px 0 2px 0",
-  borderBottom: `1px solid ${theme.custom.colors.red}`,
-  [theme.breakpoints.down("sm")]: {
-    padding: "12px 0 0 0",
-  },
-}))
-
-const PlayIcon = styled(RiPlayCircleFill)({
-  width: 36,
-  height: 36,
-})
-
-const ContentArea = styled.div(({ theme }) => ({
-  padding: "56px 0 80px",
-  [theme.breakpoints.down("sm")]: {
-    padding: "32px 0 80px",
-  },
-}))
-
-const CategoryLabel = styled(Link)(({ theme }) => ({
-  display: "block",
-  ...theme.typography.body3,
-  fontWeight: theme.typography.fontWeightBold,
-  color: theme.custom.colors.red,
-  textTransform: "uppercase",
-  letterSpacing: "1.92px",
-  marginBottom: "8px",
-  fontSize: "12px",
-  fontStyle: "normal",
-  lineHeight: "150%" /* 18px */,
-  "&:hover": {
-    textDecoration: "underline",
-  },
-}))
-
-const StyledVideoShareButton = styled(VideoShareButton)({
-  height: "40px",
-  padding: "18px 12px",
-})
-
-const VideoShareSection = styled("div")({
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "space-between",
-  flexWrap: "wrap",
-  gap: "8px",
-  marginBottom: "24px",
-  [theme.breakpoints.down("sm")]: {
-    marginBottom: "16px",
-  },
-})
-
-const VideoTitle = styled.h1(({ theme }) => ({
-  ...theme.typography.h2,
-  fontWeight: theme.typography.fontWeightBold,
-  color: theme.custom.colors.black,
-  margin: "0 0 24px",
-  "&:focus": { outline: "none" },
-  fontSize: "44px",
-  fontStyle: "normal",
-  lineHeight: "120%" /* 52.8px */,
-  letterSpacing: "-0.88px",
-  [theme.breakpoints.down("sm")]: {
-    ...theme.typography.h3,
-    margin: "0 0 14px",
-    letterSpacing: "inherit",
-  },
-}))
-
-const MetaRow = styled.div({
-  ...theme.typography.body2,
-  color: theme.custom.colors.darkGray1,
-})
-
-const StyledVideoResourcePlayer = styled(VideoResourcePlayer)(({ theme }) => ({
-  [theme.breakpoints.down("sm")]: {
-    marginTop: "0",
-  },
-}))
-
-const DescriptionText = styled(Typography)(({ theme }) => ({
-  ...theme.typography.body1,
-  color: theme.custom.colors.darkGray2,
-  marginBottom: "22px",
-  fontSize: "18px",
-  fontWeight: theme.typography.fontWeightMedium,
-  lineHeight: "30px",
-  [theme.breakpoints.down("sm")]: {
-    fontSize: "16px",
-    lineHeight: "28px",
-    marginBottom: "24px",
-  },
-}))
-
-const MoreFromTitle = styled(Typography)(({ theme }) => ({
-  ...theme.typography.body3,
-  fontWeight: theme.typography.fontWeightBold,
-  textTransform: "uppercase",
-  color: theme.custom.colors.black,
-  padding: "32px 0",
-  lineHeight: "150%",
-  letterSpacing: "1.92px",
-  [theme.breakpoints.down("sm")]: {
-    padding: "24px 0",
-  },
-}))
-
-const MoreFromList = styled.div({
-  display: "flex",
-  flexDirection: "column",
-})
-
-const BorderLine = styled.div(({ theme }) => ({
-  borderBottom: `4px solid ${theme.custom.colors.darkGray2}`,
-  marginBottom: "40px",
-  [theme.breakpoints.down("sm")]: {
-    marginBottom: "24px",
-  },
-}))
-
-const MoreFromItem = styled(Link)({
-  display: "flex",
-  alignItems: "flex-start",
-  gap: "24px",
-  padding: "24px 0",
-  borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-  textDecoration: "none",
-  "&:hover .mf-title": { color: theme.custom.colors.red },
-
-  "&:hover .video-card-title, &:focus-visible .video-card-title": {
-    color: theme.custom.colors.red,
-  },
-
-  "&:hover .play-overlay": {
-    opacity: 0.5,
-  },
-
-  "&:focus-visible .play-overlay": {
-    opacity: 0.5,
-  },
-
-  "&:first-child": {
-    padding: "0 0 24px 0",
-  },
-
-  [theme.breakpoints.down("sm")]: {
-    flexDirection: "column",
-  },
-})
-
-const MoreFromThumbnailWrapper = styled.div(({ theme }) => ({
-  position: "relative",
-  flexShrink: 0,
-  width: 160,
-  aspectRatio: "16/9",
-  backgroundColor: theme.custom.colors.black,
-  overflow: "hidden",
-  [theme.breakpoints.down("sm")]: {
-    width: "100%",
-  },
-}))
-
-const DurationBadge = styled.span(({ theme }) => ({
-  ...theme.typography.body3,
-  position: "absolute",
-  bottom: 0,
-  right: 0,
-  backgroundColor: theme.custom.colors.darkGray2,
-  color: "#fff",
-  fontWeight: theme.typography.fontWeightMedium,
-  padding: "4px 6px",
-  zIndex: 1,
-}))
-
-const MoreFromTextSide = styled.div(({ theme }) => ({
-  flex: 1,
-  minWidth: 0,
-  paddingTop: "17px",
-  [theme.breakpoints.down("sm")]: {
-    paddingTop: 0,
-  },
-}))
-
-const MoreFromItemTitle = styled(Typography)({
-  ...theme.typography.subtitle2,
-  fontWeight: theme.typography.fontWeightBold,
-  color: theme.custom.colors.black,
-  transition: "color 0.15s",
-  marginBottom: "4px",
-  fontSize: "20px",
-  lineHeight: "26px" /* 130% */,
-})
-
-const MoreFromItemMeta = styled(Typography)({
-  ...theme.typography.body2,
-  color: theme.custom.colors.silverGrayDark,
-  overflow: "hidden",
-  display: "-webkit-box",
-  WebkitLineClamp: 2,
-  WebkitBoxOrient: "vertical",
-  lineHeight: "22px",
-})
-
-const SeeAllLink = styled(Link)(({ theme }) => ({
-  display: "inline-flex",
-  alignItems: "center",
-  marginTop: "40px",
-  ...theme.typography.body1,
-  color: theme.custom.colors.red,
-  fontWeight: theme.typography.fontWeightMedium,
-  lineHeight: "150%",
-  textDecoration: "none",
-  "&:hover": { textDecoration: "underline" },
-  [theme.breakpoints.down("sm")]: {
-    marginTop: "28px",
-  },
-}))
-
-const SpacerBlock = styled.div(({ theme }) => ({
-  "& .spacer-block": {
-    display: "none",
-  },
-  [theme.breakpoints.down("sm")]: {
-    height: "8px",
-    "& .spacer-block": {
-      display: "block",
-    },
-  },
-}))
-
-const TopicText = styled.span(({ theme }) => ({
-  color: theme.custom.colors.silverGrayDark,
-  ...theme.typography.body2,
-  lineHeight: "22px",
-  paddingLeft: "8px",
-}))
-
-const DurationText = styled.span(({ theme }) => ({
-  color: theme.custom.colors.black,
-  ...theme.typography.body2,
-  lineHeight: "22px",
-  fontWeight: theme.typography.fontWeightBold,
-}))
-
-const PlayOverlay = styled.div({
-  position: "absolute",
-  inset: 0,
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  color: "#fff",
-  opacity: 0,
-  transition: "opacity 0.2s",
-  backgroundColor: "rgba(0, 0, 0, 0.18)",
-})
-
-const ScreenReaderOnly = styled.span({
-  position: "absolute",
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: "hidden",
-  clip: "rect(0, 0, 0, 0)",
-  whiteSpace: "nowrap",
-  border: 0,
-})
+/** How many sibling videos the "More from" list shows at most. */
+const MORE_FROM_LIMIT = 5
 
 type VideoDetailPageProps = {
   videoId: number
@@ -343,7 +69,7 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
         item.resource_type === VideoResourceResourceTypeEnum.Video &&
         item.id !== videoId,
     )
-    .slice(0, 5)
+    .slice(0, MORE_FROM_LIMIT)
 
   const totalPlaylistVideos = (playlistItems ?? []).filter(
     (item) => item.resource_type === VideoResourceResourceTypeEnum.Video,
@@ -375,7 +101,7 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
   const structuredData = !isLoading ? buildVideoStructuredData(video) : null
 
   return (
-    <PageWrapper>
+    <Styled.PageWrapper>
       {structuredData && (
         <script
           type="application/ld+json"
@@ -386,7 +112,7 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
           }}
         />
       )}
-      <SkipLinksNav aria-label="Skip links">
+      <Styled.SkipLinksNav aria-label="Skip links">
         <SkipLink.Trigger targetId="video-detail-main">
           Skip to main content
         </SkipLink.Trigger>
@@ -398,15 +124,19 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
             Skip to more videos
           </SkipLink.Trigger>
         )}
-      </SkipLinksNav>
+      </Styled.SkipLinksNav>
 
-      <ScreenReaderOnly role="status" aria-live="polite" aria-atomic="true">
+      <Styled.ScreenReaderOnly
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
         {loadingStatusMessage}
-      </ScreenReaderOnly>
+      </Styled.ScreenReaderOnly>
 
-      <BreadcrumbBar>
+      <Styled.BreadcrumbBar>
         <VideoContainer>
-          <StyledBreadcrumbs
+          <Styled.StyledBreadcrumbs
             variant="light"
             separatorStyle={{ margin: "0 4px" }}
             ancestors={[
@@ -426,18 +156,18 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
             current={video?.title}
           />
         </VideoContainer>
-      </BreadcrumbBar>
+      </Styled.BreadcrumbBar>
 
-      <ContentArea id="video-detail-main" tabIndex={-1}>
+      <Styled.ContentArea id="video-detail-main" tabIndex={-1}>
         <VideoContainer>
           {isLoading ? (
             <Skeleton width={120} height={18} style={{ marginBottom: 8 }} />
           ) : playlist ? (
-            <CategoryLabel
+            <Styled.CategoryLabel
               href={videoPlaylistPageView(String(playlist.id), playlist.title)}
             >
               {playlistLabel}
-            </CategoryLabel>
+            </Styled.CategoryLabel>
           ) : null}
 
           {isLoading ? (
@@ -448,31 +178,31 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
               style={{ marginBottom: 12 }}
             />
           ) : (
-            <VideoTitle ref={titleRef} tabIndex={-1}>
+            <Styled.VideoTitle ref={titleRef} tabIndex={-1}>
               {video?.title}
-            </VideoTitle>
+            </Styled.VideoTitle>
           )}
 
-          <VideoShareSection>
+          <Styled.VideoShareSection>
             {!isLoading && (duration || topicNames) && (
-              <MetaRow>
-                <DurationText>
+              <Styled.MetaRow>
+                <Styled.DurationText>
                   {duration && <span>{duration}</span>}
-                </DurationText>
-                <TopicText>{topicNames}</TopicText>
-              </MetaRow>
+                </Styled.DurationText>
+                <Styled.TopicText>{topicNames}</Styled.TopicText>
+              </Styled.MetaRow>
             )}
 
             {!isLoading && video && (
-              <StyledVideoShareButton
+              <VideoShareButton
                 video={video}
                 title={video.title ?? "video"}
                 pageUrl={`${NEXT_PUBLIC_ORIGIN}${videoDetailPageView(video.id, playlistId ?? undefined, video.title)}`}
                 playerRef={playerRef}
               />
             )}
-          </VideoShareSection>
-          <StyledVideoResourcePlayer
+          </Styled.VideoShareSection>
+          <Styled.StyledVideoResourcePlayer
             ref={playerRef}
             video={video}
             videoId={videoId}
@@ -481,127 +211,37 @@ const VideoDetailPage: React.FC<VideoDetailPageProps> = ({
             videoThumbnailAlt={videoThumbnailAlt}
             startTime={startTime}
           />
-          <BorderLine />
+          <Styled.BorderLine />
 
           {!isLoading && video?.description && (
-            <DescriptionText
+            <Styled.DescriptionText
               id="video-description"
               dangerouslySetInnerHTML={{ __html: video.description }}
             />
           )}
 
           {!isLoading && !video?.description && (
-            <ScreenReaderOnly id="video-description">
+            <Styled.ScreenReaderOnly id="video-description">
               {videoTitleLabel}. Duration: {durationLabel}. Topics:{" "}
               {topicNamesLabel}.
-            </ScreenReaderOnly>
+            </Styled.ScreenReaderOnly>
           )}
 
-          {/* More from playlist */}
           {playlistId && (
             <section id="more-from-playlist" tabIndex={-1}>
-              {itemsLoading ? (
-                <>
-                  <Skeleton
-                    variant="text"
-                    width={220}
-                    height={24}
-                    style={{ marginBottom: 8 }}
-                  />
-                  {Array.from({ length: 3 }).map((_, i) => (
-                    <div
-                      key={i}
-                      style={{
-                        display: "flex",
-                        gap: 16,
-                        padding: "16px 0",
-                        borderBottom: `1px solid ${theme.custom.colors.lightGray2}`,
-                      }}
-                    >
-                      <Skeleton variant="rectangular" width={160} height={90} />
-                      <div style={{ flex: 1 }}>
-                        <Skeleton variant="text" width="70%" height={20} />
-                        <Skeleton variant="text" width="50%" height={16} />
-                      </div>
-                    </div>
-                  ))}
-                </>
-              ) : otherVideos.length > 0 ? (
-                <>
-                  <MoreFromTitle>More from {playlistLabel}</MoreFromTitle>
-                  <MoreFromList>
-                    {otherVideos.map((item) => {
-                      const itemDuration = item.video?.duration
-                        ? formatDurationClockTime(item.video.duration)
-                        : null
-                      const imageUrl = item.image?.url ?? null
-                      const itemTopicNames = (item.topics ?? [])
-                        .map((topic) => topic.name)
-                        .filter(Boolean)
-                        .join(" · ")
-                      return (
-                        <React.Fragment key={item.id}>
-                          <MoreFromItem
-                            href={videoDetailPageView(
-                              item.id,
-                              playlistId,
-                              item.title,
-                            )}
-                            aria-label={`Open video ${item.title}`}
-                          >
-                            <MoreFromThumbnailWrapper>
-                              {imageUrl && (
-                                <Image
-                                  src={imageUrl}
-                                  alt={`Video thumbnail for ${item.title}. Duration: ${itemDuration || "Unknown duration"}. Topics: ${itemTopicNames || "No topics listed"}`}
-                                  fill
-                                  sizes="160px"
-                                  style={{ objectFit: "cover" }}
-                                />
-                              )}
-                              {itemDuration && (
-                                <DurationBadge>{itemDuration}</DurationBadge>
-                              )}
-                              <PlayOverlay className="play-overlay">
-                                <PlayIcon />
-                              </PlayOverlay>
-                            </MoreFromThumbnailWrapper>
-                            <MoreFromTextSide>
-                              <MoreFromItemTitle className="mf-title">
-                                {item.title}
-                              </MoreFromItemTitle>
-                              {item.description && (
-                                <MoreFromItemMeta
-                                  dangerouslySetInnerHTML={{
-                                    __html: item.description,
-                                  }}
-                                />
-                              )}
-                            </MoreFromTextSide>
-                          </MoreFromItem>
-                          <SpacerBlock className="spacer-block"></SpacerBlock>
-                        </React.Fragment>
-                      )
-                    })}
-                  </MoreFromList>
-                  {totalPlaylistVideos > otherVideos.length + 1 && (
-                    <SeeAllLink
-                      href={videoPlaylistPageView(
-                        String(playlistId),
-                        playlist?.title,
-                      )}
-                      aria-label={`View all videos in ${playlistLabel}`}
-                    >
-                      View all in {playlistLabel} →
-                    </SeeAllLink>
-                  )}
-                </>
-              ) : null}
+              <MoreFromPlaylist
+                playlistId={playlistId}
+                playlistLabel={playlistLabel}
+                playlistTitle={playlist?.title}
+                videos={otherVideos}
+                totalVideos={totalPlaylistVideos}
+                isLoading={itemsLoading}
+              />
             </section>
           )}
         </VideoContainer>
-      </ContentArea>
-    </PageWrapper>
+      </Styled.ContentArea>
+    </Styled.PageWrapper>
   )
 }
 

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoJsPlayer.tsx
@@ -226,7 +226,3 @@ const VideoJsPlayer: React.FC<VideoJsPlayerProps> = ({
 }
 
 export default VideoJsPlayer
-
-// Re-export for backward compatibility — the implementation lives in
-// videoSources.ts so it can be imported without pulling in video.js.
-export { resolveVideoSources } from "./videoSources"

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoResourcePlayer.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoResourcePlayer.tsx
@@ -4,7 +4,7 @@ import React, { useImperativeHandle, useMemo, useRef } from "react"
 import dynamic from "next/dynamic"
 import Image from "next/image"
 import { Skeleton, styled } from "ol-components"
-import { NoVideoMessage } from "./shared.styled"
+import { NoVideoMessage, ScreenReaderOnly } from "./shared.styled"
 import { resolveVideoSources } from "./videoSources"
 import { convertToEmbedUrl } from "@/common/utils"
 import YouTubeIframePlayer, {
@@ -69,18 +69,6 @@ const ThumbnailWrapper = styled.div({
   position: "relative",
   width: "100%",
   height: "100%",
-})
-
-const ScreenReaderOnly = styled.span({
-  position: "absolute",
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: "hidden",
-  clip: "rect(0, 0, 0, 0)",
-  whiteSpace: "nowrap",
-  border: 0,
 })
 
 export type VideoPlayerHandle = {

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.styled.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.styled.ts
@@ -6,6 +6,8 @@ export {
   SkipLinksNav,
   StyledBreadcrumbs,
   NoVideoMessage,
+  ScreenReaderOnly,
+  VideoTitle,
 } from "./shared.styled"
 
 export const PageWrapper = styled.div({
@@ -46,8 +48,6 @@ export const UpNextRight = styled.div({
   alignItems: "center",
   gap: "24px",
 })
-
-export { default as ShareButton } from "@/components/ShareButton/ShareButton"
 
 // ── Series navigation bar ──
 
@@ -190,23 +190,6 @@ export const InstitutionLabel = styled.span(({ theme }) => ({
   },
 }))
 
-export const VideoTitle = styled.h1(({ theme }) => ({
-  ...theme.typography.h2,
-  fontWeight: theme.typography.fontWeightBold,
-  color: theme.custom.colors.black,
-  margin: "0 0 16px",
-  "&:focus": { outline: "none" },
-  fontSize: "44px",
-  fontStyle: "normal",
-  lineHeight: "120%",
-  letterSpacing: "-0.88px",
-  [theme.breakpoints.down("sm")]: {
-    ...theme.typography.h3,
-    margin: "0 0 8px",
-    letterSpacing: "inherit",
-  },
-}))
-
 export const SectionDivider = styled.div(({ theme }) => ({
   borderTop: `1px solid ${theme.custom.colors.lightGray2}`,
   margin: "32px 0",
@@ -326,15 +309,3 @@ export const TopicChip = styled(Link)(({ theme }) => ({
     color: theme.custom.colors.red,
   },
 }))
-
-export const ScreenReaderOnly = styled.span({
-  position: "absolute",
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: "hidden",
-  clip: "rect(0, 0, 0, 0)",
-  whiteSpace: "nowrap",
-  border: 0,
-})

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoSeriesDetailPage.tsx
@@ -24,11 +24,6 @@ const StyledVideoResourcePlayer = styled(VideoResourcePlayer)(({ theme }) => ({
   borderBottom: `3px solid ${theme.custom.colors.darkGray2}`,
 }))
 
-const StyledVideoShareButton = styled(VideoShareButton)({
-  height: "40px",
-  padding: "18px 12px",
-})
-
 type VideoSeriesDetailPageProps = {
   videoId: number
   playlistId: number | null
@@ -171,7 +166,7 @@ const VideoSeriesDetailPage: React.FC<VideoSeriesDetailPageProps> = ({
               style={{ marginBottom: 12 }}
             />
           ) : (
-            <Styled.VideoTitle ref={titleRef} tabIndex={-1}>
+            <Styled.VideoTitle ref={titleRef} tabIndex={-1} $compact>
               {video?.title}
             </Styled.VideoTitle>
           )}
@@ -181,7 +176,7 @@ const VideoSeriesDetailPage: React.FC<VideoSeriesDetailPageProps> = ({
               <Styled.StyledDuration>{duration}</Styled.StyledDuration>
             )}
             {!itemsLoading && video && (
-              <StyledVideoShareButton
+              <VideoShareButton
                 video={video}
                 title={video?.title ?? ""}
                 pageUrl={`${NEXT_PUBLIC_ORIGIN}${videoDetailPageView(video.id, playlistId ?? undefined, video.title)}`}

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoShareButton.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoShareButton.tsx
@@ -1,11 +1,19 @@
 "use client"
 
 import React, { useState } from "react"
+import { styled } from "ol-components"
 import { RiShareForwardFill } from "@remixicon/react"
 import type { VideoResource } from "api/v1"
 import ShareDialog from "@/components/ShareDialog/ShareDialog"
+import ShareButton from "@/components/ShareButton/ShareButton"
 import type { VideoPlayerHandle } from "./VideoResourcePlayer"
-import * as Styled from "./VideoSeriesDetailPage.styled"
+
+// Both video pages sized the button identically via their own
+// `styled(VideoShareButton)` wrapper; that sizing now lives here instead.
+const StyledShareButton = styled(ShareButton)({
+  height: "40px",
+  padding: "18px 12px",
+})
 
 type VideoShareButtonProps = {
   video: VideoResource
@@ -26,14 +34,14 @@ const VideoShareButton: React.FC<VideoShareButtonProps> = ({
 
   return (
     <>
-      <Styled.ShareButton
+      <StyledShareButton
         className={className}
         aria-label={`Share ${title}`}
         onClick={() => setShareOpen(true)}
       >
         <RiShareForwardFill size={16} />
         Share
-      </Styled.ShareButton>
+      </StyledShareButton>
       <ShareDialog
         open={shareOpen}
         video={video}

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoShareDialog.tsx
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/VideoShareDialog.tsx
@@ -1,2 +1,0 @@
-export { default } from "./ShareDialog"
-export type { ShareDialogProps as VideoShareDialogProps } from "./ShareDialog"

--- a/frontends/main/src/app-pages/VideoPlaylistCollectionPage/shared.styled.ts
+++ b/frontends/main/src/app-pages/VideoPlaylistCollectionPage/shared.styled.ts
@@ -4,6 +4,7 @@ import {
   HEADER_HEIGHT,
   HEADER_HEIGHT_MD,
 } from "ol-components"
+import { RiPlayCircleFill } from "@remixicon/react"
 
 export const SkipLinksNav = styled.nav(({ theme }) => ({
   position: "absolute",
@@ -31,3 +32,104 @@ export const NoVideoMessage = styled.div({
   color: "rgba(255,255,255,0.5)",
   fontSize: 14,
 })
+
+/** Visually hidden text that remains available to screen readers. */
+export const ScreenReaderOnly = styled.span({
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
+})
+
+/**
+ * Duration (or "N videos • time") badge pinned to a thumbnail's bottom-right.
+ *
+ * `$dense` tightens the padding for the smaller thumbnails in the video detail
+ * page's "More from" list; everywhere else uses the roomier default.
+ */
+export const DurationBadge = styled.span<{ $dense?: boolean }>(
+  ({ theme, $dense }) => ({
+    ...theme.typography.body3,
+    position: "absolute",
+    bottom: 0,
+    right: 0,
+    backgroundColor: theme.custom.colors.darkGray2,
+    color: "#fff",
+    fontWeight: theme.typography.fontWeightMedium,
+    padding: $dense ? "4px 6px" : "8px",
+    zIndex: 1,
+  }),
+)
+
+/**
+ * Fixed-width 16:9 thumbnail frame, full-width on mobile. Positioning context
+ * for `DurationBadge` and `PlayOverlay`.
+ */
+export const ThumbnailWrapper = styled.div(({ theme }) => ({
+  position: "relative",
+  flexShrink: 0,
+  width: 160,
+  aspectRatio: "16/9",
+  overflow: "hidden",
+  backgroundColor: theme.custom.colors.black,
+  [theme.breakpoints.down("sm")]: {
+    width: "100%",
+  },
+}))
+
+/**
+ * Dim scrim with a centred play icon, revealed on hover/focus of the enclosing
+ * card link (which owns the `.play-overlay` opacity rules).
+ *
+ * NB: `FeaturedVideo` keeps its own overlay rather than sharing this one — it is
+ * a different treatment (always visible, scales on hover, no scrim), and only
+ * coincidentally has the same name.
+ */
+export const PlayOverlay = styled.div({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  color: "#fff",
+  opacity: 0,
+  transition: "opacity 0.2s",
+  backgroundColor: "rgba(0, 0, 0, 0.18)",
+})
+
+/** The play glyph shown inside `PlayOverlay`. */
+export const PlayIcon = styled(RiPlayCircleFill)({
+  width: 36,
+  height: 36,
+})
+
+/**
+ * `<h1>` for a video page. Focusable (without a focus ring) so the page can move
+ * focus here once loading finishes.
+ *
+ * `$compact` trims the bottom margin for the series page, which already has the
+ * series nav bar directly above the title.
+ */
+export const VideoTitle = styled.h1<{ $compact?: boolean }>(
+  ({ theme, $compact }) => ({
+    ...theme.typography.h2,
+    fontWeight: theme.typography.fontWeightBold,
+    color: theme.custom.colors.black,
+    margin: $compact ? "0 0 16px" : "0 0 24px",
+    "&:focus": { outline: "none" },
+    fontSize: "44px",
+    fontStyle: "normal",
+    lineHeight: "120%",
+    letterSpacing: "-0.88px",
+    [theme.breakpoints.down("sm")]: {
+      ...theme.typography.h3,
+      margin: $compact ? "0 0 8px" : "0 0 14px",
+      letterSpacing: "inherit",
+    },
+  }),
+)

--- a/frontends/main/src/components/ShareDialog/ShareDialog.test.tsx
+++ b/frontends/main/src/components/ShareDialog/ShareDialog.test.tsx
@@ -3,7 +3,7 @@ import { renderWithProviders, screen, user } from "@/test-utils"
 import { factories } from "api/test-utils"
 import { ResourceTypeEnum } from "api/v1"
 import type { VideoResource } from "api/v1"
-import VideoShareDialog from "./VideoShareDialog"
+import ShareDialog from "./ShareDialog"
 
 const PAGE_URL = "https://learn.mit.edu/video/42?playlist=1"
 
@@ -40,7 +40,7 @@ const makeOvsVideo = (overrides: Partial<VideoResource> = {}): VideoResource =>
 
 const renderDialog = (video: VideoResource = makeVideo()) =>
   renderWithProviders(
-    <VideoShareDialog
+    <ShareDialog
       open
       onClose={jest.fn()}
       video={video}
@@ -54,7 +54,7 @@ const renderDialogWithTime = (
   video: VideoResource = makeYouTubeVideo(),
 ) =>
   renderWithProviders(
-    <VideoShareDialog
+    <ShareDialog
       open
       onClose={jest.fn()}
       video={video}
@@ -64,7 +64,7 @@ const renderDialogWithTime = (
     />,
   )
 
-describe("VideoShareDialog", () => {
+describe("ShareDialog", () => {
   describe("tab switching", () => {
     test("defaults to the Share tab", async () => {
       renderDialog()
@@ -93,7 +93,7 @@ describe("VideoShareDialog", () => {
     test("calls onClose when the close button is clicked", async () => {
       const onClose = jest.fn()
       renderWithProviders(
-        <VideoShareDialog
+        <ShareDialog
           open
           onClose={onClose}
           video={makeVideo()}

--- a/frontends/main/src/page-components/ResourceCard/ResourceCard.test.tsx
+++ b/frontends/main/src/page-components/ResourceCard/ResourceCard.test.tsx
@@ -20,15 +20,6 @@ import { RESOURCE_DRAWER_PARAMS } from "@/common/urls"
 import invariant from "tiny-invariant"
 import { LearningResourceCard } from "ol-components"
 
-// Mock ShareDialog to avoid MUI Popper portal rendering issues in jsdom.
-// The mock renders a detectable element so we can assert on it.
-jest.mock("@/app-pages/VideoPlaylistCollectionPage/ShareDialog", () => ({
-  __esModule: true,
-  default: jest.fn(({ open }: { open: boolean }) => (
-    <div data-testid="share-dialog" data-open={String(open)} />
-  )),
-}))
-
 jest.mock("ol-components", () => {
   const actual = jest.requireActual("ol-components")
   return {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12420

### Description (What does it do?)
- As a developer, I want the video folder's dead code removed, shared styles defined once, and the 608-line VideoDetailPage decomposed, so the folder is readable, imports are unambiguous, and cards/badges/overlays stay visually consistent.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
For testing we need to test around the whole videos pages because this PR is around cleaning and de-duplicating the videos code logic, so I will request to test every corner of these videos pages.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
