### PR TITLE
Address review feedback on anonymous checkout

### DIFF
--- a/frontends/api/src/mitxonline/hooks/baskets/index.ts
+++ b/frontends/api/src/mitxonline/hooks/baskets/index.ts
@@ -1,7 +1,6 @@
 import { basketQueries } from "./queries"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { basketsApi } from "../../clients"
-import { useUserIsAuthenticated } from "../../../hooks/user"
 import type { BasketWithProduct } from "@mitodl/mitxonline-api-axios/v2"
 
 /**
@@ -10,7 +9,6 @@ import type { BasketWithProduct } from "@mitodl/mitxonline-api-axios/v2"
  */
 const useAddToBasket = () => {
   const queryClient = useQueryClient()
-  const isAuthenticated = useUserIsAuthenticated()
   return useMutation({
     mutationFn: async (productId: number): Promise<BasketWithProduct> => {
       const response = await basketsApi.basketsCreateFromProductCreate({
@@ -19,16 +17,10 @@ const useAddToBasket = () => {
       return response.data
     },
     onSuccess: async () => {
-      // Invalidate checkout query to ensure fresh data - but only once
-      // authenticated. basketState hits the checkout-payload endpoint, which
-      // creates a real order against the basket's purchaser; an anonymous
-      // basket has no purchaser, so this has to wait until after the
-      // anonymous-checkout conversion step, not fire on every cart add.
-      if (isAuthenticated) {
-        queryClient.invalidateQueries({
-          queryKey: basketQueries.basketState().queryKey,
-        })
-      }
+      // Invalidate checkout query to ensure fresh data
+      queryClient.invalidateQueries({
+        queryKey: basketQueries.basketState().queryKey,
+      })
     },
   })
 }
@@ -38,17 +30,14 @@ const useAddToBasket = () => {
  */
 const useClearBasket = () => {
   const queryClient = useQueryClient()
-  const isAuthenticated = useUserIsAuthenticated()
   return useMutation({
     mutationFn: async (): Promise<void> => {
       await basketsApi.basketsClearDestroy()
     },
     onSuccess: () => {
-      if (isAuthenticated) {
-        queryClient.invalidateQueries({
-          queryKey: basketQueries.basketState().queryKey,
-        })
-      }
+      queryClient.invalidateQueries({
+        queryKey: basketQueries.basketState().queryKey,
+      })
     },
   })
 }

--- a/frontends/api/src/mitxonline/test-utils/factories/baskets.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/baskets.ts
@@ -1,0 +1,42 @@
+import { faker } from "@faker-js/faker/locale/en"
+import invariant from "tiny-invariant"
+import type { BasketWithProduct } from "@mitodl/mitxonline-api-axios/v2"
+
+const isSet = (value: unknown) => value !== null && value !== undefined
+
+/**
+ * A basket owned by a signed-in user. See `anonymousBasket` for the other case:
+ * `user` and `anonymous_id` are mutually exclusive, and MITx Online enforces
+ * that with a database constraint (`basket_user_xor_anonymous_id`).
+ */
+const basket = (
+  overrides: Partial<BasketWithProduct> = {},
+): BasketWithProduct => {
+  const merged: BasketWithProduct = {
+    id: faker.number.int({ min: 1 }),
+    user: faker.number.int({ min: 1 }),
+    anonymous_id: null,
+    basket_items: [],
+    total_price: 0,
+    discounted_price: 0,
+    discounts: [],
+    ...overrides,
+  }
+  invariant(
+    isSet(merged.user) !== isSet(merged.anonymous_id),
+    "A basket has exactly one of `user` and `anonymous_id`. Use basket() for a signed-in user, anonymousBasket() otherwise.",
+  )
+  return merged
+}
+
+/**
+ * A basket built before the learner signed in. `anonymous_id` is a real UUID:
+ * MITx Online's handoff middleware parses it with `uuid.UUID()` and
+ * logs-and-ignores anything that doesn't.
+ */
+const anonymousBasket = (
+  overrides: Partial<BasketWithProduct> = {},
+): BasketWithProduct =>
+  basket({ user: null, anonymous_id: faker.string.uuid(), ...overrides })
+
+export { basket, anonymousBasket }

--- a/frontends/api/src/mitxonline/test-utils/factories/index.ts
+++ b/frontends/api/src/mitxonline/test-utils/factories/index.ts
@@ -8,6 +8,7 @@ import * as user from "./user"
 import * as requirements from "./requirements"
 import * as contracts from "./contracts"
 import * as orders from "./orders"
+import * as baskets from "./baskets"
 
 export {
   mitx as enrollment,
@@ -20,4 +21,5 @@ export {
   requirements,
   contracts,
   orders,
+  baskets,
 }

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -440,7 +440,7 @@ describe.each([
     const clearUrl = mitxonline.urls.baskets.clear()
     setMockResponse.delete(clearUrl, undefined)
     const basketUrl = mitxonline.urls.baskets.createFromProduct(productId)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxonline.factories.baskets.basket())
 
     renderWithProviders(<EnrolledCourseCard enrollment={enrollment} />)
     await user.click(
@@ -641,7 +641,7 @@ describe.each([
     const clearUrl = mitxonline.urls.baskets.clear()
     setMockResponse.delete(clearUrl, undefined)
     const basketUrl = mitxonline.urls.baskets.createFromProduct(productId)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxonline.factories.baskets.basket())
 
     renderWithProviders(
       <EnrolledCourseCard

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/EnrolledCourseCard.test.tsx
@@ -10,11 +10,7 @@ import {
 } from "@/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
-import {
-  makeRequest,
-  urls as learnUrls,
-  factories as learnFactories,
-} from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 import moment from "moment"
 import { EnrolledCourseCard } from "./EnrolledCourseCard"
@@ -23,17 +19,6 @@ const EnrollmentMode = {
   Audit: "audit",
   Verified: "verified",
 } as const
-
-// useAddToBasket/useClearBasket check Learn's own auth state (separate from
-// mitxonline's) before invalidating the checkout-payload query. File-scoped
-// (not per-describe) since several describe blocks below each have their own
-// tests that don't all route through setupUserApis.
-beforeEach(() => {
-  setMockResponse.get(
-    learnUrls.userMe.get(),
-    learnFactories.user.user({ is_authenticated: true }),
-  )
-})
 
 const setupUserApis = (
   overrides?: Parameters<typeof mitxonline.factories.user.user>[0],

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/HomeEnrollmentsDisplay.test.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/test-utils"
 import { HomeEnrollmentsDisplay } from "./HomeEnrollmentsDisplay"
 import * as mitxonline from "api/mitxonline-test-utils"
-import { urls as learnUrls, factories as learnFactories } from "api/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { setupEnrollments } from "./test-utils"
 import { faker } from "@faker-js/faker/locale/en"
@@ -38,17 +37,6 @@ const mockedUseFeatureFlagEnabled = jest
 
 describe("HomeEnrollmentsDisplay", () => {
   setupLocationMock()
-
-  // useAddToBasket/useClearBasket check Learn's own auth state (separate
-  // from mitxonline's) before invalidating the checkout-payload query. Set at
-  // the describe level since many tests here mock the rest of the user/
-  // enrollment APIs inline rather than through setupApis below.
-  beforeEach(() => {
-    setMockResponse.get(
-      learnUrls.userMe.get(),
-      learnFactories.user.user({ is_authenticated: true }),
-    )
-  })
 
   const setupApis = (includeExpired: boolean = true) => {
     const mitxOnlineUser = mitxonline.factories.user.user()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/OrganizationCards.test.tsx
@@ -348,7 +348,6 @@ describe("OrganizationCards", () => {
         name: "Test Organization",
         logo: undefined,
         slug: "org-test-org",
-        sso_organization_id: null,
         contracts: [
           mitxOnlineFactories.contracts.contract({
             id: 1,

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -530,7 +530,7 @@ describe("ProgramAsCourseCard", () => {
     const clearUrl = mitxonline.urls.baskets.clear()
     setMockResponse.delete(clearUrl, undefined)
     const basketUrl = mitxonline.urls.baskets.createFromProduct(product.id)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxonline.factories.baskets.basket())
 
     renderWithProviders(
       <ProgramAsCourseCard

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramAsCourseCard.test.tsx
@@ -7,11 +7,7 @@ import {
   user,
   within,
 } from "@/test-utils"
-import {
-  makeRequest,
-  urls as learnUrls,
-  factories as learnFactories,
-} from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
 import { ProgramAsCourseCard } from "./ProgramAsCourseCard"
 import { waitFor } from "@testing-library/react"
@@ -25,15 +21,6 @@ jest.mock("posthog-js/react")
 
 describe("ProgramAsCourseCard", () => {
   setupLocationMock()
-
-  // useAddToBasket/useClearBasket check Learn's own auth state (separate
-  // from mitxonline's) before invalidating the checkout-payload query.
-  beforeEach(() => {
-    setMockResponse.get(
-      learnUrls.userMe.get(),
-      learnFactories.user.user({ is_authenticated: true }),
-    )
-  })
 
   /**
    * Creates a ProgramAsCourseCard data set with:

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/ProgramEnrollmentDisplay.test.tsx
@@ -27,11 +27,7 @@ import {
 } from "@/test-utils"
 import { ProgramEnrollmentDisplay } from "./ProgramEnrollmentDisplay"
 import * as mitxonline from "api/mitxonline-test-utils"
-import {
-  makeRequest,
-  urls as learnUrls,
-  factories as learnFactories,
-} from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { faker } from "@faker-js/faker/locale/en"
 import invariant from "tiny-invariant"
@@ -43,15 +39,6 @@ const mockedUseFeatureFlagEnabled = jest
 
 describe("ProgramEnrollmentDisplay", () => {
   setupLocationMock()
-
-  // useAddToBasket/useClearBasket check Learn's own auth state (separate
-  // from mitxonline's) before invalidating the checkout-payload query.
-  beforeEach(() => {
-    setMockResponse.get(
-      learnUrls.userMe.get(),
-      learnFactories.user.user({ is_authenticated: true }),
-    )
-  })
 
   test("Filters to single program when programId is provided", async () => {
     const mitxOnlineUser = mitxonline.factories.user.user()

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -581,7 +581,7 @@ describe.each([
         const clearUrl = mitxonline.urls.baskets.clear()
         setMockResponse.delete(clearUrl, undefined)
         const basketUrl = mitxonline.urls.baskets.createFromProduct(product.id)
-        setMockResponse.post(basketUrl, { id: 1, items: [] })
+        setMockResponse.post(basketUrl, mitxonline.factories.baskets.basket())
 
         renderWithProviders(<UnenrolledCourseCard course={course} />)
 
@@ -793,7 +793,7 @@ describe.each([
       const clearUrl = mitxonline.urls.baskets.clear()
       setMockResponse.delete(clearUrl, undefined)
       const basketUrl = mitxonline.urls.baskets.createFromProduct(product.id)
-      setMockResponse.post(basketUrl, { id: 1, items: [] })
+      setMockResponse.post(basketUrl, mitxonline.factories.baskets.basket())
 
       renderWithProviders(
         <UnenrolledCourseCard

--- a/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/CoursewareDisplay/UnenrolledCourseCard.test.tsx
@@ -9,11 +9,7 @@ import {
   within,
 } from "@/test-utils"
 import * as mitxonline from "api/mitxonline-test-utils"
-import {
-  makeRequest,
-  urls as learnUrls,
-  factories as learnFactories,
-} from "api/test-utils"
+import { makeRequest } from "api/test-utils"
 import { faker } from "@faker-js/faker/locale/en"
 import moment from "moment"
 import { cartesianProduct } from "ol-test-utilities"
@@ -28,17 +24,6 @@ jest.mock("@/common/analytics/gtm", () => ({
 const mitxOnlineCourse = mitxonline.factories.courses.course
 
 const mitxUser = mitxonline.factories.user.user
-
-// useAddToBasket/useClearBasket check Learn's own auth state (separate from
-// mitxonline's) before invalidating the checkout-payload query. File-scoped
-// (not per-describe) since several describe blocks below each have their own
-// tests that don't all route through setupUserApis.
-beforeEach(() => {
-  setMockResponse.get(
-    learnUrls.userMe.get(),
-    learnFactories.user.user({ is_authenticated: true }),
-  )
-})
 
 const setupUserApis = (overrides?: Parameters<typeof mitxUser>[0]) => {
   const userData = mitxonline.factories.user.user({

--- a/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CourseEnrollArea.test.tsx
@@ -365,10 +365,10 @@ describe("CourseEnrollArea — click smoke tests", () => {
     const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
 
     setMockResponse.delete(mitxUrls.baskets.clear(), undefined)
-    setMockResponse.post(mitxUrls.baskets.createFromProduct(product.id), {
-      id: 1,
-      items: [],
-    })
+    setMockResponse.post(
+      mitxUrls.baskets.createFromProduct(product.id),
+      mitxFactories.baskets.basket(),
+    )
 
     renderWithProviders(<CourseEnrollArea course={course} selectedRun={run} />)
 

--- a/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/CoursePage.test.tsx
@@ -485,10 +485,10 @@ describe("CoursePage", () => {
         )
         setMockResponse.get(mitxUrls.enrollment.enrollmentsListV3(), [])
         setMockResponse.delete(mitxUrls.baskets.clear(), undefined)
-        setMockResponse.post(mitxUrls.baskets.createFromProduct(product.id), {
-          id: 1,
-          items: [],
-        })
+        setMockResponse.post(
+          mitxUrls.baskets.createFromProduct(product.id),
+          mitxFactories.baskets.basket(),
+        )
 
         renderWithProviders(<CoursePage readableId={course.readable_id} />)
 

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.test.tsx
@@ -12,6 +12,7 @@ import {
   factories as mitxFactories,
   urls as mitxUrls,
 } from "api/mitxonline-test-utils"
+import { mitxonlineLegacyUrl } from "@/common/mitxonline"
 import { useCourseEnrollment } from "./useCourseEnrollment"
 import type { EnrollActionKind } from "./useCourseEnrollment"
 import { getSelectedRun } from "./courseRun"
@@ -369,7 +370,7 @@ describe("useCourseEnrollment — actions", () => {
     const clearUrl = mitxUrls.baskets.clear()
     const basketUrl = mitxUrls.baskets.createFromProduct(product.id)
     setMockResponse.delete(clearUrl, undefined)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxFactories.baskets.basket())
 
     const { result } = renderHook(() => useCourseEnrollment(course, run), {
       wrapper,
@@ -569,8 +570,9 @@ describe("useCourseEnrollment — actions", () => {
     )
     const clearUrl = mitxUrls.baskets.clear()
     const basketUrl = mitxUrls.baskets.createFromProduct(product.id)
+    const anonymous = mitxFactories.baskets.anonymousBasket()
     setMockResponse.delete(clearUrl, undefined)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, anonymous)
 
     const onRequireSignup = jest.fn()
 
@@ -607,6 +609,18 @@ describe("useCourseEnrollment — actions", () => {
       expect.objectContaining({ method: "post", url: basketUrl }),
     )
     expect(onRequireSignup).not.toHaveBeenCalled()
+
+    // The anonymous basket's id comes back in the API response and has to reach
+    // MITx Online through the redirect URL: the session cookie that identifies
+    // the basket is host-only and cannot cross from Learn's API host to
+    // mitxonline's own domain.
+    const expectedUrl = new URL(mitxonlineLegacyUrl("/cart/"))
+    expectedUrl.searchParams.set("anonymous_basket_id", anonymous.anonymous_id!)
+    await waitFor(() =>
+      expect(window.location.assign).toHaveBeenCalledWith(
+        expectedUrl.toString(),
+      ),
+    )
   })
 
   test("unauthenticated paid click requires signup when the anonymous-checkout flag is off", async () => {
@@ -670,10 +684,10 @@ describe("useCourseEnrollment — actions", () => {
     const course = makeCourse({ next_run_id: run.id, courseruns: [run] })
 
     setMockResponse.delete(mitxUrls.baskets.clear(), undefined)
-    setMockResponse.post(mitxUrls.baskets.createFromProduct(product.id), {
-      id: 1,
-      items: [],
-    })
+    setMockResponse.post(
+      mitxUrls.baskets.createFromProduct(product.id),
+      mitxFactories.baskets.basket(),
+    )
 
     const { result } = renderHook(
       () =>

--- a/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useCourseEnrollment.ts
@@ -107,19 +107,12 @@ export const useCourseEnrollment = (
       }
       trackStartEnrollment(course.title)
       if (kind === "paid") {
-        // Paid checkout runs for anonymous users too. The basket and cart live
-        // on MITx Online, which supports anonymous baskets, so we hand off
-        // directly to checkout and defer account creation to the MITx Online
-        // flow (Review → Account → Verify → Payment).
         const product = selectedRun?.products?.[0]
         if (product) {
           trackBeginCheckout(course.title)
           replaceBasketItem.mutate(product.id)
         }
       } else if (kind === "free") {
-        // Free enrollment requires an account — there is no anonymous audit
-        // enrollment — so unauthenticated users are routed to signup first
-        // (handled by the guard above).
         if (selectedRun) {
           createEnrollment.mutate(
             { run_id: selectedRun.id },

--- a/frontends/main/src/app-pages/ProductPages/useProgramEnrollment.test.tsx
+++ b/frontends/main/src/app-pages/ProductPages/useProgramEnrollment.test.tsx
@@ -241,10 +241,10 @@ describe("useProgramEnrollment — actions", () => {
       products: [product],
     })
     setMockResponse.delete(mitxUrls.baskets.clear(), undefined)
-    setMockResponse.post(mitxUrls.baskets.createFromProduct(product.id), {
-      id: 1,
-      items: [],
-    })
+    setMockResponse.post(
+      mitxUrls.baskets.createFromProduct(product.id),
+      mitxFactories.baskets.basket(),
+    )
 
     const { result } = renderHook(
       () =>
@@ -374,7 +374,7 @@ describe("useProgramEnrollment — actions", () => {
     const clearUrl = mitxUrls.baskets.clear()
     const basketUrl = mitxUrls.baskets.createFromProduct(product.id)
     setMockResponse.delete(clearUrl, undefined)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxFactories.baskets.basket())
 
     const { result } = renderHook(() => useProgramEnrollment(program), {
       wrapper,
@@ -412,7 +412,7 @@ describe("useProgramEnrollment — actions", () => {
     const clearUrl = mitxUrls.baskets.clear()
     const basketUrl = mitxUrls.baskets.createFromProduct(product.id)
     setMockResponse.delete(clearUrl, undefined)
-    setMockResponse.post(basketUrl, { id: 1, items: [] })
+    setMockResponse.post(basketUrl, mitxFactories.baskets.basket())
 
     const onRequireSignup = jest.fn()
 

--- a/frontends/main/src/app-pages/ProductPages/useProgramEnrollment.ts
+++ b/frontends/main/src/app-pages/ProductPages/useProgramEnrollment.ts
@@ -90,18 +90,11 @@ export const useProgramEnrollment = (
         return
       }
       if (kind === "paid") {
-        // Paid checkout runs for anonymous users too. The basket and cart live
-        // on MITx Online, which supports anonymous baskets, so we hand off
-        // directly to checkout and defer account creation to the MITx Online
-        // flow (Review → Account → Verify → Payment).
         const product = program.products[0]
         if (product) {
           replaceBasketItem.mutate(product.id)
         }
       } else if (kind === "free") {
-        // Free enrollment requires an account — there is no anonymous program
-        // enrollment — so unauthenticated users are routed to signup first
-        // (handled by the guard above).
         createProgramEnrollment.mutate(
           { V3ProgramEnrollmentRequestRequest: { program_id: program.id } },
           {

--- a/frontends/main/src/common/mitxonline/useReplaceBasketItem.test.tsx
+++ b/frontends/main/src/common/mitxonline/useReplaceBasketItem.test.tsx
@@ -1,18 +1,10 @@
 import { act, renderHook, setupLocationMock } from "@/test-utils"
 import { mitxonlineLegacyUrl } from "@/common/mitxonline"
+import { factories as mitxFactories } from "api/mitxonline-test-utils"
 import type { BasketWithProduct } from "@mitodl/mitxonline-api-axios/v2"
 import { useReplaceBasketItem } from "./useReplaceBasketItem"
 
-const basket = (
-  overrides: Partial<BasketWithProduct> = {},
-): BasketWithProduct => ({
-  id: 7,
-  basket_items: [],
-  total_price: 0,
-  discounted_price: 0,
-  discounts: [],
-  ...overrides,
-})
+const { basket, anonymousBasket } = mitxFactories.baskets
 
 /**
  * `useAddToBasket().mutate` hands the created basket to `onSuccess` — the hook
@@ -122,8 +114,9 @@ describe("useReplaceBasketItem", () => {
 
   test("appends anonymous_basket_id to the redirect url for an anonymous basket (sync path)", () => {
     const assign = jest.mocked(window.location.assign)
+    const anonymous = anonymousBasket()
     mutate.mockImplementationOnce((_productId, opts) =>
-      opts?.onSuccess?.(basket({ id: 9, anonymous_id: "abc-123" })),
+      opts?.onSuccess?.(anonymous),
     )
     const { result } = renderHook(() => useReplaceBasketItem())
 
@@ -132,14 +125,15 @@ describe("useReplaceBasketItem", () => {
     })
 
     const calledUrl = new URL(assign.mock.calls[0][0])
-    expect(calledUrl.searchParams.get("anonymous_basket_id")).toBe("abc-123")
+    expect(calledUrl.searchParams.get("anonymous_basket_id")).toBe(
+      anonymous.anonymous_id,
+    )
   })
 
   test("appends anonymous_basket_id to the redirect url for an anonymous basket (async path)", async () => {
     const assign = jest.mocked(window.location.assign)
-    mutateAsync.mockResolvedValueOnce(
-      basket({ id: 9, anonymous_id: "abc-123" }),
-    )
+    const anonymous = anonymousBasket()
+    mutateAsync.mockResolvedValueOnce(anonymous)
     const { result } = renderHook(() => useReplaceBasketItem())
 
     await act(async () => {
@@ -147,21 +141,8 @@ describe("useReplaceBasketItem", () => {
     })
 
     const calledUrl = new URL(assign.mock.calls[0][0])
-    expect(calledUrl.searchParams.get("anonymous_basket_id")).toBe("abc-123")
-  })
-
-  test("does not append anonymous_basket_id when the basket belongs to a real user", () => {
-    const assign = jest.mocked(window.location.assign)
-    mutate.mockImplementationOnce((_productId, opts) =>
-      opts?.onSuccess?.(basket({ id: 9, user: 1, anonymous_id: null })),
+    expect(calledUrl.searchParams.get("anonymous_basket_id")).toBe(
+      anonymous.anonymous_id,
     )
-    const { result } = renderHook(() => useReplaceBasketItem())
-
-    act(() => {
-      result.current.mutate(42)
-    })
-
-    const calledUrl = new URL(assign.mock.calls[0][0])
-    expect(calledUrl.searchParams.has("anonymous_basket_id")).toBe(false)
   })
 })

--- a/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
@@ -7,12 +7,7 @@ import {
   user,
   setupLocationMock,
 } from "@/test-utils"
-import {
-  makeRequest,
-  setMockResponse,
-  urls as learnUrls,
-  factories as learnFactories,
-} from "api/test-utils"
+import { makeRequest, setMockResponse } from "api/test-utils"
 import {
   urls as mitxUrls,
   factories as mitxFactories,
@@ -66,15 +61,6 @@ describe("CourseEnrollmentDialog", () => {
   }
 
   setupLocationMock()
-
-  // useAddToBasket/useClearBasket check Learn's own auth state (separate
-  // from mitxonline's) before invalidating the checkout-payload query.
-  beforeEach(() => {
-    setMockResponse.get(
-      learnUrls.userMe.get(),
-      learnFactories.user.user({ is_authenticated: true }),
-    )
-  })
 
   describe("Course run dropdown", () => {
     test("Shows one entry for each enrollable course run", async () => {

--- a/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
+++ b/frontends/main/src/page-components/EnrollmentDialogs/CourseEnrollmentDialog.test.tsx
@@ -364,7 +364,7 @@ describe("CourseEnrollmentDialog", () => {
       const clearUrl = mitxUrls.baskets.clear()
       setMockResponse.delete(clearUrl, undefined)
       const basketUrl = mitxUrls.baskets.createFromProduct(product.id)
-      setMockResponse.post(basketUrl, { id: 1, items: [] })
+      setMockResponse.post(basketUrl, mitxFactories.baskets.basket())
 
       renderWithProviders(<div />)
       await openDialog(course)


### PR DESCRIPTION
Review follow-ups for #3709, split out so that PR's history stays readable.

Three changes: the basket checkout query is invalidated unconditionally again, the `anonymous_basket_id` handoff finally has a test that runs the real hook, and some comments and test overrides that restated the code are gone. The reasoning is in the commit messages.

### How can this be tested?

- `yarn test frontends/main/src/app-pages frontends/main/src/common/mitxonline`
- The new coverage is the "unauthenticated paid click" test in `useCourseEnrollment.test.tsx`. To confirm it isn't vacuous, delete the `url.searchParams.set("anonymous_basket_id", ...)` line in `useReplaceBasketItem.ts` — the test fails.
- Manually, with the `anonymous-checkout` flag on and logged out: click a paid CTA on a course page and confirm the redirect to mitxonline `/cart/` carries `?anonymous_basket_id=<uuid>` alongside `ecom-service=true`.
