### PR TITLE
feat(b2b): render the analytics dashboard scoped to a contract

### DIFF
--- a/frontends/api/src/analytics/clients.ts
+++ b/frontends/api/src/analytics/clients.ts
@@ -3,6 +3,8 @@ import axiosInstance from "./axios"
 import type {
   AnalyticsPageParams,
   ContentEngagementDepth,
+  ContractContentEngagementDepth,
+  ContractMonthlyEngagementTrend,
   ContractUtilization,
   EnrollmentCompletionFunnel,
   MonthlyEngagementTrend,
@@ -104,4 +106,111 @@ const analyticsOrganizationsApi = {
     ),
 }
 
-export { analyticsOrganizationsApi, B2B_DASHBOARD_ROOT }
+/**
+ * `contractId` is MITx Online's `ContractPage.page_ptr_id` — the same value the
+ * manager dashboard puts in its own URLs, and what the analytics API filters
+ * on. NOT the contract slug the MIT Learn route carries, and NOT the
+ * warehouse's `contract_pk` surrogate; resolve the slug to an id from the
+ * org's `contracts` list before calling any of these.
+ *
+ * The org segment stays in the path even though a contract id identifies a
+ * contract on its own: the API filters on both, so that a manager of one org
+ * cannot read another's contract by naming it.
+ */
+const contractRoot = (organizationId: string, contractId: string) =>
+  `${orgRoot(organizationId)}/contracts/${encodeURIComponent(contractId)}`
+
+const getContractResource = <RowT>(
+  organizationId: string,
+  contractId: string,
+  resource: string,
+  page: AnalyticsPageParams | undefined,
+  signal: AbortSignal | undefined,
+): Promise<AxiosResponse<OrgAnalyticsResponse<RowT>>> =>
+  axiosInstance.get<OrgAnalyticsResponse<RowT>>(
+    `${contractRoot(organizationId, contractId)}/${resource}`,
+    { params: page, signal },
+  )
+
+/**
+ * The contract-scoped half of the same five endpoints, mirroring MITx Online's
+ * manager dashboard (which nests contracts under an organization). Same
+ * envelope, same paging, same suppression — only the scope differs.
+ *
+ * Two of the five read materialized views that exist only at contract grain
+ * (engagement-trend, content-engagement); the rest read the same views as the
+ * org endpoints, filtered down.
+ */
+const analyticsContractsApi = {
+  contractUtilization: (
+    organizationId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getContractResource<ContractUtilization>(
+      organizationId,
+      contractId,
+      "contract-utilization",
+      page,
+      signal,
+    ),
+
+  enrollmentFunnel: (
+    organizationId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getContractResource<EnrollmentCompletionFunnel>(
+      organizationId,
+      contractId,
+      "enrollment-funnel",
+      page,
+      signal,
+    ),
+
+  engagementTrend: (
+    organizationId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getContractResource<ContractMonthlyEngagementTrend>(
+      organizationId,
+      contractId,
+      "engagement-trend",
+      page,
+      signal,
+    ),
+
+  programFunnel: (
+    organizationId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getContractResource<ProgramFunnel>(
+      organizationId,
+      contractId,
+      "program-funnel",
+      page,
+      signal,
+    ),
+
+  contentEngagement: (
+    organizationId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+    signal?: AbortSignal,
+  ) =>
+    getContractResource<ContractContentEngagementDepth>(
+      organizationId,
+      contractId,
+      "content-engagement",
+      page,
+      signal,
+    ),
+}
+
+export { analyticsOrganizationsApi, analyticsContractsApi, B2B_DASHBOARD_ROOT }

--- a/frontends/api/src/analytics/hooks/organizations/index.ts
+++ b/frontends/api/src/analytics/hooks/organizations/index.ts
@@ -1,11 +1,15 @@
 export {
   analyticsOrganizationQueries,
   analyticsOrganizationKeys,
+  analyticsContractQueries,
+  analyticsContractKeys,
 } from "./queries"
 
 export type {
   AnalyticsPageParams,
   ContentEngagementDepth,
+  ContractContentEngagementDepth,
+  ContractMonthlyEngagementTrend,
   ContractUtilization,
   EnrollmentCompletionFunnel,
   MonthlyEngagementTrend,

--- a/frontends/api/src/analytics/hooks/organizations/queries.test.ts
+++ b/frontends/api/src/analytics/hooks/organizations/queries.test.ts
@@ -3,7 +3,10 @@ import { useQuery, type UseQueryOptions } from "@tanstack/react-query"
 import { setupReactQueryTest } from "../../../hooks/test-utils"
 import { setMockResponse, makeRequest } from "../../../test-utils"
 import { factories, urls } from "../../test-utils"
-import { analyticsOrganizationQueries } from "./queries"
+import {
+  analyticsContractQueries,
+  analyticsOrganizationQueries,
+} from "./queries"
 
 const ORG_UUID = "3fa85f64-5717-4562-b3fc-2c963f66afa6"
 
@@ -113,5 +116,91 @@ describe("analyticsOrganizationQueries", () => {
 
   test("the org id is url-encoded rather than spliced into the path raw", () => {
     expect(urls.organizations.contractUtilization("a/b")).toContain("a%2Fb")
+  })
+})
+
+const CONTRACT_ID = "101"
+
+describe("analyticsContractQueries", () => {
+  test.each([
+    {
+      name: "contractUtilization",
+      query: () =>
+        erase(
+          analyticsContractQueries.contractUtilization(ORG_UUID, CONTRACT_ID),
+        ),
+      url: urls.contracts.contractUtilization(ORG_UUID, CONTRACT_ID),
+      response: factories.envelope([factories.contractUtilization()]),
+    },
+    {
+      name: "enrollmentFunnel",
+      query: () =>
+        erase(analyticsContractQueries.enrollmentFunnel(ORG_UUID, CONTRACT_ID)),
+      url: urls.contracts.enrollmentFunnel(ORG_UUID, CONTRACT_ID),
+      response: factories.envelope([factories.enrollmentCompletionFunnel()]),
+    },
+    {
+      name: "engagementTrend",
+      query: () =>
+        erase(analyticsContractQueries.engagementTrend(ORG_UUID, CONTRACT_ID)),
+      url: urls.contracts.engagementTrend(ORG_UUID, CONTRACT_ID),
+      response: factories.envelope([
+        factories.contractMonthlyEngagementTrend(),
+      ]),
+    },
+    {
+      name: "programFunnel",
+      query: () =>
+        erase(analyticsContractQueries.programFunnel(ORG_UUID, CONTRACT_ID)),
+      url: urls.contracts.programFunnel(ORG_UUID, CONTRACT_ID),
+      response: factories.envelope([factories.programFunnel()]),
+    },
+    {
+      name: "contentEngagement",
+      query: () =>
+        erase(
+          analyticsContractQueries.contentEngagement(ORG_UUID, CONTRACT_ID),
+        ),
+      url: urls.contracts.contentEngagement(ORG_UUID, CONTRACT_ID),
+      response: factories.envelope([
+        factories.contractContentEngagementDepth(),
+      ]),
+    },
+  ])(
+    "$name requests the contract-nested path",
+    async ({ query, url, response }) => {
+      const { wrapper } = setupReactQueryTest()
+      setMockResponse.get(url, response)
+
+      const { result } = renderHook(() => useQuery(query()), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "get", url }),
+      )
+    },
+  )
+
+  test("contract keys nest under the org's, and differ per contract", () => {
+    const key = analyticsContractQueries.contractUtilization(
+      ORG_UUID,
+      CONTRACT_ID,
+    ).queryKey
+    // The org prefix is intact, so invalidating an org drops its contracts too.
+    expect(key.slice(0, 3)).toEqual(["analytics", "organizations", ORG_UUID])
+    expect(key).toContain(CONTRACT_ID)
+    expect(
+      analyticsContractQueries.contractUtilization(ORG_UUID, "202").queryKey,
+    ).not.toEqual(key)
+    // And a contract-scoped result never satisfies an org-scoped read.
+    expect(key).not.toEqual(
+      analyticsOrganizationQueries.contractUtilization(ORG_UUID).queryKey,
+    )
+  })
+
+  test("the contract id is url-encoded rather than spliced into the path raw", () => {
+    expect(urls.contracts.contractUtilization(ORG_UUID, "a/b")).toContain(
+      "a%2Fb",
+    )
   })
 })

--- a/frontends/api/src/analytics/hooks/organizations/queries.ts
+++ b/frontends/api/src/analytics/hooks/organizations/queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "@tanstack/react-query"
-import { analyticsOrganizationsApi } from "../../clients"
+import { analyticsContractsApi, analyticsOrganizationsApi } from "../../clients"
 import type { AnalyticsPageParams } from "../../types"
 
 /**
@@ -96,4 +96,133 @@ const analyticsOrganizationQueries = {
     }),
 }
 
-export { analyticsOrganizationQueries, analyticsOrganizationKeys }
+/**
+ * Contract-scoped keys nest under the org's, so invalidating an organization
+ * drops its contracts' cached sections too — they are views of the same
+ * underlying data and can never be stale independently.
+ *
+ * `contractId` is MITx Online's contract id, not the route's slug.
+ */
+const analyticsContractKeys = {
+  contract: (orgId: string, contractId: string) =>
+    [
+      ...analyticsOrganizationKeys.organization(orgId),
+      "contracts",
+      contractId,
+    ] as const,
+  resource: (
+    orgId: string,
+    contractId: string,
+    resource: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    [
+      ...analyticsContractKeys.contract(orgId, contractId),
+      resource,
+      page,
+    ] as const,
+}
+
+const analyticsContractQueries = {
+  contractUtilization: (
+    orgId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    queryOptions({
+      queryKey: analyticsContractKeys.resource(
+        orgId,
+        contractId,
+        "contract-utilization",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsContractsApi
+          .contractUtilization(orgId, contractId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  enrollmentFunnel: (
+    orgId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    queryOptions({
+      queryKey: analyticsContractKeys.resource(
+        orgId,
+        contractId,
+        "enrollment-funnel",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsContractsApi
+          .enrollmentFunnel(orgId, contractId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  engagementTrend: (
+    orgId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    queryOptions({
+      queryKey: analyticsContractKeys.resource(
+        orgId,
+        contractId,
+        "engagement-trend",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsContractsApi
+          .engagementTrend(orgId, contractId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  programFunnel: (
+    orgId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    queryOptions({
+      queryKey: analyticsContractKeys.resource(
+        orgId,
+        contractId,
+        "program-funnel",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsContractsApi
+          .programFunnel(orgId, contractId, page, signal)
+          .then((res) => res.data),
+    }),
+
+  contentEngagement: (
+    orgId: string,
+    contractId: string,
+    page?: AnalyticsPageParams,
+  ) =>
+    queryOptions({
+      queryKey: analyticsContractKeys.resource(
+        orgId,
+        contractId,
+        "content-engagement",
+        page,
+      ),
+      staleTime: ANALYTICS_STALE_TIME,
+      queryFn: async ({ signal }) =>
+        analyticsContractsApi
+          .contentEngagement(orgId, contractId, page, signal)
+          .then((res) => res.data),
+    }),
+}
+
+export {
+  analyticsOrganizationQueries,
+  analyticsOrganizationKeys,
+  analyticsContractQueries,
+  analyticsContractKeys,
+}

--- a/frontends/api/src/analytics/test-utils/factories.ts
+++ b/frontends/api/src/analytics/test-utils/factories.ts
@@ -1,6 +1,8 @@
 import { faker } from "@faker-js/faker/locale/en"
 import type {
   ContentEngagementDepth,
+  ContractContentEngagementDepth,
+  ContractMonthlyEngagementTrend,
   ContractUtilization,
   EnrollmentCompletionFunnel,
   MonthlyEngagementTrend,
@@ -36,7 +38,12 @@ const contractUtilization = (
 ): ContractUtilization => ({
   organization_key: faker.string.alphanumeric(6).toUpperCase(),
   organization_name: faker.company.name(),
-  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  contract_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
+  contract_id: String(faker.number.int({ min: 1, max: 10000 })),
   b2b_contract_name: `${faker.company.name()} Contract`,
   b2b_contract_is_active: true,
   b2b_contract_start_date: "2026-01-01",
@@ -56,9 +63,18 @@ const enrollmentCompletionFunnel = (
 ): EnrollmentCompletionFunnel => ({
   organization_key: faker.string.alphanumeric(6).toUpperCase(),
   organization_name: faker.company.name(),
-  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  contract_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
+  contract_id: String(faker.number.int({ min: 1, max: 10000 })),
   b2b_contract_name: `${faker.company.name()} Contract`,
-  courserun_pk: faker.number.int({ min: 1, max: 10000 }),
+  courserun_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
   courserun_readable_id: `course-v1:MITx+${faker.string.alphanumeric(5)}+2026`,
   courserun_title: faker.commerce.productName(),
   enrolled_learners: 40,
@@ -78,10 +94,15 @@ const monthlyEngagementTrend = (
   activity_year_and_month: "2026-01",
   monthly_active_learners: 30,
   new_enrollments: 12,
+  enrolling_learners: 9,
   certificates_earned: 5,
+  certified_learners: 5,
   total_videos_watched: 900,
+  video_watchers: 22,
   total_problems_attempted: 1200,
+  problem_attempters: 19,
   total_chatbot_interactions: 80,
+  chatbot_users: 11,
   ...overrides,
 })
 
@@ -90,9 +111,18 @@ const programFunnel = (
 ): ProgramFunnel => ({
   organization_key: faker.string.alphanumeric(6).toUpperCase(),
   organization_name: faker.company.name(),
-  contract_pk: faker.number.int({ min: 1, max: 10000 }),
+  contract_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
+  contract_id: String(faker.number.int({ min: 1, max: 10000 })),
   b2b_contract_name: `${faker.company.name()} Contract`,
-  program_pk: faker.number.int({ min: 1, max: 10000 }),
+  program_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
   program_title: `${faker.commerce.department()} Program`,
   total_courses: 6,
   enrolled_in_contract_courses: 50,
@@ -112,8 +142,10 @@ const contentEngagementDepth = (
   engaged_learners: 28,
   engagement_rate_pct: 70,
   total_videos_watched: 800,
+  video_watchers: 21,
   avg_videos_per_engaged_learner: 28.6,
   total_problems_attempted: 1000,
+  problem_attempters: 18,
   avg_problems_per_engaged_learner: 35.7,
   total_chatbot_interactions: 60,
   chatbot_users: 14,
@@ -122,8 +154,36 @@ const contentEngagementDepth = (
   ...overrides,
 })
 
+const contractIdentity = () => ({
+  contract_pk: faker.string.hexadecimal({
+    length: 32,
+    casing: "lower",
+    prefix: "",
+  }),
+  contract_id: String(faker.number.int({ min: 1, max: 10000 })),
+  b2b_contract_name: `${faker.company.name()} Contract`,
+})
+
+const contractMonthlyEngagementTrend = (
+  overrides: Partial<ContractMonthlyEngagementTrend> = {},
+): ContractMonthlyEngagementTrend => ({
+  ...monthlyEngagementTrend(),
+  ...contractIdentity(),
+  ...overrides,
+})
+
+const contractContentEngagementDepth = (
+  overrides: Partial<ContractContentEngagementDepth> = {},
+): ContractContentEngagementDepth => ({
+  ...contentEngagementDepth(),
+  ...contractIdentity(),
+  ...overrides,
+})
+
 export {
   contentEngagementDepth,
+  contractContentEngagementDepth,
+  contractMonthlyEngagementTrend,
   contractUtilization,
   enrollmentCompletionFunnel,
   envelope,

--- a/frontends/api/src/analytics/test-utils/urls.ts
+++ b/frontends/api/src/analytics/test-utils/urls.ts
@@ -18,6 +18,16 @@ const orgResource = (
     organizationId,
   )}/${resource}${queryify(params)}`
 
+const contractResource = (
+  organizationId: string,
+  contractId: string,
+  resource: string,
+  params?: AnalyticsPageParams,
+) =>
+  `${getApiBaseUrl()}${B2B_DASHBOARD_ROOT}/organizations/${encodeURIComponent(
+    organizationId,
+  )}/contracts/${encodeURIComponent(contractId)}/${resource}${queryify(params)}`
+
 const organizations = {
   contractUtilization: (organizationId: string, params?: AnalyticsPageParams) =>
     orgResource(organizationId, "contract-utilization", params),
@@ -31,4 +41,40 @@ const organizations = {
     orgResource(organizationId, "content-engagement", params),
 }
 
-export { organizations }
+const contracts = {
+  contractUtilization: (
+    organizationId: string,
+    contractId: string,
+    params?: AnalyticsPageParams,
+  ) =>
+    contractResource(
+      organizationId,
+      contractId,
+      "contract-utilization",
+      params,
+    ),
+  enrollmentFunnel: (
+    organizationId: string,
+    contractId: string,
+    params?: AnalyticsPageParams,
+  ) =>
+    contractResource(organizationId, contractId, "enrollment-funnel", params),
+  engagementTrend: (
+    organizationId: string,
+    contractId: string,
+    params?: AnalyticsPageParams,
+  ) => contractResource(organizationId, contractId, "engagement-trend", params),
+  programFunnel: (
+    organizationId: string,
+    contractId: string,
+    params?: AnalyticsPageParams,
+  ) => contractResource(organizationId, contractId, "program-funnel", params),
+  contentEngagement: (
+    organizationId: string,
+    contractId: string,
+    params?: AnalyticsPageParams,
+  ) =>
+    contractResource(organizationId, contractId, "content-engagement", params),
+}
+
+export { organizations, contracts }

--- a/frontends/api/src/analytics/types.ts
+++ b/frontends/api/src/analytics/types.ts
@@ -40,7 +40,8 @@ export type OrgAnalyticsResponse<RowT> = {
 export type ContractUtilization = {
   organization_key: string
   organization_name: string
-  contract_pk: number
+  contract_pk: string
+  contract_id: string
   b2b_contract_name: string
   b2b_contract_is_active: boolean
   b2b_contract_start_date: string | null
@@ -58,9 +59,10 @@ export type ContractUtilization = {
 export type EnrollmentCompletionFunnel = {
   organization_key: string
   organization_name: string
-  contract_pk: number
+  contract_pk: string
+  contract_id: string
   b2b_contract_name: string
-  courserun_pk: number
+  courserun_pk: string
   courserun_readable_id: string
   courserun_title: string
   enrolled_learners: number
@@ -82,19 +84,25 @@ export type MonthlyEngagementTrend = {
   activity_year_and_month: string
   monthly_active_learners: number
   new_enrollments: number | null
+  enrolling_learners: number | null
   certificates_earned: number | null
-  total_videos_watched: number
-  total_problems_attempted: number
-  total_chatbot_interactions: number
+  certified_learners: number | null
+  total_videos_watched: number | null
+  video_watchers: number | null
+  total_problems_attempted: number | null
+  problem_attempters: number | null
+  total_chatbot_interactions: number | null
+  chatbot_users: number | null
 }
 
 /** `mv_b2b_program_funnel` — grain: org x contract x program. */
 export type ProgramFunnel = {
   organization_key: string
   organization_name: string
-  contract_pk: number
+  contract_pk: string
+  contract_id: string
   b2b_contract_name: string
-  program_pk: number
+  program_pk: string
   program_title: string
   total_courses: number
   enrolled_in_contract_courses: number
@@ -112,14 +120,51 @@ export type ContentEngagementDepth = {
   engaged_learners: number | null
   engagement_rate_pct: number | null
   total_videos_watched: number | null
+  video_watchers: number | null
   avg_videos_per_engaged_learner: number | null
   total_problems_attempted: number | null
+  problem_attempters: number | null
   avg_problems_per_engaged_learner: number | null
   total_chatbot_interactions: number | null
   chatbot_users: number | null
   chatbot_adoption_pct: number | null
   certificates_earned: number | null
 }
+
+/**
+ * Contract identity, carried by every row of a contract-grained view.
+ *
+ * `contract_id` is MITx Online's `ContractPage.page_ptr_id` — the value in that
+ * dashboard's URLs, and the only one the analytics API will filter on.
+ * `contract_pk` is the warehouse's own md5 surrogate: useful as a stable row
+ * key, never as a path segment.
+ */
+type ContractIdentity = {
+  contract_pk: string
+  contract_id: string
+  b2b_contract_name: string
+}
+
+/**
+ * `mv_b2b_contract_monthly_engagement_trend` — grain: org x contract x month.
+ *
+ * The same columns as {@link MonthlyEngagementTrend} plus the contract. Note
+ * these rows do NOT partition the org-level ones: a learner active under two
+ * of an org's contracts is counted in both, so summing
+ * `monthly_active_learners` across contracts can exceed the org's own figure.
+ */
+export type ContractMonthlyEngagementTrend = MonthlyEngagementTrend &
+  ContractIdentity
+
+/**
+ * `mv_b2b_contract_content_engagement_depth` — grain: org x contract x run.
+ *
+ * Unlike the trend view these rows ARE a partition of the org-level ones: a
+ * course run belongs to exactly one contract, so naming the contract labels a
+ * row rather than splitting it.
+ */
+export type ContractContentEngagementDepth = ContentEngagementDepth &
+  ContractIdentity
 
 /**
  * LIMIT/OFFSET paging, shared by every multi-row endpoint. The API caps `limit`

--- a/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
+++ b/frontends/main/src/app-pages/ContractAdminPage/ContractAdminPage.tsx
@@ -53,7 +53,7 @@ import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
 import { FeatureFlags } from "@/common/feature_flags"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
-import { organizationAnalyticsView } from "@/common/urls"
+import { contractAnalyticsView } from "@/common/urls"
 import { ErrorContent } from "../ErrorPage/ErrorPageTemplate"
 import graduateLogo from "@/public/images/dashboard/graduate.png"
 
@@ -609,15 +609,15 @@ const ContractAdminPageInternal: React.FC<ContractAdminPageInternalProps> = ({
                   </>
                 ) : null}
               </ContractSubtitle>
-              {/* Analytics is the reporting half of this dashboard and is
-                  org-scoped, so it lives at its own URL rather than under this
-                  contract. Behind its own flag: the analytics API is not
-                  deployed everywhere this page is. */}
+              {/* Analytics is the reporting half of this dashboard, and is
+                  now scoped to this contract rather than the whole org, so it
+                  lives under this contract's URL. Behind its own flag: the
+                  analytics API is not deployed everywhere this page is. */}
               {analyticsEnabled ? (
                 <AnalyticsLink
                   color="red"
                   size="small"
-                  href={organizationAnalyticsView(orgSlug)}
+                  href={contractAnalyticsView(orgSlug, contractSlug)}
                 >
                   View analytics
                 </AnalyticsLink>

--- a/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/Analytics/CoursePerformanceTable.tsx
@@ -98,7 +98,7 @@ const CoursePerformanceTable: React.FC<{
   // The view's grain includes the contract, so a course run appears once per
   // contract it is offered under. Grouping by contract keeps those rows from
   // reading as duplicates; the label is dropped when there is only one.
-  const contracts = new Map<number, EnrollmentCompletionFunnel[]>()
+  const contracts = new Map<string, EnrollmentCompletionFunnel[]>()
   rows.forEach((row) => {
     const existing = contracts.get(row.contract_pk)
     if (existing) {

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { renderWithProviders, screen, TestingErrorBoundary } from "@/test-utils"
-import { setMockResponse } from "api/test-utils"
+import { setMockResponse, makeRequest } from "api/test-utils"
 import { factories, urls } from "api/mitxonline-test-utils"
 import {
   factories as analyticsFactories,
@@ -431,7 +431,7 @@ describe("AnalyticsContent", () => {
     const courseRows = (count: number) =>
       Array.from({ length: count }, (_, index) =>
         analyticsFactories.enrollmentCompletionFunnel({
-          courserun_pk: index + 1,
+          courserun_pk: String(index + 1),
           courserun_title: `Course ${index + 1}`,
         }),
       )
@@ -606,6 +606,97 @@ describe("AnalyticsContent", () => {
       expect(
         screen.queryByRole("button", { name: /Show all/ }),
       ).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe("AnalyticsContent, contract-scoped", () => {
+  beforeEach(() => {
+    mockedUseFeatureFlagsLoaded.mockReturnValue(true)
+    mockedUseFeatureFlagEnabled.mockReturnValue(true)
+    setMockResponse.get(
+      urls.userMe.get(),
+      factories.user.user({ email: "manager@test.com" }),
+    )
+  })
+
+  test("requests the contract-nested endpoints, resolving the slug to a contract id", async () => {
+    const contract = factories.contracts.contract()
+    const org = orgWithUuid({ contracts: [contract] })
+    setManagerOrgs([org])
+
+    const contractId = String(contract.id)
+    const page = { limit: 200 }
+    // Only the contract-nested URLs are mocked. An org-scoped request would
+    // find no mock and fail the render, which is the assertion: this route must
+    // not silently fall back to org-wide numbers for a contract-scoped page.
+    setMockResponse.get(
+      analyticsUrls.contracts.contractUtilization(ORG_UUID, contractId, page),
+      analyticsFactories.envelope([analyticsFactories.contractUtilization()], {
+        as_of: AS_OF,
+      }),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.engagementTrend(ORG_UUID, contractId, page),
+      analyticsFactories.envelope(
+        [analyticsFactories.contractMonthlyEngagementTrend()],
+        { as_of: AS_OF },
+      ),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.enrollmentFunnel(ORG_UUID, contractId, page),
+      analyticsFactories.envelope(
+        [analyticsFactories.enrollmentCompletionFunnel()],
+        { as_of: AS_OF },
+      ),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.programFunnel(ORG_UUID, contractId, page),
+      analyticsFactories.envelope([analyticsFactories.programFunnel()], {
+        as_of: AS_OF,
+      }),
+    )
+
+    renderWithProviders(
+      <AnalyticsContent
+        orgSlug={org.slug.replace(/^org-/, "")}
+        contractSlug={contract.slug}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(makeRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: analyticsUrls.contracts.contractUtilization(
+            ORG_UUID,
+            contractId,
+            page,
+          ),
+        }),
+      )
+    })
+  })
+
+  test("a contract slug that is not in this org requests nothing at all", async () => {
+    const org = orgWithUuid()
+    setManagerOrgs([org])
+
+    renderWithProviders(
+      <AnalyticsContent
+        orgSlug={org.slug.replace(/^org-/, "")}
+        contractSlug="not-a-contract-of-this-org"
+      />,
+    )
+
+    // The slug resolves to no contract, so there is no id to put in the path.
+    // Better an empty state than a request with `undefined` in the URL, which
+    // the API would answer 403 — indistinguishable from a real denial.
+    await waitFor(() => {
+      expect(makeRequest).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.stringContaining("/contracts/"),
+        }),
+      )
     })
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.test.tsx
@@ -13,6 +13,7 @@ import type { OrganizationPage } from "@mitodl/mitxonline-api-axios/v2"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { allowConsoleErrors } from "ol-test-utilities"
 import { ForbiddenError } from "@/common/errors"
+import { contractAdminView } from "@/common/urls"
 import { useFeatureFlagsLoaded } from "@/common/useFeatureFlagsLoaded"
 import AnalyticsContent from "./AnalyticsContent"
 
@@ -691,12 +692,67 @@ describe("AnalyticsContent, contract-scoped", () => {
     // The slug resolves to no contract, so there is no id to put in the path.
     // Better an empty state than a request with `undefined` in the URL, which
     // the API would answer 403 — indistinguishable from a real denial.
-    await waitFor(() => {
-      expect(makeRequest).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: expect.stringContaining("/contracts/"),
-        }),
-      )
-    })
+    //
+    // Await the settled unavailable state FIRST. A bare `waitFor` around a
+    // negative assertion passes on its first tick, before the manager-org
+    // lookup has even resolved, so it would hold even if a contract request
+    // were issued a moment later.
+    await screen.findByText(/Analytics is not available for this organization/)
+    expect(makeRequest).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: expect.stringContaining("/contracts/"),
+      }),
+    )
+  })
+
+  test("'Manage seats' targets the contract being viewed, not the org's first", async () => {
+    const [first, second] = [
+      factories.contracts.contract(),
+      factories.contracts.contract(),
+    ]
+    const org = orgWithUuid({ contracts: [first, second] })
+    setManagerOrgs([org])
+
+    const contractId = String(second.id)
+    const page = { limit: 200 }
+    setMockResponse.get(
+      analyticsUrls.contracts.contractUtilization(ORG_UUID, contractId, page),
+      analyticsFactories.envelope([analyticsFactories.contractUtilization()], {
+        as_of: AS_OF,
+      }),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.engagementTrend(ORG_UUID, contractId, page),
+      analyticsFactories.envelope(
+        [analyticsFactories.contractMonthlyEngagementTrend()],
+        { as_of: AS_OF },
+      ),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.enrollmentFunnel(ORG_UUID, contractId, page),
+      analyticsFactories.envelope(
+        [analyticsFactories.enrollmentCompletionFunnel()],
+        { as_of: AS_OF },
+      ),
+    )
+    setMockResponse.get(
+      analyticsUrls.contracts.programFunnel(ORG_UUID, contractId, page),
+      analyticsFactories.envelope([analyticsFactories.programFunnel()], {
+        as_of: AS_OF,
+      }),
+    )
+
+    const orgSlug = org.slug.replace(/^org-/, "")
+    renderWithProviders(
+      <AnalyticsContent orgSlug={orgSlug} contractSlug={second.slug} />,
+    )
+
+    // Pointing at contracts[0] here would send a manager viewing the second
+    // contract's analytics to the first contract's seat admin.
+    const link = await screen.findByRole("link", { name: "Manage seats" })
+    expect(link).toHaveAttribute(
+      "href",
+      contractAdminView(orgSlug, second.slug),
+    )
   })
 })

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -2,13 +2,27 @@
 
 import React from "react"
 import Image from "next/image"
-import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import {
+  keepPreviousData,
+  useQuery,
+  type UseQueryOptions,
+} from "@tanstack/react-query"
 import type { AxiosError } from "axios"
 import { useFeatureFlagEnabled } from "posthog-js/react"
 import { Skeleton, Stack, styled, Typography } from "ol-components"
 import { ButtonLink } from "@mitodl/smoot-design"
 import { managerOrganizationQueries } from "api/mitxonline-hooks/organizations"
-import { analyticsOrganizationQueries } from "api/analytics-hooks/organizations"
+import {
+  analyticsContractQueries,
+  analyticsOrganizationQueries,
+} from "api/analytics-hooks/organizations"
+import type {
+  ContractUtilization,
+  EnrollmentCompletionFunnel,
+  MonthlyEngagementTrend,
+  OrgAnalyticsResponse,
+  ProgramFunnel,
+} from "api/analytics-hooks/organizations"
 import { isAnalyticsConfigured } from "api/runtime"
 import { matchOrganizationBySlug } from "@/common/utils"
 import { ForbiddenError } from "@/common/errors"
@@ -138,12 +152,34 @@ const isForbidden = (error: unknown) => {
   return status === 401 || status === 403
 }
 
+/**
+ * One section's query options, with the row type pinned but the query key
+ * widened. Org- and contract-scoped factories build keys of different lengths;
+ * this is what lets a single `useQuery` call accept either.
+ */
+type SectionQuery<RowT> = (page: {
+  limit: number
+}) => UseQueryOptions<OrgAnalyticsResponse<RowT>, Error>
+
+type SectionQueries = {
+  utilization: SectionQuery<ContractUtilization>
+  trend: SectionQuery<MonthlyEngagementTrend>
+  courses: SectionQuery<EnrollmentCompletionFunnel>
+  programs: SectionQuery<ProgramFunnel>
+}
+
 type AnalyticsContentInternalProps = {
   orgSlug: string
+  /**
+   * When present, the page is scoped to one contract: the same four sections,
+   * narrowed. Absent, it stays org-wide. Both routes render this component.
+   */
+  contractSlug?: string
 }
 
 const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
   orgSlug,
+  contractSlug,
 }) => {
   const {
     data: managerOrgs,
@@ -159,7 +195,19 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
   // deploy that predates mitodl/mitxonline#3789 — both must read as "analytics
   // unavailable" rather than a request with `undefined` in the path.
   const orgUuid = org?.sso_organization_id ?? null
-  const analyticsAvailable = isAnalyticsConfigured() && !!orgUuid
+  // MITx Online's contract id, resolved from the slug the route carries -- the
+  // same lookup ContractAdminPage does. The analytics API filters on this id,
+  // never on the slug, and never on the warehouse's `contract_pk` surrogate.
+  const contract = contractSlug
+    ? org?.contracts.find((c) => c.slug === contractSlug)
+    : undefined
+  const contractId = contract ? String(contract.id) : null
+  // A contract route whose slug matches nothing in this org is as unavailable
+  // as a missing org UUID: better an empty state than a request with
+  // `undefined` in the path, which the API would answer with a 403 for a
+  // contract that simply does not exist.
+  const analyticsAvailable =
+    isAnalyticsConfigured() && !!orgUuid && (!contractSlug || !!contractId)
 
   // Per-section page size. Raised only by that section's "Show all", so
   // expanding a truncated course table never refetches the other three.
@@ -180,31 +228,64 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
   // back to its skeleton, which is exactly what the option was there to prevent.
   // It behaves as documented on `useQuery` (as it does on ContractAdminPage).
   // The count is fixed and the order never changes, so this is hook-safe.
+  //
+  // Org- and contract-scoped queries return the identical envelope and row
+  // shapes, so the scope is chosen once here and nothing below this line
+  // changes with it. The hook count and order stay fixed either way.
+  //
+  // The cast on the way out is load-bearing. The two branches build query keys
+  // of different lengths (contract keys carry two more segments) and
+  // `queryOptions` is invariant in the key type, so the inferred union leaves
+  // `useQuery` unable to pick an overload. Erasing the key while keeping the
+  // row type is exactly the trade the repo's own query tests make (`erase` in
+  // hooks/organizations/queries.test.ts): the key still comes from the query
+  // factories, and nothing here reads it.
+  const scoped = React.useMemo(() => {
+    const orgId = orgUuid ?? ""
+    return contractId
+      ? {
+          utilization: (page: { limit: number }) =>
+            analyticsContractQueries.contractUtilization(
+              orgId,
+              contractId,
+              page,
+            ),
+          trend: (page: { limit: number }) =>
+            analyticsContractQueries.engagementTrend(orgId, contractId, page),
+          courses: (page: { limit: number }) =>
+            analyticsContractQueries.enrollmentFunnel(orgId, contractId, page),
+          programs: (page: { limit: number }) =>
+            analyticsContractQueries.programFunnel(orgId, contractId, page),
+        }
+      : {
+          utilization: (page: { limit: number }) =>
+            analyticsOrganizationQueries.contractUtilization(orgId, page),
+          trend: (page: { limit: number }) =>
+            analyticsOrganizationQueries.engagementTrend(orgId, page),
+          courses: (page: { limit: number }) =>
+            analyticsOrganizationQueries.enrollmentFunnel(orgId, page),
+          programs: (page: { limit: number }) =>
+            analyticsOrganizationQueries.programFunnel(orgId, page),
+        }
+  }, [orgUuid, contractId]) as unknown as SectionQueries
+
   const utilization = useQuery({
-    ...analyticsOrganizationQueries.contractUtilization(orgUuid ?? "", {
-      limit: limits.utilization,
-    }),
+    ...scoped.utilization({ limit: limits.utilization }),
     enabled: analyticsAvailable,
     placeholderData: keepPreviousData,
   })
   const trend = useQuery({
-    ...analyticsOrganizationQueries.engagementTrend(orgUuid ?? "", {
-      limit: limits.trend,
-    }),
+    ...scoped.trend({ limit: limits.trend }),
     enabled: analyticsAvailable,
     placeholderData: keepPreviousData,
   })
   const courses = useQuery({
-    ...analyticsOrganizationQueries.enrollmentFunnel(orgUuid ?? "", {
-      limit: limits.courses,
-    }),
+    ...scoped.courses({ limit: limits.courses }),
     enabled: analyticsAvailable,
     placeholderData: keepPreviousData,
   })
   const programs = useQuery({
-    ...analyticsOrganizationQueries.programFunnel(orgUuid ?? "", {
-      limit: limits.programs,
-    }),
+    ...scoped.programs({ limit: limits.programs }),
     enabled: analyticsAvailable,
     placeholderData: keepPreviousData,
   })
@@ -390,9 +471,13 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
 
 type AnalyticsContentProps = {
   orgSlug: string
+  contractSlug?: string
 }
 
-const AnalyticsContent: React.FC<AnalyticsContentProps> = ({ orgSlug }) => {
+const AnalyticsContent: React.FC<AnalyticsContentProps> = ({
+  orgSlug,
+  contractSlug,
+}) => {
   const flagEnabled = useFeatureFlagEnabled(FeatureFlags.B2BAnalyticsDashboard)
   const flagsLoaded = useFeatureFlagsLoaded()
 
@@ -406,7 +491,9 @@ const AnalyticsContent: React.FC<AnalyticsContentProps> = ({ orgSlug }) => {
     throw new ForbiddenError("Not enabled.")
   }
 
-  return <AnalyticsContentInternal orgSlug={orgSlug} />
+  return (
+    <AnalyticsContentInternal orgSlug={orgSlug} contractSlug={contractSlug} />
+  )
 }
 
 export default AnalyticsContent

--- a/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
+++ b/frontends/main/src/app-pages/DashboardPage/AnalyticsContent.tsx
@@ -347,7 +347,10 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
     return <ErrorContent title="Access denied" timSays="403" />
   }
 
-  const firstContractSlug = org.contracts[0]?.slug
+  // On a contract-scoped page this must be the contract being viewed, not the
+  // org's first one, or "Manage seats" silently sends the manager to a
+  // different contract's admin page.
+  const manageSeatsSlug = contract?.slug ?? org.contracts[0]?.slug
 
   const header = (
     <HeaderSection>
@@ -360,11 +363,11 @@ const AnalyticsContentInternal: React.FC<AnalyticsContentInternalProps> = ({
           <PageSubtitle>Analytics</PageSubtitle>
         </div>
       </OrgDetailsContainer>
-      {firstContractSlug ? (
+      {manageSeatsSlug ? (
         <ButtonLink
           size="small"
           variant="bordered"
-          href={contractAdminView(orgSlug, firstContractSlug)}
+          href={contractAdminView(orgSlug, manageSeatsSlug)}
         >
           Manage seats
         </ButtonLink>

--- a/frontends/main/src/app/(site)/dashboard/organization/[orgSlug]/contract/[contractSlug]/analytics/page.tsx
+++ b/frontends/main/src/app/(site)/dashboard/organization/[orgSlug]/contract/[contractSlug]/analytics/page.tsx
@@ -1,0 +1,22 @@
+import React from "react"
+import AnalyticsContent from "@/app-pages/DashboardPage/AnalyticsContent"
+
+/**
+ * The contract-scoped view of the same dashboard rendered by
+ * `[orgSlug]/analytics`. Nested under the contract because that is where a
+ * manager arrives from — MITx Online's manager dashboard is contract-scoped in
+ * the same shape (`manager/organizations/{org}/contracts/{contract}`).
+ */
+const Page: React.FC<
+  PageProps<"/dashboard/organization/[orgSlug]/contract/[contractSlug]/analytics">
+> = async ({ params }) => {
+  const resolved = await params
+  return (
+    <AnalyticsContent
+      orgSlug={resolved.orgSlug}
+      contractSlug={resolved.contractSlug}
+    />
+  )
+}
+
+export default Page

--- a/frontends/main/src/common/urls.ts
+++ b/frontends/main/src/common/urls.ts
@@ -104,13 +104,18 @@ export const CONTRACT_ADMIN_VIEW =
 export const contractAdminView = (orgSlug: string, contractSlug: string) =>
   generatePath(CONTRACT_ADMIN_VIEW, { orgSlug, contractSlug })
 /**
- * B2B analytics is org-scoped, not contract-scoped: the underlying materialized
- * views are keyed on the organization and break out contracts as rows.
+ * B2B analytics comes at two scopes. The org view aggregates every contract;
+ * the contract view narrows to one, mirroring how MITx Online's manager
+ * dashboard is addressed. Both are backed by their own materialized views.
  */
 export const ORGANIZATION_ANALYTICS_VIEW =
   "/dashboard/organization/[orgSlug]/analytics"
 export const organizationAnalyticsView = (orgSlug: string) =>
   generatePath(ORGANIZATION_ANALYTICS_VIEW, { orgSlug })
+export const CONTRACT_ANALYTICS_VIEW =
+  "/dashboard/organization/[orgSlug]/contract/[contractSlug]/analytics"
+export const contractAnalyticsView = (orgSlug: string, contractSlug: string) =>
+  generatePath(CONTRACT_ANALYTICS_VIEW, { orgSlug, contractSlug })
 export const PROGRAM_VIEW = "/dashboard/program/[id]"
 export const programView = (id: number) =>
   generatePath(PROGRAM_VIEW, { id: String(id) })


### PR DESCRIPTION
### What are the relevant tickets?

N/A — no GitHub issue. Tracked in the work graph as `tk-point-the-mit-learn-analytics-dashboard-at-the-c-d9d6e1`. Part of the B2B self-serve analytics effort ([mitodl/hq discussion #11845](https://github.com/mitodl/hq/discussions/11845)).

**This is the last of three PRs and cannot work alone. Draft until the other two land.** All three must ship, in this order:

| # | PR | What it adds | Why it blocks the next |
|---|----|--------------|------------------------|
| 1 | [mitodl/ol-data-platform#2559](https://github.com/mitodl/ol-data-platform/pull/2559) | `contract_id` on four MVs; two new contract-grained MVs | Without it the API's `SELECT` names a column that does not exist |
| 2 | [mitodl/ol-analytics-api#34](https://github.com/mitodl/ol-analytics-api/pull/34) | `/organizations/{org}/contracts/{contract}/…` | Without it every request from this PR 404s |
| 3 | **this PR** | the dashboard that calls those routes | — |

Between 1 and 2 there is a **deploy step, not just a merge**: the next `b2b_analytics_starrocks_job` run has to rebuild the materialized views. That is automatic (ol-data-platform#2554's drift detection, verified in production 2026-08-14) but it is not instant — merging 1 and deploying 2 in the same window will fail.

### Description (What does it do?)

The dashboard was org-scoped at every layer while [MITx Online's manager dashboard](https://github.com/mitodl/mitxonline/blob/main/b2b/views/v0/urls.py) it mirrors is contract-scoped, so a manager clicking "View analytics" from a contract page landed on org-wide numbers.

- New route `dashboard/organization/[orgSlug]/contract/[contractSlug]/analytics`, alongside the existing org-level one.
- `analyticsContractsApi` + `analyticsContractQueries`, alongside the org versions. The org endpoints are staying, so nothing currently deployed changes shape.
- `AnalyticsContent` takes an optional `contractSlug` and picks the scope once. Everything below that choice is untouched — both scopes return the identical envelope and row shapes.
- The "View analytics" button now links to the contract-scoped view, and the comment above it explaining why analytics was org-scoped is updated rather than left contradicting the code.

**The slug in the route is not the id the API filters on.** Three identifiers are in play: the route's contract **slug**, MITx Online's **`contract_id`** (`ContractPage.page_ptr_id`, what the API filters on), and the warehouse's **`contract_pk`** (an md5 surrogate that must never reach a URL). The slug resolves through the org's `contracts` list — the same lookup `ContractAdminPage` already does — and a slug matching no contract of the org reads as "unavailable" rather than issuing a request with `undefined` in the path, which the API would answer 403, indistinguishable from a real denial.

### How can this be tested?

`yarn install && npx tsc --noEmit -p main/tsconfig.json` — clean.

Tests: `npx jest src/analytics` in `frontends/api` (15 passed) and `npx jest src/app-pages/DashboardPage` in `frontends/main` (644 passed across 29 suites); `src/app-pages/ContractAdminPage` also passes (120) since the link changed. New cases:

- five `analyticsContractQueries` cases asserting each hits the contract-nested path;
- contract query keys nest under the org's (so invalidating an org drops its contracts) and differ per contract, and never collide with an org-scoped key;
- the contract id is URL-encoded, not spliced raw;
- `AnalyticsContent` requests the contract-nested endpoints with the resolved id — **only the contract URLs are mocked, so an org-scoped fallback would fail the render**, which is the point of the test;
- a contract slug not in the org issues no `/contracts/` request at all.

`prettier --check` and `eslint` clean on every changed file; pre-commit hooks passed on commit.

End-to-end against a real API is not possible until the two upstream PRs deploy.

### Additional Context

**Three type corrections fall out of touching these files.** All are pre-existing drift against the API, not consequences of this change — I fixed them here rather than leaving `types.ts` half-right, since the file is hand-written and this is the second time it has needed chasing:

- `contract_pk`, `courserun_pk` and `program_pk` were typed `number` but have been `str` in the API since [ol-analytics-api#29](https://github.com/mitodl/ol-analytics-api/pull/29) — they are md5 surrogates, not integers. `CoursePerformanceTable`'s grouping `Map<number, …>` follows.
- `MonthlyEngagementTrend`'s three activity totals became nullable in [ol-analytics-api#33](https://github.com/mitodl/ol-analytics-api/pull/33) and were still typed non-null; its five cohort columns, and `ContentEngagementDepth`'s two, were missing entirely.

This closes the separately-tracked `tk-update-mit-learn-s-hand-written-analytics-types--5f2d5b`, and is a standing argument for generating this file from the API's OpenAPI schema instead.

**One deliberate cast, in `AnalyticsContent`.** The org and contract query factories build keys of different lengths and `queryOptions` is invariant in the key type, so the inferred union leaves `useQuery` unable to pick an overload. The scope selector erases the key while keeping the row type — the same trade this repo's own query tests already make (`erase` in `hooks/organizations/queries.test.ts`). The key still comes from the query factories; nothing in the component reads it.

**Privacy note carried down from the API PR.** With both grains published, a suppressed contract is recoverable as `org_total − (other contracts)`. 4 of 58 orgs already hold more than one contract, so this is reachable on release rather than hypothetical — tracked as `tk-k-anonymity-suppress-complement-disclosure-near--8818e9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QC8Vb9vZiGMPeHd97Fy4Gj