### PR TITLE
Fix Canvas archive change detection: deterministic checksum, save after load

### DIFF
--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -15,6 +15,7 @@ from learning_resources.constants import (
     PlatformType,
 )
 from learning_resources.etl.canvas_utils import (
+    canvas_course_checksum,
     canvas_course_url,
     canvas_url_config,
     get_published_items,
@@ -22,7 +23,6 @@ from learning_resources.etl.canvas_utils import (
 )
 from learning_resources.etl.constants import ETLSource
 from learning_resources.etl.utils import (
-    calc_checksum,
     get_edx_module_id,
     process_olx_path,
 )
@@ -52,17 +52,20 @@ def sync_canvas_archive(bucket, key: str, overwrite):
         course_archive_path = Path(export_tempdir, key.rsplit("/", maxsplit=1)[-1])
         bucket.download_file(key, course_archive_path)
         url_config = canvas_url_config(bucket, export_tempdir, url_config_file)
+        checksum = canvas_course_checksum(course_archive_path, url_config)
         resource_readable_id, run = run_for_canvas_archive(
-            course_archive_path, course_folder=course_folder, overwrite=overwrite
+            course_archive_path,
+            course_folder=course_folder,
+            checksum=checksum,
+            overwrite=overwrite,
         )
-        checksum = calc_checksum(course_archive_path)
         if run:
             canvas_content_files = list(
                 transform_canvas_content_files(
                     course_archive_path, run, url_config=url_config, overwrite=overwrite
                 )
             )
-            load_content_files(
+            content_files_ids = load_content_files(
                 run,
                 canvas_content_files,
             )
@@ -73,17 +76,20 @@ def sync_canvas_archive(bucket, key: str, overwrite):
                     course_archive_path, run, overwrite=overwrite
                 ),
             )
-            run.checksum = checksum
-            run.save()
+            if content_files_ids or not canvas_content_files:
+                # only mark the archive processed once its content actually
+                # loaded (or there was legitimately nothing to load), so a
+                # failed or empty load is retried on the next sync
+                run.checksum = checksum
+                run.save(update_fields=["checksum"])
 
     return resource_readable_id
 
 
-def run_for_canvas_archive(course_archive_path, course_folder, overwrite):
+def run_for_canvas_archive(course_archive_path, course_folder, checksum, overwrite):
     """
     Generate and return a LearningResourceRun for a Canvas course
     """
-    checksum = calc_checksum(course_archive_path)
     course_info = parse_canvas_settings(course_archive_path)
     course_title = course_info.get("title", f"canvas course {course_folder}")
     url = canvas_course_url(course_archive_path)
@@ -130,8 +136,6 @@ def run_for_canvas_archive(course_archive_path, course_folder, overwrite):
     if run.checksum == checksum and not overwrite:
         log.debug("Checksums match for %s, skipping load", readable_id)
         return resource_readable_id, None
-    run.checksum = checksum
-    run.save()
     return resource_readable_id, run
 
 

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -70,15 +70,18 @@ def sync_canvas_archive(bucket, key: str, overwrite):
                 canvas_content_files,
             )
 
-            load_problem_files(
-                run,
+            canvas_problem_files = list(
                 transform_canvas_problem_files(
                     course_archive_path, run, overwrite=overwrite
-                ),
+                )
             )
-            if content_files_ids or not canvas_content_files:
+            problem_files_ids = load_problem_files(run, canvas_problem_files)
+            content_loaded = content_files_ids or not canvas_content_files
+            # load_problem_file swallows per-file errors and returns None
+            problems_loaded = any(problem_files_ids) or not canvas_problem_files
+            if content_loaded and problems_loaded:
                 # a failed or empty load must be retried on the next sync, so
-                # only mark processed once content loaded (or none was published)
+                # only mark processed once everything loaded (or was unpublished)
                 run.checksum = checksum
                 run.save(update_fields=["checksum"])
 

--- a/learning_resources/etl/canvas.py
+++ b/learning_resources/etl/canvas.py
@@ -77,9 +77,8 @@ def sync_canvas_archive(bucket, key: str, overwrite):
                 ),
             )
             if content_files_ids or not canvas_content_files:
