### PR TITLE
feat(content_feedback): allow anonymous submissions

### DIFF
--- a/content_feedback/views.py
+++ b/content_feedback/views.py
@@ -2,7 +2,7 @@
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework.generics import CreateAPIView
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 
 from content_feedback.models import ContentFeedback
 from content_feedback.serializers import ContentFeedbackSerializer
@@ -18,14 +18,21 @@ from main.throttles import RedisScopedRateThrottle
     },
 )
 class ContentFeedbackView(CreateAPIView):
-    """Accept per-block content feedback submissions (append-only)."""
+    """Accept per-block content feedback submissions (append-only).
+
+    Anonymous submissions are allowed: courseware-only learners have no
+    mit-learn/APISIX session, so requiring authentication would reject nearly
+    all of them (403). This mirrors learn-ai/AskTIM, which tolerates anonymous
+    callers and stores no user. Attributed submissions still record the user.
+    """
 
     queryset = ContentFeedback.objects.all()
     serializer_class = ContentFeedbackSerializer
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (AllowAny,)
     throttle_classes = (RedisScopedRateThrottle,)
     throttle_scope = "content_feedback"
 
     def perform_create(self, serializer):
-        """Attribute the feedback to the authenticated user (server-side)."""
-        serializer.save(user=self.request.user)
+        """Attribute to the request user when authenticated, else store null."""
+        user = self.request.user if self.request.user.is_authenticated else None
+        serializer.save(user=user)

--- a/content_feedback/views.py
+++ b/content_feedback/views.py
@@ -20,10 +20,9 @@ from main.throttles import RedisScopedRateThrottle
 class ContentFeedbackView(CreateAPIView):
     """Accept per-block content feedback submissions (append-only).
 
-    Anonymous submissions are allowed: courseware-only learners have no
-    mit-learn/APISIX session, so requiring authentication would reject nearly
-    all of them (403). This mirrors learn-ai/AskTIM, which tolerates anonymous
-    callers and stores no user. Attributed submissions still record the user.
+    Uses AllowAny: courseware-only learners have no mit-learn/APISIX session,
+    so requiring auth would 403 nearly all of them. Authenticated rows record
+    the user; anonymous rows store null (mirrors learn-ai/AskTIM).
     """
 
     queryset = ContentFeedback.objects.all()

--- a/content_feedback/views.py
+++ b/content_feedback/views.py
@@ -18,15 +18,13 @@ from main.throttles import RedisScopedRateThrottle
     },
 )
 class ContentFeedbackView(CreateAPIView):
-    """Accept per-block content feedback submissions (append-only).
-
-    Uses AllowAny: courseware-only learners have no mit-learn/APISIX session,
-    so requiring auth would 403 nearly all of them. Authenticated rows record
-    the user; anonymous rows store null (mirrors learn-ai/AskTIM).
-    """
+    """Accept per-block content feedback submissions (append-only)."""
 
     queryset = ContentFeedback.objects.all()
     serializer_class = ContentFeedbackSerializer
+    # AllowAny: courseware-only learners have no mit-learn/APISIX session, so
+    # requiring auth would 403 nearly all of them. Authenticated rows record the
+    # user; anonymous rows store null (mirrors learn-ai/AskTIM).
     permission_classes = (AllowAny,)
     throttle_classes = (RedisScopedRateThrottle,)
     throttle_scope = "content_feedback"

--- a/content_feedback/views_test.py
+++ b/content_feedback/views_test.py
@@ -26,11 +26,12 @@ def _payload(**overrides):
     return payload
 
 
-def test_submit_requires_authentication(client):
-    """Anonymous users cannot submit feedback."""
+def test_submit_allows_anonymous(client):
+    """Anonymous users can submit feedback; the record has no user."""
     response = client.post(reverse("content_feedback:v0:content_feedback"), _payload())
-    assert response.status_code in (401, 403)
-    assert ContentFeedback.objects.count() == 0
+    assert response.status_code == 201
+    assert ContentFeedback.objects.count() == 1
+    assert ContentFeedback.objects.get().user is None
 
 
 def test_submit_creates_record_for_user(user_client, user):

--- a/content_feedback/views_test.py
+++ b/content_feedback/views_test.py
@@ -2,6 +2,7 @@
 
 import pytest
 from django.urls import reverse
+from rest_framework.test import APIClient
 
 from content_feedback.factories import ContentFeedbackFactory
 from content_feedback.models import ContentFeedback
@@ -26,12 +27,25 @@ def _payload(**overrides):
     return payload
 
 
-def test_submit_allows_anonymous(client):
-    """Anonymous users can submit feedback; the record has no user."""
+def test_submit_allows_anonymous():
+    """Anonymous users can submit without a CSRF token; the record has no user."""
+    # enforce_csrf_checks=True mirrors production SessionAuthentication: CSRF is
+    # only enforced for session-authenticated callers, so an anonymous POST with
+    # no token still succeeds.
+    client = APIClient(enforce_csrf_checks=True)
     response = client.post(reverse("content_feedback:v0:content_feedback"), _payload())
     assert response.status_code == 201
     assert ContentFeedback.objects.count() == 1
     assert ContentFeedback.objects.get().user is None
+
+
+def test_authenticated_without_csrf_token_rejected(user):
+    """A session-authenticated POST without a CSRF token is rejected (403)."""
+    client = APIClient(enforce_csrf_checks=True)
+    client.force_login(user)
+    response = client.post(reverse("content_feedback:v0:content_feedback"), _payload())
+    assert response.status_code == 403
+    assert ContentFeedback.objects.count() == 0
 
 
 def test_submit_creates_record_for_user(user_client, user):
