### PR TITLE
Sitemap fix, 1 of 2: Add canonical_parent_ids and resource_type to the summary endpoint

### DIFF
--- a/frontends/api/src/generated/v1/api.ts
+++ b/frontends/api/src/generated/v1/api.ts
@@ -4966,7 +4966,75 @@ export interface LearningResourceSummary {
    * @memberof LearningResourceSummary
    */
   title: string
+  /**
+   *
+   * @type {LearningResourceSummaryResourceTypeEnum}
+   * @memberof LearningResourceSummary
+   */
+  resource_type: LearningResourceSummaryResourceTypeEnum
+  /**
+   * Ids of the parents that form part of this resource\'s URL: the parent podcasts of a podcast episode, the playlists of a video. Empty for every other resource type. Parents are not filtered by `published`, so an id here may belong to a resource this endpoint will not return.
+   * @type {Array<number>}
+   * @memberof LearningResourceSummary
+   */
+  canonical_parent_ids: Array<number>
 }
+
+/**
+ * * `course` - Course * `program` - Program * `learning_path` - Learning Path * `podcast` - Podcast * `podcast_episode` - Podcast Episode * `video` - Video * `video_playlist` - Video Playlist * `document` - Document
+ * @export
+ * @enum {string}
+ */
+
+export const LearningResourceSummaryResourceTypeEnumDescriptions = {
+  course: "Course",
+  program: "Program",
+  learning_path: "Learning Path",
+  podcast: "Podcast",
+  podcast_episode: "Podcast Episode",
+  video: "Video",
+  video_playlist: "Video Playlist",
+  document: "Document",
+} as const
+
+export const LearningResourceSummaryResourceTypeEnum = {
+  /**
+   * Course
+   */
+  Course: "course",
+  /**
+   * Program
+   */
+  Program: "program",
+  /**
+   * Learning Path
+   */
+  LearningPath: "learning_path",
+  /**
+   * Podcast
+   */
+  Podcast: "podcast",
+  /**
+   * Podcast Episode
+   */
+  PodcastEpisode: "podcast_episode",
+  /**
+   * Video
+   */
+  Video: "video",
+  /**
+   * Video Playlist
+   */
+  VideoPlaylist: "video_playlist",
+  /**
+   * Document
+   */
+  Document: "document",
+} as const
+
+export type LearningResourceSummaryResourceTypeEnum =
+  (typeof LearningResourceSummaryResourceTypeEnum)[keyof typeof LearningResourceSummaryResourceTypeEnum]
+
 /**
  * Serializer for LearningResourceTopic model
  * @export

--- a/frontends/api/src/test-utils/factories/learningResources.ts
+++ b/frontends/api/src/test-utils/factories/learningResources.ts
@@ -371,6 +371,8 @@ const learningResourceSummary: LearningResourceFactory<
     last_modified: faker.date.recent().toISOString(),
     url: faker.internet.url(),
     title: faker.lorem.words(3),
+    resource_type: learningResourceType(),
+    canonical_parent_ids: [],
     ...overrides,
   }
 }

--- a/learning_resources/constants.py
+++ b/learning_resources/constants.py
@@ -126,6 +126,17 @@ class LearningResourceRelationTypes(TextChoices):
     COURSE_LEARNING_MATERIALS = "COURSE_LEARNING_MATERIALS", "Course Learning Materials"
 
 
+# Relation types whose parent forms part of the child's URL. A resource's type
+# admits only one of them, so they can be read as a single list.
+CANONICAL_PARENT_RELATION_TYPES = (
+    LearningResourceRelationTypes.PODCAST_EPISODES.value,
+    LearningResourceRelationTypes.PLAYLIST_VIDEOS.value,
+)
+
+# Feeds Meta.ordering, so changing it needs a migration.
+RELATIONSHIP_ORDERING = ("position", "id")
+
+
 GROUP_STAFF_LISTS_EDITORS = "learning_path_editors"
 
 

--- a/learning_resources/models.py
+++ b/learning_resources/models.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Optional
 
 from django.conf import settings
+from django.contrib.postgres.expressions import ArraySubquery
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import (
@@ -343,6 +344,25 @@ class LearningResourceInstructor(TimestampedModel):
 class LearningResourceQuerySet(TimestampedModelQuerySet):
     """QuerySet for LearningResource"""
 
+    def with_canonical_parent_ids(self):
+        """
+        Annotate each resource's URL-forming parent ids; `[]` if it has none.
+
+        A correlated subquery rather than an aggregate, so the outer query
+        needs no GROUP BY. It runs per row scanned rather than per row
+        returned, so deep pages pay for the rows they skip.
+        """
+        return self.annotate(
+            canonical_parent_ids=ArraySubquery(
+                LearningResourceRelationship.objects.filter(
+                    child=OuterRef("pk"),
+                    relation_type__in=constants.CANONICAL_PARENT_RELATION_TYPES,
+                )
+                .order_by(*constants.RELATIONSHIP_ORDERING)
+                .values("parent_id")
+            )
+        )
+
     def for_serialization(self):
         """Return the list of prefetches"""
         return self.prefetch_related(
@@ -374,14 +394,16 @@ class LearningResourceQuerySet(TimestampedModelQuerySet):
                 "parents",
                 queryset=LearningResourceRelationship.objects.filter(
                     relation_type=LearningResourceRelationTypes.PODCAST_EPISODES.value,
-                ).select_related("parent"),
+                )
+                .select_related("parent")
+                .order_by(*constants.RELATIONSHIP_ORDERING),
                 to_attr="_podcasts",
             ),
             Prefetch(
                 "parents",
                 queryset=LearningResourceRelationship.objects.filter(
                     relation_type=LearningResourceRelationTypes.PLAYLIST_VIDEOS.value,
-                ),
+                ).order_by(*constants.RELATIONSHIP_ORDERING),
                 to_attr="_playlists",
             ),
             Prefetch(
@@ -1053,7 +1075,7 @@ class LearningResourceRelationshipQuerySet(TimestampedModelQuerySet):
                 relation_type=LearningResourceRelationTypes.LEARNING_PATH_ITEMS.value,
                 child__published=False,
             )
-            .order_by("position", "id")
+            .order_by(*constants.RELATIONSHIP_ORDERING)
         )
 
 
@@ -1080,7 +1102,7 @@ class LearningResourceRelationship(TimestampedModel):
     objects = LearningResourceRelationshipQuerySet.as_manager()
 
     class Meta:
-        ordering = ["position", "id"]
+        ordering = list(constants.RELATIONSHIP_ORDERING)
 
 
 class ContentFileQuerySet(TimestampedModelQuerySet):

--- a/learning_resources/serializers.py
+++ b/learning_resources/serializers.py
@@ -1883,8 +1883,34 @@ class LearningResourceSummarySerializer(serializers.ModelSerializer):
     for sitemap generation and other use cases requiring minimal data transfer.
     """
 
+    canonical_parent_ids = serializers.SerializerMethodField()
+
+    @extend_schema_field(
+        {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": (
+                "Ids of the parents that form part of this resource's URL: the "
+                "parent podcasts of a podcast episode, the playlists of a video. "
+                "Empty for every other resource type. Parents are not filtered "
+                "by `published`, so an id here may belong to a resource this "
+                "endpoint will not return."
+            ),
+        }
+    )
+    def get_canonical_parent_ids(self, instance) -> list[int]:
+        """Ids of the parents that form part of this resource's URL."""
+        return instance.canonical_parent_ids
+
     class Meta:
         """Meta configuration for LearningResourceSummarySerializer"""
 
         model = models.LearningResource
-        fields = ("id", "last_modified", "url", "title")
+        fields = (
+            "id",
+            "last_modified",
+            "url",
+            "title",
+            "resource_type",
+            "canonical_parent_ids",
+        )

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -202,7 +202,7 @@ class SummaryPagination(LargePagination):
     """
 
     def get_count(self, queryset):
-        """Count distinct pks, which the annotations play no part in"""
+        """Count distinct pks; .values() drops the annotation, .only() would not"""
         return queryset.values(*self.count_fields).distinct().count()
 
 

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -192,6 +192,20 @@ class BaseLearningResourceViewSet(viewsets.ReadOnlyModelViewSet):
         return super().list(request, *args, **kwargs)
 
 
+class SummaryPagination(LargePagination):
+    """
+    LargePagination that keeps annotations out of the count query.
+
+    Django keeps annotations in the count of a distinct queryset, so
+    canonical_parent_ids would be evaluated once per row counted. Counting
+    distinct pks is the same number for a fraction of the work.
+    """
+
+    def get_count(self, queryset):
+        """Count distinct pks, which the annotations play no part in"""
+        return queryset.values(*self.count_fields).distinct().count()
+
+
 @extend_schema_view(
     list=extend_schema(
         description="Get a paginated list of learning resources.",
@@ -337,7 +351,15 @@ class LearningResourceViewSet(
         detail=False,
         methods=["GET"],
         name="Get learning resources summary",
-        pagination_class=LargePagination,
+        pagination_class=SummaryPagination,
+    )
+    @method_decorator(
+        # no timeout: REDIS_VIEW_CACHE_DURATION is then read per request, so
+        # setting it to 0 disables this cache
+        cache_page_for_anonymous_users(
+            cache="redis",
+            key_prefix="learning_resources_summary",
+        )
     )
     def summary(self, request, **kwargs):  # noqa: ARG002
         """
@@ -351,7 +373,9 @@ class LearningResourceViewSet(
             # we don't use `self.get_queryset()` here because there are incomplatible
             # `select_related()` invocations and we don't need related data anyway
             LearningResource.objects.filter(published=True)
-            .only("id", "last_modified", "url", "title")
+            # a deferred field the serializer reads costs a query per row
+            .only("id", "last_modified", "url", "title", "resource_type")
+            .with_canonical_parent_ids()
             .distinct()
             # Deterministic order so offset pagination has stable page
             # boundaries.

--- a/learning_resources/views.py
+++ b/learning_resources/views.py
@@ -353,14 +353,6 @@ class LearningResourceViewSet(
         name="Get learning resources summary",
         pagination_class=SummaryPagination,
     )
-    @method_decorator(
-        # no timeout: REDIS_VIEW_CACHE_DURATION is then read per request, so
-        # setting it to 0 disables this cache
-        cache_page_for_anonymous_users(
-            cache="redis",
-            key_prefix="learning_resources_summary",
-        )
-    )
     def summary(self, request, **kwargs):  # noqa: ARG002
         """
         Get learning resources summary data.

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -26,6 +26,7 @@ from learning_resources.exceptions import WebhookException
 from learning_resources.factories import (
     ContentFileFactory,
     CourseFactory,
+    LearningPathFactory,
     LearningResourceDepartmentFactory,
     LearningResourceFactory,
     LearningResourceOfferorFactory,
@@ -41,6 +42,7 @@ from learning_resources.factories import (
     VideoPlaylistFactory,
 )
 from learning_resources.models import (
+    LearningResource,
     LearningResourceOfferor,
     LearningResourceRelationship,
     PodcastEpisode,
@@ -1545,6 +1547,8 @@ def test_learning_resources_summary_listing_endpoint(django_assert_num_queries, 
             "last_modified": lr.last_modified.isoformat().replace("+00:00", "Z"),
             "url": lr.url,
             "title": lr.title,
+            "resource_type": lr.resource_type,
+            "canonical_parent_ids": [],
         }
         for lr in published
     ] == sorted(resp.data.get("results"), key=lambda x: int(x["id"]))
@@ -1599,6 +1603,163 @@ def test_learning_resources_summary_includes_stored_url(client):
 
     assert by_id[mitx_course.id]["url"] == mitx_learn_url
     assert by_id[edx_course.id]["url"] == edx_url
+
+
+def _relate(parent, child, relation_type, position):
+    """Attach child to parent at an explicit position."""
+    return LearningResourceRelationship.objects.create(
+        parent=parent, child=child, relation_type=relation_type, position=position
+    )
+
+
+def _summary_by_id(client):
+    """Map the summary endpoint's results by resource id."""
+    resp = client.get(reverse("lr:v1:learning_resources_api-summary"))
+    return {item["id"]: item for item in resp.data["results"]}
+
+
+def test_summary_canonical_parent_ids_match_detail_endpoint_for_video(client):
+    """
+    A video's canonical_parent_ids must equal detail's `playlists`, in order.
+    Positions are the reverse of creation order, so ordering by id fails this.
+    """
+    video = VideoFactory.create().learning_resource
+    first_created = VideoPlaylistFactory.create().learning_resource
+    second_created = VideoPlaylistFactory.create().learning_resource
+    relation = LearningResourceRelationTypes.PLAYLIST_VIDEOS.value
+    _relate(first_created, video, relation, position=1)
+    _relate(second_created, video, relation, position=0)
+
+    detail = client.get(
+        reverse("lr:v1:learning_resources_api-detail", args=[video.id])
+    ).data
+
+    assert detail["playlists"] == [second_created.id, first_created.id]
+    assert (
+        _summary_by_id(client)[video.id]["canonical_parent_ids"]
+        == (detail["playlists"])
+    )
+
+
+def test_summary_canonical_parent_ids_match_detail_endpoint_for_episode(client):
+    """
+    An episode's canonical_parent_ids must equal detail's nested podcasts.
+    Positions are equal here because ETL never sets one, which is the shape
+    production actually has.
+    """
+    episode = PodcastEpisodeFactory.create().learning_resource
+    first_created = PodcastFactory.create(episodes=[]).learning_resource
+    second_created = PodcastFactory.create(episodes=[]).learning_resource
+    relation = LearningResourceRelationTypes.PODCAST_EPISODES.value
+    _relate(first_created, episode, relation, position=0)
+    _relate(second_created, episode, relation, position=0)
+
+    detail = client.get(
+        reverse("lr:v1:learning_resources_api-detail", args=[episode.id])
+    ).data
+
+    assert detail["podcast_episode"]["podcasts"] == [
+        first_created.id,
+        second_created.id,
+    ]
+    assert (
+        _summary_by_id(client)[episode.id]["canonical_parent_ids"]
+        == (detail["podcast_episode"]["podcasts"])
+    )
+
+
+def test_summary_canonical_parent_ids_excludes_learning_path_membership(client):
+    """Learning paths are user-created and may be private; they never surface here."""
+    course = CourseFactory.create().learning_resource
+    path = LearningPathFactory.create().learning_resource
+    _relate(
+        path,
+        course,
+        LearningResourceRelationTypes.LEARNING_PATH_ITEMS.value,
+        position=0,
+    )
+
+    assert _summary_by_id(client)[course.id]["canonical_parent_ids"] == []
+
+
+def test_summary_canonical_parent_ids_keeps_unpublished_parents(client):
+    """An unpublished parent still owns the URL, so it is not filtered out."""
+    video = VideoFactory.create().learning_resource
+    playlist = VideoPlaylistFactory.create().learning_resource
+    _relate(
+        playlist,
+        video,
+        LearningResourceRelationTypes.PLAYLIST_VIDEOS.value,
+        position=0,
+    )
+    playlist.published = False
+    playlist.save(update_fields=["published"])
+
+    detail = client.get(
+        reverse("lr:v1:learning_resources_api-detail", args=[video.id])
+    ).data
+
+    assert detail["playlists"] == [playlist.id]
+    assert _summary_by_id(client)[video.id]["canonical_parent_ids"] == [playlist.id]
+
+
+def test_summary_count_omits_the_parent_ids_annotation(
+    django_assert_num_queries, client
+):
+    """The count must not evaluate canonical_parent_ids for every row it counts."""
+    playlist = VideoPlaylistFactory.create().learning_resource
+    videos = [video.learning_resource for video in VideoFactory.create_batch(3)]
+    for position, video in enumerate(videos):
+        _relate(
+            playlist,
+            video,
+            LearningResourceRelationTypes.PLAYLIST_VIDEOS.value,
+            position=position,
+        )
+
+    with django_assert_num_queries(2) as captured:
+        resp = client.get(reverse("lr:v1:learning_resources_api-summary"))
+
+    assert resp.data["count"] == LearningResource.objects.filter(published=True).count()
+    count_sql, page_sql = (query["sql"] for query in captured.captured_queries)
+    assert "canonical_parent_ids" in page_sql
+    assert "canonical_parent_ids" not in count_sql
+
+
+@pytest.fixture
+def enabled_view_cache(settings, request):
+    """Enable view caching for tests that assert cached responses."""
+    settings.REDIS_VIEW_CACHE_DURATION = 60
+    settings.CACHES = {
+        **settings.CACHES,
+        "redis": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": request.node.nodeid,
+        },
+    }
+
+
+@pytest.mark.usefixtures("enabled_view_cache")
+def test_summary_caches_each_page_separately(client):
+    """The action is cached, per (limit, offset) rather than per path."""
+    LearningResourceFactory.create_batch(4)
+    ids = list(
+        LearningResource.objects.filter(published=True)
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+    url = reverse("lr:v1:learning_resources_api-summary")
+
+    def page(offset):
+        resp = client.get(url, {"limit": 2, "offset": offset})
+        return [item["id"] for item in resp.json()["results"]]
+
+    assert page(0) == ids[:2]
+    assert page(2) == ids[2:4]
+
+    LearningResource.objects.filter(id=ids[2]).update(published=False)
+
+    assert page(2) == ids[2:4]
 
 
 @pytest.mark.parametrize(

--- a/learning_resources/views_test.py
+++ b/learning_resources/views_test.py
@@ -1726,42 +1726,6 @@ def test_summary_count_omits_the_parent_ids_annotation(
     assert "canonical_parent_ids" not in count_sql
 
 
-@pytest.fixture
-def enabled_view_cache(settings, request):
-    """Enable view caching for tests that assert cached responses."""
-    settings.REDIS_VIEW_CACHE_DURATION = 60
-    settings.CACHES = {
-        **settings.CACHES,
-        "redis": {
-            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-            "LOCATION": request.node.nodeid,
-        },
-    }
-
-
-@pytest.mark.usefixtures("enabled_view_cache")
-def test_summary_caches_each_page_separately(client):
-    """The action is cached, per (limit, offset) rather than per path."""
-    LearningResourceFactory.create_batch(4)
-    ids = list(
-        LearningResource.objects.filter(published=True)
-        .order_by("id")
-        .values_list("id", flat=True)
-    )
-    url = reverse("lr:v1:learning_resources_api-summary")
-
-    def page(offset):
-        resp = client.get(url, {"limit": 2, "offset": offset})
-        return [item["id"] for item in resp.json()["results"]]
-
-    assert page(0) == ids[:2]
-    assert page(2) == ids[2:4]
-
-    LearningResource.objects.filter(id=ids[2]).update(published=False)
-
-    assert page(2) == ids[2:4]
-
-
 @pytest.mark.parametrize(
     "user_role",
     [

--- a/openapi/specs/v1.yaml
+++ b/openapi/specs/v1.yaml
@@ -13508,9 +13508,51 @@ components:
         title:
           type: string
           maxLength: 256
+        resource_type:
+          $ref: '#/components/schemas/LearningResourceSummaryResourceTypeEnum'
+        canonical_parent_ids:
+          type: array
+          items:
+            type: integer
+          description: 'Ids of the parents that form part of this resource''s URL:
+            the parent podcasts of a podcast episode, the playlists of a video. Empty
+            for every other resource type. Parents are not filtered by `published`,
+            so an id here may belong to a resource this endpoint will not return.'
+          readOnly: true
       required:
+      - canonical_parent_ids
       - id
+      - resource_type
       - title
+    LearningResourceSummaryResourceTypeEnum:
+      enum:
+      - course
+      - program
+      - learning_path
+      - podcast
+      - podcast_episode
+      - video
+      - video_playlist
+      - document
+      type: string
+      description: |-
+        * `course` - Course
+        * `program` - Program
+        * `learning_path` - Learning Path
+        * `podcast` - Podcast
+        * `podcast_episode` - Podcast Episode
+        * `video` - Video
+        * `video_playlist` - Video Playlist
+        * `document` - Document
+      x-enum-descriptions:
+      - Course
+      - Program
+      - Learning Path
+      - Podcast
+      - Podcast Episode
+      - Video
+      - Video Playlist
+      - Document
     LearningResourceTopic:
       type: object
       description: Serializer for LearningResourceTopic model


### PR DESCRIPTION
### What are the relevant tickets?
- For https://github.com/mitodl/hq/issues/12814

### Description (What does it do?)
Adds `canonical_parent_ids` and `resource_type` to the `api/v1/learning_resources/summary/` endpoint for use in podcast episode + video pages

### How can this be tested?
1. Verify that https://api.learn.mit.dev/api/v1/learning_resources/summary/?resource_type=podcast_episode, https://api.learn.mit.dev/api/v1/learning_resources/summary/?resource_type=video include `canonical_parent_ids`