### PR TITLE
added a fallback to populate run readable ids for contentfiles withou…

### DIFF
--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -502,6 +502,27 @@ def _content_file_embedding_context(document):
     return document.get("content", "")
 
 
+def _with_run_readable_id_fallback(serialized_document):
+    """
+    Return the document with run_readable_id defaulted to the resource
+    readable_id for run-less content files (e.g. scraped marketing pages).
+
+    The content-file search API rewrites resource_readable_id filters into
+    run_readable_id filters (see ContentFilesVectorSearchView), so every point
+    payload must carry a run_readable_id to stay reachable -- course-metadata
+    points already follow this convention. Only the Qdrant payload gets the
+    fallback; point ids still derive from the raw serialized document.
+    """
+    if serialized_document.get("run_readable_id") or not serialized_document.get(
+        "resource_readable_id"
+    ):
+        return serialized_document
+    return {
+        **serialized_document,
+        "run_readable_id": serialized_document["resource_readable_id"],
+    }
+
+
 def _process_resource_embeddings(serialized_resources):
     docs = []
     metadata = []
@@ -559,7 +580,7 @@ def update_content_file_payload(serialized_document):
 
     _set_payload(
         points,
-        serialized_document,
+        _with_run_readable_id_fallback(serialized_document),
         param_map=QDRANT_CONTENT_FILE_PARAM_MAP,
         collection_name=CONTENT_FILES_COLLECTION_NAME,
     )
@@ -847,16 +868,18 @@ def _generate_content_file_points(serialized_content, stored_payloads):
                     break
                 chunk_id, split_doc = valid_chunks[relative_index]
 
