### PR TITLE
fix(content_feedback): prevent anonymous rate-limit bypass via spoofed X-Forwarded-For

### DIFF
--- a/content_feedback/views_test.py
+++ b/content_feedback/views_test.py
@@ -155,8 +155,42 @@ def test_submit_rate_limited(user_client, mocker):
     # The limit is keyed per authenticated user: a different user still gets
     # through even after the first user is throttled. (The user_client fixture
     # shares one APIClient, so build a distinct client for the second user.)
-    # NB: anonymous requests instead key on client IP, which is spoofable via
-    # X-Forwarded-For -- tracked as a follow-up (mitodl/hq#12775).
     other_client = APIClient()
     other_client.force_login(UserFactory.create())
     assert other_client.post(url, _payload()).status_code == 201
+
+
+def test_anonymous_throttle_ignores_spoofed_xff(mocker):
+    """A rotating client-supplied X-Forwarded-For cannot bypass the anon limit.
+
+    Anonymous requests key on the real client IP, which our infrastructure
+    (APISIX + nginx = NUM_PROXIES hops) appends to X-Forwarded-For. A client can
+    prepend anything to that header, so the throttle must ignore the spoofable
+    left side and key on the trusted entry (mitodl/hq#12775).
+    """
+    from django.core.cache.backends.locmem import LocMemCache
+
+    from main.throttles import RedisScopedRateThrottle
+
+    mocker.patch.object(
+        RedisScopedRateThrottle, "cache", LocMemCache("throttle-test", {})
+    )
+    mocker.patch.object(
+        RedisScopedRateThrottle, "THROTTLE_RATES", {"content_feedback": "2/min"}
+    )
+
+    url = reverse("content_feedback:v0:content_feedback")
+    client = APIClient(enforce_csrf_checks=True)
+
+    # Same real client (203.0.113.5) and trusted proxy (10.0.0.1); only the
+    # spoofable, client-controlled left entry rotates. All three share a bucket.
+    def post(spoofed_ip):
+        return client.post(
+            url,
+            _payload(),
+            HTTP_X_FORWARDED_FOR=f"{spoofed_ip}, 203.0.113.5, 10.0.0.1",
+        )
+
+    assert post("9.9.9.1").status_code == 201
+    assert post("9.9.9.2").status_code == 201
+    assert post("9.9.9.3").status_code == 429

--- a/content_feedback/views_test.py
+++ b/content_feedback/views_test.py
@@ -161,12 +161,13 @@ def test_submit_rate_limited(user_client, mocker):
 
 
 def test_anonymous_throttle_ignores_spoofed_xff(mocker):
-    """A rotating client-supplied X-Forwarded-For cannot bypass the anon limit.
+    """The anon throttle keys on the trusted client IP, not the spoofable header.
 
