### PR TITLE
Drop the removed CMS price field from the mitxonline page factories

### DIFF
--- a/frontends/api/src/mitxonline/test-utils/factories/pages.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/pages.ts
@@ -4,7 +4,6 @@ import type { PartialFactory, Factory } from "ol-test-utilities"
 import type {
   FeatureImage,
   CoursePageItem,
-  PriceItem,
   Faculty,
   CoursePageList,
   V2Course,
@@ -32,15 +31,6 @@ const featureImage: Factory<FeatureImage> = (override) => {
     image_url: faker.internet.url(),
     title: faker.lorem.words(3),
     width: faker.number.int({ min: 100, max: 1000 }),
-    ...override,
-  }
-}
-
-const priceItem: Factory<PriceItem> = (override) => {
-  return {
-    id: faker.string.uuid(),
-    type: "price_details",
-    value: { link: "", text: "$99.00" },
     ...override,
   }
 }
@@ -156,7 +146,6 @@ const coursePageItem: PartialFactory<CoursePageItem> = (override) => {
     min_weekly_hours: `${faker.number.int({ min: 1, max: 20 })}`,
     min_weeks: faker.number.int({ min: 1, max: 12 }),
     prerequisites: makeHTMLList(2),
-    price: [priceItem()],
     title: faker.lorem.words(3),
     topic_list: [
       {
@@ -229,14 +218,6 @@ const programPageItem: PartialFactory<ProgramPageItem> = (override) => {
     max_weekly_hours: `${faker.number.int({ min: 11, max: 20 })}`,
     min_weeks: faker.number.int({ min: 24, max: 48 }),
     max_weeks: faker.number.int({ min: 48, max: 96 }),
-    price: [
-      priceItem({
-        value: {
-          text: `$${faker.number.int({ min: 250, max: 1000 })} - $${faker.number.int({ min: 1000, max: 5000 })} per course`,
-          link: "",
-        },
-      }),
-    ],
     min_price: `${faker.number.int({ min: 1000, max: 2500 })}`,
     max_price: `${faker.number.int({ min: 2500, max: 10000 })}`,
     show_stay_updated: faker.datatype.boolean(),

--- a/frontends/api/src/mitxonline/test-utils/factories/programs.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/programs.ts
@@ -40,7 +40,6 @@ const program: PartialFactory<V2ProgramDetail> = (overrides = {}) => {
       live: faker.datatype.boolean(),
       length: `${faker.number.int({ min: 1, max: 12 })} weeks`,
       effort: `${faker.number.int({ min: 1, max: 10 })} hours/week`,
-      price: faker.commerce.price(),
       list_price: faker.commerce.price(),
     },
     program_type: faker.helpers.arrayElement([


### PR DESCRIPTION
## What this does

mitxonline is removing the non-functional `price` StreamField from `CoursePage` / `ProgramPage` — mitodl/hq#6123, implemented in mitodl/mitxonline#3813. When that merges and `@mitodl/mitxonline-api-axios` is regenerated, `PriceItem` and the `price` property disappear from the generated types.

This repo references them in exactly two files, both test factories:

| File | Change |
| --- | --- |
| `frontends/api/src/mitxonline/test-utils/factories/pages.ts` | drop the `PriceItem` type import, the `priceItem` factory, and the `price` defaults on `coursePageItem` + `programPageItem` |
| `frontends/api/src/mitxonline/test-utils/factories/programs.ts` | drop `page.price`, keeping `page.list_price` right below it |

20 deletions, no additions. **Nothing outside the factories used the field** — no component, hook, or test reads `page.price`, and no non-test file imports these factories.

## ⚠️ Draft: this cannot merge until the client is regenerated

`price` is currently a **required** property, so removing it from the factories fails typecheck against today's pinned client. Measured, not guessed — with this diff on the currently pinned `2026.7.22`:

```
pages.ts(111,9)    TS2741  Property 'price' is missing in type '{…}' but required in type 'CoursePageItem'
pages.ts(197,9)    TS2741  Property 'price' is missing in type '{…}' but required in type 'ProgramPageItem'
programs.ts(34,5)  TS2741  Property 'price' is missing in type '{…}' but required in type 'ProgramPage'
```

Bumping to the already-published `2026.8.3` does not help either — I checked, and it still ships `PriceItem` (9 occurrences in `dist/esm/v2/api.d.ts`), because mitodl/mitxonline#3813 isn't merged yet.

**Merge order:** mitodl/mitxonline#3813 → regenerate + publish the client → bump `@mitodl/mitxonline-api-axios` here → merge this. It's fine to fold this diff into the version-bump PR instead of merging it separately; the point of opening it now is so the bump isn't blocked on someone rediscovering why CI went red.

## How this was validated

I generated a client from the mitxonline branch locally (`mitxonline-api-clients/scripts/local-generate.sh`, nothing pushed), packed it, and pointed `frontends/api` at the tarball. `tsc --noEmit` in `frontends/api`, four runs:

| Client | Factories | Errors |
| --- | --- | --- |
| published `2026.7.22` | unchanged | **0** — today's baseline is green |
| regenerated from mitxonline `main` | unchanged | **1** |
| regenerated from the mitxonline branch | unchanged | **5** |
| regenerated from the mitxonline branch | **this PR** | **1** |

So the price removal accounts for 4 errors and this diff clears all 4.

Runtime is unaffected. With the price-less client installed and the factories still unpatched, the product-page suites all passed — `CoursePage.test.tsx` 32/32, `ProgramPage.test.tsx` + `useProgramCertificatePrice.test.tsx` 37/37 — because `@swc/jest` strips types without checking them. This is a typecheck-only concern; nothing user-facing was ever reading the field.

## Heads-up: a second, unrelated error arrives with the same bump

The residual **1 error** in the table above is not from mitxonline#3813. It reproduces on a client generated from mitxonline `main` with these factories untouched:

```
organization.ts(21,3)  TS2741  Property 'sso_organization_id' is missing in type '{…}'
                               but required in type 'OrganizationPage'
```

That comes from mitodl/mitxonline#3789 *("look up managed orgs by sso_organization_id; expose the org UUID")*, already merged there, and it is present in the published `2026.8.3`. So **whoever does the next client bump will see two unrelated red errors**, only one of which this PR addresses. `organization.ts` needs `sso_organization_id` added to its defaults — deliberately left out of this PR to keep the two concerns separate, happy to add it here if you'd rather have one PR.

## One gotcha for anyone regenerating the client locally

Building the generated client with `npm install` pulls axios `1.19.0`, whose internal `unique symbol` trips `TS2527` in the generated `common.ts` and silently drops `common.d.ts` from the emit — which then looks like a broken client. Pinning axios `1.7.9` (closer to the package's `^1.6.5`) builds clean with all 30 `.d.ts` files, matching the published package.