-                metadata = {
-                    "resource_point_id": str(resource_vector_point_id),
-                    "chunk_number": chunk_id,
-                    "chunk_content": split_doc.page_content,
-                    **{
-                        key: split_doc.metadata[key]
-                        for key in QDRANT_CONTENT_FILE_PARAM_MAP
-                        if key in split_doc.metadata
-                    },
-                }
+                metadata = _with_run_readable_id_fallback(
+                    {
+                        "resource_point_id": str(resource_vector_point_id),
+                        "chunk_number": chunk_id,
+                        "chunk_content": split_doc.page_content,
+                        **{
+                            key: split_doc.metadata[key]
+                            for key in QDRANT_CONTENT_FILE_PARAM_MAP
+                            if key in split_doc.metadata
+                        },
+                    }
+                )
 
                 point_id = vector_point_id(
                     vector_point_key(
@@ -1184,15 +1207,25 @@ def _content_file_vector_hits(search_result):
     keys = [hit.payload.get("key") for hit in search_result]
 
     serialized_content_files = ContentFileSerializer(
-        ContentFile.objects.for_serialization().filter(
-            run__run_id__in=run_readable_ids, key__in=keys
-        ),
+        ContentFile.objects.for_serialization()
+        .filter(key__in=keys)
+        .filter(Q(run__run_id__in=run_readable_ids) | Q(run__isnull=True)),
         many=True,
     ).data
     results = []
     contentfiles_dict = {}
+    # Run-less content files (e.g. marketing pages) serialize without a
+    # run_readable_id; their Qdrant payloads carry the resource readable_id
+    # in that field instead, so key them the same way here.
     [
-        contentfiles_dict.update({(cf["run_readable_id"], cf["key"]): cf})
+        contentfiles_dict.update(
+            {
+                (
+                    cf.get("run_readable_id") or cf.get("resource_readable_id"),
+                    cf["key"],
+                ): cf
+            }
+        )
         for cf in serialized_content_files
     ]
     results = []

--- a/vector_search/utils.py
+++ b/vector_search/utils.py
@@ -1209,7 +1209,10 @@ def _content_file_vector_hits(search_result):
     serialized_content_files = ContentFileSerializer(
         ContentFile.objects.for_serialization()
         .filter(key__in=keys)
-        .filter(Q(run__run_id__in=run_readable_ids) | Q(run__isnull=True)),
+        .filter(
+            Q(run__run_id__in=run_readable_ids)
+            | Q(run__isnull=True, learning_resource__readable_id__in=run_readable_ids)
+        ),
         many=True,
     ).data
     results = []

--- a/vector_search/utils_test.py
+++ b/vector_search/utils_test.py
@@ -61,6 +61,7 @@ from vector_search.encoders.utils import dense_encoder, sparse_encoder
 from vector_search.utils import (
     _chunk_documents,
     _chunk_markdown_documents,
+    _content_file_vector_hits,
     _embed_course_metadata_as_contentfile,
     _generate_content_file_points,
     _get_text_splitter,
@@ -1268,6 +1269,132 @@ def test_update_payload_no_points(mocker):
     update_content_file_payload(serialized_files[0])
     # Verify set_payload not called
     mock_qdrant.set_payload.assert_not_called()
+
+
+def test_generate_content_points_runless_run_readable_id_fallback(mocker):
+    """
+    Run-less content files (e.g. scraped marketing pages) must get a
+    run_readable_id payload equal to the resource readable_id: the content-file
+    search API rewrites resource_readable_id filters into run_readable_id
+    filters, so points without the field are unreachable. Files with a real
+    run keep the run's id.
+    """
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_SIZE_OVERRIDE = 500
+    settings.CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP = 50
+    mocker.patch("vector_search.utils.remove_points_matching_params")
+    mock_dense = mocker.MagicMock()
+    mock_dense.embed_documents.side_effect = lambda texts: [[0.1] for _ in texts]
+    mock_dense.model_short_name.return_value = "dense"
+    mock_sparse = mocker.MagicMock()
+    mock_sparse.embed_documents.side_effect = lambda texts: [[0.2] for _ in texts]
+    mock_sparse.model_short_name.return_value = "sparse"
+    mocker.patch("vector_search.utils.dense_encoder", return_value=mock_dense)
+    mocker.patch("vector_search.utils.sparse_encoder", return_value=mock_sparse)
+
+    runless_doc = {
+        "content": "# Marketing page\n\nSome marketing content",
+        "file_type": "marketing_page",
+        "file_extension": ".md",
+        "platform": {"code": "xpro"},
+        "resource_readable_id": "program-v1:xPRO+Test",
+        "key": "https://xpro.mit.edu/programs/program-v1:xPRO+Test/",
+        "checksum": "abc",
+    }
+    run_doc = {
+        "content": "Some plain text content",
+        "file_type": "page",
+        "file_extension": ".html",
+        "platform": {"code": "x"},
+        "resource_readable_id": "r1",
+        "run_readable_id": "run1",
+        "key": "k1",
+        "checksum": "def",
+    }
+
+    points = list(_generate_content_file_points([runless_doc, run_doc], {}))
+
+    runless_payloads = [
+        point.payload for point in points if point.payload["key"] == runless_doc["key"]
+    ]
+    run_payloads = [point.payload for point in points if point.payload["key"] == "k1"]
+    assert runless_payloads
+    assert run_payloads
+    assert all(
+        payload["run_readable_id"] == "program-v1:xPRO+Test"
+        for payload in runless_payloads
+    )
+    assert all(payload["run_readable_id"] == "run1" for payload in run_payloads)
+
+
+def test_update_payload_content_file_runless_backfills_run_readable_id(mocker):
+    """
+    Payload refresh for a run-less content file writes the resource readable_id
+    into run_readable_id (healing pre-fix points without re-embedding), while
+    the point lookup keeps using the raw document so points stored without the
+    field are still found.
+    """
+    resource = LearningResourceFactory.create(is_program=True)
+    content_file = ContentFileFactory.create(
+        learning_resource=resource, content="Test content"
+    )
+    serialized = next(iter(serialize_bulk_content_files([content_file.id])))
+    assert "run_readable_id" not in serialized
+
+    mock_qdrant = mocker.MagicMock()
+    mocker.patch("vector_search.utils.qdrant_client", return_value=mock_qdrant)
+    mock_point = mocker.MagicMock()
+    mock_point.id = "test-point-id"
+    retrieve_mock = mocker.patch(
+        "vector_search.utils.retrieve_points_matching_params", return_value=[mock_point]
+    )
+
+    update_content_file_payload(serialized)
+
+    assert "run_readable_id" not in retrieve_mock.call_args[0][0]
+    payload = mock_qdrant.set_payload.call_args[1]["payload"]
+    assert payload["run_readable_id"] == resource.readable_id
+
+
+def test_content_file_vector_hits_hydrates_runless_files():
+    """
+    Search hits for run-less content files (e.g. marketing pages) are hydrated
+    with the serialized DB record, matched via the resource readable_id their
+    payloads carry in run_readable_id.
+    """
+    resource = LearningResourceFactory.create(is_program=True)
+    content_file = ContentFileFactory.create(
+        learning_resource=resource,
+        content="marketing content",
+        file_type="marketing_page",
+    )
+    run_content_file = ContentFileFactory.create(content="run file content")
+    hits = [
+        PointStruct(
+            id=1,
+            payload={
+                "run_readable_id": resource.readable_id,
+                "key": content_file.key,
+                "chunk_content": "marketing content",
+            },
+            vector=[],
+        ),
+        PointStruct(
+            id=2,
+            payload={
+                "run_readable_id": run_content_file.run.run_id,
+                "key": run_content_file.key,
+                "chunk_content": "run file content",
+            },
+            vector=[],
+        ),
+    ]
+
+    results = _content_file_vector_hits(hits)
+
+    assert results[0]["id"] == content_file.id
+    assert results[0]["resource_readable_id"] == resource.readable_id
+    assert "content" not in results[0]
+    assert results[1]["id"] == run_content_file.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12691
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue I noticed where at some point the vector endpoints stopped returning data from the marketing sites we scrape for programs and courses. 
For example: https://api.learn.mit.edu/api/v0/vector_content_files_search/?resource_readable_id=program-v1%3AMITx%2BDEDP

The program does have a ContentFile with the site content but because it had None for a run_readable_id it gets skipped in the embedding process

### How can this be tested?
1. checkout main
2. run `./manage.py scrape_marketing_pages`
3. run the following script in shell which gets a marketing page , embeds it and then checks for existence in the api:
```python
import time

from learning_resources.etl.constants import MARKETING_PAGE_FILE_TYPE
from learning_resources.models import ContentFile
from learning_resources.tasks import scrape_marketing_pages
from vector_search.constants import CONTENT_FILES_COLLECTION_NAME
from vector_search.utils import (
    _content_file_vector_hits,
    best_run_ids_for_resources,
    embed_learning_resources,
    remove_points_matching_params,
    qdrant_client,
    qdrant_query_conditions,
)

# 1. Grab any scraped marketing page (they are all run-less contentfiles)
cf = (
    ContentFile.objects.filter(
        file_type=MARKETING_PAGE_FILE_TYPE, published=True, run=None
    )
    .exclude(content="")
    .select_related("learning_resource")
    .first()
)
assert cf, "No scraped marketing pages in DB - run scrape_marketing_pages.apply() first"
rid = cf.learning_resource.readable_id
print(f"Testing contentfile {cf.id} for resource {rid!r}")

client = qdrant_client()

# 2. Clean slate: delete any existing points for this marketing page so the
#    script can be re-run (stale points from a previous run on either branch
#    would otherwise muddy the before/after)
remove_points_matching_params(
    {"key": cf.key, "resource_readable_id": rid},
    collection_name=CONTENT_FILES_COLLECTION_NAME,
)
time.sleep(2)  # deletes use wait=False

# 2. Embed it (synchronously, bypassing celery)
embed_learning_resources([cf.id], "content_file", overwrite=True)
time.sleep(3)  # upserts use wait=False

# 3. Rebuild EXACTLY the filter ContentFilesVectorSearchView uses for
#    ?resource_readable_id=<rid> (it swaps that param for a run filter)
client = qdrant_client()
params = {"run_readable_id": best_run_ids_for_resources([rid]) + [rid]}
flt = qdrant_query_conditions(params, collection_name=CONTENT_FILES_COLLECTION_NAME)
n = client.count(
    collection_name=CONTENT_FILES_COLLECTION_NAME, count_filter=flt, exact=True
).count
print(f"Points matching the API filter: {n}")

# 4. Check hit hydration for a run-less file
pts, _ = client.scroll(
    collection_name=CONTENT_FILES_COLLECTION_NAME, scroll_filter=flt,
    limit=10, with_payload=True,
)
marketing = [p for p in pts if p.payload.get("file_type") == "marketing_page"]
hit = _content_file_vector_hits(marketing)[0] if marketing else None
print("Hydrated from DB:", bool(hit and hit.get("id") == cf.id))
print("Payload run_readable_id fallback:", marketing[0].payload.get("run_readable_id") == rid if marketing else None)
```
4. note that there are 0 results
5. checkout this branch and run the same script and see we have marketing page content

