### PR TITLE
Add trackFilterCourseCatalog GTM event

### DIFF
--- a/frontends/main/src/common/analytics/gtm.test.ts
+++ b/frontends/main/src/common/analytics/gtm.test.ts
@@ -260,7 +260,10 @@ describe("trackCatalogFilter", () => {
 
 describe("trackFilterCourseCatalog", () => {
   it("pushes a filter-course-catalog event with filter name and value", () => {
-    trackFilterCourseCatalog({ filterName: "topic", filterValue: "data science" })
+    trackFilterCourseCatalog({
+      filterName: "topic",
+      filterValue: "data science",
+    })
     expect(window.dataLayer).toContainEqual({
       event: "filter-course-catalog",
       "filter-name": "topic",

--- a/frontends/main/src/common/analytics/gtm.test.ts
+++ b/frontends/main/src/common/analytics/gtm.test.ts
@@ -12,6 +12,7 @@ import {
   trackVideo50Percent,
   trackSiteSearch,
   trackCatalogFilter,
+  trackFilterCourseCatalog,
   trackReturnVisit,
   trackBeginCheckout,
   trackOrganicSocialClick,
@@ -251,6 +252,17 @@ describe("trackCatalogFilter", () => {
     trackCatalogFilter({ filterName: "topic", filterValue: "data science" })
     expect(window.dataLayer).toContainEqual({
       event: "catalog-filter",
+      "filter-name": "topic",
+      "filter-value": "data science",
+    })
+  })
+})
+
+describe("trackFilterCourseCatalog", () => {
+  it("pushes a filter-course-catalog event with filter name and value", () => {
+    trackFilterCourseCatalog({ filterName: "topic", filterValue: "data science" })
+    expect(window.dataLayer).toContainEqual({
+      event: "filter-course-catalog",
       "filter-name": "topic",
       "filter-value": "data science",
     })

--- a/frontends/main/src/common/analytics/gtm.ts
+++ b/frontends/main/src/common/analytics/gtm.ts
@@ -201,6 +201,17 @@ const trackCatalogFilter = (params: CatalogFilterParams) => {
 }
 
 /**
+ * Fired when a user applies a filter to the course catalog.
+ * Maps to "filter_course_catalog" GTM trigger.
+ */
+const trackFilterCourseCatalog = (params: CatalogFilterParams) => {
+  pushGtmEvent("filter-course-catalog", {
+    "filter-name": params.filterName,
+    "filter-value": params.filterValue,
+  })
+}
+
+/**
  * Fired once per session when a returning visitor (has visited before) loads the site.
  * Uses localStorage to detect return visitors across sessions.
  * Maps to "Return Visit" in the marketing event plan.
@@ -259,6 +270,7 @@ export {
   trackVideo50Percent,
   trackSiteSearch,
   trackCatalogFilter,
+  trackFilterCourseCatalog,
   trackReturnVisit,
   trackBeginCheckout,
   trackOrganicSocialClick,

--- a/frontends/main/src/common/analytics/gtm.ts
+++ b/frontends/main/src/common/analytics/gtm.ts
@@ -202,7 +202,7 @@ const trackCatalogFilter = (params: CatalogFilterParams) => {
 
 /**
  * Fired when a user applies a filter to the course catalog.
- * Maps to "filter_course_catalog" GTM trigger.
+ * Maps to the "filter-course-catalog" GTM trigger.
  */
 const trackFilterCourseCatalog = (params: CatalogFilterParams) => {
   pushGtmEvent("filter-course-catalog", {

--- a/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
+++ b/frontends/main/src/page-components/SearchDisplay/SearchDisplay.tsx
@@ -55,7 +55,7 @@ import type {
 import { useSearchParams } from "@mitodl/course-search-utils/next"
 import { ResourceTypeGroupTabs } from "./ResourceTypeGroupTabs"
 import ProfessionalToggle from "./ProfessionalToggle"
-import { trackCatalogFilter } from "@/common/analytics/gtm"
+import { trackFilterCourseCatalog } from "@/common/analytics/gtm"
 import SliderInput from "./SliderInput"
 
 import type { TabConfig } from "./ResourceTypeGroupTabs"
@@ -704,7 +704,8 @@ const SearchDisplay: React.FC<SearchDisplayProps> = ({
   ) => {
     actuallyToggleParamValue(name, rawValue, checked)
     captureSearchEvent()
-    if (checked) trackCatalogFilter({ filterName: name, filterValue: rawValue })
+    if (checked)
+      trackFilterCourseCatalog({ filterName: name, filterValue: rawValue })
   }
 
   const sortDropdown = (


### PR DESCRIPTION
### What are the relevant tickets?
NA

### Description (What does it do?)
Adds a new `trackFilterCourseCatalog` function that fires a `filter-course-catalog` GTM event when a user applies a filter in the course catalog. Replaces the previous `trackCatalogFilter` call in SearchDisplay with this new dedicated event.

### How can this be tested?
unpause the filter-course-catalog GTM tag here: https://tagmanager.google.com/?authuser=1#/container/accounts/6351372910/containers/250259136/workspaces/14/tags.  Then preview and test the changes and verify that the tag triggers when filtering the course catalog.