-                # only mark the archive processed once its content actually
-                # loaded (or there was legitimately nothing to load), so a
-                # failed or empty load is retried on the next sync
+                # a failed or empty load must be retried on the next sync, so
+                # only mark processed once content loaded (or none was published)
                 run.checksum = checksum
                 run.save(update_fields=["checksum"])
 

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -3,19 +3,23 @@
 import zipfile
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from defusedxml import ElementTree
+from freezegun import freeze_time
 
 from learning_resources.constants import LearningResourceType, PlatformType
 from learning_resources.etl.canvas import (
     run_for_canvas_archive,
+    sync_canvas_archive,
     transform_canvas_content_files,
     transform_canvas_problem_files,
 )
 from learning_resources.etl.canvas_utils import (
     _compact_element,
+    canvas_course_checksum,
     get_published_items,
     is_file_published,
     parse_canvas_files,
@@ -179,12 +183,11 @@ def test_run_for_canvas_archive_creates_resource_and_run(tmp_path, mocker):
         return_value={"course_id": "123", "canvas_domain": "mit.edu"},
     )
 
-    mocker.patch("learning_resources.etl.canvas.calc_checksum", return_value="abc123")
     # No resource exists yet
     zip_path = tmp_path / "archive.zip"
 
     _, run = run_for_canvas_archive(
-        zip_path, course_folder=course_folder, overwrite=True
+        zip_path, course_folder=course_folder, checksum="abc123", overwrite=True
     )
     resource = LearningResource.objects.get(readable_id=f"{course_folder}-TEST101")
     assert resource.title == "Test Course"
@@ -193,7 +196,9 @@ def test_run_for_canvas_archive_creates_resource_and_run(tmp_path, mocker):
     assert resource.platform.code == PlatformType.canvas.name
     assert run is not None
     assert run.learning_resource == resource
-    assert run.checksum == "abc123"
+    # checksum is only saved after a successful content load in
+    # sync_canvas_archive, never by run_for_canvas_archive
+    assert run.checksum is None
 
 
 @pytest.mark.django_db
@@ -210,9 +215,6 @@ def test_run_for_canvas_archive_creates_run_if_none_exists(tmp_path, mocker):
         "learning_resources.etl.canvas_utils.parse_context_xml",
         return_value={"course_id": "123", "canvas_domain": "mit.edu"},
     )