@@ -120,7 +134,6 @@ def test_factory_builds_valid_record():
 def test_submit_rate_limited(user_client, mocker):
     """Exceeding the per-user rate returns 429; a different user is unaffected."""
     from django.core.cache.backends.locmem import LocMemCache
-    from rest_framework.test import APIClient
 
     from main.factories import UserFactory
     from main.throttles import RedisScopedRateThrottle
@@ -142,6 +155,8 @@ def test_submit_rate_limited(user_client, mocker):
     # The limit is keyed per authenticated user: a different user still gets
     # through even after the first user is throttled. (The user_client fixture
     # shares one APIClient, so build a distinct client for the second user.)
+    # NB: anonymous requests instead key on client IP, which is spoofable via
+    # X-Forwarded-For -- tracked as a follow-up (mitodl/hq#12775).
     other_client = APIClient()
     other_client.force_login(UserFactory.create())
     assert other_client.post(url, _payload()).status_code == 201

--- a/openapi/specs/v0.yaml
+++ b/openapi/specs/v0.yaml
@@ -147,6 +147,8 @@ paths:
             schema:
               $ref: '#/components/schemas/ContentFeedbackRequest'
         required: true
+      security:
+      - {}
       responses:
         '201':
           content:


### PR DESCRIPTION
### What are the relevant tickets?

Part of content feedback (mitodl/hq#11629). Addresses the courseware-learner `403`: courseware-only learners have no mit-learn/APISIX session, so the `IsAuthenticated` gate rejected nearly all of them with a `NotAuthenticated` 403 (before CSRF was ever checked).

### Description (What does it do?)

Switches `POST /api/v0/content_feedback/` from `IsAuthenticated` to `AllowAny`, and attributes the row to the request user only when authenticated (else stores `user=null`). This mirrors learn-ai/AskTIM's anonymous-tolerant posture.

- The `ContentFeedback.user` FK is already `null=True`, so **no migration** is required.
- With no authenticated user, DRF's `SessionAuthentication` returns `None`, so CSRF is not enforced on anonymous submissions.
- Session-bearing (authenticated) callers are unchanged: CSRF is still enforced for them — a session POST without an `X-CSRFToken` is rejected (`403`), covered by `test_authenticated_without_csrf_token_rejected`.

### Screenshots (if appropriate):
<img width="1505" height="590" alt="Screenshot 2026-08-07 at 2 52 21 PM" src="https://github.com/user-attachments/assets/f448418a-1aaa-4245-b255-4e42a3f14b84" />
<img width="1662" height="74" alt="Screenshot 2026-08-07 at 2 55 05 PM" src="https://github.com/user-attachments/assets/c3cc80ed-1349-42d4-87af-91f981a1a2b2" />



### How can this be tested?

**1. Automated**

```
docker compose run --rm web uv run pytest content_feedback/views_test.py -v
```

`test_submit_allows_anonymous` asserts an anonymous POST returns `201` and stores `user=None`; the authenticated tests confirm the row is still attributed to the request user.

**2. Anonymous — no session at all (the behavior this PR adds)**

The whole point of the change: a caller with **no auth and no CSRF** is now accepted. Post straight to the web container:

```bash
curl -s -w '\n--> HTTP %{http_code}\n' -X POST http://localhost:8061/api/v0/content_feedback/ \
  -H 'Content-Type: application/json' \
  -d '{"course_id":"course-v1:Test+Anon+2026","block_usage_key":"block-v1:demo+type@video+block@anon-'"$(date +%s)"'","sentiment":"positive","comment":"anon test"}'
```

Returns `--> HTTP 201`. Verify the stored row has no user:

```bash
docker compose run --rm web python manage.py shell -c \
  "from content_feedback.models import ContentFeedback as F; r=F.objects.filter(course_id='course-v1:Test+Anon+2026').latest('created_on'); print('user=', r.user, '| sentiment=', r.sentiment)"
# -> user= None | sentiment= positive
```

Before this PR the identical request returned `403 NotAuthenticated`.

**3. Authenticated submissions are still attributed (live through APISIX)**

Same as #3705 §2 — the real auth path. `docker compose up -d`, log in at `http://open.odl.local:8065/login` (complete Keycloak), then from the console on the `open.odl.local:8065` origin submit once:

```js
(async () => {
  const API = "http://open.odl.local:8065";
  const me = await fetch(`${API}/api/v0/users/me/`, { credentials: "include" });
  const authed = me.status === 200;
  console.log(authed ? "authed as: " + (await me.json()).username : "logged out (" + me.status + ")");
  const csrf = document.cookie.match(/(?:^|; )csrftoken-local=([^;]+)/)?.[1];
  const res = await fetch(`${API}/api/v0/content_feedback/`, {
    method: "POST",
    credentials: "include",
    headers: { "Content-Type": "application/json", ...(csrf ? { "X-CSRFToken": csrf } : {}) },
    body: JSON.stringify({
      course_id: "course-v1:MITx+6.00+2T2026",
      block_usage_key: "block-v1:MITx+type@video+block@abc123",
      sentiment: "idea",
      comment: "live test",
    }),
  });
  console.log("submit →", res.status); // 201
})();
```

Logged in → `201`, attributed to your user. Logged out → **also `201`** now (previously `403`), stored with `user=null`.

### Additional Context

