### PR TITLE
remove GITHUB_ACCESS_TOKEN

### DIFF
--- a/learning_resources/etl/podcast.py
+++ b/learning_resources/etl/podcast.py
@@ -40,10 +40,7 @@ def github_podcast_config_files():
         A list of pyGithub contentFile objects
     """  # noqa: D401
 
-    if settings.GITHUB_ACCESS_TOKEN:
-        github_client = github.Github(settings.GITHUB_ACCESS_TOKEN)
-    else:
-        github_client = github.Github()
+    github_client = github.Github()
 
     repo = github_client.get_repo(CONFIG_FILE_REPO)
 

--- a/learning_resources/etl/podcast_test.py
+++ b/learning_resources/etl/podcast_test.py
@@ -326,10 +326,8 @@ def test_generate_aggregate_podcast_rss():
     assert result == bs(expected_rss, "xml").prettify()
 
 
-@pytest.mark.parametrize("github_token", [None, "token"])
-def test_github_podcast_config_files(settings, mock_github_client, github_token):
+def test_github_podcast_config_files(settings, mock_github_client):
     """Test the logic for retrieving podcast config files from github"""
-    settings.GITHUB_ACCESS_TOKEN = github_token
     mock_github_client.return_value.get_repo.return_value.get_contents.return_value = [
         mock_podcast_file(),
         mock_podcast_file(),

--- a/main/settings_course_etl.py
+++ b/main/settings_course_etl.py
@@ -14,9 +14,6 @@ EDX_COURSE_BUCKET_PREFIX = get_string(
     "EDX_COURSE_BUCKET_PREFIX", "edxorg-raw-data/edxorg/raw_data/course_xml/"
 )
 
-# Authentication for the github api
-GITHUB_ACCESS_TOKEN = get_string("GITHUB_ACCESS_TOKEN", None)
-
 # OCW settings
 OCW_LIVE_BUCKET = get_string("OCW_LIVE_BUCKET", None)
 OCW_ITERATOR_CHUNK_SIZE = get_int("OCW_ITERATOR_CHUNK_SIZE", 1000)


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
The GITHUB_ACCESS_TOKEN is only used by the podcast etl to get our podcast repo. That repo is public. The etl job works without GITHUB_ACCESS_TOKEN and only runs twice a day so we are unlikely to be rate limited. With GITHUB_ACCESS_TOKEN it throws an error due to the new mitodl organization token restrictions 
https://celery-monitoring.odl.mit.edu/task/?app=mitlearn&env=production&uuid=e255344d-4996-4c97-b002-edba5c606323


### How can this be tested?
run `docker-compose run web ./manage.py backpopulate_podcast_data`
it should finish