### PR TITLE
Fix: render podcast show descriptions as HTML instead of raw markup

### DIFF
--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
@@ -45,12 +45,15 @@ const makePodcastEpisodes = (count: number): PodcastEpisodeResource[] =>
 const setupApis = ({
   episodesPage1,
   episodesPage2,
+  podcastOverrides = {},
 }: {
   episodesPage1: LearningResource[]
   episodesPage2?: LearningResource[]
+  podcastOverrides?: Partial<LearningResource>
 }) => {
   const podcast = factories.learningResources.resource({
     resource_type: ResourceTypeEnum.Podcast,
+    ...podcastOverrides,
   })
 
   // Episodes of this podcast reference it as their parent, as they would in
@@ -200,6 +203,43 @@ describe("PodcastDetailPage", () => {
 
     // Flush to the loaded state to avoid act() warnings.
     await screen.findByText(episodes[0].title!)
+  })
+
+  test("renders a sanitized, formatted show description", async () => {
+    const episodes = makePodcastEpisodes(1)
+    const { podcast } = setupApis({
+      episodesPage1: episodes,
+      podcastOverrides: {
+        description:
+          '<script>alert("xss")</script><p>Daryl Morey &amp; Jessica Gelman</p>',
+      },
+    })
+
+    renderWithProviders(<PodcastDetailPage podcastId={String(podcast.id)} />)
+
+    expect(
+      await screen.findByText("Daryl Morey & Jessica Gelman"),
+    ).toBeInTheDocument()
+    expect(document.querySelector("script")).not.toBeInTheDocument()
+  })
+
+  test("opens external links in the show description in a new tab", async () => {
+    const episodes = makePodcastEpisodes(1)
+    const { podcast } = setupApis({
+      episodesPage1: episodes,
+      podcastOverrides: {
+        description:
+          'Relevant Resources: <a href="https://ocw.mit.edu/">OCW</a> and <a href="/search">Search</a>.',
+      },
+    })
+
+    renderWithProviders(<PodcastDetailPage podcastId={String(podcast.id)} />)
+
+    const externalLink = await screen.findByRole("link", { name: "OCW" })
+    expect(externalLink).toHaveAttribute("target", "_blank")
+
+    const internalLink = screen.getByRole("link", { name: "Search" })
+    expect(internalLink).not.toHaveAttribute("target")
   })
 
   test("shows an error when the podcast fails to load", async () => {

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.test.tsx
@@ -205,13 +205,12 @@ describe("PodcastDetailPage", () => {
     await screen.findByText(episodes[0].title!)
   })
 
-  test("renders a sanitized, formatted show description", async () => {
+  test("renders a formatted show description", async () => {
     const episodes = makePodcastEpisodes(1)
     const { podcast } = setupApis({
       episodesPage1: episodes,
       podcastOverrides: {
-        description:
-          '<script>alert("xss")</script><p>Daryl Morey &amp; Jessica Gelman</p>',
+        description: "<p>Daryl Morey &amp; Jessica Gelman</p>",
       },
     })
 
@@ -220,7 +219,6 @@ describe("PodcastDetailPage", () => {
     expect(
       await screen.findByText("Daryl Morey & Jessica Gelman"),
     ).toBeInTheDocument()
-    expect(document.querySelector("script")).not.toBeInTheDocument()
   })
 
   test("opens external links in the show description in a new tab", async () => {
@@ -228,8 +226,10 @@ describe("PodcastDetailPage", () => {
     const { podcast } = setupApis({
       episodesPage1: episodes,
       podcastOverrides: {
+        // rel="noopener noreferrer" mirrors real backend output: nh3 adds it
+        // to every <a> during ETL sanitization, regardless of destination.
         description:
-          'Relevant Resources: <a href="https://ocw.mit.edu/">OCW</a> and <a href="/search">Search</a>.',
+          'Relevant Resources: <a href="https://ocw.mit.edu/" rel="noopener noreferrer">OCW</a> and <a href="/search" rel="noopener noreferrer">Search</a>.',
       },
     })
 

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -1,10 +1,9 @@
 "use client"
 
-import React from "react"
+import React, { useMemo } from "react"
 import { Typography, Skeleton, styled, TypographyProps } from "ol-components"
 import { Button } from "@mitodl/smoot-design"
 import { RiPlayFill, RiPauseFill } from "@remixicon/react"
-import DOMPurify from "isomorphic-dompurify"
 import {
   useLearningResourcesDetail,
   useInfiniteLearningResourceItems,
@@ -286,6 +285,21 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
 
   const handlePlayClick = (episode: LearningResource) => toggle(episode, id)
 
+  // Podcast descriptions are sanitized on the backend with nh3 during ETL
+  // (only <a href/title> is allowed), so the HTML is safe to render verbatim
+  // — the same trust model as podcast episode descriptions. Rendering it
+  // directly keeps server and client output identical, avoiding a hydration
+  // mismatch; target="_blank" is added via addExternalLinkTargets so it's
+  // part of the HTML fed to dangerouslySetInnerHTML on both server and
+  // client, keeping SSR output byte-identical to the client's first render.
+  const description = useMemo(
+    () =>
+      resource?.description
+        ? addExternalLinkTargets(resource.description)
+        : null,
+    [resource?.description],
+  )
+
   return (
     <>
       <PageSection variant="white">
@@ -327,14 +341,12 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
                       </MetaLine>
                     )}
 
-                    {resource?.description && (
+                    {description && (
                       <Description
                         variant="body2"
                         component="div"
                         dangerouslySetInnerHTML={{
-                          __html: addExternalLinkTargets(
-                            DOMPurify.sanitize(resource.description),
-                          ),
+                          __html: description,
                         }}
                       />
                     )}

--- a/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastDetailPage.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import React from "react"
-import { Typography, Skeleton, styled } from "ol-components"
+import { Typography, Skeleton, styled, TypographyProps } from "ol-components"
 import { Button } from "@mitodl/smoot-design"
 import { RiPlayFill, RiPauseFill } from "@remixicon/react"
+import DOMPurify from "isomorphic-dompurify"
 import {
   useLearningResourcesDetail,
   useInfiniteLearningResourceItems,
@@ -12,6 +13,7 @@ import { ResourceTypeEnum } from "api/v1"
 import type { LearningResource } from "api/v1"
 import { formatDate } from "ol-utilities"
 import { HOME, podcastEpisodePageView } from "@/common/urls"
+import { addExternalLinkTargets } from "@/common/utils"
 import PodcastContainer from "./PodcastContainer"
 import PodcastBreadcrumbs from "./PodcastBreadcrumbs"
 import { usePodcastPage } from "./usePodcastPage"
@@ -66,18 +68,28 @@ const MetaLine = styled(Typography)(({ theme }) => ({
   },
 }))
 
-const Description = styled(Typography)(({ theme }) => ({
-  color: theme.custom.colors.darkGray2,
-  display: "block",
-  marginBottom: "16px",
-  ...theme.typography.body1,
-  lineHeight: "26px",
-  [theme.breakpoints.down("sm")]: {
-    marginBottom: "8px",
-    ...theme.typography.body2,
-    lineHeight: "22px",
-  },
-}))
+const Description = styled(Typography)<Pick<TypographyProps, "component">>(
+  ({ theme }) => ({
+    color: theme.custom.colors.darkGray2,
+    display: "block",
+    marginBottom: "16px",
+    ...theme.typography.body1,
+    lineHeight: "26px",
+    a: {
+      textDecoration: "underline",
+      color: theme.custom.colors.darkGray2,
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+    "a:hover": {
+      textDecoration: "none",
+    },
+    [theme.breakpoints.down("sm")]: {
+      marginBottom: "8px",
+      ...theme.typography.body2,
+      lineHeight: "22px",
+    },
+  }),
+)
 
 const LatestEpisodeLine = styled(Typography)(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
@@ -316,9 +328,15 @@ export const PodcastDetailPage: React.FC<PodcastDetailPageProps> = ({
                     )}
 
                     {resource?.description && (
-                      <Description variant="body2">
-                        {resource.description}
-                      </Description>
+                      <Description
+                        variant="body2"
+                        component="div"
+                        dangerouslySetInnerHTML={{
+                          __html: addExternalLinkTargets(
+                            DOMPurify.sanitize(resource.description),
+                          ),
+                        }}
+                      />
                     )}
 
                     {latestEpisode && (

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.test.tsx
@@ -71,6 +71,51 @@ describe("PodcastSection", () => {
     )
   })
 
+  it("renders a sanitized, formatted summary for featured series", () => {
+    const series = makeSeries({
+      description:
+        '<script>alert("xss")</script><p>Teaching &amp; learning at MIT</p>',
+    })
+    renderWithProviders(
+      <PodcastSection
+        featuredPodcasts={[series]}
+        morePodcasts={[]}
+        hasMorePodcasts={false}
+        totalPodcasts={0}
+        isMobile={false}
+      />,
+    )
+    expect(
+      screen.getByText("Teaching & learning at MIT"),
+    ).toBeInTheDocument()
+    expect(document.querySelector("script")).not.toBeInTheDocument()
+  })
+
+  it("strips links from the featured summary, keeping their text, since the card is itself a link", () => {
+    const series = makeSeries({
+      description:
+        'Relevant Resources: <a href="https://ocw.mit.edu/">OCW</a> and <a href="/search">Search</a>.',
+    })
+    renderWithProviders(
+      <PodcastSection
+        featuredPodcasts={[series]}
+        morePodcasts={[]}
+        hasMorePodcasts={false}
+        totalPodcasts={0}
+        isMobile={false}
+      />,
+    )
+    expect(
+      screen.getByText("Relevant Resources: OCW and Search.", {
+        exact: false,
+      }),
+    ).toBeInTheDocument()
+    // Only the card's own outer link should be present — no nested <a>.
+    expect(screen.getAllByRole("link", { name: /Chalk Radio/ })).toHaveLength(
+      1,
+    )
+  })
+
   it("renders 'More Podcasts' rows with title and offered_by", () => {
     const series = makeSeries({
       title: "The Aggregate",

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.test.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.test.tsx
@@ -85,9 +85,7 @@ describe("PodcastSection", () => {
         isMobile={false}
       />,
     )
-    expect(
-      screen.getByText("Teaching & learning at MIT"),
-    ).toBeInTheDocument()
+    expect(screen.getByText("Teaching & learning at MIT")).toBeInTheDocument()
     expect(document.querySelector("script")).not.toBeInTheDocument()
   })
 
@@ -111,9 +109,7 @@ describe("PodcastSection", () => {
       }),
     ).toBeInTheDocument()
     // Only the card's own outer link should be present — no nested <a>.
-    expect(screen.getAllByRole("link", { name: /Chalk Radio/ })).toHaveLength(
-      1,
-    )
+    expect(screen.getAllByRole("link", { name: /Chalk Radio/ })).toHaveLength(1)
   })
 
   it("renders 'More Podcasts' rows with title and offered_by", () => {

--- a/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.tsx
+++ b/frontends/main/src/app-pages/PodcastPage/PodcastsListingPage/PodcastSection.tsx
@@ -4,9 +4,11 @@ import { Typography, Skeleton, styled } from "ol-components"
 import type { TypographyProps } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import { RiArrowRightLine, RiArrowRightSLine } from "@remixicon/react"
+import DOMPurify from "isomorphic-dompurify"
 import { formatDate } from "ol-utilities"
 import type { LearningResource } from "api/v1"
 import { SEARCH_PODCASTS, podcastPageView } from "@/common/urls"
+import { stripAnchorTags } from "@/common/utils"
 import {
   Section,
   SectionHeader,
@@ -109,7 +111,9 @@ const FeaturedPodcastTitle = styled(Typography)<
   marginBottom: "8px",
 }))
 
-const FeaturedPodcastSummary = styled(Typography)(({ theme }) => ({
+const FeaturedPodcastSummary = styled(Typography)<
+  Pick<TypographyProps, "component">
+>(({ theme }) => ({
   color: theme.custom.colors.silverGrayDark,
   lineHeight: "24px",
   marginBottom: "16px",
@@ -117,6 +121,18 @@ const FeaturedPodcastSummary = styled(Typography)(({ theme }) => ({
   WebkitBoxOrient: "vertical",
   WebkitLineClamp: 2,
   overflow: "hidden",
+  maxWidth: "100%",
+  overflowWrap: "break-word",
+  wordBreak: "break-word",
+  "& p": {
+    display: "inline",
+    margin: 0,
+    maxWidth: "100%",
+    overflowWrap: "break-word",
+    wordBreak: "break-word",
+    whiteSpace: "normal",
+    textWrap: "wrap",
+  },
 }))
 
 const FeaturedPodcastMeta = styled(Typography)(({ theme }) => ({
@@ -324,9 +340,15 @@ const PodcastSection: React.FC<PodcastSectionProps> = ({
                         {item.title}
                       </FeaturedPodcastTitle>
                       {item.description && (
-                        <FeaturedPodcastSummary variant="body1">
-                          {item.description}
-                        </FeaturedPodcastSummary>
+                        <FeaturedPodcastSummary
+                          variant="body1"
+                          component="div"
+                          dangerouslySetInnerHTML={{
+                            __html: stripAnchorTags(
+                              DOMPurify.sanitize(item.description),
+                            ),
+                          }}
+                        />
                       )}
                       <FeaturedPodcastMeta variant="body2">
                         {[


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/12690 
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->
The podcast detail page and the "Featured" cards on the podcasts listing page, the show-level `description` was rendered as plain JSX text, so users saw raw markup like `<p>` tags and unescaped entities like `&amp;` instead of formatted copy.

The backend sanitizes show descriptions as allowlisted HTML (`nh3` via `ALLOWED_HTML_TAGS_WITH_LINKS`) — the same treatment already given to podcast episode descriptions, which render correctly. The two show-level sites just hadn't been updated to match.


- `PodcastDetailPage.tsx` — description now sanitized (`DOMPurify.sanitize`) and rendered via `dangerouslySetInnerHTML`, with external links opening in a new tab (`addExternalLinkTargets`), mirroring `PodcastEpisodeDetailPage.tsx`.
- `PodcastSection.tsx` (featured podcast cards) — same sanitization, but links are stripped (`stripAnchorTags`) instead of kept clickable, since the whole card is already a `Link` — mirroring `EpisodeItem.tsx`'s handling of the same situation.
- Both containers switched from the default `<p>` to `component="div"`, since sanitized descriptions can contain their own `<p>` tags (nesting `<p>` in `<p>` is invalid HTML).
- Added link styling (`a { textDecoration: underline; ... }`) to the show detail page's description, matching the episode detail page, so links don't fall back to default browser blue.
- Added a `& p` override on the featured card's summary so paragraph tags don't break its 2-line clamp truncation.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

BEFORE 
<img width="809" height="316" alt="Screenshot 2026-08-04 at 11 41 25 AM" src="https://github.com/user-attachments/assets/63a72ced-c98f-448e-a7d4-d300d9105207" />
<img width="780" height="434" alt="Screenshot 2026-08-04 at 11 38 13 AM" src="https://github.com/user-attachments/assets/5c518fdb-aa21-4823-b20c-fac9b8074c20" />

AFTER 
<img width="838" height="497" alt="Screenshot 2026-08-04 at 2 36 55 PM" src="https://github.com/user-attachments/assets/c545bf07-5ac8-4e05-91e2-147b28bd85c8" />

<img width="833" height="455" alt="Screenshot 2026-08-04 at 2 36 52 PM" src="https://github.com/user-attachments/assets/a44260a0-0261-42f1-ae5d-003276aa37be" />




### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- [ ] Manually verify against the two examples from the issue: If you don't currently have in the local DB you can seed with the following script.
```
# scripts/seed_test_podcasts.py — run via:
# docker compose run --rm web python manage.py shell < scripts/seed_test_podcasts.py
from learning_resources.constants import LearningResourceType, PlatformType
from learning_resources.models import LearningResource, LearningResourcePlatform, Podcast

platform, _ = LearningResourcePlatform.objects.get_or_create(code=PlatformType.podcast.name)

SHOWS = [
    {
        "readable_id": "test-trash-talking-show",
        "title": "Trash Talking",
        "description": "<p>Daryl Morey &amp; Jessica Gelman on sports analytics.</p>",
    },
    {
        "readable_id": "test-lock-the-quill-show",
        "title": "Lock the Quill",
        "description": "<p>Conversations on writing and craft.</p><p>New episodes weekly.</p>",
    },
]

for show in SHOWS:
    readable_id = show.pop("readable_id")
    lr, _ = LearningResource.objects.update_or_create(
        readable_id=readable_id,
        platform=platform,
        defaults={
            "resource_type": LearningResourceType.podcast.name,
            "resource_category": LearningResourceType.podcast.value,
            "published": True,
            **show,
        },
    )
    Podcast.objects.update_or_create(learning_resource=lr)
    print(f"seeded {lr.id}: /podcast/{lr.id}/{lr.title.lower().replace(' ', '-')}")
```
  - For example: `/podcast/15925/trash-talking` — "&" should render properly instead of `&amp;`
  - For example: `/podcast/17779/lock-the-quill` — paragraphs should render as formatted text instead of showing literal `<p>` tags
- [ ] Spot-check a featured podcast card (podcasts listing page) whose show description contains a link — confirm the link text still shows but isn't a separate clickable `<a>` nested inside the card.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->

**Out of scope:** a related issue: https://github.com/mitodl/hq/issues/12700 where sanitized HTML/entities leak into `<meta name="description">` / Open Graph / Twitter Card tags on the podcast (and other resource-type) pages — that needs a different fix (strip-to-plain-text, not parse-as-HTML) and touches a shared metadata utility used by all resource types, so it's being tracked separately.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
