### PR TITLE
Fix flaky url-matching tests with unique factory urls

### DIFF
--- a/learning_resources/factories.py
+++ b/learning_resources/factories.py
@@ -211,7 +211,9 @@ class LearningResourceFactory(DjangoModelFactory):
     title = factory.Faker("word")
     description = factory.Faker("sentence")
     full_description = factory.Faker("text")
-    url = factory.Faker("url")
+    # Unique per resource; faker urls collide often enough to flake tests
+    # that match resources by url
+    url = factory.Sequence(lambda n: f"https://example.com/resource-{n}")
     languages = factory.List(random.choices(["en", "es"]))  # noqa: S311
     last_modified = factory.Faker("date_time", tzinfo=UTC)
     created_on = factory.Faker("date_time", tzinfo=UTC)


### PR DESCRIPTION
### What are the relevant tickets?
Closes #3723

### Description (What does it do?)
Generates unique urls in `LearningResourceFactory` instead of faker urls, which collide ~0.2% of the time across 5 resources. A collision made two resources transfer to the same replacement in `test_transfer_list_resources`, and could flake any other test that matches resources by url.

### How can this be tested?
Run `pytest learning_resources/utils_test.py::test_transfer_list_resources` — all 4 parametrized cases pass. Full `learning_resources` suite run locally with no new failures.