-    Anonymous requests key on the real client IP, which our infrastructure
-    (APISIX + nginx = NUM_PROXIES hops) appends to X-Forwarded-For. A client can
-    prepend anything to that header, so the throttle must ignore the spoofable
-    left side and key on the trusted entry (mitodl/hq#12775).
+    Our infrastructure (APISIX + nginx = NUM_PROXIES hops) appends the real
+    client IP to X-Forwarded-For; a client can prepend anything to the left. So
+    the throttle must key on the trusted entry (2nd from the right), which means
+    both: rotating the spoofable left side cannot bypass the limit, and a
+    genuinely different client still gets its own bucket (mitodl/hq#12775).
     """
     from django.core.cache.backends.locmem import LocMemCache
 
@@ -182,15 +183,22 @@ def test_anonymous_throttle_ignores_spoofed_xff(mocker):
     url = reverse("content_feedback:v0:content_feedback")
     client = APIClient(enforce_csrf_checks=True)
 
-    # Same real client (203.0.113.5) and trusted proxy (10.0.0.1); only the
-    # spoofable, client-controlled left entry rotates. All three share a bucket.
-    def post(spoofed_ip):
+    # XFF shape mirrors prod: "<client-controlled>, <real client>, <trusted
+    # proxy>". NUM_PROXIES=2 keys on the real client (2nd from the right).
+    def post(spoofed_ip, real_client="203.0.113.5"):
         return client.post(
             url,
             _payload(),
-            HTTP_X_FORWARDED_FOR=f"{spoofed_ip}, 203.0.113.5, 10.0.0.1",
+            HTTP_X_FORWARDED_FOR=f"{spoofed_ip}, {real_client}, 10.0.0.1",
         )
 
+    # Rotating only the spoofable left entry does not mint new buckets: the one
+    # trusted client keys all three, so the third request is throttled.
     assert post("9.9.9.1").status_code == 201
     assert post("9.9.9.2").status_code == 201
     assert post("9.9.9.3").status_code == 429
+
+    # A genuinely different client (different 2nd-from-right entry) gets a fresh
+    # bucket. This distinguishes correct keying from a constant peer/proxy
+    # address, which would instead collapse every client into the bucket above.
+    assert post("9.9.9.9", real_client="203.0.113.9").status_code == 201

--- a/main/settings.py
+++ b/main/settings.py
@@ -649,6 +649,12 @@ REST_FRAMEWORK = {
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.NamespaceVersioning",
     "ALLOWED_VERSIONS": ["v0", "v1"],
     "ORDERING_PARAM": "sortby",
+    # Trusted reverse-proxy hops in front of the app (APISIX + nginx). Anonymous
+    # throttles identify the client via the Nth-from-last X-Forwarded-For entry;
+    # without this DRF keys on the whole header, which a client can spoof to
+    # bypass the limit (mitodl/hq#12775). nginx appends, so only the rightmost
+    # NUM_PROXIES entries are added by our infrastructure and can be trusted.
+    "NUM_PROXIES": get_int("NUM_PROXIES", 2),
     "DEFAULT_THROTTLE_RATES": {
         # Rate format is "<count>/<period>" (e.g. "10/min", "30/hour"); a blank
         # env value -> "" or None -> None -> throttle is a no-op (kill switch).


### PR DESCRIPTION
### What are the relevant tickets?

Fixes mitodl/hq#12775. Follow-up to #3738 (anonymous content-feedback submissions), part of mitodl/hq#11629.

### Description (What does it do?)

The `content_feedback` rate throttle keys anonymous requests by client IP via DRF's `get_ident`. With `NUM_PROXIES` unset, DRF keys on the **entire** `X-Forwarded-For` header — and our nginx *appends* to that header (`config/nginx.conf.erb`), so a client can prepend arbitrary values and rotate them to bypass the limit.

This sets `NUM_PROXIES = 2` in `REST_FRAMEWORK` (the trusted hops in front of the app: **APISIX + nginx**, confirmed with DevOps). DRF then reads the real client from the trusted, infra-appended entry (2nd from the right) instead of the spoofable left side. Kept env-overridable (`get_int("NUM_PROXIES", 2)`) in case the topology changes.

Now the sole guard on the open anonymous write endpoint actually holds.

### Screenshot?
<img width="989" height="589" alt="Screenshot 2026-08-11 at 3 14 58 PM" src="https://github.com/user-attachments/assets/539e2843-e937-49d4-b8e6-d51cb8b4ff28" />


### How can this be tested?

**1. Automated**

```
docker compose run --rm web uv run pytest content_feedback/views_test.py -v
```

`test_anonymous_throttle_ignores_spoofed_xff` rotates the client-controlled left entry of `X-Forwarded-For` while keeping the trusted suffix fixed and asserts the third request over a `2/min` limit is `429`. It **fails on `main`** (all `201` — bypass) and passes with this change.

**2. Manual (mirrors the local repro from mitodl/mit-learn#3738 review)**

Drop the limit so it's easy to trip, then restart web:

```bash
echo 'CONTENT_FEEDBACK_THROTTLE_RATE=2/min' >> env/backend.local.env
docker compose up -d web
```

Post straight to the web container (no proxy locally, so `curl` controls the whole header). Emulate the prod chain `<spoofed>, <real-client>, <apisix>` and rotate only the spoofable left entry:

```bash
for i in 1 2 3; do
  curl -s -o /dev/null -w "spoof #$i -> %{http_code}\n" \
    -X POST http://localhost:8061/api/v0/content_feedback/ \
    -H 'Content-Type: application/json' \
    -H "X-Forwarded-For: 9.9.9.$i, 203.0.113.5, 10.0.0.1" \
    -d '{"course_id":"course-v1:Test+XFF+2026","block_usage_key":"block-v1:demo+type@video+block@x","sentiment":"positive","comment":"xff test"}'
done
```

- **This branch →** `201, 201, 429`. Rotating the spoof no longer mints a new bucket; the trusted `203.0.113.5` keys all three.
- **See the old bypass →** set `NUM_PROXIES=99` in `env/backend.local.env` (trusts the spoofable left entry) and re-run → `201, 201, 201`, matching Matt's reproduction on `main`.

Re-running within the same minute reuses the bucket — bump the real-client IP (`203.0.113.6`) or wait 60s for a clean pass.