### PR TITLE
Fix PostHog view-event ETL crash from duplicate view events

### DIFF
--- a/learning_resources/etl/posthog.py
+++ b/learning_resources/etl/posthog.py
@@ -136,13 +136,9 @@ def load_posthog_lrd_view_event(
         log.warning(skip_warning)
         return None
 
-    lr_event, _ = LearningResourceViewEvent.objects.update_or_create(
+    lr_event, _ = LearningResourceViewEvent.objects.get_or_create(
         learning_resource=learning_resource,
         event_date=event.event_date,
-        defaults={
-            "learning_resource": learning_resource,
-            "event_date": event.event_date,
-        },
     )
 
     return lr_event

--- a/learning_resources/etl/posthog.py
+++ b/learning_resources/etl/posthog.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 import boto3
 import pandas as pd
 from django.conf import settings
+from django.db import IntegrityError, transaction
 
 from learning_resources.models import LearningResource, LearningResourceViewEvent
 from learning_resources.utils import resource_upserted_actions
@@ -149,13 +150,42 @@ def load_posthog_lrd_view_event(
         log.warning(skip_warning)
         return None
 
-    # Adopt a matching legacy row (loaded before event_uuid existed) so
-    # re-read S3 files don't duplicate it; no-op once the tail is stamped
-    LearningResourceViewEvent.objects.filter(
-        learning_resource=learning_resource,
-        event_date=event.event_date,
-        event_uuid__isnull=True,
-    ).update(event_uuid=event.event_uuid)
+    # The newest S3 file is re-read on every run (its last_modified is always
+    # later than the events it holds), so most events arrive already stored.
+    # Return early: stamping this uuid onto another legacy duplicate below
+    # would violate the unique index.
+    existing = LearningResourceViewEvent.objects.filter(
+        event_uuid=event.event_uuid
+    ).first()
+    if existing:
+        return existing
+
+    # Adopt a matching legacy row (loaded before event_uuid existed) so re-read
+    # S3 files don't duplicate it. Stamp only the oldest one; the legacy tail
+    # can hold duplicate (resource, event_date) rows.
+    legacy_row = (
+        LearningResourceViewEvent.objects.filter(
+            learning_resource=learning_resource,
+            event_date=event.event_date,
+            event_uuid__isnull=True,
+        )
+        .order_by("id")
+        .first()
+    )
+    if legacy_row:
+        try:
+            # Savepoint: the check above is not a lock, so a concurrent run can
+            # adopt a different duplicate for this uuid first. get_or_create
+            # below then finds that row.
+            with transaction.atomic():
+                LearningResourceViewEvent.objects.filter(pk=legacy_row.pk).update(
+                    event_uuid=event.event_uuid
+                )
+        except IntegrityError:
+            log.info(
+                "Legacy view event row for resource %s was adopted concurrently",
+                event.resource_id,
+            )
 
     lr_event, _ = LearningResourceViewEvent.objects.get_or_create(
         event_uuid=event.event_uuid,

--- a/learning_resources/etl/posthog.py
+++ b/learning_resources/etl/posthog.py
@@ -28,6 +28,7 @@ class PostHogLearningResourceViewEvent:
 
     resource_id: int
     event_date: datetime
+    event_uuid: str
 
 
 def posthog_extract_lrd_view_events() -> Generator[dict, None, None]:
@@ -94,11 +95,23 @@ def posthog_transform_lrd_view_events(
         # The PostHog data files contain other kinds of events, for example llm calls.
         # We only want to the resource views
 
-        if resource_id:
-            yield PostHogLearningResourceViewEvent(
-                resource_id=resource_id,
-                event_date=event.get("timestamp"),
+        if not resource_id:
+            continue
+
+        event_uuid = event.get("uuid")
+        if not event_uuid:
+            # PostHog assigns every event a uuid, so this indicates
+            # malformed source data
+            log.warning(
+                "Skipping lrd_view event without a uuid for resource %s", resource_id
             )
+            continue
+
+        yield PostHogLearningResourceViewEvent(
+            resource_id=resource_id,
+            event_date=event.get("timestamp"),
+            event_uuid=event_uuid,
+        )
 
 
 def load_posthog_lrd_view_event(
@@ -136,9 +149,20 @@ def load_posthog_lrd_view_event(
         log.warning(skip_warning)
         return None
 
-    lr_event, _ = LearningResourceViewEvent.objects.get_or_create(
+    # Adopt a matching legacy row (loaded before event_uuid existed) so
+    # re-read S3 files don't duplicate it; no-op once the tail is stamped
+    LearningResourceViewEvent.objects.filter(
         learning_resource=learning_resource,
         event_date=event.event_date,
+        event_uuid__isnull=True,
+    ).update(event_uuid=event.event_uuid)
+
+    lr_event, _ = LearningResourceViewEvent.objects.get_or_create(
+        event_uuid=event.event_uuid,
+        defaults={
+            "learning_resource": learning_resource,
+            "event_date": event.event_date,
+        },
     )
 
     return lr_event

--- a/learning_resources/etl/posthog_test.py
+++ b/learning_resources/etl/posthog_test.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from django.db import IntegrityError
 from freezegun import freeze_time
 
 from learning_resources.etl import posthog
@@ -137,3 +138,81 @@ def test_load_posthog_lrd_view_events(
     else:
         assert LearningResourceViewEvent.objects.count() == 0
         assert len([event for event in loaded_events if event is not None]) == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("runs", [1, 2])
+def test_load_posthog_lrd_view_events_duplicate_legacy_rows(
+    mocker, mock_posthog_event_bucket, settings, runs
+):
+    """Duplicate legacy rows are tolerated, and re-running the ETL stays idempotent"""
+    LearningResourceViewEvent.objects.all().delete()
+    bucket = mock_posthog_event_bucket.bucket
+    settings.POSTHOG_EVENT_S3_BUCKET = bucket.name
+    settings.POSTHOG_EVENT_S3_PREFIX = "events/"
+    with Path.open(Path("test_json/posthog/test_data.parquet.zst"), "rb") as infile:
+        bucket.put_object(
+            Key="events/file1.parquet.zst",
+            Body=infile.read(),
+            ACL="public-read",
+        )
+
+    resource = LearningResourceFactory.create(id=3235)
+    mocker.patch(
+        "learning_resources.etl.posthog.resource_upserted_actions",
+        autospec=True,
+    )
+
+    event_date = datetime(2025, 8, 28, 15, 20, 13, 620000, tzinfo=UTC)
+    legacy_rows = LearningResourceViewEventFactory.create_batch(
+        2, learning_resource=resource, event_date=event_date
+    )
+
+    for _ in range(runs):
+        posthog.load_posthog_lrd_view_events(
+            posthog.posthog_transform_lrd_view_events(
+                posthog.posthog_extract_lrd_view_events()
+            )
+        )
+
+    stamped = [
+        row
+        for row in LearningResourceViewEvent.objects.filter(
+            pk__in=[r.pk for r in legacy_rows]
+        )
+        if row.event_uuid is not None
+    ]
+    assert len(stamped) == 1
+    # The unstamped duplicate survives rather than being deleted
+    assert (
+        LearningResourceViewEvent.objects.filter(
+            learning_resource=resource, event_date=event_date, event_uuid__isnull=True
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_load_posthog_lrd_view_event_adoption_lost_to_concurrent_run(mocker):
+    """Losing the adoption race to a concurrent run doesn't crash the loader"""
+    resource = LearningResourceFactory.create()
+    event_date = now_in_utc()
+    LearningResourceViewEventFactory.create(
+        learning_resource=resource, event_date=event_date
+    )
+    event_uuid = "0198f143-cf8c-79b6-bab8-9c9063659a54"
+    # Simulates another worker stamping a different duplicate with this uuid
+    # between our existence check and the adoption update
+    mocker.patch(
+        "django.db.models.QuerySet.update",
+        side_effect=IntegrityError("duplicate key value violates unique constraint"),
+    )
+
+    lr_event = posthog.load_posthog_lrd_view_event(
+        posthog.PostHogLearningResourceViewEvent(
+            resource_id=resource.id, event_date=event_date, event_uuid=event_uuid
+        )
+    )
+
+    assert lr_event is not None
+    assert LearningResourceViewEvent.objects.filter(event_uuid=event_uuid).count() == 1

--- a/learning_resources/migrations/0119_unique_resource_view_event.py
+++ b/learning_resources/migrations/0119_unique_resource_view_event.py
@@ -27,6 +27,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # Block concurrent writes (e.g. the PostHog ETL task) for the duration
+        # of the transaction so no new duplicates appear between the dedupe
+        # and the constraint creation
+        migrations.RunSQL(
+            "LOCK TABLE learning_resources_learningresourceviewevent IN EXCLUSIVE MODE",
+            reverse_sql=migrations.RunSQL.noop,
+        ),
         migrations.RunPython(dedupe_view_events, migrations.RunPython.noop),
         migrations.AddConstraint(
             model_name="learningresourceviewevent",

--- a/learning_resources/migrations/0119_unique_resource_view_event.py
+++ b/learning_resources/migrations/0119_unique_resource_view_event.py
@@ -1,0 +1,38 @@
+"""Dedupe LearningResourceViewEvent rows, then enforce uniqueness"""
+
+from django.db import migrations, models
+from django.db.models import Count, Min
+
+
+def dedupe_view_events(apps, schema_editor):
+    """Delete duplicate view events, keeping the oldest row per pair"""
+    LearningResourceViewEvent = apps.get_model(
+        "learning_resources", "LearningResourceViewEvent"
+    )
+    dupes = (
+        LearningResourceViewEvent.objects.values("learning_resource", "event_date")
+        .annotate(num_events=Count("id"), keep_id=Min("id"))
+        .filter(num_events__gt=1)
+    )
+    for dupe in dupes:
+        LearningResourceViewEvent.objects.filter(
+            learning_resource=dupe["learning_resource"],
+            event_date=dupe["event_date"],
+        ).exclude(id=dupe["keep_id"]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("learning_resources", "0118_delete_micromasters_resources"),
+    ]
+
+    operations = [
+        migrations.RunPython(dedupe_view_events, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="learningresourceviewevent",
+            constraint=models.UniqueConstraint(
+                fields=("learning_resource", "event_date"),
+                name="unique_resource_view_event",
+            ),
+        ),
+    ]

--- a/learning_resources/migrations/0119_unique_resource_view_event.py
+++ b/learning_resources/migrations/0119_unique_resource_view_event.py
@@ -1,4 +1,4 @@
-"""Dedupe LearningResourceViewEvent rows, then enforce uniqueness"""
+"""Dedupe LearningResourceViewEvent rows and add a unique PostHog event UUID"""
 
 from django.db import migrations, models
 from django.db.models import Count, Min
@@ -28,18 +28,23 @@ class Migration(migrations.Migration):
 
     operations = [
         # Block concurrent writes (e.g. the PostHog ETL task) for the duration
-        # of the transaction so no new duplicates appear between the dedupe
-        # and the constraint creation
+        # of the transaction so no new duplicates appear during the dedupe
         migrations.RunSQL(
             "LOCK TABLE learning_resources_learningresourceviewevent IN EXCLUSIVE MODE",
             reverse_sql=migrations.RunSQL.noop,
         ),
         migrations.RunPython(dedupe_view_events, migrations.RunPython.noop),
-        migrations.AddConstraint(
+        migrations.AddField(
             model_name="learningresourceviewevent",
-            constraint=models.UniqueConstraint(
-                fields=("learning_resource", "event_date"),
-                name="unique_resource_view_event",
+            name="event_uuid",
+            field=models.UUIDField(
+                editable=False,
+                help_text=(
+                    "The PostHog event UUID. Null only for rows loaded"
+                    " before this field existed."
+                ),
+                null=True,
+                unique=True,
             ),
         ),
     ]

--- a/learning_resources/migrations/0119_unique_resource_view_event.py
+++ b/learning_resources/migrations/0119_unique_resource_view_event.py
@@ -1,24 +1,6 @@
-"""Dedupe LearningResourceViewEvent rows and add a unique PostHog event UUID"""
+"""Add the PostHog event UUID column to LearningResourceViewEvent"""
 
 from django.db import migrations, models
-from django.db.models import Count, Min
-
-
-def dedupe_view_events(apps, schema_editor):
-    """Delete duplicate view events, keeping the oldest row per pair"""
-    LearningResourceViewEvent = apps.get_model(
-        "learning_resources", "LearningResourceViewEvent"
-    )
-    dupes = (
-        LearningResourceViewEvent.objects.values("learning_resource", "event_date")
-        .annotate(num_events=Count("id"), keep_id=Min("id"))
-        .filter(num_events__gt=1)
-    )
-    for dupe in dupes:
-        LearningResourceViewEvent.objects.filter(
-            learning_resource=dupe["learning_resource"],
-            event_date=dupe["event_date"],
-        ).exclude(id=dupe["keep_id"]).delete()
 
 
 class Migration(migrations.Migration):
@@ -27,13 +9,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Block concurrent writes (e.g. the PostHog ETL task) for the duration
-        # of the transaction so no new duplicates appear during the dedupe
-        migrations.RunSQL(
-            "LOCK TABLE learning_resources_learningresourceviewevent IN EXCLUSIVE MODE",
-            reverse_sql=migrations.RunSQL.noop,
-        ),
-        migrations.RunPython(dedupe_view_events, migrations.RunPython.noop),
+        # Nullable column with no default: metadata-only, no table rewrite.
+        # The unique index is built CONCURRENTLY in the next migration.
+        # Pre-existing duplicate rows are left alone - they all have a NULL
+        # event_uuid, which never conflicts in a unique index.
         migrations.AddField(
             model_name="learningresourceviewevent",
             name="event_uuid",
@@ -44,7 +23,6 @@ class Migration(migrations.Migration):
                     " before this field existed."
                 ),
                 null=True,
-                unique=True,
             ),
         ),
     ]

--- a/learning_resources/migrations/0120_view_event_uuid_unique_index.py
+++ b/learning_resources/migrations/0120_view_event_uuid_unique_index.py
@@ -1,0 +1,46 @@
+"""Build the unique index on event_uuid concurrently to avoid blocking reads"""
+
+from django.db import migrations, models
+from django.db.models import Q
+
+INDEX_NAME = "learning_resources_lrviewevent_event_uuid_uniq"
+TABLE_NAME = "learning_resources_learningresourceviewevent"
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction
+    atomic = False
+
+    dependencies = [
+        ("learning_resources", "0119_unique_resource_view_event"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="learningresourceviewevent",
+                    constraint=models.UniqueConstraint(
+                        condition=Q(event_uuid__isnull=False),
+                        fields=("event_uuid",),
+                        name=INDEX_NAME,
+                    ),
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    [
+                        # A failed CONCURRENTLY build leaves an INVALID index
+                        # that IF NOT EXISTS would silently accept; drop any
+                        # leftover so a rerun rebuilds and enforces uniqueness
+                        f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}",
+                        # Partial: the legacy NULL rows need no index entries
+                        f"CREATE UNIQUE INDEX CONCURRENTLY {INDEX_NAME}"
+                        f" ON {TABLE_NAME} (event_uuid)"
+                        f" WHERE event_uuid IS NOT NULL",
+                    ],
+                    reverse_sql=f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}",
+                ),
+            ],
+        ),
+    ]

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -1566,14 +1566,15 @@ class LearningResourceViewEvent(TimestampedModel):
         editable=False,
         help_text="The date of the lrd_view event, as collected by PostHog.",
     )
-
-    class Meta:
-        constraints = [
-            models.UniqueConstraint(
-                fields=["learning_resource", "event_date"],
-                name="unique_resource_view_event",
-            )
-        ]
+    event_uuid = models.UUIDField(
+        unique=True,
+        null=True,
+        editable=False,
+        help_text=(
+            "The PostHog event UUID. Null only for rows loaded"
+            " before this field existed."
+        ),
+    )
 
     def __str__(self):
         """Return a string representation of the event."""

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -1567,6 +1567,14 @@ class LearningResourceViewEvent(TimestampedModel):
         help_text="The date of the lrd_view event, as collected by PostHog.",
     )
 
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["learning_resource", "event_date"],
+                name="unique_resource_view_event",
+            )
+        ]
+
     def __str__(self):
         """Return a string representation of the event."""
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -1567,7 +1567,6 @@ class LearningResourceViewEvent(TimestampedModel):
         help_text="The date of the lrd_view event, as collected by PostHog.",
     )
     event_uuid = models.UUIDField(
-        unique=True,
         null=True,
         editable=False,
         help_text=(
@@ -1575,6 +1574,17 @@ class LearningResourceViewEvent(TimestampedModel):
             " before this field existed."
         ),
     )
+
+    class Meta:
+        constraints = [
+            # Conditional so the index skips the legacy NULL rows, which would
+            # otherwise cost ~105MB of index for entries nothing ever probes.
+            models.UniqueConstraint(
+                fields=["event_uuid"],
+                condition=Q(event_uuid__isnull=False),
+                name="learning_resources_lrviewevent_event_uuid_uniq",
+            )
+        ]
 
     def __str__(self):
         """Return a string representation of the event."""


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/12673

### Description (What does it do?)
The scheduled `get_learning_resource_views` task crashes on production every run with `LearningResourceViewEvent.MultipleObjectsReturned`, so view counts are no longer updated.

Root cause: `LearningResourceViewEvent` had no uniqueness guarantee, and the loader used `update_or_create` keyed on `(learning_resource, event_date)` — a SELECT-then-INSERT race. The task is `acks_late=True, reject_on_worker_lost=True` with no concurrency guard, so a broker redelivery can run two copies concurrently — both inserted the same event, creating duplicate rows. Since the extract re-reads S3 files containing already-loaded events on every run, every subsequent run hits the duplicate pair and dies.

Changes:

- Add `event_uuid` (nullable) to `LearningResourceViewEvent`, populated from the `uuid` PostHog assigns to every event in its export. This is the event's actual identity — unlike the `(learning_resource, event_date)` pair, it can't merge two real views that land on the same microsecond.
- Loader keys `get_or_create` on `event_uuid`, which is race-safe under the unique index: a concurrent duplicate insert raises `IntegrityError` internally and Django re-fetches the existing row, so overlapping task runs converge idempotently.
- Legacy rows keep a null `event_uuid` (Postgres unique indexes treat NULLs as distinct). Because the extract re-reads the newest S3 file on every run — its `last_modified` is always later than the events it contains — the loader adopts a matching null-uuid legacy row, stamping its uuid instead of inserting a duplicate, so the transition self-backfills the overlapping tail. No bulk backfill needed.
- The loader returns early when a row with the incoming uuid already exists. This keeps repeat runs idempotent even when the legacy tail holds duplicate `(resource, event_date)` rows: without it, run 2 finds the sibling duplicate still null, stamps it with a uuid another row already holds, and raises `UniqueViolation` every run thereafter.
- That existence check is not a lock, so the adoption update runs in a savepoint and tolerates an `IntegrityError`. Two overlapping runs can pick different duplicates for the same uuid; `get_or_create` then returns whichever row won the race, instead of the task crashing.

Migration strategy (the table is ~4.9M rows on production):

- `0119` adds the column only — nullable, no default, no constraint. That is metadata-only on Postgres, so there is no table rewrite and no read-blocking lock.
- `0120` builds the unique index with `CREATE UNIQUE INDEX CONCURRENTLY` in a non-atomic migration, so reads and writes are never blocked. It drops any leftover invalid index first: a failed concurrent build leaves an `INVALID` index behind, and `IF NOT EXISTS` matches on name alone, which would silently skip the rebuild and record the migration as applied with uniqueness unenforced.
- The index is partial (`WHERE event_uuid IS NOT NULL`). Postgres btrees store entries for NULL keys, so indexing the legacy tail would cost roughly 105 MB on a 4.9M-row table for entries nothing ever probes. It is expressed as a conditional `UniqueConstraint` on the model so migration state and the database agree.
- **No dedupe migration.** Pre-existing duplicate rows are deliberately left in place. Every legacy row has a null `event_uuid`, so duplicates cannot block the index build, and the ETL no longer needs `(resource, event_date)` to be unique. Deleting them would have been irreversible (`reverse_sql` noop) with an unmeasured production blast radius, and the predicate could not distinguish an ETL double-load from two genuine views sharing a timestamp. The cost of keeping them is that view counts stay slightly inflated for those resources — pre-existing data, now bounded, since uuid-keyed `get_or_create` prevents new duplicates. Cleanup can be done out-of-band with a measured, batched job.
- **Deploy ordering.** The uuid-keyed `get_or_create` race protection assumes the unique index exists, and the Heroku release phase (`scripts/heroku-release-phase.sh`) guarantees it: `migrate` runs `0119` → `0120` before new dynos start, and a failed release aborts the deploy, leaving the old ETL live — which only writes null-uuid rows, so it can't seed duplicates that would block a retried index build.

### How can this be tested?

Automated: `pytest learning_resources/etl/posthog_test.py learning_resources/etl/pipelines_test.py` — 29 passed.

`test_load_posthog_lrd_view_events_duplicate_legacy_rows` is parametrized over one and two ETL runs and covers the legacy-duplicate path end to end: two duplicate legacy rows, exactly one stamped with the uuid, the other left null and **not** deleted, and no crash on the re-read run. Removing the early-return guard makes the two-run case fail with `duplicate key value violates unique constraint "learning_resources_lrviewevent_event_uuid_uniq"`, so the test genuinely covers the regression.

`test_load_posthog_lrd_view_event_adoption_lost_to_concurrent_run` covers the concurrent case by making the adoption update raise: the loader still returns a row rather than propagating the error. Removing the savepoint makes it fail.

Index shape, against a freshly migrated database:

```bash
docker compose run --rm web python manage.py migrate learning_resources
docker compose exec db psql -U postgres -d postgres -tAc \
  "SELECT indexdef FROM pg_indexes WHERE indexname='learning_resources_lrviewevent_event_uuid_uniq';"
```

Expected:

```
CREATE UNIQUE INDEX learning_resources_lrviewevent_event_uuid_uniq ON public.learning_resources_learningresourceviewevent USING btree (event_uuid) WHERE (event_uuid IS NOT NULL)
```

Scale: an earlier revision of these migrations was tested against a synthetic 4.9M-row copy of the table (production is ~4.9M). The concurrent index build finished in seconds with no blocking observed; the partial index is strictly smaller than the one measured there.

### Additional Context

Events missing a uuid in the export (shouldn't happen — PostHog assigns one to every event) are skipped with a warning rather than loaded unkeyed.

`view_count` on affected resources self-corrects on the next successful task run, since it recounts from the table.

