### PR TITLE
fix: add navbar for games

### DIFF
--- a/frontends/main/src/app/(site)/games/hacksnack/page.test.tsx
+++ b/frontends/main/src/app/(site)/games/hacksnack/page.test.tsx
@@ -18,7 +18,11 @@ jest.mock("./HacksnackFlagGate", () => ({
 
 describe("hacksnack page.tsx", () => {
   beforeEach(() => {
-    jest.resetAllMocks()
+    // clearAllMocks, not resetAllMocks: the latter strips implementations from
+    // every mock including the global window.IntersectionObserver stub in
+    // jest-shared-setup, which next/link needs to prefetch. Only call history
+    // needs clearing between these tests.
+    jest.clearAllMocks()
     mockHacksnackClient.mockReturnValue(
       <div data-testid="hacksnack-client">Hacksnack Client</div>,
     )

--- a/frontends/main/src/app/(site)/games/hacksnack/page.tsx
+++ b/frontends/main/src/app/(site)/games/hacksnack/page.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { Metadata } from "next"
 import { standardizeMetadata } from "@/common/metadata"
+import GameSubNav from "@/components/GameSubNav/GameSubNav"
 import HacksnackClient from "./HacksnackClient"
 import HacksnackFlagGate from "./HacksnackFlagGate"
 
@@ -12,6 +13,7 @@ const Page: React.FC = () => {
   const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY
   return (
     <HacksnackFlagGate>
+      <GameSubNav title="HackSnack" />
       <HacksnackClient googleMapsApiKey={googleMapsApiKey} />
     </HacksnackFlagGate>
   )

--- a/frontends/main/src/components/GameSubNav/GameSubNav.test.tsx
+++ b/frontends/main/src/components/GameSubNav/GameSubNav.test.tsx
@@ -1,21 +1,9 @@
 import React from "react"
-import { renderWithProviders, screen, user } from "@/test-utils"
+import { renderWithProviders, screen } from "@/test-utils"
 import GameSubNav from "./GameSubNav"
-
-jest.mock("next-nprogress-bar", () => ({
-  useRouter: jest.fn(),
-}))
-
-const mockBack = jest.fn()
-
-const { useRouter } = jest.requireMock("next-nprogress-bar")
-useRouter.mockReturnValue({ back: mockBack })
+import * as urls from "@/common/urls"
 
 describe("GameSubNav", () => {
-  beforeEach(() => {
-    mockBack.mockReset()
-  })
-
   test("shows the game's title as the page heading", () => {
     renderWithProviders(<GameSubNav title="HackSnack" />)
     expect(
@@ -23,9 +11,11 @@ describe("GameSubNav", () => {
     ).toBeInTheDocument()
   })
 
-  test("goes back when the back control is clicked", async () => {
+  test("links to the home page rather than popping history", () => {
     renderWithProviders(<GameSubNav title="HackSnack" />)
-    await user.click(screen.getByRole("button", { name: "Go back" }))
-    expect(mockBack).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole("link", { name: "Back to home" })).toHaveAttribute(
+      "href",
+      urls.HOME,
+    )
   })
 })

--- a/frontends/main/src/components/GameSubNav/GameSubNav.test.tsx
+++ b/frontends/main/src/components/GameSubNav/GameSubNav.test.tsx
@@ -1,0 +1,31 @@
+import React from "react"
+import { renderWithProviders, screen, user } from "@/test-utils"
+import GameSubNav from "./GameSubNav"
+
+jest.mock("next-nprogress-bar", () => ({
+  useRouter: jest.fn(),
+}))
+
+const mockBack = jest.fn()
+
+const { useRouter } = jest.requireMock("next-nprogress-bar")
+useRouter.mockReturnValue({ back: mockBack })
+
+describe("GameSubNav", () => {
+  beforeEach(() => {
+    mockBack.mockReset()
+  })
+
+  test("shows the game's title as the page heading", () => {
+    renderWithProviders(<GameSubNav title="HackSnack" />)
+    expect(
+      screen.getByRole("heading", { level: 1, name: "HackSnack" }),
+    ).toBeInTheDocument()
+  })
+
+  test("goes back when the back control is clicked", async () => {
+    renderWithProviders(<GameSubNav title="HackSnack" />)
+    await user.click(screen.getByRole("button", { name: "Go back" }))
+    expect(mockBack).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontends/main/src/components/GameSubNav/GameSubNav.tsx
+++ b/frontends/main/src/components/GameSubNav/GameSubNav.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import React from "react"
+// next-nprogress-bar wraps next/navigation's router so navigation drives the
+// site's progress bar; it is what the rest of the app uses.
+import { useRouter } from "next-nprogress-bar"
+import { styled, Typography } from "ol-components"
+import type { TypographyProps } from "ol-components"
+import { RiArrowLeftSLine } from "@remixicon/react"
+
+const Bar = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "16px 200px",
+  backgroundColor: theme.custom.colors.white,
+  boxShadow: "2px 2px 15px 0 rgba(0, 0, 0, 0.05)",
+  [theme.breakpoints.down("lg")]: {
+    padding: "16px 32px",
+  },
+  [theme.breakpoints.down("md")]: {
+    padding: "12px 16px",
+  },
+}))
+
+const BarInner = styled.div({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "100%",
+  maxWidth: "1272px",
+})
+
+const BackButton = styled.button({
+  display: "flex",
+  alignItems: "center",
+  flexShrink: 0,
+  boxSizing: "border-box",
+  width: "64px",
+  height: "32px",
+  padding: "0 16px",
+  border: "none",
+  background: "none",
+  cursor: "pointer",
+  color: "inherit",
+})
+
+/**
+ * Mirrors the back button's width so the title stays optically centred in the
+ * bar rather than in the space left over beside it.
+ */
+const BackButtonSpacer = styled.div({
+  flexShrink: 0,
+  width: "64px",
+  height: "32px",
+})
+
+const Title = styled(Typography)<Pick<TypographyProps, "component">>(
+  ({ theme }) => ({
+    flex: 1,
+    minWidth: 0,
+    textAlign: "center",
+    color: theme.custom.colors.black,
+  }),
+)
+
+type GameSubNavProps = {
+  /** The game's name, shown centred in the bar. */
+  title: string
+}
+
+/**
+ * The bar above a game: a back control, and the game's name centred in it.
+ */
+const GameSubNav: React.FC<GameSubNavProps> = ({ title }) => {
+  const router = useRouter()
+  return (
+    <Bar>
+      <BarInner>
+        <BackButton
+          type="button"
+          aria-label="Go back"
+          onClick={() => router.back()}
+        >
+          <RiArrowLeftSLine size={32} aria-hidden />
+        </BackButton>
+        <Title variant="h3" component="h1">
+          {title}
+        </Title>
+        <BackButtonSpacer aria-hidden />
+      </BarInner>
+    </Bar>
+  )
+}
+
+export default GameSubNav

--- a/frontends/main/src/components/GameSubNav/GameSubNav.tsx
+++ b/frontends/main/src/components/GameSubNav/GameSubNav.tsx
@@ -1,12 +1,11 @@
 "use client"
 
 import React from "react"
-// next-nprogress-bar wraps next/navigation's router so navigation drives the
-// site's progress bar; it is what the rest of the app uses.
-import { useRouter } from "next-nprogress-bar"
+import Link from "next/link"
 import { styled, Typography } from "ol-components"
 import type { TypographyProps } from "ol-components"
 import { RiArrowLeftSLine } from "@remixicon/react"
+import * as urls from "@/common/urls"
 
 const Bar = styled.div(({ theme }) => ({
   display: "flex",
@@ -31,7 +30,7 @@ const BarInner = styled.div({
   maxWidth: "1272px",
 })
 
-const BackButton = styled.button({
+const BackLink = styled(Link)({
   display: "flex",
   alignItems: "center",
   flexShrink: 0,
@@ -39,17 +38,14 @@ const BackButton = styled.button({
   width: "64px",
   height: "32px",
   padding: "0 16px",
-  border: "none",
-  background: "none",
-  cursor: "pointer",
   color: "inherit",
 })
 
 /**
- * Mirrors the back button's width so the title stays optically centred in the
+ * Mirrors the back link's width so the title stays optically centred in the
  * bar rather than in the space left over beside it.
  */
-const BackButtonSpacer = styled.div({
+const BackLinkSpacer = styled.div({
   flexShrink: 0,
   width: "64px",
   height: "32px",
@@ -70,24 +66,22 @@ type GameSubNavProps = {
 }
 
 /**
- * The bar above a game: a back control, and the game's name centred in it.
+ * The bar above a game: a link out of it, and the game's name centred in it.
+ *
+ * The link goes to a fixed destination rather than popping history, so that it
+ * still leads somewhere sensible when the game is opened directly by URL.
  */
 const GameSubNav: React.FC<GameSubNavProps> = ({ title }) => {
-  const router = useRouter()
   return (
     <Bar>
       <BarInner>
-        <BackButton
-          type="button"
-          aria-label="Go back"
-          onClick={() => router.back()}
-        >
+        <BackLink href={urls.HOME} aria-label="Back to home">
           <RiArrowLeftSLine size={32} aria-hidden />
-        </BackButton>
+        </BackLink>
         <Title variant="h3" component="h1">
           {title}
         </Title>
-        <BackButtonSpacer aria-hidden />
+        <BackLinkSpacer aria-hidden />
       </BarInner>
     </Bar>
   )

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "resolutions": {
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "video.js": "^8.23.7"
+    "video.js": "^8.23.7",
+    "@mitodl/hacksnack": "https://github.com/mitodl/hacksnack.git#aq/board-design"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3341,9 +3341,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/hacksnack@npm:^0.1.0":
+"@mitodl/hacksnack@https://github.com/mitodl/hacksnack.git#aq/board-design":
   version: 0.1.0
-  resolution: "@mitodl/hacksnack@npm:0.1.0"
+  resolution: "@mitodl/hacksnack@https://github.com/mitodl/hacksnack.git#commit=a582249d2f5d6b969932be0462c27fff8c198d21"
   dependencies:
     pdfjs-dist: "npm:^5.7.284"
   peerDependencies:
@@ -3352,8 +3352,8 @@ __metadata:
     react: ">=18"
     react-dom: ">=18"
   bin:
-    hacksnack-copy-assets: scripts/copy-assets.mjs
-  checksum: 10/2cd1aca16d5b7a803e469e99c774cfb385662e94760cc2a9a34e58e0b5f93d9d11275756f9d7ba1c819acf298f01196edf0d2d3be296ecb133955b144d447767
+    hacksnack-copy-assets: ./scripts/copy-assets.mjs
+  checksum: 10/be6abf127ef8ef6d3af43f073fa0b6990793260450b13574d9c8470918605a2599bf8a28c6a46bfd070bab93f9dc33be393e87eb96d64200e0e098d414ed1cf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12717

### Description (What does it do?)
- We are implemented cleaner design for hacksnack game for better user experience  

### Screenshots (if appropriate):
<img width="2880" height="2796" alt="image" src="https://github.com/user-attachments/assets/cce3a45b-f3d2-447c-9621-9db9fd551a91" />
<img width="2880" height="3877" alt="image" src="https://github.com/user-attachments/assets/5efdd580-c2f0-45e4-acbf-bac3f73a03f1" />




### How can this be tested?
For testing you need to install hacksnack dependency in learn and then run `yarn run dev` for running the game locally and then run the learn app using the following command `yarn run workspace dev` and then visit the following url `http://open.odl.local:8062/games/hacksnack#/demo?date=5-20-2026`

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