-    mocker.patch(
-        "learning_resources.etl.canvas.calc_checksum", return_value="checksum104"
-    )
     # Create resource with no runs
     resource = LearningResourceFactory.create(
         readable_id=f"{course_folder}-TEST104",
@@ -226,11 +228,14 @@ def test_run_for_canvas_archive_creates_run_if_none_exists(tmp_path, mocker):
     course_archive_path = tmp_path / "archive4.zip"
     course_archive_path.write_text("dummy")
     _, run = run_for_canvas_archive(
-        course_archive_path, course_folder=course_folder, overwrite=True
+        course_archive_path,
+        course_folder=course_folder,
+        checksum="checksum104",
+        overwrite=True,
     )
     assert run is not None
     assert run.learning_resource == resource
-    assert run.checksum == "checksum104"
+    assert run.checksum is None
 
 
 def make_canvas_zip(
@@ -1994,7 +1999,9 @@ def test_ingestion_finishes_with_missing_xml_files(
         "learning_resources.etl.utils.extract_text_metadata",
         return_value={"content": "test"},
     )
-    _, run = run_for_canvas_archive(zip_path, tmp_path, overwrite=True)
+    _, run = run_for_canvas_archive(
+        zip_path, tmp_path, checksum="abc123", overwrite=True
+    )
     content_results = list(
         transform_canvas_content_files(
             Path(zip_path), run, url_config={}, overwrite=True
@@ -2088,3 +2095,282 @@ def test_empty_pdf_is_skipped(tmp_path):
         )
     )
     assert result == []
+
+
+LOCK_FILES_XML_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<fileMeta xmlns="http://canvas.instructure.com/xsd/cccv1p0">
+<files>
+<file identifier="RES3">
+  <display_name>{display_name}</display_name>
+  <unlock_at>{unlock_at}</unlock_at>
+  <category>uncategorized</category>
+</file>
+</files>
+</fileMeta>
+"""
+
+LOCK_MANIFEST_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<manifest xmlns="http://www.imsglobal.org/xsd/imsccv1p1/imscp_v1p1">
+  <resources>
+    <resource identifier="RES3" type="webcontent">
+      <file href="web_resources/file3.html"/>
+    </resource>
+  </resources>
+</manifest>
+"""
+
+
+def make_timed_lock_zip(  # noqa: PLR0913
+    tmp_path,
+    unlock_at,
+    name="lock_course.zip",
+    settings_xml=DEFAULT_SETTINGS_XML,
+    manifest_xml=LOCK_MANIFEST_XML,
+    display_name="file3",
+    content=b"<html>one</html>",
+):
+    """Course archive with one file whose visibility is gated by unlock_at"""
+    zip_path = tmp_path / name
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("course_settings/course_settings.xml", settings_xml)
+        zf.writestr(
+            "course_settings/files_meta.xml",
+            LOCK_FILES_XML_TEMPLATE.format(
+                unlock_at=unlock_at, display_name=display_name
+            ).encode(),
+        )
+        zf.writestr("imsmanifest.xml", manifest_xml)
+        zf.writestr("web_resources/file3.html", content)
+    return zip_path
+
+
+UNLOCKED = "2001-01-01T00:00:00"
+
+
+def test_canvas_course_checksum_ignores_export_noise(tmp_path):
+    """
+    Archives differing only in imsmanifest.xml bytes and course_settings/*
+    bytes AND size must produce the same digest — Canvas rewrites these on
+    every no-op export (verified across 13 prod course pairs).
+    """
+    a = make_timed_lock_zip(tmp_path, UNLOCKED, name="a.zip")
+    b = make_timed_lock_zip(
+        tmp_path,
+        UNLOCKED,
+        name="b.zip",
+        settings_xml=DEFAULT_SETTINGS_XML + b"<!-- export noise, new size -->",
+        manifest_xml=LOCK_MANIFEST_XML.replace(b"<resources>", b"<resources >"),
+    )
+    assert canvas_course_checksum(a, {}) == canvas_course_checksum(b, {})
+
+
+def test_canvas_course_checksum_detects_same_size_content_edit(tmp_path):
+    """
+    A content member with identical name and size but different bytes must
+    change the digest — parity with the per-file archive_checksum gate that
+    the archive-level skip would otherwise shadow.
+    """
+    a = make_timed_lock_zip(
+        tmp_path, UNLOCKED, name="a.zip", content=b"<html>one</html>"
+    )
+    b = make_timed_lock_zip(
+        tmp_path, UNLOCKED, name="b.zip", content=b"<html>two</html>"
+    )
+    assert canvas_course_checksum(a, {}) != canvas_course_checksum(b, {})
+
+
+def test_canvas_course_checksum_independent_of_member_order(tmp_path):
+    """Zip directory order must not affect the digest"""
+    zip_a = tmp_path / "a.zip"
+    zip_b = tmp_path / "b.zip"
+    members = [
+        ("web_resources/x.html", b"xx"),
+        ("web_resources/y.html", b"yy"),
+        ("course_settings/course_settings.xml", DEFAULT_SETTINGS_XML),
+    ]
+    with zipfile.ZipFile(zip_a, "w") as zf:
+        for name, content in members:
+            zf.writestr(name, content)
+    with zipfile.ZipFile(zip_b, "w") as zf:
+        for name, content in reversed(members):
+            zf.writestr(name, content)
+    assert canvas_course_checksum(zip_a, {}) == canvas_course_checksum(zip_b, {})
+
+
+def test_canvas_course_checksum_sensitive_to_url_config(tmp_path):
+    """
+    url_config (from the .metadata.json sidecar) feeds ContentFile urls; a
+    changed url must change the digest even when the archive is unchanged.
+    """
+    zip_path = make_timed_lock_zip(tmp_path, UNLOCKED)
+    with_url = {"/file3.html": {"url": "https://mit.edu/f/1"}}
+    reminted = {"/file3.html": {"url": "https://mit.edu/f/2"}}
+    assert canvas_course_checksum(zip_path, with_url) != canvas_course_checksum(
+        zip_path, reminted
+    )
+
+
+def test_canvas_course_checksum_sensitive_to_display_name(tmp_path):
+    """
+    A same-length display_name change lives in the excluded files_meta.xml;
+    the publish-set component must still catch it (it feeds content_title).
+    """
+    a = make_timed_lock_zip(tmp_path, UNLOCKED, name="a.zip", display_name="fileA")
+    b = make_timed_lock_zip(tmp_path, UNLOCKED, name="b.zip", display_name="fileB")
+    assert canvas_course_checksum(a, {}) != canvas_course_checksum(b, {})
+
+
+def test_canvas_course_checksum_changes_when_lock_boundary_passes(tmp_path):
+    """
+    The same archive must produce a different checksum once a timed lock
+    boundary passes — publish status depends on wall-clock time, and the gate
+    must reprocess when it flips.
+    """
+    zip_path = make_timed_lock_zip(tmp_path, "2026-09-01T00:00:00")
+    with freeze_time("2026-08-15"):
+        while_locked = canvas_course_checksum(zip_path, {})
+    with freeze_time("2026-09-15"):
+        after_unlock = canvas_course_checksum(zip_path, {})
+    assert while_locked != after_unlock
+
+
+def test_canvas_course_checksum_catches_size_preserving_publish_toggle(tmp_path):
+    """
+    Two archives with identical member names/sizes but different publish
+    state must differ — the publish-set component catches what the
+    name:size structural digest cannot.
+    """
+    locked = make_timed_lock_zip(tmp_path, "2099-01-01T00:00:00", name="locked.zip")
+    unlocked = make_timed_lock_zip(tmp_path, "2001-01-01T00:00:00", name="unlocked.zip")
+    assert canvas_course_checksum(locked, {}) != canvas_course_checksum(unlocked, {})
+
+
+def test_canvas_course_checksum_is_cwd_independent(tmp_path, monkeypatch):
+    """Checksum must not embed the worker process's working directory"""
+    zip_path = make_timed_lock_zip(tmp_path, "2001-01-01T00:00:00")
+    digest = canvas_course_checksum(zip_path, {})
+    other_cwd = tmp_path / "elsewhere"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    assert canvas_course_checksum(zip_path, {}) == digest
+
+
+@pytest.fixture
+def sync_mocks(mocker, tmp_path):
+    """Bucket/url_config/loader mocks for sync_canvas_archive"""
+    zip_path = make_timed_lock_zip(tmp_path, "2001-01-01T00:00:00")
+
+    def fake_download(key, dest):
+        Path(dest).write_bytes(zip_path.read_bytes())
+
+    bucket = MagicMock()
+    bucket.download_file.side_effect = fake_download
+    mocker.patch("learning_resources.etl.canvas.canvas_url_config", return_value={})
+    mocker.patch(
+        "learning_resources.etl.utils.extract_text_metadata",
+        return_value={"content": "TEXT"},
+    )
+    mocker.patch(
+        "learning_resources.etl.canvas_utils.parse_context_xml",
+        return_value={"course_id": "123", "canvas_domain": "mit.edu"},
+    )
+    load_content = mocker.patch("learning_resources.etl.loaders.load_content_files")
+    load_problems = mocker.patch("learning_resources.etl.loaders.load_problem_files")
+    return SimpleNamespace(
+        bucket=bucket, load_content=load_content, load_problems=load_problems
+    )
+
+
+def _canvas_run(readable_id):
+    return LearningResource.objects.get(readable_id=readable_id).runs.first()
+
+
+def test_sync_canvas_archive_skips_unchanged_archive(sync_mocks):
+    """A second sync of an unchanged archive must not reload content"""
+    readable_id = sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert sync_mocks.load_content.call_count == 1
+    first_checksum = _canvas_run(readable_id).checksum
+    assert first_checksum
+
+    sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert sync_mocks.load_content.call_count == 1
+    assert _canvas_run(readable_id).checksum == first_checksum
+
+
+def test_sync_canvas_archive_saves_checksum_only_after_successful_load(sync_mocks):
+    """
+    A failed load must leave the checksum unset so the next sync retries
+    instead of silently skipping content that was never ingested.
+    """
+    sync_mocks.load_content.side_effect = Exception("load failed")
+    with pytest.raises(Exception, match="load failed"):
+        sync_canvas_archive(
+            sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+        )
+    resource = LearningResource.objects.get(etl_source=ETLSource.canvas.name)
+    assert resource.runs.first().checksum is None
+
+    sync_mocks.load_content.side_effect = None
+    sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert sync_mocks.load_content.call_count == 2
+    assert resource.runs.first().checksum
+
+
+def test_sync_canvas_archive_computes_checksum_once(mocker, sync_mocks):
+    """The course digest is computed exactly once per archive"""
+    from learning_resources.etl import canvas
+
+    spy = mocker.spy(canvas, "canvas_course_checksum")
+    sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert spy.call_count == 1
+
+
+def test_sync_canvas_archive_retries_when_nothing_loads(sync_mocks):
+    """
+    load_content_files returning [] (all files failed without raising) must
+    NOT save the checksum — the next sync retries instead of skipping content
+    that was never ingested.
+    """
+    sync_mocks.load_content.return_value = []
+    readable_id = sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert _canvas_run(readable_id).checksum is None
+
+    sync_mocks.load_content.return_value = [1]
+    sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert sync_mocks.load_content.call_count == 2
+    assert _canvas_run(readable_id).checksum
+
+
+def test_sync_canvas_archive_saves_checksum_for_legitimately_empty_course(
+    mocker, sync_mocks, tmp_path
+):
+    """
+    A course with nothing published yields no payloads and loads nothing;
+    that's not a failure — save the checksum so it isn't reprocessed weekly.
+    (The publish-set digest component unfreezes it if anything is published.)
+    """
+    locked_zip = make_timed_lock_zip(
+        tmp_path, "2099-01-01T00:00:00", name="all_locked.zip"
+    )
+
+    def fake_download(key, dest):
+        Path(dest).write_bytes(locked_zip.read_bytes())
+
+    sync_mocks.bucket.download_file.side_effect = fake_download
+    sync_mocks.load_content.return_value = []
+    readable_id = sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert _canvas_run(readable_id).checksum

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -2329,6 +2329,31 @@ def test_sync_canvas_archive_retries_when_nothing_loads(sync_mocks):
     assert _canvas_run(readable_id).checksum
 
 
+def test_sync_canvas_archive_retries_when_problem_files_fail(mocker, sync_mocks):
+    """
+    Tutor problem files yielded but none loaded (load_problem_file swallows
+    per-file errors and returns None) must NOT save the checksum, so the next
+    sync retries.
+    """
+    mocker.patch(
+        "learning_resources.etl.canvas.transform_canvas_problem_files",
+        side_effect=lambda *_args, **_kwargs: iter(
+            [{"source_path": "tutorbot/p1/problem.pdf"}]
+        ),
+    )
+    sync_mocks.load_problems.return_value = [None]
+    readable_id = sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert _canvas_run(readable_id).checksum is None
+
+    sync_mocks.load_problems.return_value = [7]
+    sync_canvas_archive(
+        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
+    )
+    assert _canvas_run(readable_id).checksum
+
+
 def test_sync_canvas_archive_saves_checksum_for_legitimately_empty_course(
     mocker, sync_mocks, tmp_path
 ):

--- a/learning_resources/etl/canvas_test.py
+++ b/learning_resources/etl/canvas_test.py
@@ -2181,20 +2181,18 @@ def test_canvas_course_checksum_detects_same_size_content_edit(tmp_path):
 
 def test_canvas_course_checksum_independent_of_member_order(tmp_path):
     """Zip directory order must not affect the digest"""
-    zip_a = tmp_path / "a.zip"
-    zip_b = tmp_path / "b.zip"
     members = [
         ("web_resources/x.html", b"xx"),
         ("web_resources/y.html", b"yy"),
         ("course_settings/course_settings.xml", DEFAULT_SETTINGS_XML),
     ]
-    with zipfile.ZipFile(zip_a, "w") as zf:
-        for name, content in members:
-            zf.writestr(name, content)
-    with zipfile.ZipFile(zip_b, "w") as zf:
-        for name, content in reversed(members):
-            zf.writestr(name, content)
-    assert canvas_course_checksum(zip_a, {}) == canvas_course_checksum(zip_b, {})
+    digests = []
+    for name, order in (("a.zip", members), ("b.zip", members[::-1])):
+        with zipfile.ZipFile(tmp_path / name, "w") as zf:
+            for member, content in order:
+                zf.writestr(member, content)
+        digests.append(canvas_course_checksum(tmp_path / name, {}))
+    assert digests[0] == digests[1]
 
 
 def test_canvas_course_checksum_sensitive_to_url_config(tmp_path):
@@ -2232,17 +2230,6 @@ def test_canvas_course_checksum_changes_when_lock_boundary_passes(tmp_path):
     with freeze_time("2026-09-15"):
         after_unlock = canvas_course_checksum(zip_path, {})
     assert while_locked != after_unlock
-
-
-def test_canvas_course_checksum_catches_size_preserving_publish_toggle(tmp_path):
-    """
-    Two archives with identical member names/sizes but different publish
-    state must differ — the publish-set component catches what the
-    name:size structural digest cannot.
-    """
-    locked = make_timed_lock_zip(tmp_path, "2099-01-01T00:00:00", name="locked.zip")
-    unlocked = make_timed_lock_zip(tmp_path, "2001-01-01T00:00:00", name="unlocked.zip")
-    assert canvas_course_checksum(locked, {}) != canvas_course_checksum(unlocked, {})
 
 
 def test_canvas_course_checksum_is_cwd_independent(tmp_path, monkeypatch):
@@ -2320,17 +2307,6 @@ def test_sync_canvas_archive_saves_checksum_only_after_successful_load(sync_mock
     )
     assert sync_mocks.load_content.call_count == 2
     assert resource.runs.first().checksum
-
-
-def test_sync_canvas_archive_computes_checksum_once(mocker, sync_mocks):
-    """The course digest is computed exactly once per archive"""
-    from learning_resources.etl import canvas
-
-    spy = mocker.spy(canvas, "canvas_course_checksum")
-    sync_canvas_archive(
-        sync_mocks.bucket, "canvas/course_content/1/abc.imscc", overwrite=False
-    )
-    assert spy.call_count == 1
 
 
 def test_sync_canvas_archive_retries_when_nothing_loads(sync_mocks):

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -715,8 +715,8 @@ def get_published_items(zipfile_path, url_config):
 # course_settings/* change bytes AND size — verified across 13 prod course
 # pairs). They are excluded from the byte digest; their semantic content
 # (publish state, titles) is covered by the publish-set component below.
-CHECKSUM_EXCLUDED_MEMBERS = ("imsmanifest.xml",)
-CHECKSUM_EXCLUDED_PREFIXES = ("course_settings/",)
+# Nothing under these paths is ever ingested as a content file (IGNORE_FILES).
+CHECKSUM_EXCLUDED = ("imsmanifest.xml", "course_settings/")
 
 
 def canvas_course_checksum(course_archive_path, url_config: dict) -> str:
@@ -732,9 +732,7 @@ def canvas_course_checksum(course_archive_path, url_config: dict) -> str:
     hasher = md5()  # noqa: S324 - non-cryptographic change detection
     with zipfile.ZipFile(course_archive_path, "r") as course_archive:
         for info in sorted(course_archive.infolist(), key=lambda i: i.filename):
-            if info.filename in CHECKSUM_EXCLUDED_MEMBERS or info.filename.startswith(
-                CHECKSUM_EXCLUDED_PREFIXES
-            ):
+            if info.filename.startswith(CHECKSUM_EXCLUDED):
                 continue
             hasher.update(f"{info.filename}\0{info.file_size}\0{info.CRC}\0".encode())
     published = get_published_items(course_archive_path, url_config)

--- a/learning_resources/etl/canvas_utils.py
+++ b/learning_resources/etl/canvas_utils.py
@@ -1,9 +1,11 @@
 import json
 import logging
+import os
 import sys
 import zipfile
 from collections import defaultdict
 from datetime import UTC
+from hashlib import md5
 from pathlib import Path
 from urllib.parse import unquote, unquote_plus
 from zoneinfo import ZoneInfo
@@ -706,3 +708,42 @@ def get_published_items(zipfile_path, url_config):
             published_items[embedded_path] = embedded
 
     return published_items
+
+
+# Export-noise carriers: Canvas rewrites these on every no-op export
+# (imsmanifest.xml embeds the export timestamp and reshuffles resources;
+# course_settings/* change bytes AND size — verified across 13 prod course
+# pairs). They are excluded from the byte digest; their semantic content
+# (publish state, titles) is covered by the publish-set component below.
+CHECKSUM_EXCLUDED_MEMBERS = ("imsmanifest.xml",)
+CHECKSUM_EXCLUDED_PREFIXES = ("course_settings/",)
+
+
+def canvas_course_checksum(course_archive_path, url_config: dict) -> str:
+    """
+    Digest of archive content + effective publish state + url metadata.
+
+    Changes when a content member's bytes change (name/size/CRC, excluding
+    the export-noise carriers), when the published set or a display title
+    changes (publish toggles, timed lock/unlock boundaries passing), or when
+    the .metadata.json url config changes — every way a course's ingested
+    content can change. Stable across Canvas's no-op scheduled exports.
+    """
+    hasher = md5()  # noqa: S324 - non-cryptographic change detection
+    with zipfile.ZipFile(course_archive_path, "r") as course_archive:
+        for info in sorted(course_archive.infolist(), key=lambda i: i.filename):
+            if info.filename in CHECKSUM_EXCLUDED_MEMBERS or info.filename.startswith(
+                CHECKSUM_EXCLUDED_PREFIXES
+            ):
+                continue
+            hasher.update(f"{info.filename}\0{info.file_size}\0{info.CRC}\0".encode())
+    published = get_published_items(course_archive_path, url_config)
+    # relpath: get_published_items keys are resolve()'d against the process
+    # cwd, which must not leak into the digest
+    for path, title in sorted(
+        (os.path.relpath(path), item.get("title") or "")
+        for path, item in published.items()
+    ):
+        hasher.update(f"{path}\0{title}\0".encode())
+    hasher.update(json.dumps(url_config, sort_keys=True, default=str).encode())
+    return hasher.hexdigest()

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -10,7 +10,6 @@ import os
 import re
 import tarfile
 import uuid
-import zipfile
 from collections import Counter
 from collections.abc import Generator
 from datetime import UTC, datetime
@@ -906,11 +905,6 @@ def calc_checksum(filename) -> str:
     Returns:
         str: The md5 checksum of the file
     """
-    if zipfile.is_zipfile(filename):
-        with zipfile.ZipFile(filename, "r") as zip_file:
-            return str(
-                hash(tuple(f"{zp.filename}:{zp.file_size}" for zp in zip_file.filelist))
-            )
     with tarfile.open(filename, "r") as tgz_file:
         return str(hash(tuple(ti.chksum for ti in tgz_file.getmembers())))
 

--- a/learning_resources/etl/utils.py
+++ b/learning_resources/etl/utils.py
@@ -898,12 +898,12 @@ def get_bucket_by_name(bucket_name: str) -> object:
 
 def calc_checksum(filename) -> str:
     """
-    Return the md5 checksum of the specified filepath
+    Return a checksum for the specified tar archive
 
     Args:
-        filename(str): The path to the file to checksum
+        filename(str): The path to the tar archive to checksum
     Returns:
-        str: The md5 checksum of the file
+        str: checksum derived from the archive members' header checksums
     """
     with tarfile.open(filename, "r") as tgz_file:
         return str(hash(tuple(ti.chksum for ti in tgz_file.getmembers())))


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12703

### Description (What does it do?)
Replaces the zip checksum calculation using Python's `hash()` with a deterministic digest (`canvas_course_checksum`) built from three things:

- **Content members** (name/size/CRC), excluding `imsmanifest.xml` and `course_settings/*` — Canvas rewrites those two on every export even when nothing changed (verified by diffing recent export pairs of 13 production courses), so including them would defeat the gate.
- **The effective publish set** (paths + display titles). Publish/unpublish toggles and timed `lock_at`/`unlock_at` boundaries change what students can see without changing the archive bytes; 31 of the 91 production Canvas courses use timed locks, so the digest has to reflect publish state, not just file contents.
- **The parsed `.metadata.json` url config**, so URL and citation-name changes propagate.

It also fixes the save ordering: the checksum used to be saved *before* content loaded, so once the gate worked, a failed load would be silently skipped forever. The checksum is now saved only after content actually loads (or when a course legitimately has nothing published).

After deploy, the first sync reprocesses each course once (same as every sync does today) and stamps the new checksum; from the second sync on, unchanged courses are skipped for the first time.

### How can this be tested?
AWS credentials must be set in `env/backend.local.env`; `COURSE_ARCHIVE_BUCKET_NAME` already defaults to the production landing bucket. Open a shell (`docker compose run --rm web python manage.py shell`):

```python
import logging
logging.basicConfig(level=logging.INFO)
logging.getLogger("learning_resources.etl.canvas").setLevel(logging.DEBUG)  # the skip message logs at DEBUG

from django.conf import settings
from learning_resources.etl.canvas import sync_canvas_archive
from learning_resources.etl.utils import get_bucket_by_name

bucket = get_bucket_by_name(settings.COURSE_ARCHIVE_BUCKET_NAME)

# Course 39194 works well for this: its archives are tiny (seconds per
# ingest), its two most recent exports are a verified no-op pair (identical
# digests as of 2026-08-05), and both have .metadata.json sidecars.
objs = list(bucket.objects.filter(Prefix="canvas/course_content/39194/"))
imsccs = sorted((o.last_modified, o.key) for o in objs if o.key.endswith(".imscc"))

newest, previous = imsccs[-1][1], imsccs[-2][1]

sync_canvas_archive(bucket, newest, overwrite=False)    # 1. loads content files
sync_canvas_archive(bucket, newest, overwrite=False)    # 2. skips
sync_canvas_archive(bucket, previous, overwrite=False)  # 3. see below
```

1. **First ingest** processes the course and loads content files (~5s for course 39194; it has one published file, the syllabus).
2. **Second ingest of the same archive** logs `Checksums match for <readable_id>, skipping load` (<1s) and leaves the ContentFile rows' `updated_on` timestamps unchanged.
3. **Ingesting the previous export** (a different S3 key) also skips: the two exports differ only in Canvas's per-export noise (`imsmanifest.xml`, `course_settings/*`), so the digest is unchanged — proving the gate holds across Canvas's key churn, which is exactly the case the old code failed. (On a course that genuinely changed between exports, this step reprocesses instead; the log makes it obvious which happened.)
4. **Cross-process determinism**: exit the shell entirely, open a new one, and re-run step 2 — it still skips. Under the old `hash()`-based checksum this is precisely what broke (each process computed a different value).
5. Everything writes only to the local dev database; the bucket is never written to.

### Additional Context
Two production datasets informed the design (details in the linked issue): a scan of all 91 Canvas courses' timed-lock usage, and a central-directory diff of consecutive export pairs for 13 courses showing that only `imsmanifest.xml` and `course_settings/*` churn on no-op exports.


