### PR TITLE
serializer performance - cache/re-use child serializer

### DIFF
--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1582,11 +1582,29 @@ class LearningResourceSerializer(serializers.Serializer):
         )
     }
 
+    def _child_serializer(self, resource_type):
+        """
+        Return a reusable serializer instance for a resource_type.
+
+        Constructing a DRF serializer deep-copies its whole field tree, so
+        building one per object makes bulk serialization (search hydration,
+        indexing) dominated by setup rather than output. Under many=True the
+        ListSerializer reuses a single child, so this cache spans the list --
+        which is how a normal many=True serializer already behaves.
+        """
+        if not hasattr(self, "_child_serializer_cache"):
+            self._child_serializer_cache = {}
+        if resource_type not in self._child_serializer_cache:
+            self._child_serializer_cache[resource_type] = self.serializer_cls_mapping[
+                resource_type
+            ](context=self.context)
+        return self._child_serializer_cache[resource_type]
+
     def to_representation(self, instance):
         """Serialize a LearningResource based on resource_type"""
-        serializer_cls = self.serializer_cls_mapping[instance.resource_type]
-
-        return serializer_cls(instance=instance, context=self.context).data
+        return self._child_serializer(instance.resource_type).to_representation(
+            instance
+        )
 
 
 class LearningResourceRelationshipSerializer(serializers.ModelSerializer):

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1587,8 +1587,8 @@ class LearningResourceSerializer(serializers.Serializer):
         Return a reusable serializer instance for a resource_type.
 
         Constructing a DRF serializer deep-copies its whole field tree, so
-        building one per object makes bulk serialization (search hydration,
-        indexing) dominated by setup rather than output. Under many=True the
+        building one per object makes bulk serialization (search hydration)
+        dominated by setup rather than output. Under many=True the
         ListSerializer reuses a single child, so this cache spans the list --
         which is how a normal many=True serializer already behaves.
         """

--- a/learning_resources/serializers_test.py
+++ b/learning_resources/serializers_test.py
@@ -418,6 +418,76 @@ def test_learning_resource_serializer(  # noqa: PLR0913
     }
 
 
+@pytest.mark.parametrize("has_context", [True, False])
+def test_learning_resource_serializer_caches_child_serializers(rf, user, has_context):
+    """LearningResourceSerializer memoizes one child serializer per resource_type"""
+    request = rf.get("/")
+    request.user = user
+    context = {"request": request} if has_context else {}
+
+    serializer = serializers.LearningResourceSerializer(context=context)
+
+    children = {}
+    for resource_type, expected_cls in serializer.serializer_cls_mapping.items():
+        child = serializer._child_serializer(resource_type)  # noqa: SLF001
+        assert isinstance(child, expected_cls)
+        assert child.context == context
+        # repeated lookups return the very same instance, not an equal one
+        assert serializer._child_serializer(resource_type) is child  # noqa: SLF001
+        children[resource_type] = child
+
+    # each resource_type gets its own child
+    assert len({id(child) for child in children.values()}) == len(children)
+
+    # the cache is per-parent-instance, so context never leaks across serializers
+    other = serializers.LearningResourceSerializer(context={})
+    for resource_type, child in children.items():
+        assert other._child_serializer(resource_type) is not child  # noqa: SLF001
+
+
+def test_learning_resource_serializer_many_matches_individual(rf, user):
+    """
+    Serializing a mixed list with many=True (which reuses a single child
+    serializer, and therefore a single child serializer cache) produces the same
+    output as serializing each resource on its own.
+    """
+    request = rf.get("/")
+    request.user = user
+    context = {"request": request}
+
+    resources = [
+        LearningResourceFactory.create(**params)
+        for params in (
+            {"is_course": True},
+            {"is_program": True},
+            {"is_learning_path": True},
+            {"is_podcast": True},
+            {"is_podcast_episode": True},
+            {"is_video": True},
+            {"is_video_playlist": True},
+            # a second course, to exercise a cache hit within one list pass
+            {"is_course": True},
+        )
+    ]
+    queryset = LearningResource.objects.for_serialization().filter(
+        pk__in=[resource.pk for resource in resources]
+    )
+    # every mapped resource_type except document is covered here
+    assert {resource.resource_type for resource in queryset} == set(
+        serializers.LearningResourceSerializer.serializer_cls_mapping
+    ) - {LearningResourceType.document.name}
+
+    results = serializers.LearningResourceSerializer(
+        queryset, many=True, context=context
+    ).data
+    expected = [
+        serializers.LearningResourceSerializer(instance=resource, context=context).data
+        for resource in queryset
+    ]
+
+    assert_json_equal(results, expected)
+
+
 def test_serialize_run_related_models():
     """
     Verify that a serialized run contains attributes for related objects


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12610
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR caches the concrete child serializers that LearningResourceSerializer returns which on a
100-resource page, Serializer.get_fields accounts for ~80% of serialization time
(0.442s of 0.549s cumulative, 1352 calls).

more details in the [ticket](https://github.com/mitodl/hq/issues/12610)

### How can this be tested?
1. download [this](https://github.com/user-attachments/files/30668223/bench_serializer.py) serializer benchmark script
2. checkout main and run it via `docker compose run --rm -T web python manage.py shell < bench_serializer.py`
3. note the stats - in particular the p50 ms/resource
4. checkout this branch and run the same. note the difference


### Additional Context
There are no functional changes so all tests should pass etc - this is purely a performance related tweak

