### PR TITLE
constrain percolation to percolate index

### DIFF
--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -669,17 +669,13 @@ def percolate_matches_for_document(document_id):
     """
     resource = LearningResource.objects.get(id=document_id)
     index = get_default_alias_name(resource.resource_type)
-    search = Search(index=get_default_alias_name(PERCOLATE_INDEX_TYPE))[0:10000]
+    search = Search(index=get_default_alias_name(PERCOLATE_INDEX_TYPE))
     percolate_ids = []
     try:
         results = search.query(
             Percolate(field="query", index=index, id=str(document_id))
-        ).execute()
-        failed_shards = results.to_dict().get("_shards", {}).get("failed", 0)
-        if failed_shards > 0:
-            msg = f"Percolate search failed on {failed_shards} shards"
-            raise RuntimeError(msg)
-        percolate_ids = [result.id for result in results.hits]
+        ).scan()
+        percolate_ids = [result.id for result in results]
     except NotFoundError:
         log.info("document %s not found in index", document_id)
     percolated_queries = PercolateQuery.objects.filter(id__in=percolate_ids)

--- a/learning_resources_search/api.py
+++ b/learning_resources_search/api.py
@@ -35,6 +35,7 @@ from learning_resources_search.constants import (
     LEARNING_RESOURCE_QUERY_FIELDS,
     LEARNING_RESOURCE_SEARCH_SORTBY_OPTIONS,
     LEARNING_RESOURCE_TYPES,
+    PERCOLATE_INDEX_TYPE,
     PROGRAM_TYPE,
     RUN_INSTRUCTORS_QUERY_FIELDS,
     RUN_LEVEL_QUERY_FIELDS,
@@ -668,12 +669,16 @@ def percolate_matches_for_document(document_id):
     """
     resource = LearningResource.objects.get(id=document_id)
     index = get_default_alias_name(resource.resource_type)
-    search = Search()
+    search = Search(index=get_default_alias_name(PERCOLATE_INDEX_TYPE))[0:10000]
     percolate_ids = []
     try:
         results = search.query(
             Percolate(field="query", index=index, id=str(document_id))
         ).execute()
+        failed_shards = results.to_dict().get("_shards", {}).get("failed", 0)
+        if failed_shards > 0:
+            msg = f"Percolate search failed on {failed_shards} shards"
+            raise RuntimeError(msg)
         percolate_ids = [result.id for result in results.hits]
     except NotFoundError:
         log.info("document %s not found in index", document_id)

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -4380,23 +4380,12 @@ def test_document_percolation(opensearch, mocker):
     plugin_log_handler = mocker.patch("learning_resources_search.plugins.log")
     executed_searches = []
 
-    def mock_execute(search_self, *args, **kwargs):
+    def mock_scan(search_self, *args, **kwargs):
         executed_searches.append(search_self)
-        return response.Response(
-            search_self,
-            {
-                "_shards": {"failed": 0, "successful": 10, "total": 10},
-                "hits": {
-                    "hits": percolate_hits,
-                    "max_score": 12.0,
-                    "total": 123,
-                },
-                "timed_out": False,
-                "took": 123,
-            },
-        )
+        for hit in percolate_hits:
+            yield response.Hit(hit)
 
-    mocker.patch.object(Search, "execute", autospec=True, side_effect=mock_execute)
+    mocker.patch.object(Search, "scan", autospec=True, side_effect=mock_scan)
 
     lr = LearningResourceFactory.create()
     percolate_matches_for_document(lr.id)
@@ -4404,41 +4393,12 @@ def test_document_percolation(opensearch, mocker):
     assert executed_searches[0]._index == [  # noqa: SLF001
         get_default_alias_name(PERCOLATE_INDEX_TYPE)
     ]
-    assert executed_searches[0].to_dict()["size"] == 10000
 
     plugin_log_handler.debug.assert_called_once_with(
         "document %i percolated - %s",
         lr.id,
         list(PercolateQuery.objects.filter(id__in=[p["id"] for p in percolate_hits])),
     )
