### PR TITLE
passing canvas_course_ids to scheduled celery task

### DIFF
--- a/learning_resources/tasks.py
+++ b/learning_resources/tasks.py
@@ -610,11 +610,13 @@ def ingest_edx_run_archive(
 
 
 @app.task(acks_late=True)
-def sync_canvas_courses(canvas_course_ids, overwrite):
+def sync_canvas_courses(canvas_course_ids=None, overwrite=False):  # noqa: FBT002
     """
     Sync all canvas course files
 
     Args:
+        canvas_course_ids (list or None): If set, sync only these canvas course
+            ids. If None, sync every course and unpublish stale ones.
         overwrite (bool): Whether to overwrite existing content files
     """
 

--- a/main/settings_celery.py
+++ b/main/settings_celery.py
@@ -136,7 +136,7 @@ CELERY_BEAT_SCHEDULE = (
             "schedule": crontab(
                 minute=0, hour=5, day_of_week=0
             ),  # 12:00 PM EST on Sundays
-            "kwargs": {"overwrite": False},
+            "kwargs": {"canvas_course_ids": None, "overwrite": False},
         },
         "update_posthog_events": {
             "task": "learning_resources.tasks.get_learning_resource_views",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12793
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR resolves an issue where a signature mismatch with learning_resources.sync_canvas_courses caused the weekly scheduled task to fail


### How can this be tested?
1. checkout main
2. in settings_celery.py find the "sync_canvas_courses-every-1-weeks" entry and set it to the following (so it tries running every minute):
```
"sync_canvas_courses-every-1-weeks": {
            "task": "learning_resources.tasks.sync_canvas_courses",
            "schedule": crontab(minute="*/1"),
            "kwargs": {"overwrite": False},
        },
```
3. set CELERY_BEAT_DISABLED = False (in the same file)
4. restart celery and note that the task continuously fails with `celery.beat.SchedulingError: Couldn't apply scheduled task sync_canvas_courses-every-1-weeks: sync_canvas_courses() missing 1 required positional argument: 'canvas_course_ids'`
5. checkout this branch and set the above settings once again, restart celery and see the task executes.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