-
-
-@pytest.mark.django_db
-def test_document_percolation_shard_failure(opensearch, mocker):
-    """Test that a RuntimeError is raised when shard failures occur during percolation."""
-    mocker.patch(
-        "learning_resources_search.indexing_api.index_percolators", autospec=True
-    )
-    mocker.patch(
-        "learning_resources_search.indexing_api._update_document_by_id", autospec=True
-    )
-
-    def mock_execute(search_self, *args, **kwargs):
-        return response.Response(
-            search_self,
-            {
-                "_shards": {"failed": 1, "successful": 9, "total": 10},
-                "hits": {"hits": [], "max_score": 0.0, "total": 0},
-                "timed_out": False,
-                "took": 123,
-            },
-        )
-
-    mocker.patch.object(Search, "execute", autospec=True, side_effect=mock_execute)
-
-    lr = LearningResourceFactory.create()
-    with pytest.raises(RuntimeError, match="Percolate search failed on 1 shards"):
-        percolate_matches_for_document(lr.id)
 
 
 @pytest.mark.parametrize(

--- a/learning_resources_search/api_test.py
+++ b/learning_resources_search/api_test.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from freezegun import freeze_time
 from opensearch_dsl import response
-from opensearch_dsl.query import Percolate
 
 from learning_resources.constants import OCW_CONTENT_CATEGORY_OPEN_TEXTBOOKS
 from learning_resources.factories import LearningResourceFactory
@@ -31,6 +30,7 @@ from learning_resources_search.constants import (
     CONTENT_FILE_TYPE,
     COURSE_TYPE,
     LEARNING_RESOURCE,
+    PERCOLATE_INDEX_TYPE,
     PROGRAM_TYPE,
 )
 from learning_resources_search.factories import PercolateQueryFactory
@@ -4371,36 +4371,74 @@ def test_document_percolation(opensearch, mocker):
             {
                 "_index": "test-index",
                 "_id": f"{query.id}",
-                "id": f"{query.id}",
+                "_source": {"id": query.id},
+                "id": query.id,
                 "_score": 12.0,
             }
         )
 
     plugin_log_handler = mocker.patch("learning_resources_search.plugins.log")
-    mocker.patch.object(Search, "execute")
+    executed_searches = []
 
-    Search.execute.return_value = response.Response(
-        Search().query(Percolate(field="query", index="test", id="test")),
-        {
-            "_shards": {"failed": 0, "successful": 10, "total": 10},
-            "hits": {
-                "hits": percolate_hits,
-                "max_score": 12.0,
-                "total": 123,
+    def mock_execute(search_self, *args, **kwargs):
+        executed_searches.append(search_self)
+        return response.Response(
+            search_self,
+            {
+                "_shards": {"failed": 0, "successful": 10, "total": 10},
+                "hits": {
+                    "hits": percolate_hits,
+                    "max_score": 12.0,
+                    "total": 123,
+                },
+                "timed_out": False,
+                "took": 123,
             },
-            "timed_out": False,
-            "took": 123,
-        },
-    ).hits
+        )
+
+    mocker.patch.object(Search, "execute", autospec=True, side_effect=mock_execute)
 
     lr = LearningResourceFactory.create()
     percolate_matches_for_document(lr.id)
+
+    assert executed_searches[0]._index == [  # noqa: SLF001
+        get_default_alias_name(PERCOLATE_INDEX_TYPE)
+    ]
+    assert executed_searches[0].to_dict()["size"] == 10000
 
     plugin_log_handler.debug.assert_called_once_with(
         "document %i percolated - %s",
         lr.id,
         list(PercolateQuery.objects.filter(id__in=[p["id"] for p in percolate_hits])),
     )
+
+
+@pytest.mark.django_db
+def test_document_percolation_shard_failure(opensearch, mocker):
+    """Test that a RuntimeError is raised when shard failures occur during percolation."""
+    mocker.patch(
+        "learning_resources_search.indexing_api.index_percolators", autospec=True
+    )
+    mocker.patch(
+        "learning_resources_search.indexing_api._update_document_by_id", autospec=True
+    )
+
+    def mock_execute(search_self, *args, **kwargs):
+        return response.Response(
+            search_self,
+            {
+                "_shards": {"failed": 1, "successful": 9, "total": 10},
+                "hits": {"hits": [], "max_score": 0.0, "total": 0},
+                "timed_out": False,
+                "took": 123,
+            },
+        )
+
+    mocker.patch.object(Search, "execute", autospec=True, side_effect=mock_execute)
+
+    lr = LearningResourceFactory.create()
+    with pytest.raises(RuntimeError, match="Percolate search failed on 1 shards"):
+        percolate_matches_for_document(lr.id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12800
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR fixes an issue where percolation uses a bare Search(), which sends no index to OpenSearch. The request therefore goes to /_search — all 128 shards in the cluster — even though the only index that can possibly match is the percolator index. On rc when manually trying to send subscription emails this caused a memory error on the opensearch instance.

### How can this be tested?
1. checkout main
2. open a django shell and percolate a single document:
```python
import logging
# Turn on DEBUG logging for the opensearch client to view HTTP endpoints
logging.getLogger("opensearch").setLevel(logging.DEBUG)
from learning_resources.models import LearningResource
from learning_resources_search.api import percolate_matches_for_document
# Pick any existing learning resource (or create one)
resource = LearningResource.objects.first()
# Run the percolate function
percolate_matches_for_document(resource.id)
```
3. in the output you should see a POST /_search (http://opensearch-node-mitopen-1:9200/_search) that does not target a specific index
4. checkout this branch and re-run the script
5. you should see a POST /<percolate_index>/_search instead which is scoped to just the percolate index
